### PR TITLE
axi_streaming_dma_rx_fifo: fix period_count clock and TLAST

### DIFF
--- a/library/common/axi_streaming_dma_rx_fifo.vhd
+++ b/library/common/axi_streaming_dma_rx_fifo.vhd
@@ -100,14 +100,16 @@ begin
 
 	period_counter: process(m_axis_aclk) is
 	begin
-		if resetn = '0' then
-			period_count <= period_len;
-		else
-			if out_stb = '1' and m_axis_tready = '1' then
-				if period_count = 0 then
-					period_count <= period_len;
-				else
-					period_count <= period_count - 1;
+		if rising_edge(m_axis_aclk) then
+			if resetn = '0' then
+				period_count <= period_len;
+			else
+				if out_stb = '1' and m_axis_tready = '1' then
+					if period_count = 0 then
+						period_count <= period_len;
+					else
+						period_count <= period_count - 1;
+					end if;
 				end if;
 			end if;
 		end if;


### PR DESCRIPTION
Hi,

this is a fix to a nasty issue found while using the axi_i2s_adi IP on ZynqMP UltraScale+.

The axi_i2s_adi is used to capture from I2S and feed it to a Xilinx AXI DMA via an AXI4 stream. But even setting correct values of `PERIOD_LEN_REG` (e.g. 7, see [this blog post](https://ez.analog.com/message/313405-axi-i2s-s2mm-tlast-issue-on-zynq-ultrascale#comment-313585)), the `m_axis_tlast` output toggles at random intervals and much less often than expected.

This seems be due to an excessive decrementing of `period_count`. This patch fixed the problem for me by adding an `if rising_edge(m_axis_aclk)` so that `period_count` and `m_axis_tlast` toggle only on the clock rising edge.
