### PR TITLE
util_dacfifo: Reduce logic on high fan-out dma_wren_s signal

### DIFF
--- a/library/util_dacfifo/util_dacfifo.v
+++ b/library/util_dacfifo/util_dacfifo.v
@@ -154,7 +154,7 @@ module util_dacfifo #(
 
   // write address generation
 
-  assign dma_wren_s = dma_valid & dma_xfer_req & dma_ready;
+  assign dma_wren_s = dma_valid & dma_ready;
 
   always @(posedge dma_clk) begin
     if(dma_rst == 1'b1) begin


### PR DESCRIPTION
The DMAC implementation guarantees that the expression `dma_valid &
dma_xfer_req` is always identical to just dma_valid.

When generating the util_dacfifo dma_wren_s signal the optimizer doesn't know
of this though and hence will route both signals into the LUT that drives
the write enable for the BRAMs.

Simplify the expression by removing dma_xfer_req from it. Considering this
can be a fairly high fan-out net and is typically the bottleneck for the
util_dacfifo timing this helps to improve the timing.

Signed-off-by: Lars-Peter Clausen <lars@metafoo.de>