### PR TITLE
adi_ip.tcl: reorder synthesis files in the file group

### DIFF
--- a/library/scripts/adi_ip.tcl
+++ b/library/scripts/adi_ip.tcl
@@ -23,6 +23,7 @@ proc adi_ip_ttcl {ip_name ip_constr_files} {
   set_property -dict [list \
     type ttcl \
   ] $f
+  ipx::reorder_files -front $ip_constr_files $proj_filegroup
 }
 
 proc adi_ip_bd {ip_name ip_bd_files} {
@@ -234,6 +235,7 @@ proc adi_ip_properties_lite {ip_name} {
     set i_module [file tail $i_file]
     regsub {_constr\.xdc} $i_module {} i_module
     ipx::add_file $i_file $i_filegroup
+    ipx::reorder_files -front $i_file $i_filegroup
     set_property SCOPED_TO_REF $i_module [ipx::get_files $i_file -of_objects $i_filegroup]
   }
   ipx::save_core


### PR DESCRIPTION
This commit fixes the following warning from the IP packaging flow:
"[IP_Flow 19-801] The last file in file group "Synthesis" should be an HDL file:
"axi_dmac_constr.ttcl".  During generation the IP Flow uses the last file to
determine library and other information when generating the top wrapper file.
If possible, please make sure that non-HDL files are located earlier in the list
of files for this file group."

Having the ttcl or other non HDL file at the end of the file group causes issues
when the project preferred language is set to VHDL. Since the synthesis file group
is set to "xilinx_anylanguagesynthesis" the tool tries to guess the type of wrapper
to be generated for that IP based on the last file from the file group.
If the file is non HDL then he defaults to the preferred language (this case VHDL)

Due some issue when the tool tries to create a VHDL wrapper for an IP that has
a Verilog top file with boolean parameters set from the IP packager he fails.
After we reorder the files after each non HDL file addition
he will create a correct Verilog wrapper for it with all parameters
which can be integrated in a VHDL system top file without issues.