### PR TITLE
Initial support for AD9172 on ZCU102

### DIFF
--- a/library/jesd204/ad_ip_jesd204_tpl_dac/ad_ip_jesd204_tpl_dac_ip.tcl
+++ b/library/jesd204/ad_ip_jesd204_tpl_dac/ad_ip_jesd204_tpl_dac_ip.tcl
@@ -52,4 +52,13 @@ adi_ip_files ad_ip_jesd204_tpl_dac [list \
 
 adi_ip_properties ad_ip_jesd204_tpl_dac
 
+adi_add_bus "link" "master" \
+	"xilinx.com:interface:axis_rtl:1.0" \
+	"xilinx.com:interface:axis:1.0" \
+	[list {"link_ready" "TREADY"} \
+	  {"link_valid" "TVALID"} \
+	  {"link_data" "TDATA"} \
+  ]
+adi_add_bus_clock "link_clk" "link"
+
 ipx::save_core [ipx::current_core]

--- a/projects/ad9172_fmc_ebz/common/ad9172_fmc_ebz_bd.tcl
+++ b/projects/ad9172_fmc_ebz/common/ad9172_fmc_ebz_bd.tcl
@@ -1,0 +1,121 @@
+source $ad_hdl_dir/library/jesd204/scripts/jesd204.tcl
+
+set NUM_OF_LANES 8
+set NUM_OF_CHANNELS 2
+set SAMPLE_WIDTH 16
+
+# dac peripherals
+
+ad_ip_instance axi_adxcvr axi_ad9172_xcvr
+ad_ip_parameter axi_ad9172_xcvr CONFIG.NUM_OF_LANES $NUM_OF_LANES
+ad_ip_parameter axi_ad9172_xcvr CONFIG.QPLL_ENABLE 1
+ad_ip_parameter axi_ad9172_xcvr CONFIG.TX_OR_RX_N 1
+
+adi_axi_jesd204_tx_create axi_ad9172_jesd 8
+
+ad_ip_instance ad_ip_jesd204_tpl_dac ad9172_tpl_core
+ad_ip_parameter ad9172_tpl_core CONFIG.NUM_LANES $NUM_OF_LANES
+ad_ip_parameter ad9172_tpl_core CONFIG.NUM_CHANNELS $NUM_OF_CHANNELS
+ad_ip_parameter ad9172_tpl_core CONFIG.CHANNEL_WIDTH $SAMPLE_WIDTH
+
+ad_ip_instance util_upack axi_ad9172_upack
+ad_ip_parameter axi_ad9172_upack CONFIG.CHANNEL_DATA_WIDTH 128
+ad_ip_parameter axi_ad9172_upack CONFIG.NUM_OF_CHANNELS $NUM_OF_CHANNELS
+
+ad_ip_instance axi_dmac axi_ad9172_dma
+ad_ip_parameter axi_ad9172_dma CONFIG.DMA_DATA_WIDTH_SRC 128
+ad_ip_parameter axi_ad9172_dma CONFIG.DMA_DATA_WIDTH_DEST 256
+ad_ip_parameter axi_ad9172_dma CONFIG.DMA_2D_TRANSFER 0
+ad_ip_parameter axi_ad9172_dma CONFIG.DMA_LENGTH_WIDTH 24
+ad_ip_parameter axi_ad9172_dma CONFIG.AXI_SLICE_DEST 0
+ad_ip_parameter axi_ad9172_dma CONFIG.AXI_SLICE_SRC 0
+ad_ip_parameter axi_ad9172_dma CONFIG.SYNC_TRANSFER_START 0
+ad_ip_parameter axi_ad9172_dma CONFIG.CYCLIC 1
+ad_ip_parameter axi_ad9172_dma CONFIG.DMA_TYPE_DEST 1
+ad_ip_parameter axi_ad9172_dma CONFIG.DMA_TYPE_SRC 0
+ad_ip_parameter axi_ad9172_dma CONFIG.FIFO_SIZE 16
+
+# transceiver core
+
+ad_ip_instance util_adxcvr util_ad9172_xcvr
+ad_ip_parameter util_ad9172_xcvr CONFIG.RX_NUM_OF_LANES 0
+ad_ip_parameter util_ad9172_xcvr CONFIG.TX_NUM_OF_LANES $NUM_OF_LANES
+ad_ip_parameter util_ad9172_xcvr CONFIG.TX_LANE_INVERT 15
+
+ad_connect  sys_cpu_resetn util_ad9172_xcvr/up_rstn
+ad_connect  sys_cpu_clk util_ad9172_xcvr/up_clk
+
+# reference clocks & resets
+
+create_bd_port -dir I tx_ref_clk_0
+
+ad_xcvrpll  tx_ref_clk_0 util_ad9172_xcvr/qpll_ref_clk_*
+ad_xcvrpll  tx_ref_clk_0 util_ad9172_xcvr/cpll_ref_clk_*
+ad_xcvrpll  axi_ad9172_xcvr/up_pll_rst util_ad9172_xcvr/up_qpll_rst_*
+
+# connections (dac)
+
+ad_xcvrcon  util_ad9172_xcvr axi_ad9172_xcvr axi_ad9172_jesd {1 0 3 2 4 7 5 6}
+ad_connect  util_ad9172_xcvr/tx_out_clk_0 ad9172_tpl_core/link_clk
+ad_connect  axi_ad9172_jesd/tx_data ad9172_tpl_core/link
+ad_connect  util_ad9172_xcvr/tx_out_clk_0 axi_ad9172_upack/dac_clk
+
+ad_ip_instance xlconcat ad9172_data_concat
+ad_ip_parameter ad9172_data_concat CONFIG.NUM_PORTS $NUM_OF_CHANNELS
+
+for {set i 0} {$i < $NUM_OF_CHANNELS} {incr i} {
+  ad_ip_instance xlslice ad9172_enable_slice_$i
+  ad_ip_parameter ad9172_enable_slice_$i CONFIG.DIN_WIDTH $NUM_OF_CHANNELS
+  ad_ip_parameter ad9172_enable_slice_$i CONFIG.DIN_FROM $i
+  ad_ip_parameter ad9172_enable_slice_$i CONFIG.DIN_TO $i
+
+  ad_ip_instance xlslice ad9172_valid_slice_$i
+  ad_ip_parameter ad9172_valid_slice_$i CONFIG.DIN_WIDTH $NUM_OF_CHANNELS
+  ad_ip_parameter ad9172_valid_slice_$i CONFIG.DIN_FROM $i
+  ad_ip_parameter ad9172_valid_slice_$i CONFIG.DIN_TO $i
+
+  ad_connect ad9172_tpl_core/enable ad9172_enable_slice_$i/Din
+  ad_connect ad9172_tpl_core/dac_valid ad9172_valid_slice_$i/Din
+
+  ad_connect ad9172_enable_slice_$i/Dout axi_ad9172_upack/dac_enable_$i
+  ad_connect ad9172_valid_slice_$i/Dout axi_ad9172_upack/dac_valid_$i
+  ad_connect axi_ad9172_upack/dac_data_$i ad9172_data_concat/In$i
+
+}
+ad_connect ad9172_tpl_core/dac_ddata ad9172_data_concat/dout
+
+ad_connect  util_ad9172_xcvr/tx_out_clk_0 axi_ad9172_fifo/dac_clk
+ad_connect  axi_ad9172_jesd_rstgen/peripheral_reset axi_ad9172_fifo/dac_rst
+ad_connect  axi_ad9172_upack/dac_valid axi_ad9172_fifo/dac_valid
+ad_connect  axi_ad9172_upack/dac_data axi_ad9172_fifo/dac_data
+ad_connect  ad9172_tpl_core/dac_dunf axi_ad9172_fifo/dac_dunf
+ad_connect  sys_cpu_clk axi_ad9172_fifo/dma_clk
+ad_connect  sys_cpu_reset axi_ad9172_fifo/dma_rst
+ad_connect  sys_cpu_clk axi_ad9172_dma/m_axis_aclk
+ad_connect  sys_cpu_resetn axi_ad9172_dma/m_src_axi_aresetn
+ad_connect  axi_ad9172_fifo/dma_xfer_req axi_ad9172_dma/m_axis_xfer_req
+ad_connect  axi_ad9172_fifo/dma_ready axi_ad9172_dma/m_axis_ready
+ad_connect  axi_ad9172_fifo/dma_data axi_ad9172_dma/m_axis_data
+ad_connect  axi_ad9172_fifo/dma_valid axi_ad9172_dma/m_axis_valid
+ad_connect  axi_ad9172_fifo/dma_xfer_last axi_ad9172_dma/m_axis_last
+
+
+# interconnect (cpu)
+
+ad_cpu_interconnect 0x44A60000 axi_ad9172_xcvr
+ad_cpu_interconnect 0x44A00000 ad9172_tpl_core
+ad_cpu_interconnect 0x44A90000 axi_ad9172_jesd
+ad_cpu_interconnect 0x7c420000 axi_ad9172_dma
+
+
+# interconnect (mem/dac)
+
+ad_mem_hp1_interconnect sys_cpu_clk sys_ps7/S_AXI_HP1
+ad_mem_hp1_interconnect sys_cpu_clk axi_ad9172_dma/m_src_axi
+
+# interrupts
+
+ad_cpu_interrupt ps-10 mb-15 axi_ad9172_jesd/irq
+ad_cpu_interrupt ps-12 mb-13 axi_ad9172_dma/irq
+
+ad_connect  axi_ad9172_fifo/bypass GND

--- a/projects/ad9172_fmc_ebz/zcu102/Makefile
+++ b/projects/ad9172_fmc_ebz/zcu102/Makefile
@@ -1,0 +1,23 @@
+####################################################################################
+## Copyright 2018(c) Analog Devices, Inc.
+## Auto-generated, do not modify!
+####################################################################################
+
+PROJECT_NAME := ad9172_fmc_ebz_zcu102
+
+M_DEPS += ../common/ad9172_fmc_ebz_bd.tcl
+M_DEPS += ../../common/zcu102/zcu102_system_constr.xdc
+M_DEPS += ../../common/zcu102/zcu102_system_bd.tcl
+M_DEPS += ../../common/xilinx/dacfifo_bd.tcl
+M_DEPS += ../../../library/jesd204/scripts/jesd204.tcl
+
+LIB_DEPS += axi_dmac
+LIB_DEPS += jesd204/ad_ip_jesd204_tpl_dac
+LIB_DEPS += jesd204/axi_jesd204_tx
+LIB_DEPS += jesd204/jesd204_tx
+LIB_DEPS += util_dacfifo
+LIB_DEPS += util_upack
+LIB_DEPS += xilinx/axi_adxcvr
+LIB_DEPS += xilinx/util_adxcvr
+
+include ../../scripts/project-xilinx.mk

--- a/projects/ad9172_fmc_ebz/zcu102/system_bd.tcl
+++ b/projects/ad9172_fmc_ebz/zcu102/system_bd.tcl
@@ -1,0 +1,18 @@
+
+set dac_fifo_name axi_ad9172_fifo
+set dac_fifo_address_width 13
+set dac_data_width 256
+set dac_dma_data_width 256
+
+source $ad_hdl_dir/projects/common/zcu102/zcu102_system_bd.tcl
+source $ad_hdl_dir/projects/common/xilinx/dacfifo_bd.tcl
+source ../common/ad9172_fmc_ebz_bd.tcl
+
+ad_ip_parameter axi_ad9172_xcvr CONFIG.XCVR_TYPE 2
+
+ad_ip_parameter util_ad9172_xcvr CONFIG.XCVR_TYPE 2
+ad_ip_parameter util_ad9172_xcvr CONFIG.QPLL_FBDIV 40
+ad_ip_parameter util_ad9172_xcvr CONFIG.QPLL_REFCLK_DIV 1
+
+ad_ip_parameter axi_ad9172_jesd/tx CONFIG.SYSREF_IOB false
+

--- a/projects/ad9172_fmc_ebz/zcu102/system_constr.xdc
+++ b/projects/ad9172_fmc_ebz/zcu102/system_constr.xdc
@@ -1,0 +1,50 @@
+
+# ad9172 FMC signals
+
+set_property  -dict {PACKAGE_PIN  AB4 IOSTANDARD LVDS DIFF_TERM_ADV TERM_100} [get_ports tx_sync_p]   ; ## D08  FMC_HPC0_LA01_CC_P        IO_L16P_T2U_N6_QBC_AD3P_66_AB4 
+set_property  -dict {PACKAGE_PIN  AC4 IOSTANDARD LVDS DIFF_TERM_ADV TERM_100} [get_ports tx_sync_n]   ; ## D09  FMC_HPC0_LA01_CC_N        IO_L16N_T2U_N7_QBC_AD3N_66_AC4 
+set_property  -dict {PACKAGE_PIN  Y4  IOSTANDARD LVDS DIFF_TERM_ADV TERM_100} [get_ports tx_sysref_p] ; ## G06  FMC_HPC0_LA00_CC_P        IO_L13P_T2L_N0_GC_QBC_66_Y4 
+set_property  -dict {PACKAGE_PIN  Y3  IOSTANDARD LVDS DIFF_TERM_ADV TERM_100} [get_ports tx_sysref_n] ; ## G07  FMC_HPC0_LA00_CC_N        IO_L13N_T2L_N1_GC_QBC_66_Y3 
+
+set_property  -dict {PACKAGE_PIN  AA1 IOSTANDARD LVCMOS18} [get_ports spi_csn_dac]                    ; ## H11  FMC_HPC0_LA04_N           IO_L21N_T3L_N5_AD8N_66_AA1
+set_property  -dict {PACKAGE_PIN  AB3 IOSTANDARD LVCMOS18} [get_ports spi_csn_clk]                    ; ## D11  FMC_HPC0_LA05_P           IO_L20P_T3L_N2_AD1P_66_AB3
+set_property  -dict {PACKAGE_PIN  AA2 IOSTANDARD LVCMOS18} [get_ports spi_miso]                       ; ## H10  FMC_HPC0_LA04_P           IO_L21P_T3L_N4_AD8P_66_AA2
+set_property  -dict {PACKAGE_PIN  Y1  IOSTANDARD LVCMOS18} [get_ports spi_mosi]                       ; ## G10  FMC_HPC0_LA03_N           IO_L22N_T3U_N7_DBC_AD0N_66_Y1
+set_property  -dict {PACKAGE_PIN  Y2  IOSTANDARD LVCMOS18} [get_ports spi_clk]                        ; ## G09  FMC_HPC0_LA03_P           IO_L22P_T3U_N6_DBC_AD0P_66_Y2
+set_property  -dict {PACKAGE_PIN  AC3 IOSTANDARD LVCMOS18} [get_ports spi_en_n]                       ; ## D12  FMC_HPC0_LA05_N           IO_L20N_T3L_N3_AD1N_66_AC3
+
+set_property  -dict {PACKAGE_PIN  U5  IOSTANDARD LVCMOS18} [get_ports pe_ctrl]                        ; ## H13  FMC_HPC0_LA07_P           IO_L18P_T2U_N10_AD2P_66_U5 
+set_property  -dict {PACKAGE_PIN  AC2 IOSTANDARD LVCMOS18} [get_ports txen_0]                         ; ## C10  FMC_HPC0_LA06_P           IO_L19P_T3L_N0_DBC_AD9P_66_AC2 
+set_property  -dict {PACKAGE_PIN  AC1 IOSTANDARD LVCMOS18} [get_ports txen_1]                         ; ## C11  FMC_HPC0_LA06_N           IO_L19N_T3L_N1_DBC_AD9N_66_AC1 
+
+set_property  -dict {PACKAGE_PIN  G8} [get_ports tx_ref_clk_p]                                        ; ## D04  FMC_HPC0_GBTCLK0_M2C_C_P  MGTREFCLK0P_229_G8 
+set_property  -dict {PACKAGE_PIN  G7} [get_ports tx_ref_clk_n]                                        ; ## D05  FMC_HPC0_GBTCLK0_M2C_C_N  MGTREFCLK0N_229_G7
+
+set_property  -dict {PACKAGE_PIN  P6} [get_ports tx_data_p[0]]                                        ; ## A38  FMC_HPC0_DP5_C2M_P        MGTHTXP1_228_P6
+set_property  -dict {PACKAGE_PIN  P5} [get_ports tx_data_n[0]]                                        ; ## A39  FMC_HPC0_DP5_C2M_N        MGTHTXN1_228_P5
+set_property  -dict {PACKAGE_PIN  R4} [get_ports tx_data_p[1]]                                        ; ## B36  FMC_HPC0_DP6_C2M_P        MGTHTXP0_228_R4
+set_property  -dict {PACKAGE_PIN  R3} [get_ports tx_data_n[1]]                                        ; ## B37  FMC_HPC0_DP6_C2M_N        MGTHTXN0_228_R3
+set_property  -dict {PACKAGE_PIN  M6} [get_ports tx_data_p[2]]                                        ; ## A34  FMC_HPC0_DP4_C2M_P        MGTHTXP3_228_M6
+set_property  -dict {PACKAGE_PIN  M5} [get_ports tx_data_n[2]]                                        ; ## A35  FMC_HPC0_DP4_C2M_N        MGTHTXN3_228_M5
+set_property  -dict {PACKAGE_PIN  N4} [get_ports tx_data_p[3]]                                        ; ## B32  FMC_HPC0_DP7_C2M_P        MGTHTXP2_228_N4
+set_property  -dict {PACKAGE_PIN  N3} [get_ports tx_data_n[3]]                                        ; ## B33  FMC_HPC0_DP7_C2M_N        MGTHTXN2_228_N3
+set_property  -dict {PACKAGE_PIN  K5} [get_ports tx_data_n[4]]                                        ; ## A31  FMC_HPC0_DP3_C2M_N        MGTHTXN0_229_K5
+set_property  -dict {PACKAGE_PIN  K6} [get_ports tx_data_p[4]]                                        ; ## A30  FMC_HPC0_DP3_C2M_P        MGTHTXP0_229_K6
+set_property  -dict {PACKAGE_PIN  F5} [get_ports tx_data_n[5]]                                        ; ## A27  FMC_HPC0_DP2_C2M_N        MGTHTXN3_229_F5
+set_property  -dict {PACKAGE_PIN  F6} [get_ports tx_data_p[5]]                                        ; ## A26  FMC_HPC0_DP2_C2M_P        MGTHTXP3_229_F6
+set_property  -dict {PACKAGE_PIN  H5} [get_ports tx_data_n[6]]                                        ; ## A23  FMC_HPC0_DP1_C2M_N        MGTHTXN1_229_H5
+set_property  -dict {PACKAGE_PIN  H6} [get_ports tx_data_p[6]]                                        ; ## A22  FMC_HPC0_DP1_C2M_P        MGTHTXP1_229_H6
+set_property  -dict {PACKAGE_PIN  G3} [get_ports tx_data_n[7]]                                        ; ## C03  FMC_HPC0_DP0_C2M_N        MGTHTXN2_229_G3
+set_property  -dict {PACKAGE_PIN  G4} [get_ports tx_data_p[7]]                                        ; ## C02  FMC_HPC0_DP0_C2M_P        MGTHTXP2_229_G4
+
+# clocks
+
+create_clock -name tx_ref_clk   -period  2.65 [get_ports tx_ref_clk_p]
+
+# exceptions
+# We can't place the sysref in IOB, instead limit the input delay of the signal
+# to the first sampling FF
+set_max_delay -from [get_ports tx_sysref_*] \
+              -to [get_pins i_system_wrapper/system_i/axi_ad9172_jesd/tx/inst/i_lmfc/sysref_r_reg/D] 2.0 \
+              -datapath_only
+

--- a/projects/ad9172_fmc_ebz/zcu102/system_project.tcl
+++ b/projects/ad9172_fmc_ebz/zcu102/system_project.tcl
@@ -1,0 +1,13 @@
+
+source ../../scripts/adi_env.tcl
+source $ad_hdl_dir/projects/scripts/adi_project.tcl
+source $ad_hdl_dir/projects/scripts/adi_board.tcl
+
+adi_project_xilinx ad9172_fmc_ebz_zcu102
+adi_project_files ad9172_fmc_ebz_zcu102 [list \
+  "system_top.v" \
+  "system_constr.xdc"\
+  "$ad_hdl_dir/projects/common/zcu102/zcu102_system_constr.xdc" ]
+
+adi_project_run ad9172_fmc_ebz_zcu102
+

--- a/projects/ad9172_fmc_ebz/zcu102/system_top.v
+++ b/projects/ad9172_fmc_ebz/zcu102/system_top.v
@@ -1,0 +1,186 @@
+// ***************************************************************************
+// ***************************************************************************
+// Copyright 2014 - 2017 (c) Analog Devices, Inc. All rights reserved.
+//
+// In this HDL repository, there are many different and unique modules, consisting
+// of various HDL (Verilog or VHDL) components. The individual modules are
+// developed independently, and may be accompanied by separate and unique license
+// terms.
+//
+// The user should read each of these license terms, and understand the
+// freedoms and responsibilities that he or she has by using this source/core.
+//
+// This core is distributed in the hope that it will be useful, but WITHOUT ANY
+// WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+// A PARTICULAR PURPOSE.
+//
+// Redistribution and use of source or resulting binaries, with or without modification
+// of this file, are permitted under one of the following two license terms:
+//
+//   1. The GNU General Public License version 2 as published by the
+//      Free Software Foundation, which can be found in the top level directory
+//      of this repository (LICENSE_GPL2), and also online at:
+//      <https://www.gnu.org/licenses/old-licenses/gpl-2.0.html>
+//
+// OR
+//
+//   2. An ADI specific BSD license, which can be found in the top level directory
+//      of this repository (LICENSE_ADIBSD), and also on-line at:
+//      https://github.com/analogdevicesinc/hdl/blob/master/LICENSE_ADIBSD
+//      This will allow to generate bit files and not release the source code,
+//      as long as it attaches to an ADI device.
+//
+// ***************************************************************************
+// ***************************************************************************
+
+`timescale 1ns/100ps
+
+/*
+Interface to FMC connector overview
+
+system_top    9172_FMC_EBZ    FMC                            FPCA
+              -------------|--------------------------------|-------------------------------------
+NC            BR40_EXT_N      B21  FMC_HPC0_GBTCLK1_M2C_C_N  L7     MGTREFCLK0N_228_L7
+NC            BR40_EXT_P      B20  FMC_HPC0_GBTCLK1_M2C_C_P  L8     MGTREFCLK0P_228_L8
+tx_ref_clk_n  BR40_N          D05  FMC_HPC0_GBTCLK0_M2C_C_N  G7     MGTREFCLK0N_229_G7
+tx_ref_clk_p  BR40_P          D04  FMC_HPC0_GBTCLK0_M2C_C_P  G8     MGTREFCLK0P_229_G8
+spi_csn_dac   FMC_CS1         H11  FMC_HPC0_LA04_N           AA1    IO_L21N_T3L_N5_AD8N_66_AA1
+spi_csn_clk   FMC_CS2         D11  FMC_HPC0_LA05_P           AB3    IO_L20P_T3L_N2_AD1P_66_AB3
+spi_miso      FMC_MISO        H10  FMC_HPC0_LA04_P           AA2    IO_L21P_T3L_N4_AD8P_66_AA2
+spi_mosi      FMC_MOSI        G10  FMC_HPC0_LA03_N           Y1     IO_L22N_T3U_N7_DBC_AD0N_66_Y1
+spi_clk       FMC_SCK         G09  FMC_HPC0_LA03_P           Y2     IO_L22P_T3U_N6_DBC_AD0P_66_Y2
+spi_en_n      FMC_SPI_EN      D12  FMC_HPC0_LA05_N           AC3    IO_L20N_T3L_N3_AD1N_66_AC3
+
+pe_ctrl       FMC_PE_CTRL     H13  FMC_HPC0_LA07_P           U5     IO_L18P_T2U_N10_AD2P_66_U5
+txen_0        FMC_TXEN_0      C10  FMC_HPC0_LA06_P           AC2    IO_L19P_T3L_N0_DBC_AD9P_66_AC2
+txen_1        FMC_TXEN_1      C11  FMC_HPC0_LA06_N           AC1    IO_L19N_T3L_N1_DBC_AD9N_66_AC1
+
+tx_data_p[0]  SERDIN0_N       A38  FMC_HPC0_DP5_C2M_P        P6     MGTHTXP1_228_P6
+tx_data_n[0]  SERDIN0_P       A39  FMC_HPC0_DP5_C2M_N        P5     MGTHTXN1_228_P5
+tx_data_p[1]  SERDIN1_N       B36  FMC_HPC0_DP6_C2M_P        R4     MGTHTXP0_228_R4
+tx_data_n[1]  SERDIN1_P       B37  FMC_HPC0_DP6_C2M_N        R3     MGTHTXN0_228_R3
+tx_data_p[2]  SERDIN2_N       A34  FMC_HPC0_DP4_C2M_P        M6     MGTHTXP3_228_M6
+tx_data_n[2]  SERDIN2_P       A35  FMC_HPC0_DP4_C2M_N        M5     MGTHTXN3_228_M5
+tx_data_p[3]  SERDIN3_N       B32  FMC_HPC0_DP7_C2M_P        N4     MGTHTXP2_228_N4
+tx_data_n[3]  SERDIN3_P       B33  FMC_HPC0_DP7_C2M_N        N3     MGTHTXN2_228_N3
+tx_data_n[4]  SERDIN4_N       A31  FMC_HPC0_DP3_C2M_N        K5     MGTHTXN0_229_K5
+tx_data_p[4]  SERDIN4_P       A30  FMC_HPC0_DP3_C2M_P        K6     MGTHTXP0_229_K6
+tx_data_n[5]  SERDIN5_N       A27  FMC_HPC0_DP2_C2M_N        F5     MGTHTXN3_229_F5
+tx_data_p[5]  SERDIN5_P       A26  FMC_HPC0_DP2_C2M_P        F6     MGTHTXP3_229_F6
+tx_data_n[6]  SERDIN6_N       A23  FMC_HPC0_DP1_C2M_N        H5     MGTHTXN1_229_H5
+tx_data_p[6]  SERDIN6_P       A22  FMC_HPC0_DP1_C2M_P        H6     MGTHTXP1_229_H6
+tx_data_n[7]  SERDIN7_N       C03  FMC_HPC0_DP0_C2M_N        G3     MGTHTXN2_229_G3
+tx_data_p[7]  SERDIN7_P       C02  FMC_HPC0_DP0_C2M_P        G4     MGTHTXP2_229_G4
+tx_sync_n     SYNC0_N         D09  FMC_HPC0_LA01_CC_N        AC4    IO_L16N_T2U_N7_QBC_AD3N_66_AC4
+tx_sync_p     SYNC0_P         D08  FMC_HPC0_LA01_CC_P        AB4    IO_L16P_T2U_N6_QBC_AD3P_66_AB4
+NC            SYNC1_N         H08  FMC_HPC0_LA02_N           V1     IO_L23N_T3U_N9_66_V1
+NC            SYNC1_P         H07  FMC_HPC0_LA02_P           V2     IO_L23P_T3U_N8_66_V2
+tx_sysref_n   SYSREF2_N       G07  FMC_HPC0_LA00_CC_N        Y3     IO_L13N_T2L_N1_GC_QBC_66_Y3
+tx_sysref_p   SYSREF2_P       G06  FMC_HPC0_LA00_CC_P        Y4     IO_L13P_T2L_N0_GC_QBC_66_Y4
+*/
+
+module system_top (
+
+  input   [12:0]  gpio_bd_i,
+  output  [ 7:0]  gpio_bd_o,
+
+  input           tx_ref_clk_p,
+  input           tx_ref_clk_n,
+  input           tx_sysref_p,
+  input           tx_sysref_n,
+  input           tx_sync_p,
+  input           tx_sync_n,
+  output  [ 7:0]  tx_data_p,
+  output  [ 7:0]  tx_data_n,
+
+  output          spi_csn_dac,
+  output          spi_csn_clk,
+  input           spi_miso,
+  output          spi_mosi,
+  output          spi_clk,
+  output          spi_en_n,
+
+  output          pe_ctrl,
+  output          txen_0,
+  output          txen_1
+
+);
+
+  // internal signals
+
+  wire    [94:0]  gpio_i;
+  wire    [94:0]  gpio_o;
+  wire    [ 2:0]  spi_csn;
+  wire            tx_ref_clk;
+  wire            tx_sysref;
+  wire            tx_sync;
+
+  // spi
+
+  assign spi_csn_dac = spi_csn[1];
+  assign spi_csn_clk = spi_csn[0];
+
+  // instantiations
+
+  IBUFDS_GTE4 i_ibufds_tx_ref_clk (
+    .CEB (1'd0),
+    .I (tx_ref_clk_p),
+    .IB (tx_ref_clk_n),
+    .O (tx_ref_clk),
+    .ODIV2 ());
+
+  IBUFDS i_ibufds_tx_sysref (
+    .I (tx_sysref_p),
+    .IB (tx_sysref_n),
+    .O (tx_sysref));
+
+  IBUFDS i_ibufds_tx_sync (
+    .I (tx_sync_p),
+    .IB (tx_sync_n),
+    .O (tx_sync));
+
+  assign gpio_bd_o = gpio_o[7:0];
+  assign pe_ctrl   = gpio_o[21];
+  assign txen_0    = gpio_o[22];
+  assign txen_1    = gpio_o[23];
+  assign spi_en_n  = 1'b0; // make FPGA master on SPI
+
+  assign gpio_i[94:21] = gpio_o[94:21];
+  assign gpio_i[20: 8] = gpio_bd_i;
+  assign gpio_i[ 7: 0] = gpio_o[7:0];
+
+  system_wrapper i_system_wrapper (
+    .gpio_i (gpio_i),
+    .gpio_o (gpio_o),
+    .spi0_csn (spi_csn),
+    .spi0_miso (spi_miso),
+    .spi0_mosi (spi_mosi),
+    .spi0_sclk (spi_clk),
+    .spi1_csn (),
+    .spi1_miso (1'd0),
+    .spi1_mosi (),
+    .spi1_sclk (),
+    .tx_data_0_n (tx_data_n[0]),
+    .tx_data_0_p (tx_data_p[0]),
+    .tx_data_1_n (tx_data_n[1]),
+    .tx_data_1_p (tx_data_p[1]),
+    .tx_data_2_n (tx_data_n[2]),
+    .tx_data_2_p (tx_data_p[2]),
+    .tx_data_3_n (tx_data_n[3]),
+    .tx_data_3_p (tx_data_p[3]),
+    .tx_data_4_n (tx_data_n[4]),
+    .tx_data_4_p (tx_data_p[4]),
+    .tx_data_5_n (tx_data_n[5]),
+    .tx_data_5_p (tx_data_p[5]),
+    .tx_data_6_n (tx_data_n[6]),
+    .tx_data_6_p (tx_data_p[6]),
+    .tx_data_7_n (tx_data_n[7]),
+    .tx_data_7_p (tx_data_p[7]),
+    .tx_ref_clk_0 (tx_ref_clk),
+    .tx_sync_0 (tx_sync),
+    .tx_sysref_0 (tx_sysref));
+
+endmodule
+
+// ***************************************************************************
+// ***************************************************************************


### PR DESCRIPTION
    Add support for the AD9172-FMC-EBZ connected to the ZCU102
    development kit.
