### PR TITLE
fmcomms5: Clean up GPIO connections on system top

### DIFF
--- a/projects/fmcomms5/zc702/system_top.v
+++ b/projects/fmcomms5/zc702/system_top.v
@@ -144,8 +144,6 @@ module system_top (
   wire    [ 63:0] gpio_i;
   wire    [ 63:0] gpio_o;
   wire    [ 63:0] gpio_t;
-  wire            gpio_open_45_45;
-  wire            gpio_open_44_44;
   wire    [ 2:0]  spi0_csn;
   wire            spi0_clk;
   wire            spi0_mosi;
@@ -180,10 +178,10 @@ module system_top (
     .I (ref_clk_s),
     .O (ref_clk));
 
-  ad_iobuf #(.DATA_WIDTH(44)) i_iobuf (
-    .dio_t (gpio_t[59:16]),
-    .dio_i (gpio_o[59:16]),
-    .dio_o (gpio_i[59:16]),
+  ad_iobuf #(.DATA_WIDTH(42)) i_iobuf (
+    .dio_t ({gpio_t[59:46], gpio_t[43:16]}),
+    .dio_i ({gpio_o[59:46], gpio_o[43:16]}),
+    .dio_o ({gpio_i[59:46], gpio_i[43:16]}),
     .dio_p ({ gpio_resetb_1,    // 59
               gpio_ad5355_lock, // 58
               gpio_ad5355_rfen, // 57
@@ -198,16 +196,14 @@ module system_top (
               gpio_enable_0,    // 48
               gpio_en_agc_0,    // 47
               gpio_resetb_0,    // 46
-              gpio_open_45_45,  // 45
-              gpio_open_44_44,  // 44
               gpio_debug_4_1,   // 43
               gpio_debug_3_1,   // 42
               gpio_debug_2_0,   // 41
               gpio_debug_1_0,   // 40
-              gpio_ctl_1,       // 36
-              gpio_ctl_0,       // 32
-              gpio_status_1,    // 24
-              gpio_status_0})); // 16
+              gpio_ctl_1,       // 39:36
+              gpio_ctl_0,       // 35:32
+              gpio_status_1,    // 31:24
+              gpio_status_0})); // 23:16
 
   ad_iobuf #(.DATA_WIDTH(16)) i_gpio_bd (
     .dio_t (gpio_t[15:0]),
@@ -222,6 +218,7 @@ module system_top (
   assign spi_mosi = spi0_mosi;
   assign spi0_miso = spi_miso;
   assign gpio_i[63:60] = gpio_o[63:60];
+  assign gpio_i[45:44] = gpio_o[45:44];
 
   system_wrapper i_system_wrapper (
     .ddr_addr (ddr_addr),

--- a/projects/fmcomms5/zc706/system_top.v
+++ b/projects/fmcomms5/zc706/system_top.v
@@ -144,9 +144,6 @@ module system_top (
   wire    [ 63:0] gpio_i;
   wire    [ 63:0] gpio_o;
   wire    [ 63:0] gpio_t;
-  wire            gpio_open_45_45;
-  wire            gpio_open_44_44;
-  wire            gpio_open_15_15;
   wire    [ 2:0]  spi0_csn;
   wire            spi0_clk;
   wire            spi0_mosi;
@@ -181,10 +178,10 @@ module system_top (
     .I (ref_clk_s),
     .O (ref_clk));
 
-  ad_iobuf #(.DATA_WIDTH(60)) i_iobuf (
-    .dio_t (gpio_t[59:0]),
-    .dio_i (gpio_o[59:0]),
-    .dio_o (gpio_i[59:0]),
+  ad_iobuf #(.DATA_WIDTH(57)) i_iobuf (
+    .dio_t ({gpio_t[59:46], gpio_t[43:16], gpio_t[14:0]}),
+    .dio_i ({gpio_o[59:46], gpio_o[43:16], gpio_o[14:0]}),
+    .dio_o ({gpio_i[59:46], gpio_i[43:16], gpio_i[14:0]}),
     .dio_p ({ gpio_resetb_1,    // 59
               gpio_ad5355_lock, // 58
               gpio_ad5355_rfen, // 57
@@ -199,18 +196,15 @@ module system_top (
               gpio_enable_0,    // 48
               gpio_en_agc_0,    // 47
               gpio_resetb_0,    // 46
-              gpio_open_45_45,  // 45
-              gpio_open_44_44,  // 44
               gpio_debug_4_1,   // 43
               gpio_debug_3_1,   // 42
               gpio_debug_2_0,   // 41
               gpio_debug_1_0,   // 40
-              gpio_ctl_1,       // 36
-              gpio_ctl_0,       // 32
-              gpio_status_1,    // 24
-              gpio_status_0,    // 16
-              gpio_open_15_15,  // 15
-              gpio_bd}));       //  0
+              gpio_ctl_1,       // 39:36
+              gpio_ctl_0,       // 35:32
+              gpio_status_1,    // 31:24
+              gpio_status_0,    // 23:16
+              gpio_bd}));       // 14: 0
 
   assign spi_ad9361_0 = spi0_csn[0];
   assign spi_ad9361_1 = spi0_csn[1];
@@ -219,6 +213,8 @@ module system_top (
   assign spi_mosi = spi0_mosi;
   assign spi0_miso = spi_miso;
   assign gpio_i[63:60] = gpio_o[63:60];
+  assign gpio_i[45:44] = gpio_o[45:44];
+  assign gpio_i[15] = gpio_o[15];
 
   system_wrapper i_system_wrapper (
     .ddr_addr (ddr_addr),

--- a/projects/fmcomms5/zcu102/system_top.v
+++ b/projects/fmcomms5/zcu102/system_top.v
@@ -111,8 +111,6 @@ module system_top (
   wire    [ 94:0] gpio_i;
   wire    [ 94:0] gpio_o;
   wire            gpio_sync;
-  wire            gpio_open_44_44;
-  wire            gpio_open_15_15;
   wire    [ 2:0]  spi0_csn;
   wire            spi0_clk;
   wire            spi0_mosi;
@@ -161,14 +159,12 @@ module system_top (
   assign gpio_en_agc_0 = gpio_o[53];
   assign gpio_resetb_0 = gpio_o[52];
   assign gpio_sync = gpio_o[51];
-  assign gpio_open_44_44 = gpio_o[50];
   assign gpio_debug_4_0 = gpio_o[49];
   assign gpio_debug_3_0 = gpio_o[48];
   assign gpio_debug_2_0 = gpio_o[47];
   assign gpio_debug_1_0 = gpio_o[46];
   assign gpio_ctl_1 = gpio_o[45:42];
   assign gpio_ctl_0 = gpio_o[41:38];
-  assign gpio_open_15_15 = gpio_o[21];
   assign gpio_bd_o = gpio_o[20:13];
   assign gpio_i[12: 0] = gpio_bd_i;
   assign gpio_i[21:13] = gpio_o[21:13];


### PR DESCRIPTION
In the system top of the FMCOMMS5 projects, there are several GPIO lines, which
can not find in the constraint file, respectively gpio_open_15_15,
gpio_open_44_44 and gpio_45_45.

These are floating GPIO pins, as their names suggest. Delete all these wires and update IOBUF instances.