### PR TITLE
Fix DAC FIFO data alignment

### DIFF
--- a/library/xilinx/axi_dacfifo/axi_dacfifo.v
+++ b/library/xilinx/axi_dacfifo/axi_dacfifo.v
@@ -117,13 +117,9 @@ module axi_dacfifo #(
   reg                                 dac_xfer_out_m1 = 1'b0;
   reg                                 dac_xfer_out_bypass = 1'b0;
 
-  wire    [(AXI_DATA_WIDTH-1):0]      axi_rd_data_s;
-  wire                                axi_rd_ready_s;
-  wire                                axi_rd_valid_s;
   wire                                axi_xfer_req_s;
   (* dont_touch = "true" *) wire    [31:0]                      axi_last_addr_s;
   (* dont_touch = "true" *) wire    [ 7:0]                      axi_last_beats_s;
-  wire                                axi_dlast_s;
   wire    [ 3:0]                      dma_last_beats_s;
   wire    [(DAC_DATA_WIDTH-1):0]      dac_data_fifo_s;
   wire    [(DAC_DATA_WIDTH-1):0]      dac_data_bypass_s;

--- a/library/xilinx/axi_dacfifo/axi_dacfifo_address_buffer.v
+++ b/library/xilinx/axi_dacfifo/axi_dacfifo_address_buffer.v
@@ -57,8 +57,8 @@ module axi_dacfifo_address_buffer #(
       waddr <= 0;
       raddr <= 0;
     end else begin
-      waddr <= (wea == 1'b1) ? waddr + 1 : waddr;
-      raddr <= (rea == 1'b1) ? raddr + 1 : raddr;
+      waddr <= (wea == 1'b1) ? waddr + 1'b1 : waddr;
+      raddr <= (rea == 1'b1) ? raddr + 1'b1 : raddr;
     end
   end
 

--- a/library/xilinx/axi_dacfifo/axi_dacfifo_address_buffer.v
+++ b/library/xilinx/axi_dacfifo/axi_dacfifo_address_buffer.v
@@ -71,7 +71,7 @@ module axi_dacfifo_address_buffer #(
     .addra (waddr),
     .dina (din),
     .clkb (clk),
-    .reb (rea),
+    .reb (1'b1),
     .addrb (raddr),
     .doutb (dout));
 

--- a/library/xilinx/axi_dacfifo/axi_dacfifo_rd.v
+++ b/library/xilinx/axi_dacfifo/axi_dacfifo_rd.v
@@ -433,7 +433,7 @@ module axi_dacfifo_rd #(
     end else begin
       dac_mem_laddr_b <= dac_mem_laddr_s;
       if (dac_mem_valid == 1'b1) begin
-        if ((dac_last_beats > 0) &&
+        if ((dac_last_beats != 0) &&
             (dac_mem_raddr == (dac_mem_laddr_b + dac_last_beats - 1))) begin
           dac_mem_raddr <= dac_mem_raddr + (MEM_RATIO - (dac_last_beats - 1));
         end else begin

--- a/library/xilinx/axi_dacfifo/axi_dacfifo_rd.v
+++ b/library/xilinx/axi_dacfifo/axi_dacfifo_rd.v
@@ -105,13 +105,7 @@ module axi_dacfifo_rd #(
 
   // internal registers
 
-  reg                                   axi_ractive = 1'b0;
-  reg     [ 1:0]                        axi_xfer_req_m = 2'b0;
-  reg     [ 7:0]                        axi_last_beats_cntr = 8'b0;
   reg                                   axi_data_req = 1'b0;
-  reg     [(AXI_DATA_WIDTH-1):0]        axi_ddata = 'b0;
-  reg                                   axi_dlast = 1'b0;
-  reg                                   axi_dvalid = 1'b0;
   reg     [ 4:0]                        axi_read_state = 5'b0;
   reg     [(AXI_MEM_ADDRESS_WIDTH-1):0] axi_mem_waddr = 'd0;
   reg     [(AXI_MEM_ADDRESS_WIDTH-1):0] axi_mem_laddr = 'd0;
@@ -147,12 +141,10 @@ module axi_dacfifo_rd #(
   wire    [(DAC_MEM_ADDRESS_WIDTH-1):0] axi_mem_waddr_s;
   wire    [(DAC_MEM_ADDRESS_WIDTH-1):0] axi_mem_laddr_s;
   wire    [(DAC_MEM_ADDRESS_WIDTH-1):0] axi_mem_waddr_b2g_s;
-  wire    [(DAC_MEM_ADDRESS_WIDTH-1):0] axi_mem_laddr_b2g_s;
   wire    [(DAC_MEM_ADDRESS_WIDTH-1):0] axi_mem_raddr_m2_g2b_s;
 
   wire    [(DAC_MEM_ADDRESS_WIDTH-1):0] dac_mem_raddr_b2g_s;
   wire    [(DAC_MEM_ADDRESS_WIDTH-1):0] dac_mem_waddr_m2_g2b_s;
-  wire    [(DAC_MEM_ADDRESS_WIDTH-1):0] dac_mem_laddr_m2_g2b_s;
   wire    [    DAC_MEM_ADDRESS_WIDTH:0] dac_mem_addr_diff_s;
   wire    [(DAC_MEM_ADDRESS_WIDTH-1):0] dac_mem_laddr_s;
 

--- a/library/xilinx/axi_dacfifo/axi_dacfifo_rd.v
+++ b/library/xilinx/axi_dacfifo/axi_dacfifo_rd.v
@@ -437,7 +437,7 @@ module axi_dacfifo_rd #(
             (dac_mem_raddr == (dac_mem_laddr_b + dac_last_beats - 1))) begin
           dac_mem_raddr <= dac_mem_raddr + (MEM_RATIO - (dac_last_beats - 1));
         end else begin
-          dac_mem_raddr <= dac_mem_raddr + 1;
+          dac_mem_raddr <= dac_mem_raddr + 1'b1;
         end
       end
       dac_mem_raddr_g <= dac_mem_raddr_b2g_s;

--- a/library/xilinx/axi_dacfifo/axi_dacfifo_wr.v
+++ b/library/xilinx/axi_dacfifo/axi_dacfifo_wr.v
@@ -171,7 +171,6 @@ module axi_dacfifo_wr #(
   wire                                      axi_waddr_ready_s;
   wire                                      axi_wready_s;
   wire                                      axi_partial_burst_s;
-  wire                                      axi_last_burst_s;
   wire                                      axi_xlast_s;
   wire                                      axi_reset_s;
 


### PR DESCRIPTION
Currently the axi_dacfifo does not work correctly if the data is not aligned to the bus width of the AXI memory mapped interface of the DDR controller. (a few samples are lost in each cycle)
