### PR TITLE
jesd204:tb: Fix the loopback_tb test bench

### DIFF
--- a/library/jesd204/tb/loopback_tb.v
+++ b/library/jesd204/tb/loopback_tb.v
@@ -267,8 +267,6 @@ module loopback_tb;
     .rx_data(rx_data),
     .rx_valid(rx_valid),
 
-    .phy_ready(1'b1),
-
     .phy_data(phy_data_in),
     .phy_charisk(phy_charisk_in),
     .phy_notintable({NUM_LANES{4'b0000}}),


### PR DESCRIPTION
The jesd204_rx instantiation contained a port that did not exist. (phy_ready)