### PR TITLE
Expose JESD parameters as registers

### DIFF
--- a/library/common/up_adc_common.v
+++ b/library/common/up_adc_common.v
@@ -148,8 +148,8 @@ module up_adc_common #(
 
   // decode block select
 
-  assign up_wreq_s = (up_waddr[13:8] == COMMON_ID) ? up_wreq : 1'b0;
-  assign up_rreq_s = (up_raddr[13:8] == COMMON_ID) ? up_rreq : 1'b0;
+  assign up_wreq_s = (up_waddr[13:7] == {COMMON_ID,1'b0}) ? up_wreq : 1'b0;
+  assign up_rreq_s = (up_raddr[13:7] == {COMMON_ID,1'b0}) ? up_rreq : 1'b0;
 
   // processor write interface
 
@@ -177,13 +177,13 @@ module up_adc_common #(
       up_core_preset <= ~up_resetn;
       up_mmcm_preset <= ~up_mmcm_resetn;
       up_wack_int <= up_wreq_s;
-      if ((up_wreq_s == 1'b1) && (up_waddr[7:0] == 8'h02)) begin
+      if ((up_wreq_s == 1'b1) && (up_waddr[6:0] == 7'h02)) begin
         up_scratch <= up_wdata;
       end
-      if ((up_wreq_s == 1'b1) && (up_waddr[7:0] == 8'h04)) begin
+      if ((up_wreq_s == 1'b1) && (up_waddr[6:0] == 7'h04)) begin
         up_pps_irq_mask <= up_wdata[0];
       end
-      if ((up_wreq_s == 1'b1) && (up_waddr[7:0] == 8'h10)) begin
+      if ((up_wreq_s == 1'b1) && (up_waddr[6:0] == 7'h10)) begin
         up_adc_clk_enb <= up_wdata[2];
         up_mmcm_resetn <= up_wdata[1];
         up_resetn <= up_wdata[0];
@@ -192,10 +192,10 @@ module up_adc_common #(
         if (up_cntrl_xfer_done_s == 1'b1) begin
           up_adc_sync <= 1'b0;
         end
-      end else if ((up_wreq_s == 1'b1) && (up_waddr[7:0] == 8'h11)) begin
+      end else if ((up_wreq_s == 1'b1) && (up_waddr[6:0] == 7'h11)) begin
         up_adc_sync <= up_wdata[3];
       end
-      if ((up_wreq_s == 1'b1) && (up_waddr[7:0] == 8'h11)) begin
+      if ((up_wreq_s == 1'b1) && (up_waddr[6:0] == 7'h11)) begin
         up_adc_sref_sync <= up_wdata[4];
         up_adc_r1_mode <= up_wdata[2];
         up_adc_ddr_edgesel <= up_wdata[1];
@@ -235,23 +235,23 @@ module up_adc_common #(
         up_drp_wdata_int <= 'd0;
         up_drp_rdata_hold_int <= 'd0;
       end else begin
-        if ((up_wreq_s == 1'b1) && (up_waddr[7:0] == 8'h1c)) begin
+        if ((up_wreq_s == 1'b1) && (up_waddr[6:0] == 7'h1c)) begin
           up_drp_sel_int <= 1'b1;
           up_drp_wr_int <= ~up_wdata[28];
         end else begin
           up_drp_sel_int <= 1'b0;
           up_drp_wr_int <= 1'b0;
         end
-        if ((up_wreq_s == 1'b1) && (up_waddr[7:0] == 8'h1c)) begin
+        if ((up_wreq_s == 1'b1) && (up_waddr[6:0] == 7'h1c)) begin
           up_drp_status_int <= 1'b1;
         end else if (up_drp_ready == 1'b1) begin
           up_drp_status_int <= 1'b0;
         end
-        if ((up_wreq_s == 1'b1) && (up_waddr[7:0] == 8'h1c)) begin
+        if ((up_wreq_s == 1'b1) && (up_waddr[6:0] == 7'h1c)) begin
           up_drp_rwn_int <= up_wdata[28];
           up_drp_addr_int <= up_wdata[27:16];
         end
-        if ((up_wreq_s == 1'b1) && (up_waddr[7:0] == 8'h1e)) begin
+        if ((up_wreq_s == 1'b1) && (up_waddr[6:0] == 7'h1e)) begin
           up_drp_wdata_int <= up_wdata;
         end
         if (up_drp_ready == 1'b1) begin
@@ -277,7 +277,7 @@ module up_adc_common #(
     end else begin
       if (up_status_ovf_s == 1'b1) begin
         up_status_ovf <= 1'b1;
-      end else if ((up_wreq_s == 1'b1) && (up_waddr[7:0] == 8'h22)) begin
+      end else if ((up_wreq_s == 1'b1) && (up_waddr[6:0] == 7'h22)) begin
         up_status_ovf <= up_status_ovf & ~up_wdata[2];
       end
     end
@@ -295,7 +295,7 @@ module up_adc_common #(
     if (up_rstn == 0) begin
       up_usr_chanmax_int <= 'd0;
     end else begin
-      if ((up_wreq_s == 1'b1) && (up_waddr[7:0] == 8'h28)) begin
+      if ((up_wreq_s == 1'b1) && (up_waddr[6:0] == 7'h28)) begin
         up_usr_chanmax_int <= up_wdata[7:0];
       end
     end
@@ -315,7 +315,7 @@ module up_adc_common #(
     if (up_rstn == 0) begin
       up_adc_gpio_out_int <= 'd0;
     end else begin
-      if ((up_wreq_s == 1'b1) && (up_waddr[7:0] == 8'h2f)) begin
+      if ((up_wreq_s == 1'b1) && (up_waddr[6:0] == 7'h2f)) begin
         up_adc_gpio_out_int <= up_wdata;
       end
     end
@@ -333,7 +333,7 @@ module up_adc_common #(
     if (up_rstn == 0) begin
       up_adc_start_code <= 'd0;
     end else begin
-      if ((up_wreq_s == 1'b1) && (up_waddr[7:0] == 8'h29)) begin
+      if ((up_wreq_s == 1'b1) && (up_waddr[6:0] == 7'h29)) begin
         up_adc_start_code <= up_wdata[31:0];
       end
     end
@@ -347,7 +347,7 @@ module up_adc_common #(
     if (up_rstn == 0) begin
       up_timer <= 32'd0;
     end else begin
-      if ((up_wreq_s == 1'b1) && (up_waddr[7:0] == 8'h40)) begin
+      if ((up_wreq_s == 1'b1) && (up_waddr[6:0] == 7'h40)) begin
         up_timer <= up_wdata;
       end else if (up_timer > 0) begin
         up_timer <= up_timer - 1'b1;
@@ -367,32 +367,32 @@ module up_adc_common #(
     end else begin
       up_rack_int <= up_rreq_s;
       if (up_rreq_s == 1'b1) begin
-        case (up_raddr[7:0])
-          8'h00: up_rdata_int <= VERSION;
-          8'h01: up_rdata_int <= ID;
-          8'h02: up_rdata_int <= up_scratch;
-          8'h03: up_rdata_int <= CONFIG;
-          8'h04: up_rdata_int <= {31'b0, up_pps_irq_mask};
-          8'h10: up_rdata_int <= {29'd0, up_adc_clk_enb, up_mmcm_resetn, up_resetn};
-          8'h11: up_rdata_int <= {27'd0, up_adc_sref_sync, up_adc_sync, up_adc_r1_mode,
+        case (up_raddr[6:0])
+          7'h00: up_rdata_int <= VERSION;
+          7'h01: up_rdata_int <= ID;
+          7'h02: up_rdata_int <= up_scratch;
+          7'h03: up_rdata_int <= CONFIG;
+          7'h04: up_rdata_int <= {31'b0, up_pps_irq_mask};
+          7'h10: up_rdata_int <= {29'd0, up_adc_clk_enb, up_mmcm_resetn, up_resetn};
+          7'h11: up_rdata_int <= {27'd0, up_adc_sref_sync, up_adc_sync, up_adc_r1_mode,
                                   up_adc_ddr_edgesel, up_adc_pin_mode};
-          8'h15: up_rdata_int <= up_adc_clk_count_s;
-          8'h16: up_rdata_int <= adc_clk_ratio;
-          8'h17: up_rdata_int <= {28'd0, up_status_pn_err, up_status_pn_oos, up_status_or, up_status_s};
-          8'h1a: up_rdata_int <= {31'd0, up_sync_status_s};
-          8'h1c: up_rdata_int <= {3'd0, up_drp_rwn_s, up_drp_addr, 16'b0};
-          8'h1d: up_rdata_int <= {14'd0, up_drp_locked, up_drp_status_s, 16'b0};
-          8'h1e: up_rdata_int <= up_drp_wdata;
-          8'h1f: up_rdata_int <= up_drp_rdata_hold_s;
-          8'h22: up_rdata_int <= {29'd0, up_status_ovf, 2'b0};
-          8'h23: up_rdata_int <= 32'd8;
-          8'h28: up_rdata_int <= {24'd0, up_usr_chanmax_in};
-          8'h29: up_rdata_int <= up_adc_start_code;
-          8'h2e: up_rdata_int <= up_adc_gpio_in;
-          8'h2f: up_rdata_int <= up_adc_gpio_out_int;
-          8'h30: up_rdata_int <= up_pps_rcounter;
-          8'h31: up_rdata_int <= {31'b0, up_pps_status};
-          8'h40: up_rdata_int <= up_timer;
+          7'h15: up_rdata_int <= up_adc_clk_count_s;
+          7'h16: up_rdata_int <= adc_clk_ratio;
+          7'h17: up_rdata_int <= {28'd0, up_status_pn_err, up_status_pn_oos, up_status_or, up_status_s};
+          7'h1a: up_rdata_int <= {31'd0, up_sync_status_s};
+          7'h1c: up_rdata_int <= {3'd0, up_drp_rwn_s, up_drp_addr, 16'b0};
+          7'h1d: up_rdata_int <= {14'd0, up_drp_locked, up_drp_status_s, 16'b0};
+          7'h1e: up_rdata_int <= up_drp_wdata;
+          7'h1f: up_rdata_int <= up_drp_rdata_hold_s;
+          7'h22: up_rdata_int <= {29'd0, up_status_ovf, 2'b0};
+          7'h23: up_rdata_int <= 32'd8;
+          7'h28: up_rdata_int <= {24'd0, up_usr_chanmax_in};
+          7'h29: up_rdata_int <= up_adc_start_code;
+          7'h2e: up_rdata_int <= up_adc_gpio_in;
+          7'h2f: up_rdata_int <= up_adc_gpio_out_int;
+          7'h30: up_rdata_int <= up_pps_rcounter;
+          7'h31: up_rdata_int <= {31'b0, up_pps_status};
+          7'h40: up_rdata_int <= up_timer;
           default: up_rdata_int <= 0;
         endcase
       end else begin

--- a/library/common/up_dac_common.v
+++ b/library/common/up_dac_common.v
@@ -153,8 +153,8 @@ module up_dac_common #(
 
   // decode block select
 
-  assign up_wreq_s = (up_waddr[13:8] == COMMON_ID) ? up_wreq : 1'b0;
-  assign up_rreq_s = (up_raddr[13:8] == COMMON_ID) ? up_rreq : 1'b0;
+  assign up_wreq_s = ({up_waddr[13:7],1'b0} == COMMON_ID) ? up_wreq : 1'b0;
+  assign up_rreq_s = ({up_raddr[13:7],1'b0} == COMMON_ID) ? up_rreq : 1'b0;
 
   assign  up_dac_ce = up_dac_clk_enb_int;
 
@@ -186,13 +186,13 @@ module up_dac_common #(
       up_core_preset <= ~up_resetn;
       up_mmcm_preset <= ~up_mmcm_resetn;
       up_wack_int <= up_wreq_s;
-      if ((up_wreq_s == 1'b1) && (up_waddr[7:0] == 8'h02)) begin
+      if ((up_wreq_s == 1'b1) && (up_waddr[6:0] == 7'h02)) begin
         up_scratch <= up_wdata;
       end
-      if ((up_wreq_s == 1'b1) && (up_waddr[7:0] == 8'h04)) begin
+      if ((up_wreq_s == 1'b1) && (up_waddr[6:0] == 7'h04)) begin
         up_pps_irq_mask <= up_wdata[0];
       end
-      if ((up_wreq_s == 1'b1) && (up_waddr[7:0] == 8'h10)) begin
+      if ((up_wreq_s == 1'b1) && (up_waddr[6:0] == 7'h10)) begin
         up_dac_clk_enb <= up_wdata[2];
         up_mmcm_resetn <= up_wdata[1];
         up_resetn <= up_wdata[0];
@@ -201,26 +201,26 @@ module up_dac_common #(
         if (up_xfer_done_s == 1'b1) begin
           up_dac_sync <= 1'b0;
         end
-      end else if ((up_wreq_s == 1'b1) && (up_waddr[7:0] == 8'h11)) begin
+      end else if ((up_wreq_s == 1'b1) && (up_waddr[6:0] == 7'h11)) begin
         up_dac_sync <= up_wdata[0];
       end
-      if ((up_wreq_s == 1'b1) && (up_waddr[7:0] == 8'h12)) begin
+      if ((up_wreq_s == 1'b1) && (up_waddr[6:0] == 7'h12)) begin
         up_dac_par_type <= up_wdata[7];
         up_dac_par_enb <= up_wdata[6];
         up_dac_r1_mode <= up_wdata[5];
         up_dac_datafmt <= up_wdata[4];
       end
-      if ((up_wreq_s == 1'b1) && (up_waddr[7:0] == 8'h13)) begin
+      if ((up_wreq_s == 1'b1) && (up_waddr[6:0] == 7'h13)) begin
         up_dac_datarate <= up_wdata[15:0];
       end
       if (up_dac_frame == 1'b1) begin
         if (up_xfer_done_s == 1'b1) begin
           up_dac_frame <= 1'b0;
         end
-      end else if ((up_wreq_s == 1'b1) && (up_waddr[7:0] == 8'h14)) begin
+      end else if ((up_wreq_s == 1'b1) && (up_waddr[6:0] == 7'h14)) begin
         up_dac_frame <= up_wdata[0];
       end
-      if ((up_wreq_s == 1'b1) && (up_waddr[7:0] == 8'h18)) begin
+      if ((up_wreq_s == 1'b1) && (up_waddr[6:0] == 7'h18)) begin
         up_dac_clksel <= up_wdata[0];
       end
     end
@@ -257,23 +257,23 @@ module up_dac_common #(
         up_drp_wdata_int <= 'd0;
         up_drp_rdata_hold_int <= 'd0;
       end else begin
-        if ((up_wreq_s == 1'b1) && (up_waddr[7:0] == 8'h1c)) begin
+        if ((up_wreq_s == 1'b1) && (up_waddr[6:0] == 7'h1c)) begin
           up_drp_sel_int <= 1'b1;
           up_drp_wr_int <= ~up_wdata[28];
         end else begin
           up_drp_sel_int <= 1'b0;
           up_drp_wr_int <= 1'b0;
         end
-        if ((up_wreq_s == 1'b1) && (up_waddr[7:0] == 8'h1c)) begin
+        if ((up_wreq_s == 1'b1) && (up_waddr[6:0] == 7'h1c)) begin
           up_drp_status_int <= 1'b1;
         end else if (up_drp_ready == 1'b1) begin
           up_drp_status_int <= 1'b0;
         end
-        if ((up_wreq_s == 1'b1) && (up_waddr[7:0] == 8'h1c)) begin
+        if ((up_wreq_s == 1'b1) && (up_waddr[6:0] == 7'h1c)) begin
           up_drp_rwn_int <= up_wdata[28];
           up_drp_addr_int <= up_wdata[27:16];
         end
-        if ((up_wreq_s == 1'b1) && (up_waddr[7:0] == 8'h1e)) begin
+        if ((up_wreq_s == 1'b1) && (up_waddr[6:0] == 7'h1e)) begin
           up_drp_wdata_int <= up_wdata;
         end
         if (up_drp_ready == 1'b1) begin
@@ -299,7 +299,7 @@ module up_dac_common #(
     end else begin
       if (up_status_unf_s == 1'b1) begin
         up_status_unf <= 1'b1;
-      end else if ((up_wreq_s == 1'b1) && (up_waddr[7:0] == 8'h22)) begin
+      end else if ((up_wreq_s == 1'b1) && (up_waddr[6:0] == 7'h22)) begin
         up_status_unf <= up_status_unf & ~up_wdata[0];
       end
     end
@@ -317,7 +317,7 @@ module up_dac_common #(
     if (up_rstn == 0) begin
       up_usr_chanmax_int <= 'd0;
     end else begin
-      if ((up_wreq_s == 1'b1) && (up_waddr[7:0] == 8'h28)) begin
+      if ((up_wreq_s == 1'b1) && (up_waddr[6:0] == 7'h28)) begin
         up_usr_chanmax_int <= up_wdata[7:0];
       end
     end
@@ -337,7 +337,7 @@ module up_dac_common #(
     if (up_rstn == 0) begin
       up_dac_gpio_out_int <= 'd0;
     end else begin
-      if ((up_wreq_s == 1'b1) && (up_waddr[7:0] == 8'h2f)) begin
+      if ((up_wreq_s == 1'b1) && (up_waddr[6:0] == 7'h2f)) begin
         up_dac_gpio_out_int <= up_wdata;
       end
     end
@@ -351,7 +351,7 @@ module up_dac_common #(
     if (up_rstn == 0) begin
       up_timer <= 32'd0;
     end else begin
-      if ((up_wreq_s == 1'b1) && (up_waddr[7:0] == 8'h40)) begin
+      if ((up_wreq_s == 1'b1) && (up_waddr[6:0] == 7'h40)) begin
         up_timer <= up_wdata;
       end else if (up_timer > 0) begin
         up_timer <= up_timer - 1'b1;
@@ -371,32 +371,32 @@ module up_dac_common #(
     end else begin
       up_rack_int <= up_rreq_s;
       if (up_rreq_s == 1'b1) begin
-        case (up_raddr[7:0])
-          8'h00: up_rdata_int <= VERSION;
-          8'h01: up_rdata_int <= ID;
-          8'h02: up_rdata_int <= up_scratch;
-          8'h03: up_rdata_int <= CONFIG;
-          8'h10: up_rdata_int <= {29'd0, up_dac_clk_enb, up_mmcm_resetn, up_resetn};
-          8'h11: up_rdata_int <= {31'd0, up_dac_sync};
-          8'h12: up_rdata_int <= {24'd0, up_dac_par_type, up_dac_par_enb, up_dac_r1_mode,
+        case (up_raddr[6:0])
+          7'h00: up_rdata_int <= VERSION;
+          7'h01: up_rdata_int <= ID;
+          7'h02: up_rdata_int <= up_scratch;
+          7'h03: up_rdata_int <= CONFIG;
+          7'h10: up_rdata_int <= {29'd0, up_dac_clk_enb, up_mmcm_resetn, up_resetn};
+          7'h11: up_rdata_int <= {31'd0, up_dac_sync};
+          7'h12: up_rdata_int <= {24'd0, up_dac_par_type, up_dac_par_enb, up_dac_r1_mode,
                               up_dac_datafmt, 4'd0};
-          8'h13: up_rdata_int <= {16'd0, up_dac_datarate};
-          8'h14: up_rdata_int <= {31'd0, up_dac_frame};
-          8'h15: up_rdata_int <= up_dac_clk_count_s;
-          8'h16: up_rdata_int <= dac_clk_ratio;
-          8'h17: up_rdata_int <= {31'd0, up_status_s};
-          8'h18: up_rdata_int <= {31'd0, up_dac_clksel};
-          8'h1c: up_rdata_int <= {3'd0, up_drp_rwn_s, up_drp_addr, 16'b0};
-          8'h1d: up_rdata_int <= {14'd0, up_drp_locked, up_drp_status_s, 16'b0};
-          8'h1e: up_rdata_int <= up_drp_wdata;
-          8'h1f: up_rdata_int <= up_drp_rdata_hold_s;
-          8'h22: up_rdata_int <= {31'd0, up_status_unf};
-          8'h28: up_rdata_int <= {24'd0, dac_usr_chanmax};
-          8'h2e: up_rdata_int <= up_dac_gpio_in;
-          8'h2f: up_rdata_int <= up_dac_gpio_out_int;
-          8'h30: up_rdata_int <= up_pps_rcounter;
-          8'h31: up_rdata_int <= up_pps_status;
-          8'h40: up_rdata_int <= up_timer;
+          7'h13: up_rdata_int <= {16'd0, up_dac_datarate};
+          7'h14: up_rdata_int <= {31'd0, up_dac_frame};
+          7'h15: up_rdata_int <= up_dac_clk_count_s;
+          7'h16: up_rdata_int <= dac_clk_ratio;
+          7'h17: up_rdata_int <= {31'd0, up_status_s};
+          7'h18: up_rdata_int <= {31'd0, up_dac_clksel};
+          7'h1c: up_rdata_int <= {3'd0, up_drp_rwn_s, up_drp_addr, 16'b0};
+          7'h1d: up_rdata_int <= {14'd0, up_drp_locked, up_drp_status_s, 16'b0};
+          7'h1e: up_rdata_int <= up_drp_wdata;
+          7'h1f: up_rdata_int <= up_drp_rdata_hold_s;
+          7'h22: up_rdata_int <= {31'd0, up_status_unf};
+          7'h28: up_rdata_int <= {24'd0, dac_usr_chanmax};
+          7'h2e: up_rdata_int <= up_dac_gpio_in;
+          7'h2f: up_rdata_int <= up_dac_gpio_out_int;
+          7'h30: up_rdata_int <= up_pps_rcounter;
+          7'h31: up_rdata_int <= up_pps_status;
+          7'h40: up_rdata_int <= up_timer;
           default: up_rdata_int <= 0;
         endcase
       end else begin

--- a/library/jesd204/ad_ip_jesd204_tpl_adc/Makefile
+++ b/library/jesd204/ad_ip_jesd204_tpl_adc/Makefile
@@ -16,6 +16,7 @@ GENERIC_DEPS += ../../common/up_axi.v
 GENERIC_DEPS += ../../common/up_clock_mon.v
 GENERIC_DEPS += ../../common/up_xfer_cntrl.v
 GENERIC_DEPS += ../../common/up_xfer_status.v
+GENERIC_DEPS += ../ad_ip_jesd204_tpl_common/up_tpl_common.v
 GENERIC_DEPS += ad_ip_jesd204_tpl_adc.v
 GENERIC_DEPS += ad_ip_jesd204_tpl_adc_channel.v
 GENERIC_DEPS += ad_ip_jesd204_tpl_adc_core.v

--- a/library/jesd204/ad_ip_jesd204_tpl_adc/ad_ip_jesd204_tpl_adc.v
+++ b/library/jesd204/ad_ip_jesd204_tpl_adc/ad_ip_jesd204_tpl_adc.v
@@ -85,6 +85,8 @@ module ad_ip_jesd204_tpl_adc #(
   localparam LINK_DATA_WIDTH = NUM_LANES * OCTETS_PER_BEAT * 8;
   localparam DMA_DATA_WIDTH = 16 * DATA_PATH_WIDTH * NUM_CHANNELS;
 
+  localparam BYTES_PER_FRAME = (NUM_CHANNELS * BITS_PER_SAMPLE * SAMPLES_PER_FRAME) / ( 8 * NUM_LANES);
+
   wire [NUM_CHANNELS-1:0] dfmt_enable_s;
   wire [NUM_CHANNELS-1:0] dfmt_sign_extend_s;
   wire [NUM_CHANNELS-1:0] dfmt_type_s;
@@ -97,7 +99,8 @@ module ad_ip_jesd204_tpl_adc #(
   ad_ip_jesd204_tpl_adc_regmap #(
     .ID (ID),
     .NUM_CHANNELS (NUM_CHANNELS),
-    .DATA_PATH_WIDTH (DATA_PATH_WIDTH)
+    .DATA_PATH_WIDTH (DATA_PATH_WIDTH),
+    .NUM_PROFILES(1)
   ) i_regmap (
     .s_axi_aclk (s_axi_aclk),
     .s_axi_aresetn (s_axi_aresetn),
@@ -133,14 +136,22 @@ module ad_ip_jesd204_tpl_adc #(
 
     .enable (enable),
 
-    .adc_dovf (adc_dovf)
+    .adc_dovf (adc_dovf),
+
+    .jesd_m (NUM_CHANNELS),
+    .jesd_l (NUM_LANES),
+    .jesd_s (SAMPLES_PER_FRAME),
+    .jesd_f (BYTES_PER_FRAME),
+    .jesd_n (CONVERTER_RESOLUTION),
+    .jesd_np (BITS_PER_SAMPLE),
+    .up_profile_sel ()
   );
 
   ad_ip_jesd204_tpl_adc_core #(
     .NUM_LANES (NUM_LANES),
     .NUM_CHANNELS (NUM_CHANNELS),
     .BITS_PER_SAMPLE (BITS_PER_SAMPLE),
-    .CONVERTER_RESOLUTION  (CONVERTER_RESOLUTION),
+    .CONVERTER_RESOLUTION (CONVERTER_RESOLUTION),
     .SAMPLES_PER_FRAME (SAMPLES_PER_FRAME),
     .OCTETS_PER_BEAT (OCTETS_PER_BEAT),
     .LINK_DATA_WIDTH (LINK_DATA_WIDTH),

--- a/library/jesd204/ad_ip_jesd204_tpl_adc/ad_ip_jesd204_tpl_adc_ip.tcl
+++ b/library/jesd204/ad_ip_jesd204_tpl_adc/ad_ip_jesd204_tpl_adc_ip.tcl
@@ -41,6 +41,7 @@ adi_ip_files ad_ip_jesd204_tpl_adc [list \
   "$ad_hdl_dir/library/xilinx/common/ad_rst_constr.xdc" \
   "$ad_hdl_dir/library/xilinx/common/up_xfer_status_constr.xdc" \
   "$ad_hdl_dir/library/xilinx/common/up_clock_mon_constr.xdc" \
+  "../ad_ip_jesd204_tpl_common/up_tpl_common.v" \
   "ad_ip_jesd204_tpl_adc_core.v" \
   "ad_ip_jesd204_tpl_adc_channel.v" \
   "ad_ip_jesd204_tpl_adc_deframer.v" \

--- a/library/jesd204/ad_ip_jesd204_tpl_adc/ad_ip_jesd204_tpl_adc_regmap.v
+++ b/library/jesd204/ad_ip_jesd204_tpl_adc/ad_ip_jesd204_tpl_adc_regmap.v
@@ -100,11 +100,11 @@ module ad_ip_jesd204_tpl_adc_regmap #(
   wire adc_rst;
 
   wire up_wreq_s;
-  wire [13:0] up_waddr_s;
+  wire [9:0] up_waddr_s;
   wire [31:0] up_wdata_s;
   wire [NUM_CHANNELS+1:0] up_wack_s;
   wire up_rreq_s;
-  wire [13:0] up_raddr_s;
+  wire [9:0] up_raddr_s;
   wire [31:0] up_rdata_s[0:NUM_CHANNELS+1];
   wire [NUM_CHANNELS+1:0] up_rack_s;
 
@@ -129,13 +129,14 @@ module ad_ip_jesd204_tpl_adc_regmap #(
   // up bus interface
 
   up_axi #(
-    .AXI_ADDRESS_WIDTH (16)
+    .AXI_ADDRESS_WIDTH (12),
+    .ADDRESS_WIDTH (10)
   ) i_up_axi (
     .up_clk (up_clk),
     .up_rstn (up_rstn),
 
     .up_axi_awvalid (s_axi_awvalid),
-    .up_axi_awaddr ({4'b0,s_axi_awaddr}),
+    .up_axi_awaddr (s_axi_awaddr),
     .up_axi_awready (s_axi_awready),
     .up_axi_wvalid (s_axi_wvalid),
     .up_axi_wdata (s_axi_wdata),
@@ -145,7 +146,7 @@ module ad_ip_jesd204_tpl_adc_regmap #(
     .up_axi_bresp (s_axi_bresp),
     .up_axi_bready (s_axi_bready),
     .up_axi_arvalid (s_axi_arvalid),
-    .up_axi_araddr ({4'b0,s_axi_araddr}),
+    .up_axi_araddr (s_axi_araddr),
     .up_axi_arready (s_axi_arready),
     .up_axi_rvalid (s_axi_rvalid),
     .up_axi_rresp (s_axi_rresp),
@@ -191,6 +192,7 @@ module ad_ip_jesd204_tpl_adc_regmap #(
   // common processor control
 
   up_adc_common #(
+    .COMMON_ID (6'h0),
     .ID (ID),
     .DRP_DISABLE (1),
     .USERPORTS_DISABLE (1),
@@ -233,11 +235,11 @@ module ad_ip_jesd204_tpl_adc_regmap #(
     .up_clk (up_clk),
     .up_rstn (up_rstn),
     .up_wreq (up_wreq_s),
-    .up_waddr (up_waddr_s),
+    .up_waddr ({4'b0,up_waddr_s}),
     .up_wdata (up_wdata_s),
     .up_wack (up_wack_s[0]),
     .up_rreq (up_rreq_s),
-    .up_raddr (up_raddr_s),
+    .up_raddr ({4'b0,up_raddr_s}),
     .up_rdata (up_rdata_s[0]),
     .up_rack (up_rack_s[0])
   );
@@ -246,6 +248,7 @@ module ad_ip_jesd204_tpl_adc_regmap #(
   genvar i;
   for (i = 0; i < NUM_CHANNELS; i = i + 1) begin: g_channel
     up_adc_channel #(
+      .COMMON_ID (6'h1),
       .CHANNEL_ID (i),
       .USERPORTS_DISABLE (1),
       .DCFILTER_DISABLE (1),
@@ -290,11 +293,11 @@ module ad_ip_jesd204_tpl_adc_regmap #(
       .up_clk (up_clk),
       .up_rstn (up_rstn),
       .up_wreq (up_wreq_s),
-      .up_waddr (up_waddr_s),
+      .up_waddr ({4'b0,up_waddr_s}),
       .up_wdata (up_wdata_s),
       .up_wack (up_wack_s[i+1]),
       .up_rreq (up_rreq_s),
-      .up_raddr (up_raddr_s),
+      .up_raddr ({4'b0,up_raddr_s}),
       .up_rdata (up_rdata_s[i+1]),
       .up_rack (up_rack_s[i+1])
     );
@@ -302,7 +305,7 @@ module ad_ip_jesd204_tpl_adc_regmap #(
   endgenerate
 
   up_tpl_common #(
-     .COMMON_ID(4'h3),            // Offset of regmap
+     .COMMON_ID(2'h3),            // Offset of regmap
      .NUM_PROFILES(NUM_PROFILES)  // Number of JESD profiles
     ) i_up_tpl_adc (
 
@@ -328,4 +331,5 @@ module ad_ip_jesd204_tpl_adc_regmap #(
     .up_rdata (up_rdata_s[NUM_CHANNELS+1]),
     .up_rack (up_rack_s[NUM_CHANNELS+1])
   );
+
 endmodule

--- a/library/jesd204/ad_ip_jesd204_tpl_adc/ad_ip_jesd204_tpl_adc_regmap.v
+++ b/library/jesd204/ad_ip_jesd204_tpl_adc/ad_ip_jesd204_tpl_adc_regmap.v
@@ -305,7 +305,7 @@ module ad_ip_jesd204_tpl_adc_regmap #(
   endgenerate
 
   up_tpl_common #(
-     .COMMON_ID(2'h3),            // Offset of regmap
+     .COMMON_ID(2'h0),            // Offset of regmap
      .NUM_PROFILES(NUM_PROFILES)  // Number of JESD profiles
     ) i_up_tpl_adc (
 

--- a/library/jesd204/ad_ip_jesd204_tpl_adc/ad_ip_jesd204_tpl_adc_regmap.v
+++ b/library/jesd204/ad_ip_jesd204_tpl_adc/ad_ip_jesd204_tpl_adc_regmap.v
@@ -26,7 +26,8 @@
 module ad_ip_jesd204_tpl_adc_regmap #(
   parameter ID = 0,
   parameter NUM_CHANNELS = 1,
-  parameter DATA_PATH_WIDTH = 1
+  parameter DATA_PATH_WIDTH = 1,
+  parameter NUM_PROFILES = 1    // Number of supported JESD profiles
 ) (
   // axi interface
   input s_axi_aclk,
@@ -67,7 +68,17 @@ module ad_ip_jesd204_tpl_adc_regmap #(
   output [NUM_CHANNELS-1:0] enable,
 
   // Underflow
-  input adc_dovf
+  input adc_dovf,
+
+  // Deframer interface
+  input [NUM_PROFILES*8-1: 0] jesd_m,
+  input [NUM_PROFILES*8-1: 0] jesd_l,
+  input [NUM_PROFILES*8-1: 0] jesd_s,
+  input [NUM_PROFILES*8-1: 0] jesd_f,
+  input [NUM_PROFILES*8-1: 0] jesd_n,
+  input [NUM_PROFILES*8-1: 0] jesd_np,
+
+  output [$clog2(NUM_PROFILES):0] up_profile_sel
 );
 
   localparam [31:0] CLK_RATIO = DATA_PATH_WIDTH;
@@ -91,11 +102,11 @@ module ad_ip_jesd204_tpl_adc_regmap #(
   wire up_wreq_s;
   wire [13:0] up_waddr_s;
   wire [31:0] up_wdata_s;
-  wire [NUM_CHANNELS:0] up_wack_s;
+  wire [NUM_CHANNELS+1:0] up_wack_s;
   wire up_rreq_s;
   wire [13:0] up_raddr_s;
-  wire [31:0] up_rdata_s[0:NUM_CHANNELS];
-  wire [NUM_CHANNELS:0] up_rack_s;
+  wire [31:0] up_rdata_s[0:NUM_CHANNELS+1];
+  wire [NUM_CHANNELS+1:0] up_rack_s;
 
   wire [NUM_CHANNELS-1:0] up_adc_pn_err_s;
   wire [NUM_CHANNELS-1:0] up_adc_pn_oos_s;
@@ -155,7 +166,7 @@ module ad_ip_jesd204_tpl_adc_regmap #(
 
   always @(*) begin
     up_rdata_all = 'h00;
-    for (n = 0; n <= NUM_CHANNELS; n = n + 1) begin
+    for (n = 0; n <= NUM_CHANNELS+1; n = n + 1) begin
       up_rdata_all = up_rdata_all | up_rdata_s[n];
     end
   end
@@ -290,4 +301,31 @@ module ad_ip_jesd204_tpl_adc_regmap #(
   end
   endgenerate
 
+  up_tpl_common #(
+     .COMMON_ID(4'h3),            // Offset of regmap
+     .NUM_PROFILES(NUM_PROFILES)  // Number of JESD profiles
+    ) i_up_tpl_adc (
+
+    .jesd_m (jesd_m),
+    .jesd_l (jesd_l),
+    .jesd_s (jesd_s),
+    .jesd_f (jesd_f),
+    .jesd_n (jesd_n),
+    .jesd_np (jesd_np),
+
+    .up_profile_sel (up_profile_sel),
+
+    // bus interface
+    .up_clk (up_clk),
+    .up_rstn (up_rstn),
+
+    .up_wreq (up_wreq_s),
+    .up_waddr (up_waddr_s),
+    .up_wdata (up_wdata_s),
+    .up_wack (up_wack_s[NUM_CHANNELS+1]),
+    .up_rreq (up_rreq_s),
+    .up_raddr (up_raddr_s),
+    .up_rdata (up_rdata_s[NUM_CHANNELS+1]),
+    .up_rack (up_rack_s[NUM_CHANNELS+1])
+  );
 endmodule

--- a/library/jesd204/ad_ip_jesd204_tpl_common/up_tpl_common.v
+++ b/library/jesd204/ad_ip_jesd204_tpl_common/up_tpl_common.v
@@ -38,7 +38,7 @@
 module up_tpl_common #(
 
   // parameters
-  parameter COMMON_ID = 4'hF,  // Offset of regmap
+  parameter COMMON_ID = 2'h3,  // Offset of regmap
   parameter NUM_PROFILES = 1   // Number of JESD profiles
   )(
 
@@ -56,11 +56,11 @@ module up_tpl_common #(
   input               up_rstn,
   input               up_clk,
   input               up_wreq,
-  input       [13:0]  up_waddr,
+  input        [9:0]  up_waddr,
   input       [31:0]  up_wdata,
   output              up_wack,
   input               up_rreq,
-  input       [13:0]  up_raddr,
+  input        [9:0]  up_raddr,
   output      [31:0]  up_rdata,
   output              up_rack
 );
@@ -77,8 +77,8 @@ module up_tpl_common #(
 
   // decode block select
 
-  assign up_wreq_s = (up_waddr[13:8] == COMMON_ID) ? up_wreq : 1'b0;
-  assign up_rreq_s = (up_raddr[13:8] == COMMON_ID) ? up_rreq : 1'b0;
+  assign up_wreq_s = (up_waddr[9:8] == COMMON_ID) ? up_wreq : 1'b0;
+  assign up_rreq_s = (up_raddr[9:8] == COMMON_ID) ? up_rreq : 1'b0;
 
   // processor write interface
 

--- a/library/jesd204/ad_ip_jesd204_tpl_common/up_tpl_common.v
+++ b/library/jesd204/ad_ip_jesd204_tpl_common/up_tpl_common.v
@@ -1,0 +1,141 @@
+// ***************************************************************************
+// ***************************************************************************
+// Copyright 2014 - 2017 (c) Analog Devices, Inc. All rights reserved.
+//
+// In this HDL repository, there are many different and unique modules, consisting
+// of various HDL (Verilog or VHDL) components. The individual modules are
+// developed independently, and may be accompanied by separate and unique license
+// terms.
+//
+// The user should read each of these license terms, and understand the
+// freedoms and responsibilities that he or she has by using this source/core.
+//
+// This core is distributed in the hope that it will be useful, but WITHOUT ANY
+// WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+// A PARTICULAR PURPOSE.
+//
+// Redistribution and use of source or resulting binaries, with or without modification
+// of this file, are permitted under one of the following two license terms:
+//
+//   1. The GNU General Public License version 2 as published by the
+//      Free Software Foundation, which can be found in the top level directory
+//      of this repository (LICENSE_GPL2), and also online at:
+//      <https://www.gnu.org/licenses/old-licenses/gpl-2.0.html>
+//
+// OR
+//
+//   2. An ADI specific BSD license, which can be found in the top level directory
+//      of this repository (LICENSE_ADIBSD), and also on-line at:
+//      https://github.com/analogdevicesinc/hdl/blob/master/LICENSE_ADIBSD
+//      This will allow to generate bit files and not release the source code,
+//      as long as it attaches to an ADI device.
+//
+// ***************************************************************************
+// ***************************************************************************
+
+`timescale 1ns/100ps
+
+module up_tpl_common #(
+
+  // parameters
+  parameter COMMON_ID = 4'hF,  // Offset of regmap
+  parameter NUM_PROFILES = 1   // Number of JESD profiles
+  )(
+
+  input [NUM_PROFILES*8-1: 0] jesd_m,
+  input [NUM_PROFILES*8-1: 0] jesd_l,
+  input [NUM_PROFILES*8-1: 0] jesd_s,
+  input [NUM_PROFILES*8-1: 0] jesd_f,
+  input [NUM_PROFILES*8-1: 0] jesd_n,
+  input [NUM_PROFILES*8-1: 0] jesd_np,
+
+  output reg [$clog2(NUM_PROFILES):0] up_profile_sel = 'h0,
+
+  // bus interface
+
+  input               up_rstn,
+  input               up_clk,
+  input               up_wreq,
+  input       [13:0]  up_waddr,
+  input       [31:0]  up_wdata,
+  output              up_wack,
+  input               up_rreq,
+  input       [13:0]  up_raddr,
+  output      [31:0]  up_rdata,
+  output              up_rack
+);
+
+  // internal registers
+  reg             up_rack_int = 'd0;
+  reg             up_wack_int = 'd0;
+  reg     [31:0]  up_rdata_int = 'd0;
+
+  // internal signals
+  wire            up_wreq_s;
+  wire            up_rreq_s;
+  reg     [31:0]  up_rdata_jesd_params;
+
+  // decode block select
+
+  assign up_wreq_s = (up_waddr[13:8] == COMMON_ID) ? up_wreq : 1'b0;
+  assign up_rreq_s = (up_raddr[13:8] == COMMON_ID) ? up_rreq : 1'b0;
+
+  // processor write interface
+
+  assign up_wack = up_wack_int;
+
+  always @(negedge up_rstn or posedge up_clk) begin
+    if (up_rstn == 0) begin
+      up_wack_int <= 'd0;
+      up_profile_sel <= 'd0;
+   end else begin
+      up_wack_int <= up_wreq_s;
+      if ((up_wreq_s == 1'b1) && (up_waddr[7:0] == 8'h00)) begin
+        up_profile_sel <= up_wdata[$clog2(NUM_PROFILES):0];
+      end
+    end
+  end
+
+  // processor read interface
+
+  assign up_rack = up_rack_int;
+  assign up_rdata = up_rdata_int;
+
+  always @(negedge up_rstn or posedge up_clk) begin
+    if (up_rstn == 0) begin
+      up_rack_int <= 'd0;
+      up_rdata_int <= 'd0;
+    end else begin
+      up_rack_int <= up_rreq_s;
+      if (up_rreq_s == 1'b1) begin
+        case (up_raddr[7:0])
+          8'h00: up_rdata_int <= up_profile_sel;
+          8'h01: up_rdata_int <= NUM_PROFILES;
+         default: up_rdata_int <= up_rdata_jesd_params;
+        endcase
+      end else begin
+        up_rdata_int <= 32'd0;
+      end
+    end
+  end
+
+  integer i;
+  always @(*) begin
+    for (i=0; i<NUM_PROFILES; i = i + 1) begin:jesd_param
+      up_rdata_jesd_params = 0;
+      if (up_rreq_s == 1'b1) begin
+        if (up_raddr[7:0] == 8'h10 + {i[6:0],1'b0}) begin
+          up_rdata_jesd_params = {jesd_f[i*8+:8], jesd_s[i*8+:8],
+                                  jesd_l[i*8+:8], jesd_m[i*8+:8]};
+        end
+        if (up_raddr[7:0] == 8'h11 + {i[6:0],1'b0}) begin
+          up_rdata_jesd_params = {16'b0,jesd_np[i*8+:8], jesd_n[i*8+:8]};
+        end
+      end
+    end
+  end
+
+endmodule
+
+// ***************************************************************************
+// ***************************************************************************

--- a/library/jesd204/ad_ip_jesd204_tpl_common/up_tpl_common.v
+++ b/library/jesd204/ad_ip_jesd204_tpl_common/up_tpl_common.v
@@ -38,7 +38,7 @@
 module up_tpl_common #(
 
   // parameters
-  parameter COMMON_ID = 2'h3,  // Offset of regmap
+  parameter COMMON_ID = 2'h0,  // Offset of regmap
   parameter NUM_PROFILES = 1   // Number of JESD profiles
   )(
 
@@ -77,8 +77,8 @@ module up_tpl_common #(
 
   // decode block select
 
-  assign up_wreq_s = (up_waddr[9:8] == COMMON_ID) ? up_wreq : 1'b0;
-  assign up_rreq_s = (up_raddr[9:8] == COMMON_ID) ? up_rreq : 1'b0;
+  assign up_wreq_s = (up_waddr[9:7] == {COMMON_ID,1'b1}) ? up_wreq : 1'b0;
+  assign up_rreq_s = (up_raddr[9:7] == {COMMON_ID,1'b1}) ? up_rreq : 1'b0;
 
   // processor write interface
 
@@ -90,7 +90,7 @@ module up_tpl_common #(
       up_profile_sel <= 'd0;
    end else begin
       up_wack_int <= up_wreq_s;
-      if ((up_wreq_s == 1'b1) && (up_waddr[7:0] == 8'h00)) begin
+      if ((up_wreq_s == 1'b1) && (up_waddr[6:0] == 7'h00)) begin
         up_profile_sel <= up_wdata[$clog2(NUM_PROFILES):0];
       end
     end
@@ -108,9 +108,9 @@ module up_tpl_common #(
     end else begin
       up_rack_int <= up_rreq_s;
       if (up_rreq_s == 1'b1) begin
-        case (up_raddr[7:0])
-          8'h00: up_rdata_int <= up_profile_sel;
-          8'h01: up_rdata_int <= NUM_PROFILES;
+        case (up_raddr[6:0])
+          7'h00: up_rdata_int <= up_profile_sel;
+          7'h01: up_rdata_int <= NUM_PROFILES;
          default: up_rdata_int <= up_rdata_jesd_params;
         endcase
       end else begin
@@ -124,11 +124,11 @@ module up_tpl_common #(
     for (i=0; i<NUM_PROFILES; i = i + 1) begin:jesd_param
       up_rdata_jesd_params = 0;
       if (up_rreq_s == 1'b1) begin
-        if (up_raddr[7:0] == 8'h10 + {i[6:0],1'b0}) begin
+        if (up_raddr[6:0] == 7'h10 + {i[5:0],1'b0}) begin
           up_rdata_jesd_params = {jesd_f[i*8+:8], jesd_s[i*8+:8],
                                   jesd_l[i*8+:8], jesd_m[i*8+:8]};
         end
-        if (up_raddr[7:0] == 8'h11 + {i[6:0],1'b0}) begin
+        if (up_raddr[6:0] == 7'h11 + {i[5:0],1'b0}) begin
           up_rdata_jesd_params = {16'b0,jesd_np[i*8+:8], jesd_n[i*8+:8]};
         end
       end

--- a/library/jesd204/ad_ip_jesd204_tpl_dac/Makefile
+++ b/library/jesd204/ad_ip_jesd204_tpl_dac/Makefile
@@ -19,6 +19,7 @@ GENERIC_DEPS += ../../common/up_dac_channel.v
 GENERIC_DEPS += ../../common/up_dac_common.v
 GENERIC_DEPS += ../../common/up_xfer_cntrl.v
 GENERIC_DEPS += ../../common/up_xfer_status.v
+GENERIC_DEPS += ../ad_ip_jesd204_tpl_common/up_tpl_common.v
 GENERIC_DEPS += ad_ip_jesd204_tpl_dac.v
 GENERIC_DEPS += ad_ip_jesd204_tpl_dac_channel.v
 GENERIC_DEPS += ad_ip_jesd204_tpl_dac_core.v

--- a/library/jesd204/ad_ip_jesd204_tpl_dac/ad_ip_jesd204_tpl_dac.v
+++ b/library/jesd204/ad_ip_jesd204_tpl_dac/ad_ip_jesd204_tpl_dac.v
@@ -85,6 +85,8 @@ module ad_ip_jesd204_tpl_dac #(
   localparam LINK_DATA_WIDTH = NUM_LANES * OCTETS_PER_BEAT * 8;
   localparam DMA_DATA_WIDTH = 16 * DATA_PATH_WIDTH * NUM_CHANNELS;
 
+  localparam BYTES_PER_FRAME = (NUM_CHANNELS * BITS_PER_SAMPLE * SAMPLES_PER_FRAME) / ( 8 * NUM_LANES);
+
   // internal signals
 
   wire dac_sync;
@@ -105,7 +107,8 @@ module ad_ip_jesd204_tpl_dac #(
   ad_ip_jesd204_tpl_dac_regmap #(
     .ID (ID),
     .NUM_CHANNELS (NUM_CHANNELS),
-    .DATA_PATH_WIDTH (DATA_PATH_WIDTH)
+    .DATA_PATH_WIDTH (DATA_PATH_WIDTH),
+    .NUM_PROFILES(1)
   ) i_regmap (
     .s_axi_aclk (s_axi_aclk),
     .s_axi_aresetn (s_axi_aresetn),
@@ -145,7 +148,15 @@ module ad_ip_jesd204_tpl_dac #(
     .dac_dds_incr_1 (dac_dds_incr_1_s),
     .dac_pat_data_0 (dac_pat_data_0_s),
     .dac_pat_data_1 (dac_pat_data_1_s),
-    .dac_data_sel (dac_data_sel_s)
+    .dac_data_sel (dac_data_sel_s),
+
+    .jesd_m (NUM_CHANNELS),
+    .jesd_l (NUM_LANES),
+    .jesd_s (SAMPLES_PER_FRAME),
+    .jesd_f (BYTES_PER_FRAME),
+    .jesd_n (CONVERTER_RESOLUTION),
+    .jesd_np (BITS_PER_SAMPLE),
+    .up_profile_sel ()
   );
 
   // core

--- a/library/jesd204/ad_ip_jesd204_tpl_dac/ad_ip_jesd204_tpl_dac_ip.tcl
+++ b/library/jesd204/ad_ip_jesd204_tpl_dac/ad_ip_jesd204_tpl_dac_ip.tcl
@@ -45,6 +45,7 @@ adi_ip_files ad_ip_jesd204_tpl_dac [list \
   "$ad_hdl_dir/library/xilinx/common/ad_rst_constr.xdc" \
   "$ad_hdl_dir/library/xilinx/common/up_xfer_status_constr.xdc" \
   "$ad_hdl_dir/library/xilinx/common/up_clock_mon_constr.xdc" \
+  "../ad_ip_jesd204_tpl_common/up_tpl_common.v" \
   "ad_ip_jesd204_tpl_dac_channel.v" \
   "ad_ip_jesd204_tpl_dac_core.v" \
   "ad_ip_jesd204_tpl_dac_framer.v" \

--- a/library/jesd204/ad_ip_jesd204_tpl_dac/ad_ip_jesd204_tpl_dac_regmap.v
+++ b/library/jesd204/ad_ip_jesd204_tpl_dac/ad_ip_jesd204_tpl_dac_regmap.v
@@ -94,11 +94,11 @@ module ad_ip_jesd204_tpl_dac_regmap #(
 
 
   wire up_wreq_s;
-  wire [13:0] up_waddr_s;
+  wire [9:0] up_waddr_s;
   wire [31:0] up_wdata_s;
   wire [NUM_CHANNELS+1:0] up_wack_s;
   wire up_rreq_s;
-  wire [13:0] up_raddr_s;
+  wire [9:0] up_raddr_s;
   wire [31:0] up_rdata_s[0:NUM_CHANNELS+1];
   wire [NUM_CHANNELS+1:0] up_rack_s;
 
@@ -116,7 +116,8 @@ module ad_ip_jesd204_tpl_dac_regmap #(
   // up bus interface
 
   up_axi #(
-    .AXI_ADDRESS_WIDTH (16)
+    .AXI_ADDRESS_WIDTH (12),
+    .ADDRESS_WIDTH (10)
   ) i_up_axi (
     .up_clk (up_clk),
     .up_rstn (up_rstn),
@@ -213,11 +214,11 @@ module ad_ip_jesd204_tpl_dac_regmap #(
     .up_rstn (up_rstn),
 
     .up_wreq (up_wreq_s),
-    .up_waddr (up_waddr_s),
+    .up_waddr ({4'b0,up_waddr_s}),
     .up_wdata (up_wdata_s),
     .up_wack (up_wack_s[0]),
     .up_rreq (up_rreq_s),
-    .up_raddr (up_raddr_s),
+    .up_raddr ({4'b0,up_raddr_s}),
     .up_rdata (up_rdata_s[0]),
     .up_rack (up_rack_s[0])
   );
@@ -264,11 +265,11 @@ module ad_ip_jesd204_tpl_dac_regmap #(
       .up_clk (up_clk),
       .up_rstn (up_rstn),
       .up_wreq (up_wreq_s),
-      .up_waddr (up_waddr_s),
+      .up_waddr ({4'b0,up_waddr_s}),
       .up_wdata (up_wdata_s),
       .up_wack (up_wack_s[i+1]),
       .up_rreq (up_rreq_s),
-      .up_raddr (up_raddr_s),
+      .up_raddr ({4'b0,up_raddr_s}),
       .up_rdata (up_rdata_s[i+1]),
       .up_rack (up_rack_s[i+1])
     );
@@ -276,7 +277,7 @@ module ad_ip_jesd204_tpl_dac_regmap #(
   endgenerate
 
   up_tpl_common #(
-     .COMMON_ID(4'h3),            // Offset of regmap
+     .COMMON_ID(2'h3),            // Offset of regmap
      .NUM_PROFILES(NUM_PROFILES)  // Number of JESD profiles
     ) i_up_tpl_dac (
 

--- a/library/jesd204/ad_ip_jesd204_tpl_dac/ad_ip_jesd204_tpl_dac_regmap.v
+++ b/library/jesd204/ad_ip_jesd204_tpl_dac/ad_ip_jesd204_tpl_dac_regmap.v
@@ -26,7 +26,8 @@
 module ad_ip_jesd204_tpl_dac_regmap #(
   parameter ID = 0,
   parameter NUM_CHANNELS = 2,
-  parameter DATA_PATH_WIDTH = 16
+  parameter DATA_PATH_WIDTH = 16,
+  parameter NUM_PROFILES = 1    // Number of supported JESD profiles
 ) (
   input s_axi_aclk,
   input s_axi_aresetn,
@@ -72,7 +73,17 @@ module ad_ip_jesd204_tpl_dac_regmap #(
   output [NUM_CHANNELS*16-1:0] dac_dds_incr_1,
 
   output [NUM_CHANNELS*16-1:0] dac_pat_data_0,
-  output [NUM_CHANNELS*16-1:0] dac_pat_data_1
+  output [NUM_CHANNELS*16-1:0] dac_pat_data_1,
+
+  // Framer interface
+  input [NUM_PROFILES*8-1: 0] jesd_m,
+  input [NUM_PROFILES*8-1: 0] jesd_l,
+  input [NUM_PROFILES*8-1: 0] jesd_s,
+  input [NUM_PROFILES*8-1: 0] jesd_f,
+  input [NUM_PROFILES*8-1: 0] jesd_n,
+  input [NUM_PROFILES*8-1: 0] jesd_np,
+
+  output [$clog2(NUM_PROFILES):0] up_profile_sel
 );
 
   // internal registers
@@ -85,11 +96,11 @@ module ad_ip_jesd204_tpl_dac_regmap #(
   wire up_wreq_s;
   wire [13:0] up_waddr_s;
   wire [31:0] up_wdata_s;
-  wire [NUM_CHANNELS:0] up_wack_s;
+  wire [NUM_CHANNELS+1:0] up_wack_s;
   wire up_rreq_s;
   wire [13:0] up_raddr_s;
-  wire [31:0] up_rdata_s[0:NUM_CHANNELS];
-  wire [NUM_CHANNELS:0] up_rack_s;
+  wire [31:0] up_rdata_s[0:NUM_CHANNELS+1];
+  wire [NUM_CHANNELS+1:0] up_rack_s;
 
   // internal clocks and resets
 
@@ -142,7 +153,7 @@ module ad_ip_jesd204_tpl_dac_regmap #(
 
   always @(*) begin
     up_rdata_all = 'h00;
-    for (n = 0; n < NUM_CHANNELS + 1; n = n + 1) begin
+    for (n = 0; n < NUM_CHANNELS + 2; n = n + 1) begin
       up_rdata_all = up_rdata_all | up_rdata_s[n];
      end
   end
@@ -263,5 +274,33 @@ module ad_ip_jesd204_tpl_dac_regmap #(
     );
   end
   endgenerate
+
+  up_tpl_common #(
+     .COMMON_ID(4'h3),            // Offset of regmap
+     .NUM_PROFILES(NUM_PROFILES)  // Number of JESD profiles
+    ) i_up_tpl_dac (
+
+    .jesd_m (jesd_m),
+    .jesd_l (jesd_l),
+    .jesd_s (jesd_s),
+    .jesd_f (jesd_f),
+    .jesd_n (jesd_n),
+    .jesd_np (jesd_np),
+
+    .up_profile_sel (up_profile_sel),
+
+    // bus interface
+    .up_clk (up_clk),
+    .up_rstn (up_rstn),
+
+    .up_wreq (up_wreq_s),
+    .up_waddr (up_waddr_s),
+    .up_wdata (up_wdata_s),
+    .up_wack (up_wack_s[NUM_CHANNELS+1]),
+    .up_rreq (up_rreq_s),
+    .up_raddr (up_raddr_s),
+    .up_rdata (up_rdata_s[NUM_CHANNELS+1]),
+    .up_rack (up_rack_s[NUM_CHANNELS+1])
+  );
 
 endmodule

--- a/library/jesd204/ad_ip_jesd204_tpl_dac/ad_ip_jesd204_tpl_dac_regmap.v
+++ b/library/jesd204/ad_ip_jesd204_tpl_dac/ad_ip_jesd204_tpl_dac_regmap.v
@@ -277,7 +277,7 @@ module ad_ip_jesd204_tpl_dac_regmap #(
   endgenerate
 
   up_tpl_common #(
-     .COMMON_ID(2'h3),            // Offset of regmap
+     .COMMON_ID(2'h0),            // Offset of regmap
      .NUM_PROFILES(NUM_PROFILES)  // Number of JESD profiles
     ) i_up_tpl_dac (
 


### PR DESCRIPTION
This change will allow software to identify the available JESD framer/deframer setting from the transport layer. 

Tested on ZC706 - AD9317