### PR TITLE
fmcomms2/zc702: Modify implementation strategy to Performance Exlpore

### DIFF
--- a/projects/fmcomms2/zc702/system_project.tcl
+++ b/projects/fmcomms2/zc702/system_project.tcl
@@ -10,8 +10,7 @@ adi_project_files fmcomms2_zc702 [list \
   "$ad_hdl_dir/library/xilinx/common/ad_iobuf.v" \
   "$ad_hdl_dir/projects/common/zc702/zc702_system_constr.xdc" ]
 
-set_property strategy Flow_PerfOptimized_high [get_runs synth_1]
-set_property strategy Performance_ExtraTimingOpt [get_runs impl_1]
+set_property strategy Performance_Explore [get_runs impl_1]
 
 adi_project_run fmcomms2_zc702
 source $ad_hdl_dir/library/axi_ad9361/axi_ad9361_delay.tcl


### PR DESCRIPTION
When we improve timing by modifying the implementation strategies,
the general rule of thumb is "less is always more".

Timing did not fail in synthesis, so we leaving the synthesis
strategy in default.
After several parallel runs with various strategies, the
"Performance_Explore" strategy gave the best result for
implementation.