### PR TITLE
adi_board.tcl: ad_xcvrcon updates

### DIFF
--- a/projects/scripts/adi_board.tcl
+++ b/projects/scripts/adi_board.tcl
@@ -268,17 +268,22 @@ proc ad_xcvrcon {u_xcvr a_xcvr a_jesd {lane_map {}} {device_clk {}}} {
     }
 
     if {$lane_map != {}} {
-      set phys_lane [expr [lindex $lane_map $n] + $index]
+      set phys_lane [lindex $lane_map $n]
+      if {$phys_lane != {}} {
+        set phys_lane [expr $phys_lane + $index]
+      }
     } else {
       set phys_lane $m
     }
 
     ad_connect  ${a_xcvr}/up_ch_${n} ${u_xcvr}/up_${txrx}_${m}
     ad_connect  ${device_clk} ${u_xcvr}/${txrx}_clk_${m}
-    if {$jesd204_type == 0} {
-      ad_connect  ${u_xcvr}/${txrx}_${phys_lane} ${a_jesd}/${txrx}_phy${n}
-    } else {
-      ad_connect  ${u_xcvr}/${txrx}_${phys_lane} ${a_jesd}/gt${n}_${txrx}
+    if {$phys_lane != {}} {
+      if {$jesd204_type == 0} {
+        ad_connect  ${u_xcvr}/${txrx}_${phys_lane} ${a_jesd}/${txrx}_phy${n}
+      } else {
+        ad_connect  ${u_xcvr}/${txrx}_${phys_lane} ${a_jesd}/gt${n}_${txrx}
+      }
     }
 
     create_bd_port -dir ${data_dir} ${m_data}_${m}_p

--- a/projects/scripts/adi_board.tcl
+++ b/projects/scripts/adi_board.tcl
@@ -171,7 +171,7 @@ proc ad_reconct {p_name_1 p_name_2} {
 # lane_map maps the logical lane $n onto the physical lane $lane_map[$n]. If no
 # lane map is provided logical lane $n is mapped onto physical lane $n.
 #
-proc ad_xcvrcon {u_xcvr a_xcvr a_jesd {lane_map {}}} {
+proc ad_xcvrcon {u_xcvr a_xcvr a_jesd {lane_map {}} {device_clk {}}} {
   
   global xcvr_index
   global xcvr_tx_index
@@ -233,7 +233,22 @@ proc ad_xcvrcon {u_xcvr a_xcvr a_jesd {lane_map {}}} {
 
   create_bd_port -dir I $m_sysref
   create_bd_port -dir ${ctrl_dir} $m_sync
-  ad_ip_instance proc_sys_reset ${a_jesd}_rstgen
+
+  if {$device_clk == {}} {
+    set device_clk ${u_xcvr}/${txrx}_out_clk_${index}
+    set rst_gen [regsub -all "/" ${a_jesd}_rstgen "_"]
+    set create_rst_gen 1
+  } else {
+    set rst_gen ${device_clk}_rstgen
+    # Only create one reset gen per clock
+    set create_rst_gen [expr {[get_bd_cells -quiet ${rst_gen}] == {}}]
+  }
+
+  if {${create_rst_gen}} {
+    ad_ip_instance proc_sys_reset ${rst_gen}
+    ad_connect ${device_clk} ${rst_gen}/slowest_sync_clk
+    ad_connect sys_cpu_resetn ${rst_gen}/ext_reset_in
+  }
 
   for {set n 0} {$n < $no_of_lanes} {incr n} {
 
@@ -259,7 +274,7 @@ proc ad_xcvrcon {u_xcvr a_xcvr a_jesd {lane_map {}}} {
     }
 
     ad_connect  ${a_xcvr}/up_ch_${n} ${u_xcvr}/up_${txrx}_${m}
-    ad_connect  ${u_xcvr}/${txrx}_out_clk_${index} ${u_xcvr}/${txrx}_clk_${m}
+    ad_connect  ${device_clk} ${u_xcvr}/${txrx}_clk_${m}
     if {$jesd204_type == 0} {
       ad_connect  ${u_xcvr}/${txrx}_${phys_lane} ${a_jesd}/${txrx}_phy${n}
     } else {
@@ -275,20 +290,17 @@ proc ad_xcvrcon {u_xcvr a_xcvr a_jesd {lane_map {}}} {
   if {$jesd204_type == 0} {
     ad_connect  ${a_jesd}/sysref $m_sysref
     ad_connect  ${a_jesd}/sync $m_sync
-    ad_connect  ${u_xcvr}/${txrx}_out_clk_${index} ${a_jesd}/device_clk
+    ad_connect  ${device_clk} ${a_jesd}/device_clk
 #    if {$tx_or_rx_n == 0} {
 #      ad_connect  ${a_xcvr}/up_status ${a_jesd}/phy_ready
 #    }
   } else {
     ad_connect  ${a_jesd}/${txrx}_sysref $m_sysref
     ad_connect  ${a_jesd}/${txrx}_sync $m_sync
-    ad_connect  ${u_xcvr}/${txrx}_out_clk_${index} ${a_jesd}/${txrx}_core_clk
+    ad_connect  ${device_clk} ${a_jesd}/${txrx}_core_clk
     ad_connect  ${a_xcvr}/up_status ${a_jesd}/${txrx}_reset_done
-    ad_connect  ${a_jesd}_rstgen/peripheral_reset ${a_jesd}/${txrx}_reset
+    ad_connect  ${rst_gen}/peripheral_reset ${a_jesd}/${txrx}_reset
   }
-
-  ad_connect  ${u_xcvr}/${txrx}_out_clk_${index} ${a_jesd}_rstgen/slowest_sync_clk
-  ad_connect  sys_cpu_resetn ${a_jesd}_rstgen/ext_reset_in
 
   if {$tx_or_rx_n == 0} {
     set xcvr_rx_index [expr ($xcvr_rx_index + $no_of_lanes)]


### PR DESCRIPTION
Two new features for the ad_xcvrcon helper function
* Be able to specify a dedicated device clock. This is necessary for deterministic latency setups
* Be able to provide sparse lane mappings. This is necessary if a design uses more than one transceiver quad, but at least two transceivers quads are not fully used. E.g. 4 lanes with 2 lanes in one quad each.