### PR TITLE
axi_dmac: fix 2d transfer address width

### DIFF
--- a/library/axi_dmac/2d_transfer.v
+++ b/library/axi_dmac/2d_transfer.v
@@ -35,6 +35,7 @@
 
 module dmac_2d_transfer #(
 
+  parameter DMA_AXI_ADDR_WIDTH = 32,
   parameter DMA_LENGTH_WIDTH = 24,
   parameter BYTES_PER_BEAT_WIDTH_SRC = 3,
   parameter BYTES_PER_BEAT_WIDTH_DEST = 3)(
@@ -45,8 +46,8 @@ module dmac_2d_transfer #(
   input req_valid,
   output reg req_ready,
 
-  input [31:BYTES_PER_BEAT_WIDTH_DEST] req_dest_address,
-  input [31:BYTES_PER_BEAT_WIDTH_SRC] req_src_address,
+  input [DMA_AXI_ADDR_WIDTH-1:BYTES_PER_BEAT_WIDTH_DEST] req_dest_address,
+  input [DMA_AXI_ADDR_WIDTH-1:BYTES_PER_BEAT_WIDTH_SRC] req_src_address,
   input [DMA_LENGTH_WIDTH-1:0] req_x_length,
   input [DMA_LENGTH_WIDTH-1:0] req_y_length,
   input [DMA_LENGTH_WIDTH-1:0] req_dest_stride,
@@ -56,15 +57,15 @@ module dmac_2d_transfer #(
 
   output reg out_req_valid,
   input out_req_ready,
-  output [31:BYTES_PER_BEAT_WIDTH_DEST] out_req_dest_address,
-  output [31:BYTES_PER_BEAT_WIDTH_SRC] out_req_src_address,
+  output [DMA_AXI_ADDR_WIDTH-1:BYTES_PER_BEAT_WIDTH_DEST] out_req_dest_address,
+  output [DMA_AXI_ADDR_WIDTH-1:BYTES_PER_BEAT_WIDTH_SRC] out_req_src_address,
   output [DMA_LENGTH_WIDTH-1:0] out_req_length,
   output reg out_req_sync_transfer_start,
   input out_eot
 );
 
-reg [31:BYTES_PER_BEAT_WIDTH_DEST] dest_address = 'h00;
-reg [31:BYTES_PER_BEAT_WIDTH_SRC] src_address = 'h00;
+reg [DMA_AXI_ADDR_WIDTH-1:BYTES_PER_BEAT_WIDTH_DEST] dest_address = 'h00;
+reg [DMA_AXI_ADDR_WIDTH-1:BYTES_PER_BEAT_WIDTH_SRC] src_address = 'h00;
 reg [DMA_LENGTH_WIDTH-1:0] x_length = 'h00;
 reg [DMA_LENGTH_WIDTH-1:0] y_length = 'h00;
 reg [DMA_LENGTH_WIDTH-1:0] dest_stride = 'h0;

--- a/library/axi_dmac/axi_dmac_transfer.v
+++ b/library/axi_dmac/axi_dmac_transfer.v
@@ -238,6 +238,7 @@ assign req_ready = req_enable & req_ready_gated;
 generate if (DMA_2D_TRANSFER == 1) begin
 
 dmac_2d_transfer #(
+  .DMA_AXI_ADDR_WIDTH(DMA_AXI_ADDR_WIDTH),
   .DMA_LENGTH_WIDTH (DMA_LENGTH_WIDTH),
   .BYTES_PER_BEAT_WIDTH_DEST (BYTES_PER_BEAT_WIDTH_DEST),
   .BYTES_PER_BEAT_WIDTH_SRC (BYTES_PER_BEAT_WIDTH_SRC)


### PR DESCRIPTION
The index on MSB of addresses was set to 31,
but the width of address in the axi_dmac depends on a parameter.
The mismatch causes issues in the Xilinx simulator which does not extends the
narrower width signal with zeros, instead the wider signal gets 'Z' on its MSBs.
When the address was incremented with the stride it became 'X' due the uninitialized
MSBs.