### PR TITLE
axi_dmac: TLAST support for 2d transfers

### DIFF
--- a/library/axi_dmac/2d_transfer.v
+++ b/library/axi_dmac/2d_transfer.v
@@ -54,6 +54,7 @@ module dmac_2d_transfer #(
   input [DMA_LENGTH_WIDTH-1:0] req_src_stride,
   input req_sync_transfer_start,
   output reg req_eot,
+  input req_last,
 
   output reg out_req_valid,
   input out_req_ready,
@@ -61,6 +62,7 @@ module dmac_2d_transfer #(
   output [DMA_AXI_ADDR_WIDTH-1:BYTES_PER_BEAT_WIDTH_SRC] out_req_src_address,
   output [DMA_LENGTH_WIDTH-1:0] out_req_length,
   output reg out_req_sync_transfer_start,
+  output out_req_last,
   input out_eot
 );
 
@@ -70,6 +72,8 @@ reg [DMA_LENGTH_WIDTH-1:0] x_length = 'h00;
 reg [DMA_LENGTH_WIDTH-1:0] y_length = 'h00;
 reg [DMA_LENGTH_WIDTH-1:0] dest_stride = 'h0;
 reg [DMA_LENGTH_WIDTH-1:0] src_stride = 'h00;
+
+reg gen_last = 'h0;
 
 reg [1:0] req_id = 'h00;
 reg [1:0] eot_id = 'h00;
@@ -116,6 +120,7 @@ always @(posedge req_aclk) begin
     dest_stride <= req_dest_stride;
     src_stride <= req_src_stride;
     out_req_sync_transfer_start <= req_sync_transfer_start;
+    gen_last <= req_last;
   end else if (out_req_valid == 1'b1 && out_req_ready == 1'b1) begin
     dest_address <= dest_address + dest_stride[DMA_LENGTH_WIDTH-1:BYTES_PER_BEAT_WIDTH_DEST];
     src_address <= src_address + src_stride[DMA_LENGTH_WIDTH-1:BYTES_PER_BEAT_WIDTH_SRC];
@@ -139,5 +144,7 @@ always @(posedge req_aclk) begin
     end
   end
 end
+
+assign out_req_last = out_last & gen_last;
 
 endmodule

--- a/library/axi_dmac/axi_dmac_transfer.v
+++ b/library/axi_dmac/axi_dmac_transfer.v
@@ -257,6 +257,7 @@ dmac_2d_transfer #(
   .req_dest_stride (req_dest_stride),
   .req_src_stride (req_src_stride),
   .req_sync_transfer_start (req_sync_transfer_start),
+  .req_last (req_last),
 
   .out_req_valid (dma_req_valid),
   .out_req_ready (dma_req_ready),
@@ -264,10 +265,9 @@ dmac_2d_transfer #(
   .out_req_src_address (dma_req_src_address),
   .out_req_length (dma_req_length),
   .out_req_sync_transfer_start (dma_req_sync_transfer_start),
+  .out_req_last (dma_req_last),
   .out_eot (dma_req_eot)
 );
-
-assign dma_req_last = 1'b0;
 
 end else begin
 


### PR DESCRIPTION
In MM2S applications like video DMA it is useful to mark the end of the stream
with the TLAST.
The change enables the generation of the TLAST on the last beat of the
last row of the 2d transfer.