### PR TITLE
Makefile: Change IP component dependency to component definition file

### DIFF
--- a/library/scripts/library.mk
+++ b/library/scripts/library.mk
@@ -23,17 +23,17 @@ CLEAN_TARGET += .Xil
 M_DEPS += $(HDL_LIBRARY_PATH)scripts/adi_env.tcl
 M_DEPS += $(HDL_LIBRARY_PATH)scripts/adi_ip.tcl
 
-M_DEPS += $(foreach dep,$(LIB_DEPS),$(HDL_LIBRARY_PATH)$(dep)/$(notdir $(dep)).xpr)
+M_DEPS += $(foreach dep,$(LIB_DEPS),$(HDL_LIBRARY_PATH)$(dep)/component.xml)
 
 .PHONY: all dep clean clean-all
-all: dep $(LIBRARY_NAME).xpr
+all: dep component.xml
 
 clean: clean-all
 
 clean-all:
 	rm -rf $(CLEAN_TARGET)
 
-$(LIBRARY_NAME).xpr: $(M_DEPS)
+component.xml: $(M_DEPS)
 	-rm -rf $(CLEAN_TARGET)
 	$(VIVADO) $(LIBRARY_NAME)_ip.tcl  >> $(LIBRARY_NAME)_ip.log 2>&1
 

--- a/projects/scripts/project-xilinx.mk
+++ b/projects/scripts/project-xilinx.mk
@@ -31,7 +31,7 @@ M_DEPS += $(HDL_PROJECT_PATH)scripts/adi_project.tcl
 M_DEPS += $(HDL_PROJECT_PATH)scripts/adi_env.tcl
 M_DEPS += $(HDL_PROJECT_PATH)scripts/adi_board.tcl
 
-M_DEPS += $(foreach dep,$(LIB_DEPS),$(HDL_LIBRARY_PATH)$(dep)/$(notdir $(dep)).xpr)
+M_DEPS += $(foreach dep,$(LIB_DEPS),$(HDL_LIBRARY_PATH)$(dep)/component.xml)
 
 .PHONY: all lib clean clean-all
 all: lib $(PROJECT_NAME).sdk/system_top.hdf


### PR DESCRIPTION
Currently the IP component dependency in the Makefile system is the Vivado
project file. The project file is only a intermediary product in producing
the IP component definition file.

If building the component definition file fails or the process is aborted
half way through it is possible that the Vivado project file for the IP
component exists, but the IP component definition file does not.

In this case there will be no attempt to build the IP component definition
file when building a project that has a dependency on the IP component.
Building the project will fail in this case.

To avoid this update the Makefile rules so that the IP component definition
file is used as the dependency. In this case the IP component will be
re-build if the component definition file does not exist, even if the
project file exists.

Signed-off-by: Lars-Peter Clausen <lars@metafoo.de>