### PR TITLE
WIP: util_cpack: add optional sync input

### DIFF
--- a/library/util_cpack/util_cpack_hw.tcl
+++ b/library/util_cpack/util_cpack_hw.tcl
@@ -36,6 +36,16 @@ set_parameter_property NUM_OF_CHANNELS TYPE INTEGER
 set_parameter_property NUM_OF_CHANNELS UNITS None
 set_parameter_property NUM_OF_CHANNELS HDL_PARAMETER true
 
+add_parameter ENABLE_SYNC_IN_BOOL BOOLEAN false
+set_parameter_property ENABLE_SYNC_IN_BOOL DISPLAY_NAME "Enable Sync Input"
+set_parameter_property ENABLE_SYNC_IN_BOOL HDL_PARAMETER false
+
+add_parameter ENABLE_SYNC_IN INTEGER 0
+set_parameter_property ENABLE_SYNC_IN TYPE INTEGER
+set_parameter_property ENABLE_SYNC_IN DERIVED true
+set_parameter_property ENABLE_SYNC_IN HDL_PARAMETER true
+set_parameter_property ENABLE_SYNC_IN VISIBLE false
+
 # defaults
 
 ad_alt_intf clock   adc_clk         input   1
@@ -51,7 +61,12 @@ add_interface_port fifo_ch_0  adc_valid_0   valid    Input  1
 add_interface_port fifo_ch_0  adc_data_0    data     Input  CHANNEL_DATA_WIDTH
 
 proc p_util_cpack {} {
-
+  if { [get_parameter_value ENABLE_SYNC_IN_BOOL] } {
+    set_parameter_value ENABLE_SYNC_IN 1
+    ad_alt_intf signal  adc_sync_in        input  1     sync
+  } else {
+    set_parameter_value ENABLE_SYNC_IN 0
+  }
   if {[get_parameter_value NUM_OF_CHANNELS] > 1} {
     add_interface fifo_ch_1 conduit end
     #set_interface_property fifo_ch_1  associatedClock if_adc_clk

--- a/library/util_cpack/util_cpack_ip.tcl
+++ b/library/util_cpack/util_cpack_ip.tcl
@@ -28,6 +28,9 @@ set_property enablement_dependency {spirit:decode(id('MODELPARAM_VALUE.NUM_OF_CH
   [ipx::get_ports *_6* -of_objects [ipx::current_core]]
 set_property enablement_dependency {spirit:decode(id('MODELPARAM_VALUE.NUM_OF_CHANNELS')) > 7} \
   [ipx::get_ports *_7* -of_objects [ipx::current_core]]
+  
+set_property enablement_dependency {spirit:decode(id('MODELPARAM_VALUE.ENABLE_SYNC_IN')) > 0} \
+  [ipx::get_ports adc_sync_in -of_objects [ipx::current_core]]
 
 ipx::remove_all_bus_interface [ipx::current_core]
 ipx::save_core [ipx::current_core]

--- a/library/util_cpack/util_cpack_mux.v
+++ b/library/util_cpack/util_cpack_mux.v
@@ -43,12 +43,14 @@ module util_cpack_mux (
 
   adc_clk,
   adc_valid,
+  adc_sync,
   adc_enable,
   adc_data,
 
   // fifo interface
 
   adc_mux_valid,
+  adc_mux_sync,
   adc_mux_enable_0,
   adc_mux_data_0,
   adc_mux_enable_1,
@@ -70,12 +72,14 @@ module util_cpack_mux (
 
   input             adc_clk;
   input             adc_valid;
+  input             adc_sync;
   input   [  7:0]   adc_enable;
   input   [127:0]   adc_data;
 
   // fifo interface
 
   output            adc_mux_valid;
+  output            adc_mux_sync;
   output            adc_mux_enable_0;
   output  [ 15:0]   adc_mux_data_0;
   output            adc_mux_enable_1;
@@ -96,7 +100,9 @@ module util_cpack_mux (
   // internal registers
 
   reg               adc_valid_d = 'd0;
+  reg               adc_sync_d = 'd0;
   reg               adc_mux_valid = 'd0;
+  reg               adc_mux_sync = 'd0;
   reg               adc_mux_enable_0 = 'd0;
   reg               adc_mux_enable_1 = 'd0;
   reg               adc_mux_enable_2 = 'd0;
@@ -158,7 +164,9 @@ module util_cpack_mux (
 
   always @(posedge adc_clk) begin
     adc_valid_d <= adc_valid;
+    adc_sync_d <= adc_sync;
     adc_mux_valid <= adc_valid_d;
+    adc_mux_sync <= adc_sync_d;
   end
 
   always @(posedge adc_clk) begin


### PR DESCRIPTION
Add a sync input to enable user logic to generate a "start of frame"
signal to the DMA engine.
