### PR TITLE
sync_bits: Change I/O names of wires "in" and "out" for VHDL users

### DIFF
--- a/library/axi_ad5766/axi_ad5766.v
+++ b/library/axi_ad5766/axi_ad5766.v
@@ -196,30 +196,30 @@ module axi_ad5766 #(
         .NUM_OF_BITS(1),
         .ASYNC_CLK(1)
     ) i_sync_enable (
-        .in(ctrl_do_enable),
+        .in_bits(ctrl_do_enable),
         .out_clk(spi_clk),
         .out_resetn(1'b1),
-        .out(spi_enable_s)
+        .out_bits(spi_enable_s)
     );
 
     sync_bits # (
         .NUM_OF_BITS(1),
         .ASYNC_CLK(1)
     ) i_sync_enabled (
-        .in(spi_enabled),
+        .in_bits(spi_enabled),
         .out_clk(ctrl_clk),
         .out_resetn(1'b1),
-        .out(ctrl_is_enabled)
+        .out_bits(ctrl_is_enabled)
     );
 
     sync_bits # (
         .NUM_OF_BITS(1),
         .ASYNC_CLK(1)
     ) i_sync_mem_reset (
-        .in(ctrl_mem_reset),
+        .in_bits(ctrl_mem_reset),
         .out_clk(spi_clk),
         .out_resetn(1'b1),
-        .out(spi_mem_reset_s)
+        .out_bits(spi_mem_reset_s)
     );
 
   end else begin

--- a/library/axi_dmac/axi_dmac_burst_memory.v
+++ b/library/axi_dmac/axi_dmac_burst_memory.v
@@ -417,20 +417,20 @@ sync_bits #(
   .NUM_OF_BITS (ID_WIDTH),
   .ASYNC_CLK (ASYNC_CLK)
 ) i_dest_sync_id (
-  .in (src_id),
+  .in_bits (src_id),
   .out_clk (dest_clk),
   .out_resetn (1'b1),
-  .out (dest_src_id)
+  .out_bits (dest_src_id)
 );
 
 sync_bits #(
   .NUM_OF_BITS (ID_WIDTH),
   .ASYNC_CLK (ASYNC_CLK)
 ) i_src_sync_id (
-  .in (dest_id),
+  .in_bits (dest_id),
   .out_clk (src_clk),
   .out_resetn (1'b1),
-  .out (src_dest_id)
+  .out_bits (src_dest_id)
 );
 
 assign dest_request_id = dest_src_id;

--- a/library/axi_dmac/axi_dmac_reset_manager.v
+++ b/library/axi_dmac/axi_dmac_reset_manager.v
@@ -267,8 +267,8 @@ sync_bits #(
 ) i_sync_control_dest (
   .out_clk (dest_clk),
   .out_resetn (1'b1),
-  .in (do_enable),
-  .out (dest_enable)
+  .in_bits (do_enable),
+  .out_bits (dest_enable)
 );
 
 sync_bits #(
@@ -277,8 +277,8 @@ sync_bits #(
 ) i_sync_status_dest (
   .out_clk (clk),
   .out_resetn (1'b1),
-  .in (dest_enabled),
-  .out (enabled_dest)
+  .in_bits (dest_enabled),
+  .out_bits (enabled_dest)
 );
 
 sync_bits #(
@@ -287,8 +287,8 @@ sync_bits #(
 ) i_sync_control_src (
   .out_clk (src_clk),
   .out_resetn (1'b1),
-  .in (do_enable),
-  .out (src_enable)
+  .in_bits (do_enable),
+  .out_bits (src_enable)
 );
 
 sync_bits #(
@@ -297,8 +297,8 @@ sync_bits #(
 ) i_sync_status_src (
   .out_clk (clk),
   .out_resetn (1'b1),
-  .in (src_enabled),
-  .out (enabled_src)
+  .in_bits (src_enabled),
+  .out_bits (enabled_src)
 );
 
 endmodule

--- a/library/axi_dmac/request_arb.v
+++ b/library/axi_dmac/request_arb.v
@@ -861,8 +861,8 @@ sync_bits #(
 ) i_sync_src_request_id (
   .out_clk(src_clk),
   .out_resetn(1'b1),
-  .in(request_id),
-  .out(src_request_id)
+  .in_bits(request_id),
+  .out_bits(src_request_id)
 );
 
 `include "inc_id.vh"
@@ -926,8 +926,8 @@ sync_bits #(
 ) i_sync_req_response_id (
   .out_clk(req_clk),
   .out_resetn(1'b1),
-  .in(dest_response_id),
-  .out(response_id)
+  .in_bits(dest_response_id),
+  .out_bits(response_id)
 );
 
 axi_register_slice #(

--- a/library/jesd204/axi_jesd204_rx/jesd204_up_ilas_mem.v
+++ b/library/jesd204/axi_jesd204_rx/jesd204_up_ilas_mem.v
@@ -65,10 +65,10 @@ reg [31:0] mem[0:3];
 reg core_ilas_captured = 1'b0;
 
 sync_bits i_cdc_ilas_ready (
-  .in(core_ilas_captured),
+  .in_bits(core_ilas_captured),
   .out_resetn(1'b1),
   .out_clk(up_clk),
-  .out(up_ilas_ready)
+  .out_bits(up_ilas_ready)
 );
 
 always @(posedge core_clk) begin

--- a/library/jesd204/axi_jesd204_rx/jesd204_up_rx_lane.v
+++ b/library/jesd204/axi_jesd204_rx/jesd204_up_rx_lane.v
@@ -77,12 +77,12 @@ wire up_ilas_ready;
 sync_bits #(
   .NUM_OF_BITS(1)
 ) i_cdc_status_ready (
-  .in({
+  .in_bits({
     core_status_ifs_ready
   }),
   .out_clk(up_clk),
   .out_resetn(1'b1),
-  .out({
+  .out_bits({
     up_status_ifs_ready
   })
 );

--- a/library/jesd204/axi_jesd204_tx/jesd204_up_tx.v
+++ b/library/jesd204/axi_jesd204_tx/jesd204_up_tx.v
@@ -84,10 +84,10 @@ wire [NUM_LINKS-1:0] up_status_sync;
 sync_bits #(
   .NUM_OF_BITS (NUM_LINKS))
 i_cdc_sync (
-  .in(core_status_sync),
+  .in_bits(core_status_sync),
   .out_clk(up_clk),
   .out_resetn(1'b1),
-  .out(up_status_sync)
+  .out_bits(up_status_sync)
 );
 
 sync_data #(

--- a/library/jesd204/jesd204_tx/jesd204_tx_ctrl.v
+++ b/library/jesd204/jesd204_tx/jesd204_tx_ctrl.v
@@ -98,10 +98,10 @@ wire [NUM_LINKS-1:0] status_sync_masked;
 sync_bits #(
   .NUM_OF_BITS (NUM_LINKS))
 i_cdc_sync (
-  .in(sync),
+  .in_bits(sync),
   .out_clk(clk),
   .out_resetn(1'b1),
-  .out(status_sync)
+  .out_bits(status_sync)
 );
 assign status_sync_masked = status_sync | cfg_links_disable;
 

--- a/library/spi_engine/spi_engine_offload/spi_engine_offload.v
+++ b/library/spi_engine/spi_engine_offload/spi_engine_offload.v
@@ -139,20 +139,20 @@ sync_bits # (
     .NUM_OF_BITS(1),
     .ASYNC_CLK(1)
 ) i_sync_enable (
-    .in(ctrl_do_enable),
+    .in_bits(ctrl_do_enable),
     .out_clk(spi_clk),
     .out_resetn(1'b1),
-    .out(spi_enable)
+    .out_bits(spi_enable)
 );
 
 sync_bits # (
     .NUM_OF_BITS(1),
     .ASYNC_CLK(1)
 ) i_sync_enabled (
-    .in(spi_enabled),
+    .in_bits(spi_enabled),
     .out_clk(ctrl_clk),
     .out_resetn(1'b1),
-    .out(ctrl_is_enabled)
+    .out_bits(ctrl_is_enabled)
 );
 
 end else begin
@@ -167,10 +167,10 @@ sync_bits #(
   .NUM_OF_BITS(1),
   .ASYNC_CLK(ASYNC_TRIG)
 ) i_sync_trigger (
-  .in(trigger),
+  .in_bits(trigger),
   .out_clk(spi_clk),
   .out_resetn(1'b1),
-  .out(trigger_s)
+  .out_bits(trigger_s)
 );
 
 always @(posedge spi_clk) begin

--- a/library/util_axis_fifo/address_gray.v
+++ b/library/util_axis_fifo/address_gray.v
@@ -116,8 +116,8 @@ sync_bits #(
 ) i_waddr_sync (
   .out_clk(m_axis_aclk),
   .out_resetn(m_axis_aresetn),
-  .in(s_axis_waddr_gray),
-  .out(m_axis_waddr_gray)
+  .in_bits(s_axis_waddr_gray),
+  .out_bits(m_axis_waddr_gray)
 );
 
 sync_bits #(
@@ -125,8 +125,8 @@ sync_bits #(
 ) i_raddr_sync (
   .out_clk(s_axis_aclk),
   .out_resetn(s_axis_aresetn),
-  .in(m_axis_raddr_gray),
-  .out(s_axis_raddr_gray)
+  .in_bits(m_axis_raddr_gray),
+  .out_bits(s_axis_raddr_gray)
 );
 
 always @(posedge s_axis_aclk)

--- a/library/util_axis_fifo/util_axis_fifo.v
+++ b/library/util_axis_fifo/util_axis_fifo.v
@@ -72,8 +72,8 @@ generate if (ADDRESS_WIDTH == 0) begin
   ) i_waddr_sync (
     .out_clk(m_axis_aclk),
     .out_resetn(m_axis_aresetn),
-    .in(s_axis_waddr),
-    .out(m_axis_waddr)
+    .in_bits(s_axis_waddr),
+    .out_bits(m_axis_waddr)
   );
 
   sync_bits #(
@@ -82,8 +82,8 @@ generate if (ADDRESS_WIDTH == 0) begin
   ) i_raddr_sync (
     .out_clk(s_axis_aclk),
     .out_resetn(s_axis_aresetn),
-    .in(m_axis_raddr),
-    .out(s_axis_raddr)
+    .in_bits(m_axis_raddr),
+    .out_bits(s_axis_raddr)
   );
 
   assign m_axis_valid = m_axis_raddr != m_axis_waddr;

--- a/library/util_cdc/sync_bits.v
+++ b/library/util_cdc/sync_bits.v
@@ -51,10 +51,10 @@ module sync_bits #(
   // be bypassed and the output signal equals the input signal.
   parameter ASYNC_CLK = 1)(
 
-  input [NUM_OF_BITS-1:0] in,
+  input [NUM_OF_BITS-1:0] in_bits,
   input out_resetn,
   input out_clk,
-  output [NUM_OF_BITS-1:0] out);
+  output [NUM_OF_BITS-1:0] out_bits);
 
 generate if (ASYNC_CLK == 1) begin
   reg [NUM_OF_BITS-1:0] cdc_sync_stage1 = 'h0;
@@ -66,14 +66,14 @@ generate if (ASYNC_CLK == 1) begin
       cdc_sync_stage1 <= 'b0;
       cdc_sync_stage2 <= 'b0;
     end else begin
-      cdc_sync_stage1 <= in;
+      cdc_sync_stage1 <= in_bits;
       cdc_sync_stage2 <= cdc_sync_stage1;
     end
   end
 
-  assign out = cdc_sync_stage2;
+  assign out_bits = cdc_sync_stage2;
 end else begin
-  assign out = in;
+  assign out_bits = in_bits;
 end endgenerate
 
 endmodule

--- a/library/util_cdc/sync_data.v
+++ b/library/util_cdc/sync_data.v
@@ -57,17 +57,17 @@ reg in_toggle_d1 = 1'b0;
 reg [NUM_OF_BITS-1:0] cdc_hold;
 
 sync_bits i_sync_out (
-  .in(in_toggle_d1),
+  .in_bits(in_toggle_d1),
   .out_clk(out_clk),
   .out_resetn(1'b1),
-  .out(out_toggle)
+  .out_bits(out_toggle)
 );
 
 sync_bits i_sync_in (
-  .in(out_toggle_d1),
+  .in_bits(out_toggle_d1),
   .out_clk(in_clk),
   .out_resetn(1'b1),
-  .out(in_toggle)
+  .out_bits(in_toggle)
 );
 
 wire in_load = in_toggle == in_toggle_d1;

--- a/library/util_cdc/sync_event.v
+++ b/library/util_cdc/sync_event.v
@@ -55,17 +55,17 @@ reg out_toggle_d1 = 1'b0;
 reg in_toggle_d1 = 1'b0;
 
 sync_bits i_sync_out (
-  .in(in_toggle_d1),
+  .in_bits(in_toggle_d1),
   .out_clk(out_clk),
   .out_resetn(1'b1),
-  .out(out_toggle)
+  .out_bits(out_toggle)
 );
 
 sync_bits i_sync_in (
-  .in(out_toggle_d1),
+  .in_bits(out_toggle_d1),
   .out_clk(in_clk),
   .out_resetn(1'b1),
-  .out(in_toggle)
+  .out_bits(in_toggle)
 );
 
 wire in_ready = in_toggle == in_toggle_d1;


### PR DESCRIPTION
Added changes from Nicholas Pillitteri njpillitteri@gmail.com (pull request #259) to simplify the merge, without the need for a rebase on his pull request