### PR TITLE
Axi smartconnect

### DIFF
--- a/projects/common/kcu105/kcu105_system_bd.tcl
+++ b/projects/common/kcu105/kcu105_system_bd.tcl
@@ -231,21 +231,12 @@ ad_cpu_interconnect 0x44A70000 axi_spi
 
 # interconnect - memory
 
-#ad_connect sys_mem_resetn axi_ddr_interconnect/ARESETN
-#ad_connect sys_mem_resetn axi_ddr_interconnect/M00_ARESETN
-
 ad_mem_hp0_interconnect sys_mem_clk axi_ddr_cntrl/C0_DDR4_S_AXI
 ad_mem_hp0_interconnect sys_cpu_clk sys_mb/M_AXI_DC
 ad_mem_hp0_interconnect sys_cpu_clk sys_mb/M_AXI_IC
 ad_mem_hp0_interconnect sys_cpu_clk axi_ethernet_dma/M_AXI_SG
 ad_mem_hp0_interconnect sys_cpu_clk axi_ethernet_dma/M_AXI_MM2S
 ad_mem_hp0_interconnect sys_cpu_clk axi_ethernet_dma/M_AXI_S2MM
-
-ad_disconnect  sys_mem_clk axi_mem_interconnect/ACLK
-ad_disconnect  sys_mem_resetn axi_mem_interconnect/ARESETN
-
-ad_connect  sys_cpu_clk axi_mem_interconnect/ACLK
-ad_connect  sys_cpu_resetn axi_mem_interconnect/ARESETN
 
 create_bd_addr_seg -range 0x20000 -offset 0x0 [get_bd_addr_spaces sys_mb/Data] \
   [get_bd_addr_segs sys_dlmb_cntlr/SLMB/Mem] SEG_dlmb_cntlr

--- a/projects/m2k/common/m2k_bd.tcl
+++ b/projects/m2k/common/m2k_bd.tcl
@@ -47,7 +47,7 @@ ad_ip_parameter bram_la CONFIG.Algorithm {Low_Power}
 ad_ip_parameter bram_la CONFIG.Use_Byte_Write_Enable {false}
 ad_ip_parameter bram_la CONFIG.Operating_Mode_A {NO_CHANGE}
 ad_ip_parameter bram_la CONFIG.Register_PortB_Output_of_Memory_Primitives {true}
-ad_ip_parameter bram_la CONFIG.Use_RSTA_Pin {false} 
+ad_ip_parameter bram_la CONFIG.Use_RSTA_Pin {false}
 ad_ip_parameter bram_la CONFIG.Port_B_Clock {100}
 ad_ip_parameter bram_la CONFIG.Port_B_Enable_Rate {100}
 ad_ip_parameter bram_la CONFIG.Write_Width_A {16}
@@ -92,7 +92,7 @@ ad_ip_parameter bram_adc CONFIG.Enable_32bit_Address false
 ad_ip_parameter bram_adc CONFIG.Use_Byte_Write_Enable false
 ad_ip_parameter bram_adc CONFIG.Operating_Mode_A {NO_CHANGE}
 ad_ip_parameter bram_adc CONFIG.Register_PortB_Output_of_Memory_Primitives true
-ad_ip_parameter bram_adc CONFIG.Use_RSTA_Pin {false} 
+ad_ip_parameter bram_adc CONFIG.Use_RSTA_Pin {false}
 ad_ip_parameter bram_adc CONFIG.Port_B_Clock 100
 ad_ip_parameter bram_adc CONFIG.Port_B_Enable_Rate 100
 ad_ip_parameter bram_adc CONFIG.Write_Width_A 32
@@ -300,8 +300,9 @@ ad_connect sys_cpu_clk pattern_generator_dmac/m_src_axi_aclk
 ad_connect logic_analyzer_dmac/m_dest_axi axi_rd_wr_combiner_logic/s_wr_axi
 ad_connect pattern_generator_dmac/m_src_axi axi_rd_wr_combiner_logic/s_rd_axi
 
-ad_mem_hp1_interconnect sys_cpu_clk sys_ps7/S_AXI_HP1
-ad_mem_hp1_interconnect sys_cpu_clk axi_rd_wr_combiner_logic/m_axi
+ad_ip_parameter sys_ps7 CONFIG.PCW_USE_S_AXI_HP1 {1}
+ad_connect sys_cpu_clk sys_ps7/S_AXI_HP1_ACLK
+ad_connect axi_rd_wr_combiner_logic/m_axi sys_ps7/S_AXI_HP1
 
 # Converter DMA
 ad_connect converter_dma_clk axi_rd_wr_combiner_converter/clk
@@ -311,12 +312,19 @@ ad_connect converter_dma_clk ad9963_dac_dmac_a/m_src_axi_aclk
 ad_connect ad9963_adc_dmac/m_dest_axi axi_rd_wr_combiner_converter/s_wr_axi
 ad_connect ad9963_dac_dmac_a/m_src_axi axi_rd_wr_combiner_converter/s_rd_axi
 
-ad_mem_hp2_interconnect converter_dma_clk sys_ps7/S_AXI_HP2
-ad_mem_hp2_interconnect converter_dma_clk axi_rd_wr_combiner_converter/m_axi
+ad_ip_parameter sys_ps7 CONFIG.PCW_USE_S_AXI_HP2 {1}
+ad_connect converter_dma_clk sys_ps7/S_AXI_HP2_ACLK
+ad_connect axi_rd_wr_combiner_converter/m_axi sys_ps7/S_AXI_HP2
 
 # Only 16-bit we can run at a slower clock
-ad_mem_hp3_interconnect sys_cpu_clk sys_ps7/S_AXI_HP3
-ad_mem_hp3_interconnect sys_cpu_clk ad9963_dac_dmac_b/m_src_axi
+ad_ip_parameter sys_ps7 CONFIG.PCW_USE_S_AXI_HP3 {1}
+
+ad_connect sys_cpu_clk sys_ps7/S_AXI_HP3_ACLK
+ad_connect sys_cpu_clk ad9963_dac_dmac_b/m_src_axi_aclk
+ad_connect ad9963_dac_dmac_b/m_src_axi sys_ps7/S_AXI_HP3
+
+create_bd_addr_seg -range 0x20000000 -offset 0x00000000 [get_bd_addr_spaces ad9963_dac_dmac_b/m_src_axi] \
+                    [get_bd_addr_segs sys_ps7/S_AXI_HP3/HP3_DDR_LOWOCM] SEG_sys_ps7_HP3_DDR_LOWOCM
 
 # Map rd-wr combiner
 assign_bd_address [get_bd_addr_segs { \

--- a/projects/pluto/system_bd.tcl
+++ b/projects/pluto/system_bd.tcl
@@ -248,12 +248,19 @@ ad_connect  axi_ad9361/dac_data_q1 GND
 ad_cpu_interconnect 0x79020000 axi_ad9361
 ad_cpu_interconnect 0x7C400000 axi_ad9361_adc_dma
 ad_cpu_interconnect 0x7C420000 axi_ad9361_dac_dma
-ad_mem_hp1_interconnect sys_cpu_clk sys_ps7/S_AXI_HP1
-ad_mem_hp1_interconnect sys_cpu_clk axi_ad9361_adc_dma/m_dest_axi
-ad_mem_hp2_interconnect sys_cpu_clk sys_ps7/S_AXI_HP2
-ad_mem_hp2_interconnect sys_cpu_clk axi_ad9361_dac_dma/m_src_axi
-ad_connect  sys_cpu_resetn axi_ad9361_adc_dma/m_dest_axi_aresetn
-ad_connect  sys_cpu_resetn axi_ad9361_dac_dma/m_src_axi_aresetn
+
+ad_ip_parameter sys_ps7 CONFIG.PCW_USE_S_AXI_HP1 {1}
+ad_connect sys_cpu_clk sys_ps7/S_AXI_HP1_ACLK
+ad_connect axi_ad9361_adc_dma/m_dest_axi sys_ps7/S_AXI_HP1
+
+ad_ip_parameter sys_ps7 CONFIG.PCW_USE_S_AXI_HP2 {1}
+ad_connect sys_cpu_clk sys_ps7/S_AXI_HP2_ACLK
+ad_connect axi_ad9361_dac_dma/m_src_axi sys_ps7/S_AXI_HP2
+
+ad_connect sys_cpu_clk axi_ad9361_dac_dma/m_src_axi_aclk
+ad_connect sys_cpu_clk axi_ad9361_adc_dma/m_dest_axi_aclk
+ad_connect sys_cpu_resetn axi_ad9361_adc_dma/m_dest_axi_aresetn
+ad_connect sys_cpu_resetn axi_ad9361_dac_dma/m_src_axi_aresetn
 
 # interrupts
 

--- a/projects/scripts/adi_board.tcl
+++ b/projects/scripts/adi_board.tcl
@@ -7,6 +7,7 @@ variable sys_hp1_interconnect_index
 variable sys_hp2_interconnect_index
 variable sys_hp3_interconnect_index
 variable sys_mem_interconnect_index
+variable sys_mem_clk_index
 
 variable xcvr_index
 variable xcvr_tx_index
@@ -22,6 +23,7 @@ set sys_hp1_interconnect_index -1
 set sys_hp2_interconnect_index -1
 set sys_hp3_interconnect_index -1
 set sys_mem_interconnect_index -1
+set sys_mem_clk_index 0
 
 set xcvr_index -1
 set xcvr_tx_index 0
@@ -389,13 +391,14 @@ proc ad_mem_hpx_interconnect {p_sel p_clk p_name} {
   global sys_hp2_interconnect_index
   global sys_hp3_interconnect_index
   global sys_mem_interconnect_index
+  global sys_mem_clk_index
 
   set p_name_int $p_name
   set p_clk_source [get_bd_pins -filter {DIR == O} -of_objects [get_bd_nets $p_clk]]
 
   if {$p_sel eq "MEM"} {
     if {$sys_mem_interconnect_index < 0} {
-      ad_ip_instance axi_interconnect axi_mem_interconnect
+      ad_ip_instance smartconnect axi_mem_interconnect
     }
     set m_interconnect_index $sys_mem_interconnect_index
     set m_interconnect_cell [get_bd_cells axi_mem_interconnect]
@@ -406,7 +409,7 @@ proc ad_mem_hpx_interconnect {p_sel p_clk p_name} {
     if {$sys_hp0_interconnect_index < 0} {
       set p_name_int sys_ps7/S_AXI_HP0
       set_property CONFIG.PCW_USE_S_AXI_HP0 {1} [get_bd_cells sys_ps7]
-      ad_ip_instance axi_interconnect axi_hp0_interconnect
+      ad_ip_instance smartconnect axi_hp0_interconnect
     }
     set m_interconnect_index $sys_hp0_interconnect_index
     set m_interconnect_cell [get_bd_cells axi_hp0_interconnect]
@@ -417,7 +420,7 @@ proc ad_mem_hpx_interconnect {p_sel p_clk p_name} {
     if {$sys_hp1_interconnect_index < 0} {
       set p_name_int sys_ps7/S_AXI_HP1
       set_property CONFIG.PCW_USE_S_AXI_HP1 {1} [get_bd_cells sys_ps7]
-      ad_ip_instance axi_interconnect axi_hp1_interconnect
+      ad_ip_instance smartconnect axi_hp1_interconnect
     }
     set m_interconnect_index $sys_hp1_interconnect_index
     set m_interconnect_cell [get_bd_cells axi_hp1_interconnect]
@@ -428,7 +431,7 @@ proc ad_mem_hpx_interconnect {p_sel p_clk p_name} {
     if {$sys_hp2_interconnect_index < 0} {
       set p_name_int sys_ps7/S_AXI_HP2
       set_property CONFIG.PCW_USE_S_AXI_HP2 {1} [get_bd_cells sys_ps7]
-      ad_ip_instance axi_interconnect axi_hp2_interconnect
+      ad_ip_instance smartconnect axi_hp2_interconnect
     }
     set m_interconnect_index $sys_hp2_interconnect_index
     set m_interconnect_cell [get_bd_cells axi_hp2_interconnect]
@@ -439,7 +442,7 @@ proc ad_mem_hpx_interconnect {p_sel p_clk p_name} {
     if {$sys_hp3_interconnect_index < 0} {
       set p_name_int sys_ps7/S_AXI_HP3
       set_property CONFIG.PCW_USE_S_AXI_HP3 {1} [get_bd_cells sys_ps7]
-      ad_ip_instance axi_interconnect axi_hp3_interconnect
+      ad_ip_instance smartconnect axi_hp3_interconnect
     }
     set m_interconnect_index $sys_hp3_interconnect_index
     set m_interconnect_cell [get_bd_cells axi_hp3_interconnect]
@@ -450,7 +453,7 @@ proc ad_mem_hpx_interconnect {p_sel p_clk p_name} {
     if {$sys_hp0_interconnect_index < 0} {
       set p_name_int sys_ps8/S_AXI_HP0_FPD
       set_property CONFIG.PSU__USE__S_AXI_GP2 {1} [get_bd_cells sys_ps8]
-      ad_ip_instance axi_interconnect axi_hp0_interconnect
+      ad_ip_instance smartconnect axi_hp0_interconnect
     }
     set m_interconnect_index $sys_hp0_interconnect_index
     set m_interconnect_cell [get_bd_cells axi_hp0_interconnect]
@@ -461,7 +464,7 @@ proc ad_mem_hpx_interconnect {p_sel p_clk p_name} {
     if {$sys_hp1_interconnect_index < 0} {
       set p_name_int sys_ps8/S_AXI_HP1_FPD
       set_property CONFIG.PSU__USE__S_AXI_GP3 {1} [get_bd_cells sys_ps8]
-      ad_ip_instance axi_interconnect axi_hp1_interconnect
+      ad_ip_instance smartconnect axi_hp1_interconnect
     }
     set m_interconnect_index $sys_hp1_interconnect_index
     set m_interconnect_cell [get_bd_cells axi_hp1_interconnect]
@@ -472,7 +475,7 @@ proc ad_mem_hpx_interconnect {p_sel p_clk p_name} {
     if {$sys_hp2_interconnect_index < 0} {
       set p_name_int sys_ps8/S_AXI_HP2_FPD
       set_property CONFIG.PSU__USE__S_AXI_GP4 {1} [get_bd_cells sys_ps8]
-      ad_ip_instance axi_interconnect axi_hp2_interconnect
+      ad_ip_instance smartconnect axi_hp2_interconnect
     }
     set m_interconnect_index $sys_hp2_interconnect_index
     set m_interconnect_cell [get_bd_cells axi_hp2_interconnect]
@@ -483,7 +486,7 @@ proc ad_mem_hpx_interconnect {p_sel p_clk p_name} {
     if {$sys_hp3_interconnect_index < 0} {
       set p_name_int sys_ps8/S_AXI_HP3_FPD
       set_property CONFIG.PSU__USE__S_AXI_GP5 {1} [get_bd_cells sys_ps8]
-      ad_ip_instance axi_interconnect axi_hp3_interconnect
+      ad_ip_instance smartconnect axi_hp3_interconnect
     }
     set m_interconnect_index $sys_hp3_interconnect_index
     set m_interconnect_cell [get_bd_cells axi_hp3_interconnect]
@@ -517,25 +520,22 @@ proc ad_mem_hpx_interconnect {p_sel p_clk p_name} {
     set_property CONFIG.NUM_SI 1 $m_interconnect_cell
     ad_connect $p_rst $m_interconnect_cell/ARESETN
     ad_connect $p_clk $m_interconnect_cell/ACLK
-    ad_connect $p_rst $m_interconnect_cell/M00_ARESETN
-    ad_connect $p_clk $m_interconnect_cell/M00_ACLK
     ad_connect $m_interconnect_cell/M00_AXI $p_name_int
     if {$p_intf_clock ne ""} {
       ad_connect $p_clk $p_intf_clock
     }
   } else {
     set_property CONFIG.NUM_SI $m_interconnect_index $m_interconnect_cell
-    ad_connect $p_rst $m_interconnect_cell/${i_str}_ARESETN
-    ad_connect $p_clk $m_interconnect_cell/${i_str}_ACLK
+    if {[lsearch [get_bd_nets -of_object [get_bd_pins $m_interconnect_cell/ACLK*]] "/$p_clk"] == -1 } {
+        incr sys_mem_clk_index
+        set_property CONFIG.NUM_CLKS [expr $sys_mem_clk_index +1] $m_interconnect_cell
+        ad_connect $p_clk $m_interconnect_cell/ACLK$sys_mem_clk_index
+    }
     ad_connect $m_interconnect_cell/${i_str}_AXI $p_name_int
     if {$p_intf_clock ne ""} {
       ad_connect $p_clk $p_intf_clock
     }
     assign_bd_address $m_addr_seg
-  }
-
-  if {$m_interconnect_index > 1} {
-    set_property CONFIG.STRATEGY {2} $m_interconnect_cell
   }
 
   if {$p_sel eq "MEM"} {set sys_mem_interconnect_index $m_interconnect_index}


### PR DESCRIPTION
Replace memory axi_interconnect with axi_smartconnect IP. VCU118 high speed designs only work with the smartconnect IP