### PR TITLE
jesd204_rx/tx: make SYSREF IOB placement optional

### DIFF
--- a/library/jesd204/jesd204_rx/Makefile
+++ b/library/jesd204/jesd204_rx/Makefile
@@ -14,7 +14,7 @@ GENERIC_DEPS += jesd204_rx_cgs.v
 GENERIC_DEPS += jesd204_rx_ctrl.v
 GENERIC_DEPS += jesd204_rx_lane.v
 
-XILINX_DEPS += jesd204_rx_constr.xdc
+XILINX_DEPS += jesd204_rx_constr.ttcl
 XILINX_DEPS += jesd204_rx_ip.tcl
 
 XILINX_DEPS += ../../jesd204/interfaces/jesd204_rx_cfg.xml

--- a/library/jesd204/jesd204_rx/jesd204_rx_constr.ttcl
+++ b/library/jesd204/jesd204_rx/jesd204_rx_constr.ttcl
@@ -41,6 +41,12 @@
 # “The design and implementation of the JESD204 HDL Core used in this project
 # is copyright © 2016-2017, Analog Devices, Inc.”
 #
+<: set ComponentName [getComponentNameString] :>
+<: setOutputDirectory "./" :>
+<: setFileName [ttcl_add $ComponentName "_constr"] :>
+<: setFileExtension ".xdc" :>
+<: setFileProcessingOrder late :>
+<: set sysref_iob [get_property PARAM_VALUE.SYSREF_IOB] :>
 
 set_property ASYNC_REG TRUE \
   [get_cells {i_lmfc/sysref_d1_reg}] \
@@ -48,5 +54,5 @@ set_property ASYNC_REG TRUE \
 
 # Make sure that the device clock to sysref skew is at least somewhat
 # predictable
-set_property IOB TRUE \
+set_property IOB <=: $sysref_iob :> \
   [get_cells {i_lmfc/sysref_r_reg}]

--- a/library/jesd204/jesd204_rx/jesd204_rx_ip.tcl
+++ b/library/jesd204/jesd204_rx/jesd204_rx_ip.tcl
@@ -54,15 +54,12 @@ adi_ip_files jesd204_rx [list \
   "jesd204_ilas_monitor.v" \
   "align_mux.v" \
   "jesd204_lane_latency_monitor.v" \
-  "jesd204_rx_constr.xdc" \
+  "jesd204_rx_constr.ttcl" \
   "jesd204_rx.v" \
 ]
 
 adi_ip_properties_lite jesd204_rx
-
-set_property PROCESSING_ORDER LATE [ipx::get_files jesd204_rx_constr.xdc \
-  -of_objects [ipx::get_file_groups -of_objects [ipx::current_core] \
-  -filter {NAME =~ *synthesis*}]]
+adi_ip_ttcl jesd204_rx "jesd204_rx_constr.ttcl"
 
 adi_ip_add_core_dependencies { \
   analog.com:user:jesd204_common:1.0 \
@@ -139,4 +136,18 @@ adi_add_bus "rx_event" "master" \
 
 adi_add_bus_clock "clk" "rx_cfg:rx_ilas_config:rx_event:rx_status:rx_data" "reset"
 
+set cc [ipx::current_core]
+set page0 [ipgui::get_pagespec -name "Page 0" -component $cc]
+
+set param [ipx::add_user_parameter SYSREF_IOB $cc]
+set_property -dict {value_resolve_type user value_format bool value true} $param
+
+set param [ipgui::add_param -name {SYSREF_IOB} -component $cc -parent $page0]
+set_property -dict [list \
+  display_name {Place SYSREF in IOB} \
+  widget {checkBox} \
+  show_label true \
+] $param
+
+ipx::create_xgui_files [ipx::current_core]
 ipx::save_core [ipx::current_core]

--- a/library/jesd204/jesd204_tx/Makefile
+++ b/library/jesd204/jesd204_tx/Makefile
@@ -9,7 +9,7 @@ GENERIC_DEPS += jesd204_tx.v
 GENERIC_DEPS += jesd204_tx_ctrl.v
 GENERIC_DEPS += jesd204_tx_lane.v
 
-XILINX_DEPS += jesd204_tx_constr.xdc
+XILINX_DEPS += jesd204_tx_constr.ttcl
 XILINX_DEPS += jesd204_tx_ip.tcl
 
 XILINX_DEPS += ../../jesd204/interfaces/jesd204_tx_cfg.xml

--- a/library/jesd204/jesd204_tx/jesd204_tx_constr.ttcl
+++ b/library/jesd204/jesd204_tx/jesd204_tx_constr.ttcl
@@ -41,6 +41,12 @@
 # “The design and implementation of the JESD204 HDL Core used in this project
 # is copyright © 2016-2017, Analog Devices, Inc.”
 #
+<: set ComponentName [getComponentNameString] :>
+<: setOutputDirectory "./" :>
+<: setFileName [ttcl_add $ComponentName "_constr"] :>
+<: setFileExtension ".xdc" :>
+<: setFileProcessingOrder late :>
+<: set sysref_iob [get_property PARAM_VALUE.SYSREF_IOB] :>
 
 set_property ASYNC_REG TRUE \
   [get_cells {i_lmfc/sysref_d1_reg}] \
@@ -48,5 +54,5 @@ set_property ASYNC_REG TRUE \
 
 # Make sure that the device clock to sysref skew is at least somewhat
 # predictable
-set_property IOB TRUE \
+set_property IOB <=: $sysref_iob :> \
   [get_cells {i_lmfc/sysref_r_reg}]

--- a/library/jesd204/jesd204_tx/jesd204_tx_ip.tcl
+++ b/library/jesd204/jesd204_tx/jesd204_tx_ip.tcl
@@ -49,15 +49,12 @@ adi_ip_create jesd204_tx
 adi_ip_files jesd204_tx [list \
   "jesd204_tx_lane.v" \
   "jesd204_tx_ctrl.v" \
-  "jesd204_tx_constr.xdc" \
+  "jesd204_tx_constr.ttcl" \
   "jesd204_tx.v"
 ]
 
 adi_ip_properties_lite jesd204_tx
-
-set_property PROCESSING_ORDER LATE [ipx::get_files jesd204_tx_constr.xdc \
-  -of_objects [ipx::get_file_groups -of_objects [ipx::current_core] \
-  -filter {NAME =~ *synthesis*}]]
+adi_ip_ttcl jesd204_tx "jesd204_tx_constr.ttcl"
 
 adi_ip_add_core_dependencies { \
   analog.com:user:jesd204_common:1.0 \
@@ -139,4 +136,18 @@ adi_add_bus "tx_ctrl" "slave" \
 adi_add_bus_clock "clk" "tx_data:tx_cfg:tx_ilas_config:tx_event:tx_status:tx_ctrl" \
   "reset"
 
+set cc [ipx::current_core]
+set page0 [ipgui::get_pagespec -name "Page 0" -component $cc]
+
+set param [ipx::add_user_parameter SYSREF_IOB $cc]
+set_property -dict {value_resolve_type user value_format bool value true} $param
+
+set param [ipgui::add_param -name {SYSREF_IOB} -component $cc -parent $page0]
+set_property -dict [list \
+  display_name {Place SYSREF in IOB} \
+  widget {checkBox} \
+  show_label true \
+] $param
+
+ipx::create_xgui_files [ipx::current_core]
 ipx::save_core [ipx::current_core]


### PR DESCRIPTION
In case when the SYSREF is connected to an FPGA IO which has a limitation
on the IOB register IN_FF clock line and the required ref clock is high
we can't use the IOB registers.
e.g. the max clock rate on zcu102 HP IO FF is 312MHz but ref clock is 375MHz;
If IOB is used in this case a pulse width violation is reported.

This change makes the IOB placement selectable in such case or
for targets which don't require class 1 operation.

This could be used also when other primitives are instantiated to capture the SYSREF and IOB would 
cause critical warnings. 