### PR TITLE
Clean adi_board.tcl

### DIFF
--- a/projects/adrv9009/common/adrv9009_bd.tcl
+++ b/projects/adrv9009/common/adrv9009_bd.tcl
@@ -180,13 +180,9 @@ ad_ip_parameter util_adrv9009_xcvr CONFIG.QPLL_FBDIV 0x080
 
 # xcvr interfaces
 
-set tx_offset 0
-set rx_offset 0
-set rx_obs_offset  $RX_NUM_OF_LANES
-
-set tx_ref_clk     tx_ref_clk_$tx_offset
-set rx_ref_clk     rx_ref_clk_$rx_offset
-set rx_obs_ref_clk rx_ref_clk_$rx_obs_offset
+set tx_ref_clk     tx_ref_clk_0
+set rx_ref_clk     rx_ref_clk_0
+set rx_obs_ref_clk rx_ref_clk_$RX_NUM_OF_LANES
 
 create_bd_port -dir I $tx_ref_clk
 create_bd_port -dir I $rx_ref_clk
@@ -195,39 +191,32 @@ ad_connect  sys_cpu_resetn util_adrv9009_xcvr/up_rstn
 ad_connect  sys_cpu_clk util_adrv9009_xcvr/up_clk
 
 # Tx
-ad_xcvrcon  util_adrv9009_xcvr axi_adrv9009_tx_xcvr axi_adrv9009_tx_jesd {0 3 2 1}
-ad_reconct  util_adrv9009_xcvr/tx_out_clk_0 axi_adrv9009_tx_clkgen/clk
-for {set i 0} {$i < $TX_NUM_OF_LANES} {incr i} {
-  ad_connect  axi_adrv9009_tx_clkgen/clk_0 util_adrv9009_xcvr/tx_clk_$i
-}
-ad_xcvrpll  $tx_ref_clk util_adrv9009_xcvr/qpll_ref_clk_0
-ad_xcvrpll  axi_adrv9009_tx_xcvr/up_pll_rst util_adrv9009_xcvr/up_qpll_rst_0
-ad_connect  axi_adrv9009_tx_clkgen/clk_0 axi_adrv9009_tx_jesd/device_clk
-ad_connect  axi_adrv9009_tx_clkgen/clk_0 axi_adrv9009_tx_jesd_rstgen/slowest_sync_clk
+ad_connect adrv9009_tx_device_clk axi_adrv9009_tx_clkgen/clk_0
+ad_xcvrcon util_adrv9009_xcvr axi_adrv9009_tx_xcvr axi_adrv9009_tx_jesd {0 3 2 1} adrv9009_tx_device_clk
+ad_connect util_adrv9009_xcvr/tx_out_clk_0 axi_adrv9009_tx_clkgen/clk
+ad_xcvrpll $tx_ref_clk util_adrv9009_xcvr/qpll_ref_clk_0
+ad_xcvrpll axi_adrv9009_tx_xcvr/up_pll_rst util_adrv9009_xcvr/up_qpll_rst_0
 
 # Rx
-ad_xcvrcon  util_adrv9009_xcvr axi_adrv9009_rx_xcvr axi_adrv9009_rx_jesd
-ad_reconct  util_adrv9009_xcvr/rx_out_clk_$rx_offset axi_adrv9009_rx_clkgen/clk
+ad_connect adrv9009_rx_device_clk axi_adrv9009_rx_clkgen/clk_0
+ad_xcvrcon  util_adrv9009_xcvr axi_adrv9009_rx_xcvr axi_adrv9009_rx_jesd {} adrv9009_rx_device_clk
+ad_connect util_adrv9009_xcvr/rx_out_clk_0 axi_adrv9009_rx_clkgen/clk
 for {set i 0} {$i < $RX_NUM_OF_LANES} {incr i} {
-  set ch [expr $rx_offset+$i]
-  ad_connect  axi_adrv9009_rx_clkgen/clk_0 util_adrv9009_xcvr/rx_clk_$ch
+  set ch [expr $i]
   ad_xcvrpll  $rx_ref_clk util_adrv9009_xcvr/cpll_ref_clk_$ch
   ad_xcvrpll  axi_adrv9009_rx_xcvr/up_pll_rst util_adrv9009_xcvr/up_cpll_rst_$ch
 }
-ad_connect  axi_adrv9009_rx_clkgen/clk_0 axi_adrv9009_rx_jesd/device_clk
-ad_connect  axi_adrv9009_rx_clkgen/clk_0 axi_adrv9009_rx_jesd_rstgen/slowest_sync_clk
 
 # Rx - OBS
-ad_xcvrcon  util_adrv9009_xcvr axi_adrv9009_rx_os_xcvr axi_adrv9009_rx_os_jesd
-ad_reconct  util_adrv9009_xcvr/rx_out_clk_$rx_obs_offset axi_adrv9009_rx_os_clkgen/clk
+ad_connect adrv9009_rx_os_device_clk axi_adrv9009_rx_os_clkgen/clk_0
+ad_xcvrcon util_adrv9009_xcvr axi_adrv9009_rx_os_xcvr axi_adrv9009_rx_os_jesd {} adrv9009_rx_os_device_clk
+ad_connect util_adrv9009_xcvr/rx_out_clk_$RX_NUM_OF_LANES axi_adrv9009_rx_os_clkgen/clk
 for {set i 0} {$i < $RX_OS_NUM_OF_LANES} {incr i} {
-  set ch [expr $rx_obs_offset+$i]
-  ad_connect  axi_adrv9009_rx_os_clkgen/clk_0 util_adrv9009_xcvr/rx_clk_$ch
+  # channel indexing starts from the last RX
+  set ch [expr $RX_NUM_OF_LANES + $i]
   ad_xcvrpll  $rx_obs_ref_clk util_adrv9009_xcvr/cpll_ref_clk_$ch
   ad_xcvrpll  axi_adrv9009_rx_os_xcvr/up_pll_rst util_adrv9009_xcvr/up_cpll_rst_$ch
 }
-ad_connect  axi_adrv9009_rx_os_clkgen/clk_0 axi_adrv9009_rx_os_jesd/device_clk
-ad_connect  axi_adrv9009_rx_os_clkgen/clk_0 axi_adrv9009_rx_os_jesd_rstgen/slowest_sync_clk
 
 # dma clock & reset
 
@@ -245,7 +234,7 @@ ad_connect  axi_adrv9009_tx_clkgen/clk_0 tx_adrv9009_tpl_core/link_clk
 ad_connect  axi_adrv9009_tx_jesd/tx_data tx_adrv9009_tpl_core/link
 
 ad_connect  axi_adrv9009_tx_clkgen/clk_0 util_adrv9009_tx_upack/clk
-ad_connect  axi_adrv9009_tx_jesd_rstgen/peripheral_reset util_adrv9009_tx_upack/reset
+ad_connect  adrv9009_tx_device_clk_rstgen/peripheral_reset util_adrv9009_tx_upack/reset
 
 ad_connect  tx_adrv9009_tpl_core/dac_valid_0 util_adrv9009_tx_upack/fifo_rd_en
 for {set i 0} {$i < $TX_NUM_OF_CONVERTERS} {incr i} {
@@ -254,7 +243,7 @@ for {set i 0} {$i < $TX_NUM_OF_CONVERTERS} {incr i} {
 }
 
 ad_connect  axi_adrv9009_tx_clkgen/clk_0 axi_adrv9009_dacfifo/dac_clk
-ad_connect  axi_adrv9009_tx_jesd_rstgen/peripheral_reset axi_adrv9009_dacfifo/dac_rst
+ad_connect  adrv9009_tx_device_clk_rstgen/peripheral_reset axi_adrv9009_dacfifo/dac_rst
 
 # TODO: Add streaming AXI interface for DAC FIFO
 ad_connect  util_adrv9009_tx_upack/s_axis_valid VCC
@@ -279,7 +268,7 @@ ad_connect  axi_adrv9009_rx_jesd/rx_sof rx_adrv9009_tpl_core/link_sof
 ad_connect  axi_adrv9009_rx_jesd/rx_data_tdata rx_adrv9009_tpl_core/link_data
 ad_connect  axi_adrv9009_rx_jesd/rx_data_tvalid rx_adrv9009_tpl_core/link_valid
 ad_connect  axi_adrv9009_rx_clkgen/clk_0 util_adrv9009_rx_cpack/clk
-ad_connect  axi_adrv9009_rx_jesd_rstgen/peripheral_reset util_adrv9009_rx_cpack/reset
+ad_connect  adrv9009_rx_device_clk_rstgen/peripheral_reset util_adrv9009_rx_cpack/reset
 
 ad_connect rx_adrv9009_tpl_core/adc_valid_0 util_adrv9009_rx_cpack/fifo_wr_en
 for {set i 0} {$i < $RX_NUM_OF_CONVERTERS} {incr i} {
@@ -299,7 +288,7 @@ ad_connect  axi_adrv9009_rx_os_jesd/rx_sof rx_os_adrv9009_tpl_core/link_sof
 ad_connect  axi_adrv9009_rx_os_jesd/rx_data_tdata rx_os_adrv9009_tpl_core/link_data
 ad_connect  axi_adrv9009_rx_os_jesd/rx_data_tvalid rx_os_adrv9009_tpl_core/link_valid
 ad_connect  axi_adrv9009_rx_os_clkgen/clk_0 util_adrv9009_rx_os_cpack/clk
-ad_connect  axi_adrv9009_rx_os_jesd_rstgen/peripheral_reset util_adrv9009_rx_os_cpack/reset
+ad_connect  adrv9009_rx_os_device_clk_rstgen/peripheral_reset util_adrv9009_rx_os_cpack/reset
 ad_connect  axi_adrv9009_rx_os_clkgen/clk_0 axi_adrv9009_rx_os_dma/fifo_wr_clk
 
 ad_connect  rx_os_adrv9009_tpl_core/adc_valid_0 util_adrv9009_rx_os_cpack/fifo_wr_en

--- a/projects/scripts/adi_board.tcl
+++ b/projects/scripts/adi_board.tcl
@@ -153,28 +153,6 @@ proc ad_disconnect {p_name_1 p_name_2} {
   }
 }
 
-proc ad_reconct {p_name_1 p_name_2} {
-
-  set m_name_1 [ad_connect_type $p_name_1]
-  set m_name_2 [ad_connect_type $p_name_2]
-
-  if {[get_property CLASS $m_name_1] eq "bd_pin"} {
-    delete_bd_objs -quiet [get_bd_nets -quiet -of_objects \
-      [find_bd_objs -relation connected_to $m_name_1]]
-    delete_bd_objs -quiet [get_bd_nets -quiet -of_objects \
-      [find_bd_objs -relation connected_to $m_name_2]]
-  }
-
-  if {[get_property CLASS $m_name_1] eq "bd_intf_pin"} {
-    delete_bd_objs -quiet [get_bd_intf_nets -quiet -of_objects \
-      [find_bd_objs -relation connected_to $m_name_1]]
-    delete_bd_objs -quiet [get_bd_intf_nets -quiet -of_objects \
-      [find_bd_objs -relation connected_to $m_name_2]]
-  }
-
-  ad_connect $p_name_1 $p_name_2
-}
-
 ###################################################################################################
 ###################################################################################################
 


### PR DESCRIPTION
Delete deprecated proc called ad_reconct. In order to do this, we had to fix two ad_xcvrcon process call in the adrv9371x and adrv9009 block design.