### PR TITLE
library: Remove unreferenced files from IP file lists

### DIFF
--- a/library/axi_ad9250/axi_ad9250_hw.tcl
+++ b/library/axi_ad9250/axi_ad9250_hw.tcl
@@ -21,7 +21,6 @@ add_fileset_file up_axi.v             VERILOG PATH $ad_hdl_dir/library/common/up
 add_fileset_file up_xfer_cntrl.v      VERILOG PATH $ad_hdl_dir/library/common/up_xfer_cntrl.v
 add_fileset_file up_xfer_status.v     VERILOG PATH $ad_hdl_dir/library/common/up_xfer_status.v
 add_fileset_file up_clock_mon.v       VERILOG PATH $ad_hdl_dir/library/common/up_clock_mon.v
-add_fileset_file up_delay_cntrl.v     VERILOG PATH $ad_hdl_dir/library/common/up_delay_cntrl.v
 add_fileset_file up_adc_common.v      VERILOG PATH $ad_hdl_dir/library/common/up_adc_common.v
 add_fileset_file up_adc_channel.v     VERILOG PATH $ad_hdl_dir/library/common/up_adc_channel.v
 add_fileset_file ad_xcvr_rx_if.v      VERILOG PATH $ad_hdl_dir/library/common/ad_xcvr_rx_if.v

--- a/library/axi_ad9671/axi_ad9671_hw.tcl
+++ b/library/axi_ad9671/axi_ad9671_hw.tcl
@@ -21,7 +21,6 @@ add_fileset_file up_axi.v             VERILOG PATH $ad_hdl_dir/library/common/up
 add_fileset_file up_xfer_cntrl.v      VERILOG PATH $ad_hdl_dir/library/common/up_xfer_cntrl.v
 add_fileset_file up_xfer_status.v     VERILOG PATH $ad_hdl_dir/library/common/up_xfer_status.v
 add_fileset_file up_clock_mon.v       VERILOG PATH $ad_hdl_dir/library/common/up_clock_mon.v
-add_fileset_file up_delay_cntrl.v     VERILOG PATH $ad_hdl_dir/library/common/up_delay_cntrl.v
 add_fileset_file up_adc_common.v      VERILOG PATH $ad_hdl_dir/library/common/up_adc_common.v
 add_fileset_file up_adc_channel.v     VERILOG PATH $ad_hdl_dir/library/common/up_adc_channel.v
 add_fileset_file ad_xcvr_rx_if.v      VERILOG PATH $ad_hdl_dir/library/common/ad_xcvr_rx_if.v

--- a/library/axi_ad9680/axi_ad9680_hw.tcl
+++ b/library/axi_ad9680/axi_ad9680_hw.tcl
@@ -21,7 +21,6 @@ add_fileset_file up_axi.v             VERILOG PATH $ad_hdl_dir/library/common/up
 add_fileset_file up_xfer_cntrl.v      VERILOG PATH $ad_hdl_dir/library/common/up_xfer_cntrl.v
 add_fileset_file up_xfer_status.v     VERILOG PATH $ad_hdl_dir/library/common/up_xfer_status.v
 add_fileset_file up_clock_mon.v       VERILOG PATH $ad_hdl_dir/library/common/up_clock_mon.v
-add_fileset_file up_delay_cntrl.v     VERILOG PATH $ad_hdl_dir/library/common/up_delay_cntrl.v
 add_fileset_file up_adc_common.v      VERILOG PATH $ad_hdl_dir/library/common/up_adc_common.v
 add_fileset_file up_adc_channel.v     VERILOG PATH $ad_hdl_dir/library/common/up_adc_channel.v
 add_fileset_file ad_xcvr_rx_if.v      VERILOG PATH $ad_hdl_dir/library/common/ad_xcvr_rx_if.v

--- a/library/axi_generic_adc/Makefile
+++ b/library/axi_generic_adc/Makefile
@@ -10,7 +10,6 @@ M_DEPS += ../common/up_adc_channel.v
 M_DEPS += ../common/up_adc_common.v
 M_DEPS += ../common/up_axi.v
 M_DEPS += ../common/up_clock_mon.v
-M_DEPS += ../common/up_delay_cntrl.v
 M_DEPS += ../common/up_xfer_cntrl.v
 M_DEPS += ../common/up_xfer_status.v
 M_DEPS += axi_generic_adc.v

--- a/library/axi_generic_adc/axi_generic_adc_ip.tcl
+++ b/library/axi_generic_adc/axi_generic_adc_ip.tcl
@@ -7,7 +7,6 @@ adi_ip_create axi_generic_adc
 adi_ip_files axi_generic_adc [list \
   "$ad_hdl_dir/library/common/ad_rst.v" \
   "$ad_hdl_dir/library/common/up_axi.v" \
-  "$ad_hdl_dir/library/common/up_delay_cntrl.v" \
   "$ad_hdl_dir/library/common/up_xfer_cntrl.v" \
   "$ad_hdl_dir/library/common/up_xfer_status.v" \
   "$ad_hdl_dir/library/common/up_clock_mon.v" \

--- a/library/axi_mc_controller/Makefile
+++ b/library/axi_mc_controller/Makefile
@@ -5,14 +5,7 @@
 
 LIBRARY_NAME := axi_mc_controller
 
-M_DEPS += ../common/ad_rst.v
-M_DEPS += ../common/up_adc_channel.v
-M_DEPS += ../common/up_adc_common.v
 M_DEPS += ../common/up_axi.v
-M_DEPS += ../common/up_clock_mon.v
-M_DEPS += ../common/up_delay_cntrl.v
-M_DEPS += ../common/up_xfer_cntrl.v
-M_DEPS += ../common/up_xfer_status.v
 M_DEPS += axi_mc_controller.v
 M_DEPS += axi_mc_controller_constr.xdc
 M_DEPS += axi_mc_controller_ip.tcl

--- a/library/axi_mc_controller/axi_mc_controller_ip.tcl
+++ b/library/axi_mc_controller/axi_mc_controller_ip.tcl
@@ -6,14 +6,6 @@ source $ad_hdl_dir/library/scripts/adi_ip.tcl
 adi_ip_create axi_mc_controller
 adi_ip_files axi_mc_controller [list \
   "$ad_hdl_dir/library/common/up_axi.v" \
-  "$ad_hdl_dir/library/common/ad_rst.v" \
-  "$ad_hdl_dir/library/common/up_delay_cntrl.v" \
-  "$ad_hdl_dir/library/common/up_xfer_cntrl.v" \
-  "$ad_hdl_dir/library/common/up_xfer_status.v" \
-  "$ad_hdl_dir/library/common/up_clock_mon.v" \
-  "$ad_hdl_dir/library/common/up_delay_cntrl.v" \
-  "$ad_hdl_dir/library/common/up_adc_common.v" \
-  "$ad_hdl_dir/library/common/up_adc_channel.v" \
   "motor_driver.v" \
   "delay.v" \
   "control_registers.v" \

--- a/library/axi_mc_current_monitor/Makefile
+++ b/library/axi_mc_current_monitor/Makefile
@@ -10,7 +10,6 @@ M_DEPS += ../common/up_adc_channel.v
 M_DEPS += ../common/up_adc_common.v
 M_DEPS += ../common/up_axi.v
 M_DEPS += ../common/up_clock_mon.v
-M_DEPS += ../common/up_delay_cntrl.v
 M_DEPS += ../common/up_xfer_cntrl.v
 M_DEPS += ../common/up_xfer_status.v
 M_DEPS += ad7401.v

--- a/library/axi_mc_current_monitor/axi_mc_current_monitor_ip.tcl
+++ b/library/axi_mc_current_monitor/axi_mc_current_monitor_ip.tcl
@@ -7,7 +7,6 @@ adi_ip_create axi_mc_current_monitor
 adi_ip_files axi_mc_current_monitor [list \
   "$ad_hdl_dir/library/common/ad_rst.v" \
   "$ad_hdl_dir/library/common/up_axi.v" \
-  "$ad_hdl_dir/library/common/up_delay_cntrl.v" \
   "$ad_hdl_dir/library/common/up_xfer_cntrl.v" \
   "$ad_hdl_dir/library/common/up_xfer_status.v" \
   "$ad_hdl_dir/library/common/up_clock_mon.v" \

--- a/library/axi_mc_speed/Makefile
+++ b/library/axi_mc_speed/Makefile
@@ -6,11 +6,9 @@
 LIBRARY_NAME := axi_mc_speed
 
 M_DEPS += ../common/ad_rst.v
-M_DEPS += ../common/up_adc_channel.v
 M_DEPS += ../common/up_adc_common.v
 M_DEPS += ../common/up_axi.v
 M_DEPS += ../common/up_clock_mon.v
-M_DEPS += ../common/up_delay_cntrl.v
 M_DEPS += ../common/up_xfer_cntrl.v
 M_DEPS += ../common/up_xfer_status.v
 M_DEPS += axi_mc_speed.v

--- a/library/axi_mc_speed/axi_mc_speed_ip.tcl
+++ b/library/axi_mc_speed/axi_mc_speed_ip.tcl
@@ -7,12 +7,10 @@ adi_ip_create axi_mc_speed
 adi_ip_files axi_mc_speed [list \
   "$ad_hdl_dir/library/common/ad_rst.v" \
   "$ad_hdl_dir/library/common/up_axi.v" \
-  "$ad_hdl_dir/library/common/up_delay_cntrl.v" \
   "$ad_hdl_dir/library/common/up_clock_mon.v" \
   "$ad_hdl_dir/library/common/up_xfer_cntrl.v" \
   "$ad_hdl_dir/library/common/up_xfer_status.v" \
   "$ad_hdl_dir/library/common/up_adc_common.v" \
-  "$ad_hdl_dir/library/common/up_adc_channel.v" \
   "debouncer.v" \
   "speed_detector.v" \
   "delay_30_degrees.v" \

--- a/projects/daq2/a10gx/Makefile
+++ b/projects/daq2/a10gx/Makefile
@@ -69,7 +69,6 @@ M_DEPS += ../../../library/common/up_axi.v
 M_DEPS += ../../../library/common/up_clock_mon.v
 M_DEPS += ../../../library/common/up_dac_channel.v
 M_DEPS += ../../../library/common/up_dac_common.v
-M_DEPS += ../../../library/common/up_delay_cntrl.v
 M_DEPS += ../../../library/common/up_xfer_cntrl.v
 M_DEPS += ../../../library/common/up_xfer_status.v
 M_DEPS += ../../../library/jesd204/jesd204_soft_pcs_rx/8b10b_decoder.v

--- a/projects/daq2/a10soc/Makefile
+++ b/projects/daq2/a10soc/Makefile
@@ -78,7 +78,6 @@ M_DEPS += ../../../library/common/up_axi.v
 M_DEPS += ../../../library/common/up_clock_mon.v
 M_DEPS += ../../../library/common/up_dac_channel.v
 M_DEPS += ../../../library/common/up_dac_common.v
-M_DEPS += ../../../library/common/up_delay_cntrl.v
 M_DEPS += ../../../library/common/up_xfer_cntrl.v
 M_DEPS += ../../../library/common/up_xfer_status.v
 M_DEPS += ../../../library/common/util_delay.v

--- a/projects/daq3/a10gx/Makefile
+++ b/projects/daq3/a10gx/Makefile
@@ -69,7 +69,6 @@ M_DEPS += ../../../library/common/up_axi.v
 M_DEPS += ../../../library/common/up_clock_mon.v
 M_DEPS += ../../../library/common/up_dac_channel.v
 M_DEPS += ../../../library/common/up_dac_common.v
-M_DEPS += ../../../library/common/up_delay_cntrl.v
 M_DEPS += ../../../library/common/up_xfer_cntrl.v
 M_DEPS += ../../../library/common/up_xfer_status.v
 M_DEPS += ../../../library/jesd204/jesd204_soft_pcs_rx/8b10b_decoder.v

--- a/projects/fmcjesdadc1/a10gx/Makefile
+++ b/projects/fmcjesdadc1/a10gx/Makefile
@@ -54,7 +54,6 @@ M_DEPS += ../../../library/common/up_adc_channel.v
 M_DEPS += ../../../library/common/up_adc_common.v
 M_DEPS += ../../../library/common/up_axi.v
 M_DEPS += ../../../library/common/up_clock_mon.v
-M_DEPS += ../../../library/common/up_delay_cntrl.v
 M_DEPS += ../../../library/common/up_xfer_cntrl.v
 M_DEPS += ../../../library/common/up_xfer_status.v
 M_DEPS += ../../../library/jesd204/jesd204_soft_pcs_rx/8b10b_decoder.v

--- a/projects/fmcjesdadc1/a10soc/Makefile
+++ b/projects/fmcjesdadc1/a10soc/Makefile
@@ -54,7 +54,6 @@ M_DEPS += ../../../library/common/up_adc_channel.v
 M_DEPS += ../../../library/common/up_adc_common.v
 M_DEPS += ../../../library/common/up_axi.v
 M_DEPS += ../../../library/common/up_clock_mon.v
-M_DEPS += ../../../library/common/up_delay_cntrl.v
 M_DEPS += ../../../library/common/up_xfer_cntrl.v
 M_DEPS += ../../../library/common/up_xfer_status.v
 M_DEPS += ../../../library/jesd204/jesd204_soft_pcs_rx/8b10b_decoder.v

--- a/projects/usdrx1/a10gx/Makefile
+++ b/projects/usdrx1/a10gx/Makefile
@@ -57,7 +57,6 @@ M_DEPS += ../../../library/common/up_adc_channel.v
 M_DEPS += ../../../library/common/up_adc_common.v
 M_DEPS += ../../../library/common/up_axi.v
 M_DEPS += ../../../library/common/up_clock_mon.v
-M_DEPS += ../../../library/common/up_delay_cntrl.v
 M_DEPS += ../../../library/common/up_xfer_cntrl.v
 M_DEPS += ../../../library/common/up_xfer_status.v
 M_DEPS += ../../../library/scripts/adi_env.tcl


### PR DESCRIPTION
Some IP core have files in their file list for common modules that are not
used by the IP itself. Remove those.

Signed-off-by: Lars-Peter Clausen <lars@metafoo.de>