### PR TITLE
axi_dmac: add tlast to the axis interface for Intel

### DIFF
--- a/library/axi_dmac/axi_dmac_hw.tcl
+++ b/library/axi_dmac/axi_dmac_hw.tcl
@@ -104,6 +104,12 @@ foreach {suffix group} { \
   set_parameter_property DMA_DATA_WIDTH_$suffix ALLOWED_RANGES {16 32 64 128 256 512 1024}
   set_parameter_property DMA_DATA_WIDTH_$suffix GROUP $group
 
+  add_parameter USE_TLAST_$suffix INTEGER 0
+  set_parameter_property USE_TLAST_$suffix DISPLAY_NAME "Use TLAST"
+  set_parameter_property USE_TLAST_$suffix HDL_PARAMETER false
+  set_parameter_property USE_TLAST_$suffix DISPLAY_HINT boolean
+  set_parameter_property USE_TLAST_$suffix GROUP $group
+
   add_parameter AXI_SLICE_$suffix INTEGER 0
   set_parameter_property AXI_SLICE_$suffix DISPLAY_NAME "Insert Register Slice"
   set_parameter_property AXI_SLICE_$suffix DISPLAY_HINT boolean
@@ -262,6 +268,13 @@ proc axi_dmac_validate {} {
     set_parameter_property DMA_AXI_PROTOCOL_$suffix VISIBLE $show_axi_protocol
   }
 
+  foreach suffix {SRC DEST} {
+    if {[get_parameter_value DMA_TYPE_$suffix] == 1} {
+      set_parameter_property USE_TLAST_$suffix VISIBLE true
+    } else {
+      set_parameter_property USE_TLAST_$suffix VISIBLE false
+    }
+  }
   set_parameter_property MAX_BYTES_PER_BURST ALLOWED_RANGES "1:$max_burst"
 }
 
@@ -297,6 +310,7 @@ ad_alt_intf clock   s_axis_aclk       input   1                       clk
 ad_alt_intf signal  s_axis_valid      input   1                       valid
 ad_alt_intf signal  s_axis_data       input   DMA_DATA_WIDTH_SRC      data
 ad_alt_intf signal  s_axis_ready      output  1                       ready
+ad_alt_intf signal  s_axis_last       input   1                       last
 ad_alt_intf signal  s_axis_xfer_req   output  1                       xfer_req
 ad_alt_intf signal  s_axis_user       input   1                       user
 
@@ -411,16 +425,27 @@ proc axi_dmac_elaborate {} {
 	  if_m_axis_last if_m_axis_xfer_req
   }
 
+  if {[get_parameter_value DMA_TYPE_DEST] == 1 &&
+      [get_parameter_value USE_TLAST_DEST] == 0} {
+    set_port_property m_axis_last termination true
+  }
+
   if {[get_parameter_value DMA_TYPE_SRC] != 1} {
     lappend disabled_intfs \
       if_s_axis_aclk if_s_axis_valid if_s_axis_data if_s_axis_ready \
-	  if_s_axis_xfer_req if_s_axis_user
+	  if_s_axis_xfer_req if_s_axis_user if_s_axis_last
   }
 
   if {[get_parameter_value DMA_TYPE_SRC] == 1 &&
       [get_parameter_value SYNC_TRANSFER_START] == 0} {
     set_port_property s_axis_user termination true
     set_port_property s_axis_user termination_value 1
+  }
+
+  if {[get_parameter_value DMA_TYPE_SRC] == 1 &&
+      [get_parameter_value USE_TLAST_SRC] == 0} {
+    set_port_property s_axis_last termination true
+    set_port_property s_axis_last termination_value 0
   }
 
   # fifo destination/source

--- a/projects/adrv9371x/common/adrv9371x_qsys.tcl
+++ b/projects/adrv9371x/common/adrv9371x_qsys.tcl
@@ -132,6 +132,7 @@ set_instance_parameter_value axi_ad9371_tx_dma {CYCLIC} {1}
 set_instance_parameter_value axi_ad9371_tx_dma {DMA_TYPE_DEST} {1}
 set_instance_parameter_value axi_ad9371_tx_dma {DMA_TYPE_SRC} {0}
 set_instance_parameter_value axi_ad9371_tx_dma {FIFO_SIZE} {16}
+set_instance_parameter_value axi_ad9371_tx_dma {USE_TLAST_DEST} {1}
 add_connection sys_dma_clk.clk avl_ad9371_tx_fifo.if_dma_clk
 add_connection sys_dma_clk.clk_reset avl_ad9371_tx_fifo.if_dma_rst
 add_connection sys_dma_clk.clk axi_ad9371_tx_dma.if_m_axis_aclk

--- a/projects/daq2/common/daq2_qsys.tcl
+++ b/projects/daq2/common/daq2_qsys.tcl
@@ -65,6 +65,7 @@ set_instance_parameter_value axi_ad9144_dma {CYCLIC} {1}
 set_instance_parameter_value axi_ad9144_dma {DMA_TYPE_DEST} {1}
 set_instance_parameter_value axi_ad9144_dma {DMA_TYPE_SRC} {0}
 set_instance_parameter_value axi_ad9144_dma {FIFO_SIZE} {16}
+set_instance_parameter_value axi_ad9144_dma {USE_TLAST_DEST} {1}
 
 add_connection sys_dma_clk.clk avl_ad9144_fifo.if_dma_clk
 add_connection sys_dma_clk.clk_reset avl_ad9144_fifo.if_dma_rst

--- a/projects/daq3/common/daq3_qsys.tcl
+++ b/projects/daq3/common/daq3_qsys.tcl
@@ -60,6 +60,7 @@ set_instance_parameter_value axi_ad9152_dma {SYNC_TRANSFER_START} {0}
 set_instance_parameter_value axi_ad9152_dma {DMA_TYPE_DEST} {1}
 set_instance_parameter_value axi_ad9152_dma {DMA_TYPE_SRC} {0}
 set_instance_parameter_value axi_ad9152_dma {FIFO_SIZE} {16}
+set_instance_parameter_value axi_ad9152_dma {USE_TLAST_DEST} {1}
 
 add_connection sys_clk.clk avl_ad9152_fifo.if_dma_clk
 add_connection sys_clk.clk_reset avl_ad9152_fifo.if_dma_rst


### PR DESCRIPTION
This change adds the TLAST signal to the AXI streaming interface
of the source side for Intel targets.
Xilinx based designs already have this since the tlast is part of the
interface definition.

In order to make the signal optional and let the tool connect a
default value to the it, the USE_TLAST_SRC/DEST parameter is
added to the configuration UI. This conditions the tlast port on
the interface of the DMAC.

Xilinx handles the optional signals much better so the parameter
is not required there.