### PR TITLE
adi_env: Normalize environment variables

### DIFF
--- a/library/scripts/adi_env.tcl
+++ b/library/scripts/adi_env.tcl
@@ -6,10 +6,10 @@ set ad_phdl_dir $ad_hdl_dir
 
 
 if [info exists ::env(ADI_HDL_DIR)] {
-  set ad_hdl_dir $::env(ADI_HDL_DIR)
+  set ad_hdl_dir [file normalize $::env(ADI_HDL_DIR)]
 }
 
 if [info exists ::env(ADI_PHDL_DIR)] {
-  set ad_phdl_dir $::env(ADI_PHDL_DIR)
+  set ad_phdl_dir [file normalize $::env(ADI_PHDL_DIR)]
 }
 

--- a/projects/scripts/adi_env.tcl
+++ b/projects/scripts/adi_env.tcl
@@ -6,10 +6,10 @@ set ad_phdl_dir $ad_hdl_dir
 
 
 if [info exists ::env(ADI_HDL_DIR)] {
-  set ad_hdl_dir $::env(ADI_HDL_DIR)
+  set ad_hdl_dir [file normalize $::env(ADI_HDL_DIR)]
 }
 
 if [info exists ::env(ADI_PHDL_DIR)] {
-  set ad_phdl_dir $::env(ADI_PHDL_DIR)
+  set ad_phdl_dir [file normalize $::env(ADI_PHDL_DIR)]
 }
 


### PR DESCRIPTION
If the ADI_HDL_DIR or ADI_PHDL_DIR are set on Windows platforms, an
invalid TCL character (e.g. backslash) may be used as a file separator,
causing issues with the build / library scripts.

Normalize the paths before using them as global TCL variables.