### PR TITLE
ad_ip_jesd204_tpl: Fix chanmax reporting for both ADC and DAC

### DIFF
--- a/library/jesd204/ad_ip_jesd204_tpl_adc/ad_ip_jesd204_tpl_adc_regmap.v
+++ b/library/jesd204/ad_ip_jesd204_tpl_adc/ad_ip_jesd204_tpl_adc_regmap.v
@@ -211,7 +211,7 @@ module ad_ip_jesd204_tpl_adc_regmap #(
     .up_drp_ready (1'd0),
     .up_drp_locked (1'd1),
     .up_usr_chanmax_out (),
-    .up_usr_chanmax_in (8'd1),
+    .up_usr_chanmax_in (NUM_CHANNELS),
     .up_adc_gpio_in (32'd0),
     .up_adc_gpio_out (),
     .up_adc_ce (),

--- a/library/jesd204/ad_ip_jesd204_tpl_dac/ad_ip_jesd204_tpl_dac_regmap.v
+++ b/library/jesd204/ad_ip_jesd204_tpl_dac/ad_ip_jesd204_tpl_dac_regmap.v
@@ -190,7 +190,7 @@ module ad_ip_jesd204_tpl_dac_regmap #(
     .up_drp_ready (1'd0),
     .up_drp_locked (1'd1),
     .up_usr_chanmax (),
-    .dac_usr_chanmax (8'd3),
+    .dac_usr_chanmax (NUM_CHANNELS),
     .up_dac_gpio_in (32'd0),
     .up_dac_gpio_out (),
     .up_dac_ce (),


### PR DESCRIPTION
Software reads the chanmax register. The TPL for both ADCs and DACs has a variable number of channels. The register should report that correctly.