### PR TITLE
PL DDR3 size is 1Gbyte

### DIFF
--- a/projects/common/zc706/zc706_plddr3_adcfifo_bd.tcl
+++ b/projects/common/zc706/zc706_plddr3_adcfifo_bd.tcl
@@ -30,7 +30,7 @@ proc ad_adcfifo_create {adc_fifo_name adc_data_width adc_dma_data_width adc_fifo
   ad_ip_parameter $adc_fifo_name CONFIG.AXI_SIZE 6
   ad_ip_parameter $adc_fifo_name CONFIG.AXI_LENGTH 4
   ad_ip_parameter $adc_fifo_name CONFIG.AXI_ADDRESS 0x80000000
-  ad_ip_parameter $adc_fifo_name CONFIG.AXI_ADDRESS_LIMIT 0xa0000000
+  ad_ip_parameter $adc_fifo_name CONFIG.AXI_ADDRESS_LIMIT 0xbfffffff
 
   ad_connect  axi_ddr_cntrl/S_AXI $adc_fifo_name/axi
   ad_connect  axi_ddr_cntrl/ui_clk $adc_fifo_name/axi_clk

--- a/projects/common/zc706/zc706_plddr3_dacfifo_bd.tcl
+++ b/projects/common/zc706/zc706_plddr3_dacfifo_bd.tcl
@@ -29,7 +29,7 @@ proc ad_dacfifo_create {dac_fifo_name dac_data_width dac_dma_data_width dac_fifo
   ad_ip_parameter $dac_fifo_name CONFIG.AXI_SIZE 6
   ad_ip_parameter $dac_fifo_name CONFIG.AXI_LENGTH 255
   ad_ip_parameter $dac_fifo_name CONFIG.AXI_ADDRESS 0x80000000
-  ad_ip_parameter $dac_fifo_name CONFIG.AXI_ADDRESS_LIMIT 0xa0000000
+  ad_ip_parameter $dac_fifo_name CONFIG.AXI_ADDRESS_LIMIT 0xbfffffff
 
   ad_connect  axi_ddr_cntrl/S_AXI $dac_fifo_name/axi
   ad_connect  axi_ddr_cntrl/ui_clk $dac_fifo_name/axi_clk


### PR DESCRIPTION
The AXI_ADDRESS_LIMIT parameter will define the high address of the interface. The ZC706 has a 1Gbyte DDR3 on the PL side. Modify the address limit, so we can use the overall size of the memory.