### PR TITLE
axi_adcfifo: Fix constraints to apply also to Ultrascale devices

### DIFF
--- a/library/xilinx/axi_adcfifo/axi_adcfifo_constr.xdc
+++ b/library/xilinx/axi_adcfifo/axi_adcfifo_constr.xdc
@@ -5,28 +5,26 @@ set_property ASYNC_REG TRUE \
   [get_cells -hier *adc_xfer_req_m_reg[0]*] \
   [get_cells -hier *axi_xfer_req_m_reg[0]*]
 
-set_false_path -from [get_cells *dma_* -hierarchical -filter {PRIMITIVE_SUBGROUP == flop}] \
-  -to [get_cells *axi_*_m* -hierarchical -filter {PRIMITIVE_SUBGROUP == flop}]
-set_false_path -from [get_cells *axi_* -hierarchical -filter {PRIMITIVE_SUBGROUP == flop}] \
-  -to [get_cells *dma_*_m* -hierarchical -filter {PRIMITIVE_SUBGROUP == flop}]
+set_false_path -from [get_cells -hier -filter {name =~ *dma_* && IS_SEQUENTIAL}] \
+               -to   [get_cells -hier -filter {name =~ *axi_*_m* && IS_SEQUENTIAL}]
+set_false_path -from [get_cells -hier -filter {name =~ *axi_* && IS_SEQUENTIAL}] \
+               -to   [get_cells -hier -filter {name =~ *dma_*_m* && IS_SEQUENTIAL}]
 
-set_false_path -from [get_cells *adc_* -hierarchical -filter {PRIMITIVE_SUBGROUP == flop}] \
-  -to [get_cells *axi_*_m* -hierarchical -filter {PRIMITIVE_SUBGROUP == flop}]
-set_false_path -from [get_cells *axi_* -hierarchical -filter {PRIMITIVE_SUBGROUP == flop}] \
-  -to [get_cells *adc_*_m* -hierarchical -filter {PRIMITIVE_SUBGROUP == flop}]
+set_false_path -from [get_cells -hier -filter {name =~ *adc_* && IS_SEQUENTIAL}] \
+               -to   [get_cells -hier -filter {name =~ *axi_*_m* && IS_SEQUENTIAL}]
+set_false_path -from [get_cells -hier -filter {name =~ *axi_* && IS_SEQUENTIAL}] \
+               -to   [get_cells -hier -filter {name =~ *adc_*_m* && IS_SEQUENTIAL}]
 
-set_false_path -from [get_cells *d_xfer_* -hierarchical -filter {PRIMITIVE_SUBGROUP == flop}] \
-  -to [get_cells *up_* -hierarchical -filter {PRIMITIVE_SUBGROUP == flop}]
-set_false_path -from [get_cells *up_xfer_* -hierarchical -filter {PRIMITIVE_SUBGROUP == flop}] \
-  -to [get_cells *d_xfer_* -hierarchical -filter {PRIMITIVE_SUBGROUP == flop}]
-set_false_path -from [get_cells *adc_rel_waddr* -hierarchical -filter {PRIMITIVE_SUBGROUP == flop}] \
-  -to [get_cells *axi_rel_waddr* -hierarchical -filter {PRIMITIVE_SUBGROUP == flop}]
-set_false_path -from [get_cells *axi_waddr_rel_reg* -hierarchical -filter {PRIMITIVE_SUBGROUP == flop}] \
-  -to [get_cells *dma_waddr_rel_reg* -hierarchical -filter {PRIMITIVE_SUBGROUP == flop}]
-set_false_path -from [get_cells *dma_raddr_rel_reg* -hierarchical -filter {PRIMITIVE_SUBGROUP == flop}] \
-  -to [get_cells *axi_raddr_rel_reg* -hierarchical -filter {PRIMITIVE_SUBGROUP == flop}]
+set_false_path -from [get_cells -hier -filter {name =~ *d_xfer_* && IS_SEQUENTIAL}] \
+               -to   [get_cells -hier -filter {name =~ *up_* && IS_SEQUENTIAL}]
+set_false_path -from [get_cells -hier -filter {name =~ *up_xfer_* && IS_SEQUENTIAL}] \
+               -to   [get_cells -hier -filter {name =~ *d_xfer_* && IS_SEQUENTIAL}]
+set_false_path -from [get_cells -hier -filter {name =~ *adc_rel_waddr* && IS_SEQUENTIAL}] \
+               -to   [get_cells -hier -filter {name =~ *axi_rel_waddr* && IS_SEQUENTIAL}]
+set_false_path -from [get_cells -hier -filter {name =~ *axi_waddr_rel_reg* && IS_SEQUENTIAL}] \
+               -to   [get_cells -hier -filter {name =~ *dma_waddr_rel_reg* && IS_SEQUENTIAL}]
+set_false_path -from [get_cells -hier -filter {name =~ *dma_raddr_rel_reg* && IS_SEQUENTIAL}] \
+               -to   [get_cells -hier -filter {name =~ *axi_raddr_rel_reg* && IS_SEQUENTIAL}]
 
-set_false_path \
-  -to [get_cells *adc_xfer_req_m_reg[0]* -hierarchical -filter {PRIMITIVE_SUBGROUP == flop}]
-set_false_path \
-  -to [get_cells *axi_xfer_req_m_reg[0]* -hierarchical -filter {PRIMITIVE_SUBGROUP == flop}]
+set_false_path -to [get_cells -hier -filter {name =~ *adc_xfer_req_m_reg[0]* && IS_SEQUENTIAL}]
+set_false_path -to [get_cells -hier -filter {name =~ *axi_xfer_req_m_reg[0]* && IS_SEQUENTIAL}]


### PR DESCRIPTION
Used IS_SEQUENTIAL instead of PRIMITVE_SUBGROUP==flop to identify ff related constraints