### PR TITLE
adrv9371: use generic TPL

### DIFF
--- a/projects/adrv9371x/common/adrv9371x_bd.tcl
+++ b/projects/adrv9371x/common/adrv9371x_bd.tcl
@@ -1,4 +1,28 @@
 
+# TX parameters
+set TX_NUM_OF_LANES 4      ; # L
+set TX_NUM_OF_CONVERTERS 4 ; # M
+set TX_SAMPLES_PER_FRAME 1 ; # S
+set TX_SAMPLE_WIDTH 16     ; # N/NP
+
+set TX_SAMPLES_PER_CHANNEL 2 ; # L * 32 / (M * N)
+
+# RX parameters
+set RX_NUM_OF_LANES 2      ; # L
+set RX_NUM_OF_CONVERTERS 4 ; # M
+set RX_SAMPLES_PER_FRAME 1 ; # S
+set RX_SAMPLE_WIDTH 16     ; # N/NP
+
+set RX_SAMPLES_PER_CHANNEL 1 ; # L * 32 / (M * N)
+
+# RX Observation parameters
+set RX_OS_NUM_OF_LANES 2      ; # L
+set RX_OS_NUM_OF_CONVERTERS 2 ; # M
+set RX_OS_SAMPLES_PER_FRAME 1 ; # S
+set RX_OS_SAMPLE_WIDTH 16     ; # N/NP
+
+set RX_OS_SAMPLES_PER_CHANNEL 2 ;  # L * 32 / (M * N)
+
 source $ad_hdl_dir/library/jesd204/scripts/jesd204.tcl
 
 # ad9371
@@ -15,20 +39,25 @@ ad_ip_parameter axi_ad9371_tx_clkgen CONFIG.VCO_MUL 8
 ad_ip_parameter axi_ad9371_tx_clkgen CONFIG.CLK0_DIV 8
 
 ad_ip_instance axi_adxcvr axi_ad9371_tx_xcvr
-ad_ip_parameter axi_ad9371_tx_xcvr CONFIG.NUM_OF_LANES 4
+ad_ip_parameter axi_ad9371_tx_xcvr CONFIG.NUM_OF_LANES $TX_NUM_OF_LANES
 ad_ip_parameter axi_ad9371_tx_xcvr CONFIG.QPLL_ENABLE 1
 ad_ip_parameter axi_ad9371_tx_xcvr CONFIG.TX_OR_RX_N 1
 ad_ip_parameter axi_ad9371_tx_xcvr CONFIG.SYS_CLK_SEL 3
 ad_ip_parameter axi_ad9371_tx_xcvr CONFIG.OUT_CLK_SEL 3
 ad_ip_parameter axi_ad9371_tx_xcvr CONFIG.LPM_OR_DFE_N 0
 
-adi_axi_jesd204_tx_create axi_ad9371_tx_jesd 4
+adi_axi_jesd204_tx_create axi_ad9371_tx_jesd $TX_NUM_OF_LANES
 
-ad_ip_instance util_upack2 util_ad9371_tx_upack { \
-  NUM_OF_CHANNELS 4 \
-  SAMPLES_PER_CHANNEL 2 \
-  SAMPLE_DATA_WIDTH 16 \
-}
+ad_ip_instance util_upack2 util_ad9371_tx_upack [list \
+  NUM_OF_CHANNELS $TX_NUM_OF_CONVERTERS \
+  SAMPLES_PER_CHANNEL $TX_SAMPLES_PER_CHANNEL \
+  SAMPLE_DATA_WIDTH $TX_SAMPLE_WIDTH \
+]
+
+adi_tpl_jesd204_tx_create tx_ad9371_tpl_core $TX_NUM_OF_LANES \
+                                             $TX_NUM_OF_CONVERTERS \
+                                             $TX_SAMPLES_PER_FRAME \
+                                             $TX_SAMPLE_WIDTH
 
 ad_ip_instance axi_dmac axi_ad9371_tx_dma
 ad_ip_parameter axi_ad9371_tx_dma CONFIG.DMA_TYPE_SRC 0
@@ -40,7 +69,7 @@ ad_ip_parameter axi_ad9371_tx_dma CONFIG.ASYNC_CLK_DEST_REQ 1
 ad_ip_parameter axi_ad9371_tx_dma CONFIG.ASYNC_CLK_SRC_DEST 1
 ad_ip_parameter axi_ad9371_tx_dma CONFIG.ASYNC_CLK_REQ_SRC 1
 ad_ip_parameter axi_ad9371_tx_dma CONFIG.DMA_2D_TRANSFER 0
-ad_ip_parameter axi_ad9371_tx_dma CONFIG.DMA_DATA_WIDTH_DEST 128
+ad_ip_parameter axi_ad9371_tx_dma CONFIG.DMA_DATA_WIDTH_DEST $dac_dma_data_width
 
 # adc peripherals
 
@@ -52,20 +81,25 @@ ad_ip_parameter axi_ad9371_rx_clkgen CONFIG.VCO_MUL 8
 ad_ip_parameter axi_ad9371_rx_clkgen CONFIG.CLK0_DIV 8
 
 ad_ip_instance axi_adxcvr axi_ad9371_rx_xcvr
-ad_ip_parameter axi_ad9371_rx_xcvr CONFIG.NUM_OF_LANES 2
+ad_ip_parameter axi_ad9371_rx_xcvr CONFIG.NUM_OF_LANES $RX_NUM_OF_LANES
 ad_ip_parameter axi_ad9371_rx_xcvr CONFIG.QPLL_ENABLE 0
 ad_ip_parameter axi_ad9371_rx_xcvr CONFIG.TX_OR_RX_N 0
 ad_ip_parameter axi_ad9371_rx_xcvr CONFIG.SYS_CLK_SEL 0
 ad_ip_parameter axi_ad9371_rx_xcvr CONFIG.OUT_CLK_SEL 3
 ad_ip_parameter axi_ad9371_rx_xcvr CONFIG.LPM_OR_DFE_N 1
 
-adi_axi_jesd204_rx_create axi_ad9371_rx_jesd 2
+adi_axi_jesd204_rx_create axi_ad9371_rx_jesd $RX_NUM_OF_LANES
 
-ad_ip_instance util_cpack2 util_ad9371_rx_cpack { \
-  NUM_OF_CHANNELS 4 \
-  SAMPLES_PER_CHANNEL 1 \
-  SAMPLE_DATA_WIDTH 16 \
-}
+ad_ip_instance util_cpack2 util_ad9371_rx_cpack [list \
+  NUM_OF_CHANNELS $RX_NUM_OF_CONVERTERS \
+  SAMPLES_PER_CHANNEL $RX_SAMPLES_PER_CHANNEL \
+  SAMPLE_DATA_WIDTH $RX_SAMPLE_WIDTH \
+]
+
+adi_tpl_jesd204_rx_create rx_ad9371_tpl_core $RX_NUM_OF_LANES \
+                                             $RX_NUM_OF_CONVERTERS \
+                                             $RX_SAMPLES_PER_FRAME \
+                                             $RX_SAMPLE_WIDTH
 
 ad_ip_instance axi_dmac axi_ad9371_rx_dma
 ad_ip_parameter axi_ad9371_rx_dma CONFIG.DMA_TYPE_SRC 2
@@ -78,7 +112,7 @@ ad_ip_parameter axi_ad9371_rx_dma CONFIG.ASYNC_CLK_DEST_REQ 1
 ad_ip_parameter axi_ad9371_rx_dma CONFIG.ASYNC_CLK_SRC_DEST 1
 ad_ip_parameter axi_ad9371_rx_dma CONFIG.ASYNC_CLK_REQ_SRC 1
 ad_ip_parameter axi_ad9371_rx_dma CONFIG.DMA_2D_TRANSFER 0
-ad_ip_parameter axi_ad9371_rx_dma CONFIG.DMA_DATA_WIDTH_SRC 64
+ad_ip_parameter axi_ad9371_rx_dma CONFIG.DMA_DATA_WIDTH_SRC [expr 32*$RX_NUM_OF_LANES]
 
 # adc-os peripherals
 
@@ -90,20 +124,25 @@ ad_ip_parameter axi_ad9371_rx_os_clkgen CONFIG.VCO_MUL 8
 ad_ip_parameter axi_ad9371_rx_os_clkgen CONFIG.CLK0_DIV 8
 
 ad_ip_instance axi_adxcvr axi_ad9371_rx_os_xcvr
-ad_ip_parameter axi_ad9371_rx_os_xcvr CONFIG.NUM_OF_LANES 2
+ad_ip_parameter axi_ad9371_rx_os_xcvr CONFIG.NUM_OF_LANES $RX_OS_NUM_OF_LANES
 ad_ip_parameter axi_ad9371_rx_os_xcvr CONFIG.QPLL_ENABLE 0
 ad_ip_parameter axi_ad9371_rx_os_xcvr CONFIG.TX_OR_RX_N 0
 ad_ip_parameter axi_ad9371_rx_os_xcvr CONFIG.SYS_CLK_SEL 0
 ad_ip_parameter axi_ad9371_rx_os_xcvr CONFIG.OUT_CLK_SEL 3
 ad_ip_parameter axi_ad9371_rx_os_xcvr CONFIG.LPM_OR_DFE_N 1
 
-adi_axi_jesd204_rx_create axi_ad9371_rx_os_jesd 2
+adi_axi_jesd204_rx_create axi_ad9371_rx_os_jesd $RX_OS_NUM_OF_LANES
 
-ad_ip_instance util_cpack2 util_ad9371_rx_os_cpack { \
-  NUM_OF_CHANNELS 2 \
-  SAMPLES_PER_CHANNEL 2 \
-  SAMPLE_DATA_WIDTH 16 \
-}
+ad_ip_instance util_cpack2 util_ad9371_rx_os_cpack [list \
+  NUM_OF_CHANNELS $RX_OS_NUM_OF_CONVERTERS \
+  SAMPLES_PER_CHANNEL $RX_OS_SAMPLES_PER_CHANNEL\
+  SAMPLE_DATA_WIDTH $RX_OS_SAMPLE_WIDTH \
+]
+
+adi_tpl_jesd204_rx_create rx_os_ad9371_tpl_core $RX_OS_NUM_OF_LANES \
+                                                $RX_OS_NUM_OF_CONVERTERS \
+                                                $RX_OS_SAMPLES_PER_FRAME \
+                                                $RX_OS_SAMPLE_WIDTH
 
 ad_ip_instance axi_dmac axi_ad9371_rx_os_dma
 ad_ip_parameter axi_ad9371_rx_os_dma CONFIG.DMA_TYPE_SRC 2
@@ -116,15 +155,14 @@ ad_ip_parameter axi_ad9371_rx_os_dma CONFIG.ASYNC_CLK_DEST_REQ 1
 ad_ip_parameter axi_ad9371_rx_os_dma CONFIG.ASYNC_CLK_SRC_DEST 1
 ad_ip_parameter axi_ad9371_rx_os_dma CONFIG.ASYNC_CLK_REQ_SRC 1
 ad_ip_parameter axi_ad9371_rx_os_dma CONFIG.DMA_2D_TRANSFER 0
-ad_ip_parameter axi_ad9371_rx_os_dma CONFIG.DMA_DATA_WIDTH_SRC 64
+ad_ip_parameter axi_ad9371_rx_os_dma CONFIG.DMA_DATA_WIDTH_SRC [expr 32*$RX_NUM_OF_LANES]
 
 # common cores
 
-ad_ip_instance axi_ad9371 axi_ad9371_core
 
 ad_ip_instance util_adxcvr util_ad9371_xcvr
-ad_ip_parameter util_ad9371_xcvr CONFIG.RX_NUM_OF_LANES 4
-ad_ip_parameter util_ad9371_xcvr CONFIG.TX_NUM_OF_LANES 4
+ad_ip_parameter util_ad9371_xcvr CONFIG.RX_NUM_OF_LANES [expr $RX_NUM_OF_LANES+$RX_OS_NUM_OF_LANES]
+ad_ip_parameter util_ad9371_xcvr CONFIG.TX_NUM_OF_LANES $TX_NUM_OF_LANES
 ad_ip_parameter util_ad9371_xcvr CONFIG.TX_OUT_DIV 2
 ad_ip_parameter util_ad9371_xcvr CONFIG.CPLL_FBDIV 4
 ad_ip_parameter util_ad9371_xcvr CONFIG.RX_CLK25_DIV 5
@@ -135,45 +173,52 @@ ad_ip_parameter util_ad9371_xcvr CONFIG.QPLL_FBDIV 0x120
 
 # xcvr interfaces
 
-create_bd_port -dir I tx_ref_clk_0
-create_bd_port -dir I rx_ref_clk_0
-create_bd_port -dir I rx_ref_clk_2
+set tx_offset 0
+set rx_offset 0
+set rx_obs_offset  $RX_NUM_OF_LANES
 
-ad_xcvrpll  tx_ref_clk_0 util_ad9371_xcvr/qpll_ref_clk_0
-ad_xcvrpll  rx_ref_clk_0 util_ad9371_xcvr/cpll_ref_clk_0
-ad_xcvrpll  rx_ref_clk_0 util_ad9371_xcvr/cpll_ref_clk_1
-ad_xcvrpll  rx_ref_clk_2 util_ad9371_xcvr/cpll_ref_clk_2
-ad_xcvrpll  rx_ref_clk_2 util_ad9371_xcvr/cpll_ref_clk_3
-ad_xcvrpll  axi_ad9371_tx_xcvr/up_pll_rst util_ad9371_xcvr/up_qpll_rst_0
-ad_xcvrpll  axi_ad9371_rx_xcvr/up_pll_rst util_ad9371_xcvr/up_cpll_rst_0
-ad_xcvrpll  axi_ad9371_rx_xcvr/up_pll_rst util_ad9371_xcvr/up_cpll_rst_1
-ad_xcvrpll  axi_ad9371_rx_os_xcvr/up_pll_rst util_ad9371_xcvr/up_cpll_rst_2
-ad_xcvrpll  axi_ad9371_rx_os_xcvr/up_pll_rst util_ad9371_xcvr/up_cpll_rst_3
+set tx_ref_clk     tx_ref_clk_$tx_offset
+set rx_ref_clk     rx_ref_clk_$rx_offset
+set rx_obs_ref_clk rx_ref_clk_$rx_obs_offset
+
+create_bd_port -dir I $tx_ref_clk
+create_bd_port -dir I $rx_ref_clk
+create_bd_port -dir I $rx_obs_ref_clk
 ad_connect  sys_cpu_resetn util_ad9371_xcvr/up_rstn
 ad_connect  sys_cpu_clk util_ad9371_xcvr/up_clk
 
-ad_xcvrcon  util_ad9371_xcvr axi_ad9371_tx_xcvr axi_ad9371_tx_jesd
+# Tx
+ad_xcvrcon  util_ad9371_xcvr axi_ad9371_tx_xcvr axi_ad9371_tx_jesd {1 2 3 0}
 ad_reconct  util_ad9371_xcvr/tx_out_clk_0 axi_ad9371_tx_clkgen/clk
-ad_connect  axi_ad9371_tx_clkgen/clk_0 util_ad9371_xcvr/tx_clk_0
-ad_connect  axi_ad9371_tx_clkgen/clk_0 util_ad9371_xcvr/tx_clk_1
-ad_connect  axi_ad9371_tx_clkgen/clk_0 util_ad9371_xcvr/tx_clk_2
-ad_connect  axi_ad9371_tx_clkgen/clk_0 util_ad9371_xcvr/tx_clk_3
+for {set i 0} {$i < $TX_NUM_OF_LANES} {incr i} {
+  ad_connect  axi_ad9371_tx_clkgen/clk_0 util_ad9371_xcvr/tx_clk_$i
+}
+ad_xcvrpll  $tx_ref_clk util_ad9371_xcvr/qpll_ref_clk_0
+ad_xcvrpll  axi_ad9371_tx_xcvr/up_pll_rst util_ad9371_xcvr/up_qpll_rst_0
 ad_connect  axi_ad9371_tx_clkgen/clk_0 axi_ad9371_tx_jesd/device_clk
 ad_connect  axi_ad9371_tx_clkgen/clk_0 axi_ad9371_tx_jesd_rstgen/slowest_sync_clk
-ad_reconct  util_ad9371_xcvr/tx_0 axi_ad9371_tx_jesd/tx_phy3
-ad_reconct  util_ad9371_xcvr/tx_1 axi_ad9371_tx_jesd/tx_phy0
-ad_reconct  util_ad9371_xcvr/tx_2 axi_ad9371_tx_jesd/tx_phy1
-ad_reconct  util_ad9371_xcvr/tx_3 axi_ad9371_tx_jesd/tx_phy2
+
+# Rx
 ad_xcvrcon  util_ad9371_xcvr axi_ad9371_rx_xcvr axi_ad9371_rx_jesd
-ad_reconct  util_ad9371_xcvr/rx_out_clk_0 axi_ad9371_rx_clkgen/clk
-ad_connect  axi_ad9371_rx_clkgen/clk_0 util_ad9371_xcvr/rx_clk_0
-ad_connect  axi_ad9371_rx_clkgen/clk_0 util_ad9371_xcvr/rx_clk_1
+ad_reconct  util_ad9371_xcvr/rx_out_clk_$rx_offset axi_ad9371_rx_clkgen/clk
+for {set i 0} {$i < $RX_NUM_OF_LANES} {incr i} {
+  set ch [expr $rx_offset+$i]
+  ad_connect  axi_ad9371_rx_clkgen/clk_0 util_ad9371_xcvr/rx_clk_$ch
+  ad_xcvrpll  $rx_ref_clk util_ad9371_xcvr/cpll_ref_clk_$ch
+  ad_xcvrpll  axi_ad9371_rx_xcvr/up_pll_rst util_ad9371_xcvr/up_cpll_rst_$ch
+}
 ad_connect  axi_ad9371_rx_clkgen/clk_0 axi_ad9371_rx_jesd/device_clk
 ad_connect  axi_ad9371_rx_clkgen/clk_0 axi_ad9371_rx_jesd_rstgen/slowest_sync_clk
+
+# Rx - OBS
 ad_xcvrcon  util_ad9371_xcvr axi_ad9371_rx_os_xcvr axi_ad9371_rx_os_jesd
-ad_reconct  util_ad9371_xcvr/rx_out_clk_2 axi_ad9371_rx_os_clkgen/clk
-ad_connect  axi_ad9371_rx_os_clkgen/clk_0 util_ad9371_xcvr/rx_clk_2
-ad_connect  axi_ad9371_rx_os_clkgen/clk_0 util_ad9371_xcvr/rx_clk_3
+ad_reconct  util_ad9371_xcvr/rx_out_clk_$rx_obs_offset axi_ad9371_rx_os_clkgen/clk
+for {set i 0} {$i < $RX_OS_NUM_OF_LANES} {incr i} {
+  set ch [expr $rx_obs_offset+$i]
+  ad_connect  axi_ad9371_rx_os_clkgen/clk_0 util_ad9371_xcvr/rx_clk_$ch
+  ad_xcvrpll  $rx_obs_ref_clk util_ad9371_xcvr/cpll_ref_clk_$ch
+  ad_xcvrpll  axi_ad9371_rx_os_xcvr/up_pll_rst util_ad9371_xcvr/up_cpll_rst_$ch
+}
 ad_connect  axi_ad9371_rx_os_clkgen/clk_0 axi_ad9371_rx_os_jesd/device_clk
 ad_connect  axi_ad9371_rx_os_clkgen/clk_0 axi_ad9371_rx_os_jesd_rstgen/slowest_sync_clk
 
@@ -189,20 +234,17 @@ ad_connect  sys_dma_reset axi_ad9371_dacfifo/dma_rst
 
 # connections (dac)
 
-ad_connect  axi_ad9371_tx_clkgen/clk_0 axi_ad9371_core/dac_clk
-ad_connect  axi_ad9371_tx_jesd/tx_data_tdata axi_ad9371_core/dac_tx_data
+ad_connect  axi_ad9371_tx_clkgen/clk_0 tx_ad9371_tpl_core/link_clk
+ad_connect  axi_ad9371_tx_jesd/tx_data tx_ad9371_tpl_core/link
+
 ad_connect  axi_ad9371_tx_clkgen/clk_0 util_ad9371_tx_upack/clk
 ad_connect  axi_ad9371_tx_jesd_rstgen/peripheral_reset util_ad9371_tx_upack/reset
 
-ad_connect  axi_ad9371_core/dac_valid_i0 util_ad9371_tx_upack/fifo_rd_en
-ad_connect  axi_ad9371_core/dac_enable_i0 util_ad9371_tx_upack/enable_0
-ad_connect  axi_ad9371_core/dac_data_i0 util_ad9371_tx_upack/fifo_rd_data_0
-ad_connect  axi_ad9371_core/dac_enable_q0 util_ad9371_tx_upack/enable_1
-ad_connect  axi_ad9371_core/dac_data_q0 util_ad9371_tx_upack/fifo_rd_data_1
-ad_connect  axi_ad9371_core/dac_enable_i1 util_ad9371_tx_upack/enable_2
-ad_connect  axi_ad9371_core/dac_data_i1 util_ad9371_tx_upack/fifo_rd_data_2
-ad_connect  axi_ad9371_core/dac_enable_q1 util_ad9371_tx_upack/enable_3
-ad_connect  axi_ad9371_core/dac_data_q1 util_ad9371_tx_upack/fifo_rd_data_3
+ad_connect  tx_ad9371_tpl_core/dac_valid_0 util_ad9371_tx_upack/fifo_rd_en
+for {set i 0} {$i < $TX_NUM_OF_CONVERTERS} {incr i} {
+  ad_connect  util_ad9371_tx_upack/fifo_rd_data_$i tx_ad9371_tpl_core/dac_data_$i
+  ad_connect  tx_ad9371_tpl_core/dac_enable_$i  util_ad9371_tx_upack/enable_$i
+}
 
 ad_connect  axi_ad9371_tx_clkgen/clk_0 axi_ad9371_dacfifo/dac_clk
 ad_connect  axi_ad9371_tx_jesd_rstgen/peripheral_reset axi_ad9371_dacfifo/dac_rst
@@ -219,28 +261,25 @@ ad_connect  axi_ad9371_dacfifo/dma_data axi_ad9371_tx_dma/m_axis_data
 ad_connect  axi_ad9371_dacfifo/dma_ready axi_ad9371_tx_dma/m_axis_ready
 ad_connect  axi_ad9371_dacfifo/dma_xfer_req axi_ad9371_tx_dma/m_axis_xfer_req
 ad_connect  axi_ad9371_dacfifo/dma_xfer_last axi_ad9371_tx_dma/m_axis_last
-ad_connect  axi_ad9371_dacfifo/dac_dunf axi_ad9371_core/dac_dunf
+ad_connect  axi_ad9371_dacfifo/dac_dunf tx_ad9371_tpl_core/dac_dunf
 ad_connect  axi_ad9371_dacfifo/bypass dac_fifo_bypass
 ad_connect  sys_dma_resetn axi_ad9371_tx_dma/m_src_axi_aresetn
 
 # connections (adc)
 
-ad_connect  axi_ad9371_rx_clkgen/clk_0 axi_ad9371_core/adc_clk
-ad_connect  axi_ad9371_rx_jesd/rx_sof axi_ad9371_core/adc_rx_sof
-ad_connect  axi_ad9371_rx_jesd/rx_data_tdata axi_ad9371_core/adc_rx_data
+ad_connect  axi_ad9371_rx_clkgen/clk_0 rx_ad9371_tpl_core/link_clk
+ad_connect  axi_ad9371_rx_jesd/rx_sof rx_ad9371_tpl_core/link_sof
+ad_connect  axi_ad9371_rx_jesd/rx_data_tdata rx_ad9371_tpl_core/link_data
+ad_connect  axi_ad9371_rx_jesd/rx_data_tvalid rx_ad9371_tpl_core/link_valid
 ad_connect  axi_ad9371_rx_clkgen/clk_0 util_ad9371_rx_cpack/clk
 ad_connect  axi_ad9371_rx_jesd_rstgen/peripheral_reset util_ad9371_rx_cpack/reset
 
-ad_connect  axi_ad9371_core/adc_valid_i0 util_ad9371_rx_cpack/fifo_wr_en
-ad_connect  axi_ad9371_core/adc_enable_i0 util_ad9371_rx_cpack/enable_0
-ad_connect  axi_ad9371_core/adc_data_i0 util_ad9371_rx_cpack/fifo_wr_data_0
-ad_connect  axi_ad9371_core/adc_enable_q0 util_ad9371_rx_cpack/enable_1
-ad_connect  axi_ad9371_core/adc_data_q0 util_ad9371_rx_cpack/fifo_wr_data_1
-ad_connect  axi_ad9371_core/adc_enable_i1 util_ad9371_rx_cpack/enable_2
-ad_connect  axi_ad9371_core/adc_data_i1 util_ad9371_rx_cpack/fifo_wr_data_2
-ad_connect  axi_ad9371_core/adc_enable_q1 util_ad9371_rx_cpack/enable_3
-ad_connect  axi_ad9371_core/adc_data_q1 util_ad9371_rx_cpack/fifo_wr_data_3
-ad_connect  axi_ad9371_core/adc_dovf util_ad9371_rx_cpack/fifo_wr_overflow
+ad_connect rx_ad9371_tpl_core/adc_valid_0 util_ad9371_rx_cpack/fifo_wr_en
+for {set i 0} {$i < $RX_NUM_OF_CONVERTERS} {incr i} {
+  ad_connect  rx_ad9371_tpl_core/adc_enable_$i util_ad9371_rx_cpack/enable_$i
+  ad_connect  rx_ad9371_tpl_core/adc_data_$i util_ad9371_rx_cpack/fifo_wr_data_$i
+}
+ad_connect  rx_ad9371_tpl_core/adc_dovf util_ad9371_rx_cpack/fifo_wr_overflow
 
 ad_connect  axi_ad9371_rx_clkgen/clk_0 axi_ad9371_rx_dma/fifo_wr_clk
 ad_connect  util_ad9371_rx_cpack/packed_fifo_wr axi_ad9371_rx_dma/fifo_wr
@@ -248,26 +287,29 @@ ad_connect  sys_dma_resetn axi_ad9371_rx_dma/m_dest_axi_aresetn
 
 # connections (adc-os)
 
-ad_connect  axi_ad9371_rx_os_clkgen/clk_0 axi_ad9371_core/adc_os_clk
-ad_connect  axi_ad9371_rx_os_jesd/rx_sof axi_ad9371_core/adc_rx_os_sof
-ad_connect  axi_ad9371_rx_os_jesd/rx_data_tdata axi_ad9371_core/adc_rx_os_data
+ad_connect  axi_ad9371_rx_os_clkgen/clk_0 rx_os_ad9371_tpl_core/link_clk
+ad_connect  axi_ad9371_rx_os_jesd/rx_sof rx_os_ad9371_tpl_core/link_sof
+ad_connect  axi_ad9371_rx_os_jesd/rx_data_tdata rx_os_ad9371_tpl_core/link_data
+ad_connect  axi_ad9371_rx_os_jesd/rx_data_tvalid rx_os_ad9371_tpl_core/link_valid
 ad_connect  axi_ad9371_rx_os_clkgen/clk_0 util_ad9371_rx_os_cpack/clk
 ad_connect  axi_ad9371_rx_os_jesd_rstgen/peripheral_reset util_ad9371_rx_os_cpack/reset
-
-ad_connect  axi_ad9371_core/adc_os_valid_i0 util_ad9371_rx_os_cpack/fifo_wr_en
-ad_connect  axi_ad9371_core/adc_os_enable_i0 util_ad9371_rx_os_cpack/enable_0
-ad_connect  axi_ad9371_core/adc_os_data_i0 util_ad9371_rx_os_cpack/fifo_wr_data_0
-ad_connect  axi_ad9371_core/adc_os_enable_q0 util_ad9371_rx_os_cpack/enable_1
-ad_connect  axi_ad9371_core/adc_os_data_q0 util_ad9371_rx_os_cpack/fifo_wr_data_1
-ad_connect  axi_ad9371_core/adc_os_dovf util_ad9371_rx_os_cpack/fifo_wr_overflow
-
 ad_connect  axi_ad9371_rx_os_clkgen/clk_0 axi_ad9371_rx_os_dma/fifo_wr_clk
+
+ad_connect  rx_os_ad9371_tpl_core/adc_valid_0 util_ad9371_rx_os_cpack/fifo_wr_en
+for {set i 0} {$i < $RX_OS_NUM_OF_CONVERTERS} {incr i} {
+  ad_connect  rx_os_ad9371_tpl_core/adc_enable_$i util_ad9371_rx_os_cpack/enable_$i
+  ad_connect  rx_os_ad9371_tpl_core/adc_data_$i util_ad9371_rx_os_cpack/fifo_wr_data_$i
+}
+ad_connect  rx_os_ad9371_tpl_core/adc_dovf util_ad9371_rx_os_cpack/fifo_wr_overflow
 ad_connect  util_ad9371_rx_os_cpack/packed_fifo_wr axi_ad9371_rx_os_dma/fifo_wr
+
 ad_connect  sys_dma_resetn axi_ad9371_rx_os_dma/m_dest_axi_aresetn
 
 # interconnect (cpu)
 
-ad_cpu_interconnect 0x44A00000 axi_ad9371_core
+ad_cpu_interconnect 0x44A00000 rx_ad9371_tpl_core
+ad_cpu_interconnect 0x44A04000 tx_ad9371_tpl_core
+ad_cpu_interconnect 0x44A08000 rx_os_ad9371_tpl_core
 ad_cpu_interconnect 0x44A80000 axi_ad9371_tx_xcvr
 ad_cpu_interconnect 0x43C00000 axi_ad9371_tx_clkgen
 ad_cpu_interconnect 0x44A90000 axi_ad9371_tx_jesd

--- a/projects/adrv9371x/kcu105/Makefile
+++ b/projects/adrv9371x/kcu105/Makefile
@@ -14,9 +14,10 @@ M_DEPS += ../../common/kcu105/kcu105_system_bd.tcl
 M_DEPS += ../../../library/xilinx/common/ad_iobuf.v
 M_DEPS += ../../../library/jesd204/scripts/jesd204.tcl
 
-LIB_DEPS += axi_ad9371
 LIB_DEPS += axi_clkgen
 LIB_DEPS += axi_dmac
+LIB_DEPS += jesd204/ad_ip_jesd204_tpl_adc
+LIB_DEPS += jesd204/ad_ip_jesd204_tpl_dac
 LIB_DEPS += jesd204/axi_jesd204_rx
 LIB_DEPS += jesd204/axi_jesd204_tx
 LIB_DEPS += jesd204/jesd204_rx

--- a/projects/adrv9371x/zc706/Makefile
+++ b/projects/adrv9371x/zc706/Makefile
@@ -13,11 +13,12 @@ M_DEPS += ../../common/zc706/zc706_plddr3_constr.xdc
 M_DEPS += ../../../library/xilinx/common/ad_iobuf.v
 M_DEPS += ../../../library/jesd204/scripts/jesd204.tcl
 
-LIB_DEPS += axi_ad9371
 LIB_DEPS += axi_clkgen
 LIB_DEPS += axi_dmac
 LIB_DEPS += axi_hdmi_tx
 LIB_DEPS += axi_spdif_tx
+LIB_DEPS += jesd204/ad_ip_jesd204_tpl_adc
+LIB_DEPS += jesd204/ad_ip_jesd204_tpl_dac
 LIB_DEPS += jesd204/axi_jesd204_rx
 LIB_DEPS += jesd204/axi_jesd204_tx
 LIB_DEPS += jesd204/jesd204_rx

--- a/projects/adrv9371x/zcu102/Makefile
+++ b/projects/adrv9371x/zcu102/Makefile
@@ -12,9 +12,10 @@ M_DEPS += ../../common/xilinx/dacfifo_bd.tcl
 M_DEPS += ../../../library/xilinx/common/ad_iobuf.v
 M_DEPS += ../../../library/jesd204/scripts/jesd204.tcl
 
-LIB_DEPS += axi_ad9371
 LIB_DEPS += axi_clkgen
 LIB_DEPS += axi_dmac
+LIB_DEPS += jesd204/ad_ip_jesd204_tpl_adc
+LIB_DEPS += jesd204/ad_ip_jesd204_tpl_dac
 LIB_DEPS += jesd204/axi_jesd204_rx
 LIB_DEPS += jesd204/axi_jesd204_tx
 LIB_DEPS += jesd204/jesd204_rx


### PR DESCRIPTION
Use the generic TPLs for a better scalability to ease lane number reductions.

Tested on ZC706