### PR TITLE
axi_dmac: patch version checking

### DIFF
--- a/library/axi_dmac/bd/bd.tcl
+++ b/library/axi_dmac/bd/bd.tcl
@@ -28,7 +28,7 @@ proc init {cellpath otherInfo} {
 
   # Versions earlier than 2017.3 infer sub-optimal asymmetric memory
   # See https://www.xilinx.com/support/answers/69179.html
-  if {[expr [version -short] > 2017.2]} {
+  if {[expr [join [lrange [split [version -short] .] 0 1] .] > 2017.2 ]} {
     set_property "CONFIG.ALLOW_ASYM_MEM" 1 $ip
   }
 }


### PR DESCRIPTION
Current implementation does not supports updated versions of Vivado
e.g. 2017.4.1 or 2018.2.1

This fix ignores the update number from the version checking.