### PR TITLE
axi_jesd204_tx: Fix multi-link constraints

### DIFF
--- a/library/jesd204/axi_jesd204_tx/axi_jesd204_tx_constr.xdc
+++ b/library/jesd204/axi_jesd204_tx/axi_jesd204_tx_constr.xdc
@@ -84,7 +84,7 @@ set_max_delay -datapath_only \
 
 set_false_path \
   -from $core_clk \
-  -to [get_pins {i_up_tx/i_cdc_sync/cdc_sync_stage1_reg[0]/D}]
+  -to [get_pins {i_up_tx/i_cdc_sync/cdc_sync_stage1_reg[*]/D}]
 
 set_false_path \
   -from [get_pins {i_up_common/up_reset_core_reg/C}] \


### PR DESCRIPTION
The constraint for the synchronizer that synchronizes the sync_status
signal of the link only works correctly for the first link. For other links
no timing exception is applied, which leads to timing failures.

Fix this by using a wildcard constraint for the synchronizer reg number.

Signed-off-by: Lars-Peter Clausen <lars@metafoo.de>