### PR TITLE
Hotfix arradio c5soc

### DIFF
--- a/library/util_clkdiv/util_clkdiv_alt.v
+++ b/library/util_clkdiv/util_clkdiv_alt.v
@@ -49,28 +49,27 @@ module util_clkdiv_alt #(
   input   clk,
   input   reset,
   output  clk_out,
-  output  reset_out
+  output reg reset_out
  );
 
 reg enable;
 reg reset_d1;
 
-assign reset_out = reset | reset_d1;
-
-always @(posedge clk) begin
+always @(posedge clk_out) begin
   reset_d1 <= reset;
+  reset_out <= reset_d1;
 end
 
 always @(posedge clk) begin
   enable <= ~enable;
 end
-  
+
 generate if (SIM_DEVICE == "CYCLONE5") begin
 	cyclonev_clkena #(
 		.clock_type ("Global Clock"),
 		.ena_register_mode ("falling edge"),
 		.lpm_type ("cyclonev_clkena")
-  ) clock_divider_by_2 ( 
+  ) clock_divider_by_2 (
 	.ena(enable),
 	.enaout(),
 	.inclk(clk),

--- a/library/util_clkdiv/util_clkdiv_constr.sdc
+++ b/library/util_clkdiv/util_clkdiv_constr.sdc
@@ -1,0 +1,3 @@
+
+set_false_path -to   [get_registers *reset_d1*]
+

--- a/library/util_clkdiv/util_clkdiv_hw.tcl
+++ b/library/util_clkdiv/util_clkdiv_hw.tcl
@@ -1,25 +1,17 @@
 
-package require -exact qsys 13.0
+package require qsys
 source ../scripts/adi_env.tcl
 source ../scripts/adi_ip_alt.tcl
 
-
-set_module_property NAME util_clkdiv
-set_module_property DESCRIPTION "Clock Division Utility"
-set_module_property VERSION 1.0
-set_module_property GROUP "Analog Devices"
-set_module_property DISPLAY_NAME util_clkdiv
-
-# files
-
-add_fileset quartus_synth QUARTUS_SYNTH "" "Quartus Synthesis"
-set_fileset_property quartus_synth TOP_LEVEL util_clkdiv_alt
-add_fileset_file util_clkdiv_alt.v       VERILOG PATH util_clkdiv_alt.v TOP_LEVEL_FILE
+ad_ip_create util_clkdiv_alt {Clock divider by 2}
+ad_ip_files util_clkdiv_alt [list\
+    util_clkdiv_constr.sdc \
+    util_clkdiv_alt.v]
 
 # defaults
 
 ad_alt_intf clock   clk             input   1
-ad_alt_intf reset   reset           input 1 if_clk
+ad_alt_intf reset   reset           input   1 if_clk
 ad_alt_intf clock   clk_out         output  1
-ad_alt_intf reset   reset_out       output 1 if_clk_out
+ad_alt_intf reset   reset_out       output  1 if_clk_out
 

--- a/projects/arradio/common/arradio_qsys.tcl
+++ b/projects/arradio/common/arradio_qsys.tcl
@@ -20,6 +20,11 @@ add_connection sys_clk.clk axi_ad9361.if_delay_clk
 add_connection sys_clk.clk axi_ad9361.s_axi_clock
 add_connection sys_clk.clk_reset axi_ad9361.s_axi_reset
 
+# clk division
+add_instance util_clkdiv_ad9361 util_clkdiv_alt 1.0
+add_connection axi_ad9361.if_l_clk util_clkdiv_ad9361.if_clk
+add_connection axi_ad9361.if_rst util_clkdiv_ad9361.if_reset
+
 # adc-wfifo & dac-rfifo
 
 add_instance util_adc_wfifo util_wfifo
@@ -29,8 +34,8 @@ set_instance_parameter_value util_adc_wfifo {DOUT_DATA_WIDTH} {16}
 set_instance_parameter_value util_adc_wfifo {DIN_ADDRESS_WIDTH} {5}
 add_connection axi_ad9361.if_l_clk util_adc_wfifo.if_din_clk
 add_connection axi_ad9361.if_rst util_adc_wfifo.if_din_rst
-add_connection sys_dma_clk.clk util_adc_wfifo.if_dout_clk
-add_connection sys_dma_clk.clk_reset util_adc_wfifo.if_dout_rstn
+add_connection util_clkdiv_ad9361.if_clk_out util_adc_wfifo.if_dout_clk
+add_connection util_clkdiv_ad9361.if_reset_out util_adc_wfifo.if_dout_rstn
 add_connection axi_ad9361.adc_ch_0 util_adc_wfifo.din_0
 add_connection axi_ad9361.adc_ch_1 util_adc_wfifo.din_1
 add_connection axi_ad9361.adc_ch_2 util_adc_wfifo.din_2
@@ -46,8 +51,8 @@ set_instance_parameter_value util_dac_rfifo {DOUT_DATA_WIDTH} {16}
 set_instance_parameter_value util_dac_rfifo {DIN_ADDRESS_WIDTH} {5}
 add_connection axi_ad9361.if_l_clk util_dac_rfifo.if_dout_clk
 add_connection axi_ad9361.if_rst util_dac_rfifo.if_dout_rst
-add_connection sys_dma_clk.clk util_dac_rfifo.if_din_clk
-add_connection sys_dma_clk.clk_reset util_dac_rfifo.if_din_rstn
+add_connection util_clkdiv_ad9361.if_clk_out util_dac_rfifo.if_din_clk
+add_connection util_clkdiv_ad9361.if_reset_out util_dac_rfifo.if_din_rstn
 add_connection util_dac_rfifo.dout_0 axi_ad9361.dac_ch_0
 add_connection util_dac_rfifo.dout_1 axi_ad9361.dac_ch_1
 add_connection util_dac_rfifo.dout_2 axi_ad9361.dac_ch_2
@@ -59,8 +64,8 @@ add_connection util_dac_rfifo.if_dout_unf axi_ad9361.if_dac_dunf
 add_instance util_adc_pack util_cpack
 set_instance_parameter_value util_adc_pack {NUM_OF_CHANNELS} {4}
 set_instance_parameter_value util_adc_pack {CHANNEL_DATA_WIDTH} {16}
-add_connection sys_dma_clk.clk util_adc_pack.if_adc_clk
-add_connection sys_dma_clk.clk_reset util_adc_pack.if_adc_rst
+add_connection util_clkdiv_ad9361.if_clk_out util_adc_pack.if_adc_clk
+add_connection util_clkdiv_ad9361.if_reset_out util_adc_pack.if_adc_rst
 add_connection util_adc_wfifo.dout_0 util_adc_pack.adc_ch_0
 add_connection util_adc_wfifo.dout_1 util_adc_pack.adc_ch_1
 add_connection util_adc_wfifo.dout_2 util_adc_pack.adc_ch_2
@@ -71,13 +76,13 @@ add_connection util_adc_wfifo.dout_3 util_adc_pack.adc_ch_3
 add_instance util_dac_upack util_upack
 set_instance_parameter_value util_dac_upack {NUM_OF_CHANNELS} {4}
 set_instance_parameter_value util_dac_upack {CHANNEL_DATA_WIDTH} {16}
-add_connection sys_dma_clk.clk util_dac_upack.if_dac_clk
+add_connection util_clkdiv_ad9361.if_clk_out util_dac_upack.if_dac_clk
 add_connection util_dac_upack.dac_ch_0 util_dac_rfifo.din_0
 add_connection util_dac_upack.dac_ch_1 util_dac_rfifo.din_1
 add_connection util_dac_upack.dac_ch_2 util_dac_rfifo.din_2
 add_connection util_dac_upack.dac_ch_3 util_dac_rfifo.din_3
 
-# adc-dma & dac-dma
+# adc-dma
 
 add_instance axi_adc_dma axi_dmac
 set_instance_parameter_value axi_adc_dma {ID} {0}
@@ -96,13 +101,13 @@ add_connection sys_clk.clk axi_adc_dma.s_axi_clock
 add_connection sys_clk.clk_reset axi_adc_dma.s_axi_reset
 add_connection sys_dma_clk.clk axi_adc_dma.m_dest_axi_clock
 add_connection sys_dma_clk.clk_reset axi_adc_dma.m_dest_axi_reset
-add_connection sys_dma_clk.clk axi_adc_dma.if_fifo_wr_clk
+add_connection util_clkdiv_ad9361.if_clk_out axi_adc_dma.if_fifo_wr_clk
 add_connection util_adc_pack.if_adc_valid axi_adc_dma.if_fifo_wr_en
 add_connection util_adc_pack.if_adc_sync axi_adc_dma.if_fifo_wr_sync
 add_connection util_adc_pack.if_adc_data axi_adc_dma.if_fifo_wr_din
 add_connection axi_adc_dma.if_fifo_wr_overflow util_adc_wfifo.if_dout_ovf
 
-# adc-dma & dac-dma
+# dac-dma
 
 add_instance axi_dac_dma axi_dmac
 set_instance_parameter_value axi_dac_dma {ID} {0}
@@ -121,7 +126,7 @@ add_connection sys_clk.clk axi_dac_dma.s_axi_clock
 add_connection sys_clk.clk_reset axi_dac_dma.s_axi_reset
 add_connection sys_dma_clk.clk axi_dac_dma.m_src_axi_clock
 add_connection sys_dma_clk.clk_reset axi_dac_dma.m_src_axi_reset
-add_connection sys_dma_clk.clk axi_dac_dma.if_fifo_rd_clk
+add_connection util_clkdiv_ad9361.if_clk_out axi_dac_dma.if_fifo_rd_clk
 add_connection util_dac_upack.if_dac_valid axi_dac_dma.if_fifo_rd_en
 add_connection axi_dac_dma.if_fifo_rd_dout util_dac_upack.if_dac_data
 add_connection axi_dac_dma.if_fifo_rd_underflow util_dac_rfifo.if_din_unf


### PR DESCRIPTION
Reduce the clock rate between the [r/w]fifo and dma's, to prevent the data be buffered inside the fifos. This way we can avoid the data loss, which appears if the valid cycles have a wider high state, than one clock cycle. This patch requires because of the incompatibility between the dac and dma data interface. Final solution will come on next release. 