### PR TITLE
Create a consistent clock tree

### DIFF
--- a/library/axi_ad9265/axi_ad9265_if.v
+++ b/library/axi_ad9265/axi_ad9265_if.v
@@ -40,7 +40,8 @@
 module axi_ad9265_if #(
 
   parameter   FPGA_TECHNOLOGY = 0,
-  parameter   IO_DELAY_GROUP = "adc_if_delay_group") (
+  parameter   IO_DELAY_GROUP = "adc_if_delay_group",
+  parameter   DELAY_REFCLK_FREQUENCY = 200) (
 
   // adc interface (clk, data, over-range)
   // nominal clock 125 MHz, up to 300 MHz
@@ -100,7 +101,8 @@ module axi_ad9265_if #(
   ad_data_in #(
     .FPGA_TECHNOLOGY (FPGA_TECHNOLOGY),
     .IODELAY_CTRL (0),
-    .IODELAY_GROUP (IO_DELAY_GROUP))
+    .IODELAY_GROUP (IO_DELAY_GROUP),
+    .REFCLK_FREQUENCY (DELAY_REFCLK_FREQUENCY))
   i_adc_data (
     .rx_clk (adc_clk),
     .rx_data_in_p (adc_data_in_p[l_inst]),
@@ -122,7 +124,8 @@ module axi_ad9265_if #(
   ad_data_in #(
     .FPGA_TECHNOLOGY (FPGA_TECHNOLOGY),
     .IODELAY_CTRL (1),
-    .IODELAY_GROUP (IO_DELAY_GROUP))
+    .IODELAY_GROUP (IO_DELAY_GROUP),
+    .REFCLK_FREQUENCY (DELAY_REFCLK_FREQUENCY))
   i_adc_or (
     .rx_clk (adc_clk),
     .rx_data_in_p (adc_or_in_p),

--- a/library/axi_ad9361/axi_ad9361.v
+++ b/library/axi_ad9361/axi_ad9361.v
@@ -65,7 +65,8 @@ module axi_ad9361 #(
   parameter   DAC_USERPORTS_DISABLE = 0,
   parameter   DAC_IQCORRECTION_DISABLE = 0,
   parameter   IO_DELAY_GROUP = "dev_if_delay_group",
-  parameter   MIMO_ENABLE = 0) (
+  parameter   MIMO_ENABLE = 0,
+  parameter   DELAY_REFCLK_FREQUENCY = 200) (
 
   // physical interface (receive-lvds)
 
@@ -331,7 +332,8 @@ module axi_ad9361 #(
     .FPGA_TECHNOLOGY (FPGA_TECHNOLOGY),
     .DAC_IODELAY_ENABLE (DAC_IODELAY_ENABLE),
     .IO_DELAY_GROUP (IO_DELAY_GROUP),
-    .CLK_DESKEW (MIMO_ENABLE))
+    .CLK_DESKEW (MIMO_ENABLE),
+    .DELAY_REFCLK_FREQUENCY (DELAY_REFCLK_FREQUENCY))
   i_dev_if (
     .rx_clk_in (rx_clk_in),
     .rx_frame_in (rx_frame_in),
@@ -393,7 +395,8 @@ module axi_ad9361 #(
     .FPGA_TECHNOLOGY (FPGA_TECHNOLOGY),
     .DAC_IODELAY_ENABLE (DAC_IODELAY_ENABLE),
     .IO_DELAY_GROUP (IO_DELAY_GROUP),
-    .CLK_DESKEW (MIMO_ENABLE))
+    .CLK_DESKEW (MIMO_ENABLE),
+    .DELAY_REFCLK_FREQUENCY (DELAY_REFCLK_FREQUENCY))
   i_dev_if (
     .rx_clk_in_p (rx_clk_in_p),
     .rx_clk_in_n (rx_clk_in_n),

--- a/library/axi_ad9361/xilinx/axi_ad9361_cmos_if.v
+++ b/library/axi_ad9361/xilinx/axi_ad9361_cmos_if.v
@@ -40,7 +40,8 @@ module axi_ad9361_cmos_if #(
   parameter   FPGA_TECHNOLOGY = 0,
   parameter   DAC_IODELAY_ENABLE = 0,
   parameter   IO_DELAY_GROUP = "dev_if_delay_group",
-  parameter   CLK_DESKEW = 0) (
+  parameter   CLK_DESKEW = 0,
+  parameter   DELAY_REFCLK_FREQUENCY = 200) (
 
   // physical interface (receive)
 
@@ -437,7 +438,8 @@ module axi_ad9361_cmos_if #(
     .SINGLE_ENDED (1),
     .FPGA_TECHNOLOGY (FPGA_TECHNOLOGY),
     .IODELAY_CTRL (0),
-    .IODELAY_GROUP (IO_DELAY_GROUP))
+    .IODELAY_GROUP (IO_DELAY_GROUP),
+    .REFCLK_FREQUENCY (DELAY_REFCLK_FREQUENCY))
   i_rx_data (
     .rx_clk (l_clk),
     .rx_data_in_p (rx_data_in[i]),
@@ -460,7 +462,8 @@ module axi_ad9361_cmos_if #(
     .SINGLE_ENDED (1),
     .FPGA_TECHNOLOGY (FPGA_TECHNOLOGY),
     .IODELAY_CTRL (1),
-    .IODELAY_GROUP (IO_DELAY_GROUP))
+    .IODELAY_GROUP (IO_DELAY_GROUP),
+    .REFCLK_FREQUENCY (DELAY_REFCLK_FREQUENCY))
   i_rx_frame (
     .rx_clk (l_clk),
     .rx_data_in_p (rx_frame_in),
@@ -484,7 +487,8 @@ module axi_ad9361_cmos_if #(
     .FPGA_TECHNOLOGY (FPGA_TECHNOLOGY),
     .IODELAY_ENABLE (DAC_IODELAY_ENABLE),
     .IODELAY_CTRL (0),
-    .IODELAY_GROUP (IO_DELAY_GROUP))
+    .IODELAY_GROUP (IO_DELAY_GROUP),
+    .REFCLK_FREQUENCY (DELAY_REFCLK_FREQUENCY))
   i_tx_data (
     .tx_clk (l_clk),
     .tx_data_p (tx_data_1[i]),
@@ -508,7 +512,8 @@ module axi_ad9361_cmos_if #(
     .FPGA_TECHNOLOGY (FPGA_TECHNOLOGY),
     .IODELAY_ENABLE (DAC_IODELAY_ENABLE),
     .IODELAY_CTRL (0),
-    .IODELAY_GROUP (IO_DELAY_GROUP))
+    .IODELAY_GROUP (IO_DELAY_GROUP),
+    .REFCLK_FREQUENCY (DELAY_REFCLK_FREQUENCY))
   i_tx_frame (
     .tx_clk (l_clk),
     .tx_data_p (tx_frame[1]),
@@ -530,7 +535,8 @@ module axi_ad9361_cmos_if #(
     .FPGA_TECHNOLOGY (FPGA_TECHNOLOGY),
     .IODELAY_ENABLE (DAC_IODELAY_ENABLE),
     .IODELAY_CTRL (0),
-    .IODELAY_GROUP (IO_DELAY_GROUP))
+    .IODELAY_GROUP (IO_DELAY_GROUP),
+    .REFCLK_FREQUENCY (DELAY_REFCLK_FREQUENCY))
   i_tx_clk (
     .tx_clk (l_clk),
     .tx_data_p (tx_clk[1]),
@@ -552,7 +558,8 @@ module axi_ad9361_cmos_if #(
     .FPGA_TECHNOLOGY (FPGA_TECHNOLOGY),
     .IODELAY_ENABLE (DAC_IODELAY_ENABLE),
     .IODELAY_CTRL (0),
-    .IODELAY_GROUP (IO_DELAY_GROUP))
+    .IODELAY_GROUP (IO_DELAY_GROUP),
+    .REFCLK_FREQUENCY (DELAY_REFCLK_FREQUENCY))
   i_enable (
     .tx_clk (l_clk),
     .tx_data_p (enable_int_p),
@@ -574,7 +581,8 @@ module axi_ad9361_cmos_if #(
     .FPGA_TECHNOLOGY (FPGA_TECHNOLOGY),
     .IODELAY_ENABLE (DAC_IODELAY_ENABLE),
     .IODELAY_CTRL (0),
-    .IODELAY_GROUP (IO_DELAY_GROUP))
+    .IODELAY_GROUP (IO_DELAY_GROUP),
+    .REFCLK_FREQUENCY (DELAY_REFCLK_FREQUENCY))
   i_txnrx (
     .tx_clk (l_clk),
     .tx_data_p (txnrx_int_p),

--- a/library/axi_ad9361/xilinx/axi_ad9361_lvds_if.v
+++ b/library/axi_ad9361/xilinx/axi_ad9361_lvds_if.v
@@ -40,7 +40,8 @@ module axi_ad9361_lvds_if #(
   parameter   FPGA_TECHNOLOGY = 0,
   parameter   DAC_IODELAY_ENABLE = 0,
   parameter   IO_DELAY_GROUP = "dev_if_delay_group",
-  parameter   CLK_DESKEW = 0) (
+  parameter   CLK_DESKEW = 0,
+  parameter   DELAY_REFCLK_FREQUENCY = 200) (
 
   // physical interface (receive)
 
@@ -533,7 +534,8 @@ module axi_ad9361_lvds_if #(
   ad_data_in #(
     .FPGA_TECHNOLOGY (FPGA_TECHNOLOGY),
     .IODELAY_CTRL (0),
-    .IODELAY_GROUP (IO_DELAY_GROUP))
+    .IODELAY_GROUP (IO_DELAY_GROUP),
+    .REFCLK_FREQUENCY (DELAY_REFCLK_FREQUENCY))
   i_rx_data (
     .rx_clk (l_clk),
     .rx_data_in_p (rx_data_in_p[i]),
@@ -555,7 +557,8 @@ module axi_ad9361_lvds_if #(
   ad_data_in #(
     .FPGA_TECHNOLOGY (FPGA_TECHNOLOGY),
     .IODELAY_CTRL (1),
-    .IODELAY_GROUP (IO_DELAY_GROUP))
+    .IODELAY_GROUP (IO_DELAY_GROUP),
+    .REFCLK_FREQUENCY (DELAY_REFCLK_FREQUENCY))
   i_rx_frame (
     .rx_clk (l_clk),
     .rx_data_in_p (rx_frame_in_p),
@@ -578,7 +581,8 @@ module axi_ad9361_lvds_if #(
     .FPGA_TECHNOLOGY (FPGA_TECHNOLOGY),
     .IODELAY_ENABLE (DAC_IODELAY_ENABLE),
     .IODELAY_CTRL (0),
-    .IODELAY_GROUP (IO_DELAY_GROUP))
+    .IODELAY_GROUP (IO_DELAY_GROUP),
+    .REFCLK_FREQUENCY (DELAY_REFCLK_FREQUENCY))
   i_tx_data (
     .tx_clk (l_clk),
     .tx_data_p (tx_data_1[i]),
@@ -601,7 +605,8 @@ module axi_ad9361_lvds_if #(
     .FPGA_TECHNOLOGY (FPGA_TECHNOLOGY),
     .IODELAY_ENABLE (DAC_IODELAY_ENABLE),
     .IODELAY_CTRL (0),
-    .IODELAY_GROUP (IO_DELAY_GROUP))
+    .IODELAY_GROUP (IO_DELAY_GROUP),
+    .REFCLK_FREQUENCY (DELAY_REFCLK_FREQUENCY))
   i_tx_frame (
     .tx_clk (l_clk),
     .tx_data_p (tx_frame),
@@ -622,7 +627,8 @@ module axi_ad9361_lvds_if #(
     .FPGA_TECHNOLOGY (FPGA_TECHNOLOGY),
     .IODELAY_ENABLE (DAC_IODELAY_ENABLE),
     .IODELAY_CTRL (0),
-    .IODELAY_GROUP (IO_DELAY_GROUP))
+    .IODELAY_GROUP (IO_DELAY_GROUP),
+    .REFCLK_FREQUENCY (DELAY_REFCLK_FREQUENCY))
   i_tx_clk (
     .tx_clk (l_clk),
     .tx_data_p (tx_clk[1]),
@@ -644,7 +650,8 @@ module axi_ad9361_lvds_if #(
     .FPGA_TECHNOLOGY (FPGA_TECHNOLOGY),
     .IODELAY_ENABLE (DAC_IODELAY_ENABLE),
     .IODELAY_CTRL (0),
-    .IODELAY_GROUP (IO_DELAY_GROUP))
+    .IODELAY_GROUP (IO_DELAY_GROUP),
+    .REFCLK_FREQUENCY (DELAY_REFCLK_FREQUENCY))
   i_enable (
     .tx_clk (l_clk),
     .tx_data_p (enable_int_p),
@@ -666,7 +673,8 @@ module axi_ad9361_lvds_if #(
     .FPGA_TECHNOLOGY (FPGA_TECHNOLOGY),
     .IODELAY_ENABLE (DAC_IODELAY_ENABLE),
     .IODELAY_CTRL (0),
-    .IODELAY_GROUP (IO_DELAY_GROUP))
+    .IODELAY_GROUP (IO_DELAY_GROUP),
+    .REFCLK_FREQUENCY (DELAY_REFCLK_FREQUENCY))
   i_txnrx (
     .tx_clk (l_clk),
     .tx_data_p (txnrx_int_p),

--- a/library/axi_ad9467/axi_ad9467.v
+++ b/library/axi_ad9467/axi_ad9467.v
@@ -37,12 +37,13 @@
 
 module axi_ad9467#(
 
-  parameter ID = 0,
+  parameter   ID = 0,
   parameter   FPGA_TECHNOLOGY = 0,
   parameter   FPGA_FAMILY = 0,
   parameter   SPEED_GRADE = 0,
   parameter   DEV_PACKAGE = 0,
-  parameter IO_DELAY_GROUP = "dev_if_delay_group") (
+  parameter   IO_DELAY_GROUP = "dev_if_delay_group",
+  parameter   DELAY_REFCLK_FREQUENCY = 200) (
 
   // physical interface
 
@@ -148,7 +149,8 @@ module axi_ad9467#(
 
   axi_ad9467_if #(
     .FPGA_TECHNOLOGY (FPGA_TECHNOLOGY),
-    .IO_DELAY_GROUP (IO_DELAY_GROUP))
+    .IO_DELAY_GROUP (IO_DELAY_GROUP),
+    .DELAY_REFCLK_FREQUENCY (DELAY_REFCLK_FREQUENCY))
   i_if (
     .adc_clk_in_p (adc_clk_in_p),
     .adc_clk_in_n (adc_clk_in_n),

--- a/library/axi_ad9467/axi_ad9467_if.v
+++ b/library/axi_ad9467/axi_ad9467_if.v
@@ -39,7 +39,8 @@
 module axi_ad9467_if #(
 
   parameter FPGA_TECHNOLOGY = 0,
-  parameter IO_DELAY_GROUP = "dev_if_delay_group") (
+  parameter IO_DELAY_GROUP = "dev_if_delay_group",
+  parameter DELAY_REFCLK_FREQUENCY = 200) (
 
   // adc interface (clk, data, over-range)
 
@@ -130,7 +131,8 @@ module axi_ad9467_if #(
   ad_data_in #(
     .FPGA_TECHNOLOGY (FPGA_TECHNOLOGY),
     .IODELAY_CTRL (0),
-    .IODELAY_GROUP (IO_DELAY_GROUP))
+    .IODELAY_GROUP (IO_DELAY_GROUP),
+    .REFCLK_FREQUENCY (DELAY_REFCLK_FREQUENCY))
   i_adc_data (
     .rx_clk (adc_clk),
     .rx_data_in_p (adc_data_in_p[l_inst]),
@@ -152,7 +154,8 @@ module axi_ad9467_if #(
   ad_data_in #(
     .FPGA_TECHNOLOGY (FPGA_TECHNOLOGY),
     .IODELAY_CTRL (1),
-    .IODELAY_GROUP (IO_DELAY_GROUP))
+    .IODELAY_GROUP (IO_DELAY_GROUP),
+    .REFCLK_FREQUENCY (DELAY_REFCLK_FREQUENCY))
   i_adc_or (
     .rx_clk (adc_clk),
     .rx_data_in_p (adc_or_in_p),

--- a/library/axi_ad9625/axi_ad9625.v
+++ b/library/axi_ad9625/axi_ad9625.v
@@ -41,7 +41,8 @@ module axi_ad9625 #(
   parameter FPGA_TECHNOLOGY = 0,
   parameter FPGA_FAMILY = 0,
   parameter SPEED_GRADE = 0,
-  parameter DEV_PACKAGE = 0) (
+  parameter DEV_PACKAGE = 0,
+  parameter DELAY_REFCLK_FREQUENCY = 200) (
 
   // jesd interface
   // rx_clk is (line-rate/40)
@@ -142,7 +143,8 @@ module axi_ad9625 #(
   assign adc_valid = 1'b1;
 
   axi_ad9625_if #(
-    .ID (ID))
+    .ID (ID),
+    .DELAY_REFCLK_FREQUENCY (DELAY_REFCLK_FREQUENCY))
   i_if (
     .rx_clk (rx_clk),
     .rx_sof (rx_sof),

--- a/library/axi_ad9963/axi_ad9963.v
+++ b/library/axi_ad9963/axi_ad9963.v
@@ -55,7 +55,8 @@ module axi_ad9963 #(
   parameter   ADC_DATAFORMAT_DISABLE = 0,
   parameter   ADC_DCFILTER_DISABLE = 0,
   parameter   ADC_IQCORRECTION_DISABLE = 0,
-  parameter   ADC_SCALECORRECTION_ONLY = 1) (
+  parameter   ADC_SCALECORRECTION_ONLY = 1,
+  parameter   DELAY_REFCLK_FREQUENCY = 200) (
 
   // physical interface (receive)
 
@@ -182,7 +183,8 @@ module axi_ad9963 #(
   axi_ad9963_if #(
     .FPGA_TECHNOLOGY (FPGA_TECHNOLOGY),
     .ADC_IODELAY_ENABLE (ADC_IODELAY_ENABLE),
-    .IO_DELAY_GROUP (IO_DELAY_GROUP))
+    .IO_DELAY_GROUP (IO_DELAY_GROUP),
+    .DELAY_REFCLK_FREQUENCY (DELAY_REFCLK_FREQUENCY))
   i_dev_if (
     .trx_clk (trx_clk),
     .trx_iq (trx_iq),

--- a/library/axi_ad9963/axi_ad9963_if.v
+++ b/library/axi_ad9963/axi_ad9963_if.v
@@ -41,7 +41,8 @@ module axi_ad9963_if #(
 
   parameter   FPGA_TECHNOLOGY = 0,
   parameter   ADC_IODELAY_ENABLE = 0,
-  parameter   IO_DELAY_GROUP = "dev_if_delay_group") (
+  parameter   IO_DELAY_GROUP = "dev_if_delay_group",
+  parameter   DELAY_REFCLK_FREQUENCY = 200) (
 
   // physical interface (receive)
 
@@ -156,7 +157,8 @@ module axi_ad9963_if #(
     .FPGA_TECHNOLOGY (FPGA_TECHNOLOGY),
     .IODELAY_ENABLE (ADC_IODELAY_ENABLE),
     .IODELAY_CTRL (0),
-    .IODELAY_GROUP (IO_DELAY_GROUP))
+    .IODELAY_GROUP (IO_DELAY_GROUP),
+    .REFCLK_FREQUENCY (DELAY_REFCLK_FREQUENCY))
   i_rx_data (
     .rx_clk (adc_clk),
     .rx_data_in_p (trx_data[l_inst]),

--- a/library/axi_fmcadc5_sync/axi_fmcadc5_sync.v
+++ b/library/axi_fmcadc5_sync/axi_fmcadc5_sync.v
@@ -44,7 +44,8 @@ module axi_fmcadc5_sync #(
   parameter [ 7:0]  FPGA_TECHNOLOGY = 0,
   parameter [ 7:0]  FPGA_FAMILY = 0,
   parameter [ 7:0]  SPEED_GRADE = 0,
-  parameter [ 7:0]  DEV_PACKAGE = 0) (
+  parameter [ 7:0]  DEV_PACKAGE = 0,
+  parameter         DELAY_REFCLK_FREQUENCY = 200) (
 
     // receive interface
 
@@ -768,7 +769,8 @@ module axi_fmcadc5_sync #(
     .SINGLE_ENDED (0),
     .IODELAY_ENABLE (1),
     .IODELAY_CTRL (1),
-    .IODELAY_GROUP ("FMCADC5_SYSREF_IODELAY_GROUP"))
+    .IODELAY_GROUP ("FMCADC5_SYSREF_IODELAY_GROUP"),
+    .REFCLK_FREQUENCY (DELAY_REFCLK_FREQUENCY))
   i_rx_sysref (
     .tx_clk (rx_clk),
     .tx_data_p (rx_sysref_e),

--- a/library/util_gmii_to_rgmii/util_gmii_to_rgmii.v
+++ b/library/util_gmii_to_rgmii/util_gmii_to_rgmii.v
@@ -43,7 +43,8 @@ module util_gmii_to_rgmii #(
   parameter PHY_AD = 5'b10000,
   parameter IODELAY_CTRL = 1'b0,
   parameter IDELAY_VALUE = 18,
-  parameter IODELAY_GROUP = "if_delay_group") (
+  parameter IODELAY_GROUP = "if_delay_group",
+  parameter REFCLK_FREQUENCY = 200) (
 
   input                   clk_20m,
   input                   clk_25m,
@@ -214,7 +215,7 @@ module util_gmii_to_rgmii #(
   IDELAYE2 #(
     .IDELAY_TYPE("FIXED"),
     .HIGH_PERFORMANCE_MODE("TRUE"),
-    .REFCLK_FREQUENCY(200.0),
+    .REFCLK_FREQUENCY(REFCLK_FREQUENCY),
     .SIGNAL_PATTERN("DATA"),
     .IDELAY_VALUE (IDELAY_VALUE),
     .DELAY_SRC("IDATAIN")
@@ -238,7 +239,7 @@ module util_gmii_to_rgmii #(
     IDELAYE2 #(
       .IDELAY_TYPE("FIXED"),
       .HIGH_PERFORMANCE_MODE("TRUE"),
-      .REFCLK_FREQUENCY(200.0),
+      .REFCLK_FREQUENCY(REFCLK_FREQUENCY),
       .SIGNAL_PATTERN("DATA"),
       .IDELAY_VALUE (IDELAY_VALUE),
       .DELAY_SRC("IDATAIN")

--- a/library/xilinx/common/ad_data_in.v
+++ b/library/xilinx/common/ad_data_in.v
@@ -43,7 +43,8 @@ module ad_data_in #(
   parameter   FPGA_TECHNOLOGY = 0,
   parameter   IODELAY_ENABLE = 1,
   parameter   IODELAY_CTRL = 0,
-  parameter   IODELAY_GROUP = "dev_if_delay_group") (
+  parameter   IODELAY_GROUP = "dev_if_delay_group",
+  parameter   REFCLK_FREQUENCY = 200) (
 
   // data interface
 
@@ -127,7 +128,7 @@ module ad_data_in #(
     .HIGH_PERFORMANCE_MODE ("FALSE"),
     .IDELAY_TYPE ("VAR_LOAD"),
     .IDELAY_VALUE (0),
-    .REFCLK_FREQUENCY (200.0),
+    .REFCLK_FREQUENCY (REFCLK_FREQUENCY),
     .PIPE_SEL ("FALSE"),
     .SIGNAL_PATTERN ("DATA"))
   i_rx_data_idelay (
@@ -154,7 +155,7 @@ module ad_data_in #(
     .SIM_DEVICE (IODELAY_SIM_DEVICE),
     .DELAY_SRC ("IDATAIN"),
     .DELAY_TYPE ("VAR_LOAD"),
-    .REFCLK_FREQUENCY (200.0),
+    .REFCLK_FREQUENCY (REFCLK_FREQUENCY),
     .DELAY_FORMAT ("COUNT"))
   i_rx_data_idelay (
     .CASC_RETURN (1'b0),

--- a/library/xilinx/common/ad_data_out.v
+++ b/library/xilinx/common/ad_data_out.v
@@ -41,7 +41,8 @@ module ad_data_out #(
   parameter   SINGLE_ENDED = 0,
   parameter   IODELAY_ENABLE = 0,
   parameter   IODELAY_CTRL = 0,
-  parameter   IODELAY_GROUP = "dev_if_delay_group") (
+  parameter   IODELAY_GROUP = "dev_if_delay_group",
+  parameter   REFCLK_FREQUENCY = 200) (
 
   // data interface
 
@@ -133,7 +134,7 @@ module ad_data_out #(
     .HIGH_PERFORMANCE_MODE ("FALSE"),
     .ODELAY_TYPE ("VAR_LOAD"),
     .ODELAY_VALUE (0),
-    .REFCLK_FREQUENCY (200.0),
+    .REFCLK_FREQUENCY (REFCLK_FREQUENCY),
     .PIPE_SEL ("FALSE"),
     .SIGNAL_PATTERN ("DATA"))
   i_tx_data_odelay (

--- a/library/xilinx/common/ad_serdes_in.v
+++ b/library/xilinx/common/ad_serdes_in.v
@@ -42,7 +42,8 @@ module ad_serdes_in #(
   parameter   SERDES_FACTOR = 8,
   parameter   DATA_WIDTH = 16,
   parameter   IODELAY_CTRL = 0,
-  parameter   IODELAY_GROUP = "dev_if_delay_group") (
+  parameter   IODELAY_GROUP = "dev_if_delay_group",
+  parameter   REFCLK_FREQUENCY = 200) (
 
   // reset and clocks
 
@@ -123,7 +124,7 @@ module ad_serdes_in #(
         .HIGH_PERFORMANCE_MODE ("FALSE"),
         .IDELAY_TYPE ("VAR_LOAD"),
         .IDELAY_VALUE (0),
-        .REFCLK_FREQUENCY (200.0),
+        .REFCLK_FREQUENCY (REFCLK_FREQUENCY),
         .PIPE_SEL ("FALSE"),
         .SIGNAL_PATTERN ("DATA"))
       i_idelay (

--- a/projects/ad6676evb/common/ad6676evb_bd.tcl
+++ b/projects/ad6676evb/common/ad6676evb_bd.tcl
@@ -56,7 +56,7 @@ ad_xcvrpll  rx_ref_clk_0 util_ad6676_xcvr/cpll_ref_clk_*
 ad_xcvrpll  axi_ad6676_xcvr/up_pll_rst util_ad6676_xcvr/up_qpll_rst_*
 ad_xcvrpll  axi_ad6676_xcvr/up_pll_rst util_ad6676_xcvr/up_cpll_rst_*
 ad_connect  sys_cpu_resetn util_ad6676_xcvr/up_rstn
-ad_connect  sys_cpu_clk util_ad6676_xcvr/up_clk
+ad_connect  $sys_cpu_clk util_ad6676_xcvr/up_clk
 
 # connections (adc)
 
@@ -86,13 +86,13 @@ ad_cpu_interconnect 0x7c420000 axi_ad6676_dma
 
 # xcvr uses hp3, and 100MHz clock for both DRP and AXI4
 
-ad_mem_hp3_interconnect sys_cpu_clk sys_ps7/S_AXI_HP3
-ad_mem_hp3_interconnect sys_cpu_clk axi_ad6676_xcvr/m_axi
+ad_mem_hp3_interconnect $sys_cpu_clk sys_ps7/S_AXI_HP3
+ad_mem_hp3_interconnect $sys_cpu_clk axi_ad6676_xcvr/m_axi
 
 # interconnect (adc)
 
-ad_mem_hp2_interconnect sys_200m_clk sys_ps7/S_AXI_HP2
-ad_mem_hp2_interconnect sys_200m_clk axi_ad6676_dma/m_dest_axi
+ad_mem_hp2_interconnect $sys_dma_clk sys_ps7/S_AXI_HP2
+ad_mem_hp2_interconnect $sys_dma_clk axi_ad6676_dma/m_dest_axi
 ad_connect  sys_cpu_resetn axi_ad6676_dma/m_dest_axi_aresetn
 
 # interrupts

--- a/projects/ad6676evb/common/ad6676evb_bd.tcl
+++ b/projects/ad6676evb/common/ad6676evb_bd.tcl
@@ -55,7 +55,7 @@ ad_xcvrpll  rx_ref_clk_0 util_ad6676_xcvr/qpll_ref_clk_*
 ad_xcvrpll  rx_ref_clk_0 util_ad6676_xcvr/cpll_ref_clk_*
 ad_xcvrpll  axi_ad6676_xcvr/up_pll_rst util_ad6676_xcvr/up_qpll_rst_*
 ad_xcvrpll  axi_ad6676_xcvr/up_pll_rst util_ad6676_xcvr/up_cpll_rst_*
-ad_connect  sys_cpu_resetn util_ad6676_xcvr/up_rstn
+ad_connect  $sys_cpu_resetn util_ad6676_xcvr/up_rstn
 ad_connect  $sys_cpu_clk util_ad6676_xcvr/up_clk
 
 # connections (adc)
@@ -93,7 +93,7 @@ ad_mem_hp3_interconnect $sys_cpu_clk axi_ad6676_xcvr/m_axi
 
 ad_mem_hp2_interconnect $sys_dma_clk sys_ps7/S_AXI_HP2
 ad_mem_hp2_interconnect $sys_dma_clk axi_ad6676_dma/m_dest_axi
-ad_connect  sys_cpu_resetn axi_ad6676_dma/m_dest_axi_aresetn
+ad_connect  $sys_cpu_resetn axi_ad6676_dma/m_dest_axi_aresetn
 
 # interrupts
 

--- a/projects/ad9208_dual_ebz/common/dual_ad9208_bd.tcl
+++ b/projects/ad9208_dual_ebz/common/dual_ad9208_bd.tcl
@@ -123,8 +123,8 @@ ad_xcvrpll  axi_ad9208_1_xcvr/up_pll_rst util_adc_1_xcvr/up_cpll_rst_*
 
 ad_connect  sys_cpu_resetn util_adc_0_xcvr/up_rstn
 ad_connect  sys_cpu_resetn util_adc_1_xcvr/up_rstn
-ad_connect  sys_cpu_clk util_adc_0_xcvr/up_clk
-ad_connect  sys_cpu_clk util_adc_1_xcvr/up_clk
+ad_connect  $sys_cpu_clk util_adc_0_xcvr/up_clk
+ad_connect  $sys_cpu_clk util_adc_1_xcvr/up_clk
 
 
 # connections (adc)
@@ -153,8 +153,8 @@ ad_connect  glbl_clk_0 axi_ad9208_fifo/adc_clk
 
 
 # dma clock domain
-ad_connect  sys_cpu_clk axi_ad9208_fifo/dma_clk
-ad_connect  sys_cpu_clk axi_ad9208_dma/s_axis_aclk
+ad_connect  $sys_cpu_clk axi_ad9208_fifo/dma_clk
+ad_connect  $sys_cpu_clk axi_ad9208_dma/s_axis_aclk
 
 # connect resets
 ad_connect  axi_ad9208_0_jesd_rstgen/peripheral_reset axi_ad9208_fifo/adc_rst
@@ -202,9 +202,9 @@ ad_cpu_interconnect 0x7c420000 axi_ad9208_dma
 
 # interconnect (gt/adc)
 
-ad_mem_hp0_interconnect sys_cpu_clk axi_ad9208_0_xcvr/m_axi
-ad_mem_hp0_interconnect sys_cpu_clk axi_ad9208_1_xcvr/m_axi
-ad_mem_hp0_interconnect sys_cpu_clk axi_ad9208_dma/m_dest_axi
+ad_mem_hp0_interconnect $sys_cpu_clk axi_ad9208_0_xcvr/m_axi
+ad_mem_hp0_interconnect $sys_cpu_clk axi_ad9208_1_xcvr/m_axi
+ad_mem_hp0_interconnect $sys_cpu_clk axi_ad9208_dma/m_dest_axi
 
 # interrupts
 

--- a/projects/ad9208_dual_ebz/common/dual_ad9208_bd.tcl
+++ b/projects/ad9208_dual_ebz/common/dual_ad9208_bd.tcl
@@ -121,8 +121,8 @@ ad_xcvrpll  rx_ref_clk_1 util_adc_1_xcvr/cpll_ref_clk_7
 ad_xcvrpll  axi_ad9208_1_xcvr/up_pll_rst util_adc_1_xcvr/up_qpll_rst_*
 ad_xcvrpll  axi_ad9208_1_xcvr/up_pll_rst util_adc_1_xcvr/up_cpll_rst_*
 
-ad_connect  sys_cpu_resetn util_adc_0_xcvr/up_rstn
-ad_connect  sys_cpu_resetn util_adc_1_xcvr/up_rstn
+ad_connect  $sys_cpu_resetn util_adc_0_xcvr/up_rstn
+ad_connect  $sys_cpu_resetn util_adc_1_xcvr/up_rstn
 ad_connect  $sys_cpu_clk util_adc_0_xcvr/up_clk
 ad_connect  $sys_cpu_clk util_adc_1_xcvr/up_clk
 
@@ -159,7 +159,7 @@ ad_connect  $sys_cpu_clk axi_ad9208_dma/s_axis_aclk
 # connect resets
 ad_connect  axi_ad9208_0_jesd_rstgen/peripheral_reset axi_ad9208_fifo/adc_rst
 ad_connect  axi_ad9208_0_jesd_rstgen/peripheral_reset util_ad9208_cpack/reset
-ad_connect  sys_cpu_resetn axi_ad9208_dma/m_dest_axi_aresetn
+ad_connect  $sys_cpu_resetn axi_ad9208_dma/m_dest_axi_aresetn
 
 
 # connect dataflow

--- a/projects/ad9265_fmc/common/ad9265_bd.tcl
+++ b/projects/ad9265_fmc/common/ad9265_bd.tcl
@@ -34,8 +34,8 @@ ad_connect    adc_data_or_n    axi_ad9265/adc_or_in_n
 
 ad_connect ad9265_clk axi_ad9265/adc_clk
 
-ad_connect ad9265_clk     axi_ad9265_dma/fifo_wr_clk
-ad_connect sys_200m_clk   axi_ad9265/delay_clk
+ad_connect ad9265_clk         axi_ad9265_dma/fifo_wr_clk
+ad_connect $sys_iodelay_clk   axi_ad9265/delay_clk
 
 ad_connect axi_ad9265/adc_valid  axi_ad9265_dma/fifo_wr_en
 ad_connect axi_ad9265/adc_data   axi_ad9265_dma/fifo_wr_din
@@ -48,8 +48,8 @@ ad_cpu_interconnect 0x44A30000 axi_ad9265_dma
 
 # interconnect (adc)
 
-ad_mem_hp2_interconnect sys_200m_clk sys_ps7/S_AXI_HP2
-ad_mem_hp2_interconnect sys_200m_clk axi_ad9265_dma/m_dest_axi
+ad_mem_hp2_interconnect $sys_dma_clk sys_ps7/S_AXI_HP2
+ad_mem_hp2_interconnect $sys_dma_clk axi_ad9265_dma/m_dest_axi
 ad_connect  sys_cpu_resetn axi_ad9265_dma/m_dest_axi_aresetn
 
 # interrupts

--- a/projects/ad9265_fmc/common/ad9265_bd.tcl
+++ b/projects/ad9265_fmc/common/ad9265_bd.tcl
@@ -50,7 +50,7 @@ ad_cpu_interconnect 0x44A30000 axi_ad9265_dma
 
 ad_mem_hp2_interconnect $sys_dma_clk sys_ps7/S_AXI_HP2
 ad_mem_hp2_interconnect $sys_dma_clk axi_ad9265_dma/m_dest_axi
-ad_connect  sys_cpu_resetn axi_ad9265_dma/m_dest_axi_aresetn
+ad_connect  $sys_cpu_resetn axi_ad9265_dma/m_dest_axi_aresetn
 
 # interrupts
 

--- a/projects/ad9434_fmc/common/ad9434_bd.tcl
+++ b/projects/ad9434_fmc/common/ad9434_bd.tcl
@@ -25,7 +25,7 @@ ad_ip_parameter axi_ad9434_dma CONFIG.DMA_DATA_WIDTH_SRC 64
 
 # ad9434 connections
 
-ad_connect  sys_200m_clk axi_ad9434/delay_clk
+ad_connect  $sys_iodelay_clk axi_ad9434/delay_clk
 ad_connect  axi_ad9434/adc_clk axi_ad9434_dma/fifo_wr_clk
 
 ad_connect  adc_clk_p  axi_ad9434/adc_clk_in_p
@@ -46,8 +46,8 @@ ad_cpu_interconnect 0x44A30000  axi_ad9434_dma
 
 # memory inteconnect
 
-ad_mem_hp1_interconnect sys_200m_clk sys_ps7/S_AXI_HP1
-ad_mem_hp1_interconnect sys_200m_clk axi_ad9434_dma/m_dest_axi
+ad_mem_hp1_interconnect $sys_dma_clk sys_ps7/S_AXI_HP1
+ad_mem_hp1_interconnect $sys_dma_clk axi_ad9434_dma/m_dest_axi
 ad_connect sys_cpu_resetn axi_ad9434_dma/m_dest_axi_aresetn
 
 # interrupts

--- a/projects/ad9434_fmc/common/ad9434_bd.tcl
+++ b/projects/ad9434_fmc/common/ad9434_bd.tcl
@@ -48,7 +48,7 @@ ad_cpu_interconnect 0x44A30000  axi_ad9434_dma
 
 ad_mem_hp1_interconnect $sys_dma_clk sys_ps7/S_AXI_HP1
 ad_mem_hp1_interconnect $sys_dma_clk axi_ad9434_dma/m_dest_axi
-ad_connect sys_cpu_resetn axi_ad9434_dma/m_dest_axi_aresetn
+ad_connect $sys_cpu_resetn axi_ad9434_dma/m_dest_axi_aresetn
 
 # interrupts
 

--- a/projects/ad9467_fmc/common/ad9467_bd.tcl
+++ b/projects/ad9467_fmc/common/ad9467_bd.tcl
@@ -34,7 +34,7 @@ ad_connect  adc_data_or_n axi_ad9467/adc_or_in_n
 
 ad_connect  axi_ad9467/adc_clk axi_ad9467_dma/fifo_wr_clk
 
-ad_connect  sys_200m_clk axi_ad9467/delay_clk
+ad_connect  $sys_iodelay_clk axi_ad9467/delay_clk
 
 ad_connect  axi_ad9467/adc_valid axi_ad9467_dma/fifo_wr_en
 ad_connect  axi_ad9467/adc_data axi_ad9467_dma/fifo_wr_din
@@ -47,8 +47,8 @@ ad_cpu_interconnect  0x44A30000 axi_ad9467_dma
 
 # memory inteconnect
 
-ad_mem_hp1_interconnect sys_cpu_clk sys_ps7/S_AXI_HP1
-ad_mem_hp1_interconnect sys_cpu_clk axi_ad9467_dma/m_dest_axi
+ad_mem_hp1_interconnect $sys_cpu_clk sys_ps7/S_AXI_HP1
+ad_mem_hp1_interconnect $sys_cpu_clk axi_ad9467_dma/m_dest_axi
 ad_connect sys_cpu_resetn axi_ad9467_dma/m_dest_axi_aresetn
 
 # interrupts

--- a/projects/ad9467_fmc/common/ad9467_bd.tcl
+++ b/projects/ad9467_fmc/common/ad9467_bd.tcl
@@ -49,7 +49,7 @@ ad_cpu_interconnect  0x44A30000 axi_ad9467_dma
 
 ad_mem_hp1_interconnect $sys_cpu_clk sys_ps7/S_AXI_HP1
 ad_mem_hp1_interconnect $sys_cpu_clk axi_ad9467_dma/m_dest_axi
-ad_connect sys_cpu_resetn axi_ad9467_dma/m_dest_axi_aresetn
+ad_connect $sys_cpu_resetn axi_ad9467_dma/m_dest_axi_aresetn
 
 # interrupts
 

--- a/projects/ad9739a_fmc/common/ad9739a_fmc_bd.tcl
+++ b/projects/ad9739a_fmc/common/ad9739a_fmc_bd.tcl
@@ -49,8 +49,8 @@ ad_cpu_interconnect 0x7c420000 axi_ad9739a_dma
 
 # interconnect (mem/dac)
 
-ad_mem_hp2_interconnect sys_200m_clk sys_ps7/S_AXI_HP2
-ad_mem_hp2_interconnect sys_200m_clk axi_ad9739a_dma/m_src_axi
+ad_mem_hp2_interconnect $sys_dma_clk sys_ps7/S_AXI_HP2
+ad_mem_hp2_interconnect $sys_dma_clk axi_ad9739a_dma/m_src_axi
 ad_connect  sys_cpu_resetn axi_ad9739a_dma/m_src_axi_aresetn
 
 # interrupts

--- a/projects/ad9739a_fmc/common/ad9739a_fmc_bd.tcl
+++ b/projects/ad9739a_fmc/common/ad9739a_fmc_bd.tcl
@@ -51,7 +51,7 @@ ad_cpu_interconnect 0x7c420000 axi_ad9739a_dma
 
 ad_mem_hp2_interconnect $sys_dma_clk sys_ps7/S_AXI_HP2
 ad_mem_hp2_interconnect $sys_dma_clk axi_ad9739a_dma/m_src_axi
-ad_connect  sys_cpu_resetn axi_ad9739a_dma/m_src_axi_aresetn
+ad_connect  $sys_cpu_resetn axi_ad9739a_dma/m_src_axi_aresetn
 
 # interrupts
 

--- a/projects/adrv9009/common/adrv9009_bd.tcl
+++ b/projects/adrv9009/common/adrv9009_bd.tcl
@@ -188,7 +188,7 @@ create_bd_port -dir I $tx_ref_clk
 create_bd_port -dir I $rx_ref_clk
 create_bd_port -dir I $rx_obs_ref_clk
 ad_connect  sys_cpu_resetn util_adrv9009_xcvr/up_rstn
-ad_connect  sys_cpu_clk util_adrv9009_xcvr/up_clk
+ad_connect  $sys_cpu_clk util_adrv9009_xcvr/up_clk
 
 # Tx
 ad_connect adrv9009_tx_device_clk axi_adrv9009_tx_clkgen/clk_0
@@ -223,7 +223,7 @@ for {set i 0} {$i < $RX_OS_NUM_OF_LANES} {incr i} {
 ad_ip_instance proc_sys_reset sys_dma_rstgen
 ad_ip_parameter sys_dma_rstgen CONFIG.C_EXT_RST_WIDTH 1
 
-ad_connect  sys_dma_clk sys_dma_rstgen/slowest_sync_clk
+ad_connect  $sys_dma_clk sys_dma_rstgen/slowest_sync_clk
 ad_connect  sys_dma_resetn sys_dma_rstgen/peripheral_aresetn
 ad_connect  sys_dma_reset sys_dma_rstgen/peripheral_reset
 ad_connect  sys_dma_reset axi_adrv9009_dacfifo/dma_rst
@@ -250,8 +250,8 @@ ad_connect  util_adrv9009_tx_upack/s_axis_valid VCC
 ad_connect  util_adrv9009_tx_upack/s_axis_ready axi_adrv9009_dacfifo/dac_valid
 ad_connect  util_adrv9009_tx_upack/s_axis_data axi_adrv9009_dacfifo/dac_data
 
-ad_connect  sys_dma_clk axi_adrv9009_dacfifo/dma_clk
-ad_connect  sys_dma_clk axi_adrv9009_tx_dma/m_axis_aclk
+ad_connect  $sys_dma_clk axi_adrv9009_dacfifo/dma_clk
+ad_connect  $sys_dma_clk axi_adrv9009_tx_dma/m_axis_aclk
 ad_connect  axi_adrv9009_dacfifo/dma_valid axi_adrv9009_tx_dma/m_axis_valid
 ad_connect  axi_adrv9009_dacfifo/dma_data axi_adrv9009_tx_dma/m_axis_data
 ad_connect  axi_adrv9009_dacfifo/dma_ready axi_adrv9009_tx_dma/m_axis_ready
@@ -321,17 +321,17 @@ ad_cpu_interconnect 0x7c440000 axi_adrv9009_rx_os_dma
 
 # gt uses hp0, and 100MHz clock for both DRP and AXI4
 
-ad_mem_hp0_interconnect sys_cpu_clk axi_adrv9009_rx_xcvr/m_axi
-ad_mem_hp0_interconnect sys_cpu_clk axi_adrv9009_rx_os_xcvr/m_axi
+ad_mem_hp0_interconnect $sys_cpu_clk axi_adrv9009_rx_xcvr/m_axi
+ad_mem_hp0_interconnect $sys_cpu_clk axi_adrv9009_rx_os_xcvr/m_axi
 
 # interconnect (mem/dac)
 
-ad_mem_hp1_interconnect sys_dma_clk sys_ps7/S_AXI_HP1
-ad_mem_hp1_interconnect sys_dma_clk axi_adrv9009_rx_os_dma/m_dest_axi
-ad_mem_hp2_interconnect sys_dma_clk sys_ps7/S_AXI_HP2
-ad_mem_hp2_interconnect sys_dma_clk axi_adrv9009_rx_dma/m_dest_axi
-ad_mem_hp3_interconnect sys_dma_clk sys_ps7/S_AXI_HP3
-ad_mem_hp3_interconnect sys_dma_clk axi_adrv9009_tx_dma/m_src_axi
+ad_mem_hp1_interconnect $sys_dma_clk sys_ps7/S_AXI_HP1
+ad_mem_hp1_interconnect $sys_dma_clk axi_adrv9009_rx_os_dma/m_dest_axi
+ad_mem_hp2_interconnect $sys_dma_clk sys_ps7/S_AXI_HP2
+ad_mem_hp2_interconnect $sys_dma_clk axi_adrv9009_rx_dma/m_dest_axi
+ad_mem_hp3_interconnect $sys_dma_clk sys_ps7/S_AXI_HP3
+ad_mem_hp3_interconnect $sys_dma_clk axi_adrv9009_tx_dma/m_src_axi
 
 # interrupts
 

--- a/projects/adrv9009/common/adrv9009_bd.tcl
+++ b/projects/adrv9009/common/adrv9009_bd.tcl
@@ -187,7 +187,7 @@ set rx_obs_ref_clk rx_ref_clk_$RX_NUM_OF_LANES
 create_bd_port -dir I $tx_ref_clk
 create_bd_port -dir I $rx_ref_clk
 create_bd_port -dir I $rx_obs_ref_clk
-ad_connect  sys_cpu_resetn util_adrv9009_xcvr/up_rstn
+ad_connect  $sys_cpu_resetn util_adrv9009_xcvr/up_rstn
 ad_connect  $sys_cpu_clk util_adrv9009_xcvr/up_clk
 
 # Tx
@@ -218,16 +218,6 @@ for {set i 0} {$i < $RX_OS_NUM_OF_LANES} {incr i} {
   ad_xcvrpll  axi_adrv9009_rx_os_xcvr/up_pll_rst util_adrv9009_xcvr/up_cpll_rst_$ch
 }
 
-# dma clock & reset
-
-ad_ip_instance proc_sys_reset sys_dma_rstgen
-ad_ip_parameter sys_dma_rstgen CONFIG.C_EXT_RST_WIDTH 1
-
-ad_connect  $sys_dma_clk sys_dma_rstgen/slowest_sync_clk
-ad_connect  sys_dma_resetn sys_dma_rstgen/peripheral_aresetn
-ad_connect  sys_dma_reset sys_dma_rstgen/peripheral_reset
-ad_connect  sys_dma_reset axi_adrv9009_dacfifo/dma_rst
-
 # connections (dac)
 
 ad_connect  axi_adrv9009_tx_clkgen/clk_0 tx_adrv9009_tpl_core/link_clk
@@ -251,6 +241,7 @@ ad_connect  util_adrv9009_tx_upack/s_axis_ready axi_adrv9009_dacfifo/dac_valid
 ad_connect  util_adrv9009_tx_upack/s_axis_data axi_adrv9009_dacfifo/dac_data
 
 ad_connect  $sys_dma_clk axi_adrv9009_dacfifo/dma_clk
+ad_connect  $sys_cpu_reset axi_adrv9009_dacfifo/dma_rst
 ad_connect  $sys_dma_clk axi_adrv9009_tx_dma/m_axis_aclk
 ad_connect  axi_adrv9009_dacfifo/dma_valid axi_adrv9009_tx_dma/m_axis_valid
 ad_connect  axi_adrv9009_dacfifo/dma_data axi_adrv9009_tx_dma/m_axis_data
@@ -259,7 +250,7 @@ ad_connect  axi_adrv9009_dacfifo/dma_xfer_req axi_adrv9009_tx_dma/m_axis_xfer_re
 ad_connect  axi_adrv9009_dacfifo/dma_xfer_last axi_adrv9009_tx_dma/m_axis_last
 ad_connect  axi_adrv9009_dacfifo/dac_dunf tx_adrv9009_tpl_core/dac_dunf
 ad_connect  axi_adrv9009_dacfifo/bypass dac_fifo_bypass
-ad_connect  sys_dma_resetn axi_adrv9009_tx_dma/m_src_axi_aresetn
+ad_connect  $sys_dma_resetn axi_adrv9009_tx_dma/m_src_axi_aresetn
 
 # connections (adc)
 
@@ -279,7 +270,7 @@ ad_connect  rx_adrv9009_tpl_core/adc_dovf util_adrv9009_rx_cpack/fifo_wr_overflo
 
 ad_connect  axi_adrv9009_rx_clkgen/clk_0 axi_adrv9009_rx_dma/fifo_wr_clk
 ad_connect  util_adrv9009_rx_cpack/packed_fifo_wr axi_adrv9009_rx_dma/fifo_wr
-ad_connect  sys_dma_resetn axi_adrv9009_rx_dma/m_dest_axi_aresetn
+ad_connect  $sys_dma_resetn axi_adrv9009_rx_dma/m_dest_axi_aresetn
 
 # connections (adc-os)
 
@@ -299,7 +290,7 @@ for {set i 0} {$i < $RX_OS_NUM_OF_CONVERTERS} {incr i} {
 ad_connect  rx_os_adrv9009_tpl_core/adc_dovf util_adrv9009_rx_os_cpack/fifo_wr_overflow
 ad_connect  util_adrv9009_rx_os_cpack/packed_fifo_wr axi_adrv9009_rx_os_dma/fifo_wr
 
-ad_connect  sys_dma_resetn axi_adrv9009_rx_os_dma/m_dest_axi_aresetn
+ad_connect  $sys_dma_resetn axi_adrv9009_rx_os_dma/m_dest_axi_aresetn
 
 # interconnect (cpu)
 
@@ -341,3 +332,4 @@ ad_cpu_interrupt ps-10 mb-15 axi_adrv9009_rx_jesd/irq
 ad_cpu_interrupt ps-11 mb-14 axi_adrv9009_rx_os_dma/irq
 ad_cpu_interrupt ps-12 mb-13- axi_adrv9009_tx_dma/irq
 ad_cpu_interrupt ps-13 mb-12 axi_adrv9009_rx_dma/irq
+

--- a/projects/adrv9009/zc706/system_bd.tcl
+++ b/projects/adrv9009/zc706/system_bd.tcl
@@ -8,5 +8,3 @@ ad_ip_parameter sys_ps7 CONFIG.PCW_FPGA2_PERIPHERAL_FREQMHZ 250
 
 source ../common/adrv9009_bd.tcl
 
-ad_connect  sys_dma_clk sys_ps7/FCLK_CLK2
-ad_connect  sys_ps7/FCLK_RESET2_N sys_dma_rstgen/ext_reset_in

--- a/projects/adrv9009/zcu102/system_bd.tcl
+++ b/projects/adrv9009/zcu102/system_bd.tcl
@@ -18,19 +18,6 @@ ad_ip_parameter axi_adrv9009_rx_dma CONFIG.FIFO_SIZE 32
 ad_ip_parameter axi_adrv9009_rx_os_dma CONFIG.FIFO_SIZE 32
 ad_ip_parameter axi_adrv9009_tx_dma CONFIG.FIFO_SIZE 32
 
-ad_ip_instance clk_wiz dma_clk_wiz
-ad_ip_parameter dma_clk_wiz CONFIG.PRIMITIVE MMCM
-ad_ip_parameter dma_clk_wiz CONFIG.RESET_TYPE ACTIVE_LOW
-ad_ip_parameter dma_clk_wiz CONFIG.USE_LOCKED false
-ad_ip_parameter dma_clk_wiz CONFIG.CLKOUT1_REQUESTED_OUT_FREQ 332.9
-ad_ip_parameter dma_clk_wiz CONFIG.PRIM_SOURCE No_buffer
-
-ad_connect sys_cpu_clk dma_clk_wiz/clk_in1
-ad_connect sys_cpu_resetn dma_clk_wiz/resetn
-
-ad_connect sys_dma_clk dma_clk_wiz/clk_out1
-ad_connect sys_dma_rstgen/ext_reset_in sys_rstgen/peripheral_reset
-
 ad_ip_parameter util_adrv9009_xcvr CONFIG.QPLL_FBDIV 80
 ad_ip_parameter util_adrv9009_xcvr CONFIG.QPLL_REFCLK_DIV 1
 

--- a/projects/adrv9371x/common/adrv9371x_bd.tcl
+++ b/projects/adrv9371x/common/adrv9371x_bd.tcl
@@ -187,7 +187,7 @@ create_bd_port -dir I $tx_ref_clk
 create_bd_port -dir I $rx_ref_clk
 create_bd_port -dir I $rx_obs_ref_clk
 ad_connect  sys_cpu_resetn util_ad9371_xcvr/up_rstn
-ad_connect  sys_cpu_clk util_ad9371_xcvr/up_clk
+ad_connect  $sys_cpu_clk util_ad9371_xcvr/up_clk
 
 # Tx
 ad_connect  ad9371_tx_device_clk axi_ad9371_tx_clkgen/clk_0
@@ -222,7 +222,7 @@ for {set i 0} {$i < $RX_OS_NUM_OF_LANES} {incr i} {
 ad_ip_instance proc_sys_reset sys_dma_rstgen
 ad_ip_parameter sys_dma_rstgen CONFIG.C_EXT_RST_WIDTH 1
 
-ad_connect  sys_dma_clk sys_dma_rstgen/slowest_sync_clk
+ad_connect  $sys_dma_clk sys_dma_rstgen/slowest_sync_clk
 ad_connect  sys_dma_resetn sys_dma_rstgen/peripheral_aresetn
 ad_connect  sys_dma_reset sys_dma_rstgen/peripheral_reset
 ad_connect  sys_dma_reset axi_ad9371_dacfifo/dma_rst
@@ -249,8 +249,8 @@ ad_connect  util_ad9371_tx_upack/s_axis_valid VCC
 ad_connect  util_ad9371_tx_upack/s_axis_ready axi_ad9371_dacfifo/dac_valid
 ad_connect  util_ad9371_tx_upack/s_axis_data axi_ad9371_dacfifo/dac_data
 
-ad_connect  sys_dma_clk axi_ad9371_dacfifo/dma_clk
-ad_connect  sys_dma_clk axi_ad9371_tx_dma/m_axis_aclk
+ad_connect  $sys_dma_clk axi_ad9371_dacfifo/dma_clk
+ad_connect  $sys_dma_clk axi_ad9371_tx_dma/m_axis_aclk
 ad_connect  axi_ad9371_dacfifo/dma_valid axi_ad9371_tx_dma/m_axis_valid
 ad_connect  axi_ad9371_dacfifo/dma_data axi_ad9371_tx_dma/m_axis_data
 ad_connect  axi_ad9371_dacfifo/dma_ready axi_ad9371_tx_dma/m_axis_ready
@@ -320,17 +320,17 @@ ad_cpu_interconnect 0x7c440000 axi_ad9371_rx_os_dma
 
 # gt uses hp3, and 100MHz clock for both DRP and AXI4
 
-ad_mem_hp3_interconnect sys_cpu_clk sys_ps7/S_AXI_HP3
-ad_mem_hp3_interconnect sys_cpu_clk axi_ad9371_rx_xcvr/m_axi
-ad_mem_hp3_interconnect sys_cpu_clk axi_ad9371_rx_os_xcvr/m_axi
+ad_mem_hp3_interconnect $sys_cpu_clk sys_ps7/S_AXI_HP3
+ad_mem_hp3_interconnect $sys_cpu_clk axi_ad9371_rx_xcvr/m_axi
+ad_mem_hp3_interconnect $sys_cpu_clk axi_ad9371_rx_os_xcvr/m_axi
 
 # interconnect (mem/dac)
 
-ad_mem_hp1_interconnect sys_dma_clk sys_ps7/S_AXI_HP1
-ad_mem_hp1_interconnect sys_dma_clk axi_ad9371_tx_dma/m_src_axi
-ad_mem_hp2_interconnect sys_dma_clk sys_ps7/S_AXI_HP2
-ad_mem_hp2_interconnect sys_dma_clk axi_ad9371_rx_dma/m_dest_axi
-ad_mem_hp2_interconnect sys_dma_clk axi_ad9371_rx_os_dma/m_dest_axi
+ad_mem_hp1_interconnect $sys_dma_clk sys_ps7/S_AXI_HP1
+ad_mem_hp1_interconnect $sys_dma_clk axi_ad9371_tx_dma/m_src_axi
+ad_mem_hp2_interconnect $sys_dma_clk sys_ps7/S_AXI_HP2
+ad_mem_hp2_interconnect $sys_dma_clk axi_ad9371_rx_dma/m_dest_axi
+ad_mem_hp2_interconnect $sys_dma_clk axi_ad9371_rx_os_dma/m_dest_axi
 
 # interrupts
 

--- a/projects/adrv9371x/common/adrv9371x_bd.tcl
+++ b/projects/adrv9371x/common/adrv9371x_bd.tcl
@@ -186,7 +186,7 @@ set rx_obs_ref_clk rx_ref_clk_$RX_NUM_OF_LANES
 create_bd_port -dir I $tx_ref_clk
 create_bd_port -dir I $rx_ref_clk
 create_bd_port -dir I $rx_obs_ref_clk
-ad_connect  sys_cpu_resetn util_ad9371_xcvr/up_rstn
+ad_connect  $sys_cpu_resetn util_ad9371_xcvr/up_rstn
 ad_connect  $sys_cpu_clk util_ad9371_xcvr/up_clk
 
 # Tx
@@ -219,13 +219,7 @@ for {set i 0} {$i < $RX_OS_NUM_OF_LANES} {incr i} {
 
 # dma clock & reset
 
-ad_ip_instance proc_sys_reset sys_dma_rstgen
-ad_ip_parameter sys_dma_rstgen CONFIG.C_EXT_RST_WIDTH 1
-
-ad_connect  $sys_dma_clk sys_dma_rstgen/slowest_sync_clk
-ad_connect  sys_dma_resetn sys_dma_rstgen/peripheral_aresetn
-ad_connect  sys_dma_reset sys_dma_rstgen/peripheral_reset
-ad_connect  sys_dma_reset axi_ad9371_dacfifo/dma_rst
+ad_connect  $sys_dma_reset axi_ad9371_dacfifo/dma_rst
 
 # connections (dac)
 
@@ -258,7 +252,7 @@ ad_connect  axi_ad9371_dacfifo/dma_xfer_req axi_ad9371_tx_dma/m_axis_xfer_req
 ad_connect  axi_ad9371_dacfifo/dma_xfer_last axi_ad9371_tx_dma/m_axis_last
 ad_connect  axi_ad9371_dacfifo/dac_dunf tx_ad9371_tpl_core/dac_dunf
 ad_connect  axi_ad9371_dacfifo/bypass dac_fifo_bypass
-ad_connect  sys_dma_resetn axi_ad9371_tx_dma/m_src_axi_aresetn
+ad_connect  $sys_dma_resetn axi_ad9371_tx_dma/m_src_axi_aresetn
 
 # connections (adc)
 
@@ -278,7 +272,7 @@ ad_connect  rx_ad9371_tpl_core/adc_dovf util_ad9371_rx_cpack/fifo_wr_overflow
 
 ad_connect  axi_ad9371_rx_clkgen/clk_0 axi_ad9371_rx_dma/fifo_wr_clk
 ad_connect  util_ad9371_rx_cpack/packed_fifo_wr axi_ad9371_rx_dma/fifo_wr
-ad_connect  sys_dma_resetn axi_ad9371_rx_dma/m_dest_axi_aresetn
+ad_connect  $sys_dma_resetn axi_ad9371_rx_dma/m_dest_axi_aresetn
 
 # connections (adc-os)
 
@@ -298,7 +292,7 @@ for {set i 0} {$i < $RX_OS_NUM_OF_CONVERTERS} {incr i} {
 ad_connect  rx_os_ad9371_tpl_core/adc_dovf util_ad9371_rx_os_cpack/fifo_wr_overflow
 ad_connect  util_ad9371_rx_os_cpack/packed_fifo_wr axi_ad9371_rx_os_dma/fifo_wr
 
-ad_connect  sys_dma_resetn axi_ad9371_rx_os_dma/m_dest_axi_aresetn
+ad_connect  $sys_dma_resetn axi_ad9371_rx_os_dma/m_dest_axi_aresetn
 
 # interconnect (cpu)
 

--- a/projects/adrv9371x/kcu105/system_bd.tcl
+++ b/projects/adrv9371x/kcu105/system_bd.tcl
@@ -8,12 +8,7 @@ source $ad_hdl_dir/projects/common/kcu105/kcu105_system_bd.tcl
 source $ad_hdl_dir/projects/common/kcu105/kcu105_system_mig.tcl
 source $ad_hdl_dir/projects/common/xilinx/dacfifo_bd.tcl
 
-ad_ip_parameter axi_ddr_cntrl CONFIG.ADDN_UI_CLKOUT3_FREQ_HZ 200
-
 source ../common/adrv9371x_bd.tcl
-
-ad_connect sys_dma_clk axi_ddr_cntrl/addn_ui_clkout3
-ad_connect sys_dma_rstgen/ext_reset_in sys_rstgen/peripheral_reset
 
 ad_ip_parameter util_ad9371_xcvr CONFIG.QPLL_FBDIV 80
 ad_ip_parameter util_ad9371_xcvr CONFIG.QPLL_REFCLK_DIV 1

--- a/projects/adrv9371x/zc706/system_bd.tcl
+++ b/projects/adrv9371x/zc706/system_bd.tcl
@@ -4,9 +4,5 @@ set dac_fifo_address_width 10
 source $ad_hdl_dir/projects/common/zc706/zc706_system_bd.tcl
 source $ad_hdl_dir/projects/common/zc706/zc706_plddr3_dacfifo_bd.tcl
 
-ad_ip_parameter sys_ps7 CONFIG.PCW_FPGA2_PERIPHERAL_FREQMHZ 200
-
 source ../common/adrv9371x_bd.tcl
 
-ad_connect  sys_dma_clk sys_ps7/FCLK_CLK2
-ad_connect  sys_ps7/FCLK_RESET2_N sys_dma_rstgen/ext_reset_in

--- a/projects/adrv9371x/zcu102/system_bd.tcl
+++ b/projects/adrv9371x/zcu102/system_bd.tcl
@@ -7,14 +7,7 @@ set dac_fifo_address_width 17
 source $ad_hdl_dir/projects/common/zcu102/zcu102_system_bd.tcl
 source $ad_hdl_dir/projects/common/xilinx/dacfifo_bd.tcl
 
-ad_ip_parameter sys_ps8 CONFIG.PSU__FPGA_PL2_ENABLE 1
-ad_ip_parameter sys_ps8 CONFIG.PSU__CRL_APB__PL2_REF_CTRL__SRCSEL {IOPLL}
-ad_ip_parameter sys_ps8 CONFIG.PSU__CRL_APB__PL2_REF_CTRL__FREQMHZ 200
-
 source ../common/adrv9371x_bd.tcl
-
-ad_connect sys_dma_clk sys_ps8/pl_clk2
-ad_connect sys_dma_rstgen/ext_reset_in sys_rstgen/peripheral_reset
 
 ad_ip_parameter axi_ad9371_tx_xcvr CONFIG.TX_DIFFCTRL 6
 

--- a/projects/cn0363/common/cn0363_bd.tcl
+++ b/projects/cn0363/common/cn0363_bd.tcl
@@ -253,7 +253,7 @@ ad_ip_parameter axi_adc	CONFIG.NUM_OF_CHANNELS 14
 ad_connect processing/overflow axi_adc/adc_dovf
 ad_connect axi_adc/adc_enable processing/channel_enable
 
-connect_bd_net -net sys_cpu_clk \
+connect_bd_net -net $sys_cpu_clk \
 	[get_bd_pins /spi/clk] \
 	[get_bd_pins /processing/clk] \
 	[get_bd_pins /axi_dma/m_dest_axi_aclk] \
@@ -275,5 +275,5 @@ ad_cpu_interconnect 0x44a30000 /axi_dma
 ad_cpu_interrupt "ps-13" "mb-13" /axi_dma/irq
 ad_cpu_interrupt "ps-12" "mb-12" /spi/irq
 
-ad_mem_hp2_interconnect sys_cpu_clk sys_ps7/S_AXI_HP2
-ad_mem_hp2_interconnect sys_cpu_clk axi_dma/m_dest_axi
+ad_mem_hp2_interconnect $sys_cpu_clk sys_ps7/S_AXI_HP2
+ad_mem_hp2_interconnect $sys_cpu_clk axi_dma/m_dest_axi

--- a/projects/cn0363/common/cn0363_bd.tcl
+++ b/projects/cn0363/common/cn0363_bd.tcl
@@ -261,7 +261,7 @@ connect_bd_net -net $sys_cpu_clk \
 	[get_bd_pins /phase_gen/CLK] \
 	[get_bd_pins /axi_adc/adc_clk]
 
-connect_bd_net -net sys_cpu_resetn \
+connect_bd_net -net $sys_cpu_resetn \
 	[get_bd_pins /spi/resetn] \
 	[get_bd_pins /processing/resetn] \
 	[get_bd_pins /axi_dma/m_dest_axi_aresetn]

--- a/projects/common/ac701/ac701_system_bd.tcl
+++ b/projects/common/ac701/ac701_system_bd.tcl
@@ -151,6 +151,12 @@ ad_connect sys_cpu_resetn axi_ddr_cntrl/aresetn
 ad_connect sys_cpu_reset sys_rstgen/peripheral_reset
 ad_connect sys_cpu_resetn sys_rstgen/peripheral_aresetn
 
+# generic system clocks pointers
+
+set sys_cpu_clk      [get_bd_nets sys_cpu_clk]
+set sys_dma_clk      [get_bd_nets sys_200m_clk]
+set sys_iodelay_clk  [get_bd_nets sys_200m_clk]
+
 ad_connect sys_cpu_clk  sys_rstgen/slowest_sync_clk
 ad_connect sys_cpu_clk  sys_mb/Clk
 ad_connect sys_cpu_clk  sys_dlmb/LMB_Clk

--- a/projects/common/ac701/ac701_system_bd.tcl
+++ b/projects/common/ac701/ac701_system_bd.tcl
@@ -64,6 +64,9 @@ ad_ip_parameter sys_mb_debug CONFIG.C_USE_UART 1
 # instance: system reset/clocks
 
 ad_ip_instance proc_sys_reset sys_rstgen
+ad_ip_parameter sys_rstgen CONFIG.C_EXT_RST_WIDTH 1
+ad_ip_instance proc_sys_reset sys_200m_rstgen
+ad_ip_parameter sys_200m_rstgen CONFIG.C_EXT_RST_WIDTH 1
 
 # instance: ddr (mig)
 
@@ -143,6 +146,7 @@ ad_connect sys_concat_intc/dout   axi_intc/intr
 # defaults (peripherals)
 
 ad_connect axi_ddr_cntrl/mmcm_locked   sys_rstgen/dcm_locked
+ad_connect axi_ddr_cntrl/mmcm_locked   sys_200m_rstgen/dcm_locked
 ad_connect axi_ddr_cntrl/device_temp_i GND
 
 ad_connect sys_cpu_clk axi_ddr_cntrl/ui_clk
@@ -150,14 +154,24 @@ ad_connect sys_200m_clk axi_ddr_cntrl/ui_addn_clk_0
 ad_connect sys_cpu_resetn axi_ddr_cntrl/aresetn
 ad_connect sys_cpu_reset sys_rstgen/peripheral_reset
 ad_connect sys_cpu_resetn sys_rstgen/peripheral_aresetn
+ad_connect sys_200m_reset sys_200m_rstgen/peripheral_reset
+ad_connect sys_200m_resetn sys_200m_rstgen/peripheral_aresetn
 
-# generic system clocks pointers
+# generic system clocks and resets pointers
 
-set sys_cpu_clk      [get_bd_nets sys_cpu_clk]
-set sys_dma_clk      [get_bd_nets sys_200m_clk]
-set sys_iodelay_clk  [get_bd_nets sys_200m_clk]
+set sys_cpu_clk           [get_bd_nets sys_cpu_clk]
+set sys_dma_clk           [get_bd_nets sys_200m_clk]
+set sys_iodelay_clk       [get_bd_nets sys_200m_clk]
+
+set sys_cpu_reset         [get_bd_nets sys_cpu_reset]
+set sys_cpu_resetn        [get_bd_nets sys_cpu_resetn]
+set sys_dma_reset         [get_bd_nets sys_200m_reset]
+set sys_dma_resetn        [get_bd_nets sys_200m_resetn]
+set sys_iodelay_reset     [get_bd_nets sys_200m_reset]
+set sys_iodelay_resetn    [get_bd_nets sys_200m_resetn]
 
 ad_connect sys_cpu_clk  sys_rstgen/slowest_sync_clk
+ad_connect sys_200m_clk  sys_200m_rstgen/slowest_sync_clk
 ad_connect sys_cpu_clk  sys_mb/Clk
 ad_connect sys_cpu_clk  sys_dlmb/LMB_Clk
 ad_connect sys_cpu_clk  sys_ilmb/LMB_Clk

--- a/projects/common/kc705/kc705_system_bd.tcl
+++ b/projects/common/kc705/kc705_system_bd.tcl
@@ -165,6 +165,12 @@ ad_connect sys_cpu_resetn axi_ddr_cntrl/aresetn
 ad_connect sys_cpu_reset  sys_rstgen/peripheral_reset
 ad_connect sys_cpu_resetn sys_rstgen/peripheral_aresetn
 
+# generic system clocks pointers
+
+set sys_cpu_clk      [get_bd_nets sys_cpu_clk]
+set sys_dma_clk      [get_bd_nets sys_200m_clk]
+set sys_iodelay_clk  [get_bd_nets sys_200m_clk]
+
 ad_connect sys_cpu_clk  sys_rstgen/slowest_sync_clk
 ad_connect sys_cpu_clk  sys_mb/Clk
 ad_connect sys_cpu_clk  sys_dlmb/LMB_Clk

--- a/projects/common/kc705/kc705_system_bd.tcl
+++ b/projects/common/kc705/kc705_system_bd.tcl
@@ -68,6 +68,9 @@ ad_ip_parameter sys_mb_debug CONFIG.C_USE_UART 1
 # instance: system reset/clocks
 
 ad_ip_instance proc_sys_reset sys_rstgen
+ad_ip_parameter sys_rstgen CONFIG.C_EXT_RST_WIDTH 1
+ad_ip_instance proc_sys_reset sys_200m_rstgen
+ad_ip_parameter sys_200m_rstgen CONFIG.C_EXT_RST_WIDTH 1
 
 # instance: ddr (mig)
 
@@ -158,12 +161,15 @@ ad_connect sys_concat_intc/dout   axi_intc/intr
 # defaults (peripherals)
 
 ad_connect axi_ddr_cntrl/mmcm_locked   sys_rstgen/dcm_locked
+ad_connect axi_ddr_cntrl/mmcm_locked   sys_200m_rstgen/dcm_locked
 
 ad_connect sys_cpu_clk    axi_ddr_cntrl/ui_addn_clk_0
 ad_connect sys_200m_clk   axi_ddr_cntrl/ui_clk
 ad_connect sys_cpu_resetn axi_ddr_cntrl/aresetn
 ad_connect sys_cpu_reset  sys_rstgen/peripheral_reset
 ad_connect sys_cpu_resetn sys_rstgen/peripheral_aresetn
+ad_connect sys_200m_reset  sys_200m_rstgen/peripheral_reset
+ad_connect sys_200m_resetn sys_200m_rstgen/peripheral_aresetn
 
 # generic system clocks pointers
 
@@ -171,7 +177,15 @@ set sys_cpu_clk      [get_bd_nets sys_cpu_clk]
 set sys_dma_clk      [get_bd_nets sys_200m_clk]
 set sys_iodelay_clk  [get_bd_nets sys_200m_clk]
 
+set sys_cpu_reset         [get_bd_nets sys_cpu_reset]
+set sys_cpu_resetn        [get_bd_nets sys_cpu_resetn]
+set sys_dma_reset         [get_bd_nets sys_200m_reset]
+set sys_dma_resetn        [get_bd_nets sys_200m_resetn]
+set sys_iodelay_reset     [get_bd_nets sys_200m_reset]
+set sys_iodelay_resetn    [get_bd_nets sys_200m_resetn]
+
 ad_connect sys_cpu_clk  sys_rstgen/slowest_sync_clk
+ad_connect sys_200m_clk sys_200m_rstgen/slowest_sync_clk
 ad_connect sys_cpu_clk  sys_mb/Clk
 ad_connect sys_cpu_clk  sys_dlmb/LMB_Clk
 ad_connect sys_cpu_clk  sys_ilmb/LMB_Clk
@@ -202,6 +216,8 @@ ad_connect sys_concat_intc/In15   GND
 
 ad_connect  sys_rst sys_rstgen/ext_reset_in
 ad_connect  sys_rst axi_ddr_cntrl/sys_rst
+ad_connect  sys_200m_rst sys_200m_rstgen/ext_reset_in
+ad_connect  sys_200m_rst axi_ddr_cntrl/ui_clk_sync_rst
 ad_connect  sys_clk_p axi_ddr_cntrl/sys_clk_p
 ad_connect  sys_clk_n axi_ddr_cntrl/sys_clk_n
 ad_connect  ddr3 axi_ddr_cntrl/DDR3

--- a/projects/common/kcu105/kcu105_system_bd.tcl
+++ b/projects/common/kcu105/kcu105_system_bd.tcl
@@ -136,6 +136,12 @@ ad_connect  sys_mem_resetn axi_ddr_cntrl_rstgen/peripheral_aresetn
 ad_connect  sys_mem_resetn axi_ddr_cntrl/c0_ddr4_aresetn
 ad_connect  sys_200m_clk axi_ddr_cntrl/addn_ui_clkout2
 
+# generic system clocks pointers
+
+set sys_cpu_clk      [get_bd_nets sys_cpu_clk]
+set sys_dma_clk      [get_bd_nets sys_200m_clk]
+set sys_iodelay_clk  [get_bd_nets sys_200m_clk]
+
 # microblaze
 
 ad_connect  sys_cpu_reset sys_rstgen/peripheral_reset

--- a/projects/common/kcu105/kcu105_system_bd.tcl
+++ b/projects/common/kcu105/kcu105_system_bd.tcl
@@ -67,6 +67,9 @@ ad_ip_parameter sys_mb_debug CONFIG.C_USE_UART 1
 # instance: system reset/clocks
 
 ad_ip_instance proc_sys_reset sys_rstgen
+ad_ip_parameter sys_rstgen CONFIG.C_EXT_RST_WIDTH 1
+ad_ip_instance proc_sys_reset sys_200m_rstgen
+ad_ip_parameter sys_200m_rstgen CONFIG.C_EXT_RST_WIDTH 1
 
 # instance: ddr4
 
@@ -127,6 +130,7 @@ ad_connect  sys_rst axi_ddr_cntrl/sys_rst
 ad_connect  sys_clk axi_ddr_cntrl/C0_SYS_CLK
 ad_connect  c0_ddr4 axi_ddr_cntrl/C0_DDR4
 ad_connect  axi_ddr_cntrl/c0_ddr4_ui_clk_sync_rst sys_rstgen/ext_reset_in
+ad_connect  axi_ddr_cntrl/c0_ddr4_ui_clk_sync_rst sys_200m_rstgen/ext_reset_in
 ad_connect  axi_ddr_cntrl/c0_ddr4_ui_clk_sync_rst axi_ddr_cntrl_rstgen/ext_reset_in
 ad_connect  sys_mem_clk axi_ddr_cntrl/c0_ddr4_ui_clk
 ad_connect  sys_mem_clk axi_ddr_cntrl_rstgen/slowest_sync_clk
@@ -135,17 +139,27 @@ ad_connect  sys_cpu_clk sys_rstgen/slowest_sync_clk
 ad_connect  sys_mem_resetn axi_ddr_cntrl_rstgen/peripheral_aresetn
 ad_connect  sys_mem_resetn axi_ddr_cntrl/c0_ddr4_aresetn
 ad_connect  sys_200m_clk axi_ddr_cntrl/addn_ui_clkout2
+ad_connect  sys_200m_clk sys_200m_rstgen/slowest_sync_clk
+ad_connect  sys_cpu_reset sys_rstgen/peripheral_reset
+ad_connect  sys_cpu_resetn sys_rstgen/peripheral_aresetn
+ad_connect  sys_200m_reset sys_200m_rstgen/peripheral_reset
+ad_connect  sys_200m_resetn sys_200m_rstgen/peripheral_aresetn
 
 # generic system clocks pointers
 
-set sys_cpu_clk      [get_bd_nets sys_cpu_clk]
-set sys_dma_clk      [get_bd_nets sys_200m_clk]
-set sys_iodelay_clk  [get_bd_nets sys_200m_clk]
+set sys_cpu_clk           [get_bd_nets sys_cpu_clk]
+set sys_dma_clk           [get_bd_nets sys_200m_clk]
+set sys_iodelay_clk       [get_bd_nets sys_200m_clk]
+
+set sys_cpu_reset         [get_bd_nets sys_cpu_reset]
+set sys_cpu_resetn        [get_bd_nets sys_cpu_resetn]
+set sys_dma_reset         [get_bd_nets sys_200m_reset]
+set sys_dma_resetn        [get_bd_nets sys_200m_resetn]
+set sys_iodelay_reset     [get_bd_nets sys_200m_reset]
+set sys_iodelay_resetn    [get_bd_nets sys_200m_resetn]
 
 # microblaze
 
-ad_connect  sys_cpu_reset sys_rstgen/peripheral_reset
-ad_connect  sys_cpu_resetn sys_rstgen/peripheral_aresetn
 ad_connect  sys_cpu_clk sys_mb/Clk
 ad_connect  sys_cpu_clk sys_dlmb/LMB_Clk
 ad_connect  sys_cpu_clk sys_ilmb/LMB_Clk

--- a/projects/common/microzed/microzed_system_bd.tcl
+++ b/projects/common/microzed/microzed_system_bd.tcl
@@ -61,6 +61,12 @@ ad_connect  sys_cpu_resetn sys_rstgen/peripheral_aresetn
 ad_connect  sys_cpu_clk sys_rstgen/slowest_sync_clk
 ad_connect  sys_rstgen/ext_reset_in sys_ps7/FCLK_RESET0_N
 
+# generic system clocks pointers
+
+set sys_cpu_clk      [get_bd_nets sys_cpu_clk]
+set sys_dma_clk      [get_bd_nets sys_200m_clk]
+set sys_iodelay_clk  [get_bd_nets sys_200m_clk]
+
 # interface connections
 
 ad_connect  ddr           sys_ps7/DDR

--- a/projects/common/microzed/microzed_system_bd.tcl
+++ b/projects/common/microzed/microzed_system_bd.tcl
@@ -51,6 +51,8 @@ ad_ip_parameter sys_concat_intc CONFIG.NUM_PORTS 16
 
 ad_ip_instance proc_sys_reset sys_rstgen
 ad_ip_parameter sys_rstgen CONFIG.C_EXT_RST_WIDTH 1
+ad_ip_instance proc_sys_reset sys_200m_rstgen
+ad_ip_parameter sys_200m_rstgen CONFIG.C_EXT_RST_WIDTH 1
 
 # system reset/clock definitions
 
@@ -60,12 +62,23 @@ ad_connect  sys_cpu_reset sys_rstgen/peripheral_reset
 ad_connect  sys_cpu_resetn sys_rstgen/peripheral_aresetn
 ad_connect  sys_cpu_clk sys_rstgen/slowest_sync_clk
 ad_connect  sys_rstgen/ext_reset_in sys_ps7/FCLK_RESET0_N
+ad_connect  sys_200m_reset sys_200m_rstgen/peripheral_reset
+ad_connect  sys_200m_resetn sys_200m_rstgen/peripheral_aresetn
+ad_connect  sys_200m_clk sys_200m_rstgen/slowest_sync_clk
+ad_connect  sys_200m_rstgen/ext_reset_in sys_ps7/FCLK_RESET1_N
 
 # generic system clocks pointers
 
-set sys_cpu_clk      [get_bd_nets sys_cpu_clk]
-set sys_dma_clk      [get_bd_nets sys_200m_clk]
-set sys_iodelay_clk  [get_bd_nets sys_200m_clk]
+set sys_cpu_clk           [get_bd_nets sys_cpu_clk]
+set sys_dma_clk           [get_bd_nets sys_200m_clk]
+set sys_iodelay_clk       [get_bd_nets sys_200m_clk]
+
+set sys_cpu_reset         [get_bd_nets sys_cpu_reset]
+set sys_cpu_resetn        [get_bd_nets sys_cpu_resetn]
+set sys_dma_reset         [get_bd_nets sys_200m_reset]
+set sys_dma_resetn        [get_bd_nets sys_200m_resetn]
+set sys_iodelay_reset     [get_bd_nets sys_200m_reset]
+set sys_iodelay_resetn    [get_bd_nets sys_200m_resetn]
 
 # interface connections
 

--- a/projects/common/vc707/vc707_system_bd.tcl
+++ b/projects/common/vc707/vc707_system_bd.tcl
@@ -171,6 +171,12 @@ ad_connect sys_cpu_resetn axi_ddr_cntrl/aresetn
 ad_connect sys_cpu_reset  sys_rstgen/peripheral_reset
 ad_connect sys_cpu_resetn sys_rstgen/peripheral_aresetn
 
+# generic system clocks pointers
+
+set sys_cpu_clk      [get_bd_nets sys_cpu_clk]
+set sys_dma_clk      [get_bd_nets sys_200m_clk]
+set sys_iodelay_clk  [get_bd_nets sys_200m_clk]
+
 ad_connect sys_cpu_clk  sys_rstgen/slowest_sync_clk
 ad_connect sys_cpu_clk  sys_mb/Clk
 ad_connect sys_cpu_clk  sys_dlmb/LMB_Clk

--- a/projects/common/vc707/vc707_system_bd.tcl
+++ b/projects/common/vc707/vc707_system_bd.tcl
@@ -66,6 +66,9 @@ ad_ip_parameter sys_mb_debug CONFIG.C_USE_UART 1
 # instance: system reset/clocks
 
 ad_ip_instance proc_sys_reset sys_rstgen
+ad_ip_parameter sys_rstgen CONFIG.C_EXT_RST_WIDTH 1
+ad_ip_instance proc_sys_reset sys_200m_rstgen
+ad_ip_parameter sys_200m_rstgen CONFIG.C_EXT_RST_WIDTH 1
 
 # instance: ddr (mig)
 
@@ -164,12 +167,15 @@ ad_connect sys_concat_intc/dout   axi_intc/intr
 
 ad_connect axi_ddr_cntrl/device_temp_i GND
 ad_connect axi_ddr_cntrl/mmcm_locked   sys_rstgen/dcm_locked
+ad_connect axi_ddr_cntrl/mmcm_locked   sys_200m_rstgen/dcm_locked
 
 ad_connect sys_cpu_clk    axi_ddr_cntrl/ui_addn_clk_0
 ad_connect sys_200m_clk   axi_ddr_cntrl/ui_clk
 ad_connect sys_cpu_resetn axi_ddr_cntrl/aresetn
 ad_connect sys_cpu_reset  sys_rstgen/peripheral_reset
 ad_connect sys_cpu_resetn sys_rstgen/peripheral_aresetn
+ad_connect sys_200m_reset  sys_200m_rstgen/peripheral_reset
+ad_connect sys_200m_resetn sys_200m_rstgen/peripheral_aresetn
 
 # generic system clocks pointers
 
@@ -178,6 +184,7 @@ set sys_dma_clk      [get_bd_nets sys_200m_clk]
 set sys_iodelay_clk  [get_bd_nets sys_200m_clk]
 
 ad_connect sys_cpu_clk  sys_rstgen/slowest_sync_clk
+ad_connect sys_200m_clk sys_200m_rstgen/slowest_sync_clk
 ad_connect sys_cpu_clk  sys_mb/Clk
 ad_connect sys_cpu_clk  sys_dlmb/LMB_Clk
 ad_connect sys_cpu_clk  sys_ilmb/LMB_Clk
@@ -208,6 +215,8 @@ ad_connect sys_concat_intc/In15   GND
 
 ad_connect  sys_rst sys_rstgen/ext_reset_in
 ad_connect  sys_rst axi_ddr_cntrl/sys_rst
+ad_connect  sys_200m_rst sys_200m_rstgen/ext_reset_in
+ad_connect  sys_200m_rst axi_ddr_cntrl/ui_clk_sync_rst
 ad_connect  sys_clk_p axi_ddr_cntrl/sys_clk_p
 ad_connect  sys_clk_n axi_ddr_cntrl/sys_clk_n
 ad_connect  ddr3 axi_ddr_cntrl/DDR3

--- a/projects/common/vc707/vc707_system_bd.tcl
+++ b/projects/common/vc707/vc707_system_bd.tcl
@@ -183,6 +183,13 @@ set sys_cpu_clk      [get_bd_nets sys_cpu_clk]
 set sys_dma_clk      [get_bd_nets sys_200m_clk]
 set sys_iodelay_clk  [get_bd_nets sys_200m_clk]
 
+set sys_cpu_reset         [get_bd_nets sys_cpu_reset]
+set sys_cpu_resetn        [get_bd_nets sys_cpu_resetn]
+set sys_dma_reset         [get_bd_nets sys_200m_reset]
+set sys_dma_resetn        [get_bd_nets sys_200m_resetn]
+set sys_iodelay_reset     [get_bd_nets sys_200m_reset]
+set sys_iodelay_resetn    [get_bd_nets sys_200m_resetn]
+
 ad_connect sys_cpu_clk  sys_rstgen/slowest_sync_clk
 ad_connect sys_200m_clk sys_200m_rstgen/slowest_sync_clk
 ad_connect sys_cpu_clk  sys_mb/Clk

--- a/projects/common/vcu118/vcu118_system_bd.tcl
+++ b/projects/common/vcu118/vcu118_system_bd.tcl
@@ -76,6 +76,7 @@ ad_ip_parameter axi_ddr_cntrl CONFIG.C0_CLOCK_BOARD_INTERFACE default_250mhz_clk
 ad_ip_parameter axi_ddr_cntrl CONFIG.C0_DDR4_BOARD_INTERFACE ddr4_sdram_c1
 ad_ip_parameter axi_ddr_cntrl CONFIG.RESET_BOARD_INTERFACE reset
 ad_ip_parameter axi_ddr_cntrl CONFIG.ADDN_UI_CLKOUT2_FREQ_HZ 250
+ad_ip_parameter axi_ddr_cntrl CONFIG.ADDN_UI_CLKOUT3_FREQ_HZ 500
 
 ad_ip_instance proc_sys_reset axi_ddr_cntrl_rstgen
 
@@ -136,6 +137,13 @@ ad_connect sys_cpu_clk sys_rstgen/slowest_sync_clk
 ad_connect sys_mem_resetn axi_ddr_cntrl_rstgen/peripheral_aresetn
 ad_connect sys_mem_resetn axi_ddr_cntrl/c0_ddr4_aresetn
 ad_connect sys_250m_clk axi_ddr_cntrl/addn_ui_clkout2
+ad_connect sys_500m_clk axi_ddr_cntrl/addn_ui_clkout3
+
+# generic system clocks pointers
+
+set sys_cpu_clk      [get_bd_nets sys_cpu_clk]
+set sys_dma_clk      [get_bd_nets sys_250m_clk]
+set sys_iodelay_clk  [get_bd_nets sys_500m_clk]
 
 # microblaze debug & interrupt
 

--- a/projects/common/vcu118/vcu118_system_bd.tcl
+++ b/projects/common/vcu118/vcu118_system_bd.tcl
@@ -68,6 +68,11 @@ ad_ip_parameter sys_mb_debug CONFIG.C_USE_UART 1
 
 # instance: system reset/clocks
 ad_ip_instance proc_sys_reset sys_rstgen
+ad_ip_parameter sys_rstgen CONFIG.C_EXT_RST_WIDTH 1
+ad_ip_instance proc_sys_reset sys_250m_rstgen
+ad_ip_parameter sys_250m_rstgen CONFIG.C_EXT_RST_WIDTH 1
+ad_ip_instance proc_sys_reset sys_500m_rstgen
+ad_ip_parameter sys_500m_rstgen CONFIG.C_EXT_RST_WIDTH 1
 
 # instance: ddr4
 
@@ -130,6 +135,8 @@ ad_connect sys_clk axi_ddr_cntrl/C0_SYS_CLK
 ad_connect ddr4 axi_ddr_cntrl/C0_DDR4
 ad_connect axi_ddr_cntrl/c0_ddr4_ui_clk_sync_rst axi_ddr_cntrl_rstgen/ext_reset_in
 ad_connect axi_ddr_cntrl/c0_ddr4_ui_clk_sync_rst sys_rstgen/ext_reset_in
+ad_connect axi_ddr_cntrl/c0_ddr4_ui_clk_sync_rst sys_250m_rstgen/ext_reset_in
+ad_connect axi_ddr_cntrl/c0_ddr4_ui_clk_sync_rst sys_500m_rstgen/ext_reset_in
 ad_connect sys_mem_clk axi_ddr_cntrl/c0_ddr4_ui_clk
 ad_connect sys_mem_clk axi_ddr_cntrl_rstgen/slowest_sync_clk
 ad_connect sys_cpu_clk axi_ddr_cntrl/addn_ui_clkout1
@@ -137,7 +144,15 @@ ad_connect sys_cpu_clk sys_rstgen/slowest_sync_clk
 ad_connect sys_mem_resetn axi_ddr_cntrl_rstgen/peripheral_aresetn
 ad_connect sys_mem_resetn axi_ddr_cntrl/c0_ddr4_aresetn
 ad_connect sys_250m_clk axi_ddr_cntrl/addn_ui_clkout2
+ad_connect sys_250m_clk sys_250m_rstgen/slowest_sync_clk
 ad_connect sys_500m_clk axi_ddr_cntrl/addn_ui_clkout3
+ad_connect sys_500m_clk sys_500m_rstgen/slowest_sync_clk
+ad_connect sys_cpu_reset sys_rstgen/peripheral_reset
+ad_connect sys_cpu_resetn sys_rstgen/peripheral_aresetn
+ad_connect sys_250m_reset sys_250m_rstgen/peripheral_reset
+ad_connect sys_250m_resetn sys_250m_rstgen/peripheral_aresetn
+ad_connect sys_500m_reset sys_500m_rstgen/peripheral_reset
+ad_connect sys_500m_resetn sys_500m_rstgen/peripheral_aresetn
 
 # generic system clocks pointers
 
@@ -145,10 +160,15 @@ set sys_cpu_clk      [get_bd_nets sys_cpu_clk]
 set sys_dma_clk      [get_bd_nets sys_250m_clk]
 set sys_iodelay_clk  [get_bd_nets sys_500m_clk]
 
+set sys_cpu_reset         [get_bd_nets sys_cpu_reset]
+set sys_cpu_resetn        [get_bd_nets sys_cpu_resetn]
+set sys_dma_reset         [get_bd_nets sys_250m_reset]
+set sys_dma_resetn        [get_bd_nets sys_250m_resetn]
+set sys_iodelay_reset     [get_bd_nets sys_500m_reset]
+set sys_iodelay_resetn    [get_bd_nets sys_500m_resetn]
+
 # microblaze debug & interrupt
 
-ad_connect sys_cpu_reset  sys_rstgen/peripheral_reset
-ad_connect sys_cpu_resetn sys_rstgen/peripheral_aresetn
 ad_connect sys_cpu_clk sys_mb/Clk
 ad_connect sys_cpu_clk sys_dlmb/LMB_Clk
 ad_connect sys_cpu_clk sys_ilmb/LMB_Clk

--- a/projects/common/zc702/zc702_system_bd.tcl
+++ b/projects/common/zc702/zc702_system_bd.tcl
@@ -71,6 +71,8 @@ ad_ip_parameter sys_concat_intc CONFIG.NUM_PORTS 16
 
 ad_ip_instance proc_sys_reset sys_rstgen
 ad_ip_parameter sys_rstgen CONFIG.C_EXT_RST_WIDTH 1
+ad_ip_instance proc_sys_reset sys_200m_rstgen
+ad_ip_parameter sys_200m_rstgen CONFIG.C_EXT_RST_WIDTH 1
 
 # hdmi peripherals
 
@@ -109,12 +111,23 @@ ad_connect  sys_cpu_reset sys_rstgen/peripheral_reset
 ad_connect  sys_cpu_resetn sys_rstgen/peripheral_aresetn
 ad_connect  sys_cpu_clk sys_rstgen/slowest_sync_clk
 ad_connect  sys_rstgen/ext_reset_in sys_ps7/FCLK_RESET0_N
+ad_connect  sys_200m_reset sys_200m_rstgen/peripheral_reset
+ad_connect  sys_200m_resetn sys_200m_rstgen/peripheral_aresetn
+ad_connect  sys_200m_clk sys_200m_rstgen/slowest_sync_clk
+ad_connect  sys_200m_rstgen/ext_reset_in sys_ps7/FCLK_RESET1_N
 
 # generic system clocks pointers
 
 set sys_cpu_clk      [get_bd_nets sys_cpu_clk]
 set sys_dma_clk      [get_bd_nets sys_200m_clk]
 set sys_iodelay_clk  [get_bd_nets sys_200m_clk]
+
+set sys_cpu_reset         [get_bd_nets sys_cpu_reset]
+set sys_cpu_resetn        [get_bd_nets sys_cpu_resetn]
+set sys_dma_reset         [get_bd_nets sys_200m_reset]
+set sys_dma_resetn        [get_bd_nets sys_200m_resetn]
+set sys_iodelay_reset     [get_bd_nets sys_200m_reset]
+set sys_iodelay_resetn    [get_bd_nets sys_200m_resetn]
 
 # interface connections
 

--- a/projects/common/zc702/zc702_system_bd.tcl
+++ b/projects/common/zc702/zc702_system_bd.tcl
@@ -110,6 +110,12 @@ ad_connect  sys_cpu_resetn sys_rstgen/peripheral_aresetn
 ad_connect  sys_cpu_clk sys_rstgen/slowest_sync_clk
 ad_connect  sys_rstgen/ext_reset_in sys_ps7/FCLK_RESET0_N
 
+# generic system clocks pointers
+
+set sys_cpu_clk      [get_bd_nets sys_cpu_clk]
+set sys_dma_clk      [get_bd_nets sys_200m_clk]
+set sys_iodelay_clk  [get_bd_nets sys_200m_clk]
+
 # interface connections
 
 ad_connect  ddr sys_ps7/DDR

--- a/projects/common/zc706/zc706_system_bd.tcl
+++ b/projects/common/zc706/zc706_system_bd.tcl
@@ -111,6 +111,12 @@ ad_connect  sys_cpu_resetn sys_rstgen/peripheral_aresetn
 ad_connect  sys_cpu_clk sys_rstgen/slowest_sync_clk
 ad_connect  sys_rstgen/ext_reset_in sys_ps7/FCLK_RESET0_N
 
+# generic system clocks pointers
+
+set sys_cpu_clk      [get_bd_nets sys_cpu_clk]
+set sys_dma_clk      [get_bd_nets sys_200m_clk]
+set sys_iodelay_clk  [get_bd_nets sys_200m_clk]
+
 # interface connections
 
 ad_connect  ddr sys_ps7/DDR

--- a/projects/common/zc706/zc706_system_bd.tcl
+++ b/projects/common/zc706/zc706_system_bd.tcl
@@ -72,6 +72,8 @@ ad_ip_parameter sys_concat_intc CONFIG.NUM_PORTS 16
 
 ad_ip_instance proc_sys_reset sys_rstgen
 ad_ip_parameter sys_rstgen CONFIG.C_EXT_RST_WIDTH 1
+ad_ip_instance proc_sys_reset sys_200m_rstgen
+ad_ip_parameter sys_200m_rstgen CONFIG.C_EXT_RST_WIDTH 1
 
 # hdmi peripherals
 
@@ -110,6 +112,10 @@ ad_connect  sys_cpu_reset sys_rstgen/peripheral_reset
 ad_connect  sys_cpu_resetn sys_rstgen/peripheral_aresetn
 ad_connect  sys_cpu_clk sys_rstgen/slowest_sync_clk
 ad_connect  sys_rstgen/ext_reset_in sys_ps7/FCLK_RESET0_N
+ad_connect  sys_200m_reset sys_200m_rstgen/peripheral_reset
+ad_connect  sys_200m_resetn sys_200m_rstgen/peripheral_aresetn
+ad_connect  sys_200m_clk sys_200m_rstgen/slowest_sync_clk
+ad_connect  sys_200m_rstgen/ext_reset_in sys_ps7/FCLK_RESET1_N
 
 # generic system clocks pointers
 

--- a/projects/common/zc706/zc706_system_bd.tcl
+++ b/projects/common/zc706/zc706_system_bd.tcl
@@ -123,6 +123,13 @@ set sys_cpu_clk      [get_bd_nets sys_cpu_clk]
 set sys_dma_clk      [get_bd_nets sys_200m_clk]
 set sys_iodelay_clk  [get_bd_nets sys_200m_clk]
 
+set sys_cpu_reset         [get_bd_nets sys_cpu_reset]
+set sys_cpu_resetn        [get_bd_nets sys_cpu_resetn]
+set sys_dma_reset         [get_bd_nets sys_200m_reset]
+set sys_dma_resetn        [get_bd_nets sys_200m_resetn]
+set sys_iodelay_reset     [get_bd_nets sys_200m_reset]
+set sys_iodelay_resetn    [get_bd_nets sys_200m_resetn]
+
 # interface connections
 
 ad_connect  ddr sys_ps7/DDR

--- a/projects/common/zcu102/zcu102_system_bd.tcl
+++ b/projects/common/zcu102/zcu102_system_bd.tcl
@@ -30,8 +30,11 @@ ad_ip_parameter sys_ps8 CONFIG.PSU__FPGA_PL0_ENABLE 1
 ad_ip_parameter sys_ps8 CONFIG.PSU__CRL_APB__PL0_REF_CTRL__SRCSEL {IOPLL}
 ad_ip_parameter sys_ps8 CONFIG.PSU__CRL_APB__PL0_REF_CTRL__FREQMHZ 100
 ad_ip_parameter sys_ps8 CONFIG.PSU__FPGA_PL1_ENABLE 1
+ad_ip_parameter sys_ps8 CONFIG.PSU__FPGA_PL2_ENABLE 1
 ad_ip_parameter sys_ps8 CONFIG.PSU__CRL_APB__PL1_REF_CTRL__SRCSEL {IOPLL}
-ad_ip_parameter sys_ps8 CONFIG.PSU__CRL_APB__PL1_REF_CTRL__FREQMHZ 200
+ad_ip_parameter sys_ps8 CONFIG.PSU__CRL_APB__PL1_REF_CTRL__FREQMHZ 250
+ad_ip_parameter sys_ps8 CONFIG.PSU__CRL_APB__PL2_REF_CTRL__SRCSEL {IOPLL}
+ad_ip_parameter sys_ps8 CONFIG.PSU__CRL_APB__PL2_REF_CTRL__FREQMHZ 500
 ad_ip_parameter sys_ps8 CONFIG.PSU__USE__IRQ0 1
 ad_ip_parameter sys_ps8 CONFIG.PSU__USE__IRQ1 1
 ad_ip_parameter sys_ps8 CONFIG.PSU__GPIO_EMIO__PERIPHERAL__ENABLE 1
@@ -55,11 +58,18 @@ ad_ip_parameter sys_rstgen CONFIG.C_EXT_RST_WIDTH 1
 # system reset/clock definitions
 
 ad_connect  sys_cpu_clk sys_ps8/pl_clk0
-ad_connect  sys_200m_clk sys_ps8/pl_clk1
+ad_connect  sys_250m_clk sys_ps8/pl_clk1
+ad_connect  sys_500m_clk sys_ps8/pl_clk2
 ad_connect  sys_cpu_reset sys_rstgen/peripheral_reset
 ad_connect  sys_cpu_resetn sys_rstgen/peripheral_aresetn
 ad_connect  sys_cpu_clk sys_rstgen/slowest_sync_clk
 ad_connect  sys_ps8/pl_resetn0 sys_rstgen/ext_reset_in
+
+# generic system clocks pointers
+
+set sys_cpu_clk      [get_bd_nets sys_cpu_clk]
+set sys_dma_clk      [get_bd_nets sys_250m_clk]
+set sys_iodelay_clk  [get_bd_nets sys_500m_clk]
 
 # gpio
 

--- a/projects/common/zcu102/zcu102_system_bd.tcl
+++ b/projects/common/zcu102/zcu102_system_bd.tcl
@@ -52,24 +52,47 @@ set_property -dict [list \
   CONFIG.PSU__CRL_APB__SPI1_REF_CTRL__FREQMHZ 100 \
 ] [get_bd_cells sys_ps8]
 
+# processor system reset instances for all the three system clocks
+
 ad_ip_instance proc_sys_reset sys_rstgen
 ad_ip_parameter sys_rstgen CONFIG.C_EXT_RST_WIDTH 1
+ad_ip_instance proc_sys_reset sys_250m_rstgen
+ad_ip_parameter sys_250m_rstgen CONFIG.C_EXT_RST_WIDTH 1
+ad_ip_instance proc_sys_reset sys_500m_rstgen
+ad_ip_parameter sys_500m_rstgen CONFIG.C_EXT_RST_WIDTH 1
 
 # system reset/clock definitions
 
 ad_connect  sys_cpu_clk sys_ps8/pl_clk0
 ad_connect  sys_250m_clk sys_ps8/pl_clk1
 ad_connect  sys_500m_clk sys_ps8/pl_clk2
+
+ad_connect  sys_ps8/pl_resetn0 sys_rstgen/ext_reset_in
+ad_connect  sys_cpu_clk sys_rstgen/slowest_sync_clk
+ad_connect  sys_ps8/pl_resetn0 sys_250m_rstgen/ext_reset_in
+ad_connect  sys_250m_clk sys_250m_rstgen/slowest_sync_clk
+ad_connect  sys_ps8/pl_resetn0 sys_500m_rstgen/ext_reset_in
+ad_connect  sys_500m_clk sys_500m_rstgen/slowest_sync_clk
+
 ad_connect  sys_cpu_reset sys_rstgen/peripheral_reset
 ad_connect  sys_cpu_resetn sys_rstgen/peripheral_aresetn
-ad_connect  sys_cpu_clk sys_rstgen/slowest_sync_clk
-ad_connect  sys_ps8/pl_resetn0 sys_rstgen/ext_reset_in
+ad_connect  sys_250m_reset sys_250m_rstgen/peripheral_reset
+ad_connect  sys_250m_resetn sys_250m_rstgen/peripheral_aresetn
+ad_connect  sys_500m_reset sys_500m_rstgen/peripheral_reset
+ad_connect  sys_500m_resetn sys_500m_rstgen/peripheral_aresetn
 
-# generic system clocks pointers
+# generic system clocks&resets pointers
 
-set sys_cpu_clk      [get_bd_nets sys_cpu_clk]
-set sys_dma_clk      [get_bd_nets sys_250m_clk]
-set sys_iodelay_clk  [get_bd_nets sys_500m_clk]
+set sys_cpu_clk            [get_bd_nets sys_cpu_clk]
+set sys_dma_clk            [get_bd_nets sys_250m_clk]
+set sys_iodelay_clk        [get_bd_nets sys_500m_clk]
+
+set  sys_cpu_reset         [get_bd_nets sys_cpu_reset]
+set  sys_cpu_resetn        [get_bd_nets sys_cpu_resetn]
+set  sys_dma_reset         [get_bd_nets sys_250m_reset]
+set  sys_dma_resetn        [get_bd_nets sys_250m_resetn]
+set  sys_iodelay_reset     [get_bd_nets sys_500m_reset]
+set  sys_iodelay_resetn    [get_bd_nets sys_500m_resetn]
 
 # gpio
 

--- a/projects/common/zed/zed_system_bd.tcl
+++ b/projects/common/zed/zed_system_bd.tcl
@@ -143,6 +143,12 @@ ad_connect  sys_cpu_resetn sys_rstgen/peripheral_aresetn
 ad_connect  sys_cpu_clk sys_rstgen/slowest_sync_clk
 ad_connect  sys_rstgen/ext_reset_in sys_ps7/FCLK_RESET0_N
 
+# generic system clocks pointers
+
+set sys_cpu_clk      [get_bd_nets sys_cpu_clk]
+set sys_dma_clk      [get_bd_nets sys_200m_clk]
+set sys_iodelay_clk  [get_bd_nets sys_200m_clk]
+
 # interface connections
 
 ad_connect  ddr           sys_ps7/DDR

--- a/projects/common/zed/zed_system_bd.tcl
+++ b/projects/common/zed/zed_system_bd.tcl
@@ -92,6 +92,8 @@ ad_ip_parameter sys_concat_intc CONFIG.NUM_PORTS 16
 
 ad_ip_instance proc_sys_reset sys_rstgen
 ad_ip_parameter sys_rstgen CONFIG.C_EXT_RST_WIDTH 1
+ad_ip_instance proc_sys_reset sys_200m_rstgen
+ad_ip_parameter sys_200m_rstgen CONFIG.C_EXT_RST_WIDTH 1
 
 ad_ip_instance util_vector_logic sys_logic_inv
 ad_ip_parameter sys_logic_inv CONFIG.C_SIZE 1
@@ -142,12 +144,23 @@ ad_connect  sys_cpu_reset sys_rstgen/peripheral_reset
 ad_connect  sys_cpu_resetn sys_rstgen/peripheral_aresetn
 ad_connect  sys_cpu_clk sys_rstgen/slowest_sync_clk
 ad_connect  sys_rstgen/ext_reset_in sys_ps7/FCLK_RESET0_N
+ad_connect  sys_200m_reset sys_200m_rstgen/peripheral_reset
+ad_connect  sys_200m_resetn sys_200m_rstgen/peripheral_aresetn
+ad_connect  sys_200m_clk sys_200m_rstgen/slowest_sync_clk
+ad_connect  sys_200m_rstgen/ext_reset_in sys_ps7/FCLK_RESET1_N
 
 # generic system clocks pointers
 
-set sys_cpu_clk      [get_bd_nets sys_cpu_clk]
-set sys_dma_clk      [get_bd_nets sys_200m_clk]
-set sys_iodelay_clk  [get_bd_nets sys_200m_clk]
+set sys_cpu_clk           [get_bd_nets sys_cpu_clk]
+set sys_dma_clk           [get_bd_nets sys_200m_clk]
+set sys_iodelay_clk       [get_bd_nets sys_200m_clk]
+
+set sys_cpu_reset         [get_bd_nets sys_cpu_reset]
+set sys_cpu_resetn        [get_bd_nets sys_cpu_resetn]
+set sys_dma_reset         [get_bd_nets sys_200m_reset]
+set sys_dma_resetn        [get_bd_nets sys_200m_resetn]
+set sys_iodelay_reset     [get_bd_nets sys_200m_reset]
+set sys_iodelay_resetn    [get_bd_nets sys_200m_resetn]
 
 # interface connections
 

--- a/projects/daq2/common/daq2_bd.tcl
+++ b/projects/daq2/common/daq2_bd.tcl
@@ -158,8 +158,8 @@ ad_connect  axi_ad9680_cpack/packed_fifo_wr_en axi_ad9680_fifo/adc_wr
 ad_connect  axi_ad9680_cpack/packed_fifo_wr_data axi_ad9680_fifo/adc_wdata
 ad_connect  axi_ad9680_cpack/packed_fifo_wr_overflow axi_ad9680_fifo/adc_wovf
 
-ad_connect  sys_cpu_clk axi_ad9680_fifo/dma_clk
-ad_connect  sys_cpu_clk axi_ad9680_dma/s_axis_aclk
+ad_connect  $sys_cpu_clk axi_ad9680_fifo/dma_clk
+ad_connect  $sys_cpu_clk axi_ad9680_dma/s_axis_aclk
 ad_connect  sys_cpu_resetn axi_ad9680_dma/m_dest_axi_aresetn
 ad_connect  axi_ad9680_fifo/dma_wr axi_ad9680_dma/s_axis_valid
 ad_connect  axi_ad9680_fifo/dma_wdata axi_ad9680_dma/s_axis_data
@@ -179,15 +179,15 @@ ad_cpu_interconnect 0x7c400000 axi_ad9680_dma
 
 # gt uses hp3, and 100MHz clock for both DRP and AXI4
 
-ad_mem_hp3_interconnect sys_cpu_clk sys_ps7/S_AXI_HP3
-ad_mem_hp3_interconnect sys_cpu_clk axi_ad9680_xcvr/m_axi
+ad_mem_hp3_interconnect $sys_cpu_clk sys_ps7/S_AXI_HP3
+ad_mem_hp3_interconnect $sys_cpu_clk axi_ad9680_xcvr/m_axi
 
 # interconnect (mem/dac)
 
-ad_mem_hp1_interconnect sys_cpu_clk sys_ps7/S_AXI_HP1
-ad_mem_hp1_interconnect sys_cpu_clk axi_ad9144_dma/m_src_axi
-ad_mem_hp2_interconnect sys_cpu_clk sys_ps7/S_AXI_HP2
-ad_mem_hp2_interconnect sys_cpu_clk axi_ad9680_dma/m_dest_axi
+ad_mem_hp1_interconnect $sys_cpu_clk sys_ps7/S_AXI_HP1
+ad_mem_hp1_interconnect $sys_cpu_clk axi_ad9144_dma/m_src_axi
+ad_mem_hp2_interconnect $sys_cpu_clk sys_ps7/S_AXI_HP2
+ad_mem_hp2_interconnect $sys_cpu_clk axi_ad9680_dma/m_dest_axi
 
 # interrupts
 

--- a/projects/daq2/common/daq2_bd.tcl
+++ b/projects/daq2/common/daq2_bd.tcl
@@ -86,8 +86,8 @@ ad_ip_parameter util_daq2_xcvr CONFIG.TX_OUT_DIV 1
 ad_ip_parameter util_daq2_xcvr CONFIG.RX_DFE_LPM_CFG 0x0104
 ad_ip_parameter util_daq2_xcvr CONFIG.RX_CDR_CFG 0x0B000023FF10400020
 
-ad_connect  sys_cpu_resetn util_daq2_xcvr/up_rstn
-ad_connect  sys_cpu_clk util_daq2_xcvr/up_clk
+ad_connect  $sys_cpu_resetn util_daq2_xcvr/up_rstn
+ad_connect  $sys_cpu_clk util_daq2_xcvr/up_clk
 
 # reference clocks & resets
 
@@ -123,10 +123,10 @@ ad_connect  axi_ad9144_upack/s_axis_ready axi_ad9144_fifo/dac_valid
 ad_connect  axi_ad9144_upack/s_axis_data axi_ad9144_fifo/dac_data
 ad_connect  axi_ad9144_core/dac_dunf axi_ad9144_fifo/dac_dunf
 
-ad_connect  sys_cpu_clk axi_ad9144_fifo/dma_clk
-ad_connect  sys_cpu_reset axi_ad9144_fifo/dma_rst
-ad_connect  sys_cpu_clk axi_ad9144_dma/m_axis_aclk
-ad_connect  sys_cpu_resetn axi_ad9144_dma/m_src_axi_aresetn
+ad_connect  $sys_cpu_clk axi_ad9144_fifo/dma_clk
+ad_connect  $sys_cpu_reset axi_ad9144_fifo/dma_rst
+ad_connect  $sys_cpu_clk axi_ad9144_dma/m_axis_aclk
+ad_connect  $sys_cpu_resetn axi_ad9144_dma/m_src_axi_aresetn
 
 ad_connect  axi_ad9144_fifo/dma_xfer_req axi_ad9144_dma/m_axis_xfer_req
 ad_connect  axi_ad9144_fifo/dma_ready axi_ad9144_dma/m_axis_ready
@@ -160,7 +160,7 @@ ad_connect  axi_ad9680_cpack/packed_fifo_wr_overflow axi_ad9680_fifo/adc_wovf
 
 ad_connect  $sys_cpu_clk axi_ad9680_fifo/dma_clk
 ad_connect  $sys_cpu_clk axi_ad9680_dma/s_axis_aclk
-ad_connect  sys_cpu_resetn axi_ad9680_dma/m_dest_axi_aresetn
+ad_connect  $sys_cpu_resetn axi_ad9680_dma/m_dest_axi_aresetn
 ad_connect  axi_ad9680_fifo/dma_wr axi_ad9680_dma/s_axis_valid
 ad_connect  axi_ad9680_fifo/dma_wdata axi_ad9680_dma/s_axis_data
 ad_connect  axi_ad9680_fifo/dma_wready axi_ad9680_dma/s_axis_ready

--- a/projects/daq3/common/daq3_bd.tcl
+++ b/projects/daq3/common/daq3_bd.tcl
@@ -88,7 +88,7 @@ ad_ip_parameter util_daq3_xcvr CONFIG.RX_DFE_LPM_CFG 0x0904
 ad_ip_parameter util_daq3_xcvr CONFIG.RX_CDR_CFG 0x0B000023FF10400020
 
 ad_connect  sys_cpu_resetn util_daq3_xcvr/up_rstn
-ad_connect  sys_cpu_clk util_daq3_xcvr/up_clk
+ad_connect  $sys_cpu_clk util_daq3_xcvr/up_clk
 
 # reference clocks & resets
 
@@ -115,9 +115,9 @@ for {set i 0} {$i < 2} {incr i} {
 }
 
 if {$sys_zynq == 0 || $sys_zynq == 1} {
-    ad_connect  sys_cpu_clk axi_ad9152_fifo/dma_clk
+    ad_connect  $sys_cpu_clk axi_ad9152_fifo/dma_clk
     ad_connect  sys_cpu_reset axi_ad9152_fifo/dma_rst
-    ad_connect  sys_cpu_clk axi_ad9152_dma/m_axis_aclk
+    ad_connect  $sys_cpu_clk axi_ad9152_dma/m_axis_aclk
     ad_connect  sys_cpu_resetn axi_ad9152_dma/m_src_axi_aresetn
     ad_connect  axi_ad9152_fifo/bypass GND
 }
@@ -148,8 +148,8 @@ if {$sys_zynq == 0 || $sys_zynq == 1} {
     ad_connect  axi_ad9680_jesd_rstgen/peripheral_reset axi_ad9680_fifo/adc_rst
     ad_connect  axi_ad9680_cpack/packed_fifo_wr_en axi_ad9680_fifo/adc_wr
     ad_connect  axi_ad9680_cpack/packed_fifo_wr_data axi_ad9680_fifo/adc_wdata
-    ad_connect  sys_cpu_clk axi_ad9680_fifo/dma_clk
-    ad_connect  sys_cpu_clk axi_ad9680_dma/s_axis_aclk
+    ad_connect  $sys_cpu_clk axi_ad9680_fifo/dma_clk
+    ad_connect  $sys_cpu_clk axi_ad9680_dma/s_axis_aclk
     ad_connect  sys_cpu_resetn axi_ad9680_dma/m_dest_axi_aresetn
     ad_connect  axi_ad9680_fifo/dma_wr axi_ad9680_dma/s_axis_valid
     ad_connect  axi_ad9680_fifo/dma_wdata axi_ad9680_dma/s_axis_data
@@ -180,12 +180,12 @@ ad_cpu_interconnect 0x7c400000 axi_ad9680_dma
 
 
 if {$sys_zynq == 0 || $sys_zynq == 1} {
-    ad_mem_hp1_interconnect sys_cpu_clk sys_ps7/S_AXI_HP1
-    ad_mem_hp1_interconnect sys_cpu_clk axi_ad9152_dma/m_src_axi
-    ad_mem_hp2_interconnect sys_cpu_clk sys_ps7/S_AXI_HP2
-    ad_mem_hp2_interconnect sys_cpu_clk axi_ad9680_dma/m_dest_axi
-    ad_mem_hp3_interconnect sys_cpu_clk sys_ps7/S_AXI_HP3
-    ad_mem_hp3_interconnect sys_cpu_clk axi_ad9680_xcvr/m_axi
+    ad_mem_hp1_interconnect $sys_cpu_clk sys_ps7/S_AXI_HP1
+    ad_mem_hp1_interconnect $sys_cpu_clk axi_ad9152_dma/m_src_axi
+    ad_mem_hp2_interconnect $sys_cpu_clk sys_ps7/S_AXI_HP2
+    ad_mem_hp2_interconnect $sys_cpu_clk axi_ad9680_dma/m_dest_axi
+    ad_mem_hp3_interconnect $sys_cpu_clk sys_ps7/S_AXI_HP3
+    ad_mem_hp3_interconnect $sys_cpu_clk axi_ad9680_xcvr/m_axi
 }
 
 # interrupts

--- a/projects/daq3/common/daq3_bd.tcl
+++ b/projects/daq3/common/daq3_bd.tcl
@@ -87,7 +87,7 @@ ad_ip_parameter util_daq3_xcvr CONFIG.TX_OUT_DIV 1
 ad_ip_parameter util_daq3_xcvr CONFIG.RX_DFE_LPM_CFG 0x0904
 ad_ip_parameter util_daq3_xcvr CONFIG.RX_CDR_CFG 0x0B000023FF10400020
 
-ad_connect  sys_cpu_resetn util_daq3_xcvr/up_rstn
+ad_connect  $sys_cpu_resetn util_daq3_xcvr/up_rstn
 ad_connect  $sys_cpu_clk util_daq3_xcvr/up_clk
 
 # reference clocks & resets
@@ -116,9 +116,9 @@ for {set i 0} {$i < 2} {incr i} {
 
 if {$sys_zynq == 0 || $sys_zynq == 1} {
     ad_connect  $sys_cpu_clk axi_ad9152_fifo/dma_clk
-    ad_connect  sys_cpu_reset axi_ad9152_fifo/dma_rst
+    ad_connect  $sys_cpu_reset axi_ad9152_fifo/dma_rst
     ad_connect  $sys_cpu_clk axi_ad9152_dma/m_axis_aclk
-    ad_connect  sys_cpu_resetn axi_ad9152_dma/m_src_axi_aresetn
+    ad_connect  $sys_cpu_resetn axi_ad9152_dma/m_src_axi_aresetn
     ad_connect  axi_ad9152_fifo/bypass GND
 }
 ad_connect  util_daq3_xcvr/tx_out_clk_0 axi_ad9152_fifo/dac_clk
@@ -150,7 +150,7 @@ if {$sys_zynq == 0 || $sys_zynq == 1} {
     ad_connect  axi_ad9680_cpack/packed_fifo_wr_data axi_ad9680_fifo/adc_wdata
     ad_connect  $sys_cpu_clk axi_ad9680_fifo/dma_clk
     ad_connect  $sys_cpu_clk axi_ad9680_dma/s_axis_aclk
-    ad_connect  sys_cpu_resetn axi_ad9680_dma/m_dest_axi_aresetn
+    ad_connect  $sys_cpu_resetn axi_ad9680_dma/m_dest_axi_aresetn
     ad_connect  axi_ad9680_fifo/dma_wr axi_ad9680_dma/s_axis_valid
     ad_connect  axi_ad9680_fifo/dma_wdata axi_ad9680_dma/s_axis_data
     ad_connect  axi_ad9680_fifo/dma_wready axi_ad9680_dma/s_axis_ready

--- a/projects/fmcadc2/common/fmcadc2_bd.tcl
+++ b/projects/fmcadc2/common/fmcadc2_bd.tcl
@@ -54,7 +54,7 @@ ad_xcvrpll  rx_ref_clk_0 util_fmcadc2_xcvr/cpll_ref_clk_*
 ad_xcvrpll  axi_ad9625_xcvr/up_pll_rst util_fmcadc2_xcvr/up_qpll_rst_*
 ad_xcvrpll  axi_ad9625_xcvr/up_pll_rst util_fmcadc2_xcvr/up_cpll_rst_*
 ad_connect  sys_cpu_resetn util_fmcadc2_xcvr/up_rstn
-ad_connect  sys_cpu_clk util_fmcadc2_xcvr/up_clk
+ad_connect  $sys_cpu_clk util_fmcadc2_xcvr/up_clk
 
 # connections (adc)
 
@@ -63,8 +63,8 @@ ad_connect  util_fmcadc2_xcvr/rx_out_clk_0 axi_ad9625_core/rx_clk
 ad_connect  rx_core_clk util_fmcadc2_xcvr/rx_out_clk_0
 ad_connect  axi_ad9625_jesd/rx_data_tdata axi_ad9625_core/rx_data
 ad_connect  axi_ad9625_jesd/rx_sof axi_ad9625_core/rx_sof
-ad_connect  sys_cpu_clk axi_ad9625_fifo/dma_clk
-ad_connect  sys_cpu_clk axi_ad9625_dma/s_axis_aclk
+ad_connect  $sys_cpu_clk axi_ad9625_fifo/dma_clk
+ad_connect  $sys_cpu_clk axi_ad9625_dma/s_axis_aclk
 ad_connect  sys_cpu_resetn axi_ad9625_dma/m_dest_axi_aresetn
 ad_connect  axi_ad9625_core/adc_clk axi_ad9625_fifo/adc_clk
 ad_connect  axi_ad9625_jesd_rstgen/peripheral_reset axi_ad9625_fifo/adc_rst
@@ -85,13 +85,13 @@ ad_cpu_interconnect 0x7c420000 axi_ad9625_dma
 
 # gt uses hp3, and 100MHz clock for both DRP and AXI4
 
-ad_mem_hp3_interconnect sys_cpu_clk sys_ps7/S_AXI_HP3
-ad_mem_hp3_interconnect sys_cpu_clk axi_ad9625_xcvr/m_axi
+ad_mem_hp3_interconnect $sys_cpu_clk sys_ps7/S_AXI_HP3
+ad_mem_hp3_interconnect $sys_cpu_clk axi_ad9625_xcvr/m_axi
 
 # interconnect (mem/adc)
 
-ad_mem_hp2_interconnect sys_cpu_clk sys_ps7/S_AXI_HP2
-ad_mem_hp2_interconnect sys_cpu_clk axi_ad9625_dma/m_dest_axi
+ad_mem_hp2_interconnect $sys_cpu_clk sys_ps7/S_AXI_HP2
+ad_mem_hp2_interconnect $sys_cpu_clk axi_ad9625_dma/m_dest_axi
 
 # interrupts
 

--- a/projects/fmcadc2/common/fmcadc2_bd.tcl
+++ b/projects/fmcadc2/common/fmcadc2_bd.tcl
@@ -53,7 +53,7 @@ ad_xcvrpll  rx_ref_clk_0 util_fmcadc2_xcvr/qpll_ref_clk_*
 ad_xcvrpll  rx_ref_clk_0 util_fmcadc2_xcvr/cpll_ref_clk_*
 ad_xcvrpll  axi_ad9625_xcvr/up_pll_rst util_fmcadc2_xcvr/up_qpll_rst_*
 ad_xcvrpll  axi_ad9625_xcvr/up_pll_rst util_fmcadc2_xcvr/up_cpll_rst_*
-ad_connect  sys_cpu_resetn util_fmcadc2_xcvr/up_rstn
+ad_connect  $sys_cpu_resetn util_fmcadc2_xcvr/up_rstn
 ad_connect  $sys_cpu_clk util_fmcadc2_xcvr/up_clk
 
 # connections (adc)
@@ -65,7 +65,7 @@ ad_connect  axi_ad9625_jesd/rx_data_tdata axi_ad9625_core/rx_data
 ad_connect  axi_ad9625_jesd/rx_sof axi_ad9625_core/rx_sof
 ad_connect  $sys_cpu_clk axi_ad9625_fifo/dma_clk
 ad_connect  $sys_cpu_clk axi_ad9625_dma/s_axis_aclk
-ad_connect  sys_cpu_resetn axi_ad9625_dma/m_dest_axi_aresetn
+ad_connect  $sys_cpu_resetn axi_ad9625_dma/m_dest_axi_aresetn
 ad_connect  axi_ad9625_core/adc_clk axi_ad9625_fifo/adc_clk
 ad_connect  axi_ad9625_jesd_rstgen/peripheral_reset axi_ad9625_fifo/adc_rst
 ad_connect  axi_ad9625_core/adc_enable axi_ad9625_fifo/adc_wr

--- a/projects/fmcadc5/common/fmcadc5_bd.tcl
+++ b/projects/fmcadc5/common/fmcadc5_bd.tcl
@@ -90,8 +90,8 @@ ad_xcvrpll  axi_ad9625_1_xcvr/up_pll_rst util_fmcadc5_1_xcvr/up_qpll_rst_*
 ad_xcvrpll  axi_ad9625_1_xcvr/up_pll_rst util_fmcadc5_1_xcvr/up_cpll_rst_*
 ad_connect  sys_cpu_resetn util_fmcadc5_0_xcvr/up_rstn
 ad_connect  sys_cpu_resetn util_fmcadc5_1_xcvr/up_rstn
-ad_connect  sys_cpu_clk util_fmcadc5_0_xcvr/up_clk
-ad_connect  sys_cpu_clk util_fmcadc5_1_xcvr/up_clk
+ad_connect  $sys_cpu_clk util_fmcadc5_0_xcvr/up_clk
+ad_connect  $sys_cpu_clk util_fmcadc5_1_xcvr/up_clk
 
 # connections (adc)
 
@@ -116,8 +116,8 @@ ad_connect  util_fmcadc5_0_xcvr/rx_out_clk_0 axi_ad9625_fifo/adc_clk
 ad_connect  axi_ad9625_0_jesd_rstgen/peripheral_reset axi_ad9625_fifo/adc_rst
 ad_connect  axi_ad9625_fifo/adc_wovf axi_ad9625_0_core/adc_dovf
 ad_connect  axi_ad9625_fifo/adc_wovf axi_ad9625_1_core/adc_dovf
-ad_connect  sys_cpu_clk axi_ad9625_fifo/dma_clk
-ad_connect  sys_cpu_clk axi_ad9625_dma/s_axis_aclk
+ad_connect  $sys_cpu_clk axi_ad9625_fifo/dma_clk
+ad_connect  $sys_cpu_clk axi_ad9625_dma/s_axis_aclk
 ad_connect  sys_cpu_resetn axi_ad9625_dma/m_dest_axi_aresetn
 ad_connect  axi_ad9625_fifo/dma_wr axi_ad9625_dma/s_axis_valid
 ad_connect  axi_ad9625_fifo/dma_wdata axi_ad9625_dma/s_axis_data
@@ -136,9 +136,9 @@ ad_cpu_interconnect 0x7c420000 axi_ad9625_dma
 
 # interconnect (gt/adc)
 
-ad_mem_hp0_interconnect sys_cpu_clk axi_ad9625_0_xcvr/m_axi
-ad_mem_hp0_interconnect sys_cpu_clk axi_ad9625_1_xcvr/m_axi
-ad_mem_hp0_interconnect sys_cpu_clk axi_ad9625_dma/m_dest_axi
+ad_mem_hp0_interconnect $sys_cpu_clk axi_ad9625_0_xcvr/m_axi
+ad_mem_hp0_interconnect $sys_cpu_clk axi_ad9625_1_xcvr/m_axi
+ad_mem_hp0_interconnect $sys_cpu_clk axi_ad9625_dma/m_dest_axi
 
 # interrupts
 
@@ -163,7 +163,7 @@ ad_disconnect  spi_sdi_i axi_spi/io1_i
 ad_ip_instance axi_fmcadc5_sync axi_fmcadc5_sync
 ad_cpu_interconnect 0x44a20000 axi_fmcadc5_sync
 ad_connect  sys_cpu_reset axi_fmcadc5_sync/delay_rst
-ad_connect  sys_200m_clk axi_fmcadc5_sync/delay_clk
+ad_connect  $sys_iodelay_clk axi_fmcadc5_sync/delay_clk
 ad_connect  util_fmcadc5_0_xcvr/rx_out_clk_0 axi_fmcadc5_sync/rx_clk
 ad_connect  axi_ad9625_0_core/adc_enable axi_fmcadc5_sync/rx_enable_0
 ad_connect  axi_ad9625_0_core/adc_data axi_fmcadc5_sync/rx_data_0

--- a/projects/fmcadc5/common/fmcadc5_bd.tcl
+++ b/projects/fmcadc5/common/fmcadc5_bd.tcl
@@ -88,8 +88,8 @@ ad_xcvrpll  rx_ref_clk_1 util_fmcadc5_1_xcvr/qpll_ref_clk_*
 ad_xcvrpll  rx_ref_clk_1 util_fmcadc5_1_xcvr/cpll_ref_clk_*
 ad_xcvrpll  axi_ad9625_1_xcvr/up_pll_rst util_fmcadc5_1_xcvr/up_qpll_rst_*
 ad_xcvrpll  axi_ad9625_1_xcvr/up_pll_rst util_fmcadc5_1_xcvr/up_cpll_rst_*
-ad_connect  sys_cpu_resetn util_fmcadc5_0_xcvr/up_rstn
-ad_connect  sys_cpu_resetn util_fmcadc5_1_xcvr/up_rstn
+ad_connect  $sys_cpu_resetn util_fmcadc5_0_xcvr/up_rstn
+ad_connect  $sys_cpu_resetn util_fmcadc5_1_xcvr/up_rstn
 ad_connect  $sys_cpu_clk util_fmcadc5_0_xcvr/up_clk
 ad_connect  $sys_cpu_clk util_fmcadc5_1_xcvr/up_clk
 
@@ -118,7 +118,7 @@ ad_connect  axi_ad9625_fifo/adc_wovf axi_ad9625_0_core/adc_dovf
 ad_connect  axi_ad9625_fifo/adc_wovf axi_ad9625_1_core/adc_dovf
 ad_connect  $sys_cpu_clk axi_ad9625_fifo/dma_clk
 ad_connect  $sys_cpu_clk axi_ad9625_dma/s_axis_aclk
-ad_connect  sys_cpu_resetn axi_ad9625_dma/m_dest_axi_aresetn
+ad_connect  $sys_cpu_resetn axi_ad9625_dma/m_dest_axi_aresetn
 ad_connect  axi_ad9625_fifo/dma_wr axi_ad9625_dma/s_axis_valid
 ad_connect  axi_ad9625_fifo/dma_wdata axi_ad9625_dma/s_axis_data
 ad_connect  axi_ad9625_fifo/dma_wready axi_ad9625_dma/s_axis_ready
@@ -162,7 +162,7 @@ ad_disconnect  spi_sdi_i axi_spi/io1_i
 
 ad_ip_instance axi_fmcadc5_sync axi_fmcadc5_sync
 ad_cpu_interconnect 0x44a20000 axi_fmcadc5_sync
-ad_connect  sys_cpu_reset axi_fmcadc5_sync/delay_rst
+ad_connect  $sys_cpu_reset axi_fmcadc5_sync/delay_rst
 ad_connect  $sys_iodelay_clk axi_fmcadc5_sync/delay_clk
 ad_connect  util_fmcadc5_0_xcvr/rx_out_clk_0 axi_fmcadc5_sync/rx_clk
 ad_connect  axi_ad9625_0_core/adc_enable axi_fmcadc5_sync/rx_enable_0

--- a/projects/fmcjesdadc1/common/fmcjesdadc1_bd.tcl
+++ b/projects/fmcjesdadc1/common/fmcjesdadc1_bd.tcl
@@ -84,7 +84,7 @@ ad_xcvrpll  rx_ref_clk_0 util_fmcjesdadc1_xcvr/cpll_ref_clk_*
 ad_xcvrpll  axi_ad9250_xcvr/up_pll_rst util_fmcjesdadc1_xcvr/up_qpll_rst_*
 ad_xcvrpll  axi_ad9250_xcvr/up_pll_rst util_fmcjesdadc1_xcvr/up_cpll_rst_*
 ad_connect  sys_cpu_resetn util_fmcjesdadc1_xcvr/up_rstn
-ad_connect  sys_cpu_clk util_fmcjesdadc1_xcvr/up_clk
+ad_connect  $sys_cpu_clk util_fmcjesdadc1_xcvr/up_clk
 
 create_bd_port -dir O rx_core_clk
 
@@ -125,14 +125,14 @@ ad_cpu_interconnect 0x7c430000 axi_ad9250_1_dma
 
 # xcvr uses hp3, and 100MHz clock for both DRP and AXI4
 
-ad_mem_hp3_interconnect sys_cpu_clk sys_ps7/S_AXI_HP3
-ad_mem_hp3_interconnect sys_cpu_clk axi_ad9250_xcvr/m_axi
+ad_mem_hp3_interconnect $sys_cpu_clk sys_ps7/S_AXI_HP3
+ad_mem_hp3_interconnect $sys_cpu_clk axi_ad9250_xcvr/m_axi
 
 # interconnect (adc)
 
-ad_mem_hp2_interconnect sys_200m_clk sys_ps7/S_AXI_HP2
-ad_mem_hp2_interconnect sys_200m_clk axi_ad9250_0_dma/m_dest_axi
-ad_mem_hp2_interconnect sys_200m_clk axi_ad9250_1_dma/m_dest_axi
+ad_mem_hp2_interconnect $sys_dma_clk sys_ps7/S_AXI_HP2
+ad_mem_hp2_interconnect $sys_dma_clk axi_ad9250_0_dma/m_dest_axi
+ad_mem_hp2_interconnect $sys_dma_clk axi_ad9250_1_dma/m_dest_axi
 
 ad_connect  sys_cpu_resetn axi_ad9250_0_dma/m_dest_axi_aresetn
 ad_connect  sys_cpu_resetn axi_ad9250_1_dma/m_dest_axi_aresetn

--- a/projects/fmcjesdadc1/common/fmcjesdadc1_bd.tcl
+++ b/projects/fmcjesdadc1/common/fmcjesdadc1_bd.tcl
@@ -83,7 +83,7 @@ ad_xcvrpll  rx_ref_clk_0 util_fmcjesdadc1_xcvr/qpll_ref_clk_*
 ad_xcvrpll  rx_ref_clk_0 util_fmcjesdadc1_xcvr/cpll_ref_clk_*
 ad_xcvrpll  axi_ad9250_xcvr/up_pll_rst util_fmcjesdadc1_xcvr/up_qpll_rst_*
 ad_xcvrpll  axi_ad9250_xcvr/up_pll_rst util_fmcjesdadc1_xcvr/up_cpll_rst_*
-ad_connect  sys_cpu_resetn util_fmcjesdadc1_xcvr/up_rstn
+ad_connect  $sys_cpu_resetn util_fmcjesdadc1_xcvr/up_rstn
 ad_connect  $sys_cpu_clk util_fmcjesdadc1_xcvr/up_clk
 
 create_bd_port -dir O rx_core_clk
@@ -134,8 +134,8 @@ ad_mem_hp2_interconnect $sys_dma_clk sys_ps7/S_AXI_HP2
 ad_mem_hp2_interconnect $sys_dma_clk axi_ad9250_0_dma/m_dest_axi
 ad_mem_hp2_interconnect $sys_dma_clk axi_ad9250_1_dma/m_dest_axi
 
-ad_connect  sys_cpu_resetn axi_ad9250_0_dma/m_dest_axi_aresetn
-ad_connect  sys_cpu_resetn axi_ad9250_1_dma/m_dest_axi_aresetn
+ad_connect  $sys_cpu_resetn axi_ad9250_0_dma/m_dest_axi_aresetn
+ad_connect  $sys_cpu_resetn axi_ad9250_1_dma/m_dest_axi_aresetn
 
 #interrupts
 

--- a/projects/fmcomms11/common/fmcomms11_bd.tcl
+++ b/projects/fmcomms11/common/fmcomms11_bd.tcl
@@ -120,7 +120,7 @@ ad_xcvrpll  rx_ref_clk_0 util_fmcomms11_xcvr/cpll_ref_clk_*
 ad_xcvrpll  axi_ad9162_xcvr/up_pll_rst util_fmcomms11_xcvr/up_qpll_rst_*
 ad_xcvrpll  axi_ad9625_xcvr/up_pll_rst util_fmcomms11_xcvr/up_cpll_rst_*
 ad_connect  sys_cpu_resetn util_fmcomms11_xcvr/up_rstn
-ad_connect  sys_cpu_clk util_fmcomms11_xcvr/up_clk
+ad_connect  $sys_cpu_clk util_fmcomms11_xcvr/up_clk
 
 # connections (dac)
 
@@ -139,9 +139,9 @@ for {set i 0} {$i < $TX_NUM_OF_CONVERTERS} {incr i} {
 
 ad_connect  util_fmcomms11_xcvr/tx_out_clk_0 axi_ad9162_fifo/dac_clk
 ad_connect  axi_ad9162_jesd_rstgen/peripheral_reset axi_ad9162_fifo/dac_rst
-ad_connect  sys_cpu_clk axi_ad9162_fifo/dma_clk
+ad_connect  $sys_cpu_clk axi_ad9162_fifo/dma_clk
 ad_connect  sys_cpu_reset axi_ad9162_fifo/dma_rst
-ad_connect  sys_cpu_clk axi_ad9162_dma/m_axis_aclk
+ad_connect  $sys_cpu_clk axi_ad9162_dma/m_axis_aclk
 ad_connect  sys_cpu_resetn axi_ad9162_dma/m_src_axi_aresetn
 ad_connect  util_ad9162_upack/s_axis_valid VCC
 ad_connect  util_ad9162_upack/s_axis_ready axi_ad9162_fifo/dac_valid
@@ -167,8 +167,8 @@ ad_connect  util_fmcomms11_xcvr/rx_out_clk_0 axi_ad9625_fifo/adc_clk
 ad_connect  axi_ad9625_jesd_rstgen/peripheral_reset axi_ad9625_fifo/adc_rst
 ad_connect  axi_ad9625_core/adc_valid_0 axi_ad9625_fifo/adc_wr
 ad_connect  axi_ad9625_core/adc_data_0 axi_ad9625_fifo/adc_wdata
-ad_connect  sys_cpu_clk axi_ad9625_fifo/dma_clk
-ad_connect  sys_cpu_clk axi_ad9625_dma/s_axis_aclk
+ad_connect  $sys_cpu_clk axi_ad9625_fifo/dma_clk
+ad_connect  $sys_cpu_clk axi_ad9625_dma/s_axis_aclk
 ad_connect  sys_cpu_resetn axi_ad9625_dma/m_dest_axi_aresetn
 ad_connect  axi_ad9625_fifo/dma_wr axi_ad9625_dma/s_axis_valid
 ad_connect  axi_ad9625_fifo/dma_wdata axi_ad9625_dma/s_axis_data
@@ -189,15 +189,15 @@ ad_cpu_interconnect 0x7c400000 axi_ad9625_dma
 
 # gt uses hp3, and 100MHz clock for both DRP and AXI4
 
-ad_mem_hp3_interconnect sys_cpu_clk sys_ps7/S_AXI_HP3
-ad_mem_hp3_interconnect sys_cpu_clk axi_ad9625_xcvr/m_axi
+ad_mem_hp3_interconnect $sys_cpu_clk sys_ps7/S_AXI_HP3
+ad_mem_hp3_interconnect $sys_cpu_clk axi_ad9625_xcvr/m_axi
 
 # interconnect (mem/dac)
 
-ad_mem_hp1_interconnect sys_cpu_clk sys_ps7/S_AXI_HP1
-ad_mem_hp1_interconnect sys_cpu_clk axi_ad9162_dma/m_src_axi
-ad_mem_hp2_interconnect sys_cpu_clk sys_ps7/S_AXI_HP2
-ad_mem_hp2_interconnect sys_cpu_clk axi_ad9625_dma/m_dest_axi
+ad_mem_hp1_interconnect $sys_cpu_clk sys_ps7/S_AXI_HP1
+ad_mem_hp1_interconnect $sys_cpu_clk axi_ad9162_dma/m_src_axi
+ad_mem_hp2_interconnect $sys_cpu_clk sys_ps7/S_AXI_HP2
+ad_mem_hp2_interconnect $sys_cpu_clk axi_ad9625_dma/m_dest_axi
 
 # interrupts
 

--- a/projects/fmcomms11/common/fmcomms11_bd.tcl
+++ b/projects/fmcomms11/common/fmcomms11_bd.tcl
@@ -119,7 +119,7 @@ ad_xcvrpll  tx_ref_clk_0 util_fmcomms11_xcvr/qpll_ref_clk_*
 ad_xcvrpll  rx_ref_clk_0 util_fmcomms11_xcvr/cpll_ref_clk_*
 ad_xcvrpll  axi_ad9162_xcvr/up_pll_rst util_fmcomms11_xcvr/up_qpll_rst_*
 ad_xcvrpll  axi_ad9625_xcvr/up_pll_rst util_fmcomms11_xcvr/up_cpll_rst_*
-ad_connect  sys_cpu_resetn util_fmcomms11_xcvr/up_rstn
+ad_connect  $sys_cpu_resetn util_fmcomms11_xcvr/up_rstn
 ad_connect  $sys_cpu_clk util_fmcomms11_xcvr/up_clk
 
 # connections (dac)
@@ -140,13 +140,14 @@ for {set i 0} {$i < $TX_NUM_OF_CONVERTERS} {incr i} {
 ad_connect  util_fmcomms11_xcvr/tx_out_clk_0 axi_ad9162_fifo/dac_clk
 ad_connect  axi_ad9162_jesd_rstgen/peripheral_reset axi_ad9162_fifo/dac_rst
 ad_connect  $sys_cpu_clk axi_ad9162_fifo/dma_clk
-ad_connect  sys_cpu_reset axi_ad9162_fifo/dma_rst
+ad_connect  $sys_cpu_reset axi_ad9162_fifo/dma_rst
 ad_connect  $sys_cpu_clk axi_ad9162_dma/m_axis_aclk
 ad_connect  sys_cpu_resetn axi_ad9162_dma/m_src_axi_aresetn
 ad_connect  util_ad9162_upack/s_axis_valid VCC
 ad_connect  util_ad9162_upack/s_axis_ready axi_ad9162_fifo/dac_valid
 ad_connect  util_ad9162_upack/s_axis_data axi_ad9162_fifo/dac_data
 ad_connect  axi_ad9162_core/dac_dunf axi_ad9162_fifo/dac_dunf
+ad_connect  $sys_cpu_resetn axi_ad9162_dma/m_src_axi_aresetn
 ad_connect  axi_ad9162_fifo/dma_xfer_req axi_ad9162_dma/m_axis_xfer_req
 ad_connect  axi_ad9162_fifo/dma_ready axi_ad9162_dma/m_axis_ready
 ad_connect  axi_ad9162_fifo/dma_data axi_ad9162_dma/m_axis_data
@@ -169,7 +170,7 @@ ad_connect  axi_ad9625_core/adc_valid_0 axi_ad9625_fifo/adc_wr
 ad_connect  axi_ad9625_core/adc_data_0 axi_ad9625_fifo/adc_wdata
 ad_connect  $sys_cpu_clk axi_ad9625_fifo/dma_clk
 ad_connect  $sys_cpu_clk axi_ad9625_dma/s_axis_aclk
-ad_connect  sys_cpu_resetn axi_ad9625_dma/m_dest_axi_aresetn
+ad_connect  $sys_cpu_resetn axi_ad9625_dma/m_dest_axi_aresetn
 ad_connect  axi_ad9625_fifo/dma_wr axi_ad9625_dma/s_axis_valid
 ad_connect  axi_ad9625_fifo/dma_wdata axi_ad9625_dma/s_axis_data
 ad_connect  axi_ad9625_fifo/dma_wready axi_ad9625_dma/s_axis_ready

--- a/projects/fmcomms2/common/fmcomms2_bd.tcl
+++ b/projects/fmcomms2/common/fmcomms2_bd.tcl
@@ -32,7 +32,7 @@ ad_ip_parameter axi_ad9361 CONFIG.ID 0
 # set to 1 for CORDIC or 2 for POLYNOMIAL
 ad_ip_parameter axi_ad9361 CONFIG.DAC_DDS_TYPE 1
 ad_ip_parameter axi_ad9361 CONFIG.DAC_DDS_CORDIC_DW 14
-ad_connect sys_200m_clk axi_ad9361/delay_clk
+ad_connect $sys_iodelay_clk axi_ad9361/delay_clk
 ad_connect axi_ad9361/l_clk axi_ad9361/clk
 ad_connect rx_clk_in_p axi_ad9361/rx_clk_in_p
 ad_connect rx_clk_in_n axi_ad9361/rx_clk_in_n
@@ -55,7 +55,7 @@ ad_connect up_txnrx axi_ad9361/up_txnrx
 
 ad_ip_instance util_tdd_sync util_ad9361_tdd_sync
 ad_ip_parameter util_ad9361_tdd_sync CONFIG.TDD_SYNC_PERIOD 10000000
-ad_connect sys_cpu_clk util_ad9361_tdd_sync/clk
+ad_connect $sys_cpu_clk util_ad9361_tdd_sync/clk
 ad_connect sys_cpu_resetn util_ad9361_tdd_sync/rstn
 ad_connect util_ad9361_tdd_sync/sync_out axi_ad9361/tdd_sync
 ad_connect util_ad9361_tdd_sync/sync_mode axi_ad9361/tdd_sync_cntr
@@ -208,10 +208,10 @@ ad_connect sys_cpu_resetn axi_ad9361_dac_dma/m_src_axi_aresetn
 ad_cpu_interconnect 0x79020000 axi_ad9361
 ad_cpu_interconnect 0x7C400000 axi_ad9361_adc_dma
 ad_cpu_interconnect 0x7C420000 axi_ad9361_dac_dma
-ad_mem_hp1_interconnect sys_cpu_clk sys_ps7/S_AXI_HP1
-ad_mem_hp1_interconnect sys_cpu_clk axi_ad9361_adc_dma/m_dest_axi
-ad_mem_hp2_interconnect sys_cpu_clk sys_ps7/S_AXI_HP2
-ad_mem_hp2_interconnect sys_cpu_clk axi_ad9361_dac_dma/m_src_axi
+ad_mem_hp1_interconnect $sys_cpu_clk sys_ps7/S_AXI_HP1
+ad_mem_hp1_interconnect $sys_cpu_clk axi_ad9361_adc_dma/m_dest_axi
+ad_mem_hp2_interconnect $sys_cpu_clk sys_ps7/S_AXI_HP2
+ad_mem_hp2_interconnect $sys_cpu_clk axi_ad9361_dac_dma/m_src_axi
 
 # interrupts
 

--- a/projects/fmcomms2/common/fmcomms2_bd.tcl
+++ b/projects/fmcomms2/common/fmcomms2_bd.tcl
@@ -56,7 +56,7 @@ ad_connect up_txnrx axi_ad9361/up_txnrx
 ad_ip_instance util_tdd_sync util_ad9361_tdd_sync
 ad_ip_parameter util_ad9361_tdd_sync CONFIG.TDD_SYNC_PERIOD 10000000
 ad_connect $sys_cpu_clk util_ad9361_tdd_sync/clk
-ad_connect sys_cpu_resetn util_ad9361_tdd_sync/rstn
+ad_connect $sys_cpu_resetn util_ad9361_tdd_sync/rstn
 ad_connect util_ad9361_tdd_sync/sync_out axi_ad9361/tdd_sync
 ad_connect util_ad9361_tdd_sync/sync_mode axi_ad9361/tdd_sync_cntr
 ad_connect tdd_sync_t axi_ad9361/tdd_sync_cntr
@@ -142,7 +142,7 @@ ad_ip_parameter axi_ad9361_adc_dma CONFIG.DMA_DATA_WIDTH_SRC 64
 
 ad_connect util_ad9361_divclk/clk_out axi_ad9361_adc_dma/fifo_wr_clk
 ad_connect util_ad9361_adc_pack/packed_fifo_wr axi_ad9361_adc_dma/fifo_wr
-ad_connect sys_cpu_resetn axi_ad9361_adc_dma/m_dest_axi_aresetn
+ad_connect $sys_cpu_resetn axi_ad9361_adc_dma/m_dest_axi_aresetn
 
 # dac-path rfifo
 
@@ -201,7 +201,7 @@ ad_ip_parameter axi_ad9361_dac_dma CONFIG.DMA_DATA_WIDTH_DEST 64
 ad_connect util_ad9361_divclk/clk_out axi_ad9361_dac_dma/m_axis_aclk
 ad_connect axi_ad9361_dac_dma/m_axis util_ad9361_dac_upack/s_axis
 
-ad_connect sys_cpu_resetn axi_ad9361_dac_dma/m_src_axi_aresetn
+ad_connect $sys_cpu_resetn axi_ad9361_dac_dma/m_src_axi_aresetn
 
 # interconnects
 

--- a/projects/fmcomms2/zcu102/system_bd.tcl
+++ b/projects/fmcomms2/zcu102/system_bd.tcl
@@ -5,4 +5,5 @@ source ../common/fmcomms2_bd.tcl
 ad_ip_parameter util_ad9361_divclk CONFIG.SIM_DEVICE ULTRASCALE
 
 ad_ip_parameter axi_ad9361 CONFIG.ADC_INIT_DELAY 11
+ad_ip_parameter axi_ad9361 CONFIG.DELAY_REFCLK_FREQUENCY 500
 

--- a/projects/fmcomms5/common/fmcomms5_bd.tcl
+++ b/projects/fmcomms5/common/fmcomms5_bd.tcl
@@ -42,7 +42,7 @@ create_bd_port -dir I up_enable_1
 create_bd_port -dir I up_txnrx_1
 
 create_bd_port -dir O sys_100m_resetn
-ad_connect sys_cpu_resetn sys_100m_resetn
+ad_connect $sys_cpu_resetn sys_100m_resetn
 
 # ad9361 core (master)
 
@@ -190,7 +190,7 @@ ad_ip_parameter axi_ad9361_adc_dma CONFIG.DMA_DATA_WIDTH_SRC 128
 ad_ip_parameter axi_ad9361_adc_dma CONFIG.DMA_DATA_WIDTH_DEST 64
 ad_connect util_ad9361_divclk/clk_out axi_ad9361_adc_dma/fifo_wr_clk
 ad_connect util_ad9361_adc_pack/packed_fifo_wr axi_ad9361_adc_dma/fifo_wr
-ad_connect sys_cpu_resetn axi_ad9361_adc_dma/m_dest_axi_aresetn
+ad_connect $sys_cpu_resetn axi_ad9361_adc_dma/m_dest_axi_aresetn
 
 # dac-path rfifo
 
@@ -261,7 +261,7 @@ ad_ip_parameter axi_ad9361_dac_dma CONFIG.DMA_2D_TRANSFER 0
 ad_ip_parameter axi_ad9361_dac_dma CONFIG.DMA_DATA_WIDTH_DEST 128
 ad_ip_parameter axi_ad9361_dac_dma CONFIG.DMA_DATA_WIDTH_SRC 64
 
-ad_connect sys_cpu_resetn axi_ad9361_dac_dma/m_src_axi_aresetn
+ad_connect $sys_cpu_resetn axi_ad9361_dac_dma/m_src_axi_aresetn
 ad_connect util_ad9361_divclk/clk_out axi_ad9361_dac_dma/m_axis_aclk
 ad_connect axi_ad9361_dac_dma/m_axis util_ad9361_dac_upack/s_axis
 

--- a/projects/fmcomms5/common/fmcomms5_bd.tcl
+++ b/projects/fmcomms5/common/fmcomms5_bd.tcl
@@ -50,7 +50,7 @@ ad_ip_instance axi_ad9361 axi_ad9361_0
 ad_ip_parameter axi_ad9361_0 CONFIG.ID 0
 ad_ip_parameter axi_ad9361_0 CONFIG.IO_DELAY_GROUP dev_0_if_delay_group
 ad_ip_parameter axi_ad9361_0 CONFIG.MIMO_ENABLE 1
-ad_connect sys_200m_clk axi_ad9361_0/delay_clk
+ad_connect $sys_iodelay_clk axi_ad9361_0/delay_clk
 ad_connect axi_ad9361_0/l_clk axi_ad9361_0/clk
 ad_connect axi_ad9361_0/dac_sync_out axi_ad9361_0/dac_sync_in
 ad_connect rx_clk_in_0_p axi_ad9361_0/rx_clk_in_p
@@ -76,7 +76,7 @@ ad_ip_instance axi_ad9361 axi_ad9361_1
 ad_ip_parameter axi_ad9361_1 CONFIG.ID 1
 ad_ip_parameter axi_ad9361_1 CONFIG.IO_DELAY_GROUP dev_1_if_delay_group
 ad_ip_parameter axi_ad9361_1 CONFIG.MIMO_ENABLE 1
-ad_connect sys_200m_clk axi_ad9361_1/delay_clk
+ad_connect $sys_iodelay_clk axi_ad9361_1/delay_clk
 ad_connect axi_ad9361_0/l_clk axi_ad9361_1/clk
 ad_connect axi_ad9361_0/dac_sync_out axi_ad9361_1/dac_sync_in
 ad_connect rx_clk_in_1_p axi_ad9361_1/rx_clk_in_p
@@ -271,10 +271,10 @@ ad_cpu_interconnect 0x79020000 axi_ad9361_0
 ad_cpu_interconnect 0x7C420000 axi_ad9361_dac_dma
 ad_cpu_interconnect 0x7C400000 axi_ad9361_adc_dma
 ad_cpu_interconnect 0x79040000 axi_ad9361_1
-ad_mem_hp2_interconnect sys_dma_clk sys_ps7/S_AXI_HP2
-ad_mem_hp2_interconnect sys_dma_clk axi_ad9361_adc_dma/m_dest_axi
-ad_mem_hp3_interconnect sys_dma_clk sys_ps7/S_AXI_HP3
-ad_mem_hp3_interconnect sys_dma_clk axi_ad9361_dac_dma/m_src_axi
+ad_mem_hp2_interconnect $sys_dma_clk sys_ps7/S_AXI_HP2
+ad_mem_hp2_interconnect $sys_dma_clk axi_ad9361_adc_dma/m_dest_axi
+ad_mem_hp3_interconnect $sys_dma_clk sys_ps7/S_AXI_HP3
+ad_mem_hp3_interconnect $sys_dma_clk axi_ad9361_dac_dma/m_src_axi
 
 # interrupts
 

--- a/projects/fmcomms5/zcu102/system_bd.tcl
+++ b/projects/fmcomms5/zcu102/system_bd.tcl
@@ -1,11 +1,6 @@
 
 source $ad_hdl_dir/projects/common/zcu102/zcu102_system_bd.tcl
 
-ad_ip_parameter sys_ps8 CONFIG.PSU__FPGA_PL2_ENABLE 1
-ad_ip_parameter sys_ps8 CONFIG.PSU__CRL_APB__PL2_REF_CTRL__FREQMHZ 200
-ad_ip_parameter sys_ps8 CONFIG.PSU__CRL_APB__PL2_REF_CTRL__DIVISOR0 3
-ad_ip_parameter sys_ps8 CONFIG.PSU__CRL_APB__PL2_REF_CTRL__DIVISOR1 2
-ad_connect  sys_dma_clk sys_ps8/pl_clk2
 source ../common/fmcomms5_bd.tcl
 
 ad_ip_parameter axi_ad9361_0 CONFIG.ADC_INIT_DELAY 8

--- a/projects/fmcomms5/zcu102/system_bd.tcl
+++ b/projects/fmcomms5/zcu102/system_bd.tcl
@@ -4,6 +4,8 @@ source $ad_hdl_dir/projects/common/zcu102/zcu102_system_bd.tcl
 source ../common/fmcomms5_bd.tcl
 
 ad_ip_parameter axi_ad9361_0 CONFIG.ADC_INIT_DELAY 8
+ad_ip_parameter axi_ad9361_0 CONFIG.DELAY_REFCLK_FREQUENCY 500
 ad_ip_parameter axi_ad9361_1 CONFIG.ADC_INIT_DELAY 8
+ad_ip_parameter axi_ad9361_1 CONFIG.DELAY_REFCLK_FREQUENCY 500
 
 ad_ip_parameter util_ad9361_divclk CONFIG.SIM_DEVICE ULTRASCALE

--- a/projects/imageon/common/imageon_bd.tcl
+++ b/projects/imageon/common/imageon_bd.tcl
@@ -56,8 +56,8 @@ ad_connect  sys_cpu_resetn axi_hdmi_rx_dma/m_dest_axi_aresetn
 ad_cpu_interconnect 0x43100000 axi_hdmi_rx_core
 ad_cpu_interconnect 0x43C20000 axi_hdmi_rx_dma
 
-ad_mem_hp2_interconnect sys_cpu_clk sys_ps7/S_AXI_HP2
-ad_mem_hp2_interconnect sys_cpu_clk axi_hdmi_rx_dma/m_dest_axi
+ad_mem_hp2_interconnect $sys_cpu_clk sys_ps7/S_AXI_HP2
+ad_mem_hp2_interconnect $sys_cpu_clk axi_hdmi_rx_dma/m_dest_axi
 
 ad_cpu_interrupt ps-12 mb-12 axi_hdmi_rx_dma/irq
 

--- a/projects/imageon/common/imageon_bd.tcl
+++ b/projects/imageon/common/imageon_bd.tcl
@@ -51,7 +51,7 @@ ad_connect  axi_hdmi_rx_core/hdmi_dma_de axi_hdmi_rx_dma/fifo_wr_en
 ad_connect  axi_hdmi_rx_core/hdmi_dma_data axi_hdmi_rx_dma/fifo_wr_din
 ad_connect  axi_hdmi_rx_core/hdmi_dma_ovf axi_hdmi_rx_dma/fifo_wr_overflow
 ad_connect  axi_hdmi_rx_core/hdmi_dma_unf GND
-ad_connect  sys_cpu_resetn axi_hdmi_rx_dma/m_dest_axi_aresetn
+ad_connect  $sys_cpu_resetn axi_hdmi_rx_dma/m_dest_axi_aresetn
 
 ad_cpu_interconnect 0x43100000 axi_hdmi_rx_core
 ad_cpu_interconnect 0x43C20000 axi_hdmi_rx_dma
@@ -79,9 +79,9 @@ ad_ip_parameter axi_spdif_rx_core CONFIG.C_DMA_TYPE 1
 
 ad_ip_parameter sys_ps7 CONFIG.PCW_USE_DMA3 1
 
-ad_connect  sys_cpu_clk axi_spdif_rx_core/DMA_REQ_ACLK
-ad_connect  sys_cpu_clk sys_ps7/DMA3_ACLK
-ad_connect  sys_cpu_resetn axi_spdif_rx_core/DMA_REQ_RSTN
+ad_connect  $sys_cpu_clk axi_spdif_rx_core/DMA_REQ_ACLK
+ad_connect  $sys_cpu_clk sys_ps7/DMA3_ACLK
+ad_connect  $sys_cpu_resetn axi_spdif_rx_core/DMA_REQ_RSTN
 ad_connect  sys_ps7/DMA3_REQ axi_spdif_rx_core/DMA_REQ
 ad_connect  sys_ps7/DMA3_ACK axi_spdif_rx_core/DMA_ACK
 ad_connect  spdif_rx axi_spdif_rx_core/spdif_rx_i

--- a/projects/motcon2_fmc/common/motcon2_fmc_bd.tcl
+++ b/projects/motcon2_fmc/common/motcon2_fmc_bd.tcl
@@ -182,17 +182,17 @@
 
   # speed detector
     # motor 1
-  ad_connect  sys_cpu_clk speed_detector_m1/ref_clk
+  ad_connect  $sys_cpu_clk speed_detector_m1/ref_clk
 
-  ad_connect  sys_cpu_clk speed_detector_m1_dma/fifo_wr_clk
+  ad_connect  $sys_cpu_clk speed_detector_m1_dma/fifo_wr_clk
 
   ad_connect  position_m1_i speed_detector_m1/position_i
   ad_connect  speed_detector_m1/new_speed_o speed_detector_m1_dma/fifo_wr_en
   ad_connect  speed_detector_m1/speed_o speed_detector_m1_dma/fifo_wr_din
     # motor 2
-  ad_connect sys_cpu_clk speed_detector_m2/ref_clk
+  ad_connect $sys_cpu_clk speed_detector_m2/ref_clk
 
-  ad_connect sys_cpu_clk speed_detector_m2_dma/fifo_wr_clk
+  ad_connect $sys_cpu_clk speed_detector_m2_dma/fifo_wr_clk
 
   ad_connect position_m2_i speed_detector_m2/position_i
   ad_connect speed_detector_m2/new_speed_o speed_detector_m2_dma/fifo_wr_en
@@ -201,9 +201,9 @@
   # current monitor
   ad_connect adc_clk_o current_monitor_m1/adc_clk_o
     # motor 1
-  ad_connect sys_cpu_clk current_monitor_m1/ref_clk
+  ad_connect $sys_cpu_clk current_monitor_m1/ref_clk
 
-  ad_connect sys_cpu_clk current_monitor_m1_dma/fifo_wr_clk
+  ad_connect $sys_cpu_clk current_monitor_m1_dma/fifo_wr_clk
 
   ad_connect current_monitor_m1/adc_clk_i sys_audio_clkgen/clk_out5
   ad_connect adc_m1_ia_dat_i current_monitor_m1/adc_ia_dat_i
@@ -211,7 +211,7 @@
   ad_connect adc_m1_vbus_dat_i current_monitor_m1/adc_vbus_dat_i
 
 
-  ad_connect sys_cpu_clk   current_monitor_m1_pack/clk
+  ad_connect $sys_cpu_clk   current_monitor_m1_pack/clk
   ad_connect sys_cpu_reset current_monitor_m1_pack/reset
 
   ad_connect current_monitor_m1/adc_enable_ia     current_monitor_m1_pack/enable_0
@@ -225,16 +225,16 @@
   ad_connect current_monitor_m1_pack/packed_fifo_wr current_monitor_m1_dma/fifo_wr
 
   # motor 2
-  ad_connect  sys_cpu_clk current_monitor_m2/ref_clk
+  ad_connect  $sys_cpu_clk current_monitor_m2/ref_clk
 
-  ad_connect  sys_cpu_clk current_monitor_m2_dma/fifo_wr_clk
+  ad_connect  $sys_cpu_clk current_monitor_m2_dma/fifo_wr_clk
 
   ad_connect  current_monitor_m2/adc_clk_i sys_audio_clkgen/clk_out5
   ad_connect  adc_m2_ia_dat_i  current_monitor_m2/adc_ia_dat_i
   ad_connect  adc_m2_ib_dat_i  current_monitor_m2/adc_ib_dat_i
   ad_connect  adc_m2_vbus_dat_i current_monitor_m2/adc_vbus_dat_i
 
-  ad_connect sys_cpu_clk current_monitor_m2_pack/clk
+  ad_connect $sys_cpu_clk current_monitor_m2_pack/clk
   ad_connect sys_cpu_reset current_monitor_m2_pack/reset
 
   ad_connect current_monitor_m2/adc_enable_ia     current_monitor_m2_pack/enable_0
@@ -249,7 +249,7 @@
 
   #controller
     # motor 1
-  ad_connect sys_cpu_clk controller_m1/ref_clk
+  ad_connect $sys_cpu_clk controller_m1/ref_clk
   ad_connect controller_m1/ctrl_data_clk sys_audio_clkgen/clk_out5
 
   ad_connect fmc_m1_en_o   controller_m1/fmc_en_o
@@ -272,7 +272,7 @@
   ad_connect controller_m2/pwm_c_i GND
 
     # motor 2
-  ad_connect sys_cpu_clk controller_m2/ref_clk
+  ad_connect $sys_cpu_clk controller_m2/ref_clk
   ad_connect controller_m2/ctrl_data_clk sys_audio_clkgen/clk_out5
 
   ad_connect  fmc_m2_en_o controller_m2/fmc_en_o
@@ -294,7 +294,7 @@
   ad_connect sys_ps7/ENET0_MDIO_T eth_mdio_t
   ad_connect sys_ps7/ENET0_MDIO_I eth_mdio_i
     # phy 1
-  ad_connect sys_200m_clk gmii_to_rgmii_eth1/idelayctrl_clk
+  ad_connect $sys_dma_clk gmii_to_rgmii_eth1/idelayctrl_clk
   ad_connect gmii_to_rgmii_eth1/gmii sys_ps7/GMII_ETHERNET_0
   ad_connect eth1_rgmii gmii_to_rgmii_eth1/rgmii
   ad_connect gmii_to_rgmii_eth1/reset sys_rstgen/peripheral_reset
@@ -344,11 +344,11 @@
   ad_cpu_interconnect  0x43200000 xadc_core
   ad_cpu_interconnect  0x41510000 iic_ee2
 
-  ad_mem_hp2_interconnect sys_cpu_clk sys_ps7/S_AXI_HP2
-  ad_mem_hp2_interconnect sys_cpu_clk speed_detector_m1_dma/m_dest_axi
-  ad_mem_hp2_interconnect sys_cpu_clk speed_detector_m2_dma/m_dest_axi
-  ad_mem_hp2_interconnect sys_cpu_clk current_monitor_m1_dma/m_dest_axi
-  ad_mem_hp2_interconnect sys_cpu_clk current_monitor_m2_dma/m_dest_axi
+  ad_mem_hp2_interconnect $sys_cpu_clk sys_ps7/S_AXI_HP2
+  ad_mem_hp2_interconnect $sys_cpu_clk speed_detector_m1_dma/m_dest_axi
+  ad_mem_hp2_interconnect $sys_cpu_clk speed_detector_m2_dma/m_dest_axi
+  ad_mem_hp2_interconnect $sys_cpu_clk current_monitor_m1_dma/m_dest_axi
+  ad_mem_hp2_interconnect $sys_cpu_clk current_monitor_m2_dma/m_dest_axi
 
   ad_cpu_interrupt ps-7 mb-7 xadc_core/ip2intc_irpt
   ad_cpu_interrupt ps-8 mb-8 current_monitor_m2_dma/irq

--- a/projects/motcon2_fmc/common/motcon2_fmc_bd.tcl
+++ b/projects/motcon2_fmc/common/motcon2_fmc_bd.tcl
@@ -212,7 +212,7 @@
 
 
   ad_connect $sys_cpu_clk   current_monitor_m1_pack/clk
-  ad_connect sys_cpu_reset current_monitor_m1_pack/reset
+  ad_connect $sys_cpu_reset current_monitor_m1_pack/reset
 
   ad_connect current_monitor_m1/adc_enable_ia     current_monitor_m1_pack/enable_0
   ad_connect current_monitor_m1/adc_enable_ib     current_monitor_m1_pack/enable_1
@@ -235,7 +235,7 @@
   ad_connect  adc_m2_vbus_dat_i current_monitor_m2/adc_vbus_dat_i
 
   ad_connect $sys_cpu_clk current_monitor_m2_pack/clk
-  ad_connect sys_cpu_reset current_monitor_m2_pack/reset
+  ad_connect $sys_cpu_reset current_monitor_m2_pack/reset
 
   ad_connect current_monitor_m2/adc_enable_ia     current_monitor_m2_pack/enable_0
   ad_connect current_monitor_m2/adc_enable_ib     current_monitor_m2_pack/enable_1
@@ -288,7 +288,7 @@
 
   # ethernet
 
-  ad_connect sys_cpu_resetn eth_phy_rst_n
+  ad_connect $sys_cpu_resetn eth_phy_rst_n
   ad_connect sys_ps7/ENET0_MDIO_MDC eth_mdio_mdc
   ad_connect sys_ps7/ENET0_MDIO_O eth_mdio_o
   ad_connect sys_ps7/ENET0_MDIO_T eth_mdio_t
@@ -324,11 +324,11 @@
   # iic
   ad_connect iic_ee2/IIC iic_ee2
 
-  ad_connect  sys_cpu_resetn speed_detector_m1_dma/m_dest_axi_aresetn
-  ad_connect  sys_cpu_resetn speed_detector_m2_dma/m_dest_axi_aresetn
-  ad_connect  sys_cpu_resetn current_monitor_m1_dma/m_dest_axi_aresetn
-  ad_connect  sys_cpu_resetn current_monitor_m2_dma/m_dest_axi_aresetn
-  ad_connect  sys_cpu_resetn xadc_core/s_axi_aresetn
+  ad_connect  $sys_cpu_resetn speed_detector_m1_dma/m_dest_axi_aresetn
+  ad_connect  $sys_cpu_resetn speed_detector_m2_dma/m_dest_axi_aresetn
+  ad_connect  $sys_cpu_resetn current_monitor_m1_dma/m_dest_axi_aresetn
+  ad_connect  $sys_cpu_resetn current_monitor_m2_dma/m_dest_axi_aresetn
+  ad_connect  $sys_cpu_resetn xadc_core/s_axi_aresetn
 
   # address map
   ad_cpu_interconnect  0x40410000 speed_detector_m1

--- a/projects/scripts/adi_board.tcl
+++ b/projects/scripts/adi_board.tcl
@@ -548,7 +548,7 @@ proc ad_mem_hpx_interconnect {p_sel p_clk p_name} {
     }
   } else {
     set_property CONFIG.NUM_SI $m_interconnect_index $m_interconnect_cell
-    if {[lsearch [get_bd_nets -of_object [get_bd_pins $m_interconnect_cell/ACLK*]] "/$p_clk"] == -1 } {
+    if {[lsearch [get_bd_nets -of_object [get_bd_pins $m_interconnect_cell/ACLK*]] $p_clk] == -1 } {
         incr sys_mem_clk_index
         set_property CONFIG.NUM_CLKS [expr $sys_mem_clk_index +1] $m_interconnect_cell
         ad_connect $p_clk $m_interconnect_cell/ACLK$sys_mem_clk_index

--- a/projects/scripts/adi_board.tcl
+++ b/projects/scripts/adi_board.tcl
@@ -548,7 +548,7 @@ proc ad_mem_hpx_interconnect {p_sel p_clk p_name} {
     }
   } else {
     set_property CONFIG.NUM_SI $m_interconnect_index $m_interconnect_cell
-    if {[lsearch [get_bd_nets -of_object [get_bd_pins $m_interconnect_cell/ACLK*]] $p_clk] == -1 } {
+    if {[lsearch [get_bd_nets -of_object [get_bd_pins $m_interconnect_cell/ACLK*]] [get_bd_nets $p_clk]] == -1 } {
         incr sys_mem_clk_index
         set_property CONFIG.NUM_CLKS [expr $sys_mem_clk_index +1] $m_interconnect_cell
         ad_connect $p_clk $m_interconnect_cell/ACLK$sys_mem_clk_index

--- a/projects/scripts/adi_project.tcl
+++ b/projects/scripts/adi_project.tcl
@@ -249,10 +249,14 @@ proc adi_project_run {project_name} {
   # Look for undefined clocks which do not show up in the timing summary
   set timing_check [check_timing -override_defaults no_clock -no_header -return_string]
   if {[regexp { (\d+) register} $timing_check -> num_regs]} {
-    if {$num_regs > 0} {
-      puts "CRITICAL WARNING: There are $num_regs registers with no clocks !!! See no_clock.log for details."
-      check_timing -override_defaults no_clock -verbose -file no_clock.log
+
+    if {[info exist num_regs]} {
+      if {$num_regs > 0} {
+        puts "CRITICAL WARNING: There are $num_regs registers with no clocks !!! See no_clock.log for details."
+        check_timing -override_defaults no_clock -verbose -file no_clock.log
+      }
     }
+
   } else {
     puts "CRITICAL WARNING: The search for undefined clocks failed !!!"
   }


### PR DESCRIPTION
Initial issue: According to DS925, the reference clock frequency for IDELAYCTRL
has to be between 300 to 800 MHz. Reconfigure the second PL clock
output of the PS8 to 335MHz.

Proposed solution: define a consistent clock tree by having three variables containing clock nets.
These nets are connected to different clock sources, depending of the used FPGA carrier. Also add sys_process_rst modules for all these clock sources.

The three clock variables are:
  - $sys_cpu_clk: having a 100MHz clock source, generated by PS7/8 or MIG, associated resets are $sys_cpu_reset and $sys_cpu_resetn
  - $sys_dma_clk: having a 200MHz or 250MHz clock source, generated by PS7/8 or MIG, associated resets are $sys_dma_reset and $sys_dma_resetn
  - $sys_iodelay_clk: having a 200MHz or 500MHz clock source, generated by PS7/8 or MIG, associated resets are $sys_iodelay_reset and $sys_iodelay_resetn 