### PR TITLE
axi_dmac: fix address width detection

### DIFF
--- a/library/axi_dmac/bd/bd.tcl
+++ b/library/axi_dmac/bd/bd.tcl
@@ -149,7 +149,7 @@ proc post_propagate {cellpath otherinfo} {
 			foreach addr_seg $addr_segs {
 				set range [get_property "range" $addr_seg]
 				set offset [get_property "offset" $addr_seg]
-				set addr_width [expr max(round(log($range + $offset) / log(2)), $addr_width)]
+				set addr_width [expr max(int(ceil(log($range - 1 + $offset) / log(2))), $addr_width)]
 			}
 		} else {
 			set addr_width 32


### PR DESCRIPTION
The round function from tcl is a rounding to nearest. Using it in address
width calculation produces incorrect values.
e.g.
 round(log(0xAF000000)/log(2)) will produce 31 instead of 32

The fix is to replace the rounding function with ceiling that guarantees
rounding up.