### PR TITLE
daq2/daq3/9371: Use AXI3 for DMAC in Intel projects

### DIFF
--- a/library/axi_dmac/axi_dmac.v
+++ b/library/axi_dmac/axi_dmac.v
@@ -54,8 +54,8 @@ module axi_dmac #(
   parameter DMA_AXI_ADDR_WIDTH = 32,
   parameter MAX_BYTES_PER_BURST = 128,
   parameter FIFO_SIZE = 8, // In bursts
-  parameter AXI_ID_WIDTH_SRC = 4,
-  parameter AXI_ID_WIDTH_DEST = 4,
+  parameter AXI_ID_WIDTH_SRC = 1,
+  parameter AXI_ID_WIDTH_DEST = 1,
   parameter DISABLE_DEBUG_REGISTERS = 0,
   parameter ENABLE_DIAGNOSTICS_IF = 0)(
   // Slave AXI interface

--- a/library/axi_dmac/axi_dmac_hw.tcl
+++ b/library/axi_dmac/axi_dmac_hw.tcl
@@ -91,7 +91,7 @@ foreach {suffix group} { \
     { "0:Memory-Mapped AXI" "1:Streaming AXI" "2:FIFO Interface" }
   set_parameter_property DMA_TYPE_$suffix GROUP $group
 
-  add_parameter  DMA_AXI_PROTOCOL_$suffix INTEGER 0
+  add_parameter  DMA_AXI_PROTOCOL_$suffix INTEGER 1
   set_parameter_property DMA_AXI_PROTOCOL_$suffix DISPLAY_NAME "AXI Protocol"
   set_parameter_property DMA_AXI_PROTOCOL_$suffix HDL_PARAMETER true
   set_parameter_property DMA_AXI_PROTOCOL_$suffix ALLOWED_RANGES { "0:AXI4" "1:AXI3" }

--- a/library/axi_dmac/axi_dmac_hw.tcl
+++ b/library/axi_dmac/axi_dmac_hw.tcl
@@ -366,13 +366,13 @@ proc add_axi_master_interface {axi_type port suffix} {
   # Some signals are mandatory in Altera's implementation of AXI3
   # awid, awlock, wid, bid, arid, arlock, rid, rlast
   # Hide them in AXI4
-  add_interface_port $port ${port}_awid awid Output 4
+  add_interface_port $port ${port}_awid awid Output 1
   add_interface_port $port ${port}_awlock awlock Output "1+DMA_AXI_PROTOCOL_${suffix}"
-  add_interface_port $port ${port}_wid wid Output 4
-  add_interface_port $port ${port}_arid arid Output 4
+  add_interface_port $port ${port}_wid wid Output 1
+  add_interface_port $port ${port}_arid arid Output 1
   add_interface_port $port ${port}_arlock arlock Output "1+DMA_AXI_PROTOCOL_${suffix}"
-  add_interface_port $port ${port}_rid rid Input 4
-  add_interface_port $port ${port}_bid bid Input 4
+  add_interface_port $port ${port}_rid rid Input 1
+  add_interface_port $port ${port}_bid bid Input 1
   add_interface_port $port ${port}_rlast rlast Input 1
   if {$axi_type == "axi4"} {
     set_port_property ${port}_awid TERMINATION true


### PR DESCRIPTION
The buffers inside the interconnect are sized based on maximum burst sizes
the masters can produce.
For AXI4 the max burst size is 128 but for these projects for the
default burst size of 128 bytes the DMACs are creating only burst of 8 or
16 beats depending on the bus width (128bits and 64 bits respectively).

These burst sizes can fit in the AXI3 protocol where the max burst
length is 16. Therefore the interconnect will be reduced.

The observed reduction is around 4 Mb of block RAM per project.
Another benefit is a better timing closure,
since these buffers reside in the DDR3 clock domain.