### PR TITLE
AXI-DMAC burst length verification

### DIFF
--- a/library/axi_dmac/axi_dmac.v
+++ b/library/axi_dmac/axi_dmac.v
@@ -617,7 +617,8 @@ dmac_request_arb #(
   .MAX_BYTES_PER_BURST(MAX_BYTES_PER_BURST),
   .FIFO_SIZE(FIFO_SIZE),
   .ID_WIDTH(ID_WIDTH),
-  .AXI_LENGTH_WIDTH(8-(4*DMA_AXI_PROTOCOL_SRC))
+  .AXI_LENGTH_WIDTH_SRC(8-(4*DMA_AXI_PROTOCOL_SRC)),
+  .AXI_LENGTH_WIDTH_DEST(8-(4*DMA_AXI_PROTOCOL_DEST))
 ) i_request_arb (
   .req_aclk(s_axi_aclk),
   .req_aresetn(s_axi_aresetn),

--- a/library/axi_dmac/axi_dmac_hw.tcl
+++ b/library/axi_dmac/axi_dmac_hw.tcl
@@ -207,6 +207,8 @@ proc axi_dmac_validate {} {
   set type_src [get_parameter_value DMA_TYPE_SRC]
   set type_dest [get_parameter_value DMA_TYPE_DEST]
 
+  set max_burst 32768
+
   if {$auto_clk == true} {
     global src_clks dest_clks
 
@@ -244,11 +246,20 @@ proc axi_dmac_validate {} {
   foreach suffix {SRC DEST} {
     if {[get_parameter_value DMA_TYPE_$suffix] == 0} {
       set show_axi_protocol true
+      set proto [get_parameter_value DMA_AXI_PROTOCOL_$suffix]
+      set width [get_parameter_value DMA_DATA_WIDTH_$suffix]
+      if {$proto == 0} {
+        set max_burst [expr min($max_burst, $width * 256 / 8)]
+      } else {
+        set max_burst [expr min($max_burst, $width * 16 / 8)]
+      }
     } else {
       set show_axi_protocol false
     }
     set_parameter_property DMA_AXI_PROTOCOL_$suffix VISIBLE $show_axi_protocol
   }
+
+  set_parameter_property MAX_BYTES_PER_BURST ALLOWED_RANGES "1:$max_burst"
 }
 
 # conditional interfaces

--- a/library/axi_dmac/axi_dmac_hw.tcl
+++ b/library/axi_dmac/axi_dmac_hw.tcl
@@ -242,12 +242,12 @@ proc axi_dmac_validate {} {
     set_parameter_property $p VISIBLE $auto_clk
   }
   foreach suffix {SRC DEST} {
-   if {[get_parameter_value DMA_TYPE_$suffix] == 0} {
-     set show_axi_protocol true
-   } else {
-     set show_axi_protocol false
-   }
-   set_parameter_property DMA_AXI_PROTOCOL_$suffix VISIBLE $show_axi_protocol
+    if {[get_parameter_value DMA_TYPE_$suffix] == 0} {
+      set show_axi_protocol true
+    } else {
+      set show_axi_protocol false
+    }
+    set_parameter_property DMA_AXI_PROTOCOL_$suffix VISIBLE $show_axi_protocol
   }
 }
 

--- a/library/axi_dmac/bd/bd.tcl
+++ b/library/axi_dmac/bd/bd.tcl
@@ -40,10 +40,24 @@ proc post_config_ip {cellpath otherinfo} {
 			continue
 		}
 
+		set axi_protocol [get_property "CONFIG.DMA_AXI_PROTOCOL_$dir" $ip]
 		set data_width [get_property "CONFIG.DMA_DATA_WIDTH_$dir" $ip]
 		set max_beats_per_burst [expr {int(ceil($max_bytes_per_burst * 8.0 / $data_width))}]
 
+		if {$axi_protocol == 0} {
+			set axi_protocol_str "AXI4"
+			if {$max_beats_per_burst > 256} {
+				set max_beats_per_burst 256
+			}
+		} else {
+			set axi_protocol_str "AXI3"
+			if {$max_beats_per_burst > 16} {
+				set max_beats_per_burst 16
+			}
+		}
+
 		set intf [get_bd_intf_pins [format "%s/m_%s_axi" $cellpath [string tolower $dir]]]
+		set_property CONFIG.PROTOCOL $axi_protocol_str $intf
 		set_property CONFIG.MAX_BURST_LENGTH $max_beats_per_burst $intf
 
 		# The core issues as many requests as the amount of data the FIFO can hold

--- a/library/axi_dmac/request_arb.v
+++ b/library/axi_dmac/request_arb.v
@@ -51,7 +51,8 @@ module dmac_request_arb #(
   parameter MAX_BYTES_PER_BURST = 128,
   parameter FIFO_SIZE = 4,
   parameter ID_WIDTH = $clog2(FIFO_SIZE*2),
-  parameter AXI_LENGTH_WIDTH = 8)(
+  parameter AXI_LENGTH_WIDTH_SRC = 8,
+  parameter AXI_LENGTH_WIDTH_DEST = 8)(
 
   input req_aclk,
   input req_aresetn,
@@ -77,7 +78,7 @@ module dmac_request_arb #(
 
   // Write address
   output [DMA_AXI_ADDR_WIDTH-1:0]     m_axi_awaddr,
-  output [AXI_LENGTH_WIDTH-1:0]       m_axi_awlen,
+  output [AXI_LENGTH_WIDTH_DEST-1:0]  m_axi_awlen,
   output [ 2:0]                       m_axi_awsize,
   output [ 1:0]                       m_axi_awburst,
   output [ 2:0]                       m_axi_awprot,
@@ -101,7 +102,7 @@ module dmac_request_arb #(
   input                               m_axi_arready,
   output                              m_axi_arvalid,
   output [DMA_AXI_ADDR_WIDTH-1:0]     m_axi_araddr,
-  output [AXI_LENGTH_WIDTH-1:0]       m_axi_arlen,
+  output [AXI_LENGTH_WIDTH_SRC-1:0]   m_axi_arlen,
   output [ 2:0]                       m_axi_arsize,
   output [ 1:0]                       m_axi_arburst,
   output [ 2:0]                       m_axi_arprot,
@@ -402,7 +403,7 @@ dmac_dest_mm_axi #(
   .DMA_ADDR_WIDTH(DMA_AXI_ADDR_WIDTH),
   .BEATS_PER_BURST_WIDTH(BEATS_PER_BURST_WIDTH_DEST),
   .BYTES_PER_BEAT_WIDTH(BYTES_PER_BEAT_WIDTH_DEST),
-  .AXI_LENGTH_WIDTH(AXI_LENGTH_WIDTH)
+  .AXI_LENGTH_WIDTH(AXI_LENGTH_WIDTH_DEST)
 ) i_dest_dma_mm (
   .m_axi_aclk(m_dest_axi_aclk),
   .m_axi_aresetn(dest_resetn),
@@ -615,7 +616,7 @@ dmac_src_mm_axi #(
   .DMA_ADDR_WIDTH(DMA_AXI_ADDR_WIDTH),
   .BEATS_PER_BURST_WIDTH(BEATS_PER_BURST_WIDTH_SRC),
   .BYTES_PER_BEAT_WIDTH(BYTES_PER_BEAT_WIDTH_SRC),
-  .AXI_LENGTH_WIDTH(AXI_LENGTH_WIDTH)
+  .AXI_LENGTH_WIDTH(AXI_LENGTH_WIDTH_SRC)
 ) i_src_dma_mm (
   .m_axi_aclk(m_src_axi_aclk),
   .m_axi_aresetn(src_resetn),


### PR DESCRIPTION
Two commits to make sure that we do not accidentally setup the core in a configuration that will generate bursts that are longer than the system can handle.