### PR TITLE
Improve the implementation of the asymmetric RAM

### DIFF
--- a/library/util_adcfifo/util_adcfifo.v
+++ b/library/util_adcfifo/util_adcfifo.v
@@ -213,6 +213,7 @@ module util_adcfifo #(
     .addra (adc_waddr_int),
     .dina (adc_wdata_int),
     .clkb (dma_clk),
+    .reb (1'b1),
     .addrb (dma_raddr),
     .doutb (dma_rdata_s));
   end

--- a/library/xilinx/axi_adcfifo/axi_adcfifo_dma.v
+++ b/library/xilinx/axi_adcfifo/axi_adcfifo_dma.v
@@ -60,7 +60,7 @@ module axi_adcfifo_dma #(
   localparam  DMA_ADDRESS_WIDTH = 8;
   localparam  AXI_ADDRESS_WIDTH = (DMA_MEM_RATIO == 2) ? (DMA_ADDRESS_WIDTH - 1) :
     ((DMA_MEM_RATIO == 4) ? (DMA_ADDRESS_WIDTH - 2) : (DMA_ADDRESS_WIDTH - 3));
- 
+
 
   // internal registers
 
@@ -157,7 +157,7 @@ module axi_adcfifo_dma #(
       end
     end
   end
-  
+
   assign dma_wready_s = (DMA_READY_ENABLE == 0) ? 1'b1 : dma_wready;
   assign dma_rd_s = (dma_raddr == dma_waddr_rel_s) ? 1'b0 : dma_wready_s;
 
@@ -198,6 +198,7 @@ module axi_adcfifo_dma #(
     .addra (axi_waddr),
     .dina (axi_ddata),
     .clkb (dma_clk),
+    .reb (1'b1),
     .addrb (dma_raddr),
     .doutb (dma_rdata_s));
 

--- a/library/xilinx/axi_dacfifo/axi_dacfifo_rd.v
+++ b/library/xilinx/axi_dacfifo/axi_dacfifo_rd.v
@@ -162,6 +162,7 @@ module axi_dacfifo_rd #(
     .addra (axi_mem_waddr),
     .dina (axi_rdata),
     .clkb (dac_clk),
+    .reb (1'b1),
     .addrb (dac_mem_raddr),
     .doutb (dac_data));
 

--- a/library/xilinx/axi_dacfifo/axi_dacfifo_wr.v
+++ b/library/xilinx/axi_dacfifo/axi_dacfifo_wr.v
@@ -188,6 +188,7 @@ module axi_dacfifo_wr #(
     .addra (dma_mem_waddr),
     .dina (dma_data),
     .clkb (axi_clk),
+    .reb (1'b1),
     .addrb (axi_mem_raddr),
     .doutb (axi_mem_rdata_s));
 

--- a/library/xilinx/axi_dacfifo/util_dacfifo_bypass.v
+++ b/library/xilinx/axi_dacfifo/util_dacfifo_bypass.v
@@ -118,6 +118,7 @@ module util_dacfifo_bypass #(
     .addra (dma_mem_waddr),
     .dina (dma_data),
     .clkb (dac_clk),
+    .reb (1'b1),
     .addrb (dac_mem_raddr),
     .doutb (dac_mem_rdata_s));
 


### PR DESCRIPTION
These modification should not change the basic functionality of the module. It's just a refactoring to support more asymmetric ratios.

Because the read interface got a read enable port too, update all the ad_mem_asym instances.