### PR TITLE
adi_ip_alt: ad_ip_create: Use 'description' for the DISPLAY_NAME propery

### DIFF
--- a/library/scripts/adi_ip_alt.tcl
+++ b/library/scripts/adi_ip_alt.tcl
@@ -93,13 +93,13 @@ proc ad_generate_module_inst { inst_name mark source_file target_file } {
 ###################################################################################################
 ###################################################################################################
 
-proc ad_ip_create {pname pdesc {pelabfunction ""} {pcomposefunction ""}} {
+proc ad_ip_create {pname pdisplay_name {pelabfunction ""} {pcomposefunction ""}} {
 
   set_module_property NAME $pname
-  set_module_property DESCRIPTION $pdesc
+  set_module_property DISPLAY_NAME $pdisplay_name
+  set_module_property DESCRIPTION $pdisplay_name
   set_module_property VERSION 1.0
   set_module_property GROUP "Analog Devices"
-  set_module_property DISPLAY_NAME $pname
   
   if {$pelabfunction ne ""} {
     set_module_property ELABORATION_CALLBACK $pelabfunction


### PR DESCRIPTION
The DISPLAY_NAME of a module is supposed to be a short human readable
description of the IP core.

Currently this is set to the name of the IP, which already has its own
property called NAME.

This causes Platform Designer to display the descriptive labels if the IP
core basically as "$ip_core_name ($ip_core_name)".

The value that all current user of ad_ip_create pass for the description
parameter matches this criteria (And not so much the requirements for the
actual DESCRIPTION property).

Change things, so that the DISPLAY_NAME property is set to what is
currently passed as the description parameter.

Signed-off-by: Lars-Peter Clausen <lars@metafoo.de>