### PR TITLE
Add support for JESD204 lane polarity inversion

### DIFF
--- a/library/altera/adi_jesd204/adi_jesd204_hw.tcl
+++ b/library/altera/adi_jesd204/adi_jesd204_hw.tcl
@@ -109,6 +109,12 @@ ad_ip_parameter LANE_MAP STRING "" false { \
   DISPLAY_NAME "Lane Mapping" \
 }
 
+ad_ip_parameter LANE_INVERT STD_LOGIC_VECTOR 0 false { \
+  DISPLAY_NAME "Lane Invert Mask" \
+  DISPLAY_HINT "hexadecimal" \
+  WIDTH 8 \
+}
+
 ad_ip_parameter SOFT_PCS BOOLEAN true false { \
   DISPLAY_NAME "Enable Soft PCS" \
 }
@@ -226,6 +232,7 @@ proc jesd204_compose {} {
   set sysclk_frequency [get_parameter_value "SYSCLK_FREQUENCY"]
   set refclk_frequency [get_parameter_value "REFCLK_FREQUENCY"]
   set lane_map [get_parameter_value "LANE_MAP"]
+  set lane_invert [get_parameter_value "LANE_INVERT"]
   set soft_pcs [get_parameter_value "SOFT_PCS"]
   set device_family [get_parameter_value "DEVICE_FAMILY"]
   set device [get_parameter_value "DEVICE"]
@@ -327,6 +334,7 @@ proc jesd204_compose {} {
   set_instance_parameter_value phy REFCLK_FREQUENCY $refclk_frequency
   set_instance_parameter_value phy NUM_OF_LANES $num_of_lanes
   set_instance_parameter_value phy REGISTER_INPUTS $register_inputs
+  set_instance_parameter_value phy LANE_INVERT $lane_invert
 
   add_connection link_clock.out_clk_1 phy.link_clk
   add_connection link_reset.out_reset phy.link_reset

--- a/library/altera/jesd204_phy/jesd204_phy_glue.v
+++ b/library/altera/jesd204_phy/jesd204_phy_glue.v
@@ -35,16 +35,20 @@
 
 module jesd204_glue #(
   parameter WIDTH = 20,
-  parameter CONST_WIDTH = 1
+  parameter CONST_WIDTH = 1,
+  parameter NUM_OF_LANES = 1,
+  parameter LANE_INVERT = 0
 ) (
   input [WIDTH-1:0] in,
   output [WIDTH-1:0] out,
-  output [CONST_WIDTH-1:0] const_out
+  output [CONST_WIDTH-1:0] const_out,
+  output [NUM_OF_LANES-1:0] polinv
 );
 
 /* There really should be a standard component in Qsys that allows to do this */
 
 assign out = in;
 assign const_out = {CONST_WIDTH{1'b0}};
+assign polinv = LANE_INVERT[NUM_OF_LANES-1:0];
 
 endmodule

--- a/library/altera/jesd204_phy/jesd204_phy_glue_hw.tcl
+++ b/library/altera/jesd204_phy/jesd204_phy_glue_hw.tcl
@@ -66,7 +66,8 @@ ad_ip_files jesd204_glue [list \
 
 ad_ip_parameter TX_OR_RX_N BOOLEAN false false
 ad_ip_parameter SOFT_PCS BOOLEAN false false
-ad_ip_parameter NUM_OF_LANES POSITIVE 4 false
+ad_ip_parameter NUM_OF_LANES POSITIVE 4 true
+ad_ip_parameter LANE_INVERT INTEGER 0 true
 ad_ip_parameter WIDTH NATURAL 20 true { \
   DERIVED true \
 }
@@ -231,6 +232,10 @@ proc jesd204_phy_glue_elab {} {
     }
 
     glue_add_const_conduit unused_tx_parallel_data $unused_width
+
+    add_interface phy_tx_polinv conduit end
+    add_interface_port phy_tx_polinv polinv tx_polinv Output $num_of_lanes
+    set_port_property polinv TERMINATION $soft_pcs
   } else {
     glue_add_if 1 rx_cdr_refclk0 clock sink true
     glue_add_if_port 1 rx_cdr_refclk0 rx_cdr_refclk0 clk Input 1 true
@@ -261,6 +266,10 @@ proc jesd204_phy_glue_elab {} {
     add_interface_port const_out const_out const_out Output 1
     set_port_property const_out TERMINATION true
     set const_offset 1
+
+    add_interface phy_rx_polinv conduit end
+    add_interface_port phy_rx_polinv polinv rx_polinv Output $num_of_lanes
+    set_port_property polinv TERMINATION $soft_pcs
   }
 
   set_interface_property reconfig_reset associatedClock reconfig_clk
@@ -268,4 +277,4 @@ proc jesd204_phy_glue_elab {} {
 
   set_parameter_value WIDTH $sig_offset
   set_parameter_value CONST_WIDTH $const_offset
-}   
+}

--- a/library/jesd204/jesd204_soft_pcs_rx/jesd204_soft_pcs_rx.v
+++ b/library/jesd204/jesd204_soft_pcs_rx/jesd204_soft_pcs_rx.v
@@ -45,7 +45,8 @@
 module jesd204_soft_pcs_rx #(
   parameter NUM_LANES = 1,
   parameter DATA_PATH_WIDTH = 4,
-  parameter REGISTER_INPUTS = 0
+  parameter REGISTER_INPUTS = 0,
+  parameter INVERT_INPUTS = 0
 ) (
    input clk,
    input reset,
@@ -94,7 +95,6 @@ if (REGISTER_INPUTS == 1) begin
   end
   assign patternalign_en_s = patternalign_en_r;
   assign data_s = data_r;
-
 end else begin
   assign patternalign_en_s = patternalign_en;
   assign data_s = data;
@@ -125,9 +125,11 @@ for (lane = 0; lane < NUM_LANES; lane = lane + 1) begin: gen_lane
 
   for (i = 0; i < DATA_PATH_WIDTH; i = i + 1) begin: gen_dpw
     localparam j = DATA_PATH_WIDTH * lane + i;
+    wire [9:0] in_char = INVERT_INPUTS ? ~data_aligned[j*10+:10] :
+                                         data_aligned[j*10+:10];
 
     jesd204_8b10b_decoder i_dec (
-      .in_char(data_aligned[j*10+:10]),
+      .in_char(in_char),
       .out_char(char_s[j*8+:8]),
       .out_charisk(charisk_s[j]),
       .out_notintable(notintable_s[j]),

--- a/library/jesd204/jesd204_soft_pcs_rx/jesd204_soft_pcs_rx_hw.tcl
+++ b/library/jesd204/jesd204_soft_pcs_rx/jesd204_soft_pcs_rx_hw.tcl
@@ -50,6 +50,7 @@ source $ad_hdl_dir/library/scripts/adi_ip_alt.tcl
 ad_ip_create jesd204_soft_pcs_rx "ADI JESD204 Transmit Soft PCS"
 
 ad_ip_parameter REGISTER_INPUTS INTEGER 0
+ad_ip_parameter INVERT_INPUTS INTEGER 0
 
 set_module_property INTERNAL true
 

--- a/library/jesd204/jesd204_soft_pcs_tx/jesd204_soft_pcs_tx.v
+++ b/library/jesd204/jesd204_soft_pcs_tx/jesd204_soft_pcs_tx.v
@@ -44,7 +44,8 @@
 
 module jesd204_soft_pcs_tx #(
   parameter NUM_LANES = 1,
-  parameter DATA_PATH_WIDTH = 4
+  parameter DATA_PATH_WIDTH = 4,
+  parameter INVERT_OUTPUTS = 0
 ) (
    input clk,
    input reset,
@@ -61,7 +62,7 @@ wire [DATA_PATH_WIDTH:0] disparity_chain[0:NUM_LANES-1];
 wire [NUM_LANES*DATA_PATH_WIDTH*10-1:0] data_s;
 
 always @(posedge clk) begin
-  data <= data_s;
+  data <= INVERT_OUTPUTS ? ~data_s : data_s;
 end
 
 generate

--- a/library/jesd204/jesd204_soft_pcs_tx/jesd204_soft_pcs_tx_hw.tcl
+++ b/library/jesd204/jesd204_soft_pcs_tx/jesd204_soft_pcs_tx_hw.tcl
@@ -51,6 +51,8 @@ ad_ip_create jesd204_soft_pcs_tx "ADI JESD204 Transmit Soft PCS"
 
 set_module_property INTERNAL true
 
+ad_ip_parameter INVERT_OUTPUTS INTEGER 0
+
 # files
 
 ad_ip_files jesd204_soft_pcs_tx [list \

--- a/library/jesd204/tb/soft_pcs_loopback_tb.v
+++ b/library/jesd204/tb/soft_pcs_loopback_tb.v
@@ -45,6 +45,7 @@
 module soft_pcs_loopback_tb;
   parameter VCD_FILE = "soft_pcs_loopback_tb.vcd";
   parameter DATA_PATH_WIDTH = 4;
+  parameter LANE_INVERT = 0;
 
   `include "tb_base.v"
 
@@ -96,7 +97,8 @@ module soft_pcs_loopback_tb;
   end
 
   jesd204_soft_pcs_tx #(
-    .DATA_PATH_WIDTH(DATA_PATH_WIDTH)
+    .DATA_PATH_WIDTH(DATA_PATH_WIDTH),
+    .INVERT_OUTPUTS(LANE_INVERT)
   ) i_soft_pcs_tx (
     .clk(pcs_clk),
     .reset(pcs_reset),
@@ -108,7 +110,8 @@ module soft_pcs_loopback_tb;
   );
 
   jesd204_soft_pcs_rx #(
-    .DATA_PATH_WIDTH(DATA_PATH_WIDTH)
+    .DATA_PATH_WIDTH(DATA_PATH_WIDTH),
+    .INVERT_INPUTS(LANE_INVERT)
   ) i_soft_pcs_rx (
     .clk(pcs_clk),
     .reset(pcs_reset),

--- a/library/xilinx/util_adxcvr/util_adxcvr.v
+++ b/library/xilinx/util_adxcvr/util_adxcvr.v
@@ -59,6 +59,7 @@ module util_adxcvr #(
   parameter   integer TX_NUM_OF_LANES = 8,
   parameter   integer TX_OUT_DIV = 1,
   parameter   integer TX_CLK25_DIV = 20,
+  parameter   integer TX_LANE_INVERT = 0,
 
   // rx-configuration
 
@@ -67,7 +68,8 @@ module util_adxcvr #(
   parameter   integer RX_CLK25_DIV = 20,
   parameter   [15:0]  RX_DFE_LPM_CFG = 16'h0104,
   parameter   [31:0]  RX_PMA_CFG = 32'h001e7080,
-  parameter   [72:0]  RX_CDR_CFG = 72'h0b000023ff10400020) (
+  parameter   [72:0]  RX_CDR_CFG = 72'h0b000023ff10400020,
+  parameter   integer RX_LANE_INVERT = 0) (
 
   input           up_rstn,
   input           up_clk,
@@ -1045,11 +1047,13 @@ module util_adxcvr #(
     .CPLL_FBDIV_4_5 (CPLL_FBDIV_4_5),
     .TX_OUT_DIV (TX_OUT_DIV),
     .TX_CLK25_DIV (TX_CLK25_DIV),
+    .TX_POLARITY ((TX_LANE_INVERT >> 0) & 1),
     .RX_OUT_DIV (RX_OUT_DIV),
     .RX_CLK25_DIV (RX_CLK25_DIV),
     .RX_DFE_LPM_CFG (RX_DFE_LPM_CFG),
     .RX_PMA_CFG (RX_PMA_CFG),
-    .RX_CDR_CFG (RX_CDR_CFG))
+    .RX_CDR_CFG (RX_CDR_CFG),
+    .RX_POLARITY ((RX_LANE_INVERT >> 0) & 1))
   i_xch_0 (
     .qpll2ch_clk (qpll2ch_clk_0),
     .qpll2ch_ref_clk (qpll2ch_ref_clk_0),
@@ -1138,11 +1142,13 @@ module util_adxcvr #(
     .CPLL_FBDIV_4_5 (CPLL_FBDIV_4_5),
     .TX_OUT_DIV (TX_OUT_DIV),
     .TX_CLK25_DIV (TX_CLK25_DIV),
+    .TX_POLARITY ((TX_LANE_INVERT >> 1) & 1),
     .RX_OUT_DIV (RX_OUT_DIV),
     .RX_CLK25_DIV (RX_CLK25_DIV),
     .RX_DFE_LPM_CFG (RX_DFE_LPM_CFG),
     .RX_PMA_CFG (RX_PMA_CFG),
-    .RX_CDR_CFG (RX_CDR_CFG))
+    .RX_CDR_CFG (RX_CDR_CFG),
+    .RX_POLARITY ((RX_LANE_INVERT >> 1) & 1))
   i_xch_1 (
     .qpll2ch_clk (qpll2ch_clk_0),
     .qpll2ch_ref_clk (qpll2ch_ref_clk_0),
@@ -1231,11 +1237,13 @@ module util_adxcvr #(
     .CPLL_FBDIV_4_5 (CPLL_FBDIV_4_5),
     .TX_OUT_DIV (TX_OUT_DIV),
     .TX_CLK25_DIV (TX_CLK25_DIV),
+    .TX_POLARITY ((TX_LANE_INVERT >> 2) & 1),
     .RX_OUT_DIV (RX_OUT_DIV),
     .RX_CLK25_DIV (RX_CLK25_DIV),
     .RX_DFE_LPM_CFG (RX_DFE_LPM_CFG),
     .RX_PMA_CFG (RX_PMA_CFG),
-    .RX_CDR_CFG (RX_CDR_CFG))
+    .RX_CDR_CFG (RX_CDR_CFG),
+    .RX_POLARITY ((RX_LANE_INVERT >> 2) & 1))
   i_xch_2 (
     .qpll2ch_clk (qpll2ch_clk_0),
     .qpll2ch_ref_clk (qpll2ch_ref_clk_0),
@@ -1324,11 +1332,13 @@ module util_adxcvr #(
     .CPLL_FBDIV_4_5 (CPLL_FBDIV_4_5),
     .TX_OUT_DIV (TX_OUT_DIV),
     .TX_CLK25_DIV (TX_CLK25_DIV),
+    .TX_POLARITY ((TX_LANE_INVERT >> 3) & 1),
     .RX_OUT_DIV (RX_OUT_DIV),
     .RX_CLK25_DIV (RX_CLK25_DIV),
     .RX_DFE_LPM_CFG (RX_DFE_LPM_CFG),
     .RX_PMA_CFG (RX_PMA_CFG),
-    .RX_CDR_CFG (RX_CDR_CFG))
+    .RX_CDR_CFG (RX_CDR_CFG),
+    .RX_POLARITY ((RX_LANE_INVERT >> 3) & 1))
   i_xch_3 (
     .qpll2ch_clk (qpll2ch_clk_0),
     .qpll2ch_ref_clk (qpll2ch_ref_clk_0),
@@ -1447,11 +1457,13 @@ module util_adxcvr #(
     .CPLL_FBDIV_4_5 (CPLL_FBDIV_4_5),
     .TX_OUT_DIV (TX_OUT_DIV),
     .TX_CLK25_DIV (TX_CLK25_DIV),
+    .TX_POLARITY ((TX_LANE_INVERT >> 4) & 1),
     .RX_OUT_DIV (RX_OUT_DIV),
     .RX_CLK25_DIV (RX_CLK25_DIV),
     .RX_DFE_LPM_CFG (RX_DFE_LPM_CFG),
     .RX_PMA_CFG (RX_PMA_CFG),
-    .RX_CDR_CFG (RX_CDR_CFG))
+    .RX_CDR_CFG (RX_CDR_CFG),
+    .RX_POLARITY ((RX_LANE_INVERT >> 4) & 1))
   i_xch_4 (
     .qpll2ch_clk (qpll2ch_clk_4),
     .qpll2ch_ref_clk (qpll2ch_ref_clk_4),
@@ -1540,11 +1552,13 @@ module util_adxcvr #(
     .CPLL_FBDIV_4_5 (CPLL_FBDIV_4_5),
     .TX_OUT_DIV (TX_OUT_DIV),
     .TX_CLK25_DIV (TX_CLK25_DIV),
+    .TX_POLARITY ((TX_LANE_INVERT >> 5) & 1),
     .RX_OUT_DIV (RX_OUT_DIV),
     .RX_CLK25_DIV (RX_CLK25_DIV),
     .RX_DFE_LPM_CFG (RX_DFE_LPM_CFG),
     .RX_PMA_CFG (RX_PMA_CFG),
-    .RX_CDR_CFG (RX_CDR_CFG))
+    .RX_CDR_CFG (RX_CDR_CFG),
+    .RX_POLARITY ((RX_LANE_INVERT >> 5) & 1))
   i_xch_5 (
     .qpll2ch_clk (qpll2ch_clk_4),
     .qpll2ch_ref_clk (qpll2ch_ref_clk_4),
@@ -1633,11 +1647,13 @@ module util_adxcvr #(
     .CPLL_FBDIV_4_5 (CPLL_FBDIV_4_5),
     .TX_OUT_DIV (TX_OUT_DIV),
     .TX_CLK25_DIV (TX_CLK25_DIV),
+    .TX_POLARITY ((TX_LANE_INVERT >> 6) & 1),
     .RX_OUT_DIV (RX_OUT_DIV),
     .RX_CLK25_DIV (RX_CLK25_DIV),
     .RX_DFE_LPM_CFG (RX_DFE_LPM_CFG),
     .RX_PMA_CFG (RX_PMA_CFG),
-    .RX_CDR_CFG (RX_CDR_CFG))
+    .RX_CDR_CFG (RX_CDR_CFG),
+    .RX_POLARITY ((RX_LANE_INVERT >> 6) & 1))
   i_xch_6 (
     .qpll2ch_clk (qpll2ch_clk_4),
     .qpll2ch_ref_clk (qpll2ch_ref_clk_4),
@@ -1726,11 +1742,13 @@ module util_adxcvr #(
     .CPLL_FBDIV_4_5 (CPLL_FBDIV_4_5),
     .TX_OUT_DIV (TX_OUT_DIV),
     .TX_CLK25_DIV (TX_CLK25_DIV),
+    .TX_POLARITY ((TX_LANE_INVERT >> 7) & 1),
     .RX_OUT_DIV (RX_OUT_DIV),
     .RX_CLK25_DIV (RX_CLK25_DIV),
     .RX_DFE_LPM_CFG (RX_DFE_LPM_CFG),
     .RX_PMA_CFG (RX_PMA_CFG),
-    .RX_CDR_CFG (RX_CDR_CFG))
+    .RX_CDR_CFG (RX_CDR_CFG),
+    .RX_POLARITY ((RX_LANE_INVERT >> 7) & 1))
   i_xch_7 (
     .qpll2ch_clk (qpll2ch_clk_4),
     .qpll2ch_ref_clk (qpll2ch_ref_clk_4),
@@ -1849,11 +1867,13 @@ module util_adxcvr #(
     .CPLL_FBDIV_4_5 (CPLL_FBDIV_4_5),
     .TX_OUT_DIV (TX_OUT_DIV),
     .TX_CLK25_DIV (TX_CLK25_DIV),
+    .TX_POLARITY ((TX_LANE_INVERT >> 8) & 1),
     .RX_OUT_DIV (RX_OUT_DIV),
     .RX_CLK25_DIV (RX_CLK25_DIV),
     .RX_DFE_LPM_CFG (RX_DFE_LPM_CFG),
     .RX_PMA_CFG (RX_PMA_CFG),
-    .RX_CDR_CFG (RX_CDR_CFG))
+    .RX_CDR_CFG (RX_CDR_CFG),
+    .RX_POLARITY ((RX_LANE_INVERT >> 8) & 1))
   i_xch_8 (
     .qpll2ch_clk (qpll2ch_clk_8),
     .qpll2ch_ref_clk (qpll2ch_ref_clk_8),
@@ -1942,11 +1962,13 @@ module util_adxcvr #(
     .CPLL_FBDIV_4_5 (CPLL_FBDIV_4_5),
     .TX_OUT_DIV (TX_OUT_DIV),
     .TX_CLK25_DIV (TX_CLK25_DIV),
+    .TX_POLARITY ((TX_LANE_INVERT >> 9) & 1),
     .RX_OUT_DIV (RX_OUT_DIV),
     .RX_CLK25_DIV (RX_CLK25_DIV),
     .RX_DFE_LPM_CFG (RX_DFE_LPM_CFG),
     .RX_PMA_CFG (RX_PMA_CFG),
-    .RX_CDR_CFG (RX_CDR_CFG))
+    .RX_CDR_CFG (RX_CDR_CFG),
+    .RX_POLARITY ((RX_LANE_INVERT >> 9) & 1))
   i_xch_9 (
     .qpll2ch_clk (qpll2ch_clk_8),
     .qpll2ch_ref_clk (qpll2ch_ref_clk_8),
@@ -2035,11 +2057,13 @@ module util_adxcvr #(
     .CPLL_FBDIV_4_5 (CPLL_FBDIV_4_5),
     .TX_OUT_DIV (TX_OUT_DIV),
     .TX_CLK25_DIV (TX_CLK25_DIV),
+    .TX_POLARITY ((TX_LANE_INVERT >> 10) & 1),
     .RX_OUT_DIV (RX_OUT_DIV),
     .RX_CLK25_DIV (RX_CLK25_DIV),
     .RX_DFE_LPM_CFG (RX_DFE_LPM_CFG),
     .RX_PMA_CFG (RX_PMA_CFG),
-    .RX_CDR_CFG (RX_CDR_CFG))
+    .RX_CDR_CFG (RX_CDR_CFG),
+    .RX_POLARITY ((RX_LANE_INVERT >> 10) & 1))
   i_xch_10 (
     .qpll2ch_clk (qpll2ch_clk_8),
     .qpll2ch_ref_clk (qpll2ch_ref_clk_8),
@@ -2128,11 +2152,13 @@ module util_adxcvr #(
     .CPLL_FBDIV_4_5 (CPLL_FBDIV_4_5),
     .TX_OUT_DIV (TX_OUT_DIV),
     .TX_CLK25_DIV (TX_CLK25_DIV),
+    .TX_POLARITY ((TX_LANE_INVERT >> 11) & 1),
     .RX_OUT_DIV (RX_OUT_DIV),
     .RX_CLK25_DIV (RX_CLK25_DIV),
     .RX_DFE_LPM_CFG (RX_DFE_LPM_CFG),
     .RX_PMA_CFG (RX_PMA_CFG),
-    .RX_CDR_CFG (RX_CDR_CFG))
+    .RX_CDR_CFG (RX_CDR_CFG),
+    .RX_POLARITY ((RX_LANE_INVERT >> 11) & 1))
   i_xch_11 (
     .qpll2ch_clk (qpll2ch_clk_8),
     .qpll2ch_ref_clk (qpll2ch_ref_clk_8),
@@ -2251,11 +2277,13 @@ module util_adxcvr #(
     .CPLL_FBDIV_4_5 (CPLL_FBDIV_4_5),
     .TX_OUT_DIV (TX_OUT_DIV),
     .TX_CLK25_DIV (TX_CLK25_DIV),
+    .TX_POLARITY ((TX_LANE_INVERT >> 12) & 1),
     .RX_OUT_DIV (RX_OUT_DIV),
     .RX_CLK25_DIV (RX_CLK25_DIV),
     .RX_DFE_LPM_CFG (RX_DFE_LPM_CFG),
     .RX_PMA_CFG (RX_PMA_CFG),
-    .RX_CDR_CFG (RX_CDR_CFG))
+    .RX_CDR_CFG (RX_CDR_CFG),
+    .RX_POLARITY ((RX_LANE_INVERT >> 12) & 1))
   i_xch_12 (
     .qpll2ch_clk (qpll2ch_clk_12),
     .qpll2ch_ref_clk (qpll2ch_ref_clk_12),
@@ -2344,11 +2372,13 @@ module util_adxcvr #(
     .CPLL_FBDIV_4_5 (CPLL_FBDIV_4_5),
     .TX_OUT_DIV (TX_OUT_DIV),
     .TX_CLK25_DIV (TX_CLK25_DIV),
+    .TX_POLARITY ((TX_LANE_INVERT >> 13) & 1),
     .RX_OUT_DIV (RX_OUT_DIV),
     .RX_CLK25_DIV (RX_CLK25_DIV),
     .RX_DFE_LPM_CFG (RX_DFE_LPM_CFG),
     .RX_PMA_CFG (RX_PMA_CFG),
-    .RX_CDR_CFG (RX_CDR_CFG))
+    .RX_CDR_CFG (RX_CDR_CFG),
+    .RX_POLARITY ((RX_LANE_INVERT >> 13) & 1))
   i_xch_13 (
     .qpll2ch_clk (qpll2ch_clk_12),
     .qpll2ch_ref_clk (qpll2ch_ref_clk_12),
@@ -2437,11 +2467,13 @@ module util_adxcvr #(
     .CPLL_FBDIV_4_5 (CPLL_FBDIV_4_5),
     .TX_OUT_DIV (TX_OUT_DIV),
     .TX_CLK25_DIV (TX_CLK25_DIV),
+    .TX_POLARITY ((TX_LANE_INVERT >> 14) & 1),
     .RX_OUT_DIV (RX_OUT_DIV),
     .RX_CLK25_DIV (RX_CLK25_DIV),
     .RX_DFE_LPM_CFG (RX_DFE_LPM_CFG),
     .RX_PMA_CFG (RX_PMA_CFG),
-    .RX_CDR_CFG (RX_CDR_CFG))
+    .RX_CDR_CFG (RX_CDR_CFG),
+    .RX_POLARITY ((RX_LANE_INVERT >> 14) & 1))
   i_xch_14 (
     .qpll2ch_clk (qpll2ch_clk_12),
     .qpll2ch_ref_clk (qpll2ch_ref_clk_12),
@@ -2530,11 +2562,13 @@ module util_adxcvr #(
     .CPLL_FBDIV_4_5 (CPLL_FBDIV_4_5),
     .TX_OUT_DIV (TX_OUT_DIV),
     .TX_CLK25_DIV (TX_CLK25_DIV),
+    .TX_POLARITY ((TX_LANE_INVERT >> 15) & 1),
     .RX_OUT_DIV (RX_OUT_DIV),
     .RX_CLK25_DIV (RX_CLK25_DIV),
     .RX_DFE_LPM_CFG (RX_DFE_LPM_CFG),
     .RX_PMA_CFG (RX_PMA_CFG),
-    .RX_CDR_CFG (RX_CDR_CFG))
+    .RX_CDR_CFG (RX_CDR_CFG),
+    .RX_POLARITY ((RX_LANE_INVERT >> 15) & 1))
   i_xch_15 (
     .qpll2ch_clk (qpll2ch_clk_12),
     .qpll2ch_ref_clk (qpll2ch_ref_clk_12),

--- a/library/xilinx/util_adxcvr/util_adxcvr_xch.v
+++ b/library/xilinx/util_adxcvr/util_adxcvr_xch.v
@@ -46,12 +46,14 @@ module util_adxcvr_xch #(
 
   parameter   integer TX_OUT_DIV = 1,
   parameter   integer TX_CLK25_DIV = 20,
+  parameter   integer TX_POLARITY = 0,
 
   parameter   integer RX_OUT_DIV = 1,
   parameter   integer RX_CLK25_DIV = 20,
   parameter   [15:0]  RX_DFE_LPM_CFG = 16'h0104,
   parameter   [31:0]  RX_PMA_CFG = 32'h001e7080,
-  parameter   [72:0]  RX_CDR_CFG = 72'h0b000023ff10400020) (
+  parameter   [72:0]  RX_CDR_CFG = 72'h0b000023ff10400020,
+  parameter   integer RX_POLARITY = 0) (
 
   // pll interface
 
@@ -658,7 +660,7 @@ module util_adxcvr_xch #(
     .RXPHDLYRESET (1'h0),
     .RXPHOVRDEN (1'h0),
     .RXPMARESET (1'h0),
-    .RXPOLARITY (1'h0),
+    .RXPOLARITY (RX_POLARITY),
     .RXPRBSCNTRESET (1'h0),
     .RXPRBSERR (),
     .RXPRBSSEL (3'h0),
@@ -715,7 +717,7 @@ module util_adxcvr_xch #(
     .TXPHOVRDEN (1'h0),
     .TXPISOPD (1'h0),
     .TXPMARESET (1'h0),
-    .TXPOLARITY (1'h0),
+    .TXPOLARITY (TX_POLARITY),
     .TXPOSTCURSOR (5'h0),
     .TXPOSTCURSORINV (1'h0),
     .TXPRBSFORCEERR (1'h0),
@@ -1369,7 +1371,7 @@ module util_adxcvr_xch #(
     .RXPLLCLKSEL (rx_pll_clk_sel_s),
     .RXPMARESET (1'h0),
     .RXPMARESETDONE (),
-    .RXPOLARITY (1'h0),
+    .RXPOLARITY (RX_POLARITY),
     .RXPRBSCNTRESET (1'h0),
     .RXPRBSERR (),
     .RXPRBSLOCKED (),
@@ -1460,7 +1462,7 @@ module util_adxcvr_xch #(
     .TXPLLCLKSEL (tx_pll_clk_sel_s),
     .TXPMARESET (1'h0),
     .TXPMARESETDONE (),
-    .TXPOLARITY (1'h0),
+    .TXPOLARITY (TX_POLARITY),
     .TXPOSTCURSOR (5'h0),
     .TXPOSTCURSORINV (1'h0),
     .TXPRBSFORCEERR (1'h0),
@@ -2244,7 +2246,7 @@ module util_adxcvr_xch #(
     .RXPLLCLKSEL (rx_pll_clk_sel_s),
     .RXPMARESET (1'd0),
     .RXPMARESETDONE (),
-    .RXPOLARITY (1'd0),
+    .RXPOLARITY (RX_POLARITY),
     .RXPRBSCNTRESET (1'd0),
     .RXPRBSERR (),
     .RXPRBSLOCKED (),
@@ -2343,7 +2345,7 @@ module util_adxcvr_xch #(
     .TXPLLCLKSEL (tx_pll_clk_sel_s),
     .TXPMARESET (1'd0),
     .TXPMARESETDONE (),
-    .TXPOLARITY (1'd0),
+    .TXPOLARITY (TX_POLARITY),
     .TXPOSTCURSOR (5'd0),
     .TXPRBSFORCEERR (1'd0),
     .TXPRBSSEL (4'd0),


### PR DESCRIPTION
Some designs choose to swap the polarity on the JESD204 lanes. This means negative pin of the converter transceiver is connected to the positive pin of the FPGA transceiver and vice versa. One reason for this is layout constraints where the positive and negative traces otherwise have to cross each other.

Such a link will work fine from a electrical perspective, but all bits will be inverted. This series adds a configuration parameter to the link layer component to flip the polarity and undo the inversion that is caused by the electrical wiring.

Since this will typically only affect some of the lanes the configuration parameter is supplied as a mask that allows to select this for each lane individually.