### PR TITLE
daq2|3: Set up OPTIMIZATION_MODE to improve timing

### DIFF
--- a/projects/daq2/a10gx/system_project.tcl
+++ b/projects/daq2/a10gx/system_project.tcl
@@ -93,4 +93,7 @@ set_location_assignment PIN_AW11  -to spi_clk               ; ## D12  FMCA_LA05_
 set_location_assignment PIN_AW13  -to spi_sdio              ; ## D14  FMCA_LA09_P
 set_location_assignment PIN_AN19  -to spi_dir               ; ## G13  FMCA_LA08_N
 
+# set optimization to get a better timing closure
+set_global_assignment -name OPTIMIZATION_MODE "HIGH PERFORMANCE EFFORT"
+
 execute_flow -compile

--- a/projects/daq3/a10gx/system_project.tcl
+++ b/projects/daq3/a10gx/system_project.tcl
@@ -101,5 +101,8 @@ set_location_assignment PIN_AW14  -to spi_dir               ; ## C11  FMCA_LA06_
 set_instance_assignment -name REMOVE_DUPLICATE_REGISTERS OFF -to "system_bd:i_system_bd|util_adcfifo:ad9680_adcfifo"
 set_instance_assignment -name REMOVE_DUPLICATE_REGISTERS OFF -to "system_bd:i_system_bd|system_bd_altera_mm_interconnect_161_mcfxx2a:mm_interconnect_0"
 
+# set optimization to get a better timing closure
+set_global_assignment -name OPTIMIZATION_MODE "HIGH PERFORMANCE EFFORT"
+
 execute_flow -compile
 


### PR DESCRIPTION
There are a random timing violations on the A10GX board using the DAQ3 and DAQ2 projects.

Setting the synthesis/implementation strategy to "HIGH PERFORMANCE EFFORT" increases the success rate of the timing closure significantly.