### PR TITLE
Multi-link Tx JESD204

### DIFF
--- a/library/jesd204/axi_jesd204_common/jesd204_up_common.v
+++ b/library/jesd204/axi_jesd204_common/jesd204_up_common.v
@@ -229,7 +229,8 @@ always @(*) begin
   /* 0x32-0x34 reserver for future use */
 
   12'h080: up_rdata <= up_cfg_lanes_disable;
-  /* 0x81-0x83 reserved for future lane disable bits (max 128 lanes) */
+  12'h081: up_rdata <= up_cfg_links_disable;
+  /* 0x82-0x83 reserved for future lane disable bits (max 128 lanes) */
   12'h084: up_rdata <= {
     /* 24-31 */ 8'h00, /* Reserved for future extensions of octets_per_frame */
     /* 16-23 */ up_cfg_octets_per_frame,
@@ -295,6 +296,9 @@ always @(posedge up_clk) begin
       case (up_waddr)
       12'h080: begin
         up_cfg_lanes_disable <= up_wdata[NUM_LANES-1:0];
+      end
+      12'h081: begin
+        up_cfg_links_disable <= up_wdata[NUM_LINKS-1:0];
       end
       12'h084: begin
         up_cfg_octets_per_frame <= up_wdata[23:16];

--- a/library/jesd204/axi_jesd204_common/jesd204_up_common.v
+++ b/library/jesd204/axi_jesd204_common/jesd204_up_common.v
@@ -229,7 +229,6 @@ always @(*) begin
   /* 0x32-0x34 reserver for future use */
 
   12'h080: up_rdata <= up_cfg_lanes_disable;
-  12'h081: up_rdata <= up_cfg_links_disable;
   /* 0x82-0x83 reserved for future lane disable bits (max 128 lanes) */
   12'h084: up_rdata <= {
     /* 24-31 */ 8'h00, /* Reserved for future extensions of octets_per_frame */
@@ -242,7 +241,6 @@ always @(*) begin
     /*    01 */ up_cfg_disable_char_replacement, /* Disable character replacement */
     /*    00 */ up_cfg_disable_scrambler /* Disable scrambler */
   };
-
   12'h086: up_rdata <= up_cfg_links_disable;
   /* 0x87-0x8f reserved for future use */
 
@@ -296,9 +294,6 @@ always @(posedge up_clk) begin
       case (up_waddr)
       12'h080: begin
         up_cfg_lanes_disable <= up_wdata[NUM_LANES-1:0];
-      end
-      12'h081: begin
-        up_cfg_links_disable <= up_wdata[NUM_LINKS-1:0];
       end
       12'h084: begin
         up_cfg_octets_per_frame <= up_wdata[23:16];

--- a/library/jesd204/axi_jesd204_tx/axi_jesd204_tx.v
+++ b/library/jesd204/axi_jesd204_tx/axi_jesd204_tx.v
@@ -45,7 +45,8 @@
 
 module axi_jesd204_tx #(
   parameter ID = 0,
-  parameter NUM_LANES = 1
+  parameter NUM_LANES = 1,
+  parameter NUM_LINKS = 1
 ) (
   input s_axi_aclk,
   input s_axi_aresetn,
@@ -77,6 +78,7 @@ module axi_jesd204_tx #(
   output core_reset,
 
   output [NUM_LANES-1:0] core_cfg_lanes_disable,
+  output [NUM_LINKS-1:0] core_cfg_links_disable,
   output [7:0] core_cfg_beats_per_multiframe,
   output [7:0] core_cfg_octets_per_frame,
   output [7:0] core_cfg_lmfc_offset,
@@ -99,7 +101,7 @@ module axi_jesd204_tx #(
   output core_ctrl_manual_sync_request,
 
   input [1:0] core_status_state,
-  input core_status_sync
+  input [NUM_LINKS-1:0] core_status_sync
 );
 
 localparam PCORE_VERSION = 32'h00010061; // 1.00.a
@@ -171,6 +173,7 @@ jesd204_up_common #(
   .PCORE_MAGIC(PCORE_MAGIC),
   .ID(ID),
   .NUM_LANES(NUM_LANES),
+  .NUM_LINKS(NUM_LINKS),
   .DATA_PATH_WIDTH(2),
   .NUM_IRQS(5),
   .EXTRA_CFG_WIDTH(21),
@@ -202,6 +205,7 @@ jesd204_up_common #(
   .core_cfg_beats_per_multiframe(core_cfg_beats_per_multiframe),
   .core_cfg_octets_per_frame(core_cfg_octets_per_frame),
   .core_cfg_lanes_disable(core_cfg_lanes_disable),
+  .core_cfg_links_disable(core_cfg_links_disable),
   .core_cfg_disable_scrambler(core_cfg_disable_scrambler),
   .core_cfg_disable_char_replacement(core_cfg_disable_char_replacement),
 
@@ -248,7 +252,8 @@ jesd204_up_sysref i_up_sysref (
 );
 
 jesd204_up_tx #(
-  .NUM_LANES(NUM_LANES)
+  .NUM_LANES(NUM_LANES),
+  .NUM_LINKS(NUM_LINKS)
 ) i_up_tx (
   .up_clk(s_axi_aclk),
   .up_reset(up_reset),

--- a/library/jesd204/axi_jesd204_tx/axi_jesd204_tx.v
+++ b/library/jesd204/axi_jesd204_tx/axi_jesd204_tx.v
@@ -104,7 +104,7 @@ module axi_jesd204_tx #(
   input [NUM_LINKS-1:0] core_status_sync
 );
 
-localparam PCORE_VERSION = 32'h00010061; // 1.00.a
+localparam PCORE_VERSION = 32'h00010161; // 1.01.a
 localparam PCORE_MAGIC = 32'h32303454; // 204T
 
 wire up_reset;

--- a/library/jesd204/axi_jesd204_tx/axi_jesd204_tx_constr.sdc
+++ b/library/jesd204/axi_jesd204_tx/axi_jesd204_tx_constr.sdc
@@ -49,7 +49,7 @@ source "$script_dir/util_cdc_constr.tcl"
 util_cdc_sync_event_constr {*|jesd204_up_sysref:i_up_sysref|sync_event:i_cdc_sysref_event}
 util_cdc_sync_event_constr {*|jesd204_up_tx:i_up_tx|sync_event:i_cdc_manual_sync_request}
 util_cdc_sync_data_constr {*|jesd204_up_tx:i_up_tx|sync_data:i_cdc_status}
-util_cdc_sync_bits_constr {*|jesd204_up_tx:i_up_tx|sync_bits:i_cdc_sync}
+util_cdc_sync_bits_constr {*|jesd204_up_tx:i_up_tx|sync_bits:*.i_cdc_sync}
 
 set_false_path \
   -from [get_registers {*|jesd204_up_common:i_up_common|up_reset_core}] \

--- a/library/jesd204/axi_jesd204_tx/axi_jesd204_tx_constr.xdc
+++ b/library/jesd204/axi_jesd204_tx/axi_jesd204_tx_constr.xdc
@@ -84,7 +84,7 @@ set_max_delay -datapath_only \
 
 set_false_path \
   -from $core_clk \
-  -to [get_pins {i_up_tx/i_cdc_sync/cdc_sync_stage1_reg[0]/D}]
+  -to [get_pins {i_up_tx/*.i_cdc_sync/cdc_sync_stage1_reg[0]/D}]
 
 set_false_path \
   -from [get_pins {i_up_common/up_reset_core_reg/C}] \

--- a/library/jesd204/axi_jesd204_tx/axi_jesd204_tx_hw.tcl
+++ b/library/jesd204/axi_jesd204_tx/axi_jesd204_tx_hw.tcl
@@ -79,6 +79,11 @@ set_parameter_property NUM_LANES DISPLAY_NAME "Number of Lanes"
 set_parameter_property NUM_LANES ALLOWED_RANGES 1:8
 set_parameter_property NUM_LANES HDL_PARAMETER true
 
+add_parameter NUM_LINKS INTEGER 1
+set_parameter_property NUM_LINKS DISPLAY_NAME "Number of Links"
+set_parameter_property NUM_LINKS ALLOWED_RANGES 1:8
+set_parameter_property NUM_LINKS HDL_PARAMETER true
+
 # axi4 slave interface
 
 ad_ip_intf_s_axi s_axi_aclk s_axi_aresetn 14
@@ -121,6 +126,7 @@ add_interface_port config core_cfg_continuous_ilas continuous_ilas Output 1
 add_interface_port config core_cfg_disable_char_replacement disable_char_replacement Output 1
 add_interface_port config core_cfg_disable_scrambler disable_scrambler Output 1
 add_interface_port config core_cfg_lanes_disable lanes_disable Output NUM_LANES
+add_interface_port config core_cfg_links_disable links_disable Output NUM_LINKS
 add_interface_port config core_cfg_lmfc_offset lmfc_offset Output 8
 add_interface_port config core_cfg_mframes_per_ilas mframes_per_ilas Output 8
 add_interface_port config core_cfg_octets_per_frame octets_per_frame Output 8

--- a/library/jesd204/axi_jesd204_tx/axi_jesd204_tx_ip.tcl
+++ b/library/jesd204/axi_jesd204_tx/axi_jesd204_tx_ip.tcl
@@ -74,6 +74,7 @@ adi_add_bus "tx_cfg" "master" \
   "analog.com:interface:jesd204_tx_cfg:1.0" \
   { \
     { "core_cfg_lanes_disable" "lanes_disable" } \
+    { "core_cfg_links_disable" "links_disable" } \
     { "core_cfg_beats_per_multiframe" "beats_per_multiframe" } \
     { "core_cfg_octets_per_frame" "octets_per_frame" } \
     { "core_cfg_lmfc_offset" "lmfc_offset" } \

--- a/library/jesd204/axi_jesd204_tx/jesd204_up_tx.v
+++ b/library/jesd204/axi_jesd204_tx/jesd204_up_tx.v
@@ -43,7 +43,8 @@
 //
 
 module jesd204_up_tx # (
-  parameter NUM_LANES = 1
+  parameter NUM_LANES = 1,
+  parameter NUM_LINKS = 1
 ) (
   input up_clk,
   input up_reset,
@@ -69,21 +70,26 @@ module jesd204_up_tx # (
   output core_ctrl_manual_sync_request,
 
   input [1:0] core_status_state,
-  input core_status_sync
+  input [NUM_LINKS-1:0] core_status_sync
 );
 
 reg [31:0] up_cfg_ilas_data[0:NUM_LANES-1][0:3];
 reg up_ctrl_manual_sync_request = 1'b0;
 
 wire [1:0] up_status_state;
-wire up_status_sync;
+wire [NUM_LINKS-1:0] up_status_sync;
 
-sync_bits i_cdc_sync (
-  .in(core_status_sync),
-  .out_clk(up_clk),
-  .out_resetn(1'b1),
-  .out(up_status_sync)
-);
+genvar j;
+generate
+  for (j=0; j<NUM_LINKS; j=j+1) begin : SYNC_CDC
+    sync_bits i_cdc_sync (
+      .in(core_status_sync[j]),
+      .out_clk(up_clk),
+      .out_resetn(1'b1),
+      .out(up_status_sync[j])
+    );
+  end
+endgenerate
 
 sync_data #(
   .NUM_OF_BITS(2)
@@ -122,8 +128,8 @@ always @(*) begin
 
   /* JESD TX status */
   12'ha0: up_rdata <= {
-    /* 05-31 */ 23'h00, /* Reserved for future additions */
-    /*    04 */ up_status_sync, /* Raw value of the SYNC pin */
+    /* 12-31 */ 20'h00, /* Reserved for future additions */
+    /* 04-11 */ up_status_sync, /* Raw value of the SYNC pin */
     /* 02-03 */ 2'b0, /* Reserved fo future extension of the status_state field */
     /* 00-01 */ up_status_state /* State of the internal state machine (0=CGS, 1=ILAS, 2=DATA) */
   };

--- a/library/jesd204/axi_jesd204_tx/jesd204_up_tx.v
+++ b/library/jesd204/axi_jesd204_tx/jesd204_up_tx.v
@@ -79,17 +79,14 @@ reg up_ctrl_manual_sync_request = 1'b0;
 wire [1:0] up_status_state;
 wire [NUM_LINKS-1:0] up_status_sync;
 
-genvar j;
-generate
-  for (j=0; j<NUM_LINKS; j=j+1) begin : SYNC_CDC
-    sync_bits i_cdc_sync (
-      .in(core_status_sync[j]),
-      .out_clk(up_clk),
-      .out_resetn(1'b1),
-      .out(up_status_sync[j])
-    );
-  end
-endgenerate
+sync_bits #(
+  .NUM_OF_BITS (NUM_LINKS))
+i_cdc_sync (
+  .in(core_status_sync),
+  .out_clk(up_clk),
+  .out_resetn(1'b1),
+  .out(up_status_sync)
+);
 
 sync_data #(
   .NUM_OF_BITS(2)

--- a/library/jesd204/interfaces/interfaces_ip.tcl
+++ b/library/jesd204/interfaces/interfaces_ip.tcl
@@ -49,6 +49,7 @@ source $ad_hdl_dir/library/scripts/adi_ip.tcl
 
 adi_if_define "jesd204_tx_cfg"
 adi_if_ports output -1 lanes_disable
+adi_if_ports output -1 links_disable
 adi_if_ports output 8 beats_per_multiframe
 adi_if_ports output 8 octets_per_frame
 adi_if_ports output 8 lmfc_offset

--- a/library/jesd204/jesd204_tx/jesd204_tx.v
+++ b/library/jesd204/jesd204_tx/jesd204_tx.v
@@ -43,7 +43,8 @@
 //
 
 module jesd204_tx #(
-  parameter NUM_LANES = 1
+  parameter NUM_LANES = 1,
+  parameter NUM_LINKS = 1
 ) (
   input clk,
   input reset,
@@ -55,13 +56,14 @@ module jesd204_tx #(
   output lmfc_edge,
   output lmfc_clk,
 
-  input sync,
+  input [NUM_LINKS-1:0] sync,
 
   input [32*NUM_LANES-1:0] tx_data,
   output tx_ready,
   input tx_valid,
 
   input [NUM_LANES-1:0] cfg_lanes_disable,
+  input [NUM_LINKS-1:0] cfg_links_disable,
   input [7:0] cfg_beats_per_multiframe,
   input [7:0] cfg_octets_per_frame,
   input [7:0] cfg_lmfc_offset,
@@ -83,7 +85,7 @@ module jesd204_tx #(
   output event_sysref_edge,
   output event_sysref_alignment_error,
 
-  output status_sync,
+  output [NUM_LINKS-1:0] status_sync,
   output [1:0] status_state
 );
 
@@ -138,6 +140,7 @@ jesd204_lmfc i_lmfc (
 
 jesd204_tx_ctrl #(
   .NUM_LANES(NUM_LANES),
+  .NUM_LINKS(NUM_LINKS),
   .DATA_PATH_WIDTH(DATA_PATH_WIDTH)
 ) i_tx_ctrl (
   .clk(clk),
@@ -159,6 +162,7 @@ jesd204_tx_ctrl #(
   .ilas_config_data(ilas_config_data),
 
   .cfg_lanes_disable(cfg_lanes_disable),
+  .cfg_links_disable(cfg_links_disable),
   .cfg_continuous_cgs(cfg_continuous_cgs),
   .cfg_continuous_ilas(cfg_continuous_ilas),
   .cfg_skip_ilas(cfg_skip_ilas),

--- a/library/jesd204/jesd204_tx/jesd204_tx_ctrl.v
+++ b/library/jesd204/jesd204_tx/jesd204_tx_ctrl.v
@@ -101,7 +101,7 @@ i_cdc_sync (
   .out_resetn(1'b1),
   .out(status_sync)
 );
-assign status_sync_masked = status_sync ^ cfg_links_disable;
+assign status_sync_masked = status_sync | cfg_links_disable;
 
 always @(posedge clk) begin
   if (reset == 1'b1) begin

--- a/library/jesd204/jesd204_tx/jesd204_tx_ctrl.v
+++ b/library/jesd204/jesd204_tx/jesd204_tx_ctrl.v
@@ -93,17 +93,14 @@ reg cgs_enable = 1'b1;
 
 wire [NUM_LINKS-1:0] status_sync_cdc;
 
-genvar i;
-generate
-  for (i=0; i<NUM_LINKS; i=i+1) begin : SYNC_CDC
-    sync_bits i_cdc_sync (
-      .in(sync[i]),
-      .out_clk(clk),
-      .out_resetn(1'b1),
-      .out(status_sync_cdc[i])
-    );
-  end
-endgenerate
+sync_bits #(
+  .NUM_OF_BITS (NUM_LINKS))
+i_cdc_sync (
+  .in(sync),
+  .out_clk(clk),
+  .out_resetn(1'b1),
+  .out(status_sync_cdc)
+);
 assign status_sync = status_sync_cdc ^ cfg_links_disable;
 
 always @(posedge clk) begin

--- a/library/jesd204/jesd204_tx/jesd204_tx_ctrl.v
+++ b/library/jesd204/jesd204_tx/jesd204_tx_ctrl.v
@@ -44,12 +44,13 @@
 
 module jesd204_tx_ctrl #(
   parameter NUM_LANES = 1,
+  parameter NUM_LINKS = 1,
   parameter DATA_PATH_WIDTH = 4
 ) (
   input clk,
   input reset,
 
-  input sync,
+  input [NUM_LINKS-1:0] sync,
   input lmfc_edge,
 
   output reg [NUM_LANES-1:0] lane_cgs_enable,
@@ -65,6 +66,7 @@ module jesd204_tx_ctrl #(
   input [DATA_PATH_WIDTH*8*NUM_LANES-1:0] ilas_config_data,
 
   input [NUM_LANES-1:0] cfg_lanes_disable,
+  input [NUM_LINKS-1:0] cfg_links_disable,
   input cfg_continuous_cgs,
   input cfg_continuous_ilas,
   input cfg_skip_ilas,
@@ -73,7 +75,7 @@ module jesd204_tx_ctrl #(
 
   input ctrl_manual_sync_request,
 
-  output status_sync,
+  output [NUM_LINKS-1:0] status_sync,
   output reg [1:0] status_state
 );
 
@@ -89,16 +91,24 @@ reg ilas_config_rd_d1 = 1'b1;
 reg last_ilas_mframe = 1'b0;
 reg cgs_enable = 1'b1;
 
-sync_bits i_cdc_sync (
-  .in(sync),
-  .out_clk(clk),
-  .out_resetn(1'b1),
-  .out(status_sync)
-);
+wire [NUM_LINKS-1:0] status_sync_cdc;
+
+genvar i;
+generate
+  for (i=0; i<NUM_LINKS; i=i+1) begin : SYNC_CDC
+    sync_bits i_cdc_sync (
+      .in(sync[i]),
+      .out_clk(clk),
+      .out_resetn(1'b1),
+      .out(status_sync_cdc[i])
+    );
+  end
+endgenerate
+assign status_sync = status_sync_cdc ^ cfg_links_disable;
 
 always @(posedge clk) begin
   if (reset == 1'b1) begin
-    sync_request <= 1'b0;
+    sync_request <= {NUM_LINKS{1'b0}};
   end else begin
     /* TODO: SYNC must be asserted at least 4 frames before interpreted as a
      * sync request and the /K28.5/ symbol generation has lasted for at
@@ -106,7 +116,7 @@ always @(posedge clk) begin
     if (cfg_continuous_cgs == 1'b1) begin
       sync_request <= 1'b1;
     end else begin
-      sync_request <= ~status_sync | ctrl_manual_sync_request;
+      sync_request <= ~(&status_sync) | ctrl_manual_sync_request;
     end
   end
 end

--- a/library/jesd204/jesd204_tx/jesd204_tx_ctrl.v
+++ b/library/jesd204/jesd204_tx/jesd204_tx_ctrl.v
@@ -91,7 +91,7 @@ reg ilas_config_rd_d1 = 1'b1;
 reg last_ilas_mframe = 1'b0;
 reg cgs_enable = 1'b1;
 
-wire [NUM_LINKS-1:0] status_sync_cdc;
+wire [NUM_LINKS-1:0] status_sync_masked;
 
 sync_bits #(
   .NUM_OF_BITS (NUM_LINKS))
@@ -99,9 +99,9 @@ i_cdc_sync (
   .in(sync),
   .out_clk(clk),
   .out_resetn(1'b1),
-  .out(status_sync_cdc)
+  .out(status_sync)
 );
-assign status_sync = status_sync_cdc ^ cfg_links_disable;
+assign status_sync_masked = status_sync ^ cfg_links_disable;
 
 always @(posedge clk) begin
   if (reset == 1'b1) begin
@@ -113,7 +113,7 @@ always @(posedge clk) begin
     if (cfg_continuous_cgs == 1'b1) begin
       sync_request <= 1'b1;
     end else begin
-      sync_request <= ~(&status_sync) | ctrl_manual_sync_request;
+      sync_request <= ~(&status_sync_masked) | ctrl_manual_sync_request;
     end
   end
 end

--- a/library/jesd204/jesd204_tx/jesd204_tx_hw.tcl
+++ b/library/jesd204/jesd204_tx/jesd204_tx_hw.tcl
@@ -72,6 +72,11 @@ set_parameter_property NUM_LANES DISPLAY_NAME "Number of Lanes"
 set_parameter_property NUM_LANES ALLOWED_RANGES 1:8
 set_parameter_property NUM_LANES HDL_PARAMETER true
 
+add_parameter NUM_LINKS INTEGER 1
+set_parameter_property NUM_LINKS DISPLAY_NAME "Number of Links"
+set_parameter_property NUM_LINKS ALLOWED_RANGES 1:8
+set_parameter_property NUM_LINKS HDL_PARAMETER true
+
 # clock
 
 add_interface clock clock end
@@ -137,6 +142,7 @@ add_interface_port config cfg_continuous_ilas continuous_ilas Input 1
 add_interface_port config cfg_disable_char_replacement disable_char_replacement Input 1
 add_interface_port config cfg_disable_scrambler disable_scrambler Input 1
 add_interface_port config cfg_lanes_disable lanes_disable Input NUM_LANES
+add_interface_port config cfg_links_disable links_disable Input NUM_LINKS
 add_interface_port config cfg_lmfc_offset lmfc_offset Input 8
 add_interface_port config cfg_mframes_per_ilas mframes_per_ilas Input 8
 add_interface_port config cfg_octets_per_frame octets_per_frame Input 8

--- a/library/jesd204/jesd204_tx/jesd204_tx_ip.tcl
+++ b/library/jesd204/jesd204_tx/jesd204_tx_ip.tcl
@@ -90,6 +90,7 @@ adi_add_bus "tx_cfg" "slave" \
   "analog.com:interface:jesd204_tx_cfg:1.0" \
   { \
     { "cfg_lanes_disable" "lanes_disable" } \
+    { "cfg_links_disable" "links_disable" } \
     { "cfg_beats_per_multiframe" "beats_per_multiframe" } \
     { "cfg_octets_per_frame" "octets_per_frame" } \
     { "cfg_lmfc_offset" "lmfc_offset" } \

--- a/library/jesd204/jesd204_tx_static_config/jesd204_tx_static_config.v
+++ b/library/jesd204/jesd204_tx_static_config/jesd204_tx_static_config.v
@@ -44,6 +44,7 @@
 
 module jesd204_tx_static_config #(
   parameter NUM_LANES = 1,
+  parameter NUM_LINKS = 1,
   parameter OCTETS_PER_FRAME = 1,
   parameter FRAMES_PER_MULTIFRAME = 32,
   parameter NUM_CONVERTERS = 1,
@@ -55,6 +56,7 @@ module jesd204_tx_static_config #(
   input clk,
 
   output [NUM_LANES-1:0] cfg_lanes_disable,
+  output [NUM_LINKS-1:0] cfg_links_disable,
   output [7:0] cfg_beats_per_multiframe,
   output [7:0] cfg_octets_per_frame,
   output [7:0] cfg_lmfc_offset,
@@ -84,6 +86,7 @@ assign cfg_mframes_per_ilas = 3;
 assign cfg_disable_scrambler = SCR ? 1'b0 : 1'b1;
 assign cfg_disable_char_replacement = cfg_disable_scrambler;
 assign cfg_lanes_disable = {NUM_LANES{1'b0}};
+assign cfg_links_disable = {NUM_LINKS{1'b0}};
 
 jesd204_ilas_config_static #(
   .DID(8'h00),

--- a/library/jesd204/scripts/jesd204.tcl
+++ b/library/jesd204/scripts/jesd204.tcl
@@ -42,10 +42,14 @@
 # is copyright © 2016-2017, Analog Devices, Inc.”
 #
 
-proc adi_axi_jesd204_tx_create {ip_name num_lanes} {
+proc adi_axi_jesd204_tx_create {ip_name num_lanes {num_links 1}} {
 
   if {$num_lanes < 1 || $num_lanes > 8} {
     return -code 1 "ERROR: Invalid number of JESD204B lanes. (Supported range 1-8)"
+  }
+
+  if {$num_links < 1 || $num_links > 8} {
+    return -code 1 "ERROR: Invalid number of JESD204B links. (Supported range 1-8)"
   }
 
   startgroup
@@ -58,7 +62,9 @@ proc adi_axi_jesd204_tx_create {ip_name num_lanes} {
     ad_ip_instance jesd204_tx "${ip_name}/tx"
 
     ad_ip_parameter "${ip_name}/tx_axi" CONFIG.NUM_LANES $num_lanes
+    ad_ip_parameter "${ip_name}/tx_axi" CONFIG.NUM_LINKS $num_links
     ad_ip_parameter "${ip_name}/tx"     CONFIG.NUM_LANES $num_lanes
+    ad_ip_parameter "${ip_name}/tx"     CONFIG.NUM_LINKS $num_links
 
     ad_connect "${ip_name}/tx_axi/core_reset" "${ip_name}/tx/reset"
     ad_connect "${ip_name}/tx_axi/tx_ctrl" "${ip_name}/tx/tx_ctrl"
@@ -80,7 +86,7 @@ proc adi_axi_jesd204_tx_create {ip_name num_lanes} {
 
     # JESD204 processing
     create_bd_pin -dir I -type clk "${ip_name}/device_clk"
-    create_bd_pin -dir I "${ip_name}/sync"
+    create_bd_pin -dir I -from [expr $num_links - 1] -to 0 "${ip_name}/sync"
     create_bd_pin -dir I "${ip_name}/sysref"
 
     create_bd_intf_pin -mode Slave -vlnv xilinx.com:interface:axis_rtl:1.0 "${ip_name}/tx_data"

--- a/library/jesd204/tb/axi_jesd204_tx_regmap_tb.v
+++ b/library/jesd204/tb/axi_jesd204_tx_regmap_tb.v
@@ -240,14 +240,14 @@ module axi_jesd204_tx_tb;
     write_reg_and_update('h200, {NUM_LANES{1'b1}});
     check_all_registers();
 
-    /* Check links disable */
-    write_reg_and_update('h204, {NUM_LANES{1'b1}});
-    check_all_registers();
-
     /* Check JESD common config */
     write_reg_and_update('h210, 32'hff03ff);
     check_all_registers();
     write_reg_and_update('h214, 32'h03);
+    check_all_registers();
+
+    /* Check links disable */
+    write_reg_and_update('h218, {NUM_LINKS{1'b1}});
     check_all_registers();
 
     /* Check JESD TX configuration */
@@ -294,9 +294,9 @@ module axi_jesd204_tx_tb;
 
     /* Should be read-only when core is out of reset */
     invert_register('h200);
-    invert_register('h204);
     invert_register('h210);
     invert_register('h214);
+    invert_register('h218);
     invert_register('h240);
     invert_register('h244);
     for (i = 0; i < NUM_LANES; i = i + 1) begin

--- a/library/jesd204/tb/axi_jesd204_tx_regmap_tb.v
+++ b/library/jesd204/tb/axi_jesd204_tx_regmap_tb.v
@@ -157,7 +157,7 @@ module axi_jesd204_tx_tb;
     for (i = 0; i < 1024; i = i + 1)
       expected_reg_mem[i] <= 'h00;
     /* Non zero power-on-reset values */
-    set_reset_reg_value('h00, 32'h00010061); /* PCORE version register */
+    set_reset_reg_value('h00, 32'h00010161); /* PCORE version register */
     set_reset_reg_value('h0c, 32'h32303454); /* PCORE magic register */
     set_reset_reg_value('h10, NUM_LANES); /* Number of lanes */
     set_reset_reg_value('h14, 'h2); /* Datapath width */

--- a/library/jesd204/tb/axi_jesd204_tx_regmap_tb.v
+++ b/library/jesd204/tb/axi_jesd204_tx_regmap_tb.v
@@ -161,6 +161,7 @@ module axi_jesd204_tx_tb;
     set_reset_reg_value('h0c, 32'h32303454); /* PCORE magic register */
     set_reset_reg_value('h10, NUM_LANES); /* Number of lanes */
     set_reset_reg_value('h14, 'h2); /* Datapath width */
+    set_reset_reg_value('h18, NUM_LINKS); /* Number of links */
     set_reset_reg_value('hc0, 'h1); /* Link disable */
     set_reset_reg_value('hc4, 'h1); /* Core state */
 //    set_reset_reg_value('hc8, 'h80000); /* clock monitor */

--- a/library/jesd204/tb/loopback_tb.v
+++ b/library/jesd204/tb/loopback_tb.v
@@ -45,6 +45,7 @@
 module loopback_tb;
   parameter VCD_FILE = "loopback_tb.vcd";
   parameter NUM_LANES = 4;
+  parameter NUM_LINKS = 1;
   parameter OCTETS_PER_FRAME = 4;
   parameter FRAMES_PER_MULTIFRAME = 16;
   parameter ENABLE_SCRAMBLER = 1;
@@ -95,7 +96,7 @@ module loopback_tb;
   wire [NUM_LANES*4-1:0] phy_charisk_out;
   wire [NUM_LANES*32-1:0] phy_data_in;
   wire [NUM_LANES*4-1:0] phy_charisk_in;
-  wire sync;
+  wire [NUM_LINKS-1:0] sync;
 
   reg [5:0] sysref_counter = 'h00;
   reg sysref_rx = 1'b0;
@@ -133,6 +134,7 @@ module loopback_tb;
   end endgenerate
 
   wire [NUM_LANES-1:0] tx_cfg_lanes_disable;
+  wire [NUM_LINKS-1:0] tx_cfg_links_disable;
   wire [7:0] tx_cfg_beats_per_multiframe;
   wire [7:0] tx_cfg_octets_per_frame;
   wire [7:0] tx_cfg_lmfc_offset;
@@ -151,6 +153,7 @@ module loopback_tb;
 
   jesd204_tx_static_config #(
     .NUM_LANES(NUM_LANES),
+    .NUM_LINKS(NUM_LINKS),
     .OCTETS_PER_FRAME(OCTETS_PER_FRAME),
     .FRAMES_PER_MULTIFRAME(FRAMES_PER_MULTIFRAME),
     .SCR(ENABLE_SCRAMBLER)
@@ -158,6 +161,7 @@ module loopback_tb;
     .clk(clk),
 
     .cfg_lanes_disable(tx_cfg_lanes_disable),
+    .cfg_links_disable(tx_cfg_links_disable),
     .cfg_beats_per_multiframe(tx_cfg_beats_per_multiframe),
     .cfg_octets_per_frame(tx_cfg_octets_per_frame),
     .cfg_lmfc_offset(tx_cfg_lmfc_offset),
@@ -176,12 +180,14 @@ module loopback_tb;
   );
 
   jesd204_tx #(
-    .NUM_LANES(NUM_LANES)
+    .NUM_LANES(NUM_LANES),
+    .NUM_LINKS(NUM_LINKS)
   ) i_tx (
     .clk(clk),
     .reset(reset),
 
     .cfg_lanes_disable(tx_cfg_lanes_disable),
+    .cfg_links_disable(tx_cfg_links_disable),
     .cfg_beats_per_multiframe(tx_cfg_beats_per_multiframe),
     .cfg_octets_per_frame(tx_cfg_octets_per_frame),
     .cfg_lmfc_offset(tx_cfg_lmfc_offset),

--- a/library/jesd204/tb/tx_tb.v
+++ b/library/jesd204/tb/tx_tb.v
@@ -44,36 +44,19 @@
 
 module tx_tb;
   parameter VCD_FILE = "tx_tb.vcd";
-  parameter NUM_LANES = 1;
-  parameter NUM_LINKS = 1;
+  parameter NUM_LANES = 4;
+  parameter NUM_LINKS = 2;
   parameter OCTETS_PER_FRAME = 4;
   parameter FRAMES_PER_MULTIFRAME = 32;
 
   `include "tb_base.v"
 
-  reg [31:0] tx_data = 'h00000000;
-  wire tx_ready;
-
-  always @(posedge clk) begin
-    if (reset == 1'b1) begin
-      tx_data <= 'h00000000;
-    end else if (tx_ready == 1'b1) begin
-      tx_data <= tx_data + 1'b1;
-    end
-  end
 
   reg [NUM_LINKS-1:0] sync = {NUM_LINKS{1'b1}};
   reg [31:0] counter = 'h00;
+  reg [31:0] tx_data = 'h00000000;
 
-  always @(posedge clk) begin
-    counter <= counter + 1'b1;
-    if (counter >= 'h10 && counter <= 'h30) begin
-      sync <= {NUM_LINKS{1'b0}};
-    end else begin
-      sync <= {NUM_LINKS{1'b1}};
-    end
-  end
-
+  wire tx_ready;
   wire [NUM_LANES-1:0] cfg_lanes_disable;
   wire [NUM_LINKS-1:0] cfg_links_disable;
   wire [7:0] cfg_beats_per_multiframe;
@@ -87,10 +70,41 @@ module tx_tb;
   wire [7:0] cfg_mframes_per_ilas;
   wire cfg_disable_char_replacement;
   wire cfg_disable_scrambler;
-
   wire tx_ilas_config_rd;
   wire [1:0] tx_ilas_config_addr;
   wire [32*NUM_LANES-1:0] tx_ilas_config_data;
+
+  always @(posedge clk) begin
+    if (reset == 1'b1) begin
+      tx_data <= 'h00000000;
+    end else if (tx_ready == 1'b1) begin
+      tx_data <= tx_data + 1'b1;
+    end
+  end
+
+  /* Generate independent SYNCs
+  *
+  *  Each SYNC will be asserted/deasserted at different clock edges.
+  *  The assertion/deassertion order: first SYNC[0], ..., last SYNC[NUM_LINKS-1]
+  */
+  always @(posedge clk) begin
+    counter <= counter + 1'b1;
+  end
+
+  genvar i;
+  generate
+    for (i=1; i<=NUM_LINKS; i=i+1) begin: SYNC_GENERATOR
+      always @(posedge clk) begin
+        if (counter >= (32'h100 | (i << 4)) && counter <= (32'h300 | (i << 4))) begin
+          sync[i-1] <= 1'b0;
+        end else begin
+          sync[i-1] <= 1'b1;
+        end
+      end
+    end
+  endgenerate
+
+  // DUT with static configuration
 
   jesd204_tx_static_config #(
     .NUM_LANES(NUM_LANES),
@@ -141,6 +155,8 @@ module tx_tb;
     .ilas_config_rd(tx_ilas_config_rd),
     .ilas_config_addr(tx_ilas_config_addr),
     .ilas_config_data(tx_ilas_config_data),
+
+    .ctrl_manual_sync_request (1'b0),
 
     .tx_ready(tx_ready),
     .tx_data({NUM_LANES{tx_data}}),

--- a/library/jesd204/tb/tx_tb.v
+++ b/library/jesd204/tb/tx_tb.v
@@ -45,6 +45,7 @@
 module tx_tb;
   parameter VCD_FILE = "tx_tb.vcd";
   parameter NUM_LANES = 1;
+  parameter NUM_LINKS = 1;
   parameter OCTETS_PER_FRAME = 4;
   parameter FRAMES_PER_MULTIFRAME = 32;
 
@@ -61,19 +62,20 @@ module tx_tb;
     end
   end
 
-  reg sync = 1'b1;
+  reg [NUM_LINKS-1:0] sync = {NUM_LINKS{1'b1}};
   reg [31:0] counter = 'h00;
 
   always @(posedge clk) begin
     counter <= counter + 1'b1;
     if (counter >= 'h10 && counter <= 'h30) begin
-      sync <= 1'b0;
+      sync <= {NUM_LINKS{1'b0}};
     end else begin
-      sync <= 1'b1;
+      sync <= {NUM_LINKS{1'b1}};
     end
   end
 
   wire [NUM_LANES-1:0] cfg_lanes_disable;
+  wire [NUM_LINKS-1:0] cfg_links_disable;
   wire [7:0] cfg_beats_per_multiframe;
   wire [7:0] cfg_octets_per_frame;
   wire [7:0] cfg_lmfc_offset;
@@ -92,10 +94,12 @@ module tx_tb;
 
   jesd204_tx_static_config #(
     .NUM_LANES(NUM_LANES),
+    .NUM_LINKS(NUM_LINKS),
     .OCTETS_PER_FRAME(OCTETS_PER_FRAME),
     .FRAMES_PER_MULTIFRAME(FRAMES_PER_MULTIFRAME)
   ) i_cfg (
     .cfg_lanes_disable(cfg_lanes_disable),
+    .cfg_links_disable(cfg_links_disable),
     .cfg_beats_per_multiframe(cfg_beats_per_multiframe),
     .cfg_octets_per_frame(cfg_octets_per_frame),
     .cfg_lmfc_offset(cfg_lmfc_offset),
@@ -114,12 +118,14 @@ module tx_tb;
   );
 
   jesd204_tx #(
-    .NUM_LANES(NUM_LANES)
+    .NUM_LANES(NUM_LANES),
+    .NUM_LINKS(NUM_LINKS)
   ) i_tx (
     .clk(clk),
     .reset(reset),
 
     .cfg_lanes_disable(cfg_lanes_disable),
+    .cfg_links_disable(cfg_links_disable),
     .cfg_beats_per_multiframe(cfg_beats_per_multiframe),
     .cfg_octets_per_frame(cfg_octets_per_frame),
     .cfg_lmfc_offset(cfg_lmfc_offset),


### PR DESCRIPTION
A multi-link is a link where multiple converter devices are connected to a single logic device (FPGA). All links involved in a multi-link are synchronous and established at the same time. For a TX link, this means that the FPGA receives multiple SYNC signals, one for each link. The state machine of the TX link peripheral must combine those SYNC signals into a single SYNC signal that is asserted when either of the external SYNC signals is asserted.

Dynamic multi-link support must allow selecting to which converter devices on the multi-link the SYNC signal is propagated too. This is useful when depending on the use case profile some converter devices are supposed to be disabled.

Add the cfg_links_disable[0x081] register for multi-link control and propagate its value to the TX FSM.
