### PR TITLE
axi_jesd204_common: Fix dependancies so that the IP can be generated …

### DIFF
--- a/library/jesd204/axi_jesd204_common/Makefile
+++ b/library/jesd204/axi_jesd204_common/Makefile
@@ -8,6 +8,10 @@ LIBRARY_NAME := axi_jesd204_common
 GENERIC_DEPS += jesd204_up_common.v
 GENERIC_DEPS += jesd204_up_sysref.v
 
+XILINX_DEPS += ../../common/up_clock_mon.v
+XILINX_DEPS += ../../xilinx/common/up_clock_mon_constr.xdc
 XILINX_DEPS += axi_jesd204_common_ip.tcl
+
+XILINX_LIB_DEPS += util_cdc
 
 include ../../scripts/library.mk

--- a/library/jesd204/axi_jesd204_common/axi_jesd204_common_ip.tcl
+++ b/library/jesd204/axi_jesd204_common/axi_jesd204_common_ip.tcl
@@ -48,12 +48,17 @@ source $ad_hdl_dir/library/scripts/adi_ip.tcl
 adi_ip_create axi_jesd204_common
 
 add_files -fileset [get_filesets sources_1] [list \
+  "../../xilinx/common/up_clock_mon_constr.xdc" \
+  "../../common/up_clock_mon.v" \
   "jesd204_up_common.v" \
   "jesd204_up_sysref.v" \
 ]
 
 adi_ip_properties_lite axi_jesd204_common
 
+adi_ip_add_core_dependencies { \
+  analog.com:user:util_cdc:1.0 \
+}
 set_property display_name "ADI AXI JESD204B Common Library" [ipx::current_core]
 set_property description "ADI AXI JESD204B Common Library" [ipx::current_core]
 set_property hide_in_gui {1} [ipx::current_core]

--- a/library/jesd204/axi_jesd204_rx/Makefile
+++ b/library/jesd204/axi_jesd204_rx/Makefile
@@ -6,13 +6,11 @@
 LIBRARY_NAME := axi_jesd204_rx
 
 GENERIC_DEPS += ../../common/up_axi.v
-GENERIC_DEPS += ../../common/up_clock_mon.v
 GENERIC_DEPS += axi_jesd204_rx.v
 GENERIC_DEPS += jesd204_up_ilas_mem.v
 GENERIC_DEPS += jesd204_up_rx.v
 GENERIC_DEPS += jesd204_up_rx_lane.v
 
-XILINX_DEPS += ../../xilinx/common/up_clock_mon_constr.xdc
 XILINX_DEPS += axi_jesd204_rx_constr.xdc
 XILINX_DEPS += axi_jesd204_rx_ip.tcl
 
@@ -26,11 +24,11 @@ XILINX_DEPS += ../../jesd204/interfaces/jesd204_rx_status.xml
 XILINX_DEPS += ../../jesd204/interfaces/jesd204_rx_status_rtl.xml
 
 XILINX_LIB_DEPS += jesd204/axi_jesd204_common
-XILINX_LIB_DEPS += util_cdc
 
 XILINX_INTERFACE_DEPS += jesd204/interfaces
 
 ALTERA_DEPS += ../../altera/common/up_clock_mon_constr.sdc
+ALTERA_DEPS += ../../common/up_clock_mon.v
 ALTERA_DEPS += ../../util_cdc/sync_bits.v
 ALTERA_DEPS += ../../util_cdc/sync_data.v
 ALTERA_DEPS += ../../util_cdc/sync_event.v

--- a/library/jesd204/axi_jesd204_rx/axi_jesd204_rx_ip.tcl
+++ b/library/jesd204/axi_jesd204_rx/axi_jesd204_rx_ip.tcl
@@ -47,9 +47,7 @@ source $ad_hdl_dir/library/scripts/adi_ip.tcl
 
 adi_ip_create axi_jesd204_rx
 adi_ip_files axi_jesd204_rx [list \
-  "../../xilinx/common/up_clock_mon_constr.xdc" \
   "../../common/up_axi.v" \
-  "../../common/up_clock_mon.v" \
   "jesd204_up_rx.v" \
   "jesd204_up_rx_lane.v" \
   "jesd204_up_ilas_mem.v" \
@@ -65,7 +63,6 @@ set_property PROCESSING_ORDER LATE [ipx::get_files axi_jesd204_rx_constr.xdc \
 
 adi_ip_add_core_dependencies { \
   analog.com:user:axi_jesd204_common:1.0 \
-  analog.com:user:util_cdc:1.0 \
 }
 
 set_property display_name "ADI JESD204B Receive AXI Interface" [ipx::current_core]

--- a/library/jesd204/axi_jesd204_tx/Makefile
+++ b/library/jesd204/axi_jesd204_tx/Makefile
@@ -6,11 +6,9 @@
 LIBRARY_NAME := axi_jesd204_tx
 
 GENERIC_DEPS += ../../common/up_axi.v
-GENERIC_DEPS += ../../common/up_clock_mon.v
 GENERIC_DEPS += axi_jesd204_tx.v
 GENERIC_DEPS += jesd204_up_tx.v
 
-XILINX_DEPS += ../../xilinx/common/up_clock_mon_constr.xdc
 XILINX_DEPS += axi_jesd204_tx_constr.xdc
 XILINX_DEPS += axi_jesd204_tx_ip.tcl
 
@@ -26,11 +24,11 @@ XILINX_DEPS += ../../jesd204/interfaces/jesd204_tx_status.xml
 XILINX_DEPS += ../../jesd204/interfaces/jesd204_tx_status_rtl.xml
 
 XILINX_LIB_DEPS += jesd204/axi_jesd204_common
-XILINX_LIB_DEPS += util_cdc
 
 XILINX_INTERFACE_DEPS += jesd204/interfaces
 
 ALTERA_DEPS += ../../altera/common/up_clock_mon_constr.sdc
+ALTERA_DEPS += ../../common/up_clock_mon.v
 ALTERA_DEPS += ../../util_cdc/sync_bits.v
 ALTERA_DEPS += ../../util_cdc/sync_data.v
 ALTERA_DEPS += ../../util_cdc/sync_event.v

--- a/library/jesd204/axi_jesd204_tx/axi_jesd204_tx_ip.tcl
+++ b/library/jesd204/axi_jesd204_tx/axi_jesd204_tx_ip.tcl
@@ -47,9 +47,7 @@ source $ad_hdl_dir/library/scripts/adi_ip.tcl
 
 adi_ip_create axi_jesd204_tx
 adi_ip_files axi_jesd204_tx [list \
-  "../../xilinx/common/up_clock_mon_constr.xdc" \
   "../../common/up_axi.v" \
-  "../../common/up_clock_mon.v" \
   "axi_jesd204_tx_constr.xdc" \
   "jesd204_up_tx.v" \
   "axi_jesd204_tx.v" \
@@ -63,7 +61,6 @@ set_property PROCESSING_ORDER LATE [ipx::get_files axi_jesd204_tx_constr.xdc \
 
 adi_ip_add_core_dependencies { \
   analog.com:user:axi_jesd204_common:1.0 \
-  analog.com:user:util_cdc:1.0 \
 }
 
 set_property display_name "ADI JESD204B Transmit AXI Interface" [ipx::current_core]


### PR DESCRIPTION
…Out Of Context

up_clock_common module and util_cdc IP are used as part of the axi_jesd204_common IP. Add them as dependencies and remove the dependencies from axi_jesd204_rx/tx, as they use axi_jesd_common.
This should allow out of context synthesis