### PR TITLE
axi_ad9361: Mark rst output as active high

### DIFF
--- a/library/axi_ad9361/axi_ad9361_ip.tcl
+++ b/library/axi_ad9361/axi_ad9361_ip.tcl
@@ -93,7 +93,9 @@ set_property value s_axi [ipx::get_bus_parameters ASSOCIATED_BUSIF \
 ipx::infer_bus_interface clk xilinx.com:signal:clock_rtl:1.0 [ipx::current_core]
 ipx::infer_bus_interface l_clk xilinx.com:signal:clock_rtl:1.0 [ipx::current_core]
 ipx::infer_bus_interface delay_clk xilinx.com:signal:clock_rtl:1.0 [ipx::current_core]
-ipx::infer_bus_interface rst xilinx.com:signal:reset_rtl:1.0 [ipx::current_core]
+set reset_intf [ipx::infer_bus_interface rst xilinx.com:signal:reset_rtl:1.0 [ipx::current_core]]
+set reset_polarity [ipx::add_bus_parameter "POLARITY" $reset_intf]
+set_property value "ACTIVE_HIGH" $reset_polarity
 
 ipx::infer_bus_interface gps_pps_irq xilinx.com:signal:interrupt_rtl:1.0 [ipx::current_core]
 


### PR DESCRIPTION
By default inferred output reset signals have an active low polarity. The
axi_ad9361 rst output signal is active high though. Currently when
connecting it to a input reset with active high polarity will generate an
error in IPI.

Fix this by explicitly marking the polarity of the rst signal as active
high.

Signed-off-by: Lars-Peter Clausen <lars@metafoo.de>