### PR TITLE
fmcadc5: remove SYSREF from IOB

### DIFF
--- a/projects/fmcadc5/common/fmcadc5_bd.tcl
+++ b/projects/fmcadc5/common/fmcadc5_bd.tcl
@@ -45,8 +45,10 @@ ad_ip_parameter axi_ad9625_1_xcvr CONFIG.SYS_CLK_SEL 0x0
 ad_ip_parameter axi_ad9625_1_xcvr CONFIG.OUT_CLK_SEL 0x2
 
 adi_axi_jesd204_rx_create axi_ad9625_0_jesd 8
+ad_ip_parameter axi_ad9625_0_jesd/rx CONFIG.SYSREF_IOB false
 
 adi_axi_jesd204_rx_create axi_ad9625_1_jesd 8
+ad_ip_parameter axi_ad9625_1_jesd/rx CONFIG.SYSREF_IOB false
 
 ad_ip_instance axi_ad9625 axi_ad9625_0_core
 ad_ip_parameter axi_ad9625_0_core CONFIG.ID 0

--- a/projects/fmcadc5/vc707/system_project.tcl
+++ b/projects/fmcadc5/vc707/system_project.tcl
@@ -13,9 +13,6 @@ adi_project_files fmcadc5_vc707 [list \
   "system_constr.xdc"\
   "system_top.v"]
 
-set_property is_enabled false [get_files  *system_rx_0/jesd204_rx_constr.xdc]
-set_property is_enabled false [get_files  *system_rx_1/jesd204_rx_constr.xdc]
-
 adi_project_run fmcadc5_vc707
 
 


### PR DESCRIPTION
The SYSREF for RX is generated internally,
disable the IOB attribute from it to avoid critical warnings.