### PR TITLE
Streaming interface for hdmi tx

### DIFF
--- a/library/axi_hdmi_tx/axi_hdmi_tx_ip.tcl
+++ b/library/axi_hdmi_tx/axi_hdmi_tx_ip.tcl
@@ -54,6 +54,14 @@ set_property enablement_dependency {spirit:decode(id('MODELPARAM_VALUE.INTERFACE
 set_property enablement_dependency {spirit:decode(id('MODELPARAM_VALUE.INTERFACE')) == "16_BIT_EMBEDDED_SYNC"} \
   [ipx::get_ports *hdmi_16_es_data* -of_objects [ipx::current_core]]
 
+adi_add_bus "s_axis" "slave" \
+         "xilinx.com:interface:axis_rtl:1.0" \
+         "xilinx.com:interface:axis:1.0" \
+         [list {"vdma_ready" "TREADY"} \
+           {"vdma_valid" "TVALID"} \
+           {"vdma_data" "TDATA"} \
+           {"vdma_end_of_frame" "TLAST"} ]
+
 ipx::infer_bus_interface hdmi_clk xilinx.com:signal:clock_rtl:1.0 [ipx::current_core]
 ipx::infer_bus_interface hdmi_out_clk xilinx.com:signal:clock_rtl:1.0 [ipx::current_core]
 ipx::infer_bus_interface vdma_clk xilinx.com:signal:clock_rtl:1.0 [ipx::current_core]

--- a/projects/adrv9361z7035/common/ccfmc_bd.tcl
+++ b/projects/adrv9361z7035/common/ccfmc_bd.tcl
@@ -98,10 +98,7 @@ ad_connect  axi_hdmi_core/hdmi_16_vsync hdmi_vsync
 ad_connect  axi_hdmi_core/hdmi_16_data_e hdmi_data_e
 ad_connect  axi_hdmi_core/hdmi_16_data hdmi_data
 
-ad_connect  axi_hdmi_core/vdma_valid axi_hdmi_dma/m_axis_valid
-ad_connect  axi_hdmi_core/vdma_data axi_hdmi_dma/m_axis_data
-ad_connect  axi_hdmi_core/vdma_ready axi_hdmi_dma/m_axis_ready
-ad_connect  axi_hdmi_core/vdma_end_of_frame axi_hdmi_dma/m_axis_last
+ad_connect  axi_hdmi_dma/m_axis axi_hdmi_core/s_axis
 ad_connect  sys_cpu_resetn axi_hdmi_dma/s_axi_aresetn
 ad_connect  sys_cpu_resetn axi_hdmi_dma/m_src_axi_aresetn
 ad_connect  sys_cpu_clk axi_hdmi_dma/s_axi_aclk

--- a/projects/common/zc702/zc702_system_bd.tcl
+++ b/projects/common/zc702/zc702_system_bd.tcl
@@ -153,10 +153,7 @@ ad_connect  axi_hdmi_core/hdmi_16_vsync hdmi_vsync
 ad_connect  axi_hdmi_core/hdmi_16_data_e hdmi_data_e
 ad_connect  axi_hdmi_core/hdmi_16_data hdmi_data
 
-ad_connect  axi_hdmi_core/vdma_valid axi_hdmi_dma/m_axis_valid
-ad_connect  axi_hdmi_core/vdma_data axi_hdmi_dma/m_axis_data
-ad_connect  axi_hdmi_core/vdma_ready axi_hdmi_dma/m_axis_ready
-ad_connect  axi_hdmi_core/vdma_end_of_frame axi_hdmi_dma/m_axis_last
+ad_connect axi_hdmi_dma/m_axis axi_hdmi_core/s_axis
 ad_connect  sys_cpu_resetn axi_hdmi_dma/s_axi_aresetn
 ad_connect  sys_cpu_resetn axi_hdmi_dma/m_src_axi_aresetn
 ad_connect  sys_cpu_clk axi_hdmi_dma/s_axi_aclk

--- a/projects/common/zc706/zc706_system_bd.tcl
+++ b/projects/common/zc706/zc706_system_bd.tcl
@@ -154,10 +154,7 @@ ad_connect  axi_hdmi_core/hdmi_24_vsync hdmi_vsync
 ad_connect  axi_hdmi_core/hdmi_24_data_e hdmi_data_e
 ad_connect  axi_hdmi_core/hdmi_24_data hdmi_data
 
-ad_connect  axi_hdmi_core/vdma_valid axi_hdmi_dma/m_axis_valid
-ad_connect  axi_hdmi_core/vdma_data axi_hdmi_dma/m_axis_data
-ad_connect  axi_hdmi_core/vdma_ready axi_hdmi_dma/m_axis_ready
-ad_connect  axi_hdmi_core/vdma_end_of_frame axi_hdmi_dma/m_axis_last
+ad_connect  axi_hdmi_dma/m_axis axi_hdmi_core/s_axis
 ad_connect  sys_cpu_resetn axi_hdmi_dma/s_axi_aresetn
 ad_connect  sys_cpu_resetn axi_hdmi_dma/m_src_axi_aresetn
 ad_connect  sys_cpu_clk axi_hdmi_dma/s_axi_aclk

--- a/projects/common/zed/zed_system_bd.tcl
+++ b/projects/common/zed/zed_system_bd.tcl
@@ -198,10 +198,7 @@ ad_connect  axi_hdmi_core/hdmi_16_vsync hdmi_vsync
 ad_connect  axi_hdmi_core/hdmi_16_data_e hdmi_data_e
 ad_connect  axi_hdmi_core/hdmi_16_data hdmi_data
 
-ad_connect  axi_hdmi_core/vdma_valid axi_hdmi_dma/m_axis_valid
-ad_connect  axi_hdmi_core/vdma_data axi_hdmi_dma/m_axis_data
-ad_connect  axi_hdmi_core/vdma_ready axi_hdmi_dma/m_axis_ready
-ad_connect  axi_hdmi_core/vdma_end_of_frame axi_hdmi_dma/m_axis_last
+ad_connect  axi_hdmi_dma/m_axis axi_hdmi_core/s_axis
 
 ad_connect sys_cpu_resetn axi_hdmi_dma/s_axi_aresetn
 ad_connect sys_cpu_resetn axi_hdmi_dma/m_src_axi_aresetn


### PR DESCRIPTION
Combine the ready, valid, data and tlast signals in a s_axis interface.
Update for all projects.

Build tested on:
adv7511/zed,zc702/zc706 and adrv9361_z7035/ccfmc.
Run test on adv7511/zc702