### PR TITLE
util_adcfifo: Synchronize the ad_rst and use it as a synchronous reset

### DIFF
--- a/library/util_adcfifo/Makefile
+++ b/library/util_adcfifo/Makefile
@@ -6,6 +6,7 @@
 LIBRARY_NAME := util_adcfifo
 
 GENERIC_DEPS += ../common/ad_axis_inf_rx.v
+GENERIC_DEPS += ../common/ad_rst.v
 GENERIC_DEPS += util_adcfifo.v
 
 XILINX_DEPS += ../common/ad_mem_asym.v

--- a/library/util_adcfifo/util_adcfifo.v
+++ b/library/util_adcfifo/util_adcfifo.v
@@ -89,6 +89,7 @@ module util_adcfifo #(
 
   // internal signals
 
+  wire                                  adc_rst_s;
   wire                                  dma_waddr_rel_t_s;
   wire        [DMA_ADDRESS_WIDTH-1:0]   dma_waddr_rel_s;
   wire                                  dma_wready_s;
@@ -99,8 +100,15 @@ module util_adcfifo #(
 
   assign adc_wovf = 1'd0;
 
-  always @(posedge adc_clk or posedge adc_rst) begin
-    if (adc_rst == 1'b1) begin
+  // synchronize the adc_rst to the adc_clk clock domain
+  ad_rst i_adc_rst_sync (
+    .rst_async (adc_rst),
+    .clk (adc_clk),
+    .rstn (),
+    .rst (adc_rst_s));
+
+  always @(posedge adc_clk) begin
+    if (adc_rst_s == 1'b1) begin
       adc_xfer_req_m <= 'd0;
       adc_xfer_init <= 'd0;
       adc_xfer_enable <= 'd0;
@@ -116,8 +124,8 @@ module util_adcfifo #(
     end
   end
 
-  always @(posedge adc_clk or posedge adc_rst) begin
-    if (adc_rst == 1'b1) begin
+  always @(posedge adc_clk) begin
+    if (adc_rst_s == 1'b1) begin
       adc_wr_int <= 'd0;
       adc_wdata_int <= 'd0;
       adc_waddr_int <= 'd0;
@@ -136,8 +144,8 @@ module util_adcfifo #(
     end
   end
 
-  always @(posedge adc_clk or posedge adc_rst) begin
-    if (adc_rst == 1'b1) begin
+  always @(posedge adc_clk) begin
+    if (adc_rst_s == 1'b1) begin
       adc_waddr_rel_t <= 'd0;
       adc_waddr_rel <= 'd0;
     end else begin

--- a/library/util_adcfifo/util_adcfifo_hw.tcl
+++ b/library/util_adcfifo/util_adcfifo_hw.tcl
@@ -9,6 +9,7 @@ set_module_property ELABORATION_CALLBACK p_util_adcfifo
 # files
 
 ad_ip_files util_adcfifo [list\
+  $ad_hdl_dir/library/common/ad_rst.v \
   $ad_hdl_dir/library/common/ad_axis_inf_rx.v \
   util_adcfifo.v \
   util_adcfifo_constr.sdc]

--- a/library/util_adcfifo/util_adcfifo_ip.tcl
+++ b/library/util_adcfifo/util_adcfifo_ip.tcl
@@ -5,6 +5,7 @@ source $ad_hdl_dir/library/scripts/adi_ip.tcl
 
 adi_ip_create util_adcfifo
 adi_ip_files util_adcfifo [list \
+  "$ad_hdl_dir/library/common/ad_rst.v" \
   "$ad_hdl_dir/library/common/ad_axis_inf_rx.v" \
   "$ad_hdl_dir/library/common/ad_mem_asym.v" \
   "util_adcfifo.v" \


### PR DESCRIPTION
This improvement will solve a couple of [DRC REQP-1839] warning: The RAMB36E1 has an input control pin  which is driven by a register that has an active asychronous set or reset. This may cause corruption of the memory contents and/or read values when the set/reset is asserted and is not analyzed by the default static timing analysis. It is suggested to eliminate the use of a set/reset to registers driving this RAMB pin or else use a synchronous reset in which the assertion of the reset is timed by default.