### PR TITLE
axi_hdmi_tx: Added INTERFACE parameter for selecting the interface type

### DIFF
--- a/library/axi_hdmi_tx/axi_hdmi_tx.v
+++ b/library/axi_hdmi_tx/axi_hdmi_tx.v
@@ -38,7 +38,7 @@ module axi_hdmi_tx #(
   parameter   ID = 0,
   parameter   CR_CB_N = 0,
   parameter   DEVICE_TYPE = 0,
-  parameter   EMBEDDED_SYNC = 0,
+  parameter   INTERFACE = "16_BIT",
   parameter   OUT_CLK_POLARITY = 0) (
 
   // hdmi interface
@@ -103,6 +103,7 @@ module axi_hdmi_tx #(
 
   /* 0 = Launch on rising edge, 1 = Launch on falling edge */
 
+  localparam  EMBEDDED_SYNC = (INTERFACE == "16_BIT_EMBEDDED_SYNC") ? 1 : 0;
   localparam  XILINX_7SERIES = 0;
   localparam  XILINX_ULTRASCALE = 1;
   localparam  ALTERA_5SERIES = 16;

--- a/library/axi_hdmi_tx/axi_hdmi_tx_ip.tcl
+++ b/library/axi_hdmi_tx/axi_hdmi_tx_ip.tcl
@@ -30,6 +30,30 @@ adi_ip_files axi_hdmi_tx [list \
 
 adi_ip_properties axi_hdmi_tx
 
+set_property driver_value 0 [ipx::get_ports *hsync* -of_objects [ipx::current_core]]
+set_property driver_value 0 [ipx::get_ports *vsync* -of_objects [ipx::current_core]]
+set_property driver_value 0 [ipx::get_ports *data* -of_objects [ipx::current_core]]
+set_property driver_value 0 [ipx::get_ports *es_data* -of_objects [ipx::current_core]]
+
+set_property driver_value 0 [ipx::get_ports *vdma_fs* -of_objects [ipx::current_core]]
+set_property driver_value 0 [ipx::get_ports *vdma_valid* -of_objects [ipx::current_core]]
+set_property driver_value 0 [ipx::get_ports *vdma_data* -of_objects [ipx::current_core]]
+set_property driver_value 0 [ipx::get_ports *vdma_ready* -of_objects [ipx::current_core]]
+
+set_property value_format string [ipx::get_user_parameters INTERFACE -of_objects [ipx::current_core]]
+set_property value_format string [ipx::get_hdl_parameters INTERFACE -of_objects [ipx::current_core]]
+set_property value_validation_list {16_BIT 24_BIT 36_BIT 16_BIT_EMBEDDED_SYNC} \
+  [ipx::get_user_parameters INTERFACE -of_objects [ipx::current_core]]
+
+set_property enablement_dependency {spirit:decode(id('MODELPARAM_VALUE.INTERFACE')) == "16_BIT"} \
+  [ipx::get_ports *hdmi_16* -of_objects [ipx::current_core]]
+set_property enablement_dependency {spirit:decode(id('MODELPARAM_VALUE.INTERFACE')) == "24_BIT"} \
+  [ipx::get_ports *hdmi_24* -of_objects [ipx::current_core]]
+set_property enablement_dependency {spirit:decode(id('MODELPARAM_VALUE.INTERFACE')) == "36_BIT"} \
+  [ipx::get_ports *hdmi_36* -of_objects [ipx::current_core]]
+set_property enablement_dependency {spirit:decode(id('MODELPARAM_VALUE.INTERFACE')) == "16_BIT_EMBEDDED_SYNC"} \
+  [ipx::get_ports *hdmi_16_es_data* -of_objects [ipx::current_core]]
+
 ipx::infer_bus_interface hdmi_clk xilinx.com:signal:clock_rtl:1.0 [ipx::current_core]
 ipx::infer_bus_interface hdmi_out_clk xilinx.com:signal:clock_rtl:1.0 [ipx::current_core]
 ipx::infer_bus_interface vdma_clk xilinx.com:signal:clock_rtl:1.0 [ipx::current_core]

--- a/projects/adrv9361z7035/common/ccfmc_bd.tcl
+++ b/projects/adrv9361z7035/common/ccfmc_bd.tcl
@@ -44,6 +44,7 @@ ad_ip_parameter sys_rgmii_rstgen CONFIG.C_EXT_RST_WIDTH 1
 ad_ip_instance axi_clkgen axi_hdmi_clkgen
 ad_ip_instance axi_hdmi_tx axi_hdmi_core
 ad_ip_parameter axi_hdmi_core CONFIG.OUT_CLK_POLARITY 1
+ad_ip_parameter axi_hdmi_core CONFIG.INTERFACE 16_BIT
 
 ad_ip_instance axi_vdma axi_hdmi_dma
 ad_ip_parameter axi_hdmi_dma CONFIG.c_m_axis_mm2s_tdata_width 64

--- a/projects/common/mitx045/mitx045_system_bd.tcl
+++ b/projects/common/mitx045/mitx045_system_bd.tcl
@@ -103,6 +103,7 @@ ad_ip_parameter sys_rstgen CONFIG.C_EXT_RST_WIDTH 1
 
 ad_ip_instance axi_clkgen axi_hdmi_clkgen
 ad_ip_instance axi_hdmi_tx axi_hdmi_core
+ad_ip_parameter axi_hdmi_core CONFIG.INTERFACE 16_BIT
 
 ad_ip_instance axi_vdma axi_hdmi_dma
 ad_ip_parameter axi_hdmi_dma CONFIG.C_M_AXIS_MM2S_TDATA_WIDTH 64
@@ -114,7 +115,7 @@ ad_ip_parameter axi_hdmi_dma CONFIG.C_INCLUDE_S2MM 0
 ad_ip_instance clk_wiz sys_audio_clkgen
 ad_ip_parameter sys_audio_clkgen CONFIG.CLKOUT1_REQUESTED_OUT_FREQ 12.288
 ad_ip_parameter sys_audio_clkgen CONFIG.USE_LOCKED false
-ad_ip_parameter sys_audio_clkgen CONFIG.USE_RESET true 
+ad_ip_parameter sys_audio_clkgen CONFIG.USE_RESET true
 ad_ip_parameter sys_audio_clkgen CONFIG.USE_PHASE_ALIGNMENT false
 ad_ip_parameter sys_audio_clkgen CONFIG.RESET_TYPE ACTIVE_LOW
 ad_ip_parameter sys_audio_clkgen CONFIG.PRIM_SOURCE No_buffer

--- a/projects/common/zc702/zc702_system_bd.tcl
+++ b/projects/common/zc702/zc702_system_bd.tcl
@@ -93,6 +93,7 @@ ad_ip_parameter sys_rstgen CONFIG.C_EXT_RST_WIDTH 1
 
 ad_ip_instance axi_clkgen axi_hdmi_clkgen
 ad_ip_instance axi_hdmi_tx axi_hdmi_core
+ad_ip_parameter axi_hdmi_core CONFIG.INTERFACE 16_BIT
 
 ad_ip_instance axi_vdma axi_hdmi_dma
 ad_ip_parameter axi_hdmi_dma CONFIG.c_m_axis_mm2s_tdata_width 64

--- a/projects/common/zc706/zc706_system_bd.tcl
+++ b/projects/common/zc706/zc706_system_bd.tcl
@@ -94,6 +94,7 @@ ad_ip_parameter sys_rstgen CONFIG.C_EXT_RST_WIDTH 1
 
 ad_ip_instance axi_clkgen axi_hdmi_clkgen
 ad_ip_instance axi_hdmi_tx axi_hdmi_core
+ad_ip_parameter axi_hdmi_core CONFIG.INTERFACE 24_BIT
 
 ad_ip_instance axi_vdma axi_hdmi_dma
 ad_ip_parameter axi_hdmi_dma CONFIG.C_M_AXIS_MM2S_TDATA_WIDTH 64

--- a/projects/common/zed/zed_system_bd.tcl
+++ b/projects/common/zed/zed_system_bd.tcl
@@ -117,6 +117,7 @@ ad_ip_parameter sys_logic_inv CONFIG.C_OPERATION not
 
 ad_ip_instance axi_clkgen axi_hdmi_clkgen
 ad_ip_instance axi_hdmi_tx axi_hdmi_core
+ad_ip_parameter axi_hdmi_core CONFIG.INTERFACE 16_BIT
 
 ad_ip_instance axi_vdma axi_hdmi_dma
 ad_ip_parameter axi_hdmi_dma CONFIG.C_M_AXIS_MM2S_TDATA_WIDTH 64

--- a/projects/imageon/common/imageon_bd.tcl
+++ b/projects/imageon/common/imageon_bd.tcl
@@ -13,7 +13,7 @@ delete_bd_objs [get_bd_ports hdmi_hsync]
 delete_bd_objs [get_bd_ports hdmi_data_e]
 delete_bd_objs [get_bd_ports hdmi_data]
 
-ad_ip_parameter axi_hdmi_core CONFIG.EMBEDDED_SYNC 1
+ad_ip_parameter axi_hdmi_core CONFIG.INTERFACE 16_BIT_EMBEDDED_SYNC
 ad_ip_parameter axi_hdmi_core CONFIG.OUT_CLK_POLARITY 1
 
 create_bd_port -dir O hdmi_tx_clk


### PR DESCRIPTION
Update all carriers/projects bd for configurable video interface:
- common zc702, zc706, zed
- adrv9361z7035/ccfmc_lvds
- imageon