### PR TITLE
Create the dacfifo/adcfifo infrastructure with procedures.

### DIFF
--- a/projects/adrv9009/a10gx/system_qsys.tcl
+++ b/projects/adrv9009/a10gx/system_qsys.tcl
@@ -1,8 +1,5 @@
 
-set dac_fifo_name avl_adrv9009_tx_fifo
 set dac_fifo_address_width 10
-set dac_data_width 128
-set dac_dma_data_width 128
 
 source $ad_hdl_dir/projects/common/a10gx/a10gx_system_qsys.tcl
 source $ad_hdl_dir/projects/common/altera/dacfifo_qsys.tcl

--- a/projects/adrv9009/a10soc/system_qsys.tcl
+++ b/projects/adrv9009/a10soc/system_qsys.tcl
@@ -1,11 +1,6 @@
 
-set dac_fifo_name avl_adrv9009_tx_fifo
 set dac_fifo_address_width 10
-set dac_data_width 128
-set dac_dma_data_width 128
 
 source $ad_hdl_dir/projects/common/a10soc/a10soc_system_qsys.tcl
 source $ad_hdl_dir/projects/common/a10soc/a10soc_plddr4_dacfifo_qsys.tcl
 source ../common/adrv9009_qsys.tcl
-
-

--- a/projects/adrv9009/common/adrv9009_bd.tcl
+++ b/projects/adrv9009/common/adrv9009_bd.tcl
@@ -23,6 +23,10 @@ set RX_OS_SAMPLE_WIDTH 16     ; # N/NP
 
 set RX_OS_SAMPLES_PER_CHANNEL 1 ;  # L * 32 / (M * N)
 
+set dac_fifo_name axi_adrv9009_dacfifo
+set dac_data_width [expr 32*$TX_NUM_OF_LANES]
+set dac_dma_data_width 128
+
 source $ad_hdl_dir/library/jesd204/scripts/jesd204.tcl
 
 # adrv9009
@@ -70,6 +74,8 @@ ad_ip_parameter axi_adrv9009_tx_dma CONFIG.DMA_DATA_WIDTH_DEST $dac_dma_data_wid
 ad_ip_parameter axi_adrv9009_tx_dma CONFIG.MAX_BYTES_PER_BURST 256
 ad_ip_parameter axi_adrv9009_tx_dma CONFIG.AXI_SLICE_DEST true
 ad_ip_parameter axi_adrv9009_tx_dma CONFIG.AXI_SLICE_SRC true
+
+ad_dacfifo_create $dac_fifo_name $dac_data_width $dac_dma_data_width $dac_fifo_address_width
 
 # adc peripherals
 

--- a/projects/adrv9009/common/adrv9009_qsys.tcl
+++ b/projects/adrv9009/common/adrv9009_qsys.tcl
@@ -1,3 +1,6 @@
+set dac_fifo_name avl_adrv9009_tx_fifo
+set dac_data_width 128
+set dac_dma_data_width 128
 
 # adrv9009_tx JESD204
 
@@ -116,6 +119,8 @@ add_connection axi_adrv9009.adc_os_ch_3 axi_adrv9009_rx_os_cpack.adc_ch_3
 add_connection axi_adrv9009_rx_os_cpack.if_fifo_wr_overflow axi_adrv9009.if_adc_os_dovf
 
 # dac fifo
+
+ad_dacfifo_create $dac_fifo_name $dac_data_width $dac_dma_data_width $dac_fifo_address_width
 
 add_interface tx_fifo_bypass conduit end
 set_interface_property tx_fifo_bypass EXPORT_OF avl_adrv9009_tx_fifo.if_bypass

--- a/projects/adrv9009/zc706/system_bd.tcl
+++ b/projects/adrv9009/zc706/system_bd.tcl
@@ -1,8 +1,5 @@
 
-set dac_fifo_name axi_adrv9009_dacfifo
 set dac_fifo_address_width 10
-set dac_data_width 128     ; # should be 32*L (number of TX lanes)
-set dac_dma_data_width 128
 
 source $ad_hdl_dir/projects/common/zc706/zc706_system_bd.tcl
 source $ad_hdl_dir/projects/common/zc706/zc706_plddr3_dacfifo_bd.tcl

--- a/projects/adrv9009/zcu102/system_bd.tcl
+++ b/projects/adrv9009/zcu102/system_bd.tcl
@@ -1,9 +1,6 @@
 
 ## FIFO depth is 18Mb - 1M samples
-set dac_fifo_name axi_adrv9009_dacfifo
 set dac_fifo_address_width 17
-set dac_data_width 128     ; # should be 32*L (number of TX lanes)
-set dac_dma_data_width 128
 
 ## NOTE: With this configuration the #36Kb BRAM utilization is at ~57%
 

--- a/projects/adrv9371x/a10gx/system_qsys.tcl
+++ b/projects/adrv9371x/a10gx/system_qsys.tcl
@@ -1,8 +1,5 @@
 
-set dac_fifo_name avl_ad9371_tx_fifo
 set dac_fifo_address_width 10
-set dac_data_width 128
-set dac_dma_data_width 128
 
 source $ad_hdl_dir/projects/common/a10gx/a10gx_system_qsys.tcl
 source $ad_hdl_dir/projects/common/altera/dacfifo_qsys.tcl

--- a/projects/adrv9371x/a10soc/system_qsys.tcl
+++ b/projects/adrv9371x/a10soc/system_qsys.tcl
@@ -1,8 +1,5 @@
 
-set dac_fifo_name avl_ad9371_tx_fifo
 set dac_fifo_address_width 10
-set dac_data_width 128
-set dac_dma_data_width 128
 
 source $ad_hdl_dir/projects/common/a10soc/a10soc_system_qsys.tcl
 source $ad_hdl_dir/projects/common/a10soc/a10soc_plddr4_dacfifo_qsys.tcl

--- a/projects/adrv9371x/common/adrv9371x_bd.tcl
+++ b/projects/adrv9371x/common/adrv9371x_bd.tcl
@@ -23,6 +23,10 @@ set RX_OS_SAMPLE_WIDTH 16     ; # N/NP
 
 set RX_OS_SAMPLES_PER_CHANNEL 2 ;  # L * 32 / (M * N)
 
+set dac_fifo_name axi_ad9371_dacfifo
+set dac_data_width [expr 32*$TX_NUM_OF_LANES]
+set dac_dma_data_width 128
+
 source $ad_hdl_dir/library/jesd204/scripts/jesd204.tcl
 
 # ad9371
@@ -70,6 +74,8 @@ ad_ip_parameter axi_ad9371_tx_dma CONFIG.ASYNC_CLK_SRC_DEST 1
 ad_ip_parameter axi_ad9371_tx_dma CONFIG.ASYNC_CLK_REQ_SRC 1
 ad_ip_parameter axi_ad9371_tx_dma CONFIG.DMA_2D_TRANSFER 0
 ad_ip_parameter axi_ad9371_tx_dma CONFIG.DMA_DATA_WIDTH_DEST $dac_dma_data_width
+
+ad_dacfifo_create $dac_fifo_name $dac_data_width $dac_dma_data_width $dac_fifo_address_width
 
 # adc peripherals
 

--- a/projects/adrv9371x/common/adrv9371x_qsys.tcl
+++ b/projects/adrv9371x/common/adrv9371x_qsys.tcl
@@ -1,3 +1,6 @@
+set dac_fifo_name avl_ad9371_tx_fifo
+set dac_data_width 128
+set dac_dma_data_width 128
 
 # ad9371_tx JESD204
 
@@ -115,6 +118,8 @@ add_connection axi_ad9371.adc_os_ch_1 axi_ad9371_rx_os_cpack.adc_ch_1
 add_connection axi_ad9371_rx_os_cpack.if_fifo_wr_overflow axi_ad9371.if_adc_os_dovf
 
 # dac fifo
+
+ad_dacfifo_create $dac_fifo_name $dac_data_width $dac_dma_data_width $dac_fifo_address_width
 
 add_interface tx_fifo_bypass conduit end
 set_interface_property tx_fifo_bypass EXPORT_OF avl_ad9371_tx_fifo.if_bypass

--- a/projects/adrv9371x/kcu105/system_bd.tcl
+++ b/projects/adrv9371x/kcu105/system_bd.tcl
@@ -1,9 +1,6 @@
 
 ## FIFO depth is 8Mb - 500k samples
-set dac_fifo_name axi_ad9371_dacfifo
 set dac_fifo_address_width 16
-set dac_data_width 128
-set dac_dma_data_width 128
 
 ## NOTE: With this configuration the #36Kb BRAM utilization is at ~68%
 

--- a/projects/adrv9371x/zc706/system_bd.tcl
+++ b/projects/adrv9371x/zc706/system_bd.tcl
@@ -1,8 +1,5 @@
 
-set dac_fifo_name axi_ad9371_dacfifo
 set dac_fifo_address_width 10
-set dac_data_width 128
-set dac_dma_data_width 128
 
 source $ad_hdl_dir/projects/common/zc706/zc706_system_bd.tcl
 source $ad_hdl_dir/projects/common/zc706/zc706_plddr3_dacfifo_bd.tcl

--- a/projects/adrv9371x/zcu102/system_bd.tcl
+++ b/projects/adrv9371x/zcu102/system_bd.tcl
@@ -1,9 +1,6 @@
 
 ## FIFO depth is 16Mb - 1M samples
-set dac_fifo_name axi_ad9371_dacfifo
 set dac_fifo_address_width 17
-set dac_data_width 128
-set dac_dma_data_width 128
 
 ## NOTE: With this configuration the #36Kb BRAM utilization is at ~51%
 

--- a/projects/common/a10soc/a10soc_plddr4_dacfifo_qsys.tcl
+++ b/projects/common/a10soc/a10soc_plddr4_dacfifo_qsys.tcl
@@ -1,3 +1,4 @@
+proc ad_dacfifo_create {dac_fifo_name dac_data_width dac_dma_data_width dac_fifo_address_width} {
 
 # pl-ddr4 settings
 
@@ -77,3 +78,4 @@ add_connection sys_ddr4_cntrl.emif_usr_clk_clock_source $dac_fifo_name.avl_clock
 add_connection $dac_fifo_name.amm_ddr sys_ddr4_cntrl.ctrl_amm_avalon_slave_0
 set_connection_parameter_value $dac_fifo_name.amm_ddr/sys_ddr4_cntrl.ctrl_amm_avalon_slave_0 baseAddress {0x0}
 
+}

--- a/projects/common/a10soc/a10soc_plddr4_dacfifo_qsys.tcl
+++ b/projects/common/a10soc/a10soc_plddr4_dacfifo_qsys.tcl
@@ -1,81 +1,81 @@
 proc ad_dacfifo_create {dac_fifo_name dac_data_width dac_dma_data_width dac_fifo_address_width} {
 
-# pl-ddr4 settings
+  # pl-ddr4 settings
 
-add_instance sys_ddr4_cntrl altera_emif
-set_instance_parameter_value sys_ddr4_cntrl {PROTOCOL_ENUM} {PROTOCOL_DDR4}
-set_instance_parameter_value sys_ddr4_cntrl {PHY_DDR4_MEM_CLK_FREQ_MHZ} {1066.667}
-set_instance_parameter_value sys_ddr4_cntrl {PHY_DDR4_DEFAULT_REF_CLK_FREQ} {0}
-set_instance_parameter_value sys_ddr4_cntrl {PHY_DDR4_USER_REF_CLK_FREQ_MHZ} {133.333}
-set_instance_parameter_value sys_ddr4_cntrl {PHY_DDR4_RATE_ENUM} {RATE_QUARTER}
-set_instance_parameter_value sys_ddr4_cntrl {MEM_DDR4_FORMAT_ENUM} {MEM_FORMAT_UDIMM}
-set_instance_parameter_value sys_ddr4_cntrl {MEM_DDR4_DQ_WIDTH} {64}
-set_instance_parameter_value sys_ddr4_cntrl {MEM_DDR4_DQ_PER_DQS} {8}
-set_instance_parameter_value sys_ddr4_cntrl {MEM_DDR4_ROW_ADDR_WIDTH} {15}
-set_instance_parameter_value sys_ddr4_cntrl {MEM_DDR4_COL_ADDR_WIDTH} {10}
-set_instance_parameter_value sys_ddr4_cntrl {MEM_DDR4_BANK_ADDR_WIDTH} {2}
-set_instance_parameter_value sys_ddr4_cntrl {MEM_DDR4_BANK_GROUP_WIDTH} {1}
-set_instance_parameter_value sys_ddr4_cntrl {MEM_DDR4_DM_EN} {1}
-set_instance_parameter_value sys_ddr4_cntrl {MEM_DDR4_ALERT_N_PLACEMENT_ENUM} {DDR4_ALERT_N_PLACEMENT_AC_LANES}
-set_instance_parameter_value sys_ddr4_cntrl {MEM_DDR4_ALERT_N_AC_LANE} {3}
-set_instance_parameter_value sys_ddr4_cntrl {MEM_DDR4_ALERT_N_AC_PIN} {0}
-set_instance_parameter_value sys_ddr4_cntrl {MEM_DDR4_TCL} {18}
-set_instance_parameter_value sys_ddr4_cntrl {MEM_DDR4_WTCL} {14}
-set_instance_parameter_value sys_ddr4_cntrl {MEM_DDR4_RTT_NOM_ENUM} {DDR4_RTT_NOM_RZQ_4}
-set_instance_parameter_value sys_ddr4_cntrl {PHY_DDR4_IO_VOLTAGE} {1.2}
-set_instance_parameter_value sys_ddr4_cntrl {PHY_DDR4_DEFAULT_IO} {0}
-set_instance_parameter_value sys_ddr4_cntrl {PHY_DDR4_USER_AC_IO_STD_ENUM} {IO_STD_SSTL_12}
-set_instance_parameter_value sys_ddr4_cntrl {PHY_DDR4_USER_AC_MODE_ENUM} {OUT_OCT_40_CAL}
-set_instance_parameter_value sys_ddr4_cntrl {PHY_DDR4_USER_CK_IO_STD_ENUM} {IO_STD_SSTL_12}
-set_instance_parameter_value sys_ddr4_cntrl {PHY_DDR4_USER_CK_MODE_ENUM} {OUT_OCT_40_CAL}
-set_instance_parameter_value sys_ddr4_cntrl {PHY_DDR4_USER_DATA_IO_STD_ENUM} {IO_STD_POD_12}
-set_instance_parameter_value sys_ddr4_cntrl {PHY_DDR4_USER_DATA_OUT_MODE_ENUM} {OUT_OCT_48_CAL}
-set_instance_parameter_value sys_ddr4_cntrl {PHY_DDR4_USER_DATA_IN_MODE_ENUM} {IN_OCT_60_CAL}
-set_instance_parameter_value sys_ddr4_cntrl {PHY_DDR4_USER_PLL_REF_CLK_IO_STD_ENUM} {IO_STD_LVDS}
-set_instance_parameter_value sys_ddr4_cntrl {PHY_DDR4_USER_RZQ_IO_STD_ENUM} {IO_STD_CMOS_12}
-set_instance_parameter_value sys_ddr4_cntrl {MEM_DDR4_SPEEDBIN_ENUM} {DDR4_SPEEDBIN_2400}
-set_instance_parameter_value sys_ddr4_cntrl {MEM_DDR4_TDQSQ_UI} {0.16}
-set_instance_parameter_value sys_ddr4_cntrl {MEM_DDR4_TDQSCK_PS} {165}
-set_instance_parameter_value sys_ddr4_cntrl {MEM_DDR4_TWLS_PS} {108.0}
-set_instance_parameter_value sys_ddr4_cntrl {MEM_DDR4_TWLH_PS} {108.0}
-set_instance_parameter_value sys_ddr4_cntrl {MEM_DDR4_TINIT_US} {500}
-set_instance_parameter_value sys_ddr4_cntrl {MEM_DDR4_TRAS_NS} {32.0}
-set_instance_parameter_value sys_ddr4_cntrl {MEM_DDR4_TRCD_NS} {15.0}
-set_instance_parameter_value sys_ddr4_cntrl {MEM_DDR4_TRP_NS} {15.0}
-set_instance_parameter_value sys_ddr4_cntrl {MEM_DDR4_TWR_NS} {15.0}
-set_instance_parameter_value sys_ddr4_cntrl {MEM_DDR4_TRRD_S_CYC} {7}
-set_instance_parameter_value sys_ddr4_cntrl {MEM_DDR4_TRRD_L_CYC} {8}
-set_instance_parameter_value sys_ddr4_cntrl {MEM_DDR4_TFAW_NS} {30.0}
-set_instance_parameter_value sys_ddr4_cntrl {MEM_DDR4_TCCD_S_CYC} {4}
-set_instance_parameter_value sys_ddr4_cntrl {MEM_DDR4_TCCD_L_CYC} {6}
-set_instance_parameter_value sys_ddr4_cntrl {MEM_DDR4_TWTR_S_CYC} {3}
-set_instance_parameter_value sys_ddr4_cntrl {MEM_DDR4_TWTR_L_CYC} {9}
-set_instance_parameter_value sys_ddr4_cntrl {CTRL_DDR4_ECC_EN} {0}
+  add_instance sys_ddr4_cntrl altera_emif
+  set_instance_parameter_value sys_ddr4_cntrl {PROTOCOL_ENUM} {PROTOCOL_DDR4}
+  set_instance_parameter_value sys_ddr4_cntrl {PHY_DDR4_MEM_CLK_FREQ_MHZ} {1066.667}
+  set_instance_parameter_value sys_ddr4_cntrl {PHY_DDR4_DEFAULT_REF_CLK_FREQ} {0}
+  set_instance_parameter_value sys_ddr4_cntrl {PHY_DDR4_USER_REF_CLK_FREQ_MHZ} {133.333}
+  set_instance_parameter_value sys_ddr4_cntrl {PHY_DDR4_RATE_ENUM} {RATE_QUARTER}
+  set_instance_parameter_value sys_ddr4_cntrl {MEM_DDR4_FORMAT_ENUM} {MEM_FORMAT_UDIMM}
+  set_instance_parameter_value sys_ddr4_cntrl {MEM_DDR4_DQ_WIDTH} {64}
+  set_instance_parameter_value sys_ddr4_cntrl {MEM_DDR4_DQ_PER_DQS} {8}
+  set_instance_parameter_value sys_ddr4_cntrl {MEM_DDR4_ROW_ADDR_WIDTH} {15}
+  set_instance_parameter_value sys_ddr4_cntrl {MEM_DDR4_COL_ADDR_WIDTH} {10}
+  set_instance_parameter_value sys_ddr4_cntrl {MEM_DDR4_BANK_ADDR_WIDTH} {2}
+  set_instance_parameter_value sys_ddr4_cntrl {MEM_DDR4_BANK_GROUP_WIDTH} {1}
+  set_instance_parameter_value sys_ddr4_cntrl {MEM_DDR4_DM_EN} {1}
+  set_instance_parameter_value sys_ddr4_cntrl {MEM_DDR4_ALERT_N_PLACEMENT_ENUM} {DDR4_ALERT_N_PLACEMENT_AC_LANES}
+  set_instance_parameter_value sys_ddr4_cntrl {MEM_DDR4_ALERT_N_AC_LANE} {3}
+  set_instance_parameter_value sys_ddr4_cntrl {MEM_DDR4_ALERT_N_AC_PIN} {0}
+  set_instance_parameter_value sys_ddr4_cntrl {MEM_DDR4_TCL} {18}
+  set_instance_parameter_value sys_ddr4_cntrl {MEM_DDR4_WTCL} {14}
+  set_instance_parameter_value sys_ddr4_cntrl {MEM_DDR4_RTT_NOM_ENUM} {DDR4_RTT_NOM_RZQ_4}
+  set_instance_parameter_value sys_ddr4_cntrl {PHY_DDR4_IO_VOLTAGE} {1.2}
+  set_instance_parameter_value sys_ddr4_cntrl {PHY_DDR4_DEFAULT_IO} {0}
+  set_instance_parameter_value sys_ddr4_cntrl {PHY_DDR4_USER_AC_IO_STD_ENUM} {IO_STD_SSTL_12}
+  set_instance_parameter_value sys_ddr4_cntrl {PHY_DDR4_USER_AC_MODE_ENUM} {OUT_OCT_40_CAL}
+  set_instance_parameter_value sys_ddr4_cntrl {PHY_DDR4_USER_CK_IO_STD_ENUM} {IO_STD_SSTL_12}
+  set_instance_parameter_value sys_ddr4_cntrl {PHY_DDR4_USER_CK_MODE_ENUM} {OUT_OCT_40_CAL}
+  set_instance_parameter_value sys_ddr4_cntrl {PHY_DDR4_USER_DATA_IO_STD_ENUM} {IO_STD_POD_12}
+  set_instance_parameter_value sys_ddr4_cntrl {PHY_DDR4_USER_DATA_OUT_MODE_ENUM} {OUT_OCT_48_CAL}
+  set_instance_parameter_value sys_ddr4_cntrl {PHY_DDR4_USER_DATA_IN_MODE_ENUM} {IN_OCT_60_CAL}
+  set_instance_parameter_value sys_ddr4_cntrl {PHY_DDR4_USER_PLL_REF_CLK_IO_STD_ENUM} {IO_STD_LVDS}
+  set_instance_parameter_value sys_ddr4_cntrl {PHY_DDR4_USER_RZQ_IO_STD_ENUM} {IO_STD_CMOS_12}
+  set_instance_parameter_value sys_ddr4_cntrl {MEM_DDR4_SPEEDBIN_ENUM} {DDR4_SPEEDBIN_2400}
+  set_instance_parameter_value sys_ddr4_cntrl {MEM_DDR4_TDQSQ_UI} {0.16}
+  set_instance_parameter_value sys_ddr4_cntrl {MEM_DDR4_TDQSCK_PS} {165}
+  set_instance_parameter_value sys_ddr4_cntrl {MEM_DDR4_TWLS_PS} {108.0}
+  set_instance_parameter_value sys_ddr4_cntrl {MEM_DDR4_TWLH_PS} {108.0}
+  set_instance_parameter_value sys_ddr4_cntrl {MEM_DDR4_TINIT_US} {500}
+  set_instance_parameter_value sys_ddr4_cntrl {MEM_DDR4_TRAS_NS} {32.0}
+  set_instance_parameter_value sys_ddr4_cntrl {MEM_DDR4_TRCD_NS} {15.0}
+  set_instance_parameter_value sys_ddr4_cntrl {MEM_DDR4_TRP_NS} {15.0}
+  set_instance_parameter_value sys_ddr4_cntrl {MEM_DDR4_TWR_NS} {15.0}
+  set_instance_parameter_value sys_ddr4_cntrl {MEM_DDR4_TRRD_S_CYC} {7}
+  set_instance_parameter_value sys_ddr4_cntrl {MEM_DDR4_TRRD_L_CYC} {8}
+  set_instance_parameter_value sys_ddr4_cntrl {MEM_DDR4_TFAW_NS} {30.0}
+  set_instance_parameter_value sys_ddr4_cntrl {MEM_DDR4_TCCD_S_CYC} {4}
+  set_instance_parameter_value sys_ddr4_cntrl {MEM_DDR4_TCCD_L_CYC} {6}
+  set_instance_parameter_value sys_ddr4_cntrl {MEM_DDR4_TWTR_S_CYC} {3}
+  set_instance_parameter_value sys_ddr4_cntrl {MEM_DDR4_TWTR_L_CYC} {9}
+  set_instance_parameter_value sys_ddr4_cntrl {CTRL_DDR4_ECC_EN} {0}
 
-add_interface sys_ddr_ref_clk clock sink
-set_interface_property sys_ddr_ref_clk EXPORT_OF sys_ddr4_cntrl.pll_ref_clk_clock_sink
-add_interface sys_ddr_oct conduit end
-set_interface_property sys_ddr_oct EXPORT_OF sys_ddr4_cntrl.oct_conduit_end
-add_interface sys_ddr_mem conduit end
-set_interface_property sys_ddr_mem EXPORT_OF sys_ddr4_cntrl.mem_conduit_end
-add_interface sys_ddr_status conduit end
-set_interface_property sys_ddr_status EXPORT_OF sys_ddr4_cntrl.status_conduit_end
+  add_interface sys_ddr_ref_clk clock sink
+  set_interface_property sys_ddr_ref_clk EXPORT_OF sys_ddr4_cntrl.pll_ref_clk_clock_sink
+  add_interface sys_ddr_oct conduit end
+  set_interface_property sys_ddr_oct EXPORT_OF sys_ddr4_cntrl.oct_conduit_end
+  add_interface sys_ddr_mem conduit end
+  set_interface_property sys_ddr_mem EXPORT_OF sys_ddr4_cntrl.mem_conduit_end
+  add_interface sys_ddr_status conduit end
+  set_interface_property sys_ddr_status EXPORT_OF sys_ddr4_cntrl.status_conduit_end
 
-add_instance $dac_fifo_name avl_dacfifo
-set_instance_parameter_value $dac_fifo_name {DAC_DATA_WIDTH} $dac_data_width
-set_instance_parameter_value $dac_fifo_name {DMA_DATA_WIDTH} $dac_dma_data_width
-set_instance_parameter_value $dac_fifo_name {AVL_DATA_WIDTH} {512}
-set_instance_parameter_value $dac_fifo_name {AVL_ADDRESS_WIDTH} {25}
-set_instance_parameter_value $dac_fifo_name {AVL_BASE_ADDRESS} {0}
-set_instance_parameter_value $dac_fifo_name {AVL_ADDRESS_LIMIT} {0x8fffffff}
-set_instance_parameter_value $dac_fifo_name {DAC_MEM_ADDRESS_WIDTH} {12}
-set_instance_parameter_value $dac_fifo_name {DMA_MEM_ADDRESS_WIDTH} {12}
-set_instance_parameter_value $dac_fifo_name {AVL_BURST_LENGTH} {64}
+  add_instance $dac_fifo_name avl_dacfifo
+  set_instance_parameter_value $dac_fifo_name {DAC_DATA_WIDTH} $dac_data_width
+  set_instance_parameter_value $dac_fifo_name {DMA_DATA_WIDTH} $dac_dma_data_width
+  set_instance_parameter_value $dac_fifo_name {AVL_DATA_WIDTH} {512}
+  set_instance_parameter_value $dac_fifo_name {AVL_ADDRESS_WIDTH} {25}
+  set_instance_parameter_value $dac_fifo_name {AVL_BASE_ADDRESS} {0}
+  set_instance_parameter_value $dac_fifo_name {AVL_ADDRESS_LIMIT} {0x8fffffff}
+  set_instance_parameter_value $dac_fifo_name {DAC_MEM_ADDRESS_WIDTH} {12}
+  set_instance_parameter_value $dac_fifo_name {DMA_MEM_ADDRESS_WIDTH} {12}
+  set_instance_parameter_value $dac_fifo_name {AVL_BURST_LENGTH} {64}
 
-add_connection sys_clk.clk_reset sys_ddr4_cntrl.global_reset_reset_sink
-add_connection sys_ddr4_cntrl.emif_usr_reset_reset_source $dac_fifo_name.avl_reset
-add_connection sys_ddr4_cntrl.emif_usr_clk_clock_source $dac_fifo_name.avl_clock
-add_connection $dac_fifo_name.amm_ddr sys_ddr4_cntrl.ctrl_amm_avalon_slave_0
-set_connection_parameter_value $dac_fifo_name.amm_ddr/sys_ddr4_cntrl.ctrl_amm_avalon_slave_0 baseAddress {0x0}
+  add_connection sys_clk.clk_reset sys_ddr4_cntrl.global_reset_reset_sink
+  add_connection sys_ddr4_cntrl.emif_usr_reset_reset_source $dac_fifo_name.avl_reset
+  add_connection sys_ddr4_cntrl.emif_usr_clk_clock_source $dac_fifo_name.avl_clock
+  add_connection $dac_fifo_name.amm_ddr sys_ddr4_cntrl.ctrl_amm_avalon_slave_0
+  set_connection_parameter_value $dac_fifo_name.amm_ddr/sys_ddr4_cntrl.ctrl_amm_avalon_slave_0 baseAddress {0x0}
 
 }

--- a/projects/common/altera/dacfifo_qsys.tcl
+++ b/projects/common/altera/dacfifo_qsys.tcl
@@ -1,4 +1,6 @@
 
+proc ad_dacfifo_create {dac_fifo_name dac_data_width dac_dma_data_width dac_fifo_address_width} {
+
 if {$dac_data_width != $dac_dma_data_width} {
   return -code error [format "ERROR: util_dacfifo dac/dma widths must be the same!"]
 }
@@ -7,4 +9,5 @@ add_instance $dac_fifo_name util_dacfifo
 set_instance_parameter_value $dac_fifo_name {ADDRESS_WIDTH} $dac_fifo_address_width
 set_instance_parameter_value $dac_fifo_name {DATA_WIDTH} $dac_data_width
 
+}
 

--- a/projects/common/altera/dacfifo_qsys.tcl
+++ b/projects/common/altera/dacfifo_qsys.tcl
@@ -1,13 +1,13 @@
 
 proc ad_dacfifo_create {dac_fifo_name dac_data_width dac_dma_data_width dac_fifo_address_width} {
 
-if {$dac_data_width != $dac_dma_data_width} {
-  return -code error [format "ERROR: util_dacfifo dac/dma widths must be the same!"]
-}
+  if {$dac_data_width != $dac_dma_data_width} {
+    return -code error [format "ERROR: util_dacfifo dac/dma widths must be the same!"]
+  }
 
-add_instance $dac_fifo_name util_dacfifo
-set_instance_parameter_value $dac_fifo_name {ADDRESS_WIDTH} $dac_fifo_address_width
-set_instance_parameter_value $dac_fifo_name {DATA_WIDTH} $dac_data_width
+  add_instance $dac_fifo_name util_dacfifo
+  set_instance_parameter_value $dac_fifo_name {ADDRESS_WIDTH} $dac_fifo_address_width
+  set_instance_parameter_value $dac_fifo_name {DATA_WIDTH} $dac_data_width
 
 }
 

--- a/projects/common/xilinx/adcfifo_bd.tcl
+++ b/projects/common/xilinx/adcfifo_bd.tcl
@@ -1,10 +1,13 @@
 # sys bram (use only when dma is not capable of keeping up).
 # generic fifo interface - existence is oblivious to software.
 
+proc ad_adcfifo_create {adc_fifo_name adc_data_width adc_dma_data_width adc_fifo_address_width} {
+
 ad_ip_instance util_adcfifo $adc_fifo_name
 ad_ip_parameter $adc_fifo_name CONFIG.ADC_DATA_WIDTH $adc_data_width
 ad_ip_parameter $adc_fifo_name CONFIG.DMA_DATA_WIDTH $adc_dma_data_width
 ad_ip_parameter $adc_fifo_name CONFIG.DMA_READY_ENABLE 1
 ad_ip_parameter $adc_fifo_name CONFIG.DMA_ADDRESS_WIDTH $adc_fifo_address_width
 
+}
 

--- a/projects/common/xilinx/adcfifo_bd.tcl
+++ b/projects/common/xilinx/adcfifo_bd.tcl
@@ -3,11 +3,11 @@
 
 proc ad_adcfifo_create {adc_fifo_name adc_data_width adc_dma_data_width adc_fifo_address_width} {
 
-ad_ip_instance util_adcfifo $adc_fifo_name
-ad_ip_parameter $adc_fifo_name CONFIG.ADC_DATA_WIDTH $adc_data_width
-ad_ip_parameter $adc_fifo_name CONFIG.DMA_DATA_WIDTH $adc_dma_data_width
-ad_ip_parameter $adc_fifo_name CONFIG.DMA_READY_ENABLE 1
-ad_ip_parameter $adc_fifo_name CONFIG.DMA_ADDRESS_WIDTH $adc_fifo_address_width
+  ad_ip_instance util_adcfifo $adc_fifo_name
+  ad_ip_parameter $adc_fifo_name CONFIG.ADC_DATA_WIDTH $adc_data_width
+  ad_ip_parameter $adc_fifo_name CONFIG.DMA_DATA_WIDTH $adc_dma_data_width
+  ad_ip_parameter $adc_fifo_name CONFIG.DMA_READY_ENABLE 1
+  ad_ip_parameter $adc_fifo_name CONFIG.DMA_ADDRESS_WIDTH $adc_fifo_address_width
 
 }
 

--- a/projects/common/xilinx/dacfifo_bd.tcl
+++ b/projects/common/xilinx/dacfifo_bd.tcl
@@ -1,5 +1,6 @@
 # sys bram (use only when dma is not capable of keeping up).
 # generic fifo interface - existence is oblivious to software.
+proc ad_dacfifo_create {dac_fifo_name dac_data_width dac_dma_data_width dac_fifo_address_width} {
 
 if {$dac_data_width != $dac_dma_data_width} {
   return -code error [format "ERROR: util_dacfifo dac/dma widths must be the same!"]
@@ -9,3 +10,4 @@ ad_ip_instance util_dacfifo $dac_fifo_name
 ad_ip_parameter $dac_fifo_name CONFIG.DATA_WIDTH $dac_data_width
 ad_ip_parameter $dac_fifo_name CONFIG.ADDRESS_WIDTH $dac_fifo_address_width
 
+}

--- a/projects/common/xilinx/dacfifo_bd.tcl
+++ b/projects/common/xilinx/dacfifo_bd.tcl
@@ -2,12 +2,12 @@
 # generic fifo interface - existence is oblivious to software.
 proc ad_dacfifo_create {dac_fifo_name dac_data_width dac_dma_data_width dac_fifo_address_width} {
 
-if {$dac_data_width != $dac_dma_data_width} {
-  return -code error [format "ERROR: util_dacfifo dac/dma widths must be the same!"]
-}
+  if {$dac_data_width != $dac_dma_data_width} {
+    return -code error [format "ERROR: util_dacfifo dac/dma widths must be the same!"]
+  }
 
-ad_ip_instance util_dacfifo $dac_fifo_name
-ad_ip_parameter $dac_fifo_name CONFIG.DATA_WIDTH $dac_data_width
-ad_ip_parameter $dac_fifo_name CONFIG.ADDRESS_WIDTH $dac_fifo_address_width
+  ad_ip_instance util_dacfifo $dac_fifo_name
+  ad_ip_parameter $dac_fifo_name CONFIG.DATA_WIDTH $dac_data_width
+  ad_ip_parameter $dac_fifo_name CONFIG.ADDRESS_WIDTH $dac_fifo_address_width
 
 }

--- a/projects/common/zc706/zc706_plddr3_adcfifo_bd.tcl
+++ b/projects/common/zc706/zc706_plddr3_adcfifo_bd.tcl
@@ -1,6 +1,10 @@
 # pl ddr3 (use only when dma is not capable of keeping up).
 # generic fifo interface - existence is oblivious to software.
 
+proc ad_adcfifo_create {adc_fifo_name adc_data_width adc_dma_data_width adc_fifo_address_width} {
+
+upvar ad_hdl_dir ad_hdl_dir
+
 ad_ip_instance proc_sys_reset axi_rstgen
 ad_ip_instance mig_7series axi_ddr_cntrl
 
@@ -38,3 +42,4 @@ ad_connect  axi_ddr_cntrl/device_temp_i GND
 
 assign_bd_address [get_bd_addr_segs -of_objects [get_bd_cells axi_ddr_cntrl]]
 
+}

--- a/projects/common/zc706/zc706_plddr3_adcfifo_bd.tcl
+++ b/projects/common/zc706/zc706_plddr3_adcfifo_bd.tcl
@@ -3,43 +3,43 @@
 
 proc ad_adcfifo_create {adc_fifo_name adc_data_width adc_dma_data_width adc_fifo_address_width} {
 
-upvar ad_hdl_dir ad_hdl_dir
+  upvar ad_hdl_dir ad_hdl_dir
 
-ad_ip_instance proc_sys_reset axi_rstgen
-ad_ip_instance mig_7series axi_ddr_cntrl
+  ad_ip_instance proc_sys_reset axi_rstgen
+  ad_ip_instance mig_7series axi_ddr_cntrl
 
-file copy -force $ad_hdl_dir/projects/common/zc706/zc706_plddr3_mig.prj [get_property IP_DIR \
-  [get_ips [get_property CONFIG.Component_Name [get_bd_cells axi_ddr_cntrl]]]]
-ad_ip_parameter axi_ddr_cntrl CONFIG.XML_INPUT_FILE zc706_plddr3_mig.prj
+  file copy -force $ad_hdl_dir/projects/common/zc706/zc706_plddr3_mig.prj [get_property IP_DIR \
+    [get_ips [get_property CONFIG.Component_Name [get_bd_cells axi_ddr_cntrl]]]]
+  ad_ip_parameter axi_ddr_cntrl CONFIG.XML_INPUT_FILE zc706_plddr3_mig.prj
 
-create_bd_port -dir I -type rst sys_rst
-set_property CONFIG.POLARITY ACTIVE_HIGH [get_bd_ports sys_rst]
+  create_bd_port -dir I -type rst sys_rst
+  set_property CONFIG.POLARITY ACTIVE_HIGH [get_bd_ports sys_rst]
 
-create_bd_intf_port -mode Master -vlnv xilinx.com:interface:ddrx_rtl:1.0 ddr3
-create_bd_intf_port -mode Slave -vlnv xilinx.com:interface:diff_clock_rtl:1.0 sys_clk
+  create_bd_intf_port -mode Master -vlnv xilinx.com:interface:ddrx_rtl:1.0 ddr3
+  create_bd_intf_port -mode Slave -vlnv xilinx.com:interface:diff_clock_rtl:1.0 sys_clk
 
-ad_connect  sys_rst axi_ddr_cntrl/sys_rst
-ad_connect  sys_clk axi_ddr_cntrl/SYS_CLK
-ad_connect  ddr3 axi_ddr_cntrl/DDR3
+  ad_connect  sys_rst axi_ddr_cntrl/sys_rst
+  ad_connect  sys_clk axi_ddr_cntrl/SYS_CLK
+  ad_connect  ddr3 axi_ddr_cntrl/DDR3
 
-ad_ip_instance axi_adcfifo $adc_fifo_name
-ad_ip_parameter $adc_fifo_name CONFIG.ADC_DATA_WIDTH $adc_data_width
-ad_ip_parameter $adc_fifo_name CONFIG.DMA_DATA_WIDTH $adc_dma_data_width
-ad_ip_parameter $adc_fifo_name CONFIG.AXI_DATA_WIDTH 512
-ad_ip_parameter $adc_fifo_name CONFIG.DMA_READY_ENABLE 1
-ad_ip_parameter $adc_fifo_name CONFIG.AXI_SIZE 6
-ad_ip_parameter $adc_fifo_name CONFIG.AXI_LENGTH 4
-ad_ip_parameter $adc_fifo_name CONFIG.AXI_ADDRESS 0x80000000
-ad_ip_parameter $adc_fifo_name CONFIG.AXI_ADDRESS_LIMIT 0xa0000000
+  ad_ip_instance axi_adcfifo $adc_fifo_name
+  ad_ip_parameter $adc_fifo_name CONFIG.ADC_DATA_WIDTH $adc_data_width
+  ad_ip_parameter $adc_fifo_name CONFIG.DMA_DATA_WIDTH $adc_dma_data_width
+  ad_ip_parameter $adc_fifo_name CONFIG.AXI_DATA_WIDTH 512
+  ad_ip_parameter $adc_fifo_name CONFIG.DMA_READY_ENABLE 1
+  ad_ip_parameter $adc_fifo_name CONFIG.AXI_SIZE 6
+  ad_ip_parameter $adc_fifo_name CONFIG.AXI_LENGTH 4
+  ad_ip_parameter $adc_fifo_name CONFIG.AXI_ADDRESS 0x80000000
+  ad_ip_parameter $adc_fifo_name CONFIG.AXI_ADDRESS_LIMIT 0xa0000000
 
-ad_connect  axi_ddr_cntrl/S_AXI $adc_fifo_name/axi
-ad_connect  axi_ddr_cntrl/ui_clk $adc_fifo_name/axi_clk
-ad_connect  axi_ddr_cntrl/ui_clk axi_rstgen/slowest_sync_clk
-ad_connect  sys_cpu_resetn axi_rstgen/ext_reset_in
-ad_connect  axi_rstgen/peripheral_aresetn $adc_fifo_name/axi_resetn
-ad_connect  axi_rstgen/peripheral_aresetn axi_ddr_cntrl/aresetn
-ad_connect  axi_ddr_cntrl/device_temp_i GND
+  ad_connect  axi_ddr_cntrl/S_AXI $adc_fifo_name/axi
+  ad_connect  axi_ddr_cntrl/ui_clk $adc_fifo_name/axi_clk
+  ad_connect  axi_ddr_cntrl/ui_clk axi_rstgen/slowest_sync_clk
+  ad_connect  sys_cpu_resetn axi_rstgen/ext_reset_in
+  ad_connect  axi_rstgen/peripheral_aresetn $adc_fifo_name/axi_resetn
+  ad_connect  axi_rstgen/peripheral_aresetn axi_ddr_cntrl/aresetn
+  ad_connect  axi_ddr_cntrl/device_temp_i GND
 
-assign_bd_address [get_bd_addr_segs -of_objects [get_bd_cells axi_ddr_cntrl]]
+  assign_bd_address [get_bd_addr_segs -of_objects [get_bd_cells axi_ddr_cntrl]]
 
 }

--- a/projects/common/zc706/zc706_plddr3_dacfifo_bd.tcl
+++ b/projects/common/zc706/zc706_plddr3_dacfifo_bd.tcl
@@ -1,6 +1,10 @@
 # pl ddr3 (use only when dma is not capable of keeping up).
 # generic fifo interface - existence is oblivious to software.
 
+proc ad_dacfifo_create {dac_fifo_name dac_data_width dac_dma_data_width dac_fifo_address_width} {
+
+upvar ad_hdl_dir ad_hdl_dir
+
 ad_ip_instance proc_sys_reset axi_rstgen
 ad_ip_instance mig_7series axi_ddr_cntrl
 
@@ -37,3 +41,4 @@ ad_connect  axi_ddr_cntrl/device_temp_i GND
 
 assign_bd_address [get_bd_addr_segs -of_objects [get_bd_cells axi_ddr_cntrl]]
 
+}

--- a/projects/common/zc706/zc706_plddr3_dacfifo_bd.tcl
+++ b/projects/common/zc706/zc706_plddr3_dacfifo_bd.tcl
@@ -3,42 +3,42 @@
 
 proc ad_dacfifo_create {dac_fifo_name dac_data_width dac_dma_data_width dac_fifo_address_width} {
 
-upvar ad_hdl_dir ad_hdl_dir
+  upvar ad_hdl_dir ad_hdl_dir
 
-ad_ip_instance proc_sys_reset axi_rstgen
-ad_ip_instance mig_7series axi_ddr_cntrl
+  ad_ip_instance proc_sys_reset axi_rstgen
+  ad_ip_instance mig_7series axi_ddr_cntrl
 
-file copy -force $ad_hdl_dir/projects/common/zc706/zc706_plddr3_mig.prj [get_property IP_DIR \
-  [get_ips [get_property CONFIG.Component_Name [get_bd_cells axi_ddr_cntrl]]]]
-ad_ip_parameter axi_ddr_cntrl CONFIG.XML_INPUT_FILE zc706_plddr3_mig.prj
+  file copy -force $ad_hdl_dir/projects/common/zc706/zc706_plddr3_mig.prj [get_property IP_DIR \
+    [get_ips [get_property CONFIG.Component_Name [get_bd_cells axi_ddr_cntrl]]]]
+  ad_ip_parameter axi_ddr_cntrl CONFIG.XML_INPUT_FILE zc706_plddr3_mig.prj
 
-create_bd_port -dir I -type rst sys_rst
-set_property CONFIG.POLARITY ACTIVE_HIGH [get_bd_ports sys_rst]
+  create_bd_port -dir I -type rst sys_rst
+  set_property CONFIG.POLARITY ACTIVE_HIGH [get_bd_ports sys_rst]
 
-create_bd_intf_port -mode Master -vlnv xilinx.com:interface:ddrx_rtl:1.0 ddr3
-create_bd_intf_port -mode Slave -vlnv xilinx.com:interface:diff_clock_rtl:1.0 sys_clk
+  create_bd_intf_port -mode Master -vlnv xilinx.com:interface:ddrx_rtl:1.0 ddr3
+  create_bd_intf_port -mode Slave -vlnv xilinx.com:interface:diff_clock_rtl:1.0 sys_clk
 
-ad_connect  sys_rst axi_ddr_cntrl/sys_rst
-ad_connect  sys_clk axi_ddr_cntrl/SYS_CLK
-ad_connect  ddr3 axi_ddr_cntrl/DDR3
+  ad_connect  sys_rst axi_ddr_cntrl/sys_rst
+  ad_connect  sys_clk axi_ddr_cntrl/SYS_CLK
+  ad_connect  ddr3 axi_ddr_cntrl/DDR3
 
-ad_ip_instance axi_dacfifo $dac_fifo_name
-ad_ip_parameter $dac_fifo_name CONFIG.DAC_DATA_WIDTH $dac_data_width
-ad_ip_parameter $dac_fifo_name CONFIG.DMA_DATA_WIDTH $dac_dma_data_width
-ad_ip_parameter $dac_fifo_name CONFIG.AXI_DATA_WIDTH 512
-ad_ip_parameter $dac_fifo_name CONFIG.AXI_SIZE 6
-ad_ip_parameter $dac_fifo_name CONFIG.AXI_LENGTH 255
-ad_ip_parameter $dac_fifo_name CONFIG.AXI_ADDRESS 0x80000000
-ad_ip_parameter $dac_fifo_name CONFIG.AXI_ADDRESS_LIMIT 0xa0000000
+  ad_ip_instance axi_dacfifo $dac_fifo_name
+  ad_ip_parameter $dac_fifo_name CONFIG.DAC_DATA_WIDTH $dac_data_width
+  ad_ip_parameter $dac_fifo_name CONFIG.DMA_DATA_WIDTH $dac_dma_data_width
+  ad_ip_parameter $dac_fifo_name CONFIG.AXI_DATA_WIDTH 512
+  ad_ip_parameter $dac_fifo_name CONFIG.AXI_SIZE 6
+  ad_ip_parameter $dac_fifo_name CONFIG.AXI_LENGTH 255
+  ad_ip_parameter $dac_fifo_name CONFIG.AXI_ADDRESS 0x80000000
+  ad_ip_parameter $dac_fifo_name CONFIG.AXI_ADDRESS_LIMIT 0xa0000000
 
-ad_connect  axi_ddr_cntrl/S_AXI $dac_fifo_name/axi
-ad_connect  axi_ddr_cntrl/ui_clk $dac_fifo_name/axi_clk
-ad_connect  axi_ddr_cntrl/ui_clk axi_rstgen/slowest_sync_clk
-ad_connect  sys_cpu_resetn axi_rstgen/ext_reset_in
-ad_connect  axi_rstgen/peripheral_aresetn $dac_fifo_name/axi_resetn
-ad_connect  axi_rstgen/peripheral_aresetn axi_ddr_cntrl/aresetn
-ad_connect  axi_ddr_cntrl/device_temp_i GND
+  ad_connect  axi_ddr_cntrl/S_AXI $dac_fifo_name/axi
+  ad_connect  axi_ddr_cntrl/ui_clk $dac_fifo_name/axi_clk
+  ad_connect  axi_ddr_cntrl/ui_clk axi_rstgen/slowest_sync_clk
+  ad_connect  sys_cpu_resetn axi_rstgen/ext_reset_in
+  ad_connect  axi_rstgen/peripheral_aresetn $dac_fifo_name/axi_resetn
+  ad_connect  axi_rstgen/peripheral_aresetn axi_ddr_cntrl/aresetn
+  ad_connect  axi_ddr_cntrl/device_temp_i GND
 
-assign_bd_address [get_bd_addr_segs -of_objects [get_bd_cells axi_ddr_cntrl]]
+  assign_bd_address [get_bd_addr_segs -of_objects [get_bd_cells axi_ddr_cntrl]]
 
 }

--- a/projects/daq2/a10gx/system_qsys.tcl
+++ b/projects/daq2/a10gx/system_qsys.tcl
@@ -1,8 +1,5 @@
 
-set dac_fifo_name avl_ad9144_fifo
 set dac_fifo_address_width 10
-set dac_data_width 128
-set dac_dma_data_width 128
 
 source $ad_hdl_dir/projects/common/a10gx/a10gx_system_qsys.tcl
 source $ad_hdl_dir/projects/common/altera/dacfifo_qsys.tcl

--- a/projects/daq2/a10soc/system_qsys.tcl
+++ b/projects/daq2/a10soc/system_qsys.tcl
@@ -1,8 +1,5 @@
 
-set dac_fifo_name avl_ad9144_fifo
 set dac_fifo_address_width 10
-set dac_data_width 128
-set dac_dma_data_width 128
 
 source $ad_hdl_dir/projects/common/a10soc/a10soc_system_qsys.tcl
 source $ad_hdl_dir/projects/common/a10soc/a10soc_plddr4_dacfifo_qsys.tcl

--- a/projects/daq2/common/daq2_bd.tcl
+++ b/projects/daq2/common/daq2_bd.tcl
@@ -1,6 +1,14 @@
 
 source $ad_hdl_dir/library/jesd204/scripts/jesd204.tcl
 
+set adc_fifo_name axi_ad9680_fifo
+set adc_data_width 128
+set adc_dma_data_width 64
+
+set dac_fifo_name axi_ad9144_fifo
+set dac_data_width 128
+set dac_dma_data_width 128
+
 # dac peripherals
 
 ad_ip_instance axi_adxcvr axi_ad9144_xcvr
@@ -31,6 +39,8 @@ ad_ip_parameter axi_ad9144_dma CONFIG.CYCLIC 0
 ad_ip_parameter axi_ad9144_dma CONFIG.DMA_DATA_WIDTH_SRC 128
 ad_ip_parameter axi_ad9144_dma CONFIG.DMA_DATA_WIDTH_DEST 128
 
+ad_dacfifo_create $dac_fifo_name $dac_data_width $dac_dma_data_width $dac_fifo_address_width
+
 # adc peripherals
 
 ad_ip_instance axi_adxcvr axi_ad9680_xcvr
@@ -60,6 +70,8 @@ ad_ip_parameter axi_ad9680_dma CONFIG.DMA_2D_TRANSFER 0
 ad_ip_parameter axi_ad9680_dma CONFIG.CYCLIC 0
 ad_ip_parameter axi_ad9680_dma CONFIG.DMA_DATA_WIDTH_SRC 64
 ad_ip_parameter axi_ad9680_dma CONFIG.DMA_DATA_WIDTH_DEST 64
+
+ad_adcfifo_create $adc_fifo_name $adc_data_width $adc_dma_data_width $adc_fifo_address_width
 
 # shared transceiver core
 

--- a/projects/daq2/common/daq2_qsys.tcl
+++ b/projects/daq2/common/daq2_qsys.tcl
@@ -1,4 +1,8 @@
 
+set dac_fifo_name avl_ad9144_fifo
+set dac_data_width 128
+set dac_dma_data_width 128
+
 # ad9144-xcvr
 
 add_instance ad9144_jesd204 adi_jesd204
@@ -44,6 +48,8 @@ add_connection axi_ad9144_core.dac_ch_0 util_ad9144_upack.dac_ch_0
 add_connection axi_ad9144_core.dac_ch_1 util_ad9144_upack.dac_ch_1
 
 # dac fifo
+
+ad_dacfifo_create $dac_fifo_name $dac_data_width $dac_dma_data_width $dac_fifo_address_width
 
 add_interface tx_fifo_bypass conduit end
 set_interface_property tx_fifo_bypass EXPORT_OF avl_ad9144_fifo.if_bypass

--- a/projects/daq2/kc705/system_bd.tcl
+++ b/projects/daq2/kc705/system_bd.tcl
@@ -1,15 +1,9 @@
 
 ## FIFO depth is 4Mb - 250k samples
-set adc_fifo_name axi_ad9680_fifo
 set adc_fifo_address_width 16
-set adc_data_width 128
-set adc_dma_data_width 64
 
 ## FIFO depth is 4Mb - 250k samples
-set dac_fifo_name axi_ad9144_fifo
 set dac_fifo_address_width 15
-set dac_data_width 128
-set dac_dma_data_width 128
 
 ## NOTE: With this configuration the #36Kb BRAM utilization is at ~80%
 

--- a/projects/daq2/kcu105/system_bd.tcl
+++ b/projects/daq2/kcu105/system_bd.tcl
@@ -1,15 +1,9 @@
 
 ## FIFO depth is 4Mb - 250k samples
-set adc_fifo_name axi_ad9680_fifo
 set adc_fifo_address_width 16
-set adc_data_width 128
-set adc_dma_data_width 64
 
 ## FIFO depth is 4Mb - 250k samples
-set dac_fifo_name axi_ad9144_fifo
 set dac_fifo_address_width 15
-set dac_data_width 128
-set dac_dma_data_width 128
 
 ## NOTE: With this configuration the #36Kb BRAM utilization is at ~70%
 

--- a/projects/daq2/vc707/system_bd.tcl
+++ b/projects/daq2/vc707/system_bd.tcl
@@ -1,15 +1,9 @@
 
 ## FIFO depth is 8Mb - 500k samples
-set adc_fifo_name axi_ad9680_fifo
 set adc_fifo_address_width 17
-set adc_data_width 128
-set adc_dma_data_width 64
 
 ## FIFO depth is 8Mb - 500k samples
-set dac_fifo_name axi_ad9144_fifo
 set dac_fifo_address_width 16
-set dac_data_width 128
-set dac_dma_data_width 128
 
 ## NOTE: With this configuration the #36Kb BRAM utilization is at ~68.45%
 

--- a/projects/daq2/zc706/system_bd.tcl
+++ b/projects/daq2/zc706/system_bd.tcl
@@ -1,15 +1,9 @@
 
 ## FIFO depth is 1GB, PL_DDR is used
-set adc_fifo_name axi_ad9680_fifo
 set adc_fifo_address_width 16
-set adc_data_width 128
-set adc_dma_data_width 64
 
 ## FIFO depth is 8Mb - 500k samples
-set dac_fifo_name axi_ad9144_fifo
 set dac_fifo_address_width 16
-set dac_data_width 128
-set dac_dma_data_width 128
 
 ## NOTE: With this configuration the #36Kb BRAM utilization is at ~51%
 

--- a/projects/daq2/zcu102/system_bd.tcl
+++ b/projects/daq2/zcu102/system_bd.tcl
@@ -1,15 +1,9 @@
 
 ## FIFO depth is 8Mb - 500k samples
-set adc_fifo_name axi_ad9680_fifo
 set adc_fifo_address_width 17
-set adc_data_width 128
-set adc_dma_data_width 64
 
 ## FIFO depth is 8Mb - 500k samples
-set dac_fifo_name axi_ad9144_fifo
 set dac_fifo_address_width 16
-set dac_data_width 128
-set dac_dma_data_width 128
 
 ## NOTE: With this configuration the #36Kb BRAM utilization is at ~57%
 

--- a/projects/daq3/a10gx/system_qsys.tcl
+++ b/projects/daq3/a10gx/system_qsys.tcl
@@ -1,8 +1,5 @@
 
-set dac_fifo_name avl_ad9152_fifo
 set dac_fifo_address_width 10
-set dac_data_width 128
-set dac_dma_data_width 128
 
 source $ad_hdl_dir/projects/common/a10gx/a10gx_system_qsys.tcl
 source $ad_hdl_dir/projects/common/altera/dacfifo_qsys.tcl

--- a/projects/daq3/common/daq3_bd.tcl
+++ b/projects/daq3/common/daq3_bd.tcl
@@ -1,6 +1,14 @@
 
 source $ad_hdl_dir/library/jesd204/scripts/jesd204.tcl
 
+set adc_fifo_name axi_ad9680_fifo
+set adc_data_width 128
+set adc_dma_data_width 64
+
+set dac_fifo_name axi_ad9152_fifo
+set dac_data_width 128
+set dac_dma_data_width 128
+
 # dac peripherals
 
 ad_ip_instance axi_adxcvr axi_ad9152_xcvr
@@ -29,6 +37,8 @@ ad_ip_parameter axi_ad9152_dma CONFIG.DMA_2D_TRANSFER 0
 ad_ip_parameter axi_ad9152_dma CONFIG.CYCLIC 0
 ad_ip_parameter axi_ad9152_dma CONFIG.DMA_DATA_WIDTH_SRC 128
 ad_ip_parameter axi_ad9152_dma CONFIG.DMA_DATA_WIDTH_DEST 128
+
+ad_dacfifo_create $dac_fifo_name $dac_data_width $dac_dma_data_width $dac_fifo_address_width
 
 # adc peripherals
 
@@ -59,6 +69,10 @@ ad_ip_parameter axi_ad9680_dma CONFIG.DMA_2D_TRANSFER 0
 ad_ip_parameter axi_ad9680_dma CONFIG.CYCLIC 0
 ad_ip_parameter axi_ad9680_dma CONFIG.DMA_DATA_WIDTH_SRC 64
 ad_ip_parameter axi_ad9680_dma CONFIG.DMA_DATA_WIDTH_DEST 64
+
+if {$sys_zynq == 0 || $sys_zynq == 1} {
+  ad_adcfifo_create $adc_fifo_name $adc_data_width $adc_dma_data_width $adc_fifo_address_width
+}
 
 # shared transceiver core
 

--- a/projects/daq3/common/daq3_qsys.tcl
+++ b/projects/daq3/common/daq3_qsys.tcl
@@ -1,3 +1,6 @@
+set dac_fifo_name avl_ad9152_fifo
+set dac_data_width 128
+set dac_dma_data_width 128
 
 # ad9152-xcvr
 
@@ -43,6 +46,8 @@ add_connection axi_ad9152_core.dac_ch_0 util_ad9152_upack.dac_ch_0
 add_connection axi_ad9152_core.dac_ch_1 util_ad9152_upack.dac_ch_1
 
 # dac fifo
+
+ad_dacfifo_create $dac_fifo_name $dac_data_width $dac_dma_data_width $dac_fifo_address_width
 
 add_interface tx_fifo_bypass conduit end
 set_interface_property tx_fifo_bypass EXPORT_OF avl_ad9152_fifo.if_bypass

--- a/projects/daq3/kcu105/system_bd.tcl
+++ b/projects/daq3/kcu105/system_bd.tcl
@@ -1,15 +1,9 @@
 
 ## FIFO depth is 4Mb - 250k samples
-set adc_fifo_name axi_ad9680_fifo
 set adc_fifo_address_width 16
-set adc_data_width 128
-set adc_dma_data_width 64
 
 ## FIFO depth is 4Mb - 250k samples
-set dac_fifo_name axi_ad9152_fifo
 set dac_fifo_address_width 15
-set dac_data_width 128
-set dac_dma_data_width 128
 
 ## NOTE: With this configuration the #36Kb BRAM utilization is at ~70%
 

--- a/projects/daq3/zc706/system_bd.tcl
+++ b/projects/daq3/zc706/system_bd.tcl
@@ -1,15 +1,9 @@
 
 ## FIFO depth is 1GB, PL_DDR is used
-set adc_fifo_name axi_ad9680_fifo
 set adc_fifo_address_width 16
-set adc_data_width 128
-set adc_dma_data_width 64
 
 ## FIFO depth is 8Mb - 500k samples
-set dac_fifo_name axi_ad9152_fifo
 set dac_fifo_address_width 16
-set dac_data_width 128
-set dac_dma_data_width 128
 
 ## NOTE: With this configuration the #36Kb BRAM utilization is at ~47%
 

--- a/projects/daq3/zcu102/system_bd.tcl
+++ b/projects/daq3/zcu102/system_bd.tcl
@@ -1,9 +1,6 @@
 
 ## FIFO depth is 8Mb - 500k samples
-set dac_fifo_name axi_ad9152_fifo
 set dac_fifo_address_width 16
-set dac_data_width 128
-set dac_dma_data_width 128
 
 ## NOTE: With this configuration the #36Kb BRAM utilization is at ~28%
 

--- a/projects/fmcadc2/common/fmcadc2_bd.tcl
+++ b/projects/fmcadc2/common/fmcadc2_bd.tcl
@@ -1,6 +1,10 @@
 
 source $ad_hdl_dir/library/jesd204/scripts/jesd204.tcl
 
+set adc_fifo_name axi_ad9625_fifo
+set adc_data_width 256
+set adc_dma_data_width 64
+
 # adc peripherals
 
 ad_ip_instance axi_ad9625 axi_ad9625_core
@@ -27,6 +31,8 @@ ad_ip_parameter axi_ad9625_dma CONFIG.DMA_2D_TRANSFER 0
 ad_ip_parameter axi_ad9625_dma CONFIG.CYCLIC 0
 ad_ip_parameter axi_ad9625_dma CONFIG.DMA_DATA_WIDTH_SRC 64
 ad_ip_parameter axi_ad9625_dma CONFIG.DMA_DATA_WIDTH_DEST 64
+
+ad_adcfifo_create $adc_fifo_name $adc_data_width $adc_dma_data_width $adc_fifo_address_width
 
 ad_ip_instance util_adxcvr util_fmcadc2_xcvr
 ad_ip_parameter util_fmcadc2_xcvr CONFIG.QPLL_FBDIV 0x80 ;# N = 40

--- a/projects/fmcadc2/vc707/system_bd.tcl
+++ b/projects/fmcadc2/vc707/system_bd.tcl
@@ -1,9 +1,6 @@
 
 ## FIFO depth is 16Mb - 1M samples
-set adc_fifo_name axi_ad9625_fifo
 set adc_fifo_address_width 18
-set adc_data_width 256
-set adc_dma_data_width 64
 
 ## NOTE: With this configuration the #36Kb BRAM utilization is at ~68%
 

--- a/projects/fmcadc2/zc706/system_bd.tcl
+++ b/projects/fmcadc2/zc706/system_bd.tcl
@@ -1,8 +1,5 @@
 
-set adc_fifo_name axi_ad9625_fifo
 set adc_fifo_address_width 18
-set adc_data_width 256
-set adc_dma_data_width 64
 
 source $ad_hdl_dir/projects/common/zc706/zc706_system_bd.tcl
 source $ad_hdl_dir/projects/common/zc706/zc706_plddr3_adcfifo_bd.tcl

--- a/projects/fmcadc4/common/fmcadc4_bd.tcl
+++ b/projects/fmcadc4/common/fmcadc4_bd.tcl
@@ -1,6 +1,10 @@
 
 source $ad_hdl_dir/library/jesd204/scripts/jesd204.tcl
 
+set adc_fifo_name axi_ad9680_fifo
+set adc_data_width 256
+set adc_dma_data_width 64
+
 # fmcadc4
 
 # adc peripherals
@@ -29,6 +33,8 @@ ad_ip_parameter axi_ad9680_dma CONFIG.DMA_2D_TRANSFER 0
 ad_ip_parameter axi_ad9680_dma CONFIG.CYCLIC 0
 ad_ip_parameter axi_ad9680_dma CONFIG.DMA_DATA_WIDTH_SRC 64
 ad_ip_parameter axi_ad9680_dma CONFIG.DMA_DATA_WIDTH_DEST 64
+
+ad_adcfifo_create $adc_fifo_name $adc_data_width $adc_dma_data_width $adc_fifo_address_width
 
 ad_ip_instance util_cpack2 axi_ad9680_cpack { \
   NUM_OF_CHANNELS 4 \

--- a/projects/fmcadc4/zc706/system_bd.tcl
+++ b/projects/fmcadc4/zc706/system_bd.tcl
@@ -1,8 +1,5 @@
 
-set adc_fifo_name axi_ad9680_fifo
 set adc_fifo_address_width 18
-set adc_data_width 256
-set adc_dma_data_width 64
 
 source $ad_hdl_dir/projects/common/zc706/zc706_system_bd.tcl
 source $ad_hdl_dir/projects/common/zc706/zc706_plddr3_adcfifo_bd.tcl

--- a/projects/fmcadc5/common/fmcadc5_bd.tcl
+++ b/projects/fmcadc5/common/fmcadc5_bd.tcl
@@ -2,6 +2,10 @@
 
 source $ad_hdl_dir/library/jesd204/scripts/jesd204.tcl
 
+set adc_fifo_name axi_ad9625_fifo
+set adc_data_width 512
+set adc_dma_data_width 64
+
 # adc peripherals
 
 ad_ip_instance util_adxcvr util_fmcadc5_0_xcvr
@@ -68,6 +72,8 @@ ad_ip_parameter axi_ad9625_dma CONFIG.DMA_2D_TRANSFER 0
 ad_ip_parameter axi_ad9625_dma CONFIG.CYCLIC 0
 ad_ip_parameter axi_ad9625_dma CONFIG.DMA_DATA_WIDTH_SRC 64
 ad_ip_parameter axi_ad9625_dma CONFIG.DMA_DATA_WIDTH_DEST 64
+
+ad_adcfifo_create $adc_fifo_name $adc_data_width $adc_dma_data_width $adc_fifo_address_width
 
 # reference clocks & resets
 

--- a/projects/fmcadc5/vc707/system_bd.tcl
+++ b/projects/fmcadc5/vc707/system_bd.tcl
@@ -1,9 +1,6 @@
 
 ## FIFO depth is 16Mb - 1M Samples
-set adc_fifo_name axi_ad9625_fifo
 set adc_fifo_address_width 18
-set adc_data_width 512
-set adc_dma_data_width 64
 
 ## NOTE: With this configuration the #36Kb BRAM utilization is at ~70%
 


### PR DESCRIPTION
Create the dacfifo/adcfifo infrastructure with procedures.

This will allow moving the parameters of the dac/adcfifo inside
the block design so it can be calculated based on other parameters.