### PR TITLE
adrv936x, fmcomms2/5, usrpe31x: Fix warning on the dac path

### DIFF
--- a/projects/adrv9361z7035/common/adrv9361z7035_bd.tcl
+++ b/projects/adrv9361z7035/common/adrv9361z7035_bd.tcl
@@ -365,7 +365,6 @@ ad_ip_instance axi_dmac axi_ad9361_dac_dma
 ad_ip_parameter axi_ad9361_dac_dma CONFIG.DMA_TYPE_SRC 0
 ad_ip_parameter axi_ad9361_dac_dma CONFIG.DMA_TYPE_DEST 2
 ad_ip_parameter axi_ad9361_dac_dma CONFIG.CYCLIC 1
-ad_ip_parameter axi_ad9361_dac_dma CONFIG.SYNC_TRANSFER_START 0
 ad_ip_parameter axi_ad9361_dac_dma CONFIG.AXI_SLICE_SRC 0
 ad_ip_parameter axi_ad9361_dac_dma CONFIG.AXI_SLICE_DEST 1
 ad_ip_parameter axi_ad9361_dac_dma CONFIG.DMA_2D_TRANSFER 0

--- a/projects/adrv9364z7020/common/adrv9364z7020_bd.tcl
+++ b/projects/adrv9364z7020/common/adrv9364z7020_bd.tcl
@@ -365,7 +365,6 @@ ad_ip_instance axi_dmac axi_ad9361_dac_dma
 ad_ip_parameter axi_ad9361_dac_dma CONFIG.DMA_TYPE_SRC 0
 ad_ip_parameter axi_ad9361_dac_dma CONFIG.DMA_TYPE_DEST 2
 ad_ip_parameter axi_ad9361_dac_dma CONFIG.CYCLIC 1
-ad_ip_parameter axi_ad9361_dac_dma CONFIG.SYNC_TRANSFER_START 0
 ad_ip_parameter axi_ad9361_dac_dma CONFIG.AXI_SLICE_SRC 0
 ad_ip_parameter axi_ad9361_dac_dma CONFIG.AXI_SLICE_DEST 1
 ad_ip_parameter axi_ad9361_dac_dma CONFIG.DMA_2D_TRANSFER 0

--- a/projects/fmcomms2/common/fmcomms2_bd.tcl
+++ b/projects/fmcomms2/common/fmcomms2_bd.tcl
@@ -76,13 +76,13 @@ ad_ip_parameter util_ad9361_divclk_sel CONFIG.C_SIZE 2
 ad_connect util_ad9361_divclk_sel_concat/dout util_ad9361_divclk_sel/Op1
 
 ad_ip_instance util_clkdiv util_ad9361_divclk
-ad_connect util_ad9361_divclk_sel/Res util_ad9361_divclk/clk_sel 
+ad_connect util_ad9361_divclk_sel/Res util_ad9361_divclk/clk_sel
 ad_connect axi_ad9361/l_clk util_ad9361_divclk/clk
 
 # resets at divided clock
 
 ad_ip_instance proc_sys_reset util_ad9361_divclk_reset
-ad_connect sys_rstgen/peripheral_aresetn util_ad9361_divclk_reset/ext_reset_in 
+ad_connect sys_rstgen/peripheral_aresetn util_ad9361_divclk_reset/ext_reset_in
 ad_connect util_ad9361_divclk/clk_out util_ad9361_divclk_reset/slowest_sync_clk
 
 # adc-path wfifo
@@ -201,7 +201,6 @@ ad_ip_instance axi_dmac axi_ad9361_dac_dma
 ad_ip_parameter axi_ad9361_dac_dma CONFIG.DMA_TYPE_SRC 0
 ad_ip_parameter axi_ad9361_dac_dma CONFIG.DMA_TYPE_DEST 2
 ad_ip_parameter axi_ad9361_dac_dma CONFIG.CYCLIC 1
-ad_ip_parameter axi_ad9361_dac_dma CONFIG.SYNC_TRANSFER_START 0
 ad_ip_parameter axi_ad9361_dac_dma CONFIG.AXI_SLICE_SRC 0
 ad_ip_parameter axi_ad9361_dac_dma CONFIG.AXI_SLICE_DEST 1
 ad_ip_parameter axi_ad9361_dac_dma CONFIG.DMA_2D_TRANSFER 0

--- a/projects/fmcomms5/common/fmcomms5_bd.tcl
+++ b/projects/fmcomms5/common/fmcomms5_bd.tcl
@@ -290,7 +290,6 @@ ad_ip_instance axi_dmac axi_ad9361_dac_dma
 ad_ip_parameter axi_ad9361_dac_dma CONFIG.DMA_TYPE_SRC 0
 ad_ip_parameter axi_ad9361_dac_dma CONFIG.DMA_TYPE_DEST 2
 ad_ip_parameter axi_ad9361_dac_dma CONFIG.CYCLIC 1
-ad_ip_parameter axi_ad9361_dac_dma CONFIG.SYNC_TRANSFER_START 0
 ad_ip_parameter axi_ad9361_dac_dma CONFIG.AXI_SLICE_SRC 0
 ad_ip_parameter axi_ad9361_dac_dma CONFIG.AXI_SLICE_DEST 1
 ad_ip_parameter axi_ad9361_dac_dma CONFIG.DMA_2D_TRANSFER 0

--- a/projects/usrpe31x/system_bd.tcl
+++ b/projects/usrpe31x/system_bd.tcl
@@ -114,7 +114,7 @@ ad_connect  sys_ps7/SPI0_SS1_O spi0_csn_1
 ad_connect  sys_ps7/SPI0_SS2_O spi0_csn_2
 ad_connect  sys_ps7/SPI0_SCLK_O spi0_clk
 ad_connect  sys_ps7/SPI0_MOSI_O spi0_mosi
-ad_connect  sys_ps7/SPI0_MISO_I spi0_miso 
+ad_connect  sys_ps7/SPI0_MISO_I spi0_miso
 ad_connect  sys_ps7/SPI0_SS_I VCC
 ad_connect  sys_ps7/SPI0_SCLK_I GND
 ad_connect  sys_ps7/SPI0_MOSI_I GND
@@ -123,7 +123,7 @@ ad_connect  sys_ps7/SPI1_SS_I spi1_csn
 ad_connect  sys_ps7/SPI1_SCLK_I spi1_clk
 ad_connect  sys_ps7/SPI1_MOSI_I spi1_mosi
 ad_connect  sys_ps7/SPI1_MISO_O spi1_miso
-ad_connect  sys_ps7/SPI1_MISO_I GND 
+ad_connect  sys_ps7/SPI1_MISO_I GND
 
 # interrupts
 
@@ -155,7 +155,6 @@ ad_ip_instance axi_dmac axi_ad9361_dac_dma
 ad_ip_parameter axi_ad9361_dac_dma CONFIG.DMA_TYPE_SRC 0
 ad_ip_parameter axi_ad9361_dac_dma CONFIG.DMA_TYPE_DEST 2
 ad_ip_parameter axi_ad9361_dac_dma CONFIG.CYCLIC 1
-ad_ip_parameter axi_ad9361_dac_dma CONFIG.SYNC_TRANSFER_START 0
 ad_ip_parameter axi_ad9361_dac_dma CONFIG.AXI_SLICE_SRC 0
 ad_ip_parameter axi_ad9361_dac_dma CONFIG.AXI_SLICE_DEST 1
 ad_ip_parameter axi_ad9361_dac_dma CONFIG.DMA_2D_TRANSFER 0


### PR DESCRIPTION
Fix warnining regarding SYNC_TRANSFER_START parameter which doesn't
apply when axi_dmac is configured for the tx path.