### PR TITLE
axi_dmac: Include TLAST in AXIS slave port

### DIFF
--- a/library/axi_dmac/axi_dmac_ip.tcl
+++ b/library/axi_dmac/axi_dmac_ip.tcl
@@ -54,7 +54,8 @@ adi_add_bus "m_axis" "master" \
 	"xilinx.com:interface:axis:1.0" \
 	[list {"m_axis_ready" "TREADY"} \
 	  {"m_axis_valid" "TVALID"} \
-	  {"m_axis_data" "TDATA"} ]
+	  {"m_axis_data" "TDATA"} \
+	  {"m_axis_last" "TLAST"} ]
 adi_add_bus_clock "m_axis_aclk" "m_axis"
 
 adi_set_bus_dependency "m_src_axi" "m_src_axi" \


### PR DESCRIPTION
Bundle the TLAST signal in with the other AXIS slave signals to enable
easier connection between AXIS devices that use TLAST

Signed-off-by: Matt Fornero <matt.fornero@mathworks.com>