### PR TITLE
axi_dmac: Don't add CDC constraints when all clocks are synchronous

### DIFF
--- a/library/axi_dmac/axi_dmac_constr.ttcl
+++ b/library/axi_dmac/axi_dmac_constr.ttcl
@@ -11,10 +11,12 @@ set req_clk [get_clocks -of_objects [get_ports s_axi_aclk]]
 set src_clk [get_clocks -of_objects [get_ports -quiet {fifo_wr_clk s_axis_aclk m_src_axi_aclk}]]
 set dest_clk [get_clocks -of_objects [get_ports -quiet {fifo_rd_clk m_axis_aclk m_dest_axi_aclk}]]
 
+<: if {$async_req_src || $async_src_dest || $async_dest_req} { :>
 set_property ASYNC_REG TRUE \
 	[get_cells -quiet -hier *cdc_sync_stage1_reg*] \
 	[get_cells -quiet -hier *cdc_sync_stage2_reg*]
 
+<: } :>
 <: if {$async_req_src} { :>
 set_max_delay -quiet -datapath_only \
 	-from $req_clk \


### PR DESCRIPTION
When all clocks are synchronous there are no synchronizers and the
constraint for the CDC registers can't find any cells which generates a
warning. To avoid this don't add CDC constraints when all the clocks are
synchronous.

Signed-off-by: Lars-Peter Clausen <lars@metafoo.de>