### PR TITLE
pluto: Fix the adc/dac dma mapping to to ps7 S_AXI_HP1/S_AXI_HP2

### DIFF
--- a/projects/pluto/system_bd.tcl
+++ b/projects/pluto/system_bd.tcl
@@ -253,9 +253,19 @@ ad_ip_parameter sys_ps7 CONFIG.PCW_USE_S_AXI_HP1 {1}
 ad_connect sys_cpu_clk sys_ps7/S_AXI_HP1_ACLK
 ad_connect axi_ad9361_adc_dma/m_dest_axi sys_ps7/S_AXI_HP1
 
+create_bd_addr_seg -range 0x20000000 -offset 0x00000000 \
+                    [get_bd_addr_spaces axi_ad9361_adc_dma/m_dest_axi] \
+                    [get_bd_addr_segs sys_ps7/S_AXI_HP1/HP1_DDR_LOWOCM] \
+                    SEG_sys_ps7_HP1_DDR_LOWOCM
+
 ad_ip_parameter sys_ps7 CONFIG.PCW_USE_S_AXI_HP2 {1}
 ad_connect sys_cpu_clk sys_ps7/S_AXI_HP2_ACLK
 ad_connect axi_ad9361_dac_dma/m_src_axi sys_ps7/S_AXI_HP2
+
+create_bd_addr_seg -range 0x20000000 -offset 0x00000000 \
+                    [get_bd_addr_spaces axi_ad9361_dac_dma/m_src_axi] \
+                    [get_bd_addr_segs sys_ps7/S_AXI_HP2/HP2_DDR_LOWOCM] \
+                    SEG_sys_ps7_HP2_DDR_LOWOCM
 
 ad_connect sys_cpu_clk axi_ad9361_dac_dma/m_src_axi_aclk
 ad_connect sys_cpu_clk axi_ad9361_adc_dma/m_dest_axi_aclk


### PR DESCRIPTION
After the commit that removed the interconnects from HP ports
in order to reduce utilization; the directly connected DMAs were not
assigned to a specific range and address.
This change adds back the address and offset.

Tested on Pluto.