### PR TITLE
fmcomms5: Remove wire that are redeclarations of ports

### DIFF
--- a/projects/fmcomms5/zc702/system_top.v
+++ b/projects/fmcomms5/zc702/system_top.v
@@ -154,10 +154,6 @@ module system_top (
   wire            spi1_clk;
   wire            spi1_mosi;
   wire            spi1_miso;
-  wire            txnrx_0;
-  wire            enable_0;
-  wire            txnrx_1;
-  wire            enable_1;
 
   // multi-chip synchronization
 

--- a/projects/fmcomms5/zc706/system_top.v
+++ b/projects/fmcomms5/zc706/system_top.v
@@ -155,10 +155,6 @@ module system_top (
   wire            spi1_clk;
   wire            spi1_mosi;
   wire            spi1_miso;
-  wire            txnrx_0;
-  wire            enable_0;
-  wire            txnrx_1;
-  wire            enable_1;
 
   // multi-chip synchronization
 

--- a/projects/fmcomms5/zcu102/system_top.v
+++ b/projects/fmcomms5/zcu102/system_top.v
@@ -121,10 +121,6 @@ module system_top (
   wire                    spi1_clk;
   wire                    spi1_mosi;
   wire                    spi1_miso;
-  wire                    txnrx_0;
-  wire                    enable_0;
-  wire                    txnrx_1;
-  wire                    enable_1;
 
   // multi-chip synchronization
 


### PR DESCRIPTION
Fixes the following warnings:
	[Synth 8-2611] redeclaration of ansi port txnrx_0 is not allowed
	[Synth 8-2611] redeclaration of ansi port enable_0 is not allowed
	[Synth 8-2611] redeclaration of ansi port enable_1 is not allowed
	[Synth 8-2611] redeclaration of ansi port txnrx_1 is not allowed

This is a leftover of commit 1c23cf46216a ("all: Update verilog files to
verilog-2001").

Signed-off-by: Lars-Peter Clausen <lars@metafoo.de>