### PR TITLE
fix missing clock definitions

### DIFF
--- a/library/axi_fmcadc5_sync/axi_fmcadc5_sync_constr.xdc
+++ b/library/axi_fmcadc5_sync/axi_fmcadc5_sync_constr.xdc
@@ -40,3 +40,7 @@ set_false_path -to [get_cells -hier -filter {name =~ *rx_sync_mode* && IS_SEQUEN
 set_false_path -to [get_cells -hier -filter {name =~ *rx_sync_disable_1* && IS_SEQUENTIAL}]
 set_false_path -to [get_cells -hier -filter {name =~ *rx_sync_disable_0* && IS_SEQUENTIAL}]
 
+# Define spi clock
+create_generated_clock -name spi_clk  \
+  -source [get_pins -hier up_spi_clk_int_reg/C] \
+  -divide_by 2 [get_pins -hier up_spi_clk_int_reg/Q]

--- a/projects/adrv9361z7035/common/ccfmc_constr.xdc
+++ b/projects/adrv9361z7035/common/ccfmc_constr.xdc
@@ -144,7 +144,10 @@ set_property  -dict {PACKAGE_PIN  AE5}  [get_ports gt_rx_n[1]]                  
 
 ## clocks
 
-create_clock -name ref_clk        -period  4.00 [get_ports gt_ref_clk_0_p]
+create_clock -name ref_clk_0      -period  4.00 [get_ports gt_ref_clk_0_p]
+create_clock -name ref_clk_1      -period  4.00 [get_ports gt_ref_clk_1_p]
+create_clock -name clk0           -period  4.00 [get_ports clk_0_p]
+create_clock -name clk1           -period  4.00 [get_ports clk_1_p]
 create_clock -name xcvr_clk_0     -period  8.00 [get_pins i_system_wrapper/system_i/axi_pz_xcvrlb/inst/g_lanes[0].i_xcvrlb_1/i_xch/i_gtxe2_channel/RXOUTCLK]
 create_clock -name xcvr_clk_1     -period  8.00 [get_pins i_system_wrapper/system_i/axi_pz_xcvrlb/inst/g_lanes[1].i_xcvrlb_1/i_xch/i_gtxe2_channel/RXOUTCLK]
 

--- a/projects/common/ac701/ac701_system_constr.xdc
+++ b/projects/common/ac701/ac701_system_constr.xdc
@@ -71,3 +71,8 @@ set_property -dict  {PACKAGE_PIN  K25   IOSTANDARD  LVCMOS33  DRIVE 8 SLEW SLOW}
 
 set_property CFGBVS VCCO [current_design]
 set_property CONFIG_VOLTAGE 3.3 [current_design]
+
+# Create SPI clock
+create_generated_clock -name spi_clk  \
+  -source [get_pins i_system_wrapper/system_i/axi_spi/ext_spi_clk] \
+  -divide_by 2 [get_pins i_system_wrapper/system_i/axi_spi/sck_o]

--- a/projects/common/kc705/kc705_system_constr.xdc
+++ b/projects/common/kc705/kc705_system_constr.xdc
@@ -87,3 +87,8 @@ set_property -dict  {PACKAGE_PIN  L21   IOSTANDARD  LVCMOS25  DRIVE 8 SLEW SLOW}
 #Setting the Configuration Bank Voltage Select
 set_property CFGBVS VCCO [current_design]
 set_property CONFIG_VOLTAGE 2.5 [current_design]
+
+# Create SPI clock
+create_generated_clock -name spi_clk  \
+  -source [get_pins i_system_wrapper/system_i/axi_spi/ext_spi_clk] \
+  -divide_by 2 [get_pins i_system_wrapper/system_i/axi_spi/sck_o]

--- a/projects/common/kcu105/kcu105_system_constr.xdc
+++ b/projects/common/kcu105/kcu105_system_constr.xdc
@@ -55,3 +55,8 @@ create_clock -name phy_clk      -period  1.60 [get_ports phy_clk_p]
 #Setting the Configuration Bank Voltage Select
 set_property CFGBVS GND [current_design]
 set_property CONFIG_VOLTAGE 1.8 [current_design]
+
+# Create SPI clock
+create_generated_clock -name spi_clk  \
+  -source [get_pins i_system_wrapper/system_i/axi_spi/ext_spi_clk] \
+  -divide_by 2 [get_pins i_system_wrapper/system_i/axi_spi/sck_o]

--- a/projects/common/vc707/vc707_system_constr.xdc
+++ b/projects/common/vc707/vc707_system_constr.xdc
@@ -18,6 +18,9 @@ set_property PACKAGE_PIN AM7 [get_ports sgmii_rxn]
 set_property PACKAGE_PIN AH8 [get_ports mgt_clk_p]
 set_property PACKAGE_PIN AH7 [get_ports mgt_clk_n]
 
+# Define the 125 MHz SGMII clock 
+create_clock -name mgt_clk  -period  8.00  [get_ports mgt_clk_p]
+
 set_property -dict  {PACKAGE_PIN  AJ33  IOSTANDARD  LVCMOS18} [get_ports phy_rstn]
 set_property -dict  {PACKAGE_PIN  AH31  IOSTANDARD  LVCMOS18} [get_ports mdio_mdc]
 set_property -dict  {PACKAGE_PIN  AK33  IOSTANDARD  LVCMOS18} [get_ports mdio_mdio]

--- a/projects/common/vc707/vc707_system_constr.xdc
+++ b/projects/common/vc707/vc707_system_constr.xdc
@@ -76,3 +76,8 @@ set_property -dict  {PACKAGE_PIN  AU32  IOSTANDARD  LVCMOS18  DRIVE 8 SLEW SLOW}
 #Setting the Configuration Bank Voltage Select
 set_property CFGBVS GND [current_design]
 set_property CONFIG_VOLTAGE 1.8 [current_design]
+
+# Create SPI clock
+create_generated_clock -name spi_clk  \
+  -source [get_pins i_system_wrapper/system_i/axi_spi/ext_spi_clk] \
+  -divide_by 2 [get_pins i_system_wrapper/system_i/axi_spi/sck_o]

--- a/projects/common/vcu118/vcu118_system_constr.xdc
+++ b/projects/common/vcu118/vcu118_system_constr.xdc
@@ -53,3 +53,7 @@ set_property -dict  {PACKAGE_PIN  AL25  IOSTANDARD  LVCMOS18} [get_ports iic_rst
 set_property -dict  {PACKAGE_PIN  AM24  IOSTANDARD  LVCMOS18  DRIVE 8 SLEW SLOW} [get_ports iic_scl]
 set_property -dict  {PACKAGE_PIN  AL24  IOSTANDARD  LVCMOS18  DRIVE 8 SLEW SLOW} [get_ports iic_sda]
 
+# Create SPI clock
+create_generated_clock -name spi_clk  \
+  -source [get_pins i_system_wrapper/system_i/axi_spi/ext_spi_clk] \
+  -divide_by 2 [get_pins i_system_wrapper/system_i/axi_spi/sck_o]

--- a/projects/common/zc702/zc702_system_constr.xdc
+++ b/projects/common/zc702/zc702_system_constr.xdc
@@ -43,3 +43,6 @@ set_property  -dict {PACKAGE_PIN  H22   IOSTANDARD LVCMOS25} [get_ports gpio_bd[
 set_property  -dict {PACKAGE_PIN  G22   IOSTANDARD LVCMOS25} [get_ports gpio_bd[6]]   ; ## XADC_GPIO_2
 set_property  -dict {PACKAGE_PIN  H18   IOSTANDARD LVCMOS25} [get_ports gpio_bd[7]]   ; ## XADC_GPIO_3
 
+# Define SPI clock
+create_clock -name spi0_clk      -period 20   [get_pins -hier */EMIOSPI0SCLKO]
+create_clock -name spi1_clk      -period 20   [get_pins -hier */EMIOSPI1SCLKO]

--- a/projects/common/zc706/zc706_system_constr.xdc
+++ b/projects/common/zc706/zc706_system_constr.xdc
@@ -61,3 +61,6 @@ set_property  -dict {PACKAGE_PIN  J15   IOSTANDARD LVCMOS15} [get_ports gpio_bd[
 set_property  -dict {PACKAGE_PIN  J16   IOSTANDARD LVCMOS15} [get_ports gpio_bd[13]]          ; ## XADC_GPIO_2
 set_property  -dict {PACKAGE_PIN  J14   IOSTANDARD LVCMOS15} [get_ports gpio_bd[14]]          ; ## XADC_GPIO_3
 
+# Define SPI clock
+create_clock -name spi0_clk      -period 20   [get_pins -hier */EMIOSPI0SCLKO]
+create_clock -name spi1_clk      -period 20   [get_pins -hier */EMIOSPI1SCLKO]

--- a/projects/common/zcu102/zcu102_system_constr.xdc
+++ b/projects/common/zcu102/zcu102_system_constr.xdc
@@ -25,3 +25,6 @@ set_property  -dict {PACKAGE_PIN  AH13  IOSTANDARD LVCMOS33} [get_ports gpio_bd_
 set_property  -dict {PACKAGE_PIN  AH14  IOSTANDARD LVCMOS33} [get_ports gpio_bd_o[6]]           ; ## GPIO_LED_6
 set_property  -dict {PACKAGE_PIN  AL12  IOSTANDARD LVCMOS33} [get_ports gpio_bd_o[7]]           ; ## GPIO_LED_7
 
+# Define SPI clock
+create_clock -name spi0_clk      -period 20   [get_pins -hier */EMIOSPI0SCLKO]
+create_clock -name spi1_clk      -period 20   [get_pins -hier */EMIOSPI1SCLKO]

--- a/projects/common/zed/zed_system_constr.xdc
+++ b/projects/common/zed/zed_system_constr.xdc
@@ -87,3 +87,6 @@ set_property  -dict {PACKAGE_PIN  J15   IOSTANDARD LVCMOS25} [get_ports gpio_bd[
 
 set_property  -dict {PACKAGE_PIN  G17   IOSTANDARD LVCMOS25} [get_ports gpio_bd[31]]      ; ## OTG-RESETN
 
+# Define SPI clock
+create_clock -name spi0_clk      -period 20   [get_pins -hier */EMIOSPI0SCLKO]
+create_clock -name spi1_clk      -period 20   [get_pins -hier */EMIOSPI1SCLKO]

--- a/projects/fmcomms5/zc702/system_constr.xdc
+++ b/projects/fmcomms5/zc702/system_constr.xdc
@@ -132,6 +132,7 @@ set_property  -dict {PACKAGE_PIN  U11   IOSTANDARD LVCMOS25}  [get_ports gpio_ca
 
 create_clock -name rx_0_clk       -period   5.00 [get_ports rx_clk_in_0_p]
 create_clock -name rx_1_clk       -period   5.00 [get_ports rx_clk_in_1_p]
+create_clock -name ref_clk        -period   5.00 [get_ports ref_clk_p]
 
 # gpio (pmods)
 

--- a/projects/fmcomms5/zc706/system_constr.xdc
+++ b/projects/fmcomms5/zc706/system_constr.xdc
@@ -132,3 +132,4 @@ set_property  -dict {PACKAGE_PIN  AK30  IOSTANDARD LVCMOS25}  [get_ports gpio_ca
 
 create_clock -name rx_0_clk       -period   4.00 [get_ports rx_clk_in_0_p]
 create_clock -name rx_1_clk       -period   4.00 [get_ports rx_clk_in_1_p]
+create_clock -name ref_clk        -period   4.00 [get_ports ref_clk_p]

--- a/projects/fmcomms5/zcu102/system_constr.xdc
+++ b/projects/fmcomms5/zcu102/system_constr.xdc
@@ -132,3 +132,4 @@ set_property  -dict {PACKAGE_PIN  R12   IOSTANDARD LVCMOS18}  [get_ports gpio_ca
 
 create_clock -name rx_0_clk       -period   4.00 [get_ports rx_clk_in_0_p]
 create_clock -name rx_1_clk       -period   4.00 [get_ports rx_clk_in_1_p]
+create_clock -name ref_clk        -period   4.00 [get_ports ref_clk_p]


### PR DESCRIPTION
For SPI we use two approached based on the processing system:
Zynq based systems:  create a 50 MHz clock on the output of the primitive
MicroBlaze based systems:  create a generated clock on the output of the SPI cores

Testing: all affected projects compiled.