### PR TITLE
adrv9371: Move lane remapping after the transceivers 

### DIFF
--- a/projects/adrv9371x/a10gx/system_project.tcl
+++ b/projects/adrv9371x/a10gx/system_project.tcl
@@ -12,20 +12,20 @@ set_location_assignment PIN_AL8   -to ref_clk0               ; ## D04  FMCA_GBTC
 set_location_assignment PIN_AL7   -to "ref_clk0(n)"          ; ## D05  FMCA_GBTCLK0_M2C_N
 set_location_assignment PIN_AJ8   -to ref_clk1               ; ## B20  FMCA_GBTCLK1_M2C_P
 set_location_assignment PIN_AJ7   -to "ref_clk1(n)"          ; ## B21  FMCA_GBTCLK1_M2C_N
-set_location_assignment PIN_BA7   -to rx_serial_data[0]      ; ## A02  FMCA_DP1_M2C_P
-set_location_assignment PIN_BA8   -to "rx_serial_data[0](n)" ; ## A03  FMCA_DP1_M2C_N
-set_location_assignment PIN_AY5   -to rx_serial_data[1]      ; ## A06  FMCA_DP2_M2C_P
-set_location_assignment PIN_AY6   -to "rx_serial_data[1](n)" ; ## A07  FMCA_DP2_M2C_N
-set_location_assignment PIN_AW7   -to rx_serial_data[2]      ; ## C06  FMCA_DP0_M2C_P
-set_location_assignment PIN_AW8   -to "rx_serial_data[2](n)" ; ## C07  FMCA_DP0_M2C_N
+set_location_assignment PIN_AW7   -to rx_serial_data[0]      ; ## C06  FMCA_DP0_M2C_P
+set_location_assignment PIN_AW8   -to "rx_serial_data[0](n)" ; ## C07  FMCA_DP0_M2C_N
+set_location_assignment PIN_BA7   -to rx_serial_data[1]      ; ## A02  FMCA_DP1_M2C_P
+set_location_assignment PIN_BA8   -to "rx_serial_data[1](n)" ; ## A03  FMCA_DP1_M2C_N
+set_location_assignment PIN_AY5   -to rx_serial_data[2]      ; ## A06  FMCA_DP2_M2C_P
+set_location_assignment PIN_AY6   -to "rx_serial_data[2](n)" ; ## A07  FMCA_DP2_M2C_N
 set_location_assignment PIN_AV5   -to rx_serial_data[3]      ; ## A10  FMCA_DP3_M2C_P
 set_location_assignment PIN_AV6   -to "rx_serial_data[3](n)" ; ## A11  FMCA_DP3_M2C_N
-set_location_assignment PIN_BD5   -to tx_serial_data[0]      ; ## A22  FMCA_DP1_C2M_P (tx_serial_data_p[0])
-set_location_assignment PIN_BD6   -to "tx_serial_data[0](n)" ; ## A23  FMCA_DP1_C2M_N (tx_serial_data_n[0])
-set_location_assignment PIN_BB5   -to tx_serial_data[1]      ; ## A26  FMCA_DP2_C2M_P (tx_serial_data_p[1])
-set_location_assignment PIN_BB6   -to "tx_serial_data[1](n)" ; ## A27  FMCA_DP2_C2M_N (tx_serial_data_n[1])
-set_location_assignment PIN_BC7   -to tx_serial_data[2]      ; ## C02  FMCA_DP0_C2M_P (tx_serial_data_p[2])
-set_location_assignment PIN_BC8   -to "tx_serial_data[2](n)" ; ## C03  FMCA_DP0_C2M_N (tx_serial_data_n[2])
+set_location_assignment PIN_BC7   -to tx_serial_data[0]      ; ## C02  FMCA_DP0_C2M_P (tx_serial_data_p[2])
+set_location_assignment PIN_BC8   -to "tx_serial_data[0](n)" ; ## C03  FMCA_DP0_C2M_N (tx_serial_data_n[2])
+set_location_assignment PIN_BD5   -to tx_serial_data[1]      ; ## A22  FMCA_DP1_C2M_P (tx_serial_data_p[0])
+set_location_assignment PIN_BD6   -to "tx_serial_data[1](n)" ; ## A23  FMCA_DP1_C2M_N (tx_serial_data_n[0])
+set_location_assignment PIN_BB5   -to tx_serial_data[2]      ; ## A26  FMCA_DP2_C2M_P (tx_serial_data_p[1])
+set_location_assignment PIN_BB6   -to "tx_serial_data[2](n)" ; ## A27  FMCA_DP2_C2M_N (tx_serial_data_n[1])
 set_location_assignment PIN_BC3   -to tx_serial_data[3]      ; ## A30  FMCA_DP3_C2M_P (tx_serial_data_p[3])
 set_location_assignment PIN_BC4   -to "tx_serial_data[3](n)" ; ## A31  FMCA_DP3_C2M_N (tx_serial_data_n[3])
 

--- a/projects/adrv9371x/a10soc/system_project.tcl
+++ b/projects/adrv9371x/a10soc/system_project.tcl
@@ -13,20 +13,20 @@ set_location_assignment PIN_N29   -to ref_clk0               ; ## D04  FMC_HPC_G
 set_location_assignment PIN_N28   -to "ref_clk0(n)"          ; ## D05  FMC_HPC_GBTCLK0_M2C_N (NC)
 set_location_assignment PIN_R29   -to ref_clk1               ; ## B20  FMC_HPC_GBTCLK1_M2C_P
 set_location_assignment PIN_R28   -to "ref_clk1(n)"          ; ## B21  FMC_HPC_GBTCLK1_M2C_N
-set_location_assignment PIN_R33   -to rx_serial_data[0]      ; ## A02  FMC_HPC_DP1_M2C_P
-set_location_assignment PIN_R32   -to "rx_serial_data[0](n)" ; ## A03  FMC_HPC_DP1_M2C_N
-set_location_assignment PIN_P35   -to rx_serial_data[1]      ; ## A06  FMC_HPC_DP2_M2C_P
-set_location_assignment PIN_P34   -to "rx_serial_data[1](n)" ; ## A07  FMC_HPC_DP2_M2C_N
-set_location_assignment PIN_T31   -to rx_serial_data[2]      ; ## C06  FMC_HPC_DP0_M2C_P
-set_location_assignment PIN_T30   -to "rx_serial_data[2](n)" ; ## C07  FMC_HPC_DP0_M2C_N
+set_location_assignment PIN_T31   -to rx_serial_data[0]      ; ## C06  FMC_HPC_DP0_M2C_P
+set_location_assignment PIN_T30   -to "rx_serial_data[0](n)" ; ## C07  FMC_HPC_DP0_M2C_N
+set_location_assignment PIN_R33   -to rx_serial_data[1]      ; ## A02  FMC_HPC_DP1_M2C_P
+set_location_assignment PIN_R32   -to "rx_serial_data[1](n)" ; ## A03  FMC_HPC_DP1_M2C_N
+set_location_assignment PIN_P35   -to rx_serial_data[2]      ; ## A06  FMC_HPC_DP2_M2C_P
+set_location_assignment PIN_P34   -to "rx_serial_data[2](n)" ; ## A07  FMC_HPC_DP2_M2C_N
 set_location_assignment PIN_P31   -to rx_serial_data[3]      ; ## A10  FMC_HPC_DP3_M2C_P
 set_location_assignment PIN_P30   -to "rx_serial_data[3](n)" ; ## A11  FMC_HPC_DP3_M2C_N
-set_location_assignment PIN_M39   -to tx_serial_data[0]      ; ## A22  FMC_HPC_DP1_C2M_P (tx_serial_data_p[3])
-set_location_assignment PIN_M38   -to "tx_serial_data[0](n)" ; ## A23  FMC_HPC_DP1_C2M_N (tx_serial_data_n[3])
-set_location_assignment PIN_L37   -to tx_serial_data[1]      ; ## A26  FMC_HPC_DP2_C2M_P (tx_serial_data_p[0])
-set_location_assignment PIN_L36   -to "tx_serial_data[1](n)" ; ## A27  FMC_HPC_DP2_C2M_N (tx_serial_data_n[0])
-set_location_assignment PIN_N37   -to tx_serial_data[2]      ; ## C02  FMC_HPC_DP0_C2M_P (tx_serial_data_p[1])
-set_location_assignment PIN_N36   -to "tx_serial_data[2](n)" ; ## C03  FMC_HPC_DP0_C2M_N (tx_serial_data_n[1])
+set_location_assignment PIN_N37   -to tx_serial_data[0]      ; ## C02  FMC_HPC_DP0_C2M_P (tx_serial_data_p[1])
+set_location_assignment PIN_N36   -to "tx_serial_data[0](n)" ; ## C03  FMC_HPC_DP0_C2M_N (tx_serial_data_n[1])
+set_location_assignment PIN_M39   -to tx_serial_data[1]      ; ## A22  FMC_HPC_DP1_C2M_P (tx_serial_data_p[3])
+set_location_assignment PIN_M38   -to "tx_serial_data[1](n)" ; ## A23  FMC_HPC_DP1_C2M_N (tx_serial_data_n[3])
+set_location_assignment PIN_L37   -to tx_serial_data[2]      ; ## A26  FMC_HPC_DP2_C2M_P (tx_serial_data_p[0])
+set_location_assignment PIN_L36   -to "tx_serial_data[2](n)" ; ## A27  FMC_HPC_DP2_C2M_N (tx_serial_data_n[0])
 set_location_assignment PIN_K39   -to tx_serial_data[3]      ; ## A30  FMC_HPC_DP3_C2M_P (tx_serial_data_p[2])
 set_location_assignment PIN_K38   -to "tx_serial_data[3](n)" ; ## A31  FMC_HPC_DP3_C2M_N (tx_serial_data_n[2])
 

--- a/projects/adrv9371x/common/adrv9371x_bd.tcl
+++ b/projects/adrv9371x/common/adrv9371x_bd.tcl
@@ -137,7 +137,7 @@ ad_xcvrpll  axi_ad9371_rx_os_xcvr/up_pll_rst util_ad9371_xcvr/up_cpll_rst_3
 ad_connect  sys_cpu_resetn util_ad9371_xcvr/up_rstn
 ad_connect  sys_cpu_clk util_ad9371_xcvr/up_clk
 
-ad_xcvrcon  util_ad9371_xcvr axi_ad9371_tx_xcvr axi_ad9371_tx_jesd
+ad_xcvrcon  util_ad9371_xcvr axi_ad9371_tx_xcvr axi_ad9371_tx_jesd {1 3 0 2}
 ad_reconct  util_ad9371_xcvr/tx_out_clk_0 axi_ad9371_tx_clkgen/clk
 ad_connect  axi_ad9371_tx_clkgen/clk_0 util_ad9371_xcvr/tx_clk_0
 ad_connect  axi_ad9371_tx_clkgen/clk_0 util_ad9371_xcvr/tx_clk_1
@@ -145,10 +145,6 @@ ad_connect  axi_ad9371_tx_clkgen/clk_0 util_ad9371_xcvr/tx_clk_2
 ad_connect  axi_ad9371_tx_clkgen/clk_0 util_ad9371_xcvr/tx_clk_3
 ad_connect  axi_ad9371_tx_clkgen/clk_0 axi_ad9371_tx_jesd/device_clk
 ad_connect  axi_ad9371_tx_clkgen/clk_0 axi_ad9371_tx_jesd_rstgen/slowest_sync_clk
-ad_reconct  util_ad9371_xcvr/tx_0 axi_ad9371_tx_jesd/tx_phy3
-ad_reconct  util_ad9371_xcvr/tx_1 axi_ad9371_tx_jesd/tx_phy0
-ad_reconct  util_ad9371_xcvr/tx_2 axi_ad9371_tx_jesd/tx_phy1
-ad_reconct  util_ad9371_xcvr/tx_3 axi_ad9371_tx_jesd/tx_phy2
 ad_xcvrcon  util_ad9371_xcvr axi_ad9371_rx_xcvr axi_ad9371_rx_jesd
 ad_reconct  util_ad9371_xcvr/rx_out_clk_0 axi_ad9371_rx_clkgen/clk
 ad_connect  axi_ad9371_rx_clkgen/clk_0 util_ad9371_xcvr/rx_clk_0
@@ -161,6 +157,15 @@ ad_connect  axi_ad9371_rx_os_clkgen/clk_0 util_ad9371_xcvr/rx_clk_2
 ad_connect  axi_ad9371_rx_os_clkgen/clk_0 util_ad9371_xcvr/rx_clk_3
 ad_connect  axi_ad9371_rx_os_clkgen/clk_0 axi_ad9371_rx_os_jesd/device_clk
 ad_connect  axi_ad9371_rx_os_clkgen/clk_0 axi_ad9371_rx_os_jesd_rstgen/slowest_sync_clk
+
+# lane re-mapping for RX
+# because the four RX lanes are shared between two JESD204 IP (RX and RX_OS) we
+# are reconnecting/remapping the lanes manually
+
+ad_reconct  axi_ad9371_rx_jesd/rx_phy0    util_ad9371_xcvr/rx_2
+ad_reconct  axi_ad9371_rx_jesd/rx_phy1    util_ad9371_xcvr/rx_0
+ad_reconct  axi_ad9371_rx_os_jesd/rx_phy0 util_ad9371_xcvr/rx_1
+ad_reconct  axi_ad9371_rx_os_jesd/rx_phy1 util_ad9371_xcvr/rx_3
 
 # dma clock & reset
 

--- a/projects/adrv9371x/kcu105/system_constr.xdc
+++ b/projects/adrv9371x/kcu105/system_constr.xdc
@@ -82,9 +82,9 @@ create_clock -name rx_os_div_clk  -period  8.00 [get_pins i_system_wrapper/syste
 set_property LOC GTHE3_COMMON_X0Y4 [get_cells -hierarchical -filter {NAME =~ *i_ibufds_ref_clk1}]
 set_property BEL GTHE3_COMMON.IBUFDS1_GTE3 [get_cells -hierarchical -filter {NAME =~ *i_ibufds_ref_clk1}]
 
-set_property LOC GTHE3_CHANNEL_X0Y17 [get_cells -hierarchical -filter {NAME =~ *util_ad9371_xcvr/inst/i_xch_0/i_gthe3_channel}]
-set_property LOC GTHE3_CHANNEL_X0Y18 [get_cells -hierarchical -filter {NAME =~ *util_ad9371_xcvr/inst/i_xch_1/i_gthe3_channel}]
-set_property LOC GTHE3_CHANNEL_X0Y16 [get_cells -hierarchical -filter {NAME =~ *util_ad9371_xcvr/inst/i_xch_2/i_gthe3_channel}]
+set_property LOC GTHE3_CHANNEL_X0Y16 [get_cells -hierarchical -filter {NAME =~ *util_ad9371_xcvr/inst/i_xch_0/i_gthe3_channel}]
+set_property LOC GTHE3_CHANNEL_X0Y17 [get_cells -hierarchical -filter {NAME =~ *util_ad9371_xcvr/inst/i_xch_1/i_gthe3_channel}]
+set_property LOC GTHE3_CHANNEL_X0Y18 [get_cells -hierarchical -filter {NAME =~ *util_ad9371_xcvr/inst/i_xch_2/i_gthe3_channel}]
 set_property LOC GTHE3_CHANNEL_X0Y19 [get_cells -hierarchical -filter {NAME =~ *util_ad9371_xcvr/inst/i_xch_3/i_gthe3_channel}]
 
 set_false_path -from [get_cells i_system_wrapper/system_i/axi_ad9371_rx_jesd_rstgen/U0/PR_OUT_DFF[0].peripheral_reset_reg[0]]

--- a/projects/adrv9371x/zc706/system_constr.xdc
+++ b/projects/adrv9371x/zc706/system_constr.xdc
@@ -5,22 +5,22 @@ set_property  -dict {PACKAGE_PIN  AD10} [get_ports ref_clk0_p]                  
 set_property  -dict {PACKAGE_PIN  AD9 } [get_ports ref_clk0_n]                                        ; ## D05  FMC_HPC_GBTCLK0_M2C_N (NC)
 set_property  -dict {PACKAGE_PIN  AA8 } [get_ports ref_clk1_p]                                        ; ## B20  FMC_HPC_GBTCLK1_M2C_P
 set_property  -dict {PACKAGE_PIN  AA7 } [get_ports ref_clk1_n]                                        ; ## B21  FMC_HPC_GBTCLK1_M2C_N
-set_property  -dict {PACKAGE_PIN  AJ8 } [get_ports rx_data_p[0]]                                      ; ## A02  FMC_HPC_DP1_M2C_P
-set_property  -dict {PACKAGE_PIN  AJ7 } [get_ports rx_data_n[0]]                                      ; ## A03  FMC_HPC_DP1_M2C_N
-set_property  -dict {PACKAGE_PIN  AG8 } [get_ports rx_data_p[1]]                                      ; ## A06  FMC_HPC_DP2_M2C_P
-set_property  -dict {PACKAGE_PIN  AG7 } [get_ports rx_data_n[1]]                                      ; ## A07  FMC_HPC_DP2_M2C_N
-set_property  -dict {PACKAGE_PIN  AH10} [get_ports rx_data_p[2]]                                      ; ## C06  FMC_HPC_DP0_M2C_P
-set_property  -dict {PACKAGE_PIN  AH9 } [get_ports rx_data_n[2]]                                      ; ## C07  FMC_HPC_DP0_M2C_N
-set_property  -dict {PACKAGE_PIN  AE8 } [get_ports rx_data_p[3]]                                      ; ## A10  FMC_HPC_DP3_M2C_P
-set_property  -dict {PACKAGE_PIN  AE7 } [get_ports rx_data_n[3]]                                      ; ## A11  FMC_HPC_DP3_M2C_N
-set_property  -dict {PACKAGE_PIN  AK6 } [get_ports tx_data_p[0]]                                      ; ## A22  FMC_HPC_DP1_C2M_P (tx_data_p[3])
-set_property  -dict {PACKAGE_PIN  AK5 } [get_ports tx_data_n[0]]                                      ; ## A23  FMC_HPC_DP1_C2M_N (tx_data_n[3])
-set_property  -dict {PACKAGE_PIN  AJ4 } [get_ports tx_data_p[1]]                                      ; ## A26  FMC_HPC_DP2_C2M_P (tx_data_p[0])
-set_property  -dict {PACKAGE_PIN  AJ3 } [get_ports tx_data_n[1]]                                      ; ## A27  FMC_HPC_DP2_C2M_N (tx_data_n[0])
-set_property  -dict {PACKAGE_PIN  AK10} [get_ports tx_data_p[2]]                                      ; ## C02  FMC_HPC_DP0_C2M_P (tx_data_p[1])
-set_property  -dict {PACKAGE_PIN  AK9 } [get_ports tx_data_n[2]]                                      ; ## C03  FMC_HPC_DP0_C2M_N (tx_data_n[1])
-set_property  -dict {PACKAGE_PIN  AK2 } [get_ports tx_data_p[3]]                                      ; ## A30  FMC_HPC_DP3_C2M_P (tx_data_p[2])
-set_property  -dict {PACKAGE_PIN  AK1 } [get_ports tx_data_n[3]]                                      ; ## A31  FMC_HPC_DP3_C2M_N (tx_data_n[2])
+set_property  -dict {PACKAGE_PIN  AH10} [get_ports rx_data_p[0]]                                      ; ## C06  FMC_HPC_DP0_M2C_P (serdesout_p[2])
+set_property  -dict {PACKAGE_PIN  AH9 } [get_ports rx_data_n[0]]                                      ; ## C07  FMC_HPC_DP0_M2C_N (serdesout_n[2])
+set_property  -dict {PACKAGE_PIN  AJ8 } [get_ports rx_data_p[1]]                                      ; ## A02  FMC_HPC_DP1_M2C_P (serdesout_p[0])
+set_property  -dict {PACKAGE_PIN  AJ7 } [get_ports rx_data_n[1]]                                      ; ## A03  FMC_HPC_DP1_M2C_N (serdesout_n[0])
+set_property  -dict {PACKAGE_PIN  AG8 } [get_ports rx_data_p[2]]                                      ; ## A06  FMC_HPC_DP2_M2C_P (serdesout_p[1])
+set_property  -dict {PACKAGE_PIN  AG7 } [get_ports rx_data_n[2]]                                      ; ## A07  FMC_HPC_DP2_M2C_N (serdesout_n[1])
+set_property  -dict {PACKAGE_PIN  AE8 } [get_ports rx_data_p[3]]                                      ; ## A10  FMC_HPC_DP3_M2C_P (serdesout_p[3])
+set_property  -dict {PACKAGE_PIN  AE7 } [get_ports rx_data_n[3]]                                      ; ## A11  FMC_HPC_DP3_M2C_N (serdesout_n[3])
+set_property  -dict {PACKAGE_PIN  AK10} [get_ports tx_data_p[0]]                                      ; ## C02  FMC_HPC_DP0_C2M_P (serdesin_p[1])
+set_property  -dict {PACKAGE_PIN  AK9 } [get_ports tx_data_n[0]]                                      ; ## C03  FMC_HPC_DP0_C2M_N (serdesin_n[1])
+set_property  -dict {PACKAGE_PIN  AK6 } [get_ports tx_data_p[1]]                                      ; ## A22  FMC_HPC_DP1_C2M_P (serdesin_p[3])
+set_property  -dict {PACKAGE_PIN  AK5 } [get_ports tx_data_n[1]]                                      ; ## A23  FMC_HPC_DP1_C2M_N (serdesin_n[3])
+set_property  -dict {PACKAGE_PIN  AJ4 } [get_ports tx_data_p[2]]                                      ; ## A26  FMC_HPC_DP2_C2M_P (serdesin_p[0])
+set_property  -dict {PACKAGE_PIN  AJ3 } [get_ports tx_data_n[2]]                                      ; ## A27  FMC_HPC_DP2_C2M_N (serdesin_n[0])
+set_property  -dict {PACKAGE_PIN  AK2 } [get_ports tx_data_p[3]]                                      ; ## A30  FMC_HPC_DP3_C2M_P (serdesin_p[2])
+set_property  -dict {PACKAGE_PIN  AK1 } [get_ports tx_data_n[3]]                                      ; ## A31  FMC_HPC_DP3_C2M_N (serdesin_n[2])
 set_property  -dict {PACKAGE_PIN  AH19  IOSTANDARD LVDS_25} [get_ports rx_sync_p]                     ; ## G09  FMC_HPC_LA03_P
 set_property  -dict {PACKAGE_PIN  AJ19  IOSTANDARD LVDS_25} [get_ports rx_sync_n]                     ; ## G10  FMC_HPC_LA03_N
 set_property  -dict {PACKAGE_PIN  T29   IOSTANDARD LVDS_25} [get_ports rx_os_sync_p]                  ; ## G27  FMC_HPC_LA25_P (Sniffer)
@@ -46,25 +46,25 @@ set_property  -dict {PACKAGE_PIN  AH23  IOSTANDARD LVCMOS25} [get_ports ad9371_t
 set_property  -dict {PACKAGE_PIN  AJ20  IOSTANDARD LVCMOS25} [get_ports ad9371_reset_b]               ; ## H10  FMC_HPC_LA04_P
 set_property  -dict {PACKAGE_PIN  AK20  IOSTANDARD LVCMOS25} [get_ports ad9371_gpint]                 ; ## H11  FMC_HPC_LA04_N
 
-set_property  -dict {PACKAGE_PIN  Y22   IOSTANDARD LVCMOS25} [get_ports ad9371_gpio_00]               ; ## H19  FMC_HPC_LA15_P          
-set_property  -dict {PACKAGE_PIN  Y23   IOSTANDARD LVCMOS25} [get_ports ad9371_gpio_01]               ; ## H20  FMC_HPC_LA15_N          
-set_property  -dict {PACKAGE_PIN  AA24  IOSTANDARD LVCMOS25} [get_ports ad9371_gpio_02]               ; ## G18  FMC_HPC_LA16_P          
-set_property  -dict {PACKAGE_PIN  AB24  IOSTANDARD LVCMOS25} [get_ports ad9371_gpio_03]               ; ## G19  FMC_HPC_LA16_N          
-set_property  -dict {PACKAGE_PIN  W29   IOSTANDARD LVCMOS25} [get_ports ad9371_gpio_04]               ; ## H25  FMC_HPC_LA21_P          
-set_property  -dict {PACKAGE_PIN  W30   IOSTANDARD LVCMOS25} [get_ports ad9371_gpio_05]               ; ## H26  FMC_HPC_LA21_N          
-set_property  -dict {PACKAGE_PIN  W25   IOSTANDARD LVCMOS25} [get_ports ad9371_gpio_06]               ; ## C22  FMC_HPC_LA18_CC_P       
-set_property  -dict {PACKAGE_PIN  W26   IOSTANDARD LVCMOS25} [get_ports ad9371_gpio_07]               ; ## C23  FMC_HPC_LA18_CC_N       
-set_property  -dict {PACKAGE_PIN  V27   IOSTANDARD LVCMOS25} [get_ports ad9371_gpio_15]               ; ## G24  FMC_HPC_LA22_P     (LVDS Pairs?)    
-set_property  -dict {PACKAGE_PIN  W28   IOSTANDARD LVCMOS25} [get_ports ad9371_gpio_08]               ; ## G25  FMC_HPC_LA22_N     (LVDS Pairs?)    
-set_property  -dict {PACKAGE_PIN  T24   IOSTANDARD LVCMOS25} [get_ports ad9371_gpio_09]               ; ## H22  FMC_HPC_LA19_P     (LVDS Pairs?)    
-set_property  -dict {PACKAGE_PIN  T25   IOSTANDARD LVCMOS25} [get_ports ad9371_gpio_10]               ; ## H23  FMC_HPC_LA19_N     (LVDS Pairs?)    
-set_property  -dict {PACKAGE_PIN  U25   IOSTANDARD LVCMOS25} [get_ports ad9371_gpio_11]               ; ## G21  FMC_HPC_LA20_P     (LVDS Pairs?)    
-set_property  -dict {PACKAGE_PIN  V26   IOSTANDARD LVCMOS25} [get_ports ad9371_gpio_12]               ; ## G22  FMC_HPC_LA20_N     (LVDS Pairs?)    
-set_property  -dict {PACKAGE_PIN  R25   IOSTANDARD LVCMOS25} [get_ports ad9371_gpio_14]               ; ## G30  FMC_HPC_LA29_P     (LVDS Pairs?)    
-set_property  -dict {PACKAGE_PIN  R26   IOSTANDARD LVCMOS25} [get_ports ad9371_gpio_13]               ; ## G31  FMC_HPC_LA29_N     (LVDS Pairs?)    
+set_property  -dict {PACKAGE_PIN  Y22   IOSTANDARD LVCMOS25} [get_ports ad9371_gpio_00]               ; ## H19  FMC_HPC_LA15_P
+set_property  -dict {PACKAGE_PIN  Y23   IOSTANDARD LVCMOS25} [get_ports ad9371_gpio_01]               ; ## H20  FMC_HPC_LA15_N
+set_property  -dict {PACKAGE_PIN  AA24  IOSTANDARD LVCMOS25} [get_ports ad9371_gpio_02]               ; ## G18  FMC_HPC_LA16_P
+set_property  -dict {PACKAGE_PIN  AB24  IOSTANDARD LVCMOS25} [get_ports ad9371_gpio_03]               ; ## G19  FMC_HPC_LA16_N
+set_property  -dict {PACKAGE_PIN  W29   IOSTANDARD LVCMOS25} [get_ports ad9371_gpio_04]               ; ## H25  FMC_HPC_LA21_P
+set_property  -dict {PACKAGE_PIN  W30   IOSTANDARD LVCMOS25} [get_ports ad9371_gpio_05]               ; ## H26  FMC_HPC_LA21_N
+set_property  -dict {PACKAGE_PIN  W25   IOSTANDARD LVCMOS25} [get_ports ad9371_gpio_06]               ; ## C22  FMC_HPC_LA18_CC_P
+set_property  -dict {PACKAGE_PIN  W26   IOSTANDARD LVCMOS25} [get_ports ad9371_gpio_07]               ; ## C23  FMC_HPC_LA18_CC_N
+set_property  -dict {PACKAGE_PIN  V27   IOSTANDARD LVCMOS25} [get_ports ad9371_gpio_15]               ; ## G24  FMC_HPC_LA22_P     (LVDS Pairs?)
+set_property  -dict {PACKAGE_PIN  W28   IOSTANDARD LVCMOS25} [get_ports ad9371_gpio_08]               ; ## G25  FMC_HPC_LA22_N     (LVDS Pairs?)
+set_property  -dict {PACKAGE_PIN  T24   IOSTANDARD LVCMOS25} [get_ports ad9371_gpio_09]               ; ## H22  FMC_HPC_LA19_P     (LVDS Pairs?)
+set_property  -dict {PACKAGE_PIN  T25   IOSTANDARD LVCMOS25} [get_ports ad9371_gpio_10]               ; ## H23  FMC_HPC_LA19_N     (LVDS Pairs?)
+set_property  -dict {PACKAGE_PIN  U25   IOSTANDARD LVCMOS25} [get_ports ad9371_gpio_11]               ; ## G21  FMC_HPC_LA20_P     (LVDS Pairs?)
+set_property  -dict {PACKAGE_PIN  V26   IOSTANDARD LVCMOS25} [get_ports ad9371_gpio_12]               ; ## G22  FMC_HPC_LA20_N     (LVDS Pairs?)
+set_property  -dict {PACKAGE_PIN  R25   IOSTANDARD LVCMOS25} [get_ports ad9371_gpio_14]               ; ## G30  FMC_HPC_LA29_P     (LVDS Pairs?)
+set_property  -dict {PACKAGE_PIN  R26   IOSTANDARD LVCMOS25} [get_ports ad9371_gpio_13]               ; ## G31  FMC_HPC_LA29_N     (LVDS Pairs?)
 set_property  -dict {PACKAGE_PIN  AF23  IOSTANDARD LVCMOS25} [get_ports ad9371_gpio_17]               ; ## G15  FMC_HPC_LA12_P     (LVDS Pairs?)
 set_property  -dict {PACKAGE_PIN  AF24  IOSTANDARD LVCMOS25} [get_ports ad9371_gpio_16]               ; ## G16  FMC_HPC_LA12_N     (LVDS Pairs?)
-set_property  -dict {PACKAGE_PIN  AH24  IOSTANDARD LVCMOS25} [get_ports ad9371_gpio_18]               ; ## D12  FMC_HPC_LA05_N          
+set_property  -dict {PACKAGE_PIN  AH24  IOSTANDARD LVCMOS25} [get_ports ad9371_gpio_18]               ; ## D12  FMC_HPC_LA05_N
 
 # clocks
 

--- a/projects/adrv9371x/zcu102/system_constr.xdc
+++ b/projects/adrv9371x/zcu102/system_constr.xdc
@@ -62,30 +62,20 @@ create_clock -name tx_div_clk     -period  8.00 [get_pins i_system_wrapper/syste
 create_clock -name rx_div_clk     -period  8.00 [get_pins i_system_wrapper/system_i/util_ad9371_xcvr/inst/i_xch_0/i_gthe4_channel/RXOUTCLK]
 create_clock -name rx_os_div_clk  -period  8.00 [get_pins i_system_wrapper/system_i/util_ad9371_xcvr/inst/i_xch_2/i_gthe4_channel/RXOUTCLK]
 
-set_false_path -from [get_cells i_system_wrapper/system_i/axi_ad9371_rx_jesd_rstgen/U0/PR_OUT_DFF[0].peripheral_reset_reg[0]]
-set_false_path -from [get_cells i_system_wrapper/system_i/axi_ad9371_tx_jesd_rstgen/U0/PR_OUT_DFF[0].peripheral_reset_reg[0]]
-set_false_path -from [get_cells i_system_wrapper/system_i/axi_ad9371_rx_os_jesd_rstgen/U0/PR_OUT_DFF[0].peripheral_reset_reg[0]]
+set_property  -dict {PACKAGE_PIN  H2   } [get_ports rx_data_p[0]]                                      ; ## C06  FMC_HPC0_DP0_M2C_P
+set_property  -dict {PACKAGE_PIN  H1   } [get_ports rx_data_n[0]]                                      ; ## C07  FMC_HPC0_DP0_M2C_N
+set_property  -dict {PACKAGE_PIN  J4   } [get_ports rx_data_p[1]]                                      ; ## A02  FMC_HPC0_DP1_M2C_P
+set_property  -dict {PACKAGE_PIN  J3   } [get_ports rx_data_n[1]]                                      ; ## A03  FMC_HPC0_DP1_M2C_N
+set_property  -dict {PACKAGE_PIN  F2   } [get_ports rx_data_p[2]]                                      ; ## A06  FMC_HPC0_DP2_M2C_P
+set_property  -dict {PACKAGE_PIN  F1   } [get_ports rx_data_n[2]]                                      ; ## A07  FMC_HPC0_DP2_M2C_N
+set_property  -dict {PACKAGE_PIN  K2   } [get_ports rx_data_p[3]]                                      ; ## A10  FMC_HPC0_DP3_M2C_P
+set_property  -dict {PACKAGE_PIN  K1   } [get_ports rx_data_n[3]]                                      ; ## A11  FMC_HPC0_DP3_M2C_N
+set_property  -dict {PACKAGE_PIN  G4   } [get_ports tx_data_p[0]]                                      ; ## C02  FMC_HPC0_DP0_C2M_P (tx_data_p[1])
+set_property  -dict {PACKAGE_PIN  G3   } [get_ports tx_data_n[0]]                                      ; ## C03  FMC_HPC0_DP0_C2M_N (tx_data_n[1])
+set_property  -dict {PACKAGE_PIN  H6   } [get_ports tx_data_p[1]]                                      ; ## A22  FMC_HPC0_DP1_C2M_P (tx_data_p[3])
+set_property  -dict {PACKAGE_PIN  H5   } [get_ports tx_data_n[1]]                                      ; ## A23  FMC_HPC0_DP1_C2M_N (tx_data_n[3])
+set_property  -dict {PACKAGE_PIN  F6   } [get_ports tx_data_p[2]]                                      ; ## A26  FMC_HPC0_DP2_C2M_P (tx_data_p[0])
+set_property  -dict {PACKAGE_PIN  F5   } [get_ports tx_data_n[2]]                                      ; ## A27  FMC_HPC0_DP2_C2M_N (tx_data_n[0])
+set_property  -dict {PACKAGE_PIN  K6   } [get_ports tx_data_p[3]]                                      ; ## A30  FMC_HPC0_DP3_C2M_P (tx_data_p[2])
+set_property  -dict {PACKAGE_PIN  K5   } [get_ports tx_data_n[3]]                                      ; ## A31  FMC_HPC0_DP3_C2M_N (tx_data_n[2])
 
-# pin assignments below are for reference only and are ignored by the tool!
-
-# set_property  -dict {PACKAGE_PIN  G8   } [get_ports ref_clk0_p]                                       ; ## D04  FMC_HPC0_GBTCLK0_M2C_C_P
-# set_property  -dict {PACKAGE_PIN  G7   } [get_ports ref_clk0_n]                                       ; ## D05  FMC_HPC0_GBTCLK0_M2C_C_N
-# set_property  -dict {PACKAGE_PIN  L8   } [get_ports ref_clk1_p]                                       ; ## B20  FMC_HPC0_GBTCLK1_M2C_C_P
-# set_property  -dict {PACKAGE_PIN  L7   } [get_ports ref_clk1_n]                                       ; ## B21  FMC_HPC0_GBTCLK1_M2C_C_N
-
-# set_property  -dict {PACKAGE_PIN  J4   } [get_ports rx_data_p[0]]                                      ; ## A02  FMC_HPC0_DP1_M2C_P
-# set_property  -dict {PACKAGE_PIN  J3   } [get_ports rx_data_n[0]]                                      ; ## A03  FMC_HPC0_DP1_M2C_N
-# set_property  -dict {PACKAGE_PIN  F2   } [get_ports rx_data_p[1]]                                      ; ## A06  FMC_HPC0_DP2_M2C_P
-# set_property  -dict {PACKAGE_PIN  F1   } [get_ports rx_data_n[1]]                                      ; ## A07  FMC_HPC0_DP2_M2C_N
-# set_property  -dict {PACKAGE_PIN  H2   } [get_ports rx_data_p[2]]                                      ; ## C06  FMC_HPC0_DP0_M2C_P
-# set_property  -dict {PACKAGE_PIN  H1   } [get_ports rx_data_n[2]]                                      ; ## C07  FMC_HPC0_DP0_M2C_N
-# set_property  -dict {PACKAGE_PIN  K2   } [get_ports rx_data_p[3]]                                      ; ## A10  FMC_HPC0_DP3_M2C_P
-# set_property  -dict {PACKAGE_PIN  K1   } [get_ports rx_data_n[3]]                                      ; ## A11  FMC_HPC0_DP3_M2C_N
-# set_property  -dict {PACKAGE_PIN  H6   } [get_ports tx_data_p[0]]                                      ; ## A22  FMC_HPC0_DP1_C2M_P (tx_data_p[3])
-# set_property  -dict {PACKAGE_PIN  H5   } [get_ports tx_data_n[0]]                                      ; ## A23  FMC_HPC0_DP1_C2M_N (tx_data_n[3])
-# set_property  -dict {PACKAGE_PIN  F6   } [get_ports tx_data_p[1]]                                      ; ## A26  FMC_HPC0_DP2_C2M_P (tx_data_p[0])
-# set_property  -dict {PACKAGE_PIN  F5   } [get_ports tx_data_n[1]]                                      ; ## A27  FMC_HPC0_DP2_C2M_N (tx_data_n[0])
-# set_property  -dict {PACKAGE_PIN  G4   } [get_ports tx_data_p[2]]                                      ; ## C02  FMC_HPC0_DP0_C2M_P (tx_data_p[1])
-# set_property  -dict {PACKAGE_PIN  G3   } [get_ports tx_data_n[2]]                                      ; ## C03  FMC_HPC0_DP0_C2M_N (tx_data_n[1])
-# set_property  -dict {PACKAGE_PIN  K6   } [get_ports tx_data_p[3]]                                      ; ## A30  FMC_HPC0_DP3_C2M_P (tx_data_p[2])
-# set_property  -dict {PACKAGE_PIN  K5   } [get_ports tx_data_n[3]]                                      ; ## A31  FMC_HPC0_DP3_C2M_N (tx_data_n[2])


### PR DESCRIPTION
Move all the lane remapping after the transceivers, this way the
verification of the remapping will be easier, and we could avoid confusions.

This scheme can be adapted to all JESD204B projects in the future.

TODOs: currently the ad_xcvrcon process does not support automatic/parametric
remapping in cases where multiple JESD204 IPs are connected to the same
XCVR module. Modify the script so it can see all the available physical
lanes right at the first process call.