### PR TITLE
scripts/adi_xilinx_msg.tcl: Overrides the default msg limit to 2000

### DIFF
--- a/projects/scripts/adi_project.tcl
+++ b/projects/scripts/adi_project.tcl
@@ -116,6 +116,12 @@ proc adi_project_xilinx {project_name {mode 0}} {
   ## Load custom message severity definitions
   source $ad_hdl_dir/projects/scripts/adi_xilinx_msg.tcl
 
+  ## In Vivado there is a limit for the number of warnings and errors which are
+  ## displayed by the tool for a particular error or warning; the default value
+  ## of this limit is 100.
+  ## Overrides the default limit to 2000.
+  set_param messaging.defaultLimit 2000
+
   create_bd_design "system"
   source system_bd.tcl
 


### PR DESCRIPTION
In Vivado there is a limit for the number of warnings and errors which are displayed by the tool for a particular error or warning; the default value of this limit is 100. 
This commit overrides the default given limit to 2000.