### PR TITLE
Top levels with parameters

### DIFF
--- a/projects/scripts/adi_project.tcl
+++ b/projects/scripts/adi_project.tcl
@@ -29,7 +29,7 @@ set p_device "none"
 set sys_zynq 1
 set ADI_POWER_OPTIMIZATION 0
 
-proc adi_project_xilinx {project_name {mode 0}} {
+proc adi_project_xilinx {project_name {mode 0} {parameter_list {}} } {
 
   global ad_hdl_dir
   global ad_phdl_dir
@@ -144,6 +144,15 @@ proc adi_project_xilinx {project_name {mode 0}} {
   ## of this limit is 100.
   ## Overrides the default limit to 2000.
   set_param messaging.defaultLimit 2000
+
+  # Set parameters of the top level file
+  # Make the same parameters available to system_bd.tcl
+  set proj_params [get_property generic [current_fileset]]
+  foreach {param value} $parameter_list {
+    lappend proj_params $param=$value
+    set ad_project_params($param) $value
+  }
+  set_property generic $proj_params [current_fileset]
 
   create_bd_design "system"
   source system_bd.tcl

--- a/projects/scripts/adi_project_alt.tcl
+++ b/projects/scripts/adi_project_alt.tcl
@@ -7,7 +7,7 @@ set family "none"
 set device "none"
 set version "18.1.0"
 
-proc adi_project_altera {project_name} {
+proc adi_project_altera {project_name {parameter_list {}}} {
 
   global ad_hdl_dir
   global ad_phdl_dir
@@ -96,6 +96,7 @@ proc adi_project_altera {project_name} {
   puts $QFILE "set_module_property NAME {system_bd}"
   puts $QFILE "set_project_property DEVICE_FAMILY {$family}"
   puts $QFILE "set_project_property DEVICE $device"
+  puts $QFILE "foreach {param value} {$parameter_list} { set ad_project_params(\$param) \$value }"
   puts $QFILE "source system_qsys.tcl"
   puts $QFILE "set_interconnect_requirement {\$system} {qsys_mm.clockCrossingAdapter} {AUTO}"
   puts $QFILE "set_interconnect_requirement {\$system} {qsys_mm.burstAdapterImplementation} {PER_BURST_TYPE_CONVERTER}"
@@ -152,5 +153,10 @@ proc adi_project_altera {project_name} {
   set_global_assignment -name TIMEQUEST_DO_CCPP_REMOVAL ON
   set_global_assignment -name TIMEQUEST_REPORT_SCRIPT $ad_hdl_dir/projects/scripts/adi_tquest.tcl
   set_global_assignment -name ON_CHIP_BITSTREAM_DECOMPRESSION OFF
+
+  # set top level file parameters
+  foreach {param value} $parameter_list {
+    set_parameter -name $param $value
+  }
 }
 


### PR DESCRIPTION
Allow the top level files to have parameters.
Pass the parameters from system_project.tcl to the Vivado/Quartus project and
to the block design scripts through ad_project_params variable.

Usage:

1. create a project with a list of parameters:

adi_project_xilinx  my_project [list PARAM_A PARAM_A_VALUE PARAM_B PARAM_B_VALUE]
or
adi_project_altera  my_project [list PARAM_A PARAM_A_VALUE PARAM_B PARAM_B_VALUE]

2. access the parameter in QSYS or block design through the $ad_project_params variable

e.g
  set PARAM_A $ad_project_params(PARAM_A)
  set PARAM_B $ad_project_params(PARAM_B)

3. In system_top.v use PARAM_A and PARAM_B as parameters/generics


**Example project:** https://github.com/analogdevicesinc/hdl/tree/dev_ad9136_fmc/projects/dac_fmc_ebz

