### PR TITLE
jesd204:tpl: add missing dependencies for Intel

### DIFF
--- a/library/jesd204/ad_ip_jesd204_tpl_adc/ad_ip_jesd204_tpl_adc_hw.tcl
+++ b/library/jesd204/ad_ip_jesd204_tpl_adc/ad_ip_jesd204_tpl_adc_hw.tcl
@@ -39,6 +39,7 @@ ad_ip_files ad_ip_jesd204_tpl_adc [list \
   $ad_hdl_dir/library/common/up_adc_common.v \
   $ad_hdl_dir/library/common/up_adc_channel.v \
   $ad_hdl_dir/library/common/ad_xcvr_rx_if.v \
+  $ad_hdl_dir/library/jesd204/ad_ip_jesd204_tpl_common/up_tpl_common.v \
   $ad_hdl_dir/library/jesd204/ad_ip_jesd204_tpl_adc/ad_ip_jesd204_tpl_adc_regmap.v \
   $ad_hdl_dir/library/jesd204/ad_ip_jesd204_tpl_adc/ad_ip_jesd204_tpl_adc_pnmon.v \
   $ad_hdl_dir/library/jesd204/ad_ip_jesd204_tpl_adc/ad_ip_jesd204_tpl_adc_channel.v \

--- a/library/jesd204/ad_ip_jesd204_tpl_dac/ad_ip_jesd204_tpl_dac_hw.tcl
+++ b/library/jesd204/ad_ip_jesd204_tpl_dac/ad_ip_jesd204_tpl_dac_hw.tcl
@@ -55,6 +55,7 @@ ad_ip_files ad_ip_jesd204_tpl_dac [list \
   ad_ip_jesd204_tpl_dac_framer.v \
   ad_ip_jesd204_tpl_dac_pn.v \
   ad_ip_jesd204_tpl_dac_regmap.v \
+  ../ad_ip_jesd204_tpl_common/up_tpl_common.v \
 ]
 
 # parameters


### PR DESCRIPTION
When TPLs are directly instantiated in QSYS they fail to build due dependency issues. 

Tested with AD9172+A10SoC