### PR TITLE
axi_clkgen: Add speedgrade and family register

### DIFF
--- a/library/axi_clkgen/axi_clkgen.v
+++ b/library/axi_clkgen/axi_clkgen.v
@@ -39,6 +39,7 @@ module axi_clkgen #(
   parameter         ID = 0,
   parameter         DEVICE_TYPE = 0,
   parameter         SPEED_GRADE = 0,
+  parameter         FPGA_DEV_PACKAGE = 0,
   parameter         CLKSEL_EN = 0,
   parameter real    CLKIN_PERIOD  = 5.000,
   parameter real    CLKIN2_PERIOD  = 5.000,
@@ -148,6 +149,7 @@ module axi_clkgen #(
   up_clkgen #(
     .ID(ID),
     .FAMILY(DEVICE_TYPE),
+    .FPGA_DEV_PACKAGE(FPGA_DEV_PACKAGE),
     .SPEED_GRADE(SPEED_GRADE)
   ) i_up_clkgen (
     .mmcm_rst (mmcm_rst),

--- a/library/axi_clkgen/axi_clkgen.v
+++ b/library/axi_clkgen/axi_clkgen.v
@@ -38,6 +38,7 @@ module axi_clkgen #(
 
   parameter         ID = 0,
   parameter         DEVICE_TYPE = 0,
+  parameter         SPEED_GRADE = 0,
   parameter         CLKSEL_EN = 0,
   parameter real    CLKIN_PERIOD  = 5.000,
   parameter real    CLKIN2_PERIOD  = 5.000,
@@ -145,7 +146,9 @@ module axi_clkgen #(
   // processor interface
 
   up_clkgen #(
-    .ID(ID)
+    .ID(ID),
+    .FAMILY(DEVICE_TYPE),
+    .SPEED_GRADE(SPEED_GRADE)
   ) i_up_clkgen (
     .mmcm_rst (mmcm_rst),
     .clk_sel (up_clk_sel_s),

--- a/library/axi_clkgen/axi_clkgen_ip.tcl
+++ b/library/axi_clkgen/axi_clkgen_ip.tcl
@@ -42,7 +42,7 @@ set_property -dict [list \
 ] $param
 
 set_property value_format string [ipx::get_hdl_parameters SPEED_GRADE -of_objects [ipx::current_core]]
-set_property value_format string [ipx::get_hdl_parameters SPEED_GRADE -of_objects [ipx::current_core]]
+set_property value_format string [ipx::get_user_parameters SPEED_GRADE -of_objects [ipx::current_core]]
 
 set part [get_property PART [current_project]]
 foreach x [list_property $part] {

--- a/library/axi_clkgen/axi_clkgen_ip.tcl
+++ b/library/axi_clkgen/axi_clkgen_ip.tcl
@@ -41,21 +41,61 @@ set_property -dict [list \
 	widget {checkBox} \
 ] $param
 
-set_property value_format string [ipx::get_hdl_parameters SPEED_GRADE -of_objects [ipx::current_core]]
-set_property value_format string [ipx::get_user_parameters SPEED_GRADE -of_objects [ipx::current_core]]
-
 set part [get_property PART [current_project]]
-foreach x [list_property $part] {
-  if { $x == "SPEED_GRADE" } {
-    set speed [get_property $x $part]
-    puts $speed
-    set_property value $speed [ipx::get_user_parameters SPEED_GRADE -of_objects [ipx::current_core]]
-    set_property value $speed [ipx::get_hdl_parameters SPEED_GRADE -of_objects [ipx::current_core]]
-  }
-  if { $x == "FAMILY" } {
-    set family [get_property $x $part]
-  }
+
+# capture the device speedgrade
+set speed [get_property SPEED $part]
+
+switch $speed {
+	-1   { set speed_enc 10 }
+	-1L  { set speed_enc 11 }
+	-1H  { set speed_enc 12 }
+	-1HV { set speed_enc 13 }
+	-1LV { set speed_enc 14 }
+	-2   { set speed_enc 20 }
+	-2L  { set speed_enc 21 }
+	-2LV { set speed_enc 22 }
+	-3   { set speed_enc 30 }
+	default {
+		puts "Undefined speed grade \"$speed\"!"
+		exit -1
+	}
 }
+
+set_property value $speed [ipx::get_user_parameters SPEED_GRADE -of_objects [ipx::current_core]]
+set_property value $speed_enc [ipx::get_hdl_parameters SPEED_GRADE -of_objects [ipx::current_core]]
+set_property enablement_value false [ipx::get_user_parameters SPEED_GRADE -of_objects [ipx::current_core]]
+
+# capture device package
+set package_string [get_property PACKAGE $part]
+
+switch -regexp -- $package_string {
+	^rf   { set package_enc 1  }
+	^fl   { set package_enc 2  }
+	^ff   { set package_enc 3  }
+	^fb   { set package_enc 4  }
+	^hc   { set package_enc 5  }
+	^fh   { set package_enc 6  }
+	^cs   { set package_enc 7  }
+	^cp   { set package_enc 8  }
+	^ft   { set package_enc 9  }
+	^fg   { set package_enc 10 }
+	^sb   { set package_enc 11 }
+	^rb   { set package_enc 12 }
+	^rs   { set package_enc 13 }
+	^cl   { set package_enc 14 }
+	^sf   { set package_enc 15 }
+	^ba   { set package_enc 16 }
+	^fa   { set package_enc 17 }
+	default {
+		puts "Undefined pakage \"$package_enc\"!"
+		exit -1
+	}
+}
+
+set_property value $package_string [ipx::get_user_parameters FPGA_DEV_PACKAGE -of_objects [ipx::current_core]]
+set_property value $package_enc [ipx::get_hdl_parameters FPGA_DEV_PACKAGE -of_objects [ipx::current_core]]
+set_property enablement_value false [ipx::get_user_parameters FPGA_DEV_PACKAGE -of_objects [ipx::current_core]]
 
 set_property enablement_tcl_expr {$ENABLE_CLKIN2} [ipx::get_user_parameters CLKIN2_PERIOD -of_objects $cc]
 set_property enablement_tcl_expr {$ENABLE_CLKOUT1} [ipx::get_user_parameters CLK1_DIV -of_objects $cc]

--- a/library/axi_clkgen/axi_clkgen_ip.tcl
+++ b/library/axi_clkgen/axi_clkgen_ip.tcl
@@ -41,6 +41,22 @@ set_property -dict [list \
 	widget {checkBox} \
 ] $param
 
+set_property value_format string [ipx::get_hdl_parameters SPEED_GRADE -of_objects [ipx::current_core]]
+set_property value_format string [ipx::get_hdl_parameters SPEED_GRADE -of_objects [ipx::current_core]]
+
+set part [get_property PART [current_project]]
+foreach x [list_property $part] {
+  if { $x == "SPEED_GRADE" } {
+    set speed [get_property $x $part]
+    puts $speed
+    set_property value $speed [ipx::get_user_parameters SPEED_GRADE -of_objects [ipx::current_core]]
+    set_property value $speed [ipx::get_hdl_parameters SPEED_GRADE -of_objects [ipx::current_core]]
+  }
+  if { $x == "FAMILY" } {
+    set family [get_property $x $part]
+  }
+}
+
 set_property enablement_tcl_expr {$ENABLE_CLKIN2} [ipx::get_user_parameters CLKIN2_PERIOD -of_objects $cc]
 set_property enablement_tcl_expr {$ENABLE_CLKOUT1} [ipx::get_user_parameters CLK1_DIV -of_objects $cc]
 set_property enablement_tcl_expr {$ENABLE_CLKOUT1} [ipx::get_user_parameters CLK1_PHASE -of_objects $cc]

--- a/library/common/up_clkgen.v
+++ b/library/common/up_clkgen.v
@@ -37,7 +37,9 @@
 
 module up_clkgen #(
 
-  parameter   ID = 0) (
+  parameter         ID = 0,
+  parameter [ 7:0]  FAMILY = 0,
+  parameter [ 7:0]  SPEED_GRADE = 0) (
 
   // mmcm reset
 
@@ -161,6 +163,7 @@ module up_clkgen #(
           8'h00: up_rdata <= PCORE_VERSION;
           8'h01: up_rdata <= ID;
           8'h02: up_rdata <= up_scratch;
+          8'h03: up_rdata <= {16'd0,SPEED_GRADE,FAMILY}; // [16,8,8]
           8'h10: up_rdata <= {30'd0, up_mmcm_resetn, up_resetn};
           8'h11: up_rdata <= {31'd0, up_clk_sel};
           8'h17: up_rdata <= {31'd0, up_drp_locked};

--- a/library/common/up_clkgen.v
+++ b/library/common/up_clkgen.v
@@ -39,6 +39,7 @@ module up_clkgen #(
 
   parameter         ID = 0,
   parameter [ 7:0]  FAMILY = 0,
+  parameter [ 7:0]  FPGA_DEV_PACKAGE = 0,
   parameter [ 7:0]  SPEED_GRADE = 0) (
 
   // mmcm reset
@@ -163,7 +164,7 @@ module up_clkgen #(
           8'h00: up_rdata <= PCORE_VERSION;
           8'h01: up_rdata <= ID;
           8'h02: up_rdata <= up_scratch;
-          8'h03: up_rdata <= {16'd0,SPEED_GRADE,FAMILY}; // [16,8,8]
+          8'h07: up_rdata <= {8'd0,FPGA_DEV_PACKAGE,SPEED_GRADE,FAMILY}; // [8,8,8,8]
           8'h10: up_rdata <= {30'd0, up_mmcm_resetn, up_resetn};
           8'h11: up_rdata <= {31'd0, up_clk_sel};
           8'h17: up_rdata <= {31'd0, up_drp_locked};


### PR DESCRIPTION
This register will help software choose the correct settings for
configuring the mmcms at runtime.

Next step is to document ADI's numbering notation of vendor families.