### PR TITLE
axi_i2s_adi: fixed xdc

### DIFF
--- a/library/axi_i2s_adi/axi_i2s_adi_ip.tcl
+++ b/library/axi_i2s_adi/axi_i2s_adi_ip.tcl
@@ -20,6 +20,11 @@ adi_ip_files axi_i2s_adi [list \
 ]
 
 adi_ip_properties axi_i2s_adi
+
+set_property PROCESSING_ORDER LATE [ipx::get_files axi_i2s_adi_constr.xdc \
+  -of_objects [ipx::get_file_groups -of_objects [ipx::current_core] \
+  -filter {NAME =~ *synthesis*}]] 
+
 adi_ip_infer_streaming_interfaces axi_i2s_adi
 
 adi_add_bus "dma_ack_rx" "slave" \


### PR DESCRIPTION
ip now sets the xdc to late so that the timing constraints are set in the correct context