### PR TITLE
scripts/adi_project.tcl: make search for undefined clocks more robust

### DIFF
--- a/projects/scripts/adi_project.tcl
+++ b/projects/scripts/adi_project.tcl
@@ -212,10 +212,13 @@ proc adi_project_run {project_name} {
 
   # Look for undefined clocks which do not show up in the timing summary
   set timing_check [check_timing -override_defaults no_clock -no_header -return_string]
-  regexp {are (\d+) register} $timing_check -> num_regs
-  if {$num_regs > 0} {
-    puts "CRITICAL WARNING: There are $num_regs registers with no clocks !!! See no_clock.log for details."
-    check_timing -override_defaults no_clock -verbose -file no_clock.log
+  if {[regexp { (\d+) register} $timing_check -> num_regs]} {
+    if {$num_regs > 0} {
+      puts "CRITICAL WARNING: There are $num_regs registers with no clocks !!! See no_clock.log for details."
+      check_timing -override_defaults no_clock -verbose -file no_clock.log
+    }
+  } else {
+    puts "CRITICAL WARNING: The search for undefined clocks failed !!!"
   }
 
   file mkdir $project_name.sdk


### PR DESCRIPTION
Since we parse the output of a command it is likely to break in the
future if the format of the sting changes. Create a warning for that case.


Required by some of the ZCU102 projects which currently fail to build.