### PR TITLE
ad_dds_2: Don't try to round if signal is not truncated

### DIFF
--- a/library/common/ad_dds_2.v
+++ b/library/common/ad_dds_2.v
@@ -97,7 +97,7 @@ module ad_dds_2 #(
 
     // set desired data width
     always @(posedge clk) begin
-      if (DDS_DW <= DDS_D_DW) begin // truncation
+      if (DDS_DW < DDS_D_DW) begin // truncation
         // fair rownding
         dds_data_rownd <= dds_data_int + {(C_T_WIDTH){dds_data_int[DDS_D_DW-1]}};
         dds_data_width <= dds_data_rownd[DDS_D_DW-1:DDS_D_DW-DDS_DW];


### PR DESCRIPTION
If DDS_DW is equal to DDS_D_DW there is no signal truncation and
consequentially no rounding should be performed. But the check whether
rounding should be performed currently is for if DDS_DW is less or equal to
DDS_D_DW.

When both are equal C_T_WIDTH is 0. This results in the expression
'{(C_T_WIDTH){dds_data_int[DDS_D_DW-1]}};' being a 0 width signal. This is
not legal Verilog, but both the Intel and Xilinx tools seem to accept it
nevertheless.

But the iverilog simulation tools generates the following error:

	ad_dds_2.v:102: error: Concatenation repeat may not be zero in this context.

Xilinx Vivado also generates the following warning:

	WARNING: [Synth 8-693] zero replication count - replication ignored [ad_dds_2.v:102]

Change the condition so that truncation is only performed when DDS_DW is
less than DDS_D_DW. This fixes both the error and the warning.

Tested on AD9144-FMC-EBZ with ZC706 and Arria10 SoC Dev kit.