### PR TITLE
adi_board.tcl: ad_ip_instance: Add support for specifying IP parameters

### DIFF
--- a/projects/scripts/adi_board.tcl
+++ b/projects/scripts/adi_board.tcl
@@ -31,10 +31,18 @@ set xcvr_instance NONE
 ###################################################################################################
 ###################################################################################################
 
-proc ad_ip_instance {i_ip i_name} {
+proc ad_ip_instance {i_ip i_name {i_params {}}} {
 
-  create_bd_cell -type ip -vlnv [get_ipdefs -all -filter "VLNV =~ *:${i_ip}:* && \
-    design_tool_contexts =~ *IPI* && UPGRADE_VERSIONS == \"\""] ${i_name}
+  set cell [create_bd_cell -type ip -vlnv [get_ipdefs -all -filter "VLNV =~ *:${i_ip}:* && \
+    design_tool_contexts =~ *IPI* && UPGRADE_VERSIONS == \"\""] ${i_name}]
+  if {$i_params != {}} {
+    set config {}
+    # Add CONFIG. prefix to all config options
+    foreach {k v} $i_params {
+      lappend config "CONFIG.$k" $v
+    }
+    set_property -dict $config $cell
+  }
 }
 
 proc ad_ip_parameter {i_name i_param i_value} {


### PR DESCRIPTION
Add support for specifying a set of parameter value pairs when
instantiating an IP core to the ad_ip_instance command. This has the
convenience of not having to repeatedly call ad_ip_parameter with the name
of the core that got just created for each parameter that needs to be set.

It is also useful for cases where some parameters have mutually exclusive
values and both (or more) have to be set at the same time.

This also slightly speeds things up. Whenever a parameter is changed the
core needs to be updated and post configuration scripts might run. When
setting all parameters at the same time this only happens once instead of
once for each parameter.

For example the following sequence

  ad_ip_instance axi_dmac axi_ad9136_dma
  ad_ip_parameter axi_ad9136_dma CONFIG.DMA_TYPE_SRC 0
  ad_ip_parameter axi_ad9136_dma CONFIG.DMA_TYPE_DEST 1
  ad_ip_parameter axi_ad9136_dma CONFIG.DMA_DATA_WIDTH_SRC 64
  ad_ip_parameter axi_ad9136_dma CONFIG.DMA_DATA_WIDTH_DEST 256

can now be replaced with

  ad_ip_instance axi_dmac axi_ad9136_dma [list \\
    DMA_TYPE_SRC 0 \\
    DMA_TYPE_DEST 1 \\
    DMA_DATA_WIDTH_SRC 64 \\
    DMA_DATA_WIDTH_DEST 256 \\
  ]

Signed-off-by: Lars-Peter Clausen <lars@metafoo.de>