### PR TITLE
axi_dmac: fix transfer start synchronization

### DIFF
--- a/library/axi_dmac/axi_dmac.v
+++ b/library/axi_dmac/axi_dmac.v
@@ -382,7 +382,8 @@ axi_dmac_regmap #(
   .DMA_CYCLIC(CYCLIC),
   .HAS_DEST_ADDR(HAS_DEST_ADDR),
   .HAS_SRC_ADDR(HAS_SRC_ADDR),
-  .DMA_2D_TRANSFER(DMA_2D_TRANSFER)
+  .DMA_2D_TRANSFER(DMA_2D_TRANSFER),
+  .SYNC_TRANSFER_START(SYNC_TRANSFER_START)
 ) i_regmap (
   .s_axi_aclk(s_axi_aclk),
   .s_axi_aresetn(s_axi_aresetn),

--- a/library/axi_dmac/axi_dmac_regmap.v
+++ b/library/axi_dmac/axi_dmac_regmap.v
@@ -45,7 +45,8 @@ module axi_dmac_regmap #(
   parameter DMA_CYCLIC = 0,
   parameter HAS_DEST_ADDR = 1,
   parameter HAS_SRC_ADDR = 1,
-  parameter DMA_2D_TRANSFER = 0
+  parameter DMA_2D_TRANSFER = 0,
+  parameter SYNC_TRANSFER_START = 0
 ) (
   // Slave AXI interface
   input s_axi_aclk,
@@ -221,7 +222,8 @@ axi_dmac_regmap_request #(
   .DMA_CYCLIC(DMA_CYCLIC),
   .HAS_DEST_ADDR(HAS_DEST_ADDR),
   .HAS_SRC_ADDR(HAS_SRC_ADDR),
-  .DMA_2D_TRANSFER(DMA_2D_TRANSFER)
+  .DMA_2D_TRANSFER(DMA_2D_TRANSFER),
+  .SYNC_TRANSFER_START(SYNC_TRANSFER_START)
 ) i_regmap_request (
   .clk(s_axi_aclk),
   .reset(~s_axi_aresetn),

--- a/library/axi_dmac/data_mover.v
+++ b/library/axi_dmac/data_mover.v
@@ -185,10 +185,10 @@ end endgenerate
  * one has s_axi_sync set. This will be the first beat that is passsed through.
  */
 always @(posedge clk) begin
-  if (m_axi_valid == 1'b1) begin
-    needs_sync <= 1'b0;
-  end else if (req_ready == 1'b1) begin
+  if (req_ready == 1'b1) begin
     needs_sync <= req_sync_transfer_start;
+  end else if (m_axi_valid == 1'b1) begin
+    needs_sync <= 1'b0;
   end
 end
 


### PR DESCRIPTION
This change will fix the transfer start synchronization mechanism used
in the AXIS streaming and FIFO source interfaces.