### PR TITLE
altera: adi_jesd204: Add support for more than 6 transmit lanes

### DIFF
--- a/library/altera/adi_jesd204/Makefile
+++ b/library/altera/adi_jesd204/Makefile
@@ -5,6 +5,8 @@
 
 LIBRARY_NAME := adi_jesd204
 
+ALTERA_DEPS += adi_jesd204_glue.v
+ALTERA_DEPS += adi_jesd204_glue_hw.tcl
 ALTERA_DEPS += adi_jesd204_hw.tcl
 
 ALTERA_LIB_DEPS += altera/axi_adxcvr

--- a/library/altera/adi_jesd204/adi_jesd204_glue.v
+++ b/library/altera/adi_jesd204/adi_jesd204_glue.v
@@ -1,0 +1,45 @@
+// ***************************************************************************
+// ***************************************************************************
+// Copyright 2014 - 2017 (c) Analog Devices, Inc. All rights reserved.
+//
+// In this HDL repository, there are many different and unique modules, consisting
+// of various HDL (Verilog or VHDL) components. The individual modules are
+// developed independently, and may be accompanied by separate and unique license
+// terms.
+//
+// The user should read each of these license terms, and understand the
+// freedoms and responsibilities that he or she has by using this source/core.
+//
+// This core is distributed in the hope that it will be useful, but WITHOUT ANY
+// WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+// A PARTICULAR PURPOSE.
+//
+// Redistribution and use of source or resulting binaries, with or without modification
+// of this file, are permitted under one of the following two license terms:
+//
+//   1. The GNU General Public License version 2 as published by the
+//      Free Software Foundation, which can be found in the top level directory
+//      of this repository (LICENSE_GPL2), and also online at:
+//      <https://www.gnu.org/licenses/old-licenses/gpl-2.0.html>
+//
+// OR
+//
+//   2. An ADI specific BSD license, which can be found in the top level directory
+//      of this repository (LICENSE_ADIBSD), and also on-line at:
+//      https://github.com/analogdevicesinc/hdl/blob/master/LICENSE_ADIBSD
+//      This will allow to generate bit files and not release the source code,
+//      as long as it attaches to an ADI device.
+//
+// ***************************************************************************
+// ***************************************************************************
+
+module adi_jesd204_glue (
+  input in_pll_powerdown,
+  output out_pll_powerdown,
+  output out_mcgb_rst
+);
+
+assign out_pll_powerdown = in_pll_powerdown;
+assign out_mcgb_rst = in_pll_powerdown;
+
+endmodule

--- a/library/altera/adi_jesd204/adi_jesd204_glue_hw.tcl
+++ b/library/altera/adi_jesd204/adi_jesd204_glue_hw.tcl
@@ -1,0 +1,68 @@
+#
+# The ADI JESD204 Core is released under the following license, which is
+# different than all other HDL cores in this repository.
+#
+# Please read this, and understand the freedoms and responsibilities you have
+# by using this source code/core.
+#
+# The JESD204 HDL, is copyright © 2016-2017 Analog Devices Inc.
+#
+# This core is free software, you can use run, copy, study, change, ask
+# questions about and improve this core. Distribution of source, or resulting
+# binaries (including those inside an FPGA or ASIC) require you to release the
+# source of the entire project (excluding the system libraries provide by the
+# tools/compiler/FPGA vendor). These are the terms of the GNU General Public
+# License version 2 as published by the Free Software Foundation.
+#
+# This core  is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+# A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License version 2
+# along with this source code, and binary.  If not, see
+# <http://www.gnu.org/licenses/>.
+#
+# Commercial licenses (with commercial support) of this JESD204 core are also
+# available under terms different than the General Public License. (e.g. they
+# do not require you to accompany any image (FPGA or ASIC) using the JESD204
+# core with any corresponding source code.) For these alternate terms you must
+# purchase a license from Analog Devices Technology Licensing Office. Users
+# interested in such a license should contact jesd204-licensing@analog.com for
+# more information. This commercial license is sub-licensable (if you purchase
+# chips from Analog Devices, incorporate them into your PCB level product, and
+# purchase a JESD204 license, end users of your product will also have a
+# license to use this core in a commercial setting without releasing their
+# source code).
+#
+# In addition, we kindly ask you to acknowledge ADI in any program, application
+# or publication in which you use this JESD204 HDL core. (You are not required
+# to do so; it is up to your common sense to decide whether you want to comply
+# with this request or not.) For general publications, we suggest referencing :
+# “The design and implementation of the JESD204 HDL Core used in this project
+# is copyright © 2016-2017, Analog Devices, Inc.”
+#
+
+package require qsys
+source ../../scripts/adi_env.tcl
+source ../../scripts/adi_ip_alt.tcl
+
+
+ad_ip_create adi_jesd204_glue {Glue} jesd204_phy_glue_elab
+set_module_property INTERNAL true
+
+# files
+
+ad_ip_files adi_jesd204_glue [list \
+  adi_jesd204_glue.v \
+]
+
+# parameters
+
+proc jesd204_phy_glue_elab {} {
+  add_interface in_pll_powerdown conduit end
+  add_interface_port in_pll_powerdown in_pll_powerdown pll_powerdown Input 1
+  add_interface out_pll_powerdown conduit end
+  add_interface_port out_pll_powerdown out_pll_powerdown pll_powerdown Output 1
+  add_interface out_mcgb_rst conduit end
+  add_interface_port out_mcgb_rst out_mcgb_rst mcgb_rst Output 1
+}

--- a/library/altera/jesd204_phy/jesd204_phy_hw.tcl
+++ b/library/altera/jesd204_phy/jesd204_phy_hw.tcl
@@ -158,8 +158,13 @@ proc jesd204_phy_composition_callback {} {
   set_interface_property reconfig_reset EXPORT_OF phy_glue.reconfig_reset
 
   if {$tx} {
-    add_interface serial_clk hssi_serial_clock end
-    set_interface_property serial_clk EXPORT_OF phy_glue.tx_serial_clk0
+    add_interface serial_clk_x1 hssi_serial_clock end
+    set_interface_property serial_clk_x1 EXPORT_OF phy_glue.tx_serial_clk_x1
+
+    if {$num_of_lanes > 6} {
+      add_interface serial_clk_xN hssi_serial_clock end
+      set_interface_property serial_clk_xN EXPORT_OF phy_glue.tx_serial_clk_xN
+    }
 
     add_connection link_clock.clk phy_glue.tx_coreclkin
 


### PR DESCRIPTION
On Arria10 there are 6 transceivers in a single bank. If more than 6
transceivers are used these will end up in multiple banks.

The ATX PLL can directly connect to the transceivers in the same bank
through the 1x clock network. To connect to transceivers in another bank it
has to go through a master clock generation block (MCGB) and the xN clock
network.

Add support for instantiating the MCGB if more than 6 lanes are used. In
this case the first 6 transceivers will still have a direct connection to
the PLL while all other transceivers will be clocked by the MCGB.

Note that this requires that the first 6 transceivers are all in the same
bank.

This has been tested with Arria10 SoC Dev Kit and the AD9136-FMC-EBZ and AD9172-FMC-EBZ on Linux.