### PR TITLE
ad_rst: Fix constraints for Intel designs

### DIFF
--- a/library/altera/common/up_rst_constr.sdc
+++ b/library/altera/common/up_rst_constr.sdc
@@ -1,6 +1,4 @@
 
-set_false_path  -from [get_registers *up_*rst_async*] -to [get_registers *ad_rst:i_core_rst_reg|rst_sync_d]
-set_false_path  -from [get_registers *up_*rst_async*] -to [get_registers *ad_rst:i_core_rst_reg|rstn]
-
-set_false_path  -from [get_registers *up_core_preset] -to [get_registers *ad_rst:i_core_rst_reg|rst_async_d*]
+set_false_path  -to [get_pins -hierarchical -nocase rst_async_d*|CLRN]
+set_false_path  -to [get_pins -hierarchical -nocase rst_sync|CLRN]
 


### PR DESCRIPTION
The ad_rst module's SDC constraint have some invalid paths. Because of it all Intel design's timing failed.

This patch should fix this issue. 