### PR TITLE
axi_dmac: diagnostic interface

### DIFF
--- a/library/axi_dmac/axi_dmac.v
+++ b/library/axi_dmac/axi_dmac.v
@@ -215,6 +215,7 @@ module axi_dmac #(
   output                                   fifo_rd_xfer_req,
 
   // Diagnostics interface
+  output [15:0] dest_diag_level_beats,
   output  [7:0] dest_diag_level_bursts
 );
 
@@ -539,6 +540,7 @@ axi_dmac_transfer #(
   .dbg_src_response_id(src_response_id),
   .dbg_status(dbg_status),
 
+  .dest_diag_level_beats(dest_diag_level_beats),
   .dest_diag_level_bursts(dest_diag_level_bursts)
 );
 

--- a/library/axi_dmac/axi_dmac_burst_memory.v
+++ b/library/axi_dmac/axi_dmac_burst_memory.v
@@ -63,6 +63,7 @@ module axi_dmac_burst_memory #(
   output [ID_WIDTH-1:0] dest_data_response_id,
 
   // Diagnostics interface
+  output [15:0] dest_diag_level_beats,
   output  [7:0] dest_diag_level_bursts
 );
 
@@ -83,6 +84,8 @@ localparam ADDRESS_WIDTH = BURST_LEN_WIDTH + ID_WIDTH - 1;
 
 localparam AUX_FIFO_SIZE = 2**(ID_WIDTH-1);
 
+localparam BEAT_CNT_WIDTH = ENABLE_DIAGNOSTICS_IF ? ADDRESS_WIDTH + 1 :
+                                                    BURST_LEN_WIDTH;
 /*
  * The burst memory is separated into 2**(ID_WIDTH-1) segments. Each segment can
  * hold up to BURST_LEN beats. The addresses that are used to access the memory
@@ -110,13 +113,13 @@ localparam AUX_FIFO_SIZE = 2**(ID_WIDTH-1);
 reg [ID_WIDTH-1:0] src_id_next;
 reg [ID_WIDTH-1:0] src_id = 'h0;
 reg src_id_reduced_msb = 1'b0;
-reg [BURST_LEN_WIDTH-1:0] src_beat_counter = 'h00;
+reg [BEAT_CNT_WIDTH-1:0] src_beat_counter = 'h00;
 
 reg [ID_WIDTH-1:0] dest_id_next = 'h0;
 reg dest_id_reduced_msb_next = 1'b0;
 reg dest_id_reduced_msb = 1'b0;
 reg [ID_WIDTH-1:0] dest_id = 'h0;
-reg [BURST_LEN_WIDTH-1:0] dest_beat_counter = 'h00;
+reg [BEAT_CNT_WIDTH-1:0] dest_beat_counter = 'h00;
 reg [BURST_LEN_WIDTH-1:0] dest_burst_len = 'h00;
 reg dest_valid = 1'b0;
 reg dest_mem_data_valid = 1'b0;
@@ -161,7 +164,7 @@ end endgenerate
 
 assign src_beat = src_mem_data_valid;
 assign src_last_beat = src_beat & src_mem_data_last;
-assign src_waddr = {src_id_reduced,src_beat_counter};
+assign src_waddr = {src_id_reduced,src_beat_counter[BURST_LEN_WIDTH-1:0]};
 
 assign src_data_request_id = src_dest_id;
 
@@ -193,16 +196,16 @@ end
 
 always @(posedge src_clk) begin
   if (src_last_beat == 1'b1) begin
-    burst_len_mem[src_id_reduced] <= src_beat_counter;
+    burst_len_mem[src_id_reduced] <= src_beat_counter[BURST_LEN_WIDTH-1:0];
   end
 end
 
 assign dest_ready = ~dest_mem_data_valid | dest_mem_data_ready;
-assign dest_last = dest_beat_counter == dest_burst_len;
+assign dest_last = dest_beat_counter[BURST_LEN_WIDTH-1:0] == dest_burst_len;
 
 assign dest_beat = dest_valid & dest_ready;
 assign dest_last_beat = dest_last & dest_beat;
-assign dest_raddr = {dest_id_reduced,dest_beat_counter};
+assign dest_raddr = {dest_id_reduced,dest_beat_counter[BURST_LEN_WIDTH-1:0]};
 
 assign dest_burst_valid = dest_data_request_id != dest_id_next;
 assign dest_burst_ready = ~dest_valid | dest_last_beat;
@@ -365,6 +368,32 @@ assign dest_data_response_id = dest_id;
 generate if (ENABLE_DIAGNOSTICS_IF == 1) begin
 
   reg [ID_WIDTH-1:0] _dest_diag_level_bursts = 'h0;
+  reg [BEAT_CNT_WIDTH-1:0] _dest_diag_level_beats = 'h0;
+
+  wire [BEAT_CNT_WIDTH-1:0] dest_src_beat_counter_s;
+
+  sync_gray #(
+    .DATA_WIDTH(BEAT_CNT_WIDTH),
+    .ASYNC_CLK(ASYNC_CLK)
+  ) i_scr_beat_cnt_sync (
+    .in_clk(src_clk),
+    .in_resetn(~src_reset),
+    .out_clk(dest_clk),
+    .out_resetn(1'b1),
+    .in_count(src_beat_counter),
+    .out_count(dest_src_beat_counter_s)
+  );
+
+  // calculate buffer fullness in locations 
+  always @(posedge dest_clk) begin
+    if (dest_reset == 1'b1) begin
+      _dest_diag_level_beats <= 'h0;
+    end else begin
+      _dest_diag_level_beats <= dest_src_beat_counter_s - dest_beat_counter;
+    end
+  end
+
+  assign dest_diag_level_beats = {{{16-BEAT_CNT_WIDTH}{1'b0}},_dest_diag_level_beats};
 
   // calculate buffer fullness in bursts
   always @(posedge dest_clk) begin
@@ -377,6 +406,7 @@ generate if (ENABLE_DIAGNOSTICS_IF == 1) begin
   assign dest_diag_level_bursts = {{{8-ID_WIDTH}{1'b0}},_dest_diag_level_bursts};
 
 end else begin
+  assign dest_diag_level_beats = 'h0;
   assign dest_diag_level_bursts = 'h0;
 end
 endgenerate

--- a/library/axi_dmac/axi_dmac_constr.ttcl
+++ b/library/axi_dmac/axi_dmac_constr.ttcl
@@ -7,6 +7,7 @@
 <: set async_req_src [getBooleanValue "ASYNC_CLK_REQ_SRC"] :>
 <: set async_src_dest [getBooleanValue "ASYNC_CLK_SRC_DEST"] :>
 <: set disable_debug_registers [getBooleanValue "DISABLE_DEBUG_REGISTERS"] :>
+<: set enable_diagnostics_if [getBooleanValue "ENABLE_DIAGNOSTICS_IF"] :>
 
 set req_clk [get_clocks -of_objects [get_ports s_axi_aclk]]
 set src_clk [get_clocks -of_objects [get_ports -quiet {fifo_wr_clk s_axis_aclk m_src_axi_aclk}]]
@@ -201,4 +202,12 @@ set_false_path -quiet \
 set_false_path -quiet \
 	-from [get_cells -quiet -hier *reset_sync_reg* -filter {name =~ *i_reset_manager* && IS_SEQUENTIAL}] \
 	-to [get_cells -quiet -hier *up_rdata_reg* -filter {IS_SEQUENTIAL}]
+<: } :>
+
+<: if {!$enable_diagnostics_if} { :>
+set_max_delay -quiet -datapath_only \
+	-from $src_clk\
+	-to [get_cells -quiet -hier *cdc_sync_stage1_reg* \
+		-filter {NAME =~ *i_store_and_forward/i_scr_beat_cnt_sync* && IS_SEQUENTIAL}] \
+	[get_property -min PERIOD $src_clk]
 <: } :>

--- a/library/axi_dmac/axi_dmac_hw.tcl
+++ b/library/axi_dmac/axi_dmac_hw.tcl
@@ -492,4 +492,5 @@ set_parameter_property ENABLE_DIAGNOSTICS_IF HDL_PARAMETER true
 set_parameter_property ENABLE_DIAGNOSTICS_IF GROUP $group
 
 add_interface diagnostics_if conduit end
+add_interface_port diagnostics_if dest_diag_level_beats dest_diag_level_beats Output "16"
 add_interface_port diagnostics_if dest_diag_level_bursts dest_diag_level_bursts Output "8"

--- a/library/axi_dmac/axi_dmac_ip.tcl
+++ b/library/axi_dmac/axi_dmac_ip.tcl
@@ -77,6 +77,8 @@ adi_set_bus_dependency "m_axis" "m_axis" \
 	"(spirit:decode(id('MODELPARAM_VALUE.DMA_TYPE_DEST')) = 1)"
 adi_set_ports_dependency "fifo_rd" \
 	"(spirit:decode(id('MODELPARAM_VALUE.DMA_TYPE_DEST')) = 2)"
+adi_set_ports_dependency "dest_diag_level_beats" \
+	"(spirit:decode(id('MODELPARAM_VALUE.ENABLE_DIAGNOSTICS_IF')) = 1)"
 adi_set_ports_dependency "dest_diag_level_bursts" \
 	"(spirit:decode(id('MODELPARAM_VALUE.ENABLE_DIAGNOSTICS_IF')) = 1)"
 

--- a/library/axi_dmac/axi_dmac_transfer.v
+++ b/library/axi_dmac/axi_dmac_transfer.v
@@ -164,6 +164,7 @@ module axi_dmac_transfer #(
   output [11:0] dbg_status,
 
   // Diagnostics interface
+  output [15:0] dest_diag_level_beats,
   output [7:0] dest_diag_level_bursts
 );
 
@@ -410,7 +411,9 @@ dmac_request_arb #(
   .dbg_src_data_id (dbg_src_data_id),
   .dbg_src_response_id (dbg_src_response_id),
 
+  .dest_diag_level_beats(dest_diag_level_beats),
   .dest_diag_level_bursts(dest_diag_level_bursts)
 );
+
 
 endmodule

--- a/library/axi_dmac/request_arb.v
+++ b/library/axi_dmac/request_arb.v
@@ -169,6 +169,7 @@ module dmac_request_arb #(
   output src_enabled,
 
   // Diagnostics interface
+  output [15:0] dest_diag_level_beats,
   output  [7:0] dest_diag_level_bursts
 );
 
@@ -791,6 +792,7 @@ axi_dmac_burst_memory #(
   .dest_data_request_id(dest_data_request_id),
   .dest_data_response_id(dest_data_response_id),
 
+  .dest_diag_level_beats(dest_diag_level_beats),
   .dest_diag_level_bursts(dest_diag_level_bursts)
 );
 


### PR DESCRIPTION
This change adds a diagnostic interface to the DMAC core.
The interface exposes internal information about the core,
information which can't be exposed through AXI registers
due the latency and update rate.

Such information is the fullness of the internal buffer.
For flexibility this is exposed in bursts and beats as well
with reduced resource utilization due the reuse of the
existing beat counters.
The exposed signals are driven from the destination clock domain,
as this is reflected in their name.

The signals have a fixed size and they are dimensioned by
taking in account the supported maximum number of bursts of 128 and
burst length of 256 beats.