### PR TITLE
axi_dmac: Be more specific about debug register timing exceptions

### DIFF
--- a/library/axi_dmac/axi_dmac_constr.sdc
+++ b/library/axi_dmac/axi_dmac_constr.sdc
@@ -4,7 +4,9 @@ set_false_path -to    [get_registers *axi_dmac*cdc_sync_stage1*]
 set_false_path -from  [get_registers *axi_dmac*cdc_sync_fifo_ram*]
 set_false_path -from  [get_registers *axi_dmac*eot_mem*]
 set_false_path -to    [get_registers *axi_dmac*reset_shift*]
-set_false_path -from  [get_registers *axi_dmac*cdc_sync_stage2*]      -to [get_registers *axi_dmac*up_rdata*]
-set_false_path -from  [get_registers *axi_dmac*id*]                   -to [get_registers *axi_dmac*up_rdata*]
-set_false_path -from  [get_registers *axi_dmac*address*]              -to [get_registers *axi_dmac*up_rdata*]
+
+# Debug signals
+set_false_path -from  [get_registers *axi_dmac*|*i_request_arb*|cdc_sync_stage2*]  -to [get_registers *axi_dmac*up_rdata*]
+set_false_path -from  [get_registers *axi_dmac*|*i_request_arb*|*id*]              -to [get_registers *axi_dmac*up_rdata*]
+set_false_path -from  [get_registers *axi_dmac*|*i_request_arb*|address*]          -to [get_registers *axi_dmac*up_rdata*]
 


### PR DESCRIPTION
The timing exceptions for the debug paths are currently a bit to broad and
can include paths that should not have an exception.

All the debug signals are coming from the i_request_arb instance, so
include that in the match to avoid false positives.

For most projects this wont have been a problem since there is usually a
fair amount of slack on the paths that were affected by this. But in
projects with high utilization this might result in undefined behavior.

I checked some projects and didn't find any where the this caused paths that were longer that they should have been, but we probably still want to add to add this to the release branch.