### PR TITLE
Maximize the depth of each internal adc|dac_fifo instance

### DIFF
--- a/projects/adrv9371x/kcu105/system_bd.tcl
+++ b/projects/adrv9371x/kcu105/system_bd.tcl
@@ -1,8 +1,11 @@
 
+## FIFO depth is 8Mb - 500k samples
 set dac_fifo_name axi_ad9371_dacfifo
-set dac_fifo_address_width 10
+set dac_fifo_address_width 16
 set dac_data_width 128
 set dac_dma_data_width 128
+
+## NOTE: With this configuration the #36Kb BRAM utilization is at ~68%
 
 source $ad_hdl_dir/projects/common/kcu105/kcu105_system_bd.tcl
 source $ad_hdl_dir/projects/common/kcu105/kcu105_system_mig.tcl

--- a/projects/adrv9371x/zcu102/system_bd.tcl
+++ b/projects/adrv9371x/zcu102/system_bd.tcl
@@ -1,8 +1,11 @@
 
+## FIFO depth is 16Mb - 1M samples
 set dac_fifo_name axi_ad9371_dacfifo
-set dac_fifo_address_width 10
+set dac_fifo_address_width 17
 set dac_data_width 128
 set dac_dma_data_width 128
+
+## NOTE: With this configuration the #36Kb BRAM utilization is at ~51%
 
 source $ad_hdl_dir/projects/common/zcu102/zcu102_system_bd.tcl
 source $ad_hdl_dir/projects/common/xilinx/dacfifo_bd.tcl

--- a/projects/daq2/kc705/system_bd.tcl
+++ b/projects/daq2/kc705/system_bd.tcl
@@ -1,17 +1,20 @@
 
+## FIFO depth is 4Mb - 250k samples
 set adc_fifo_name axi_ad9680_fifo
 set adc_fifo_address_width 16
 set adc_data_width 128
 set adc_dma_data_width 64
 
+## FIFO depth is 4Mb - 250k samples
 set dac_fifo_name axi_ad9144_fifo
-set dac_fifo_address_width 10
+set dac_fifo_address_width 15
 set dac_data_width 128
 set dac_dma_data_width 128
+
+## NOTE: With this configuration the #36Kb BRAM utilization is at ~80%
 
 source $ad_hdl_dir/projects/common/kc705/kc705_system_bd.tcl
 source $ad_hdl_dir/projects/common/xilinx/adcfifo_bd.tcl
 source $ad_hdl_dir/projects/common/xilinx/dacfifo_bd.tcl
 source ../common/daq2_bd.tcl
-
 

--- a/projects/daq2/kcu105/system_bd.tcl
+++ b/projects/daq2/kcu105/system_bd.tcl
@@ -1,13 +1,17 @@
 
+## FIFO depth is 4Mb - 250k samples
 set adc_fifo_name axi_ad9680_fifo
 set adc_fifo_address_width 16
 set adc_data_width 128
 set adc_dma_data_width 64
 
+## FIFO depth is 4Mb - 250k samples
 set dac_fifo_name axi_ad9144_fifo
-set dac_fifo_address_width 10
+set dac_fifo_address_width 15
 set dac_data_width 128
 set dac_dma_data_width 128
+
+## NOTE: With this configuration the #36Kb BRAM utilization is at ~70%
 
 source $ad_hdl_dir/projects/common/kcu105/kcu105_system_bd.tcl
 source $ad_hdl_dir/projects/common/xilinx/adcfifo_bd.tcl

--- a/projects/daq2/vc707/system_bd.tcl
+++ b/projects/daq2/vc707/system_bd.tcl
@@ -1,13 +1,17 @@
 
+## FIFO depth is 8Mb - 500k samples
 set adc_fifo_name axi_ad9680_fifo
-set adc_fifo_address_width 16
+set adc_fifo_address_width 17
 set adc_data_width 128
 set adc_dma_data_width 64
 
+## FIFO depth is 8Mb - 500k samples
 set dac_fifo_name axi_ad9144_fifo
-set dac_fifo_address_width 10
+set dac_fifo_address_width 16
 set dac_data_width 128
 set dac_dma_data_width 128
+
+## NOTE: With this configuration the #36Kb BRAM utilization is at ~68.45%
 
 source $ad_hdl_dir/projects/common/vc707/vc707_system_bd.tcl
 source $ad_hdl_dir/projects/common/xilinx/adcfifo_bd.tcl

--- a/projects/daq2/zc706/system_bd.tcl
+++ b/projects/daq2/zc706/system_bd.tcl
@@ -1,13 +1,17 @@
 
+## FIFO depth is 1GB, PL_DDR is used
 set adc_fifo_name axi_ad9680_fifo
 set adc_fifo_address_width 16
 set adc_data_width 128
 set adc_dma_data_width 64
 
+## FIFO depth is 8Mb - 500k samples
 set dac_fifo_name axi_ad9144_fifo
 set dac_fifo_address_width 16
 set dac_data_width 128
 set dac_dma_data_width 128
+
+## NOTE: With this configuration the #36Kb BRAM utilization is at ~51%
 
 source $ad_hdl_dir/projects/common/zc706/zc706_system_bd.tcl
 source $ad_hdl_dir/projects/common/zc706/zc706_plddr3_adcfifo_bd.tcl

--- a/projects/daq2/zcu102/system_bd.tcl
+++ b/projects/daq2/zcu102/system_bd.tcl
@@ -1,13 +1,17 @@
 
+## FIFO depth is 8Mb - 500k samples
 set adc_fifo_name axi_ad9680_fifo
-set adc_fifo_address_width 16
+set adc_fifo_address_width 17
 set adc_data_width 128
 set adc_dma_data_width 64
 
+## FIFO depth is 8Mb - 500k samples
 set dac_fifo_name axi_ad9144_fifo
-set dac_fifo_address_width 10
+set dac_fifo_address_width 16
 set dac_data_width 128
 set dac_dma_data_width 128
+
+## NOTE: With this configuration the #36Kb BRAM utilization is at ~57%
 
 source $ad_hdl_dir/projects/common/zcu102/zcu102_system_bd.tcl
 source $ad_hdl_dir/projects/common/xilinx/adcfifo_bd.tcl

--- a/projects/daq3/kcu105/system_bd.tcl
+++ b/projects/daq3/kcu105/system_bd.tcl
@@ -1,13 +1,17 @@
 
+## FIFO depth is 4Mb - 250k samples
 set adc_fifo_name axi_ad9680_fifo
 set adc_fifo_address_width 16
 set adc_data_width 128
 set adc_dma_data_width 64
 
+## FIFO depth is 4Mb - 250k samples
 set dac_fifo_name axi_ad9152_fifo
-set dac_fifo_address_width 10
+set dac_fifo_address_width 15
 set dac_data_width 128
 set dac_dma_data_width 128
+
+## NOTE: With this configuration the #36Kb BRAM utilization is at ~70%
 
 source $ad_hdl_dir/projects/common/kcu105/kcu105_system_bd.tcl
 source $ad_hdl_dir/projects/common/xilinx/adcfifo_bd.tcl

--- a/projects/daq3/zc706/system_bd.tcl
+++ b/projects/daq3/zc706/system_bd.tcl
@@ -1,13 +1,17 @@
 
+## FIFO depth is 1GB, PL_DDR is used
 set adc_fifo_name axi_ad9680_fifo
 set adc_fifo_address_width 16
 set adc_data_width 128
 set adc_dma_data_width 64
 
+## FIFO depth is 8Mb - 500k samples
 set dac_fifo_name axi_ad9152_fifo
-set dac_fifo_address_width 10
+set dac_fifo_address_width 16
 set dac_data_width 128
 set dac_dma_data_width 128
+
+## NOTE: With this configuration the #36Kb BRAM utilization is at ~47%
 
 source $ad_hdl_dir/projects/common/zc706/zc706_system_bd.tcl
 source $ad_hdl_dir/projects/common/zc706/zc706_plddr3_adcfifo_bd.tcl

--- a/projects/daq3/zcu102/system_bd.tcl
+++ b/projects/daq3/zcu102/system_bd.tcl
@@ -1,13 +1,17 @@
 
+## FIFO depth is 8Mb - 500k samples
 set adc_fifo_name axi_ad9680_fifo
-set adc_fifo_address_width 16
+set adc_fifo_address_width 17
 set adc_data_width 128
 set adc_dma_data_width 64
 
+## FIFO depth is 8Mb - 500k samples
 set dac_fifo_name axi_ad9152_fifo
-set dac_fifo_address_width 10
+set dac_fifo_address_width 16
 set dac_data_width 128
 set dac_dma_data_width 128
+
+## NOTE: With this configuration the #36Kb BRAM utilization is at ~57%
 
 source $ad_hdl_dir/projects/common/zcu102/zcu102_system_bd.tcl
 source $ad_hdl_dir/projects/common/xilinx/dacfifo_bd.tcl

--- a/projects/fmcadc2/vc707/system_bd.tcl
+++ b/projects/fmcadc2/vc707/system_bd.tcl
@@ -1,8 +1,11 @@
 
+## FIFO depth is 16Mb - 1M samples
 set adc_fifo_name axi_ad9625_fifo
 set adc_fifo_address_width 18
 set adc_data_width 256
 set adc_dma_data_width 64
+
+## NOTE: With this configuration the #36Kb BRAM utilization is at ~68%
 
 source $ad_hdl_dir/projects/common/vc707/vc707_system_bd.tcl
 source $ad_hdl_dir/projects/common/xilinx/adcfifo_bd.tcl

--- a/projects/fmcadc5/vc707/system_bd.tcl
+++ b/projects/fmcadc5/vc707/system_bd.tcl
@@ -1,14 +1,17 @@
 
+## FIFO depth is 16Mb - 1M Samples
 set adc_fifo_name axi_ad9625_fifo
 set adc_fifo_address_width 18
 set adc_data_width 512
 set adc_dma_data_width 64
 
+## NOTE: With this configuration the #36Kb BRAM utilization is at ~70%
+
 source $ad_hdl_dir/projects/common/vc707/vc707_system_bd.tcl
 source $ad_hdl_dir/projects/common/xilinx/adcfifo_bd.tcl
 source ../common/fmcadc5_bd.tcl
 
-# ila 
+# ila
 
 ad_ip_instance util_mfifo mfifo_adc
 ad_ip_parameter mfifo_adc CONFIG.NUM_OF_CHANNELS 1


### PR DESCRIPTION
The affected projects are (with new depths):
  - FMCADC2/VC707 - 16Mb
  - FMCADC5/VC707 - 16Mb
  - DAQ2/ZC706  - ADC@1GB and DAC@8Mb
  - DAQ2/KC705  - ADC@4Mb and DAC@4Mb
  - DAQ2/VC707  - ADC@8Mb and DAC@8Mb
  - DAQ2/KCU105 - ADC@4Mb and DAC@4Mb
  - DAQ2/ZCU102 - ADC@8Mb and DAC@8Mb
  - DAQ3/ZC706  - ADC@1GB and DAC@8Mb
  - DAQ3/KCU105 - ADC@4Mb and DAC@4Mb
  - DAQ3/ZCU102 - ADC@8Mb and DAC@8Mb
  - ADRV9371x/KCU105 - DAC@8Mb
  - ADRV9371x/ZCU102 - DAC@16Mb