### PR TITLE
adrv9009: Improved data throughput and DAC FIFO size

### DIFF
--- a/projects/adrv9009/common/adrv9009_bd.tcl
+++ b/projects/adrv9009/common/adrv9009_bd.tcl
@@ -262,19 +262,19 @@ ad_cpu_interconnect 0x43C20000 axi_adrv9009_rx_os_clkgen
 ad_cpu_interconnect 0x44AB0000 axi_adrv9009_rx_os_jesd
 ad_cpu_interconnect 0x7c440000 axi_adrv9009_rx_os_dma
 
-# gt uses hp3, and 100MHz clock for both DRP and AXI4
+# gt uses hp0, and 100MHz clock for both DRP and AXI4
 
-ad_mem_hp3_interconnect sys_cpu_clk sys_ps7/S_AXI_HP3
-ad_mem_hp3_interconnect sys_cpu_clk axi_adrv9009_rx_xcvr/m_axi
-ad_mem_hp3_interconnect sys_cpu_clk axi_adrv9009_rx_os_xcvr/m_axi
+ad_mem_hp0_interconnect sys_cpu_clk axi_adrv9009_rx_xcvr/m_axi
+ad_mem_hp0_interconnect sys_cpu_clk axi_adrv9009_rx_os_xcvr/m_axi
 
 # interconnect (mem/dac)
 
 ad_mem_hp1_interconnect sys_dma_clk sys_ps7/S_AXI_HP1
-ad_mem_hp1_interconnect sys_dma_clk axi_adrv9009_tx_dma/m_src_axi
+ad_mem_hp1_interconnect sys_dma_clk axi_adrv9009_rx_os_dma/m_dest_axi
 ad_mem_hp2_interconnect sys_dma_clk sys_ps7/S_AXI_HP2
 ad_mem_hp2_interconnect sys_dma_clk axi_adrv9009_rx_dma/m_dest_axi
-ad_mem_hp2_interconnect sys_dma_clk axi_adrv9009_rx_os_dma/m_dest_axi
+ad_mem_hp3_interconnect sys_dma_clk sys_ps7/S_AXI_HP3
+ad_mem_hp3_interconnect sys_dma_clk axi_adrv9009_tx_dma/m_src_axi
 
 # interrupts
 

--- a/projects/adrv9009/zcu102/system_bd.tcl
+++ b/projects/adrv9009/zcu102/system_bd.tcl
@@ -1,6 +1,6 @@
 
 set dac_fifo_name axi_adrv9009_dacfifo
-set dac_fifo_address_width 10
+set dac_fifo_address_width 17
 set dac_data_width 128
 set dac_dma_data_width 128
 
@@ -9,9 +9,17 @@ source $ad_hdl_dir/projects/common/xilinx/dacfifo_bd.tcl
 
 ad_ip_parameter sys_ps8 CONFIG.PSU__FPGA_PL2_ENABLE 1
 ad_ip_parameter sys_ps8 CONFIG.PSU__CRL_APB__PL2_REF_CTRL__SRCSEL {IOPLL}
-ad_ip_parameter sys_ps8 CONFIG.PSU__CRL_APB__PL2_REF_CTRL__FREQMHZ 200
+ad_ip_parameter sys_ps8 CONFIG.PSU__CRL_APB__PL2_REF_CTRL__FREQMHZ 300
+
+ad_mem_hp0_interconnect sys_cpu_clk sys_ps8/S_AXI_HP0
 
 source ../common/adrv9009_bd.tcl
+
+ad_ip_parameter axi_adrv9009_tx_dma CONFIG.DMA_DATA_WIDTH_SRC 128
+ad_ip_parameter axi_adrv9009_rx_dma CONFIG.DMA_DATA_WIDTH_DEST 128
+ad_ip_parameter axi_adrv9009_rx_os_dma CONFIG.DMA_DATA_WIDTH_DEST 128
+ad_ip_parameter axi_adrv9009_rx_dma CONFIG.FIFO_SIZE {16}
+ad_ip_parameter axi_adrv9009_rx_os_dma CONFIG.FIFO_SIZE {16}
 
 ad_connect sys_dma_clk sys_ps8/pl_clk2
 ad_connect sys_dma_rstgen/ext_reset_in sys_rstgen/peripheral_reset


### PR DESCRIPTION
Moved XCVR related connections to HP0, where the HP shares the MUX with the Video DMA
HP1 and HP2 are used for RX OS and RX DMAs, sharing the MUX. Usually they shouldn't run at the same time.
HP3 is used for TX DMA, sharing the MUX with the FPD DMA controller
All HPx and DMA buswidths have been increased to 128 bits
The HPx-DMA clock has been increased to 300 MHz
DAC FIFO address size has been increased to 17