### PR TITLE
Multi-link Rx JESD204

### DIFF
--- a/library/jesd204/axi_jesd204_common/jesd204_up_common.v
+++ b/library/jesd204/axi_jesd204_common/jesd204_up_common.v
@@ -47,6 +47,7 @@ module jesd204_up_common # (
   parameter PCORE_MAGIC = 0,
   parameter ID = 0,
   parameter NUM_LANES = 1,
+  parameter NUM_LINKS = 1,
   parameter DATA_PATH_WIDTH = 2,
   parameter MAX_OCTETS_PER_FRAME = 256,
   parameter NUM_IRQS = 1,
@@ -78,6 +79,7 @@ module jesd204_up_common # (
   output up_cfg_is_writeable,
 
   output reg [NUM_LANES-1:0] core_cfg_lanes_disable,
+  output reg [NUM_LINKS-1:0] core_cfg_links_disable,
   output reg [7:0] core_cfg_beats_per_multiframe,
   output reg [7:0] core_cfg_octets_per_frame,
   output reg core_cfg_disable_scrambler,
@@ -159,6 +161,7 @@ always @(posedge core_clk) begin
     core_cfg_beats_per_multiframe <= up_cfg_beats_per_multiframe;
     core_cfg_octets_per_frame <= up_cfg_octets_per_frame;
     core_cfg_lanes_disable <= up_cfg_lanes_disable;
+    core_cfg_links_disable <= up_cfg_links_disable;
     core_cfg_disable_scrambler <= up_cfg_disable_scrambler;
     core_cfg_disable_char_replacement <= up_cfg_disable_char_replacement;
     core_extra_cfg <= up_extra_cfg;
@@ -192,6 +195,7 @@ end
 reg [7:0] up_cfg_octets_per_frame = 'h00;
 reg [9-DATA_PATH_WIDTH:0] up_cfg_beats_per_multiframe = 'h00;
 reg [NUM_LANES-1:0] up_cfg_lanes_disable = {NUM_LANES{1'b0}};
+reg [NUM_LINKS-1:0] up_cfg_links_disable = {NUM_LINKS{1'b0}};
 reg up_cfg_disable_char_replacement = 1'b0;
 reg up_cfg_disable_scrambler = 1'b0;
 
@@ -224,7 +228,8 @@ always @(*) begin
   /* 0x32-0x34 reserver for future use */
 
   12'h080: up_rdata <= up_cfg_lanes_disable;
-  /* 0x81-0x83 reserved for future lane disable bits (max 128 lanes) */
+  12'h081: up_rdata <= up_cfg_links_disable;
+  /* 0x82-0x83 reserved for future lane disable bits (max 128 lanes) */
   12'h084: up_rdata <= {
     /* 24-31 */ 8'h00, /* Reserved for future extensions of octets_per_frame */
     /* 16-23 */ up_cfg_octets_per_frame,
@@ -262,6 +267,7 @@ always @(posedge up_clk) begin
     up_cfg_octets_per_frame <= 'h00;
     up_cfg_beats_per_multiframe <= 'h00;
     up_cfg_lanes_disable <= {NUM_LANES{1'b0}};
+    up_cfg_links_disable <= {NUM_LINKS{1'b0}};
 
     up_cfg_disable_char_replacement <= 1'b0;
     up_cfg_disable_scrambler <= 1'b0;
@@ -287,6 +293,9 @@ always @(posedge up_clk) begin
       case (up_waddr)
       12'h080: begin
         up_cfg_lanes_disable <= up_wdata[NUM_LANES-1:0];
+      end
+      12'h081: begin
+        up_cfg_links_disable <= up_wdata[NUM_LINKS-1:0];
       end
       12'h084: begin
         up_cfg_octets_per_frame <= up_wdata[23:16];

--- a/library/jesd204/axi_jesd204_common/jesd204_up_common.v
+++ b/library/jesd204/axi_jesd204_common/jesd204_up_common.v
@@ -212,7 +212,8 @@ always @(*) begin
   /* Core configuration */
   12'h004: up_rdata <= NUM_LANES;
   12'h005: up_rdata <= DATA_PATH_WIDTH;
-  /* 0x06-0x0f reserved for future use */
+  12'h006: up_rdata <= {24'b0, NUM_LINKS[7:0]};
+  /* 0x07-0x0f reserved for future use */
   /* 0x10-0x1f reserved for core specific HDL configuration information */
 
   /* IRQ block */

--- a/library/jesd204/axi_jesd204_common/jesd204_up_common.v
+++ b/library/jesd204/axi_jesd204_common/jesd204_up_common.v
@@ -228,8 +228,7 @@ always @(*) begin
   /* 0x32-0x34 reserver for future use */
 
   12'h080: up_rdata <= up_cfg_lanes_disable;
-  12'h081: up_rdata <= up_cfg_links_disable;
-  /* 0x82-0x83 reserved for future lane disable bits (max 128 lanes) */
+  /* 0x81-0x83 reserved for future lane disable bits (max 128 lanes) */
   12'h084: up_rdata <= {
     /* 24-31 */ 8'h00, /* Reserved for future extensions of octets_per_frame */
     /* 16-23 */ up_cfg_octets_per_frame,
@@ -241,7 +240,9 @@ always @(*) begin
     /*    01 */ up_cfg_disable_char_replacement, /* Disable character replacement */
     /*    00 */ up_cfg_disable_scrambler /* Disable scrambler */
   };
-  /* 0x86-0x8f reserved for future use */
+
+  12'h086: up_rdata <= up_cfg_links_disable;
+  /* 0x87-0x8f reserved for future use */
 
   /* 0x90-0x9f reserved for core specific configuration options */
 
@@ -294,9 +295,6 @@ always @(posedge up_clk) begin
       12'h080: begin
         up_cfg_lanes_disable <= up_wdata[NUM_LANES-1:0];
       end
-      12'h081: begin
-        up_cfg_links_disable <= up_wdata[NUM_LINKS-1:0];
-      end
       12'h084: begin
         up_cfg_octets_per_frame <= up_wdata[23:16];
         up_cfg_beats_per_multiframe <= up_wdata[9:DATA_PATH_WIDTH];
@@ -304,6 +302,9 @@ always @(posedge up_clk) begin
       12'h085: begin
         up_cfg_disable_char_replacement <= up_wdata[1];
         up_cfg_disable_scrambler <= up_wdata[0];
+      end
+      12'h086: begin
+        up_cfg_links_disable <= up_wdata[NUM_LINKS-1:0];
       end
       endcase
     end

--- a/library/jesd204/axi_jesd204_rx/axi_jesd204_rx.v
+++ b/library/jesd204/axi_jesd204_rx/axi_jesd204_rx.v
@@ -44,7 +44,8 @@
 
 module axi_jesd204_rx #(
   parameter ID = 0,
-  parameter NUM_LANES = 1
+  parameter NUM_LANES = 1,
+  parameter NUM_LINKS = 1
 ) (
   input s_axi_aclk,
   input s_axi_aresetn,
@@ -76,6 +77,7 @@ module axi_jesd204_rx #(
   output core_reset,
 
   output [NUM_LANES-1:0] core_cfg_lanes_disable,
+  output [NUM_LINKS-1:0] core_cfg_links_disable,
   output [7:0] core_cfg_beats_per_multiframe,
   output [7:0] core_cfg_octets_per_frame,
   output core_cfg_disable_scrambler,
@@ -166,6 +168,7 @@ jesd204_up_common #(
   .PCORE_MAGIC(PCORE_MAGIC),
   .ID(ID),
   .NUM_LANES(NUM_LANES),
+  .NUM_LINKS(NUM_LINKS),
   .DATA_PATH_WIDTH(2),
   .NUM_IRQS(5),
   .EXTRA_CFG_WIDTH(19)
@@ -194,6 +197,7 @@ jesd204_up_common #(
   .core_cfg_beats_per_multiframe(core_cfg_beats_per_multiframe),
   .core_cfg_octets_per_frame(core_cfg_octets_per_frame),
   .core_cfg_lanes_disable(core_cfg_lanes_disable),
+  .core_cfg_links_disable(core_cfg_links_disable),
   .core_cfg_disable_scrambler(core_cfg_disable_scrambler),
   .core_cfg_disable_char_replacement(core_cfg_disable_char_replacement),
 

--- a/library/jesd204/axi_jesd204_rx/axi_jesd204_rx.v
+++ b/library/jesd204/axi_jesd204_rx/axi_jesd204_rx.v
@@ -101,7 +101,7 @@ module axi_jesd204_rx #(
   input [14*NUM_LANES-1:0] core_status_lane_latency
 );
 
-localparam PCORE_VERSION = 32'h00010061; // 1.00.a
+localparam PCORE_VERSION = 32'h00010161; // 1.01.a
 localparam PCORE_MAGIC = 32'h32303452; // 204R
 
 /* Register interface signals */

--- a/library/jesd204/axi_jesd204_rx/axi_jesd204_rx_hw.tcl
+++ b/library/jesd204/axi_jesd204_rx/axi_jesd204_rx_hw.tcl
@@ -81,6 +81,11 @@ set_parameter_property NUM_LANES DISPLAY_NAME "Number of Lanes"
 set_parameter_property NUM_LANES ALLOWED_RANGES 1:8
 set_parameter_property NUM_LANES HDL_PARAMETER true
 
+add_parameter NUM_LINKS INTEGER 1
+set_parameter_property NUM_LINKS DISPLAY_NAME "Number of Links"
+set_parameter_property NUM_LINKS ALLOWED_RANGES 1:8
+set_parameter_property NUM_LINKS HDL_PARAMETER true
+
 # axi4 slave interface
 
 ad_ip_intf_s_axi s_axi_aclk s_axi_aresetn 14
@@ -123,6 +128,7 @@ add_interface_port config core_cfg_buffer_early_release buffer_early_release Out
 add_interface_port config core_cfg_disable_char_replacement disable_char_replacement Output 1
 add_interface_port config core_cfg_disable_scrambler disable_scrambler Output 1
 add_interface_port config core_cfg_lanes_disable lanes_disable Output NUM_LANES
+add_interface_port config core_cfg_links_disable links_disable Output NUM_LINKS
 add_interface_port config core_cfg_lmfc_offset lmfc_offset Output 8
 add_interface_port config core_cfg_octets_per_frame octets_per_frame Output 8
 add_interface_port config core_cfg_sysref_disable sysref_disable Output 1

--- a/library/jesd204/axi_jesd204_rx/axi_jesd204_rx_ip.tcl
+++ b/library/jesd204/axi_jesd204_rx/axi_jesd204_rx_ip.tcl
@@ -76,6 +76,7 @@ adi_add_bus "rx_cfg" "master" \
   "analog.com:interface:jesd204_rx_cfg:1.0" \
   { \
     { "core_cfg_lanes_disable" "lanes_disable" } \
+    { "core_cfg_links_disable" "links_disable" } \
     { "core_cfg_beats_per_multiframe" "beats_per_multiframe" } \
     { "core_cfg_octets_per_frame" "octets_per_frame" } \
     { "core_cfg_lmfc_offset" "lmfc_offset" } \

--- a/library/jesd204/interfaces/interfaces_ip.tcl
+++ b/library/jesd204/interfaces/interfaces_ip.tcl
@@ -79,6 +79,7 @@ adi_if_ports output 1 manual_sync_request
 
 adi_if_define "jesd204_rx_cfg"
 adi_if_ports output -1 lanes_disable
+adi_if_ports output -1 links_disable
 adi_if_ports output 8 beats_per_multiframe
 adi_if_ports output 8 octets_per_frame
 adi_if_ports output 8 lmfc_offset

--- a/library/jesd204/jesd204_rx/jesd204_rx.v
+++ b/library/jesd204/jesd204_rx/jesd204_rx.v
@@ -43,7 +43,8 @@
 //
 
 module jesd204_rx #(
-  parameter NUM_LANES = 1
+  parameter NUM_LANES = 1,
+  parameter NUM_LINKS = 1
 ) (
   input clk,
   input reset,
@@ -60,7 +61,7 @@ module jesd204_rx #(
   output event_sysref_alignment_error,
   output event_sysref_edge,
 
-  output sync,
+  output [NUM_LINKS-1:0] sync,
 
   output phy_en_char_align,
 
@@ -70,6 +71,7 @@ module jesd204_rx #(
   output [3:0] rx_sof,
 
   input [NUM_LANES-1:0] cfg_lanes_disable,
+  input [NUM_LINKS-1:0] cfg_links_disable,
   input [7:0] cfg_beats_per_multiframe,
   input [7:0] cfg_octets_per_frame,
   input [7:0] cfg_lmfc_offset,
@@ -225,12 +227,14 @@ jesd204_lmfc i_lmfc (
 );
 
 jesd204_rx_ctrl #(
-  .NUM_LANES(NUM_LANES)
+  .NUM_LANES(NUM_LANES),
+  .NUM_LINKS(NUM_LINKS)
 ) i_rx_ctrl (
   .clk(clk),
   .reset(reset),
 
   .cfg_lanes_disable(cfg_lanes_disable),
+  .cfg_links_disable(cfg_links_disable),
 
   .phy_ready(1'b1),
   .phy_en_char_align(phy_en_char_align),

--- a/library/jesd204/jesd204_rx/jesd204_rx_ctrl.v
+++ b/library/jesd204/jesd204_rx/jesd204_rx_ctrl.v
@@ -117,7 +117,7 @@ always @(posedge clk) begin
     latency_monitor_reset <= 1'b1;
   end
   STATE_CGS: begin
-    sync_n <= {NUM_LINKS{1'b0}} ^ cfg_links_disable;
+    sync_n <= cfg_links_disable;
     cgs_rst <= cfg_lanes_disable;
   end
   STATE_SYNCHRONIZED: begin

--- a/library/jesd204/jesd204_rx/jesd204_rx_hw.tcl
+++ b/library/jesd204/jesd204_rx/jesd204_rx_hw.tcl
@@ -76,6 +76,11 @@ set_parameter_property NUM_LANES DISPLAY_NAME "Number of Lanes"
 set_parameter_property NUM_LANES ALLOWED_RANGES 1:8
 set_parameter_property NUM_LANES HDL_PARAMETER true
 
+add_parameter NUM_LINKS INTEGER 1
+set_parameter_property NUM_LINKS DISPLAY_NAME "Number of Links"
+set_parameter_property NUM_LINKS ALLOWED_RANGES 1:8
+set_parameter_property NUM_LINKS HDL_PARAMETER true
+
 #ad_ip_parameter PORT_ENABLE_RX_EOF BOOLEAN false false
 #ad_ip_parameter PORT_ENABLE_LMFC_CLK BOOLEAN false false
 #ad_ip_parameter PORT_ENABLE_LMFC_EDGE BOOLEAN false false
@@ -105,7 +110,7 @@ add_interface_port sysref sysref export Input 1
 add_interface sync conduit end
 set_interface_property sync associatedClock clock
 set_interface_property sync associatedReset reset
-add_interface_port sync sync export Output 1
+add_interface_port sync sync export Output NUM_LINKS
 
 # config interface
 
@@ -119,6 +124,7 @@ add_interface_port config cfg_buffer_early_release buffer_early_release Input 1
 add_interface_port config cfg_disable_char_replacement disable_char_replacement Input 1
 add_interface_port config cfg_disable_scrambler disable_scrambler Input 1
 add_interface_port config cfg_lanes_disable lanes_disable Input NUM_LANES
+add_interface_port config cfg_links_disable links_disable Input NUM_LINKS
 add_interface_port config cfg_lmfc_offset lmfc_offset Input 8
 add_interface_port config cfg_octets_per_frame octets_per_frame Input 8
 add_interface_port config cfg_sysref_disable sysref_disable Input 1

--- a/library/jesd204/jesd204_rx/jesd204_rx_ip.tcl
+++ b/library/jesd204/jesd204_rx/jesd204_rx_ip.tcl
@@ -95,6 +95,7 @@ adi_add_bus "rx_cfg" "slave" \
   "analog.com:interface:jesd204_rx_cfg:1.0" \
   { \
     { "cfg_lanes_disable" "lanes_disable" } \
+    { "cfg_links_disable" "links_disable" } \
     { "cfg_beats_per_multiframe" "beats_per_multiframe" } \
     { "cfg_octets_per_frame" "octets_per_frame" } \
     { "cfg_lmfc_offset" "lmfc_offset" } \

--- a/library/jesd204/jesd204_rx_static_config/jesd204_rx_static_config.v
+++ b/library/jesd204/jesd204_rx_static_config/jesd204_rx_static_config.v
@@ -44,6 +44,7 @@
 
 module jesd204_rx_static_config #(
   parameter NUM_LANES = 1,
+  parameter NUM_LINKS = 1,
   parameter OCTETS_PER_FRAME = 1,
   parameter FRAMES_PER_MULTIFRAME = 32,
   parameter SCR = 1,
@@ -52,6 +53,7 @@ module jesd204_rx_static_config #(
   input clk,
 
   output [NUM_LANES-1:0] cfg_lanes_disable,
+  output [NUM_LINKS-1:0] cfg_links_disable,
   output [7:0] cfg_beats_per_multiframe,
   output [7:0] cfg_octets_per_frame,
   output [7:0] cfg_lmfc_offset,
@@ -72,6 +74,7 @@ assign cfg_sysref_disable = 1'b0;
 assign cfg_buffer_delay = 'h0;
 assign cfg_buffer_early_release = BUFFER_EARLY_RELEASE;
 assign cfg_lanes_disable = {NUM_LANES{1'b0}};
+assign cfg_links_disable = {NUM_LINKS{1'b0}};
 assign cfg_disable_scrambler = SCR ? 1'b0 : 1'b1;
 assign cfg_disable_char_replacement = cfg_disable_scrambler;
 

--- a/library/jesd204/scripts/jesd204.tcl
+++ b/library/jesd204/scripts/jesd204.tcl
@@ -108,10 +108,14 @@ proc adi_axi_jesd204_tx_create {ip_name num_lanes} {
   return -options $resultoptions $resulttext
 }
 
-proc adi_axi_jesd204_rx_create {ip_name num_lanes} {
+proc adi_axi_jesd204_rx_create {ip_name num_lanes {num_links 1}} {
 
   if {$num_lanes < 1 || $num_lanes > 8} {
     return -code 1 "ERROR: Invalid number of JESD204B lanes. (Supported range 1-8)"
+  }
+
+  if {$num_links < 1 || $num_links > 8} {
+    return -code 1 "ERROR: Invalid number of JESD204B links. (Supported range 1-8)"
   }
 
   startgroup
@@ -124,7 +128,9 @@ proc adi_axi_jesd204_rx_create {ip_name num_lanes} {
     ad_ip_instance jesd204_rx "${ip_name}/rx"
 
     ad_ip_parameter "${ip_name}/rx_axi" CONFIG.NUM_LANES $num_lanes
+    ad_ip_parameter "${ip_name}/rx_axi" CONFIG.NUM_LINKS $num_links
     ad_ip_parameter "${ip_name}/rx"     CONFIG.NUM_LANES $num_lanes
+    ad_ip_parameter "${ip_name}/rx"     CONFIG.NUM_LINKS $num_links
 
     ad_connect "${ip_name}/rx_axi/core_reset" "${ip_name}/rx/reset"
     ad_connect "${ip_name}/rx_axi/rx_cfg" "${ip_name}/rx/rx_cfg"
@@ -145,7 +151,7 @@ proc adi_axi_jesd204_rx_create {ip_name num_lanes} {
 
     # JESD204 processing
     create_bd_pin -dir I -type clk "${ip_name}/device_clk"
-    create_bd_pin -dir O "${ip_name}/sync"
+    create_bd_pin -dir O -from [expr $num_links - 1] -to 0 "${ip_name}/sync"
     create_bd_pin -dir I "${ip_name}/sysref"
     create_bd_pin -dir O "${ip_name}/phy_en_char_align"
 #    create_bd_pin -dir I "${ip_name}/phy_ready"

--- a/library/jesd204/tb/axi_jesd204_rx_regmap_tb.v
+++ b/library/jesd204/tb/axi_jesd204_rx_regmap_tb.v
@@ -273,14 +273,14 @@ module axi_jesd204_rx_tb;
     write_reg_and_update('h200, {NUM_LANES{1'b1}});
     check_all_registers();
 
-    /* Check links enable */
-    write_reg_and_update('h204, {NUM_LINKS{1'b1}});
-    check_all_registers();
-
     /* Check JESD common config */
     write_reg_and_update('h210, 32'hff03ff);
     check_all_registers();
     write_reg_and_update('h214, 32'h03);
+    check_all_registers();
+
+    /* Check links enable */
+    write_reg_and_update('h218, {NUM_LINKS{1'b1}});
     check_all_registers();
 
     /* Check JESD RX configuration */
@@ -293,8 +293,8 @@ module axi_jesd204_rx_tb;
 
     /* Should be read-only when core is out of reset */
     invert_register('h200); /* lanes enable */
-    invert_register('h204); /* links enable */
     invert_register('h210); /* octets per frame, beats per multiframe */
+    invert_register('h218); /* links enable */
     invert_register('h240); /* char replacement, scrambler */
 
     check_all_registers();

--- a/library/jesd204/tb/axi_jesd204_rx_regmap_tb.v
+++ b/library/jesd204/tb/axi_jesd204_rx_regmap_tb.v
@@ -160,6 +160,7 @@ module axi_jesd204_rx_tb;
     set_reset_reg_value('h00, 32'h00010061); /* PCORE version register */
     set_reset_reg_value('h0c, 32'h32303452); /* PCORE magic register */
     set_reset_reg_value('h10, NUM_LANES); /* Number of lanes */
+    set_reset_reg_value('h18, NUM_LINKS); /* Number of links */
     set_reset_reg_value('h40, 32'h00000100); /* Elastic buffer size */
     set_reset_reg_value('h14, 'h2); /* Datapath width */
     set_reset_reg_value('hc0, 'h1); /* Core reset */

--- a/library/jesd204/tb/axi_jesd204_rx_regmap_tb.v
+++ b/library/jesd204/tb/axi_jesd204_rx_regmap_tb.v
@@ -45,6 +45,7 @@
 module axi_jesd204_rx_tb;
   parameter VCD_FILE = "axi_jesd204_rx_regmap_tb.vcd";
   parameter NUM_LANES = 2;
+  parameter NUM_LINKS = 1;
 
   `define TIMEOUT 1000000
   `include "tb_base.v"
@@ -272,6 +273,10 @@ module axi_jesd204_rx_tb;
     write_reg_and_update('h200, {NUM_LANES{1'b1}});
     check_all_registers();
 
+    /* Check links enable */
+    write_reg_and_update('h204, {NUM_LINKS{1'b1}});
+    check_all_registers();
+
     /* Check JESD common config */
     write_reg_and_update('h210, 32'hff03ff);
     check_all_registers();
@@ -287,10 +292,10 @@ module axi_jesd204_rx_tb;
     check_all_registers();
 
     /* Should be read-only when core is out of reset */
-    invert_register('h200);
-    invert_register('h204);
-    invert_register('h210);
-    invert_register('h240);
+    invert_register('h200); /* lanes enable */
+    invert_register('h204); /* links enable */
+    invert_register('h210); /* octets per frame, beats per multiframe */
+    invert_register('h240); /* char replacement, scrambler */
 
     check_all_registers();
 
@@ -308,7 +313,8 @@ module axi_jesd204_rx_tb;
   end
 
   axi_jesd204_rx #(
-    .NUM_LANES(NUM_LANES)
+    .NUM_LANES(NUM_LANES),
+    .NUM_LINKS(NUM_LINKS)
   ) i_axi (
     .s_axi_aclk(s_axi_aclk),
     .s_axi_aresetn(s_axi_aresetn),

--- a/library/jesd204/tb/axi_jesd204_rx_regmap_tb.v
+++ b/library/jesd204/tb/axi_jesd204_rx_regmap_tb.v
@@ -157,7 +157,7 @@ module axi_jesd204_rx_tb;
     for (i = 0; i < 1024; i = i + 1)
       expected_reg_mem[i] <= 'h00;
     /* Non zero power-on-reset values */
-    set_reset_reg_value('h00, 32'h00010061); /* PCORE version register */
+    set_reset_reg_value('h00, 32'h00010161); /* PCORE version register */
     set_reset_reg_value('h0c, 32'h32303452); /* PCORE magic register */
     set_reset_reg_value('h10, NUM_LANES); /* Number of lanes */
     set_reset_reg_value('h18, NUM_LINKS); /* Number of links */

--- a/library/jesd204/tb/rx_tb.v
+++ b/library/jesd204/tb/rx_tb.v
@@ -45,6 +45,7 @@
 module rx_tb;
   parameter VCD_FILE = "rx_tb.vcd";
   parameter NUM_LANES = 1;
+  parameter NUM_LINKS = 1;
   parameter OCTETS_PER_FRAME = 8;
   parameter FRAMES_PER_MULTIFRAME = 32;
 
@@ -96,12 +97,13 @@ module rx_tb;
   reg [3:0] charisk = 4'b1111;
   reg [3:0] disperr = 4'b0000;
   reg [3:0] notintable = 4'b0000;
+  wire [NUM_LINKS-1:0] sync;
 
   integer counter = 'h00;
   wire [31:0] counter2 = (counter - 'h10) * 4;
 
   always @(posedge clk) begin
-    if (sync == 1'b0) begin
+    if ( &sync == 1'b0 ) begin
       counter <= 'h00;
       charisk <= 4'b1111;
       data <= {KCHAR_CGS,KCHAR_CGS,KCHAR_CGS,KCHAR_CGS};
@@ -134,6 +136,7 @@ module rx_tb;
   end
 
   wire [NUM_LANES-1:0] cfg_lanes_disable;
+  wire [NUM_LINKS-1:0] cfg_links_disable;
   wire [7:0] cfg_beats_per_multiframe;
   wire [7:0] cfg_octets_per_frame;
   wire [7:0] cfg_lmfc_offset;
@@ -144,12 +147,14 @@ module rx_tb;
 
   jesd204_rx_static_config #(
     .NUM_LANES(NUM_LANES),
+    .NUM_LINKS(NUM_LINKS),
     .OCTETS_PER_FRAME(OCTETS_PER_FRAME),
     .FRAMES_PER_MULTIFRAME(FRAMES_PER_MULTIFRAME)
   ) i_cfg (
     .clk(clk),
 
     .cfg_lanes_disable(cfg_lanes_disable),
+    .cfg_links_disable(cfg_links_disable),
     .cfg_beats_per_multiframe(cfg_beats_per_multiframe),
     .cfg_octets_per_frame(cfg_octets_per_frame),
     .cfg_lmfc_offset(cfg_lmfc_offset),
@@ -160,12 +165,14 @@ module rx_tb;
   );
 
   jesd204_rx #(
-    .NUM_LANES(NUM_LANES)
+    .NUM_LANES(NUM_LANES),
+    .NUM_LINKS(NUM_LINKS)
   ) i_rx (
     .clk(clk),
     .reset(reset),
 
     .cfg_lanes_disable(cfg_lanes_disable),
+    .cfg_links_disable(cfg_links_disable),
     .cfg_beats_per_multiframe(cfg_beats_per_multiframe),
     .cfg_octets_per_frame(cfg_octets_per_frame),
     .cfg_lmfc_offset(cfg_lmfc_offset),


### PR DESCRIPTION
A multi-link is a link where multiple converter devices are connected to a single logic device (FPGA). All links involved in a multi-link are synchronous and established at the same time. For an RX link, this means that the SYNC signal needs to be propagated from the FPGA to each converter.

Dynamic multi-link support must allow selecting which converter devices on the multi-link the SYNC signal is propagated too. This is useful when depending on the use case profile some converter devices are supposed to be disabled.

Add the cfg_links_disable[0x081] register for multi-link control and propagate its value to the RX FSM.
