### PR TITLE
fmcadc2: VC707, specifically connect spi_csn[2:0] to the fmcadc2_spi …

### DIFF
--- a/projects/fmcadc2/vc707/system_top.v
+++ b/projects/fmcadc2/vc707/system_top.v
@@ -149,7 +149,7 @@ module system_top (
     .spi_adf4355 (gpio_o[36]),
     .spi_adf4355_ce (gpio_o[37]),
     .spi_clk (spi_clk),
-    .spi_csn (spi_csn),
+    .spi_csn (spi_csn[2:0]),
     .spi_mosi (spi_mosi),
     .spi_miso (spi_miso),
     .spi_adc_csn (spi_adc_csn),


### PR DESCRIPTION
…module