### PR TITLE
axi_dmac: infer interrupt line for Xilinx projects

### DIFF
--- a/library/axi_dmac/axi_dmac_ip.tcl
+++ b/library/axi_dmac/axi_dmac_ip.tcl
@@ -191,6 +191,9 @@ foreach port {"s_axis_user" "fifo_wr_sync"} {
 	set_property DRIVER_VALUE "1" [ipx::get_ports $port]
 }
 
+# Infer interrupt
+ipx::infer_bus_interface irq xilinx.com:signal:interrupt_rtl:1.0 [ipx::current_core]
+
 set cc [ipx::current_core]
 
 # The core does not issue narrow bursts


### PR DESCRIPTION
The interrupt controller from Microblaze based projects requires that
all its inputs have attributes which define the sensitivity of the
interrupt line. Other case it defaults to EDGE_RISING which is not the
case for DMAC, leading to incorrect interrupt reporting and handling in
case of such projects.

Tested on 
VCU118 : dual_ad9208