### PR TITLE
axi_dmac: Fix bus resize block reset

### DIFF
--- a/library/axi_dmac/request_arb.v
+++ b/library/axi_dmac/request_arb.v
@@ -839,7 +839,7 @@ util_axis_resize #(
   .MASTER_DATA_WIDTH(DMA_DATA_WIDTH)
 ) i_src_repack (
   .clk(src_clk),
-  .resetn(src_resetn & src_enable),
+  .resetn(src_resetn & ~src_sync_id),
   .s_valid(src_fifo_valid),
   .s_ready(src_fifo_ready),
   .s_data(src_fifo_data),
@@ -874,7 +874,7 @@ util_axis_resize #(
   .MASTER_DATA_WIDTH(DMA_DATA_WIDTH_DEST)
 ) i_dest_repack (
   .clk(dest_clk),
-  .resetn(dest_resetn & dest_enable),
+  .resetn(dest_resetn & ~dest_sync_id),
   .s_valid(dest_fifo_valid),
   .s_ready(dest_fifo_ready),
   .s_data(dest_fifo_data),


### PR DESCRIPTION
When the source and destination bus widths don't match a resize block is
inserted on the side of the narrower bus. This resize block can contain
partial data.

To ensure that there is no residual partial data is left in the resize
block after a transfer shutdown the resize block is reset when the DMA is
disabled.

Currently this is implemented by tying the reset signal of the resize block
to the enable signal of the DMA. This enable signal is only a indicator
though that the DMA should shutdown. For a proper shutdown outstanding
transactions still need to be completed.

The data that is in the resize block might be required to complete those
transactions. So performing the reset when the enable signal goes low can
lead to a situation where the DMA tries to complete a transaction but can't
do it because the data required to do so has been erased by resetting the
resize block. This leads to a dead lock and the system has to be rebooted
to recover from it.

To solve this use the sync_id signal to reset the resize block. The sync_id
signal will only be asserted when both the destination and source side
module have indicated that they are ready to be reset and there are no more
pending transactions.

Signed-off-by: Lars-Peter Clausen <lars@metafoo.de>