### PR TITLE
DMA cleanups

### DIFF
--- a/library/axi_dmac/axi_dmac_resize_dest.v
+++ b/library/axi_dmac/axi_dmac_resize_dest.v
@@ -97,7 +97,7 @@ end else begin
       if (last_beat == 1'b1) begin
         count <= 'h0;
       end else begin
-        count <= count + 1;
+        count <= count + 1'b1;
       end
     end
   end

--- a/library/axi_dmac/axi_dmac_response_manager.v
+++ b/library/axi_dmac/axi_dmac_response_manager.v
@@ -242,7 +242,7 @@ always @(posedge req_clk) begin
   if (req_resetn == 1'b0) begin
     transfer_id <= 'h0;
   end else if ((state == STATE_ACC && req_eot) || do_compl) begin
-    transfer_id <= transfer_id + 1;
+    transfer_id <= transfer_id + 1'b1;
   end
 end
 
@@ -251,9 +251,9 @@ always @(posedge req_clk) begin
   if (req_resetn == 1'b0) begin
     to_complete_count <= 'h0;
   end else if (completion_req_valid & ~do_compl) begin
-    to_complete_count <= to_complete_count + 1;
+    to_complete_count <= to_complete_count + 1'b1;
   end else if (~completion_req_valid & do_compl) begin
-    to_complete_count <= to_complete_count - 1;
+    to_complete_count <= to_complete_count - 1'b1;
   end
 end
 

--- a/library/axi_dmac/axi_dmac_response_manager.v
+++ b/library/axi_dmac/axi_dmac_response_manager.v
@@ -100,6 +100,7 @@ reg [BYTES_PER_BURST_WIDTH-1:0] req_response_dest_data_burst_length = 'h0;
 wire response_dest_valid;
 reg response_dest_ready = 1'b1;
 wire response_dest_resp_eot;
+wire response_dest_partial;
 wire [BYTES_PER_BURST_WIDTH-1:0] response_dest_data_burst_length;
 
 reg [1:0] to_complete_count = 'h0;

--- a/library/axi_dmac/axi_dmac_response_manager.v
+++ b/library/axi_dmac/axi_dmac_response_manager.v
@@ -92,7 +92,6 @@ localparam DEST_SRC_RATIO_WIDTH = DEST_SRC_RATIO > 64 ? 7 :
 localparam BYTES_PER_BEAT_WIDTH = DEST_SRC_RATIO_WIDTH + BYTES_PER_BEAT_WIDTH_SRC;
 localparam BURST_LEN_WIDTH = BYTES_PER_BURST_WIDTH - BYTES_PER_BEAT_WIDTH;
 
-wire do_acc_st;
 wire do_compl;
 reg req_eot = 1'b0;
 reg req_response_partial = 1'b0;
@@ -100,7 +99,6 @@ reg [BYTES_PER_BURST_WIDTH-1:0] req_response_dest_data_burst_length = 'h0;
 
 wire response_dest_valid;
 reg response_dest_ready = 1'b1;
-wire [1:0] response_dest_resp;
 wire response_dest_resp_eot;
 wire [BYTES_PER_BURST_WIDTH-1:0] response_dest_data_burst_length;
 

--- a/library/axi_dmac/request_arb.v
+++ b/library/axi_dmac/request_arb.v
@@ -212,6 +212,8 @@ wire req_gen_valid;
 wire req_gen_ready;
 wire req_src_valid;
 wire req_src_ready;
+wire src_req_spltr_valid;
+wire src_req_spltr_ready;
 
 wire dest_req_valid;
 wire dest_req_ready;

--- a/library/axi_dmac/request_arb.v
+++ b/library/axi_dmac/request_arb.v
@@ -208,13 +208,8 @@ wire [ID_WIDTH-1:0] request_id;
 wire [ID_WIDTH-1:0] source_id;
 wire [ID_WIDTH-1:0] response_id;
 
-wire enabled_src;
-wire enabled_dest;
-
 wire req_gen_valid;
 wire req_gen_ready;
-wire src_dest_valid;
-wire src_dest_ready;
 wire req_src_valid;
 wire req_src_ready;
 

--- a/library/axi_dmac/src_fifo_inf.v
+++ b/library/axi_dmac/src_fifo_inf.v
@@ -101,6 +101,10 @@ dmac_data_mover # (
   .response_id(response_id),
   .eot(eot),
 
+  .rewind_req_valid(),
+  .rewind_req_ready(1'b0),
+  .rewind_req_data(),
+
   .bl_valid(bl_valid),
   .bl_ready(bl_ready),
   .measured_last_burst_length(measured_last_burst_length),

--- a/library/axi_dmac/tb/dma_read_shutdown_tb.v
+++ b/library/axi_dmac/tb/dma_read_shutdown_tb.v
@@ -45,8 +45,8 @@ module dmac_dma_read_shutdown_tb;
 
   reg fifo_clk = 1'b0;
 
-  wire awvalid;
-  wire awready;
+  wire arvalid;
+  wire arready;
   wire [31:0] araddr;
   wire [7:0] arlen;
   wire [2:0] arsize;

--- a/library/axi_dmac/tb/dma_read_shutdown_tb.v
+++ b/library/axi_dmac/tb/dma_read_shutdown_tb.v
@@ -149,6 +149,7 @@ module dmac_dma_read_shutdown_tb;
     .req_dest_stride(24'h00),
     .req_src_stride(24'h00),
     .req_sync_transfer_start(1'b0),
+    .req_response_ready (1'b0),
     .req_last(1'b0),
 
     .fifo_rd_clk(fifo_clk),
@@ -157,7 +158,28 @@ module dmac_dma_read_shutdown_tb;
     .fifo_rd_underflow(),
     .fifo_rd_dout(),
 
-    .dbg_status(dbg_status)
+    .dbg_status(dbg_status),
+
+    /* Unused interfaces */
+    .m_dest_axi_aclk (1'b0),
+    .m_dest_axi_aresetn(1'b0),
+    .m_axi_awready (1'b0),
+    .m_axi_wready (1'b0),
+    .m_axi_bvalid (1'b0),
+    .m_axi_bresp (2'b00),
+
+    .s_axis_aclk (1'b0),
+    .s_axis_valid (1'b0),
+    .s_axis_data ('h00),
+    .s_axis_user (1'b0),
+    .s_axis_last (1'b0),
+
+    .m_axis_aclk (1'b0),
+    .m_axis_ready (1'b0),
+    .fifo_wr_clk (1'b0),
+    .fifo_wr_en (1'b0),
+    .fifo_wr_din ('h00),
+    .fifo_wr_sync (1'b0)
   );
 
 endmodule

--- a/library/axi_dmac/tb/dma_read_tb.v
+++ b/library/axi_dmac/tb/dma_read_tb.v
@@ -148,12 +148,35 @@ module dmac_dma_read_tb;
     .req_dest_stride(24'h00),
     .req_src_stride(24'h00),
     .req_sync_transfer_start(1'b0),
+    .req_last(1'b0),
+    .req_response_ready(1'b0),
 
     .fifo_rd_clk(clk),
     .fifo_rd_en(fifo_rd_en),
     .fifo_rd_valid(fifo_rd_valid),
     .fifo_rd_underflow(fifo_rd_underflow),
-    .fifo_rd_dout(fifo_rd_dout)
+    .fifo_rd_dout(fifo_rd_dout),
+
+    /* Unused interfaces */
+    .m_dest_axi_aclk (1'b0),
+    .m_dest_axi_aresetn(1'b0),
+    .m_axi_awready (1'b0),
+    .m_axi_wready (1'b0),
+    .m_axi_bvalid (1'b0),
+    .m_axi_bresp (2'b00),
+
+    .s_axis_aclk (1'b0),
+    .s_axis_valid (1'b0),
+    .s_axis_data ('h00),
+    .s_axis_user (1'b0),
+    .s_axis_last (1'b0),
+
+    .m_axis_aclk (1'b0),
+    .m_axis_ready (1'b0),
+    .fifo_wr_clk (1'b0),
+    .fifo_wr_en (1'b0),
+    .fifo_wr_din ('h00),
+    .fifo_wr_sync (1'b0)
   );
 
   always @(posedge clk) begin: dout

--- a/library/axi_dmac/tb/dma_read_tb.v
+++ b/library/axi_dmac/tb/dma_read_tb.v
@@ -50,8 +50,8 @@ module dmac_dma_read_tb;
   wire req_ready;
   reg [23:0] req_length = REQ_LEN_INIT - 1;
 
-  wire awvalid;
-  wire awready;
+  wire arvalid;
+  wire arready;
   wire [31:0] araddr;
   wire [7:0] arlen;
   wire [2:0] arsize;
@@ -64,6 +64,8 @@ module dmac_dma_read_tb;
   wire rready;
   wire [1:0] rresp;
   wire [WIDTH_SRC-1:0] rdata;
+
+  wire eot;
 
   always @(posedge clk) begin
     if (reset != 1'b1 && req_ready == 1'b1) begin

--- a/library/axi_dmac/tb/dma_write_shutdown_tb
+++ b/library/axi_dmac/tb/dma_write_shutdown_tb
@@ -2,7 +2,7 @@
 
 SOURCE="$0.v"
 SOURCE+=" axi_write_slave.v axi_slave.v"
-SOURCE+=" ../axi_dmac_transfer.v ../request_arb.v ../request_generator.v ../splitter.v"
+SOURCE+=" ../axi_dmac_transfer.v ../request_arb.v ../request_generator.v"
 SOURCE+=" ../2d_transfer.v"
 SOURCE+=" ../axi_dmac_resize_src.v ../axi_dmac_resize_dest.v"
 SOURCE+=" ../axi_dmac_burst_memory.v"

--- a/library/axi_dmac/tb/dma_write_shutdown_tb.v
+++ b/library/axi_dmac/tb/dma_write_shutdown_tb.v
@@ -164,7 +164,27 @@ module dmac_dma_write_shutdown_tb;
     .fifo_wr_sync(1'b1),
     .fifo_wr_xfer_req(),
 
-    .dbg_status(dbg_status)
+    .dbg_status(dbg_status),
+
+    /* Unused interfaces */
+    .m_src_axi_aclk(1'b0),
+    .m_src_axi_aresetn(1'b0),
+    .m_axi_arready(1'b0),
+    .m_axi_rdata('h00),
+    .m_axi_rlast(1'b0),
+    .m_axi_rvalid(1'b0),
+    .m_axi_rresp(2'b00),
+
+    .s_axis_aclk(1'b0),
+    .s_axis_valid(1'b0),
+    .s_axis_data('h00),
+    .s_axis_user(1'b0),
+    .s_axis_last(1'b0),
+
+    .m_axis_aclk(1'b0),
+    .m_axis_ready(1'b0),
+    .fifo_rd_clk(1'b0),
+    .fifo_rd_en(1'b0)
   );
 
 endmodule

--- a/library/axi_dmac/tb/dma_write_tb
+++ b/library/axi_dmac/tb/dma_write_tb
@@ -2,7 +2,7 @@
 
 SOURCE="dma_write_tb.v"
 SOURCE+=" axi_write_slave.v axi_slave.v"
-SOURCE+=" ../axi_dmac_transfer.v ../2d_transfer.v ../request_arb.v ../request_generator.v ../splitter.v"
+SOURCE+=" ../axi_dmac_transfer.v ../2d_transfer.v ../request_arb.v ../request_generator.v"
 SOURCE+=" ../axi_dmac_resize_src.v ../axi_dmac_resize_dest.v"
 SOURCE+=" ../axi_dmac_burst_memory.v"
 SOURCE+=" ../axi_dmac_reset_manager.v ../data_mover.v ../axi_register_slice.v"

--- a/library/axi_dmac/tb/dma_write_tb.v
+++ b/library/axi_dmac/tb/dma_write_tb.v
@@ -154,13 +154,34 @@ module dmac_dma_write_tb;
     .req_dest_stride(24'h00),
     .req_src_stride(24'h00),
     .req_sync_transfer_start(1'b0),
+    .req_last(1'b1),
 
     .fifo_wr_clk(clk),
     .fifo_wr_en(fifo_wr_en),
     .fifo_wr_din(fifo_wr_din),
     .fifo_wr_overflow(fifo_wr_overflow),
     .fifo_wr_sync(1'b1),
-    .fifo_wr_xfer_req(fifo_wr_xfer_req)
+    .fifo_wr_xfer_req(fifo_wr_xfer_req),
+
+    /* Unused interfaces */
+    .m_src_axi_aclk(1'b0),
+    .m_src_axi_aresetn(1'b0),
+    .m_axi_arready(1'b0),
+    .m_axi_rdata('h00),
+    .m_axi_rlast(1'b0),
+    .m_axi_rvalid(1'b0),
+    .m_axi_rresp(2'b00),
+
+    .s_axis_aclk(1'b0),
+    .s_axis_valid(1'b0),
+    .s_axis_data('h00),
+    .s_axis_user(1'b0),
+    .s_axis_last(1'b0),
+
+    .m_axis_aclk(1'b0),
+    .m_axis_ready(1'b0),
+    .fifo_rd_clk(1'b0),
+    .fifo_rd_en(1'b0)
   );
 
   always @(posedge clk) begin: fifo_wr

--- a/library/axi_dmac/tb/dma_write_tb.v
+++ b/library/axi_dmac/tb/dma_write_tb.v
@@ -67,6 +67,10 @@ module dmac_dma_write_tb;
   reg [WIDTH_SRC-1:0] fifo_wr_din = 'b0;
   reg fifo_wr_rq = 'b0;
   wire fifo_wr_xfer_req;
+  wire fifo_wr_en;
+  wire fifo_wr_overflow;
+
+  wire eot;
 
   wire bready;
   wire bvalid;

--- a/library/axi_dmac/tb/regmap_tb.v
+++ b/library/axi_dmac/tb/regmap_tb.v
@@ -54,7 +54,7 @@ module dmac_regmap_tb;
 
   localparam VAL_DBG_SRC_ADDR = 32'h76543210;
   localparam VAL_DBG_DEST_ADDR = 32'hfedcba98;
-  localparam VAL_DBG_STATUS = 8'ha5;
+  localparam VAL_DBG_STATUS = 12'h5a5;
   localparam VAL_DBG_IDS0 = 32'h01234567;
   localparam VAL_DBG_IDS1 = 32'h89abcdef;
 

--- a/library/axi_dmac/tb/regmap_tb.v
+++ b/library/axi_dmac/tb/regmap_tb.v
@@ -72,6 +72,7 @@ module dmac_regmap_tb;
   wire s_axi_awready;
   wire s_axi_wready;
   wire s_axi_bready = 1'b1;
+  wire s_axi_bvalid;
   wire [3:0] s_axi_wstrb = 4'b1111;
   wire [2:0] s_axi_awprot = 3'b000;
   wire [2:0] s_axi_arprot = 3'b000;
@@ -225,6 +226,7 @@ module dmac_regmap_tb;
   endtask
 
   reg request_ready = 1'b0;
+  wire request_valid;
   wire [31:BYTES_PER_BEAT] request_dest_address;
   wire [31:BYTES_PER_BEAT] request_src_address;
   wire [DMA_LENGTH_WIDTH-1:0] request_x_length;

--- a/library/axi_dmac/tb/regmap_tb.v
+++ b/library/axi_dmac/tb/regmap_tb.v
@@ -172,7 +172,7 @@ module dmac_regmap_tb;
     for (i = 0; i < NUM_REGS; i = i + 1)
       expected_reg_mem[i] <= 'h00;
     /* Non zero power-on-reset values */
-    set_reset_reg_value('h00, 32'h00040161); /* PCORE version register */
+    set_reset_reg_value('h00, 32'h00040261); /* PCORE version register */
     set_reset_reg_value('h0c, 32'h444d4143); /* PCORE magic register */
     set_reset_reg_value('h80, 'h3); /* IRQ mask */
 

--- a/library/axi_dmac/tb/regmap_tb.v
+++ b/library/axi_dmac/tb/regmap_tb.v
@@ -375,6 +375,9 @@ module dmac_regmap_tb;
     .request_last(request_last),
 
     .response_eot(response_eot),
+    .response_partial(1'b0),
+    .response_valid(1'b0),
+    .response_measured_burst_length(7'h0),
 
     .dbg_src_addr(VAL_DBG_SRC_ADDR),
     .dbg_dest_addr(VAL_DBG_DEST_ADDR),

--- a/library/axi_dmac/tb/run_tb.sh
+++ b/library/axi_dmac/tb/run_tb.sh
@@ -3,12 +3,20 @@ NAME=`basename $0`
 if [[ ${SIMULATOR} != "modelsim" ]]; then
 
   #Icarus flow
+  WARNINGS="-Wimplicit -Wportbind -Wselect-range -Wtimescale"
+
+  # Version 10 does not have these warnings
+  iverilog -v 2>&1 | grep -o "version 1[^0]" > /dev/null
+  if [[ $? = 0 ]]; then
+    WARNINGS+=" -Wfloating-nets -Wanachronisms -Wimplicit-dimensions"
+  fi
+
   mkdir -p run
   mkdir -p vcd
-  iverilog -o run/run_${NAME} -I.. ${SOURCE} $1 || exit 1
+  iverilog ${WARNINGS} -o run/run_${NAME} -I.. ${SOURCE} $1 || exit 1
 
   cd vcd
-  ../run/run_${NAME}
+  vvp -n ../run/run_${NAME}
 
 else
 


### PR DESCRIPTION
A set of small cleanup patches that fix mostly cosmetic issues with the DMAC core.

This is on top of dev_dma_unaligned_mm.