### PR TITLE
scripts: updated adi_project.tcl

### DIFF
--- a/projects/scripts/adi_project.tcl
+++ b/projects/scripts/adi_project.tcl
@@ -212,14 +212,19 @@ proc adi_project_run {project_name} {
 
   file mkdir $project_name.sdk
 
-  if [expr [get_property SLACK [get_timing_paths]] < 0] {
-    file copy -force $project_name.runs/impl_1/system_top.sysdef $project_name.sdk/system_top_bad_timing.hdf
-  } else {
+  set timing_paths_list [get_property -quiet SLACK [get_timing_paths -quiet]]
+  if {[llength $timing_paths_list] == 0} {
+    puts "no timing paths found"
     file copy -force $project_name.runs/impl_1/system_top.sysdef $project_name.sdk/system_top.hdf
-  }
-
-  if [expr [get_property SLACK [get_timing_paths]] < 0] {
-    return -code error [format "ERROR: Timing Constraints NOT met!"]
+  } else {
+    if [expr [get_property SLACK [get_timing_paths]] < 0] {
+      file copy -force $project_name.runs/impl_1/system_top.sysdef $project_name.sdk/system_top_bad_timing.hdf
+    } else {
+      file copy -force $project_name.runs/impl_1/system_top.sysdef $project_name.sdk/system_top.hdf
+    }
+    if [expr [get_property SLACK [get_timing_paths]] < 0] {
+      return -code error [format "ERROR: Timing Constraints NOT met!"]
+    }
   }
 }
 

--- a/projects/scripts/adi_project.tcl
+++ b/projects/scripts/adi_project.tcl
@@ -212,19 +212,11 @@ proc adi_project_run {project_name} {
 
   file mkdir $project_name.sdk
 
-  set timing_paths_list [get_property -quiet SLACK [get_timing_paths -quiet]]
-  if {[llength $timing_paths_list] == 0} {
-    puts "no timing paths found"
-    file copy -force $project_name.runs/impl_1/system_top.sysdef $project_name.sdk/system_top.hdf
+  if [expr [string match *VIOLATED* $[report_timing_summary -return_string]] == 1] {
+    file copy -force $project_name.runs/impl_1/system_top.sysdef $project_name.sdk/system_top_bad_timing.hdf
+    return -code error [format "ERROR: Timing Constraints NOT met!"]
   } else {
-    if [expr [get_property SLACK [get_timing_paths]] < 0] {
-      file copy -force $project_name.runs/impl_1/system_top.sysdef $project_name.sdk/system_top_bad_timing.hdf
-    } else {
-      file copy -force $project_name.runs/impl_1/system_top.sysdef $project_name.sdk/system_top.hdf
-    }
-    if [expr [get_property SLACK [get_timing_paths]] < 0] {
-      return -code error [format "ERROR: Timing Constraints NOT met!"]
-    }
+    file copy -force $project_name.runs/impl_1/system_top.sysdef $project_name.sdk/system_top.hdf
   }
 }
 


### PR DESCRIPTION
fixed timing paths evaluation where no timing paths would lead to a failure to export the .hdf