### PR TITLE
Talise SOM multi-sync

### DIFF
--- a/library/common/util_axis_syncgen.v
+++ b/library/common/util_axis_syncgen.v
@@ -1,0 +1,93 @@
+// ***************************************************************************
+// ***************************************************************************
+// Copyright 2014 - 2017 (c) Analog Devices, Inc. All rights reserved.
+//
+// In this HDL repository, there are many different and unique modules, consisting
+// of various HDL (Verilog or VHDL) components. The individual modules are
+// developed independently, and may be accompanied by separate and unique license
+// terms.
+//
+// The user should read each of these license terms, and understand the
+// freedoms and responsibilities that he or she has by using this source/core.
+//
+// This core is distributed in the hope that it will be useful, but WITHOUT ANY
+// WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+// A PARTICULAR PURPOSE.
+//
+// Redistribution and use of source or resulting binaries, with or without modification
+// of this file, are permitted under one of the following two license terms:
+//
+//   1. The GNU General Public License version 2 as published by the
+//      Free Software Foundation, which can be found in the top level directory
+//      of this repository (LICENSE_GPL2), and also online at:
+//      <https://www.gnu.org/licenses/old-licenses/gpl-2.0.html>
+//
+// OR
+//
+//   2. An ADI specific BSD license, which can be found in the top level directory
+//      of this repository (LICENSE_ADIBSD), and also on-line at:
+//      https://github.com/analogdevicesinc/hdl/blob/master/LICENSE_ADIBSD
+//      This will allow to generate bit files and not release the source code,
+//      as long as it attaches to an ADI device.
+//
+// ***************************************************************************
+// ***************************************************************************
+
+`timescale 1ns/100ps
+
+module util_axis_syncgen #(
+
+  parameter ASYNC_SYNC = 1) (
+
+  input      s_axis_aclk,
+  input      s_axis_aresetn,
+  input      s_axis_ready,
+  input      s_axis_valid,
+
+  input      ext_sync,
+  output     s_axis_sync);
+
+  wire       sync_int_s;
+  wire       sync_ack_s;
+  wire       sync_ack_int_s;
+  reg        synced = 1'b0;
+  reg        sync_int_d = 1'b0;
+  reg        s_axis_sync_int = 1'b0;
+
+  // generate CDC for external sync
+
+  sync_bits #(
+    .NUM_OF_BITS (1),
+    .ASYNC_CLK (ASYNC_SYNC))
+  i_axis_ext_sync (
+    .in_bits (ext_sync),
+    .out_clk (s_axis_aclk),
+    .out_resetn (s_axis_aresetn),
+    .out_bits (sync_int_s));
+
+  // generate the sync signal
+
+  assign sync_ack_s = sync_int_s & s_axis_ready & s_axis_valid;
+  assign sync_ack_int_s = s_axis_sync_int & s_axis_ready & s_axis_valid;
+
+  always @(posedge s_axis_aclk) begin
+    if (s_axis_aresetn == 1'b0) begin
+      sync_int_d <= 1'b0;
+      s_axis_sync_int <= 1'b0;
+      synced <= 1'b0;
+    end else begin
+      sync_int_d <= sync_int_s;
+      if (sync_int_s && ~sync_int_d) begin
+        s_axis_sync_int <= 1'b1;
+        synced <= 1'b0;
+      end
+      if (sync_ack_int_s) begin
+        synced <= 1'b1;
+        s_axis_sync_int <= 1'b0;
+      end
+    end
+  end
+
+  assign s_axis_sync = s_axis_sync_int | (sync_ack_s & ~synced);
+
+endmodule

--- a/library/common/util_reset_gen.v
+++ b/library/common/util_reset_gen.v
@@ -1,0 +1,81 @@
+// ***************************************************************************
+// ***************************************************************************
+// Copyright 2014 - 2017 (c) Analog Devices, Inc. All rights reserved.
+//
+// In this HDL repository, there are many different and unique modules, consisting
+// of various HDL (Verilog or VHDL) components. The individual modules are
+// developed independently, and may be accompanied by separate and unique license
+// terms.
+//
+// The user should read each of these license terms, and understand the
+// freedoms and responsibilities that he or she has by using this source/core.
+//
+// This core is distributed in the hope that it will be useful, but WITHOUT ANY
+// WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+// A PARTICULAR PURPOSE.
+//
+// Redistribution and use of source or resulting binaries, with or without modification
+// of this file, are permitted under one of the following two license terms:
+//
+//   1. The GNU General Public License version 2 as published by the
+//      Free Software Foundation, which can be found in the top level directory
+//      of this repository (LICENSE_GPL2), and also online at:
+//      <https://www.gnu.org/licenses/old-licenses/gpl-2.0.html>
+//
+// OR
+//
+//   2. An ADI specific BSD license, which can be found in the top level directory
+//      of this repository (LICENSE_ADIBSD), and also on-line at:
+//      https://github.com/analogdevicesinc/hdl/blob/master/LICENSE_ADIBSD
+//      This will allow to generate bit files and not release the source code,
+//      as long as it attaches to an ADI device.
+//
+// ***************************************************************************
+// ***************************************************************************
+
+`timescale 1ns/100ps
+
+module util_reset_gen #(
+
+  parameter ASYNC_CLK = 1) (
+
+  input           clk,
+
+  input           sync_ext_in,
+  output          sync_ext_out,
+
+  output  reg     reset,
+  output          resetn);
+
+  reg   [ 2:0]    sync_ext_int = 3'd0;
+
+  wire            sync_ext_int_s;
+
+  // generate CDC for external sync
+
+  sync_bits #(
+    .NUM_OF_BITS (1),
+    .ASYNC_CLK (ASYNC_CLK))
+  i_axis_ext_sync (
+    .in_bits (sync_ext_in),
+    .out_clk (clk),
+    .out_resetn (1'b0),
+    .out_bits (sync_ext_int_s));
+
+  // latch the sync signal
+
+  always @(posedge clk) begin
+    sync_ext_int <= {sync_ext_int[1:0], sync_ext_int_s};
+  end
+
+  // generate reset at the positive edge of sync
+
+  always @(posedge clk) begin
+    reset <= sync_ext_int_s & ~sync_ext_int[0];
+  end
+
+  assign resetn = ~reset;
+  assign sync_ext_out = sync_ext_int[2];
+
+endmodule
+

--- a/library/jesd204/ad_ip_jesd204_tpl_dac/ad_ip_jesd204_tpl_dac.v
+++ b/library/jesd204/ad_ip_jesd204_tpl_dac/ad_ip_jesd204_tpl_dac.v
@@ -54,6 +54,7 @@ module ad_ip_jesd204_tpl_dac #(
   output [NUM_CHANNELS-1:0] dac_valid,
   input [NUM_LANES*8*OCTETS_PER_BEAT-1:0] dac_ddata,
   input dac_dunf,
+  input dac_sync_ext,   // synchronize multiple TPL instance to an external signal
 
   // axi interface
 
@@ -93,7 +94,8 @@ module ad_ip_jesd204_tpl_dac #(
 
   // internal signals
 
-  wire dac_sync;
+  wire dac_sync_s;
+  wire dac_sync_regmap_s;
   wire dac_dds_format;
 
   wire [NUM_CHANNELS*16-1:0] dac_dds_scale_0_s;
@@ -145,7 +147,7 @@ module ad_ip_jesd204_tpl_dac #(
 
     .dac_dunf (dac_dunf),
 
-    .dac_sync (dac_sync),
+    .dac_sync (dac_sync_regmap_s),
     .dac_dds_format (dac_dds_format),
 
     .dac_dds_scale_0 (dac_dds_scale_0_s),
@@ -166,6 +168,10 @@ module ad_ip_jesd204_tpl_dac #(
     .jesd_np (BITS_PER_SAMPLE),
     .up_profile_sel ()
   );
+
+  // DAC sync generation
+
+  assign dac_sync_s = dac_sync_ext | dac_sync_regmap_s;
 
   // core
 
@@ -195,7 +201,7 @@ module ad_ip_jesd204_tpl_dac #(
     .dac_valid (dac_valid),
     .dac_ddata (dac_ddata),
 
-    .dac_sync (dac_sync),
+    .dac_sync (dac_sync_s),
     .dac_dds_format (dac_dds_format),
 
     .dac_dds_scale_0 (dac_dds_scale_0_s),

--- a/library/jesd204/scripts/jesd204.tcl
+++ b/library/jesd204/scripts/jesd204.tcl
@@ -238,6 +238,7 @@ proc adi_tpl_jesd204_tx_create {ip_name num_of_lanes num_of_converters samples_p
       create_bd_pin -dir O "${ip_name}/dac_valid_${i}"
       create_bd_pin -dir I "${ip_name}/dac_data_${i}"
     }
+    create_bd_pin -dir I "${ip_name}/dac_sync_ext"
 
     # Generic TPL core
     ad_ip_instance ad_ip_jesd204_tpl_dac "${ip_name}/tpl_core" [list \
@@ -289,6 +290,7 @@ proc adi_tpl_jesd204_tx_create {ip_name num_of_lanes num_of_converters samples_p
     }
     ad_connect ${ip_name}/data_concat/dout ${ip_name}/tpl_core/dac_ddata
     ad_connect ${ip_name}/dac_dunf ${ip_name}/tpl_core/dac_dunf
+    ad_connect ${ip_name}/dac_sync_ext ${ip_name}/tpl_core/dac_sync_ext
 
   } resulttext resultoptions]
 

--- a/projects/adrv9009_zu11eg_som/Makefile
+++ b/projects/adrv9009_zu11eg_som/Makefile
@@ -12,6 +12,8 @@ M_DEPS += adrv9009_zu11eg_som_constr.xdc
 M_DEPS += carrier_constr.xdc
 M_DEPS += ../../library/xilinx/common/ad_iobuf.v
 M_DEPS += ../../library/jesd204/scripts/jesd204.tcl
+M_DEPS += ../../library/common/util_axis_syncgen.v
+M_DEPS += ../../library/common/ad_edge_detect.v
 
 LIB_DEPS += axi_dmac
 LIB_DEPS += axi_i2s_adi
@@ -25,6 +27,7 @@ LIB_DEPS += jesd204/jesd204_rx
 LIB_DEPS += jesd204/jesd204_tx
 LIB_DEPS += util_pack/util_cpack2
 LIB_DEPS += util_pack/util_upack2
+LIB_DEPS += util_cdc
 LIB_DEPS += xilinx/axi_adxcvr
 LIB_DEPS += xilinx/axi_dacfifo
 LIB_DEPS += xilinx/util_adxcvr

--- a/projects/adrv9009_zu11eg_som/Makefile
+++ b/projects/adrv9009_zu11eg_som/Makefile
@@ -13,6 +13,7 @@ M_DEPS += carrier_constr.xdc
 M_DEPS += ../../library/xilinx/common/ad_iobuf.v
 M_DEPS += ../../library/jesd204/scripts/jesd204.tcl
 M_DEPS += ../../library/common/util_axis_syncgen.v
+M_DEPS += ../../library/common/util_reset_gen.v
 M_DEPS += ../../library/common/ad_edge_detect.v
 
 LIB_DEPS += axi_dmac

--- a/projects/adrv9009_zu11eg_som/system_bd.tcl
+++ b/projects/adrv9009_zu11eg_som/system_bd.tcl
@@ -2,7 +2,8 @@
 ## add RTL sources which will be instantiated in system_bd directly
 adi_project_files adrv9009_zu11eg_som [list \
   "$ad_hdl_dir/library/common/ad_edge_detect.v" \
-  "$ad_hdl_dir/library/util_cdc/sync_bits.v" ]
+  "$ad_hdl_dir/library/util_cdc/sync_bits.v" \
+  "$ad_hdl_dir/library/common/util_reset_gen.v" \
   "$ad_hdl_dir/library/common/util_axis_syncgen.v" ]
 
 # create board design

--- a/projects/adrv9009_zu11eg_som/system_bd.tcl
+++ b/projects/adrv9009_zu11eg_som/system_bd.tcl
@@ -1,3 +1,10 @@
+
+## add RTL sources which will be instantiated in system_bd directly
+adi_project_files adrv9009_zu11eg_som [list \
+  "$ad_hdl_dir/library/common/ad_edge_detect.v" \
+  "$ad_hdl_dir/library/util_cdc/sync_bits.v" ]
+  "$ad_hdl_dir/library/common/util_axis_syncgen.v" ]
+
 # create board design
 # default ports
 


### PR DESCRIPTION
Add a synchronization logic, which starts the RX _DMA/TX_DDS at a positive edge of the SYSREF.
This way we can synchronize the capture in multiple Talise SOMs, if they have a fully synchronous JESD204 link.

NOTE: There are a lot of integration work, that needs to be done in this task, so be nice with it. Current goal is to make something that works.