### PR TITLE
Fix a few simple warnings generated by Quartus

### DIFF
--- a/library/common/ad_datafmt.v
+++ b/library/common/ad_datafmt.v
@@ -65,8 +65,6 @@ module ad_datafmt #(
   // internal signals
 
   wire                        type_s;
-  wire                        signext_s;
-  wire                        sign_s;
   wire    [15:0]              data_out_s;
 
   // data-path disable
@@ -84,15 +82,18 @@ module ad_datafmt #(
   // if offset-binary convert to 2's complement first
 
   assign type_s = dfmt_enable & dfmt_type;
-  assign signext_s = dfmt_enable & dfmt_se;
-  assign sign_s = signext_s & (type_s ^ data[(DATA_WIDTH-1)]);
 
   generate
   if (DATA_WIDTH < 16) begin
-  assign data_out_s[15:DATA_WIDTH] = {(16-DATA_WIDTH){sign_s}};
+    wire signext_s;
+    wire sign_s;
+
+    assign signext_s = dfmt_enable & dfmt_se;
+    assign sign_s = signext_s & (type_s ^ data[(DATA_WIDTH-1)]);
+    assign data_out_s[15:DATA_WIDTH] = {(16-DATA_WIDTH){sign_s}};
   end
   endgenerate
-  
+
   assign data_out_s[(DATA_WIDTH-1)] = type_s ^ data[(DATA_WIDTH-1)];
   assign data_out_s[(DATA_WIDTH-2):0] = data[(DATA_WIDTH-2):0];
 

--- a/library/common/ad_sysref_gen.v
+++ b/library/common/ad_sysref_gen.v
@@ -65,9 +65,9 @@ module ad_sysref_gen (
   // free running counter for periodic SYSREF generation
   always @(posedge core_clk) begin
     if (sysref_en_int) begin
-      counter <= (counter < SYSREF_HALFPERIOD) ? counter + 1 : 0;
+      counter <= (counter < SYSREF_HALFPERIOD) ? counter + 1'b1 : 8'h0;
     end else begin
-      counter <= 0;
+      counter <= 8'h0;
     end
   end
 

--- a/library/util_dacfifo/util_dacfifo.v
+++ b/library/util_dacfifo/util_dacfifo.v
@@ -108,6 +108,7 @@ module util_dacfifo #(
   wire    [(ADDRESS_WIDTH-1):0]       dma_raddr_g2b_s;
   wire    [(ADDRESS_WIDTH-1):0]       dac_waddr_g2b_s;
   wire    [(ADDRESS_WIDTH-1):0]       dac_lastaddr_g2b_s;
+  wire                                dac_mem_ren_s;
 
   // DMA / Write interface
 
@@ -163,7 +164,7 @@ module util_dacfifo #(
       dma_xfer_out_bypass <= 1'b0;
     end else begin
       if (dma_wren_s == 1'b1) begin
-        dma_waddr <= dma_waddr + 1;
+        dma_waddr <= dma_waddr + 1'b1;
         dma_xfer_out_fifo <= 1'b0;
       end
       if (dma_xfer_last == 1'b1) begin
@@ -262,10 +263,10 @@ module util_dacfifo #(
       dac_raddr_g <= 'b0;
     end else begin
       if (dac_mem_ren_s == 1'b1) begin
-        if (dac_lastaddr == 'b0) begin
-          dac_raddr <= dac_raddr + 1;
+        if (dac_lastaddr == 'b0 || dac_raddr < dac_lastaddr) begin
+          dac_raddr <= dac_raddr + 1'b1;
         end else begin
-          dac_raddr <= (dac_raddr < dac_lastaddr) ? (dac_raddr + 1) : 'b0;
+          dac_raddr <= 'b0;
         end
       end
       dac_raddr_g <= dac_raddr_b2g_s;


### PR DESCRIPTION
Most of these probably shouldn't even be warnings. But fixing them makes it easier to filter through the noise when looking for warnings that point out actual issues.