### PR TITLE
axi_dmac/tb: Add support for xsim

### DIFF
--- a/library/axi_dmac/tb/run_tb.sh
+++ b/library/axi_dmac/tb/run_tb.sh
@@ -1,21 +1,24 @@
 NAME=`basename $0`
 
-if [[ ${SIMULATOR} != "modelsim" ]]; then
-
-  #Icarus flow
-  mkdir -p run
-  mkdir -p vcd
-  iverilog -o run/run_${NAME} -I.. ${SOURCE} $1 || exit 1
-
-  cd vcd
-  ../run/run_${NAME}
-
-else
-
-  # ModelSim flow
-  vlib work
-
-  vlog ${SOURCE} || exit 1
-  vsim "dmac_"${NAME} -do "add log /* -r; run -a" -gui || exit 1
-
-fi
+case "$SIMULATOR" in
+	modelsim)
+  		# ModelSim flow
+  		vlib work
+  		vlog ${SOURCE} || exit 1
+  		vsim "dmac_"${NAME} -do "add log /* -r; run -a" -gui || exit 1
+		;;
+	xsim)
+  		# xsim flow
+  		xvlog -log ${NAME}_xvlog.log --sourcelibdir . ${SOURCE}
+  		xelab -log ${NAME}_xelab.log -debug all dmac_${NAME}
+  		xsim work.dmac_${NAME} -R
+		;;
+	*)
+  		#Icarus flow is the default
+  		mkdir -p run
+  		mkdir -p vcd
+  		iverilog -o run/run_${NAME} -I.. ${SOURCE} $1 || exit 1
+  		cd vcd
+  		../run/run_${NAME}
+		;;
+esac


### PR DESCRIPTION
Add support for Vivado's simulator. By default the run script is using
the Icarus simulator.

If the user want to switch to another simulator, it can be explicitly
specify the required simulator tool in the SIMULATOR variable.
Currently, beside Icarus, Modelsim (SIMULATOR="modelsim") and Vivado's
xsim (SIMULATOR="xsim") is supported.