### PR TITLE
Remove all Xilinx 6 series primitives

### DIFF
--- a/library/xilinx/common/ad_data_clk.v
+++ b/library/xilinx/common/ad_data_clk.v
@@ -48,7 +48,6 @@ module ad_data_clk #(
   output              clk);
 
   localparam  VIRTEX7 = 0;
-  localparam  VIRTEX6 = 1;
   localparam  ULTRASCALE_PLUS = 2;
   localparam  ULTRASCALE = 3;
 
@@ -75,19 +74,9 @@ module ad_data_clk #(
   end
   endgenerate
 
-  generate
-  if (DEVICE_TYPE == VIRTEX6) begin
-  BUFR #(.BUFR_DIVIDE("BYPASS")) i_clk_rbuf (
-    .CLR (1'b0),
-    .CE (1'b1),
-    .I (clk_ibuf_s),
-    .O (clk));
-  end else begin
   BUFG i_clk_gbuf (
     .I (clk_ibuf_s),
     .O (clk));
-  end
-  endgenerate
 
 endmodule
 

--- a/library/xilinx/common/ad_data_in.v
+++ b/library/xilinx/common/ad_data_in.v
@@ -70,19 +70,16 @@ module ad_data_in #(
 
   localparam  NONE = -1;
   localparam  VIRTEX7 = 0;
-  localparam  VIRTEX6 = 1;
   localparam  ULTRASCALE_PLUS = 2;
   localparam  ULTRASCALE = 3;
 
   localparam  IODELAY_CTRL_ENABLED = (IODELAY_ENABLE == 1) ? IODELAY_CTRL : 0;
   localparam  IODELAY_CTRL_SIM_DEVICE = (DEVICE_TYPE == ULTRASCALE_PLUS) ? "ULTRASCALE" :
-    (DEVICE_TYPE == ULTRASCALE) ? "ULTRASCALE" :
-    (DEVICE_TYPE == VIRTEX7) ? "7SERIES" : "VIRTEX6";
+    (DEVICE_TYPE == ULTRASCALE) ? "ULTRASCALE" : "7SERIES";
 
   localparam  IODELAY_DEVICE_TYPE = (IODELAY_ENABLE == 1) ? DEVICE_TYPE : NONE;
-  localparam  IODELAY_SIM_DEVICE = (DEVICE_TYPE == ULTRASCALE_PLUS) ? "ULTRASCALE_PLUS_ES1" :
-    (DEVICE_TYPE == ULTRASCALE) ? "ULTRASCALE" :
-    (DEVICE_TYPE == VIRTEX7) ? "7SERIES" : "VIRTEX6";
+  localparam  IODELAY_SIM_DEVICE = (DEVICE_TYPE == ULTRASCALE_PLUS) ? "ULTRASCALE_PLUS" :
+    (DEVICE_TYPE == ULTRASCALE) ? "ULTRASCALE" : "7SERIES";
 
   // internal signals
 
@@ -120,36 +117,6 @@ module ad_data_in #(
   endgenerate
 
   // idelay
-
-  generate
-  if (IODELAY_DEVICE_TYPE == VIRTEX6) begin
-  (* IODELAY_GROUP = IODELAY_GROUP *)
-  IODELAYE1 #(
-    .CINVCTRL_SEL ("FALSE"),
-    .DELAY_SRC ("I"),
-    .HIGH_PERFORMANCE_MODE ("TRUE"),
-    .IDELAY_TYPE ("VAR_LOADABLE"),
-    .IDELAY_VALUE (0),
-    .ODELAY_TYPE ("FIXED"),
-    .ODELAY_VALUE (0),
-    .REFCLK_FREQUENCY (200.0),
-    .SIGNAL_PATTERN ("DATA"))
-  i_rx_data_idelay (
-    .T (1'b1),
-    .CE (1'b0),
-    .INC (1'b0),
-    .CLKIN (1'b0),
-    .DATAIN (1'b0),
-    .ODATAIN (1'b0),
-    .CINVCTRL (1'b0),
-    .C (up_clk),
-    .IDATAIN (rx_data_ibuf_s),
-    .DATAOUT (rx_data_idelay_s),
-    .RST (up_dld),
-    .CNTVALUEIN (up_dwdata),
-    .CNTVALUEOUT (up_drdata));
-  end
-  endgenerate
 
   generate
   if (IODELAY_DEVICE_TYPE == VIRTEX7) begin
@@ -229,7 +196,7 @@ module ad_data_in #(
   endgenerate
 
   generate
-  if ((DEVICE_TYPE == VIRTEX7) || (DEVICE_TYPE == VIRTEX6)) begin
+  if (DEVICE_TYPE == VIRTEX7) begin
   IDDR #(.DDR_CLK_EDGE ("SAME_EDGE")) i_rx_data_iddr (
     .CE (1'b1),
     .R (1'b0),

--- a/library/xilinx/common/ad_data_out.v
+++ b/library/xilinx/common/ad_data_out.v
@@ -66,19 +66,16 @@ module ad_data_out #(
 
   localparam  NONE = -1;
   localparam  VIRTEX7 = 0;
-  localparam  VIRTEX6 = 1;
   localparam  ULTRASCALE_PLUS = 2;
   localparam  ULTRASCALE = 3;
 
   localparam  IODELAY_CTRL_ENABLED = (IODELAY_ENABLE == 1) ? IODELAY_CTRL : 0;
   localparam  IODELAY_CTRL_SIM_DEVICE = (DEVICE_TYPE == ULTRASCALE_PLUS) ? "ULTRASCALE" :
-    (DEVICE_TYPE == ULTRASCALE) ? "ULTRASCALE" :
-    (DEVICE_TYPE == VIRTEX7) ? "7SERIES" : "VIRTEX6";
+    (DEVICE_TYPE == ULTRASCALE) ? "ULTRASCALE" : "7SERIES";
 
   localparam  IODELAY_DEVICE_TYPE = (IODELAY_ENABLE == 1) ? DEVICE_TYPE : NONE;
   localparam  IODELAY_SIM_DEVICE = (DEVICE_TYPE == ULTRASCALE_PLUS) ? "ULTRASCALE_PLUS_ES1" :
-    (DEVICE_TYPE == ULTRASCALE) ? "ULTRASCALE" :
-    (DEVICE_TYPE == VIRTEX7) ? "7SERIES" : "VIRTEX6";
+    (DEVICE_TYPE == ULTRASCALE) ? "ULTRASCALE" : "7SERIES";
 
   // internal signals
 
@@ -113,7 +110,7 @@ module ad_data_out #(
   endgenerate
 
   generate
-  if ((DEVICE_TYPE == VIRTEX7) || (DEVICE_TYPE == VIRTEX6)) begin
+  if (DEVICE_TYPE == VIRTEX7) begin
   ODDR #(.DDR_CLK_EDGE ("SAME_EDGE")) i_tx_data_oddr (
     .CE (1'b1),
     .R (1'b0),

--- a/library/xilinx/common/ad_mmcm_drp.v
+++ b/library/xilinx/common/ad_mmcm_drp.v
@@ -73,7 +73,6 @@ module ad_mmcm_drp #(
   output  reg             up_drp_locked);
 
   localparam  MMCM_DEVICE_7SERIES = 0;
-  localparam  MMCM_DEVICE_VIRTEX6 = 1;
   localparam  MMCM_DEVICE_ULTRASCALE = 2;
 
 
@@ -237,73 +236,6 @@ module ad_mmcm_drp #(
       .PWRDWN (1'b0),
       .CDDCREQ (1'b0),
       .CDDCDONE (),
-      .RST (mmcm_rst));
-
-      BUFG i_fb_clk_bufg  (.I (mmcm_fb_clk_s),  .O (bufg_fb_clk_s));
-      BUFG i_clk_0_bufg   (.I (mmcm_clk_0_s),   .O (mmcm_clk_0));
-      BUFG i_clk_1_bufg   (.I (mmcm_clk_1_s),   .O (mmcm_clk_1));
-      BUFG i_clk_2_bufg   (.I (mmcm_clk_2_s),   .O (mmcm_clk_2));
-
-  end else if (MMCM_DEVICE_TYPE == MMCM_DEVICE_VIRTEX6) begin 
-
-    MMCM_ADV #(
-      .BANDWIDTH ("OPTIMIZED"),
-      .CLKOUT4_CASCADE ("FALSE"),
-      .CLOCK_HOLD ("FALSE"),
-      .COMPENSATION ("ZHOLD"),
-      .STARTUP_WAIT ("FALSE"),
-      .DIVCLK_DIVIDE (MMCM_VCO_DIV),
-      .CLKFBOUT_MULT_F (MMCM_VCO_MUL),
-      .CLKFBOUT_PHASE (0.000),
-      .CLKFBOUT_USE_FINE_PS ("FALSE"),
-      .CLKOUT0_DIVIDE_F (MMCM_CLK0_DIV),
-      .CLKOUT0_PHASE (MMCM_CLK0_PHASE),
-      .CLKOUT0_DUTY_CYCLE (0.500),
-      .CLKOUT0_USE_FINE_PS ("FALSE"),
-      .CLKOUT1_DIVIDE (MMCM_CLK1_DIV),
-      .CLKOUT1_PHASE (MMCM_CLK1_PHASE),
-      .CLKOUT1_DUTY_CYCLE (0.500),
-      .CLKOUT1_USE_FINE_PS ("FALSE"),
-      .CLKOUT2_DIVIDE (MMCM_CLK2_DIV),
-      .CLKOUT2_PHASE (MMCM_CLK2_PHASE),
-      .CLKOUT2_DUTY_CYCLE (0.500),
-      .CLKOUT2_USE_FINE_PS ("FALSE"),
-      .CLKIN1_PERIOD (MMCM_CLKIN_PERIOD),
-      .CLKIN2_PERIOD (MMCM_CLKIN2_PERIOD),
-      .REF_JITTER1 (0.010))
-    i_mmcm (
-      .CLKIN1 (clk),
-      .CLKFBIN (bufg_fb_clk_s),
-      .CLKFBOUT (mmcm_fb_clk_s),
-      .CLKOUT0 (mmcm_clk_0_s),
-      .CLKOUT1 (mmcm_clk_1_s),
-      .CLKOUT2 (mmcm_clk_2_s),
-      .LOCKED (mmcm_locked_s),
-      .DCLK (up_clk),
-      .DEN (up_drp_sel),
-      .DADDR (up_drp_addr[6:0]),
-      .DWE (up_drp_wr),
-      .DI (up_drp_wdata),
-      .DO (up_drp_rdata_s),
-      .DRDY (up_drp_ready_s),
-      .CLKFBOUTB (),
-      .CLKOUT0B (),
-      .CLKOUT1B (),
-      .CLKOUT2B (),
-      .CLKOUT3 (),
-      .CLKOUT3B (),
-      .CLKOUT4 (),
-      .CLKOUT5 (),
-      .CLKOUT6 (),
-      .CLKIN2 (clk2),
-      .CLKINSEL (clk_sel),
-      .PSCLK (1'b0),
-      .PSEN (1'b0),
-      .PSINCDEC (1'b0),
-      .PSDONE (),
-      .CLKINSTOPPED (),
-      .CLKFBSTOPPED (),
-      .PWRDWN (1'b0),
       .RST (mmcm_rst));
 
       BUFG i_fb_clk_bufg  (.I (mmcm_fb_clk_s),  .O (bufg_fb_clk_s));

--- a/library/xilinx/common/ad_serdes_in.v
+++ b/library/xilinx/common/ad_serdes_in.v
@@ -79,7 +79,6 @@ module ad_serdes_in #(
   input                           delay_rst,
   output                          delay_locked);
 
-  localparam  DEVICE_6SERIES  = 1;
   localparam  DEVICE_7SERIES  = 0;
   localparam  DATA_RATE = (DDR_OR_SDR_N) ? "DDR" : "SDR";
 
@@ -107,7 +106,7 @@ module ad_serdes_in #(
   // received data interface: ibuf -> idelay -> iserdes
 
   genvar l_inst;
-  generate if (DEVICE_TYPE == 0) begin
+  generate if (DEVICE_TYPE == DEVICE_7SERIES) begin
     for (l_inst = 0; l_inst <= (DATA_WIDTH-1); l_inst = l_inst + 1) begin: g_data
 
       IBUFDS i_ibuf (
@@ -188,130 +187,6 @@ module ad_serdes_in #(
         .SHIFTIN2 (1'b0));
       end /* g_data */
 
-    end else begin
-
-    for (l_inst = 0; l_inst <= (DATA_WIDTH-1); l_inst = l_inst + 1) begin: g_data
-
-      IBUFDS i_ibuf (
-        .I (data_in_p[l_inst]),
-        .IB (data_in_n[l_inst]),
-        .O (data_in_ibuf_s[l_inst]));
-
-      (* IODELAY_GROUP = IODELAY_GROUP *)
-      IODELAYE1 #(
-        .CINVCTRL_SEL ("FALSE"),
-        .DELAY_SRC ("I"),
-        .HIGH_PERFORMANCE_MODE ("TRUE"),
-        .IDELAY_TYPE ("VAR_LOADABLE"),
-        .IDELAY_VALUE (0),
-        .ODELAY_TYPE ("FIXED"),
-        .ODELAY_VALUE (0),
-        .REFCLK_FREQUENCY (200.0),
-        .SIGNAL_PATTERN ("DATA"))
-      i_idelay (
-        .T (1'b1),
-        .CE (1'b0),
-        .INC (1'b0),
-        .CLKIN (1'b0),
-        .DATAIN (1'b0),
-        .ODATAIN (1'b0),
-        .CINVCTRL (1'b0),
-        .C (up_clk),
-        .IDATAIN (data_in_ibuf_s[l_inst]),
-        .DATAOUT (data_in_idelay_s[l_inst]),
-        .RST (up_dld[l_inst]),
-        .CNTVALUEIN (up_dwdata[((5*l_inst)+4):(5*l_inst)]),
-        .CNTVALUEOUT (up_drdata[((5*l_inst)+4):(5*l_inst)]));
-
-      ISERDESE1 #(
-        .DATA_RATE (DATA_RATE),
-        .DATA_WIDTH (SERDES_FACTOR),
-        .DYN_CLKDIV_INV_EN ("FALSE"),
-        .DYN_CLK_INV_EN ("FALSE"),
-        .INIT_Q1 (1'b0),
-        .INIT_Q2 (1'b0),
-        .INIT_Q3 (1'b0),
-        .INIT_Q4 (1'b0),
-        .INTERFACE_TYPE ("NETWORKING"),
-        .IOBDELAY ("NONE"),
-        .NUM_CE (1),
-        .OFB_USED ("FALSE"),
-        .SERDES_MODE ("MASTER"),
-        .SRVAL_Q1 (1'b0),
-        .SRVAL_Q2 (1'b0),
-        .SRVAL_Q3 (1'b0),
-        .SRVAL_Q4 (1'b0))
-      i_iserdes_m (
-        .O (),
-        .Q1 (data_s0[l_inst]),
-        .Q2 (data_s1[l_inst]),
-        .Q3 (data_s2[l_inst]),
-        .Q4 (data_s3[l_inst]),
-        .Q5 (data_s4[l_inst]),
-        .Q6 (data_s5[l_inst]),
-        .SHIFTOUT1 (data_shift1_s[l_inst]),
-        .SHIFTOUT2 (data_shift2_s[l_inst]),
-        .BITSLIP (1'b0),
-        .CE1 (1'b1),
-        .CE2 (1'b1),
-        .CLK (clk),
-        .CLKB (~clk),
-        .CLKDIV (div_clk),
-        .OCLK (1'b0),
-        .DYNCLKDIVSEL (1'b0),
-        .DYNCLKSEL (1'b0),
-        .D (1'b0),
-        .DDLY (data_in_idelay_s[l_inst]),
-        .OFB (1'b0),
-        .RST (rst),
-        .SHIFTIN1 (1'b0),
-        .SHIFTIN2 (1'b0));
-
-      ISERDESE1 #(
-        .DATA_RATE (DATA_RATE),
-        .DATA_WIDTH (SERDES_FACTOR),
-        .DYN_CLKDIV_INV_EN ("FALSE"),
-        .DYN_CLK_INV_EN ("FALSE"),
-        .INIT_Q1 (1'b0),
-        .INIT_Q2 (1'b0),
-        .INIT_Q3 (1'b0),
-        .INIT_Q4 (1'b0),
-        .INTERFACE_TYPE ("NETWORKING"),
-        .IOBDELAY ("NONE"),
-        .NUM_CE (1),
-        .OFB_USED ("FALSE"),
-        .SERDES_MODE ("SLAVE"),
-        .SRVAL_Q1 (1'b0),
-        .SRVAL_Q2 (1'b0),
-        .SRVAL_Q3 (1'b0),
-        .SRVAL_Q4 (1'b0))
-      i_iserdes_s (
-        .O (),
-        .Q1 (),
-        .Q2 (),
-        .Q3 (data_s6[l_inst]),
-        .Q4 (data_s7[l_inst]),
-        .Q5 (),
-        .Q6 (),
-        .SHIFTOUT1 (),
-        .SHIFTOUT2 (),
-        .BITSLIP (1'b0),
-        .CE1 (1'b1),
-        .CE2 (1'b1),
-        .CLK (clk),
-        .CLKB (~clk),
-        .CLKDIV (div_clk),
-        .OCLK (1'b0),
-        .DYNCLKDIVSEL (1'b0),
-        .DYNCLKSEL (1'b0),
-        .D (1'b0),
-        .DDLY (data_in_idelay_s[l_inst]),
-        .OFB (1'b0),
-        .RST (rst),
-        .SHIFTIN1 (data_shift1_s[l_inst]),
-        .SHIFTIN2 (data_shift2_s[l_inst]));
-
-      end /* g_data */
     end
   endgenerate
 

--- a/library/xilinx/common/ad_serdes_out.v
+++ b/library/xilinx/common/ad_serdes_out.v
@@ -64,7 +64,6 @@ module ad_serdes_out #(
   output  [(DATA_WIDTH-1):0]  data_out_p,
   output  [(DATA_WIDTH-1):0]  data_out_n);
 
-  localparam  DEVICE_6SERIES = 1;
   localparam  DEVICE_7SERIES = 0;
   localparam  DR_OQ_DDR = DDR_OR_SDR_N == 1'b1 ? "DDR": "SDR";
 
@@ -115,82 +114,6 @@ module ad_serdes_out #(
         .TFB (),
         .TBYTEIN (1'b0),
         .TBYTEOUT (),
-        .TCE (1'b0),
-        .RST (rst));
-    end
-
-    if (DEVICE_TYPE == DEVICE_6SERIES) begin
-      OSERDESE1  #(
-        .DATA_RATE_OQ (DR_OQ_DDR),
-        .DATA_RATE_TQ ("SDR"),
-        .DATA_WIDTH (SERDES_FACTOR),
-        .INTERFACE_TYPE ("DEFAULT"),
-        .TRISTATE_WIDTH (1),
-        .SERDES_MODE ("MASTER"))
-      i_serdes_m (
-        .D1 (data_s0[l_inst]),
-        .D2 (data_s1[l_inst]),
-        .D3 (data_s2[l_inst]),
-        .D4 (data_s3[l_inst]),
-        .D5 (data_s4[l_inst]),
-        .D6 (data_s5[l_inst]),
-        .T1 (1'b0),
-        .T2 (1'b0),
-        .T3 (1'b0),
-        .T4 (1'b0),
-        .SHIFTIN1 (serdes_shift1_s[l_inst]),
-        .SHIFTIN2 (serdes_shift2_s[l_inst]),
-        .SHIFTOUT1 (),
-        .SHIFTOUT2 (),
-        .OCE (1'b1),
-        .CLK (clk),
-        .CLKDIV (div_clk),
-        .CLKPERF (1'b0),
-        .CLKPERFDELAY (1'b0),
-        .WC (1'b0),
-        .ODV (1'b0),
-        .OQ (data_out_s[l_inst]),
-        .TQ (),
-        .OCBEXTEND (),
-        .OFB (),
-        .TFB (),
-        .TCE (1'b0),
-        .RST (rst));
-
-      OSERDESE1  #(
-        .DATA_RATE_OQ (DR_OQ_DDR),
-        .DATA_RATE_TQ ("SDR"),
-        .DATA_WIDTH (SERDES_FACTOR),
-        .INTERFACE_TYPE ("DEFAULT"),
-        .TRISTATE_WIDTH (1),
-        .SERDES_MODE ("SLAVE"))
-      i_serdes_s (
-        .D1 (1'b0),
-        .D2 (1'b0),
-        .D3 (data_s6[l_inst]),
-        .D4 (data_s7[l_inst]),
-        .D5 (1'b0),
-        .D6 (1'b0),
-        .T1 (1'b0),
-        .T2 (1'b0),
-        .T3 (1'b0),
-        .T4 (1'b0),
-        .SHIFTIN1 (1'b0),
-        .SHIFTIN2 (1'b0),
-        .SHIFTOUT1 (serdes_shift1_s[l_inst]),
-        .SHIFTOUT2 (serdes_shift2_s[l_inst]),
-        .OCE (1'b1),
-        .CLK (clk),
-        .CLKDIV (div_clk),
-        .CLKPERF (1'b0),
-        .CLKPERFDELAY (1'b0),
-        .WC (1'b0),
-        .ODV (1'b0),
-        .OQ (),
-        .TQ (),
-        .OCBEXTEND (),
-        .OFB (),
-        .TFB (),
         .TCE (1'b0),
         .RST (rst));
     end


### PR DESCRIPTION
These primitives are not used or supported by the newer versions of Vivado.
This is the first step in the process of adding a generic encoding for vendor device series and families.