### PR TITLE
OOC synthesis flow support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+ipcache
 *.ip_user_files
 *.cache
 *.data

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+*.ip_user_files
 *.cache
 *.data
 *.xpr

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 ipcache
 *.ip_user_files
+*.dcp
 *.cache
 *.data
 *.xpr

--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ SUBPROJECTS := $(foreach projname,$(PROJECTS), \
 	$(foreach archname,$(notdir $(subst /Makefile,,$(wildcard projects/$(projname)/*/Makefile))), \
 		$(projname).$(archname)))
 
-.PHONY: lib all clean clean-all $(SUBPROJECTS)
+.PHONY: lib all clean clean-ipcache clean-all $(SUBPROJECTS)
 
 $(SUBPROJECTS):
 	$(MAKE) -C projects/$(subst .,/,$@)
@@ -41,8 +41,12 @@ all:
 clean:
 	$(MAKE) -C projects/ clean
 
+clean-ipcache:
+	$(call clean, \
+		ipcache, \
+		$(HL)IP Cache$(NC))
 
-clean-all:clean
+clean-all:clean clean-ipcache
 	$(MAKE) -C projects/ clean
 	$(MAKE) -C library/ clean
 

--- a/library/axi_adc_decimate/Makefile
+++ b/library/axi_adc_decimate/Makefile
@@ -15,6 +15,7 @@ GENERIC_DEPS += cic_decim.v
 GENERIC_DEPS += fir_decim.v
 
 XILINX_DEPS += ../xilinx/common/up_xfer_cntrl_constr.xdc
+XILINX_DEPS += ../xilinx/common/ad_mul.v
 XILINX_DEPS += axi_adc_decimate_ip.tcl
 
 XILINX_LIB_DEPS += util_cic

--- a/library/axi_adc_decimate/axi_adc_decimate_ip.tcl
+++ b/library/axi_adc_decimate/axi_adc_decimate_ip.tcl
@@ -8,6 +8,7 @@ adi_ip_files axi_adc_decimate [list \
   "$ad_hdl_dir/library/common/up_xfer_cntrl.v" \
   "$ad_hdl_dir/library/common/up_axi.v" \
   "$ad_hdl_dir/library/common/ad_iqcor.v" \
+  "$ad_hdl_dir/library/xilinx/common/ad_mul.v" \
   "$ad_hdl_dir/library/xilinx/common/up_xfer_cntrl_constr.xdc" \
   "fir_decim.v" \
   "cic_decim.v" \

--- a/library/axi_mc_controller/Makefile
+++ b/library/axi_mc_controller/Makefile
@@ -11,6 +11,7 @@ GENERIC_DEPS += control_registers.v
 GENERIC_DEPS += delay.v
 GENERIC_DEPS += motor_driver.v
 
+XILINX_DEPS += axi_mc_controller_constr.xdc
 XILINX_DEPS += axi_mc_controller_ip.tcl
 
 include ../scripts/library.mk

--- a/library/axi_mc_controller/axi_mc_controller_constr.xdc
+++ b/library/axi_mc_controller/axi_mc_controller_constr.xdc
@@ -1,0 +1,3 @@
+create_generated_clock -name [current_instance]/pwm_ctrl -source [get_ports ref_clk]  \
+  -divide_by 2 [get_pins pwm_gen_clk_reg/Q]
+

--- a/library/axi_mc_controller/axi_mc_controller_ip.tcl
+++ b/library/axi_mc_controller/axi_mc_controller_ip.tcl
@@ -9,6 +9,7 @@ adi_ip_files axi_mc_controller [list \
   "motor_driver.v" \
   "delay.v" \
   "control_registers.v" \
+  "axi_mc_controller_constr.xdc" \
   "axi_mc_controller.v" ]
 
 adi_ip_properties axi_mc_controller

--- a/library/axi_mc_current_monitor/Makefile
+++ b/library/axi_mc_current_monitor/Makefile
@@ -16,6 +16,7 @@ GENERIC_DEPS += ad7401.v
 GENERIC_DEPS += axi_mc_current_monitor.v
 GENERIC_DEPS += dec256sinc24b.v
 
+XILINX_DEPS += axi_mc_current_monitor_constr.xdc
 XILINX_DEPS += axi_mc_current_monitor_ip.tcl
 
 include ../scripts/library.mk

--- a/library/axi_mc_current_monitor/axi_mc_current_monitor_constr.xdc
+++ b/library/axi_mc_current_monitor/axi_mc_current_monitor_constr.xdc
@@ -1,0 +1,7 @@
+create_generated_clock -name [current_instance]/ia_clk -source [get_ports adc_clk_i] \
+  -divide_by 256 [get_pins ia_if/filter/word_count_reg[7]/Q]
+create_generated_clock -name [current_instance]/ib_clk -source [get_ports adc_clk_i] \
+  -divide_by 256 [get_pins ib_if/filter/word_count_reg[7]/Q]
+create_generated_clock -name [current_instance]/vbus_clk -source [get_ports adc_clk_i] \
+  -divide_by 256 [get_pins vbus_if/filter/word_count_reg[7]/Q]
+

--- a/library/axi_mc_current_monitor/axi_mc_current_monitor_ip.tcl
+++ b/library/axi_mc_current_monitor/axi_mc_current_monitor_ip.tcl
@@ -14,6 +14,7 @@ adi_ip_files axi_mc_current_monitor [list \
   "$ad_hdl_dir/library/common/up_adc_channel.v" \
   "dec256sinc24b.v" \
   "ad7401.v" \
+  "axi_mc_current_monitor_constr.xdc" \
   "axi_mc_current_monitor.v" ]
 
 adi_ip_properties axi_mc_current_monitor

--- a/library/jesd204/axi_jesd204_rx/Makefile
+++ b/library/jesd204/axi_jesd204_rx/Makefile
@@ -12,6 +12,7 @@ GENERIC_DEPS += jesd204_up_rx.v
 GENERIC_DEPS += jesd204_up_rx_lane.v
 
 XILINX_DEPS += axi_jesd204_rx_constr.xdc
+XILINX_DEPS += axi_jesd204_rx_ooc.ttcl
 XILINX_DEPS += axi_jesd204_rx_ip.tcl
 
 XILINX_DEPS += ../../jesd204/interfaces/jesd204_rx_cfg.xml

--- a/library/jesd204/axi_jesd204_rx/axi_jesd204_rx_ip.tcl
+++ b/library/jesd204/axi_jesd204_rx/axi_jesd204_rx_ip.tcl
@@ -52,10 +52,13 @@ adi_ip_files axi_jesd204_rx [list \
   "jesd204_up_rx_lane.v" \
   "jesd204_up_ilas_mem.v" \
   "axi_jesd204_rx_constr.xdc" \
+  "axi_jesd204_rx_ooc.ttcl" \
   "axi_jesd204_rx.v" \
 ]
 
 adi_ip_properties axi_jesd204_rx
+
+adi_ip_ttcl axi_jesd204_rx "axi_jesd204_rx_ooc.ttcl"
 
 set_property PROCESSING_ORDER LATE [ipx::get_files axi_jesd204_rx_constr.xdc \
   -of_objects [ipx::get_file_groups -of_objects [ipx::current_core] \

--- a/library/jesd204/axi_jesd204_rx/axi_jesd204_rx_ooc.ttcl
+++ b/library/jesd204/axi_jesd204_rx/axi_jesd204_rx_ooc.ttcl
@@ -1,0 +1,61 @@
+#
+# The ADI JESD204 Core is released under the following license, which is
+# different than all other HDL cores in this repository.
+#
+# Please read this, and understand the freedoms and responsibilities you have
+# by using this source code/core.
+#
+# The JESD204 HDL, is copyright © 2016-2017 Analog Devices Inc.
+#
+# This core is free software, you can use run, copy, study, change, ask
+# questions about and improve this core. Distribution of source, or resulting
+# binaries (including those inside an FPGA or ASIC) require you to release the
+# source of the entire project (excluding the system libraries provide by the
+# tools/compiler/FPGA vendor). These are the terms of the GNU General Public
+# License version 2 as published by the Free Software Foundation.
+#
+# This core  is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+# A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License version 2
+# along with this source code, and binary.  If not, see
+# <http://www.gnu.org/licenses/>.
+#
+# Commercial licenses (with commercial support) of this JESD204 core are also
+# available under terms different than the General Public License. (e.g. they
+# do not require you to accompany any image (FPGA or ASIC) using the JESD204
+# core with any corresponding source code.) For these alternate terms you must
+# purchase a license from Analog Devices Technology Licensing Office. Users
+# interested in such a license should contact jesd204-licensing@analog.com for
+# more information. This commercial license is sub-licensable (if you purchase
+# chips from Analog Devices, incorporate them into your PCB level product, and
+# purchase a JESD204 license, end users of your product will also have a
+# license to use this core in a commercial setting without releasing their
+# source code).
+#
+# In addition, we kindly ask you to acknowledge ADI in any program, application
+# or publication in which you use this JESD204 HDL core. (You are not required
+# to do so; it is up to your common sense to decide whether you want to comply
+# with this request or not.) For general publications, we suggest referencing :
+# “The design and implementation of the JESD204 HDL Core used in this project
+# is copyright © 2016-2017, Analog Devices, Inc.”
+#
+
+<: setFileUsedIn { out_of_context synthesis implementation } :>
+<: ;#Component and file information :>
+<: set ComponentName [getComponentNameString] :>
+<: setOutputDirectory "./" :>
+<: setFileName $ComponentName :>
+<: setFileExtension "_ooc.xdc" :>
+
+# This XDC is used only for OOC mode of synthesis, implementation.
+# These are default values for timing driven synthesis during OOC flow.
+# These values will be overwritten during implementation with information
+# from top level.
+
+create_clock -name s_axi_aclk -period 10  [get_ports s_axi_aclk]
+create_clock -name core_clk   -period 2.5 [get_ports core_clk]
+
+################################################################################
+

--- a/library/jesd204/axi_jesd204_tx/Makefile
+++ b/library/jesd204/axi_jesd204_tx/Makefile
@@ -10,6 +10,7 @@ GENERIC_DEPS += axi_jesd204_tx.v
 GENERIC_DEPS += jesd204_up_tx.v
 
 XILINX_DEPS += axi_jesd204_tx_constr.xdc
+XILINX_DEPS += axi_jesd204_tx_ooc.ttcl
 XILINX_DEPS += axi_jesd204_tx_ip.tcl
 
 XILINX_DEPS += ../../jesd204/interfaces/jesd204_tx_cfg.xml

--- a/library/jesd204/axi_jesd204_tx/axi_jesd204_tx_ip.tcl
+++ b/library/jesd204/axi_jesd204_tx/axi_jesd204_tx_ip.tcl
@@ -49,11 +49,14 @@ adi_ip_create axi_jesd204_tx
 adi_ip_files axi_jesd204_tx [list \
   "../../common/up_axi.v" \
   "axi_jesd204_tx_constr.xdc" \
+  "axi_jesd204_tx_ooc.ttcl" \
   "jesd204_up_tx.v" \
   "axi_jesd204_tx.v" \
 ]
 
 adi_ip_properties axi_jesd204_tx
+
+adi_ip_ttcl axi_jesd204_tx "axi_jesd204_tx_ooc.ttcl"
 
 set_property PROCESSING_ORDER LATE [ipx::get_files axi_jesd204_tx_constr.xdc \
   -of_objects [ipx::get_file_groups -of_objects [ipx::current_core] \

--- a/library/jesd204/axi_jesd204_tx/axi_jesd204_tx_ooc.ttcl
+++ b/library/jesd204/axi_jesd204_tx/axi_jesd204_tx_ooc.ttcl
@@ -1,0 +1,61 @@
+#
+# The ADI JESD204 Core is released under the following license, which is
+# different than all other HDL cores in this repository.
+#
+# Please read this, and understand the freedoms and responsibilities you have
+# by using this source code/core.
+#
+# The JESD204 HDL, is copyright © 2016-2017 Analog Devices Inc.
+#
+# This core is free software, you can use run, copy, study, change, ask
+# questions about and improve this core. Distribution of source, or resulting
+# binaries (including those inside an FPGA or ASIC) require you to release the
+# source of the entire project (excluding the system libraries provide by the
+# tools/compiler/FPGA vendor). These are the terms of the GNU General Public
+# License version 2 as published by the Free Software Foundation.
+#
+# This core  is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+# A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License version 2
+# along with this source code, and binary.  If not, see
+# <http://www.gnu.org/licenses/>.
+#
+# Commercial licenses (with commercial support) of this JESD204 core are also
+# available under terms different than the General Public License. (e.g. they
+# do not require you to accompany any image (FPGA or ASIC) using the JESD204
+# core with any corresponding source code.) For these alternate terms you must
+# purchase a license from Analog Devices Technology Licensing Office. Users
+# interested in such a license should contact jesd204-licensing@analog.com for
+# more information. This commercial license is sub-licensable (if you purchase
+# chips from Analog Devices, incorporate them into your PCB level product, and
+# purchase a JESD204 license, end users of your product will also have a
+# license to use this core in a commercial setting without releasing their
+# source code).
+#
+# In addition, we kindly ask you to acknowledge ADI in any program, application
+# or publication in which you use this JESD204 HDL core. (You are not required
+# to do so; it is up to your common sense to decide whether you want to comply
+# with this request or not.) For general publications, we suggest referencing :
+# “The design and implementation of the JESD204 HDL Core used in this project
+# is copyright © 2016-2017, Analog Devices, Inc.”
+#
+
+<: setFileUsedIn { out_of_context synthesis implementation } :>
+<: ;#Component and file information :>
+<: set ComponentName [getComponentNameString] :>
+<: setOutputDirectory "./" :>
+<: setFileName $ComponentName :>
+<: setFileExtension "_ooc.xdc" :>
+
+# This XDC is used only for OOC mode of synthesis, implementation.
+# These are default values for timing driven synthesis during OOC flow.
+# These values will be overwritten during implementation with information
+# from top level.
+
+create_clock -name s_axi_aclk -period 10  [get_ports s_axi_aclk]
+create_clock -name core_clk   -period 2.5 [get_ports core_clk]
+
+################################################################################
+

--- a/library/util_clkdiv/Makefile
+++ b/library/util_clkdiv/Makefile
@@ -8,6 +8,7 @@ LIBRARY_NAME := util_clkdiv
 
 XILINX_DEPS += util_clkdiv.v
 XILINX_DEPS += util_clkdiv_constr.xdc
+XILINX_DEPS += util_clkdiv_ooc.ttcl
 XILINX_DEPS += util_clkdiv_ip.tcl
 
 ALTERA_DEPS += util_clkdiv_alt.v

--- a/library/util_clkdiv/util_clkdiv_ip.tcl
+++ b/library/util_clkdiv/util_clkdiv_ip.tcl
@@ -4,9 +4,12 @@ source $ad_hdl_dir/library/scripts/adi_ip.tcl
 adi_ip_create util_clkdiv
 adi_ip_files util_clkdiv [list \
   "util_clkdiv_constr.xdc" \
+  "util_clkdiv_ooc.ttcl" \
   "util_clkdiv.v" ]
 
 adi_ip_properties_lite util_clkdiv
+
+adi_ip_ttcl util_clkdiv "util_clkdiv_ooc.ttcl"
 
 set_property processing_order LATE [ipx::get_files "util_clkdiv_constr.xdc" \
                   -of_objects [ipx::get_file_groups -of_objects [ipx::current_core] -filter {NAME =~ *synthesis*}]]

--- a/library/util_clkdiv/util_clkdiv_ooc.ttcl
+++ b/library/util_clkdiv/util_clkdiv_ooc.ttcl
@@ -1,0 +1,17 @@
+
+<: setFileUsedIn { out_of_context synthesis implementation } :>
+<: ;#Component and file information :>
+<: set ComponentName [getComponentNameString] :>
+<: setOutputDirectory "./" :>
+<: setFileName $ComponentName :>
+<: setFileExtension "_ooc.xdc" :>
+
+# This XDC is used only for OOC mode of synthesis, implementation.
+# These are default values for timing driven synthesis during OOC flow.
+# These values will be overwritten during implementation with information
+# from top level.
+
+create_clock -name clk -period 10 [get_ports clk]
+
+################################################################################
+

--- a/library/util_dacfifo/Makefile
+++ b/library/util_dacfifo/Makefile
@@ -13,6 +13,7 @@ GENERIC_DEPS += util_dacfifo.v
 GENERIC_DEPS += util_dacfifo_bypass.v
 
 XILINX_DEPS += util_dacfifo_constr.xdc
+XILINX_DEPS += util_dacfifo_ooc.ttcl
 XILINX_DEPS += util_dacfifo_ip.tcl
 
 ALTERA_DEPS += util_dacfifo_constr.sdc

--- a/library/util_dacfifo/util_dacfifo_ip.tcl
+++ b/library/util_dacfifo/util_dacfifo_ip.tcl
@@ -11,9 +11,13 @@ adi_ip_files util_dacfifo [list \
   "$ad_hdl_dir/library/common/ad_g2b.v" \
   "util_dacfifo.v" \
   "util_dacfifo_bypass.v" \
+  "util_dacfifo_ooc.ttcl" \
   "util_dacfifo_constr.xdc"]
 
+
 adi_ip_properties_lite util_dacfifo
+
+adi_ip_ttcl util_dacfifo "util_dacfifo_ooc.ttcl"
 
 ipx::infer_bus_interface dma_clk xilinx.com:signal:clock_rtl:1.0 [ipx::current_core]
 ipx::infer_bus_interface dma_rst xilinx.com:signal:reset_rtl:1.0 [ipx::current_core]

--- a/library/util_dacfifo/util_dacfifo_ooc.ttcl
+++ b/library/util_dacfifo/util_dacfifo_ooc.ttcl
@@ -1,0 +1,17 @@
+
+<: setFileUsedIn { out_of_context synthesis implementation } :>
+<: ;#Component and file information :>
+<: set ComponentName [getComponentNameString] :>
+<: setOutputDirectory "./" :>
+<: setFileName $ComponentName :>
+<: setFileExtension "_ooc.xdc" :>
+
+# This XDC is used only for OOC mode of synthesis, implementation.
+# These are default values for timing driven synthesis during OOC flow.
+# These values will be overwritten during implementation with information
+# from top level.
+
+create_clock -name dma_clk -period 8 [get_ports dma_clk]
+create_clock -name dac_clk -period 3.2 [get_ports dac_clk]
+
+################################################################################

--- a/projects/motcon2_fmc/zed/system_constr.xdc
+++ b/projects/motcon2_fmc/zed/system_constr.xdc
@@ -109,35 +109,6 @@ create_clock -period 8.000 -name rgmii_rxc2 [get_ports eth2_rgmii_rxc]
 
 create_clock -name mdio_mdc -period 400 [get_pins i_system_wrapper/system_i/sys_ps7/inst/PS7_i/EMIOENET0MDIOMDC]
 
-create_generated_clock -name pwm_ctrl_1 -source [get_pins i_system_wrapper/system_i/controller_m1/inst/ref_clk]  \
--divide_by 2 [get_pins i_system_wrapper/system_i/controller_m1/inst/pwm_gen_clk_reg/Q]
-create_generated_clock -name pwm_ctrl_2 -source [get_pins i_system_wrapper/system_i/controller_m2/inst/ref_clk]  \
--divide_by 2 [get_pins i_system_wrapper/system_i/controller_m2/inst/pwm_gen_clk_reg/Q]
-
-create_generated_clock -name cm1_ia -source [get_pins i_system_wrapper/system_i/current_monitor_m1/inst/adc_clk_i]  \
--divide_by 256 [get_pins i_system_wrapper/system_i/current_monitor_m1/inst/ia_if/filter/word_count_reg[7]/Q]
-create_generated_clock -name cm1_ib -source [get_pins i_system_wrapper/system_i/current_monitor_m1/inst/adc_clk_i]  \
--divide_by 256 [get_pins i_system_wrapper/system_i/current_monitor_m1/inst/ib_if/filter/word_count_reg[7]/Q]
-create_generated_clock -name cm1_vbus -source [get_pins i_system_wrapper/system_i/current_monitor_m1/inst/adc_clk_i]  \
--divide_by 256 [get_pins i_system_wrapper/system_i/current_monitor_m1/inst/vbus_if/filter/word_count_reg[7]/Q]
-
-create_generated_clock -name cm2_ia -source [get_pins i_system_wrapper/system_i/current_monitor_m2/inst/adc_clk_i]  \
--divide_by 256 [get_pins i_system_wrapper/system_i/current_monitor_m2/inst/ia_if/filter/word_count_reg[7]/Q]
-create_generated_clock -name cm2_ib -source [get_pins i_system_wrapper/system_i/current_monitor_m2/inst/adc_clk_i]  \
--divide_by 256 [get_pins i_system_wrapper/system_i/current_monitor_m2/inst/ib_if/filter/word_count_reg[7]/Q]
-create_generated_clock -name cm2_vbus -source [get_pins i_system_wrapper/system_i/current_monitor_m2/inst/adc_clk_i]  \
--divide_by 256 [get_pins i_system_wrapper/system_i/current_monitor_m2/inst/vbus_if/filter/word_count_reg[7]/Q]
-
-set_clock_groups -asynchronous \
-    -group [get_clocks {cm1_ia cm1_ib cm1_vbus }]
-
-set_clock_groups -asynchronous \
-    -group [get_clocks {cm2_ia cm2_ib cm2_vbus }]
-
-set_clock_groups -asynchronous \
-        -group [get_clocks {pwm_ctrl_1 }] \
-        -group [get_clocks {pwm_ctrl_2 }]
-
 # Ethernet 1
 #IDELAY
 set_property IDELAY_VALUE 16 [get_cells */*/gmii_to_rgmii_eth1/inst/*delay_rgmii_rx_ctl]

--- a/projects/scripts/adi_project.tcl
+++ b/projects/scripts/adi_project.tcl
@@ -117,6 +117,14 @@ proc adi_project_xilinx {project_name {mode 0}} {
     lappend lib_dirs $ad_phdl_dir/library
   }
 
+  # Set a common IP cache for all projects
+  if {$ADI_USE_OOC_SYNTHESIS == 1} {
+    if {[file exists $ad_hdl_dir/ipcache] == 0} {
+      file mkdir $ad_hdl_dir/ipcache
+    }
+    config_ip_cache -import_from_project -use_cache_location $ad_hdl_dir/ipcache
+  }
+
   set_property ip_repo_paths $lib_dirs [current_fileset]
   update_ip_catalog
 

--- a/projects/scripts/adi_project.tcl
+++ b/projects/scripts/adi_project.tcl
@@ -22,6 +22,8 @@ if {[info exists ::env(ADI_USE_OOC_SYNTHESIS)]} {
   set ADI_USE_OOC_SYNTHESIS 0
 }
 
+set ADI_USE_INCR_COMP 1
+
 set p_board "not-applicable"
 set p_device "none"
 set sys_zynq 1
@@ -37,6 +39,7 @@ proc adi_project_xilinx {project_name {mode 0}} {
   global REQUIRED_VIVADO_VERSION
   global IGNORE_VERSION_CHECK
   global ADI_USE_OOC_SYNTHESIS
+  global ADI_USE_INCR_COMP
 
   if [regexp "_ac701$" $project_name] {
     set p_device "xc7a200tfbg676-2"
@@ -160,6 +163,13 @@ proc adi_project_xilinx {project_name {mode 0}} {
   } else {
     write_hwdef -file "$project_name.data/$project_name.hwdef"
   }
+
+  if {$ADI_USE_INCR_COMP == 1} {
+    if {[file exists ./reference.dcp]} {
+      set_property incremental_checkpoint ./reference.dcp [get_runs impl_1]
+    }
+  }
+
 }
 
 proc adi_project_files {project_name project_files} {
@@ -171,7 +181,7 @@ proc adi_project_files {project_name project_files} {
 proc adi_project_run {project_name} {
   global ADI_POWER_OPTIMIZATION
   global ADI_USE_OOC_SYNTHESIS
-  
+
   if {$ADI_USE_OOC_SYNTHESIS == 1} {
     launch_runs -jobs 4 system_*_synth_1 synth_1
   } else {

--- a/projects/scripts/project-xilinx.mk
+++ b/projects/scripts/project-xilinx.mk
@@ -33,13 +33,15 @@ M_DEPS += $(wildcard system_constr.xdc) # Not all projects have this file
 M_DEPS += $(HDL_PROJECT_PATH)scripts/adi_project.tcl
 M_DEPS += $(HDL_PROJECT_PATH)scripts/adi_env.tcl
 M_DEPS += $(HDL_PROJECT_PATH)scripts/adi_board.tcl
+M_DEPS += prepare_incremental_compile
 
 M_DEPS += $(foreach dep,$(LIB_DEPS),$(HDL_LIBRARY_PATH)$(dep)/component.xml)
 
-.PHONY: all lib clean clean-all
+.PHONY: all lib clean clean-all prepare_incremental_compile 
 all: lib $(PROJECT_NAME).sdk/system_top.hdf
 
 clean:
+	-rm -f reference.dcp
 	$(call clean, \
 		$(CLEAN_TARGET), \
 		$(HL)$(PROJECT_NAME)$(NC) project)
@@ -48,6 +50,19 @@ clean-all: clean
 	@for lib in $(LIB_DEPS); do \
 		$(MAKE) -C $(HDL_LIBRARY_PATH)$${lib} clean; \
 	done
+
+MODE ?= "default"
+
+prepare_incremental_compile:
+	@if [ $(MODE) = incr ]; then \
+		if [ -f */impl_1/system_top_routed.dcp ]; then \
+			echo Found previous run result at `ls */impl_1/system_top_routed.dcp`; \
+			cp -u */impl_1/system_top_routed.dcp ./reference.dcp ; \
+		fi; \
+		if [ -f ./reference.dcp ]; then \
+			echo Using reference checkpoint for incremental compilation; \
+		fi; \
+	fi; 
 
 $(PROJECT_NAME).sdk/system_top.hdf: $(M_DEPS)
 	-rm -rf $(CLEAN_TARGET)


### PR DESCRIPTION
**Add support for OOC synthesis flow** through ADI_USE_OOC_SYNTHESIS environment variable 
Add common IP cache support to reuse synthesis results from one project to another

Usage:
    from command line set any value to the ADI_USE_OOC_SYNTHESIS variable
    e.g. export ADI_USE_OOC_SYNTHESIS=y

Tested:
 All Xilinx projects compiled with Vivado 2018.2


**Add support for incremental compilation** 
Usage: 
    on  a previously built project run make with the following option:
         make MODE=incr
