### PR TITLE
jesd204: Add RX error statistics

### DIFF
--- a/library/jesd204/axi_jesd204_rx/axi_jesd204_rx.v
+++ b/library/jesd204/axi_jesd204_rx/axi_jesd204_rx.v
@@ -95,6 +95,11 @@ module axi_jesd204_rx #(
   input core_event_sysref_alignment_error,
   input core_event_sysref_edge,
 
+  output [2:0] core_cfg_err_statistics_mask,
+  output core_cfg_err_statistics_reset,
+
+  input [32*NUM_LANES-1:0] core_status_err_statistics_cnt,
+
   input [1:0] core_status_ctrl_state,
   input [2*NUM_LANES-1:0] core_status_lane_cgs_state,
   input [NUM_LANES-1:0] core_status_lane_ifs_ready,
@@ -260,10 +265,15 @@ jesd204_up_rx #(
   .up_cfg_buffer_early_release(up_cfg_buffer_early_release),
   .up_cfg_buffer_delay(up_cfg_buffer_delay),
 
+  .core_cfg_err_statistics_reset(core_cfg_err_statistics_reset),
+  .core_cfg_err_statistics_mask(core_cfg_err_statistics_mask),
+
   .core_status_ctrl_state(core_status_ctrl_state),
   .core_status_lane_cgs_state(core_status_lane_cgs_state),
   .core_status_lane_ifs_ready(core_status_lane_ifs_ready),
   .core_status_lane_latency(core_status_lane_latency),
+
+  .core_status_err_statistics_cnt(core_status_err_statistics_cnt),
 
   .core_ilas_config_valid(core_ilas_config_valid),
   .core_ilas_config_addr(core_ilas_config_addr),

--- a/library/jesd204/axi_jesd204_rx/axi_jesd204_rx.v
+++ b/library/jesd204/axi_jesd204_rx/axi_jesd204_rx.v
@@ -95,8 +95,8 @@ module axi_jesd204_rx #(
   input core_event_sysref_alignment_error,
   input core_event_sysref_edge,
 
-  output [2:0] core_cfg_err_statistics_mask,
-  output core_cfg_err_statistics_reset,
+  output [2:0] core_ctrl_err_statistics_mask,
+  output core_ctrl_err_statistics_reset,
 
   input [32*NUM_LANES-1:0] core_status_err_statistics_cnt,
 
@@ -265,8 +265,8 @@ jesd204_up_rx #(
   .up_cfg_buffer_early_release(up_cfg_buffer_early_release),
   .up_cfg_buffer_delay(up_cfg_buffer_delay),
 
-  .core_cfg_err_statistics_reset(core_cfg_err_statistics_reset),
-  .core_cfg_err_statistics_mask(core_cfg_err_statistics_mask),
+  .core_ctrl_err_statistics_reset(core_ctrl_err_statistics_reset),
+  .core_ctrl_err_statistics_mask(core_ctrl_err_statistics_mask),
 
   .core_status_ctrl_state(core_status_ctrl_state),
   .core_status_lane_cgs_state(core_status_lane_cgs_state),

--- a/library/jesd204/axi_jesd204_rx/axi_jesd204_rx.v
+++ b/library/jesd204/axi_jesd204_rx/axi_jesd204_rx.v
@@ -106,7 +106,7 @@ module axi_jesd204_rx #(
   input [14*NUM_LANES-1:0] core_status_lane_latency
 );
 
-localparam PCORE_VERSION = 32'h00010161; // 1.01.a
+localparam PCORE_VERSION = 32'h00010261; // 1.02.a
 localparam PCORE_MAGIC = 32'h32303452; // 204R
 
 /* Register interface signals */

--- a/library/jesd204/axi_jesd204_rx/axi_jesd204_rx_constr.sdc
+++ b/library/jesd204/axi_jesd204_rx/axi_jesd204_rx_constr.sdc
@@ -47,6 +47,7 @@ set script_dir [file dirname [info script]]
 source "$script_dir/util_cdc_constr.tcl"
 
 util_cdc_sync_data_constr {*|jesd204_up_rx:i_up_rx|sync_data:i_cdc_status}
+util_cdc_sync_data_constr {*|jesd204_up_rx:i_up_rx|sync_data:i_cdc_cfg}
 util_cdc_sync_event_constr {*|jesd204_up_sysref:i_up_sysref|sync_event:i_cdc_sysref_event}
 util_cdc_sync_bits_constr {*|jesd204_up_rx:i_up_rx|jesd204_up_rx_lane:gen_lane[*].i_up_rx_lane|sync_bits:i_cdc_status_ready}
 

--- a/library/jesd204/axi_jesd204_rx/axi_jesd204_rx_hw.tcl
+++ b/library/jesd204/axi_jesd204_rx/axi_jesd204_rx_hw.tcl
@@ -133,6 +133,8 @@ add_interface_port config core_cfg_lmfc_offset lmfc_offset Output 8
 add_interface_port config core_cfg_octets_per_frame octets_per_frame Output 8
 add_interface_port config core_cfg_sysref_disable sysref_disable Output 1
 add_interface_port config core_cfg_sysref_oneshot sysref_oneshot Output 1
+add_interface_port config core_cfg_err_statistics_reset err_statistics_reset Output 1
+add_interface_port config core_cfg_err_statistics_mask err_statistics_mask Output 3
 
 # status interface
 
@@ -144,6 +146,7 @@ add_interface_port status core_status_ctrl_state ctrl_state Input 2
 add_interface_port status core_status_lane_cgs_state lane_cgs_state Input 2*NUM_LANES
 add_interface_port status core_status_lane_ifs_ready lane_ifs_ready Input NUM_LANES
 add_interface_port status core_status_lane_latency lane_latency Input 14*NUM_LANES
+add_interface_port status core_status_err_statistics_cnt err_statistics_cnt Input 32*NUM_LANES
 
 # event interface
 

--- a/library/jesd204/axi_jesd204_rx/axi_jesd204_rx_hw.tcl
+++ b/library/jesd204/axi_jesd204_rx/axi_jesd204_rx_hw.tcl
@@ -133,8 +133,8 @@ add_interface_port config core_cfg_lmfc_offset lmfc_offset Output 8
 add_interface_port config core_cfg_octets_per_frame octets_per_frame Output 8
 add_interface_port config core_cfg_sysref_disable sysref_disable Output 1
 add_interface_port config core_cfg_sysref_oneshot sysref_oneshot Output 1
-add_interface_port config core_cfg_err_statistics_reset err_statistics_reset Output 1
-add_interface_port config core_cfg_err_statistics_mask err_statistics_mask Output 3
+add_interface_port config core_ctrl_err_statistics_reset err_statistics_reset Output 1
+add_interface_port config core_ctrl_err_statistics_mask err_statistics_mask Output 3
 
 # status interface
 

--- a/library/jesd204/axi_jesd204_rx/axi_jesd204_rx_ip.tcl
+++ b/library/jesd204/axi_jesd204_rx/axi_jesd204_rx_ip.tcl
@@ -82,8 +82,8 @@ adi_add_bus "rx_cfg" "master" \
     { "core_cfg_lmfc_offset" "lmfc_offset" } \
     { "core_cfg_sysref_oneshot" "sysref_oneshot" } \
     { "core_cfg_sysref_disable" "sysref_disable" } \
-    { "core_cfg_err_statistics_reset" "err_statistics_reset" } \
-    { "core_cfg_err_statistics_mask" "err_statistics_mask" } \
+    { "core_ctrl_err_statistics_reset" "err_statistics_reset" } \
+    { "core_ctrl_err_statistics_mask" "err_statistics_mask" } \
     { "core_cfg_buffer_early_release" "buffer_early_release" } \
     { "core_cfg_buffer_delay" "buffer_delay" } \
     { "core_cfg_disable_char_replacement" "disable_char_replacement" } \

--- a/library/jesd204/axi_jesd204_rx/axi_jesd204_rx_ip.tcl
+++ b/library/jesd204/axi_jesd204_rx/axi_jesd204_rx_ip.tcl
@@ -82,6 +82,8 @@ adi_add_bus "rx_cfg" "master" \
     { "core_cfg_lmfc_offset" "lmfc_offset" } \
     { "core_cfg_sysref_oneshot" "sysref_oneshot" } \
     { "core_cfg_sysref_disable" "sysref_disable" } \
+    { "core_cfg_err_statistics_reset" "err_statistics_reset" } \
+    { "core_cfg_err_statistics_mask" "err_statistics_mask" } \
     { "core_cfg_buffer_early_release" "buffer_early_release" } \
     { "core_cfg_buffer_delay" "buffer_delay" } \
     { "core_cfg_disable_char_replacement" "disable_char_replacement" } \
@@ -113,6 +115,7 @@ adi_add_bus "rx_status" "slave" \
     { "core_status_lane_cgs_state" "lane_cgs_state" } \
     { "core_status_lane_ifs_ready" "lane_ifs_ready" } \
     { "core_status_lane_latency" "lane_latency" } \
+    { "core_status_err_statistics_cnt" "err_statistics_cnt" } \
   }
 
 ipx::infer_bus_interface irq xilinx.com:signal:interrupt_rtl:1.0 [ipx::current_core]

--- a/library/jesd204/axi_jesd204_rx/jesd204_up_rx.v
+++ b/library/jesd204/axi_jesd204_rx/jesd204_up_rx.v
@@ -69,8 +69,8 @@ module jesd204_up_rx # (
   input [14*NUM_LANES-1:0] core_status_lane_latency,
 
   input [32*NUM_LANES-1:0] core_status_err_statistics_cnt,
-  output [2:0] core_cfg_err_statistics_mask,
-  output core_cfg_err_statistics_reset,
+  output [2:0] core_ctrl_err_statistics_mask,
+  output core_ctrl_err_statistics_reset,
 
   input up_cfg_is_writeable,
   output reg up_cfg_buffer_early_release,
@@ -84,8 +84,8 @@ wire [2*NUM_LANES-1:0] up_status_lane_cgs_state;
 wire [31:0] up_lane_rdata[0:NUM_LANES-1];
 wire [32*NUM_LANES-1:0] up_status_err_statistics_cnt;
 
-reg up_cfg_err_statistics_reset = 0;
-reg [2:0] up_cfg_err_statistics_mask = 3'h0;
+reg up_ctrl_err_statistics_reset = 0;
+reg [2:0] up_ctrl_err_statistics_mask = 3'h0;
 
 sync_data #(
   .NUM_OF_BITS(2+NUM_LANES*(2+32))
@@ -109,13 +109,13 @@ sync_data #(
 ) i_cdc_cfg (
   .in_clk(up_clk),
   .in_data({
-    up_cfg_err_statistics_mask,
-    up_cfg_err_statistics_reset
+    up_ctrl_err_statistics_mask,
+    up_ctrl_err_statistics_reset
   }),
   .out_clk(core_clk),
   .out_data({
-    core_cfg_err_statistics_mask,
-    core_cfg_err_statistics_reset
+    core_ctrl_err_statistics_mask,
+    core_ctrl_err_statistics_reset
   })
 );
 
@@ -136,9 +136,9 @@ always @(*) begin
   };
   12'h91: up_rdata <= {
     /* 11-31 */ 21'h00, /* Reserved for future additions */
-    /* 08-10 */ up_cfg_err_statistics_mask,
+    /* 08-10 */ up_ctrl_err_statistics_mask,
     /* 01-07 */ 7'h0,
-    /*    00 */ up_cfg_err_statistics_reset
+    /*    00 */ up_ctrl_err_statistics_reset
   };
   /* 0x92-0x9f reserved for future use */
 
@@ -163,8 +163,8 @@ always @(posedge up_clk) begin
   if (up_reset == 1'b1) begin
     up_cfg_buffer_early_release <= 1'b0;
     up_cfg_buffer_delay <= 'h00;
-    up_cfg_err_statistics_mask <= 3'h0;
-    up_cfg_err_statistics_reset <= 1'b0;
+    up_ctrl_err_statistics_mask <= 3'h0;
+    up_ctrl_err_statistics_reset <= 1'b0;
   end else if (up_wreq == 1'b1 && up_cfg_is_writeable == 1'b1) begin
     case (up_waddr)
     /* JESD RX configuraton */
@@ -176,8 +176,8 @@ always @(posedge up_clk) begin
   end else if (up_wreq == 1'b1) begin
     case (up_waddr)
     12'h91: begin
-      up_cfg_err_statistics_mask <= up_wdata[10:8];
-      up_cfg_err_statistics_reset <= up_wdata[0];
+      up_ctrl_err_statistics_mask <= up_wdata[10:8];
+      up_ctrl_err_statistics_reset <= up_wdata[0];
     end
     endcase
   end

--- a/library/jesd204/axi_jesd204_rx/jesd204_up_rx.v
+++ b/library/jesd204/axi_jesd204_rx/jesd204_up_rx.v
@@ -69,7 +69,7 @@ module jesd204_up_rx # (
   input [14*NUM_LANES-1:0] core_status_lane_latency,
 
   input [32*NUM_LANES-1:0] core_status_err_statistics_cnt,
-  output[2:0] core_cfg_err_statistics_mask,
+  output [2:0] core_cfg_err_statistics_mask,
   output core_cfg_err_statistics_reset,
 
   input up_cfg_is_writeable,
@@ -84,11 +84,11 @@ wire [2*NUM_LANES-1:0] up_status_lane_cgs_state;
 wire [31:0] up_lane_rdata[0:NUM_LANES-1];
 wire [32*NUM_LANES-1:0] up_status_err_statistics_cnt;
 
-reg up_cfg_err_statistics_reset;
-reg [2:0]up_cfg_err_statistics_mask;
+reg up_cfg_err_statistics_reset = 0;
+reg [2:0] up_cfg_err_statistics_mask = 3'h0;
 
 sync_data #(
-  .NUM_OF_BITS(2+NUM_LANES*(2)+NUM_LANES*(32))
+  .NUM_OF_BITS(2+NUM_LANES*(2+32))
 ) i_cdc_status (
   .in_clk(core_clk),
   .in_data({
@@ -135,9 +135,9 @@ always @(*) begin
     /* 00-01 */ 2'b00 /* Data path width alignment */
   };
   12'h91: up_rdata <= {
-    /* 12-31 */ 21'h00, /* Reserved for future additions */
-    /* 08-11*/ up_cfg_err_statistics_mask,
-    /* 01-08 */ 7'h0,
+    /* 11-31 */ 21'h00, /* Reserved for future additions */
+    /* 08-10 */ up_cfg_err_statistics_mask,
+    /* 01-07 */ 7'h0,
     /*    00 */ up_cfg_err_statistics_reset
   };
   /* 0x92-0x9f reserved for future use */
@@ -194,7 +194,7 @@ generate for (i = 0; i < NUM_LANES; i = i + 1) begin: gen_lane
       .up_rdata(up_lane_rdata[i]),
 
       .up_status_cgs_state(up_status_lane_cgs_state[2*i+1:2*i]),
-      .up_status_err_statistics_cnt(up_status_err_statistics_cnt[32*(i+1)-1:32*i]),
+      .up_status_err_statistics_cnt(up_status_err_statistics_cnt[32*i+31:32*i]),
 
       .core_clk(core_clk),
       .core_reset(core_reset),

--- a/library/jesd204/axi_jesd204_rx/jesd204_up_rx.v
+++ b/library/jesd204/axi_jesd204_rx/jesd204_up_rx.v
@@ -68,6 +68,10 @@ module jesd204_up_rx # (
   input [NUM_LANES-1:0] core_status_lane_ifs_ready,
   input [14*NUM_LANES-1:0] core_status_lane_latency,
 
+  input [32*NUM_LANES-1:0] core_status_err_statistics_cnt,
+  output[2:0] core_cfg_err_statistics_mask,
+  output core_cfg_err_statistics_reset,
+
   input up_cfg_is_writeable,
   output reg up_cfg_buffer_early_release,
   output reg [7:0] up_cfg_buffer_delay
@@ -78,19 +82,40 @@ localparam ELASTIC_BUFFER_SIZE = 256;
 wire [1:0] up_status_ctrl_state;
 wire [2*NUM_LANES-1:0] up_status_lane_cgs_state;
 wire [31:0] up_lane_rdata[0:NUM_LANES-1];
+wire [32*NUM_LANES-1:0] up_status_err_statistics_cnt;
+
+reg up_cfg_err_statistics_reset;
+reg [2:0]up_cfg_err_statistics_mask;
 
 sync_data #(
-  .NUM_OF_BITS(2+NUM_LANES*(2))
+  .NUM_OF_BITS(2+NUM_LANES*(2)+NUM_LANES*(32))
 ) i_cdc_status (
   .in_clk(core_clk),
   .in_data({
+    core_status_err_statistics_cnt,
     core_status_ctrl_state,
     core_status_lane_cgs_state
   }),
   .out_clk(up_clk),
   .out_data({
+    up_status_err_statistics_cnt,
     up_status_ctrl_state,
     up_status_lane_cgs_state
+  })
+);
+
+sync_data #(
+  .NUM_OF_BITS(4)
+) i_cdc_cfg (
+  .in_clk(up_clk),
+  .in_data({
+    up_cfg_err_statistics_mask,
+    up_cfg_err_statistics_reset
+  }),
+  .out_clk(core_clk),
+  .out_data({
+    core_cfg_err_statistics_mask,
+    core_cfg_err_statistics_reset
   })
 );
 
@@ -109,7 +134,13 @@ always @(*) begin
     /* 02-09 */ up_cfg_buffer_delay, /* Buffer release delay */
     /* 00-01 */ 2'b00 /* Data path width alignment */
   };
-  /* 0x91-0x9f reserved for future use */
+  12'h91: up_rdata <= {
+    /* 12-31 */ 21'h00, /* Reserved for future additions */
+    /* 08-11*/ up_cfg_err_statistics_mask,
+    /* 01-08 */ 7'h0,
+    /*    00 */ up_cfg_err_statistics_reset
+  };
+  /* 0x92-0x9f reserved for future use */
 
   /* JESD RX status */
   12'ha0: up_rdata <= {
@@ -132,12 +163,21 @@ always @(posedge up_clk) begin
   if (up_reset == 1'b1) begin
     up_cfg_buffer_early_release <= 1'b0;
     up_cfg_buffer_delay <= 'h00;
+    up_cfg_err_statistics_mask <= 3'h0;
+    up_cfg_err_statistics_reset <= 1'b0;
   end else if (up_wreq == 1'b1 && up_cfg_is_writeable == 1'b1) begin
     case (up_waddr)
     /* JESD RX configuraton */
     12'h090: begin
       up_cfg_buffer_early_release <= up_wdata[16];
       up_cfg_buffer_delay <= up_wdata[9:2];
+    end
+    endcase
+  end else if (up_wreq == 1'b1) begin
+    case (up_waddr)
+    12'h91: begin
+      up_cfg_err_statistics_mask <= up_wdata[10:8];
+      up_cfg_err_statistics_reset <= up_wdata[0];
     end
     endcase
   end
@@ -154,6 +194,7 @@ generate for (i = 0; i < NUM_LANES; i = i + 1) begin: gen_lane
       .up_rdata(up_lane_rdata[i]),
 
       .up_status_cgs_state(up_status_lane_cgs_state[2*i+1:2*i]),
+      .up_status_err_statistics_cnt(up_status_err_statistics_cnt[32*(i+1)-1:32*i]),
 
       .core_clk(core_clk),
       .core_reset(core_reset),

--- a/library/jesd204/axi_jesd204_rx/jesd204_up_rx_lane.v
+++ b/library/jesd204/axi_jesd204_rx/jesd204_up_rx_lane.v
@@ -51,6 +51,7 @@ module jesd204_up_rx_lane (
   output reg [31:0] up_rdata,
 
   input [1:0] up_status_cgs_state,
+  input [31:0] up_status_err_statistics_cnt,
 
   input core_clk,
   input core_reset,
@@ -113,6 +114,9 @@ always @(*) begin
     2'b01: up_rdata <= {
       /* 14-31 */ 18'h00, /* Reserved for future use */
       /* 00-13 */ up_status_latency
+    };
+    2'b10: up_rdata <= {
+      /* 00-31 */ up_status_err_statistics_cnt
     };
     default: up_rdata <= 'h00;
     endcase

--- a/library/jesd204/interfaces/interfaces_ip.tcl
+++ b/library/jesd204/interfaces/interfaces_ip.tcl
@@ -88,6 +88,8 @@ adi_if_ports output 1 buffer_early_release
 adi_if_ports output 1 buffer_delay
 adi_if_ports output 1 disable_char_replacement
 adi_if_ports output 1 disable_scrambler
+adi_if_ports output 1 err_statistics_reset
+adi_if_ports output 3 err_statistics_mask
 
 adi_if_define "jesd204_rx_status"
 adi_if_ports output 3 ctrl_state
@@ -96,6 +98,7 @@ adi_if_ports output -1 lane_frame_align
 adi_if_ports output -1 lane_ifs_ready
 adi_if_ports output -1 lane_latency_ready
 adi_if_ports output -1 lane_latency
+adi_if_ports output -1 err_statistics_cnt
 
 adi_if_define "jesd204_rx_ilas_config"
 adi_if_ports output -1 valid

--- a/library/jesd204/jesd204_rx/jesd204_rx.v
+++ b/library/jesd204/jesd204_rx/jesd204_rx.v
@@ -82,8 +82,8 @@ module jesd204_rx #(
   input cfg_disable_char_replacement,
   input cfg_disable_scrambler,
 
-  input cfg_err_statistics_reset,
-  input [2:0] cfg_err_statistics_mask,
+  input ctrl_err_statistics_reset,
+  input [2:0] ctrl_err_statistics_mask,
 
   output [32*NUM_LANES-1:0] status_err_statistics_cnt,
 
@@ -310,8 +310,8 @@ for (i = 0; i < NUM_LANES; i = i + 1) begin: gen_lane
     .buffer_release_n(buffer_release_n),
     .buffer_ready_n(buffer_ready_n[i]),
 
-    .cfg_err_statistics_reset(cfg_err_statistics_reset),
-    .cfg_err_statistics_mask(cfg_err_statistics_mask),
+    .ctrl_err_statistics_reset(ctrl_err_statistics_reset),
+    .ctrl_err_statistics_mask(ctrl_err_statistics_mask),
     .status_err_statistics_cnt(status_err_statistics_cnt[32*i+31:32*i]),
 
     .ilas_config_valid(ilas_config_valid[i]),

--- a/library/jesd204/jesd204_rx/jesd204_rx.v
+++ b/library/jesd204/jesd204_rx/jesd204_rx.v
@@ -312,7 +312,7 @@ for (i = 0; i < NUM_LANES; i = i + 1) begin: gen_lane
 
     .cfg_err_statistics_reset(cfg_err_statistics_reset),
     .cfg_err_statistics_mask(cfg_err_statistics_mask),
-    .status_err_statistics_cnt(status_err_statistics_cnt[32*(i+1)-1:32*i]),
+    .status_err_statistics_cnt(status_err_statistics_cnt[32*i+31:32*i]),
 
     .ilas_config_valid(ilas_config_valid[i]),
     .ilas_config_addr(ilas_config_addr[2*i+1:2*i]),

--- a/library/jesd204/jesd204_rx/jesd204_rx.v
+++ b/library/jesd204/jesd204_rx/jesd204_rx.v
@@ -82,6 +82,11 @@ module jesd204_rx #(
   input cfg_disable_char_replacement,
   input cfg_disable_scrambler,
 
+  input cfg_err_statistics_reset,
+  input [2:0] cfg_err_statistics_mask,
+
+  output [32*NUM_LANES-1:0] status_err_statistics_cnt,
+
   output [NUM_LANES-1:0] ilas_config_valid,
   output [NUM_LANES*2-1:0] ilas_config_addr,
   output [NUM_LANES*32-1:0] ilas_config_data,
@@ -304,6 +309,10 @@ for (i = 0; i < NUM_LANES; i = i + 1) begin: gen_lane
 
     .buffer_release_n(buffer_release_n),
     .buffer_ready_n(buffer_ready_n[i]),
+
+    .cfg_err_statistics_reset(cfg_err_statistics_reset),
+    .cfg_err_statistics_mask(cfg_err_statistics_mask),
+    .status_err_statistics_cnt(status_err_statistics_cnt[32*(i+1)-1:32*i]),
 
     .ilas_config_valid(ilas_config_valid[i]),
     .ilas_config_addr(ilas_config_addr[2*i+1:2*i]),

--- a/library/jesd204/jesd204_rx/jesd204_rx_hw.tcl
+++ b/library/jesd204/jesd204_rx/jesd204_rx_hw.tcl
@@ -129,6 +129,8 @@ add_interface_port config cfg_lmfc_offset lmfc_offset Input 8
 add_interface_port config cfg_octets_per_frame octets_per_frame Input 8
 add_interface_port config cfg_sysref_disable sysref_disable Input 1
 add_interface_port config cfg_sysref_oneshot sysref_oneshot Input 1
+add_interface_port config cfg_err_statistics_reset err_statistics_reset Input 1
+add_interface_port config cfg_err_statistics_mask err_statistics_mask Input 3
 
 # status interface
 
@@ -140,6 +142,7 @@ add_interface_port status status_ctrl_state ctrl_state Output 2
 add_interface_port status status_lane_cgs_state lane_cgs_state Output 2*NUM_LANES
 add_interface_port status status_lane_ifs_ready lane_ifs_ready Output NUM_LANES
 add_interface_port status status_lane_latency lane_latency Output 14*NUM_LANES
+add_interface_port status status_err_statistics_cnt err_statistics_cnt Output 32*NUM_LANES
 
 # event interface
 

--- a/library/jesd204/jesd204_rx/jesd204_rx_hw.tcl
+++ b/library/jesd204/jesd204_rx/jesd204_rx_hw.tcl
@@ -129,8 +129,8 @@ add_interface_port config cfg_lmfc_offset lmfc_offset Input 8
 add_interface_port config cfg_octets_per_frame octets_per_frame Input 8
 add_interface_port config cfg_sysref_disable sysref_disable Input 1
 add_interface_port config cfg_sysref_oneshot sysref_oneshot Input 1
-add_interface_port config cfg_err_statistics_reset err_statistics_reset Input 1
-add_interface_port config cfg_err_statistics_mask err_statistics_mask Input 3
+add_interface_port config ctrl_err_statistics_reset err_statistics_reset Input 1
+add_interface_port config ctrl_err_statistics_mask err_statistics_mask Input 3
 
 # status interface
 

--- a/library/jesd204/jesd204_rx/jesd204_rx_ip.tcl
+++ b/library/jesd204/jesd204_rx/jesd204_rx_ip.tcl
@@ -104,6 +104,8 @@ adi_add_bus "rx_cfg" "slave" \
     { "cfg_buffer_delay" "buffer_delay" } \
     { "cfg_buffer_early_release" "buffer_early_release" } \
     { "cfg_disable_char_replacement" "disable_char_replacement" } \
+    { "cfg_err_statistics_reset" "err_statistics_reset" } \
+    { "cfg_err_statistics_mask" "err_statistics_mask" } \
     { "cfg_disable_scrambler" "disable_scrambler" } \
   }
 
@@ -113,6 +115,7 @@ adi_add_bus "rx_status" "master" \
   { \
     { "status_ctrl_state" "ctrl_state" } \
     { "status_lane_cgs_state" "lane_cgs_state" } \
+    { "status_err_statistics_cnt" "err_statistics_cnt" } \
     { "status_lane_ifs_ready" "lane_ifs_ready" } \
     { "status_lane_latency" "lane_latency" } \
   }

--- a/library/jesd204/jesd204_rx/jesd204_rx_ip.tcl
+++ b/library/jesd204/jesd204_rx/jesd204_rx_ip.tcl
@@ -104,8 +104,8 @@ adi_add_bus "rx_cfg" "slave" \
     { "cfg_buffer_delay" "buffer_delay" } \
     { "cfg_buffer_early_release" "buffer_early_release" } \
     { "cfg_disable_char_replacement" "disable_char_replacement" } \
-    { "cfg_err_statistics_reset" "err_statistics_reset" } \
-    { "cfg_err_statistics_mask" "err_statistics_mask" } \
+    { "ctrl_err_statistics_reset" "err_statistics_reset" } \
+    { "ctrl_err_statistics_mask" "err_statistics_mask" } \
     { "cfg_disable_scrambler" "disable_scrambler" } \
   }
 

--- a/library/jesd204/jesd204_rx/jesd204_rx_lane.v
+++ b/library/jesd204/jesd204_rx/jesd204_rx_lane.v
@@ -73,8 +73,8 @@ module jesd204_rx_lane #(
   output [1:0] ilas_config_addr,
   output [DATA_PATH_WIDTH*8-1:0] ilas_config_data,
 
-  input cfg_err_statistics_reset,
-  input [2:0]cfg_err_statistics_mask,
+  input ctrl_err_statistics_reset,
+  input [2:0]ctrl_err_statistics_mask,
   output reg [31:0] status_err_statistics_cnt,
 
   output [1:0] status_cgs_state,
@@ -146,17 +146,17 @@ end
 endgenerate
 
 always @(posedge clk) begin
-  if (cfg_err_statistics_mask[0] == 1'b1) begin
+  if (ctrl_err_statistics_mask[0] == 1'b1) begin
     phy_disperr_cnt <= phy_disperr[0] + phy_disperr[1] + phy_disperr[2] + phy_disperr[3];
   end else begin
     phy_disperr_cnt <= 3'h0;
   end
-  if (cfg_err_statistics_mask[1] == 1'b1) begin
+  if (ctrl_err_statistics_mask[1] == 1'b1) begin
     phy_notintable_cnt <= phy_notintable[0] + phy_notintable[1] + phy_notintable[2] + phy_notintable[3];
   end else begin
     phy_notintable_cnt <= 3'h0;
   end
-  if (cfg_err_statistics_mask[2] == 1'b1) begin
+  if (ctrl_err_statistics_mask[2] == 1'b1) begin
     phy_unexpectedk_cnt <= unexpected_char[0] + unexpected_char[1] + unexpected_char[2] + unexpected_char[3];
   end else begin
     phy_unexpectedk_cnt <= 3'h0;
@@ -164,7 +164,7 @@ always @(posedge clk) begin
 end
 
 always @(posedge clk) begin
-  if (cfg_err_statistics_reset == 1'b1 || cgs_ready == 1'b0) begin
+  if (ctrl_err_statistics_reset == 1'b1 || cgs_ready == 1'b0) begin
     status_err_statistics_cnt <= 32'h0;
   end else if (status_err_statistics_cnt[31:4] != 28'hfffffff) begin
     status_err_statistics_cnt <= status_err_statistics_cnt + phy_notintable_cnt + phy_disperr_cnt + phy_unexpectedk_cnt;

--- a/library/jesd204/jesd204_rx/jesd204_rx_lane.v
+++ b/library/jesd204/jesd204_rx/jesd204_rx_lane.v
@@ -146,17 +146,17 @@ end
 endgenerate
 
 always @(posedge clk) begin
-  if (ctrl_err_statistics_mask[0] == 1'b1) begin
+  if (ctrl_err_statistics_mask[0] == 1'b0 && cgs_ready == 1'b1) begin
     phy_disperr_cnt <= phy_disperr[0] + phy_disperr[1] + phy_disperr[2] + phy_disperr[3];
   end else begin
     phy_disperr_cnt <= 3'h0;
   end
-  if (ctrl_err_statistics_mask[1] == 1'b1) begin
+  if (ctrl_err_statistics_mask[1] == 1'b0 && cgs_ready == 1'b1) begin
     phy_notintable_cnt <= phy_notintable[0] + phy_notintable[1] + phy_notintable[2] + phy_notintable[3];
   end else begin
     phy_notintable_cnt <= 3'h0;
   end
-  if (ctrl_err_statistics_mask[2] == 1'b1) begin
+  if (ctrl_err_statistics_mask[2] == 1'b0 && cgs_ready == 1'b1) begin
     phy_unexpectedk_cnt <= unexpected_char[0] + unexpected_char[1] + unexpected_char[2] + unexpected_char[3];
   end else begin
     phy_unexpectedk_cnt <= 3'h0;
@@ -164,7 +164,7 @@ always @(posedge clk) begin
 end
 
 always @(posedge clk) begin
-  if (ctrl_err_statistics_reset == 1'b1 || cgs_ready == 1'b0) begin
+  if (ctrl_err_statistics_reset == 1'b1) begin
     status_err_statistics_cnt <= 32'h0;
   end else if (status_err_statistics_cnt[31:4] != 28'hfffffff) begin
     status_err_statistics_cnt <= status_err_statistics_cnt + phy_notintable_cnt + phy_disperr_cnt + phy_unexpectedk_cnt;

--- a/library/jesd204/jesd204_rx/jesd204_rx_lane.v
+++ b/library/jesd204/jesd204_rx/jesd204_rx_lane.v
@@ -166,10 +166,8 @@ end
 always @(posedge clk) begin
   if (cfg_err_statistics_reset == 1'b1 || cgs_ready == 1'b0) begin
     status_err_statistics_cnt <= 32'h0;
-  end else begin
-    if (status_err_statistics_cnt[31:4] != 28'hfffffff) begin
-      status_err_statistics_cnt <= status_err_statistics_cnt + phy_notintable_cnt + phy_disperr_cnt + phy_unexpectedk_cnt;
-    end
+  end else if (status_err_statistics_cnt[31:4] != 28'hfffffff) begin
+    status_err_statistics_cnt <= status_err_statistics_cnt + phy_notintable_cnt + phy_disperr_cnt + phy_unexpectedk_cnt;
   end
 end
 

--- a/library/jesd204/jesd204_rx/jesd204_rx_lane.v
+++ b/library/jesd204/jesd204_rx/jesd204_rx_lane.v
@@ -146,17 +146,17 @@ end
 endgenerate
 
 always @(posedge clk) begin
-  if (cfg_err_statistics_mask[0] == 1) begin
+  if (cfg_err_statistics_mask[0] == 1'b1) begin
     phy_disperr_cnt <= phy_disperr[0] + phy_disperr[1] + phy_disperr[2] + phy_disperr[3];
   end else begin
     phy_disperr_cnt <= 2'h0;
   end
-  if (cfg_err_statistics_mask[1] == 1) begin
+  if (cfg_err_statistics_mask[1] == 1'b1) begin
     phy_notintable_cnt <= phy_notintable[0] + phy_notintable[1] + phy_notintable[2] + phy_notintable[3];
   end else begin
     phy_notintable_cnt <= 2'h0;
   end
-  if (cfg_err_statistics_mask[2] == 1) begin
+  if (cfg_err_statistics_mask[2] == 1'b1) begin
     phy_unexpectedk_cnt <= unexpected_char[0] + unexpected_char[1] + unexpected_char[2] + unexpected_char[3];
   end else begin
     phy_unexpectedk_cnt <= 2'h0;

--- a/library/jesd204/jesd204_rx/jesd204_rx_lane.v
+++ b/library/jesd204/jesd204_rx/jesd204_rx_lane.v
@@ -104,9 +104,9 @@ wire [DATA_PATH_WIDTH*8-1:0] data_scrambled_s;
 wire [DATA_PATH_WIDTH*8-1:0] data_scrambled;
 
 reg  [DATA_PATH_WIDTH-1:0] unexpected_char;
-reg  [1:0] phy_disperr_cnt;
-reg  [1:0] phy_notintable_cnt;
-reg  [1:0] phy_unexpectedk_cnt;
+reg  [2:0] phy_disperr_cnt;
+reg  [2:0] phy_notintable_cnt;
+reg  [2:0] phy_unexpectedk_cnt;
 
 wire ilas_monitor_reset_s;
 wire ilas_monitor_reset;
@@ -149,17 +149,17 @@ always @(posedge clk) begin
   if (cfg_err_statistics_mask[0] == 1'b1) begin
     phy_disperr_cnt <= phy_disperr[0] + phy_disperr[1] + phy_disperr[2] + phy_disperr[3];
   end else begin
-    phy_disperr_cnt <= 2'h0;
+    phy_disperr_cnt <= 3'h0;
   end
   if (cfg_err_statistics_mask[1] == 1'b1) begin
     phy_notintable_cnt <= phy_notintable[0] + phy_notintable[1] + phy_notintable[2] + phy_notintable[3];
   end else begin
-    phy_notintable_cnt <= 2'h0;
+    phy_notintable_cnt <= 3'h0;
   end
   if (cfg_err_statistics_mask[2] == 1'b1) begin
     phy_unexpectedk_cnt <= unexpected_char[0] + unexpected_char[1] + unexpected_char[2] + unexpected_char[3];
   end else begin
-    phy_unexpectedk_cnt <= 2'h0;
+    phy_unexpectedk_cnt <= 3'h0;
   end
 end
 

--- a/library/jesd204/tb/axi_jesd204_rx_regmap_tb.v
+++ b/library/jesd204/tb/axi_jesd204_rx_regmap_tb.v
@@ -350,8 +350,8 @@ module axi_jesd204_rx_tb;
     .core_event_sysref_edge(1'b0),
 
     .core_status_err_statistics_cnt(),
-    .core_cfg_err_statistics_mask(),
-    .core_cfg_err_statistics_reset(),
+    .core_ctrl_err_statistics_mask(),
+    .core_ctrl_err_statistics_reset(),
 
     .core_status_ctrl_state(2'b00),
     .core_status_lane_cgs_state(4'b0000),

--- a/library/jesd204/tb/axi_jesd204_rx_regmap_tb.v
+++ b/library/jesd204/tb/axi_jesd204_rx_regmap_tb.v
@@ -349,6 +349,10 @@ module axi_jesd204_rx_tb;
     .core_event_sysref_alignment_error(1'b0),
     .core_event_sysref_edge(1'b0),
 
+    .core_status_err_statistics_cnt(),
+    .core_cfg_err_statistics_mask(),
+    .core_cfg_err_statistics_reset(),
+
     .core_status_ctrl_state(2'b00),
     .core_status_lane_cgs_state(4'b0000),
     .core_status_lane_ifs_ready({NUM_LANES{1'b0}}),

--- a/library/jesd204/tb/rx_lane_tb.v
+++ b/library/jesd204/tb/rx_lane_tb.v
@@ -134,8 +134,8 @@ module rx_lane_tb;
     .ilas_config_addr(ilas_config_addr),
     .ilas_config_data(ilas_config_data),
 
-    .cfg_err_statistics_reset(1'b0),
-    .cfg_err_statistics_mask(3'h7),
+    .ctrl_err_statistics_reset(1'b0),
+    .ctrl_err_statistics_mask(3'h7),
     .status_err_statistics_cnt(status_err_statistics_cnt),
 
     .status_cgs_state(status_cgs_state),

--- a/library/jesd204/tb/rx_lane_tb.v
+++ b/library/jesd204/tb/rx_lane_tb.v
@@ -49,17 +49,42 @@ module rx_lane_tb;
 
   reg [31:0] data = {4{{3'd5,5'd28}}};
   reg [3:0] disperr = 4'b0000;
+  reg [3:0] notintable = 4'b0000;
   reg [3:0] charisk = 4'b1111;
+
+  wire ilas_config_valid;
+  wire [1:0] ilas_config_addr;
+  wire [4*8-1:0] ilas_config_data;
+  wire [31:0] status_err_statistics_cnt;
+
+  wire [4*8-1:0] rx_data;
+
+  wire [1:0] status_cgs_state;
+  wire status_ifs_ready;
+  wire [1:0] status_frame_align;
 
   integer counter = 'h00;
   wire [31:0] counter2 = (counter - 'h20) * 4;
 
-/*  always @(posedge clk) begin
-    if ($random % 10 == 0)
+  always @(posedge clk) begin
+    if ($urandom % 400 == 0)
       disperr <= 4'b1111;
+    else if ($urandom % 400 == 1)
+      disperr <= 4'b0001;
+    else if ($urandom % 400 == 2)
+      disperr <= 4'b0011;
+    else if ($urandom % 400 == 3)
+      disperr <= 4'b0111;
     else
       disperr <= 4'b0000;
-  end*/
+  end
+
+  always @(posedge clk) begin
+    if ($random % 500 == 0)
+      notintable <= 4'b1111;
+    else
+      notintable <= 4'b0000;
+  end
 
   always @(posedge clk) begin
     counter <= counter + 1;
@@ -87,18 +112,35 @@ module rx_lane_tb;
 
   jesd204_rx_lane i_rx_lane (
     .clk(clk),
+    .reset(1'b0),
 
     .phy_data(data),
     .phy_charisk(charisk),
     .phy_disperr(disperr),
-    .phy_notintable(4'b0000),
+    .phy_notintable(notintable),
 
     .cgs_reset(reset),
+    .cgs_ready(),
+
+    .ifs_reset(1'b0),
+
+    .rx_data(rx_data),
 
     .buffer_release_n(buffer_release_n),
     .buffer_ready_n(buffer_ready_n),
 
-    .cfg_disable_scrambler(1'b0)
+    .cfg_disable_scrambler(1'b0),
+    .ilas_config_valid(ilas_config_valid),
+    .ilas_config_addr(ilas_config_addr),
+    .ilas_config_data(ilas_config_data),
+
+    .cfg_err_statistics_reset(1'b0),
+    .cfg_err_statistics_mask(3'h7),
+    .status_err_statistics_cnt(status_err_statistics_cnt),
+
+    .status_cgs_state(status_cgs_state),
+    .status_ifs_ready(status_ifs_ready),
+    .status_frame_align(status_frame_align)
   );
 
 endmodule

--- a/library/jesd204/tb/rx_tb.v
+++ b/library/jesd204/tb/rx_tb.v
@@ -145,6 +145,20 @@ module rx_tb;
   wire cfg_disable_scrambler;
   wire cfg_buffer_early_release;
 
+  always @(posedge clk) begin
+    if ($urandom % 400 == 0)
+      disperr <= 4'b1111;
+    else if ($urandom % 400 == 1)
+      disperr <= 4'b0001;
+    else if ($urandom % 400 == 2)
+      disperr <= 4'b0011;
+    else if ($urandom % 400 == 3)
+      disperr <= 4'b0111;
+    else
+      disperr <= 4'b0000;
+  end
+  wire [NUM_LANES*32-1:0] status_err_statistics_cnt;
+
   jesd204_rx_static_config #(
     .NUM_LANES(NUM_LANES),
     .NUM_LINKS(NUM_LINKS),
@@ -181,13 +195,17 @@ module rx_tb;
     .cfg_disable_scrambler(cfg_disable_scrambler),
     .cfg_buffer_early_release(cfg_buffer_early_release),
 
+    .cfg_err_statistics_reset(1'b0),
+    .cfg_err_statistics_mask(3'h7),
+
+    .status_err_statistics_cnt(status_err_statistics_cnt),
+
     .phy_en_char_align(en_align),
 
     .phy_data({NUM_LANES{data}}),
     .phy_charisk({NUM_LANES{charisk}}),
     .phy_notintable({NUM_LANES{notintable}}),
     .phy_disperr({NUM_LANES{disperr}}),
-
     .sync(sync),
     .sysref(sysref)
   );

--- a/library/jesd204/tb/rx_tb.v
+++ b/library/jesd204/tb/rx_tb.v
@@ -195,8 +195,8 @@ module rx_tb;
     .cfg_disable_scrambler(cfg_disable_scrambler),
     .cfg_buffer_early_release(cfg_buffer_early_release),
 
-    .cfg_err_statistics_reset(1'b0),
-    .cfg_err_statistics_mask(3'h7),
+    .ctrl_err_statistics_reset(1'b0),
+    .ctrl_err_statistics_mask(3'h7),
 
     .status_err_statistics_cnt(status_err_statistics_cnt),
 


### PR DESCRIPTION
Added 32 bit error countr per lane, register 0x308 + lane*0x20

On the control part,register 0x244 added a counter reset and counter mask
Bit 0 resets the counter if set to 1
Bit 8 masks the disparity errors, when set to 0
Bit 9 masks the not in table errors when set to 0
Bit 10 masks the unexpected k errors

At this point, the unexpected K errors are counted when a character other than k28 is detected
The counter starts adding the errors when the CGS phase is complete