### PR TITLE
scripts: patch incremental compile

### DIFF
--- a/projects/scripts/project-xilinx.mk
+++ b/projects/scripts/project-xilinx.mk
@@ -62,7 +62,9 @@ prepare_incremental_compile:
 		if [ -f ./reference.dcp ]; then \
 			echo Using reference checkpoint for incremental compilation; \
 		fi; \
-	fi; 
+	else \
+		rm -f reference.dcp; \
+	fi;
 
 $(PROJECT_NAME).sdk/system_top.hdf: $(M_DEPS)
 	-rm -rf $(CLEAN_TARGET)


### PR DESCRIPTION
Clear the reference checkpoint if the incremental compilation is not
selected through the make option. Other case the scripts will silently
use the reference.dcp checkpoint if that exists.