### PR TITLE
util_cdc: Silence warnings about unused sequential logic

### DIFF
--- a/library/util_cdc/sync_bits.v
+++ b/library/util_cdc/sync_bits.v
@@ -53,20 +53,24 @@ module sync_bits #(
   input out_clk,
   output [NUM_OF_BITS-1:0] out);
 
-reg [NUM_OF_BITS-1:0] cdc_sync_stage1 = 'h0;
-reg [NUM_OF_BITS-1:0] cdc_sync_stage2 = 'h0;
+generate if (ASYNC_CLK == 1) begin
+  reg [NUM_OF_BITS-1:0] cdc_sync_stage1 = 'h0;
+  reg [NUM_OF_BITS-1:0] cdc_sync_stage2 = 'h0;
 
-always @(posedge out_clk)
-begin
-  if (out_resetn == 1'b0) begin
-    cdc_sync_stage1 <= 'b0;
-    cdc_sync_stage2 <= 'b0;
-  end else begin
-    cdc_sync_stage1 <= in;
-    cdc_sync_stage2 <= cdc_sync_stage1;
+  always @(posedge out_clk)
+  begin
+    if (out_resetn == 1'b0) begin
+      cdc_sync_stage1 <= 'b0;
+      cdc_sync_stage2 <= 'b0;
+    end else begin
+      cdc_sync_stage1 <= in;
+      cdc_sync_stage2 <= cdc_sync_stage1;
+    end
   end
-end
 
-assign out = ASYNC_CLK ? cdc_sync_stage2 : in;
+  assign out = cdc_sync_stage2;
+end else begin
+  assign out = in;
+end endgenerate
 
 endmodule


### PR DESCRIPTION
Some parts of the util_cdc library rely on dead logic elimination to remove
unused logic. Unfortunately with newer Vivado versions this results in
warnings about unused sequential elements being removed. Like:

	WARNING: [Synth 8-6014] Unused sequential element cdc_sync_stage1_reg was removed.

To avoid this encase the logic in generate blocks that makes sure they are
not generated when not needed.

Signed-off-by: Lars-Peter Clausen <lars@metafoo.de>