### PR TITLE
Add generated files for Intel projects to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,11 +59,13 @@ db
 *.qpf
 *.qws
 *.sof
+*.rbf
 system_qsys_script.tcl
 hc_output
 hps_isw_handoff
 hps_sdram_*.csv
 incremental_db
+system_bd/
 reconfig_mif
 *.sopcinfo
 *.jdi


### PR DESCRIPTION
The system_db folder is autogenerated and contains all the files that are
generated by the Platform Designer tool.

The extension for Intel binary bitstreams is rbf.

Add both of those to the .gitignore since they should not be under version
control and just end up as clutter in `git status` otherwise.

Signed-off-by: Lars-Peter Clausen <lars@metafoo.de>