### PR TITLE
Adrv9009 throughput

### DIFF
--- a/projects/adrv9009/common/adrv9009_bd.tcl
+++ b/projects/adrv9009/common/adrv9009_bd.tcl
@@ -36,6 +36,7 @@ ad_ip_parameter axi_adrv9009_tx_dma CONFIG.ASYNC_CLK_SRC_DEST 1
 ad_ip_parameter axi_adrv9009_tx_dma CONFIG.ASYNC_CLK_REQ_SRC 1
 ad_ip_parameter axi_adrv9009_tx_dma CONFIG.DMA_2D_TRANSFER 0
 ad_ip_parameter axi_adrv9009_tx_dma CONFIG.DMA_DATA_WIDTH_DEST 128
+ad_ip_parameter axi_adrv9009_tx_dma CONFIG.MAX_BYTES_PER_BURST 256
 
 # adc peripherals
 
@@ -69,6 +70,7 @@ ad_ip_parameter axi_adrv9009_rx_dma CONFIG.ASYNC_CLK_SRC_DEST 1
 ad_ip_parameter axi_adrv9009_rx_dma CONFIG.ASYNC_CLK_REQ_SRC 1
 ad_ip_parameter axi_adrv9009_rx_dma CONFIG.DMA_2D_TRANSFER 0
 ad_ip_parameter axi_adrv9009_rx_dma CONFIG.DMA_DATA_WIDTH_SRC 64
+ad_ip_parameter axi_adrv9009_rx_dma CONFIG.MAX_BYTES_PER_BURST 256
 
 # adc-os peripherals
 
@@ -102,6 +104,7 @@ ad_ip_parameter axi_adrv9009_rx_os_dma CONFIG.ASYNC_CLK_SRC_DEST 1
 ad_ip_parameter axi_adrv9009_rx_os_dma CONFIG.ASYNC_CLK_REQ_SRC 1
 ad_ip_parameter axi_adrv9009_rx_os_dma CONFIG.DMA_2D_TRANSFER 0
 ad_ip_parameter axi_adrv9009_rx_os_dma CONFIG.DMA_DATA_WIDTH_SRC 64
+ad_ip_parameter axi_adrv9009_rx_os_dma CONFIG.MAX_BYTES_PER_BURST 256
 
 # common cores
 

--- a/projects/adrv9009/common/adrv9009_bd.tcl
+++ b/projects/adrv9009/common/adrv9009_bd.tcl
@@ -29,14 +29,14 @@ ad_ip_instance axi_dmac axi_adrv9009_tx_dma
 ad_ip_parameter axi_adrv9009_tx_dma CONFIG.DMA_TYPE_SRC 0
 ad_ip_parameter axi_adrv9009_tx_dma CONFIG.DMA_TYPE_DEST 1
 ad_ip_parameter axi_adrv9009_tx_dma CONFIG.CYCLIC 1
-ad_ip_parameter axi_adrv9009_tx_dma CONFIG.AXI_SLICE_SRC 0
-ad_ip_parameter axi_adrv9009_tx_dma CONFIG.AXI_SLICE_DEST 1
 ad_ip_parameter axi_adrv9009_tx_dma CONFIG.ASYNC_CLK_DEST_REQ 1
 ad_ip_parameter axi_adrv9009_tx_dma CONFIG.ASYNC_CLK_SRC_DEST 1
 ad_ip_parameter axi_adrv9009_tx_dma CONFIG.ASYNC_CLK_REQ_SRC 1
 ad_ip_parameter axi_adrv9009_tx_dma CONFIG.DMA_2D_TRANSFER 0
 ad_ip_parameter axi_adrv9009_tx_dma CONFIG.DMA_DATA_WIDTH_DEST 128
 ad_ip_parameter axi_adrv9009_tx_dma CONFIG.MAX_BYTES_PER_BURST 256
+ad_ip_parameter axi_adrv9009_tx_dma CONFIG.AXI_SLICE_DEST true
+ad_ip_parameter axi_adrv9009_tx_dma CONFIG.AXI_SLICE_SRC true
 
 # adc peripherals
 
@@ -63,14 +63,14 @@ ad_ip_parameter axi_adrv9009_rx_dma CONFIG.DMA_TYPE_SRC 2
 ad_ip_parameter axi_adrv9009_rx_dma CONFIG.DMA_TYPE_DEST 0
 ad_ip_parameter axi_adrv9009_rx_dma CONFIG.CYCLIC 0
 ad_ip_parameter axi_adrv9009_rx_dma CONFIG.SYNC_TRANSFER_START 1
-ad_ip_parameter axi_adrv9009_rx_dma CONFIG.AXI_SLICE_SRC 0
-ad_ip_parameter axi_adrv9009_rx_dma CONFIG.AXI_SLICE_DEST 0
 ad_ip_parameter axi_adrv9009_rx_dma CONFIG.ASYNC_CLK_DEST_REQ 1
 ad_ip_parameter axi_adrv9009_rx_dma CONFIG.ASYNC_CLK_SRC_DEST 1
 ad_ip_parameter axi_adrv9009_rx_dma CONFIG.ASYNC_CLK_REQ_SRC 1
 ad_ip_parameter axi_adrv9009_rx_dma CONFIG.DMA_2D_TRANSFER 0
 ad_ip_parameter axi_adrv9009_rx_dma CONFIG.DMA_DATA_WIDTH_SRC 64
 ad_ip_parameter axi_adrv9009_rx_dma CONFIG.MAX_BYTES_PER_BURST 256
+ad_ip_parameter axi_adrv9009_rx_dma CONFIG.AXI_SLICE_DEST true
+ad_ip_parameter axi_adrv9009_rx_dma CONFIG.AXI_SLICE_SRC true
 
 # adc-os peripherals
 
@@ -97,14 +97,14 @@ ad_ip_parameter axi_adrv9009_rx_os_dma CONFIG.DMA_TYPE_SRC 2
 ad_ip_parameter axi_adrv9009_rx_os_dma CONFIG.DMA_TYPE_DEST 0
 ad_ip_parameter axi_adrv9009_rx_os_dma CONFIG.CYCLIC 0
 ad_ip_parameter axi_adrv9009_rx_os_dma CONFIG.SYNC_TRANSFER_START 1
-ad_ip_parameter axi_adrv9009_rx_os_dma CONFIG.AXI_SLICE_SRC 0
-ad_ip_parameter axi_adrv9009_rx_os_dma CONFIG.AXI_SLICE_DEST 0
 ad_ip_parameter axi_adrv9009_rx_os_dma CONFIG.ASYNC_CLK_DEST_REQ 1
 ad_ip_parameter axi_adrv9009_rx_os_dma CONFIG.ASYNC_CLK_SRC_DEST 1
 ad_ip_parameter axi_adrv9009_rx_os_dma CONFIG.ASYNC_CLK_REQ_SRC 1
 ad_ip_parameter axi_adrv9009_rx_os_dma CONFIG.DMA_2D_TRANSFER 0
 ad_ip_parameter axi_adrv9009_rx_os_dma CONFIG.DMA_DATA_WIDTH_SRC 64
 ad_ip_parameter axi_adrv9009_rx_os_dma CONFIG.MAX_BYTES_PER_BURST 256
+ad_ip_parameter axi_adrv9009_rx_os_dma CONFIG.AXI_SLICE_DEST true
+ad_ip_parameter axi_adrv9009_rx_os_dma CONFIG.AXI_SLICE_SRC true
 
 # common cores
 

--- a/projects/adrv9009/zcu102/system_bd.tcl
+++ b/projects/adrv9009/zcu102/system_bd.tcl
@@ -1,6 +1,6 @@
 
 set dac_fifo_name axi_adrv9009_dacfifo
-set dac_fifo_address_width 17
+set dac_fifo_address_width 14
 set dac_data_width 128
 set dac_dma_data_width 128
 

--- a/projects/adrv9009/zcu102/system_bd.tcl
+++ b/projects/adrv9009/zcu102/system_bd.tcl
@@ -7,10 +7,6 @@ set dac_dma_data_width 128
 source $ad_hdl_dir/projects/common/zcu102/zcu102_system_bd.tcl
 source $ad_hdl_dir/projects/common/xilinx/dacfifo_bd.tcl
 
-ad_ip_parameter sys_ps8 CONFIG.PSU__FPGA_PL2_ENABLE 1
-ad_ip_parameter sys_ps8 CONFIG.PSU__CRL_APB__PL2_REF_CTRL__SRCSEL {IOPLL}
-ad_ip_parameter sys_ps8 CONFIG.PSU__CRL_APB__PL2_REF_CTRL__FREQMHZ 300
-
 ad_mem_hp0_interconnect sys_cpu_clk sys_ps8/S_AXI_HP0
 
 source ../common/adrv9009_bd.tcl
@@ -22,7 +18,17 @@ ad_ip_parameter axi_adrv9009_rx_dma CONFIG.FIFO_SIZE 32
 ad_ip_parameter axi_adrv9009_rx_os_dma CONFIG.FIFO_SIZE 32
 ad_ip_parameter axi_adrv9009_tx_dma CONFIG.FIFO_SIZE 32
 
-ad_connect sys_dma_clk sys_ps8/pl_clk2
+ad_ip_instance clk_wiz dma_clk_wiz
+ad_ip_parameter dma_clk_wiz CONFIG.PRIMITIVE PLL
+ad_ip_parameter dma_clk_wiz CONFIG.RESET_TYPE ACTIVE_LOW
+ad_ip_parameter dma_clk_wiz CONFIG.USE_LOCKED false
+ad_ip_parameter dma_clk_wiz CONFIG.CLKOUT1_REQUESTED_OUT_FREQ 325
+ad_ip_parameter dma_clk_wiz CONFIG.PRIM_SOURCE No_buffer
+
+ad_connect sys_cpu_clk dma_clk_wiz/clk_in1
+ad_connect sys_cpu_resetn dma_clk_wiz/resetn
+
+ad_connect sys_dma_clk dma_clk_wiz/clk_out1
 ad_connect sys_dma_rstgen/ext_reset_in sys_rstgen/peripheral_reset
 
 ad_ip_parameter axi_adrv9009_tx_xcvr CONFIG.XCVR_TYPE 2

--- a/projects/adrv9009/zcu102/system_bd.tcl
+++ b/projects/adrv9009/zcu102/system_bd.tcl
@@ -18,8 +18,9 @@ source ../common/adrv9009_bd.tcl
 ad_ip_parameter axi_adrv9009_tx_dma CONFIG.DMA_DATA_WIDTH_SRC 128
 ad_ip_parameter axi_adrv9009_rx_dma CONFIG.DMA_DATA_WIDTH_DEST 128
 ad_ip_parameter axi_adrv9009_rx_os_dma CONFIG.DMA_DATA_WIDTH_DEST 128
-ad_ip_parameter axi_adrv9009_rx_dma CONFIG.FIFO_SIZE {16}
-ad_ip_parameter axi_adrv9009_rx_os_dma CONFIG.FIFO_SIZE {16}
+ad_ip_parameter axi_adrv9009_rx_dma CONFIG.FIFO_SIZE 32
+ad_ip_parameter axi_adrv9009_rx_os_dma CONFIG.FIFO_SIZE 32
+ad_ip_parameter axi_adrv9009_tx_dma CONFIG.FIFO_SIZE 32
 
 ad_connect sys_dma_clk sys_ps8/pl_clk2
 ad_connect sys_dma_rstgen/ext_reset_in sys_rstgen/peripheral_reset

--- a/projects/adrv9009/zcu102/system_bd.tcl
+++ b/projects/adrv9009/zcu102/system_bd.tcl
@@ -19,10 +19,10 @@ ad_ip_parameter axi_adrv9009_rx_os_dma CONFIG.FIFO_SIZE 32
 ad_ip_parameter axi_adrv9009_tx_dma CONFIG.FIFO_SIZE 32
 
 ad_ip_instance clk_wiz dma_clk_wiz
-ad_ip_parameter dma_clk_wiz CONFIG.PRIMITIVE PLL
+ad_ip_parameter dma_clk_wiz CONFIG.PRIMITIVE MMCM
 ad_ip_parameter dma_clk_wiz CONFIG.RESET_TYPE ACTIVE_LOW
 ad_ip_parameter dma_clk_wiz CONFIG.USE_LOCKED false
-ad_ip_parameter dma_clk_wiz CONFIG.CLKOUT1_REQUESTED_OUT_FREQ 325
+ad_ip_parameter dma_clk_wiz CONFIG.CLKOUT1_REQUESTED_OUT_FREQ 332.9
 ad_ip_parameter dma_clk_wiz CONFIG.PRIM_SOURCE No_buffer
 
 ad_connect sys_cpu_clk dma_clk_wiz/clk_in1


### PR DESCRIPTION
ADRV9009 throughput related changes. Increase DMAs store-and-forward size and dma_clk to maximum possible frequency for the HP ports.