### PR TITLE
common zed, zc702 and zc706: Remove parameter assignment

### DIFF
--- a/projects/common/zc702/zc702_system_bd.tcl
+++ b/projects/common/zc702/zc702_system_bd.tcl
@@ -82,7 +82,6 @@ ad_ip_instance axi_dmac axi_hdmi_dma
 ad_ip_parameter axi_hdmi_dma CONFIG.DMA_TYPE_SRC 0
 ad_ip_parameter axi_hdmi_dma CONFIG.DMA_TYPE_DEST 1
 ad_ip_parameter axi_hdmi_dma CONFIG.CYCLIC true
-ad_ip_parameter axi_hdmi_dma CONFIG.SYNC_TRANSFER_START 0
 ad_ip_parameter axi_hdmi_dma CONFIG.AXI_SLICE_SRC 0
 ad_ip_parameter axi_hdmi_dma CONFIG.AXI_SLICE_DEST 0
 ad_ip_parameter axi_hdmi_dma CONFIG.DMA_2D_TRANSFER true

--- a/projects/common/zc706/zc706_system_bd.tcl
+++ b/projects/common/zc706/zc706_system_bd.tcl
@@ -83,7 +83,6 @@ ad_ip_instance axi_dmac axi_hdmi_dma
 ad_ip_parameter axi_hdmi_dma CONFIG.DMA_TYPE_SRC 0
 ad_ip_parameter axi_hdmi_dma CONFIG.DMA_TYPE_DEST 1
 ad_ip_parameter axi_hdmi_dma CONFIG.CYCLIC true
-ad_ip_parameter axi_hdmi_dma CONFIG.SYNC_TRANSFER_START 0
 ad_ip_parameter axi_hdmi_dma CONFIG.AXI_SLICE_SRC 0
 ad_ip_parameter axi_hdmi_dma CONFIG.AXI_SLICE_DEST 0
 ad_ip_parameter axi_hdmi_dma CONFIG.DMA_2D_TRANSFER true

--- a/projects/common/zed/zed_system_bd.tcl
+++ b/projects/common/zed/zed_system_bd.tcl
@@ -107,7 +107,6 @@ ad_ip_instance axi_dmac axi_hdmi_dma
 ad_ip_parameter axi_hdmi_dma CONFIG.DMA_TYPE_SRC 0
 ad_ip_parameter axi_hdmi_dma CONFIG.DMA_TYPE_DEST 1
 ad_ip_parameter axi_hdmi_dma CONFIG.CYCLIC true
-ad_ip_parameter axi_hdmi_dma CONFIG.SYNC_TRANSFER_START 0
 ad_ip_parameter axi_hdmi_dma CONFIG.AXI_SLICE_SRC 0
 ad_ip_parameter axi_hdmi_dma CONFIG.AXI_SLICE_DEST 0
 ad_ip_parameter axi_hdmi_dma CONFIG.DMA_2D_TRANSFER true


### PR DESCRIPTION
The SYNC_TRANSFER_START parameter is disabled in this configuration
of the axi_dmac, trying to set the parameter will generate a warning.