### PR TITLE
Fix util dacfifo constraints

### DIFF
--- a/library/util_dacfifo/util_dacfifo_bypass.v
+++ b/library/util_dacfifo/util_dacfifo_bypass.v
@@ -87,8 +87,6 @@ module util_dacfifo_bypass #(
   reg     [(DMA_ADDRESS_WIDTH-1):0]     dac_mem_waddr_m1 = 'd0;
   reg     [(DMA_ADDRESS_WIDTH-1):0]     dac_mem_waddr_m2 = 'd0;
   reg     [(DMA_ADDRESS_WIDTH-1):0]     dac_mem_waddr = 'd0;
-  reg                                   dac_xfer_out = 1'b0;
-  reg                                   dac_xfer_out_m1 = 1'b0;
 
   // internal signals
 
@@ -249,12 +247,8 @@ module util_dacfifo_bypass #(
 
   always @(posedge dac_clk) begin
     if (dac_rst == 1'b1) begin
-      dac_xfer_out_m1 <= 1'b0;
-      dac_xfer_out <= 1'b0;
       dac_dunf <= 1'b0;
     end else begin
-      dac_xfer_out_m1 <= dma_xfer_req;
-      dac_xfer_out <= dac_xfer_out_m1;
       if (dac_valid == 1'b1) begin
         dac_dunf <= dac_mem_empty_s;
       end

--- a/library/util_dacfifo/util_dacfifo_constr.xdc
+++ b/library/util_dacfifo/util_dacfifo_constr.xdc
@@ -1,34 +1,32 @@
 
-set_property ASYNC_REG TRUE [get_cells -hier -filter {name =~ *dma_raddr_m*}] \
-  [get_cells -hier -filter {name =~ *dac_waddr_m*}] \
-  [get_cells -hier -filter {name =~ *dac_lastaddr_m*}] \
-  [get_cells -hier -filter {name =~ *dac_xfer_out_*}] \
-  [get_cells -hier -filter {name =~ *dma_bypass*}] \
-  [get_cells -hier -filter {name =~ *dac_bypass*}] \
-  [get_cells -hier -filter {name =~ *dac_xfer_req_m*}]
+set_property ASYNC_REG TRUE [get_cells -hierarchical -filter {name =~ *dac_waddr_m*}] \
+  [get_cells -hierarchical -filter {name =~ *dac_lastaddr_m*}] \
+  [get_cells -hierarchical -filter {name =~ *dac_xfer_out_*}] \
+  [get_cells -hierarchical -filter {name =~ *dma_bypass*}] \
+  [get_cells -hierarchical -filter {name =~ *dac_bypass*}] \
+  [get_cells -hierarchical -filter {name =~ *dac_xfer_req_m*}]
 
-set_false_path -from [get_cells -hier -filter {name =~ *dac_raddr_g* && IS_SEQUENTIAL}] \
-               -to [get_cells -hier -filter {name =~ *dma_raddr_m1* && IS_SEQUENTIAL}]
-set_false_path -from [get_cells -hier -filter {name =~ *dma_waddr_g* && IS_SEQUENTIAL}] \
-               -to [get_cells -hier -filter {name =~ *dac_waddr_m1* && IS_SEQUENTIAL}]
-set_false_path -from [get_cells -hier -filter {name =~ *dma_lastaddr_g* && IS_SEQUENTIAL}] \
-               -to [get_cells -hier -filter {name =~ *dac_lastaddr_m1* && IS_SEQUENTIAL}]
-set_false_path -from [get_cells -hier -filter {name =~ *dma_xfer_out_fifo* && IS_SEQUENTIAL}] \
-               -to [get_cells -hier -filter {name =~ *dac_xfer_out_fifo_m1* && IS_SEQUENTIAL}]
-set_false_path -to [get_cells -hier -filter {name =~ *dac_bypass_m1* && IS_SEQUENTIAL}]
-set_false_path -to [get_cells -hier -filter {name =~ *dma_bypass_m1* && IS_SEQUENTIAL}]
+set_false_path -from [get_cells -hierarchical -filter {name =~ *dma_waddr_g* && IS_SEQUENTIAL}] \
+               -to [get_cells -hierarchical -filter {name =~ *dac_waddr_m1* && IS_SEQUENTIAL}]
+set_false_path -from [get_cells -hierarchical -filter {name =~ *dma_lastaddr_g* && IS_SEQUENTIAL}] \
+               -to [get_cells -hierarchical -filter {name =~ *dac_lastaddr_m1* && IS_SEQUENTIAL}]
+set_false_path -from [get_cells -hierarchical -filter {name =~ *dma_xfer_out_fifo* && IS_SEQUENTIAL}] \
+               -to [get_cells -hierarchical -filter {name =~ *dac_xfer_out_fifo_m1* && IS_SEQUENTIAL}]
+set_false_path -to [get_cells -hierarchical -filter {name =~ *dac_bypass_m1* && IS_SEQUENTIAL}]
+set_false_path -to [get_cells -hierarchical -filter {name =~ *dma_bypass_m1* && IS_SEQUENTIAL}]
 
 # util_dacfifo_bypass CDC false-paths
 
-set_property ASYNC_REG TRUE [get_cells -hier -filter {name =~ *dac_mem_*_m*}] \
-  [get_cells -hier -filter {name =~ *dma_mem_*_m*}] \
-  [get_cells -hier -filter {name =~ *dma_rst_m1*}] \
-  [get_cells -hier -filter {name =~ *dac_xfer_out_m1*}]
+set_property ASYNC_REG TRUE [get_cells -hierarchical -filter {name =~ *dac_mem_*_m*}] \
+  [get_cells -hierarchical -filter {name =~ *dma_mem_*_m*}] \
+  [get_cells -hierarchical -filter {name =~ *dma_rst_m1*}] \
 
-set_false_path -from [get_cells  -hier -filter {name =~ */dma_mem_waddr_g* && IS_SEQUENTIAL}] \
-               -to   [get_cells  -hier -filter {name =~ */dac_mem_waddr_m1* && IS_SEQUENTIAL}]
-set_false_path -from [get_cells  -hier -filter {name =~ */dac_mem_raddr_g* && IS_SEQUENTIAL}] \
-               -to   [get_cells  -hier -filter {name =~ */dma_mem_raddr_m1* && IS_SEQUENTIAL}]
-set_false_path -to   [get_cells  -hier -filter {name =~ */dma_rst_m1_reg && IS_SEQUENTIAL}]
-set_false_path -to   [get_cells  -hier -filter {name =~ */dac_xfer_req_m1_reg && IS_SEQUENTIAL}]
+set_false_path -from [get_cells  -hierarchical -filter {name =~ */dma_mem_waddr_g* && IS_SEQUENTIAL}] \
+               -to   [get_cells  -hierarchical -filter {name =~ */dac_mem_waddr_m1* && IS_SEQUENTIAL}]
+set_false_path -from [get_cells  -hierarchical -filter {name =~ */dac_mem_raddr_g* && IS_SEQUENTIAL}] \
+               -to   [get_cells  -hierarchical -filter {name =~ */dma_mem_raddr_m1* && IS_SEQUENTIAL}]
+set_false_path -to   [get_cells  -hierarchical -filter {name =~ */dma_rst_m1_reg && IS_SEQUENTIAL}]
+set_false_path -to   [get_cells  -hierarchical -filter {name =~ */dac_xfer_req_m1_reg && IS_SEQUENTIAL}]
+set_false_path -from [get_cells  -hierarchical -filter {name =~ */dma_xfer_req* && IS_SEQUENTIAL}] \
+               -to   [get_cells  -hierarchical -filter {name =~ */dac_mem_waddr_m1* && IS_SEQUENTIAL}]
 


### PR DESCRIPTION
Few clean up commits to solve a critical warning generated by a wrongly defined constraint in the util_dacfifo_constr.xdc .