### PR TITLE
adi_board.tcl: ad_xcvrcon: Fix width of sync port for multi-link setups

### DIFF
--- a/projects/scripts/adi_board.tcl
+++ b/projects/scripts/adi_board.tcl
@@ -240,8 +240,14 @@ proc ad_xcvrcon {u_xcvr a_xcvr a_jesd {lane_map {}} {device_clk {}}} {
     set m_data ${txrx}_data_${xcvr_index}
   }
 
+  if {$jesd204_type == 0} {
+    set num_of_links [get_property CONFIG.NUM_LINKS [get_bd_cells $a_jesd/$txrx]]
+  } else {
+    set num_of_links 1
+  }
+
   create_bd_port -dir I $m_sysref
-  create_bd_port -dir ${ctrl_dir} $m_sync
+  create_bd_port -from [expr $num_of_links - 1] -to 0 -dir ${ctrl_dir} $m_sync
 
   if {$device_clk == {}} {
     set device_clk ${u_xcvr}/${txrx}_out_clk_${index}


### PR DESCRIPTION
Each individual link of a multi-link has its own sync signal. The top level
sync port that is created by the ad_xcvrcon function is always a single bit
single though.

This results in only the sync signal of the first link being routed while
others are ignored.

To fix this make sure that for multi-link setups the sync port is a vector
port with the width equal to the number of links.

Tested on DAQ2 with NUM_LINKS=1 and on AD9144-FMC-EBZ with NUM_LINKS=2