### PR TITLE
Fix FMCOMMS11

### DIFF
--- a/projects/fmcomms11/common/fmcomms11_bd.tcl
+++ b/projects/fmcomms11/common/fmcomms11_bd.tcl
@@ -140,6 +140,10 @@ ad_connect  sys_cpu_clk axi_ad9162_fifo/dma_clk
 ad_connect  sys_cpu_reset axi_ad9162_fifo/dma_rst
 ad_connect  sys_cpu_clk axi_ad9162_dma/m_axis_aclk
 ad_connect  sys_cpu_resetn axi_ad9162_dma/m_src_axi_aresetn
+ad_connect  util_ad9162_upack/s_axis_valid VCC
+ad_connect  util_ad9162_upack/s_axis_ready axi_ad9162_fifo/dac_valid
+ad_connect  util_ad9162_upack/s_axis_data axi_ad9162_fifo/dac_data
+ad_connect  axi_ad9162_core/dac_dunf axi_ad9162_fifo/dac_dunf
 ad_connect  axi_ad9162_fifo/dma_xfer_req axi_ad9162_dma/m_axis_xfer_req
 ad_connect  axi_ad9162_fifo/dma_ready axi_ad9162_dma/m_axis_ready
 ad_connect  axi_ad9162_fifo/dma_data axi_ad9162_dma/m_axis_data

--- a/projects/fmcomms11/common/fmcomms11_bd.tcl
+++ b/projects/fmcomms11/common/fmcomms11_bd.tcl
@@ -19,12 +19,10 @@ set RX_SAMPLE_WIDTH 16 ; # N/NP
 # Data path FIFO attributes
 
 set adc_fifo_name axi_ad9625_fifo
-set adc_fifo_address_width 18
 set adc_data_width 256
 set adc_dma_data_width 64
 
 set dac_fifo_name axi_ad9162_fifo
-set dac_fifo_address_width 10
 set dac_data_width 256
 set dac_dma_data_width 256
 

--- a/projects/fmcomms11/common/fmcomms11_bd.tcl
+++ b/projects/fmcomms11/common/fmcomms11_bd.tcl
@@ -28,6 +28,10 @@ set dac_fifo_address_width 10
 set dac_data_width 256
 set dac_dma_data_width 256
 
+# DAC FIFO bypass
+
+create_bd_port -dir I dac_fifo_bypass
+
 # dac peripherals
 
 ad_ip_instance axi_adxcvr axi_ad9162_xcvr
@@ -141,6 +145,7 @@ ad_connect  axi_ad9162_fifo/dma_ready axi_ad9162_dma/m_axis_ready
 ad_connect  axi_ad9162_fifo/dma_data axi_ad9162_dma/m_axis_data
 ad_connect  axi_ad9162_fifo/dma_valid axi_ad9162_dma/m_axis_valid
 ad_connect  axi_ad9162_fifo/dma_xfer_last axi_ad9162_dma/m_axis_last
+ad_connect  dac_fifo_bypass axi_ad9162_fifo/bypass
 
 # connections (adc)
 
@@ -193,8 +198,4 @@ ad_cpu_interrupt ps-10 mb-15 axi_ad9162_jesd/irq
 ad_cpu_interrupt ps-11 mb-14 axi_ad9625_jesd/irq
 ad_cpu_interrupt ps-12 mb-12 axi_ad9162_dma/irq
 ad_cpu_interrupt ps-13 mb-13 axi_ad9625_dma/irq
-
-# unused
-
-ad_connect  axi_ad9162_fifo/bypass GND
 

--- a/projects/fmcomms11/common/fmcomms11_bd.tcl
+++ b/projects/fmcomms11/common/fmcomms11_bd.tcl
@@ -14,7 +14,7 @@ set TX_SAMPLES_PER_CHANNEL [expr [expr $TX_NUM_OF_LANES * 32 ] / \
 set RX_NUM_OF_LANES 8      ; # L
 set RX_NUM_OF_CONVERTERS 1 ; # M
 set RX_SAMPLES_PER_FRAME 4 ; # S
-set RX_SAMPLE_WIDTH 16 ; # N/NP
+set RX_SAMPLE_WIDTH 16     ; # N/NP
 
 # Data path FIFO attributes
 
@@ -32,10 +32,11 @@ create_bd_port -dir I dac_fifo_bypass
 
 # dac peripherals
 
-ad_ip_instance axi_adxcvr axi_ad9162_xcvr
-ad_ip_parameter axi_ad9162_xcvr CONFIG.NUM_OF_LANES 8
-ad_ip_parameter axi_ad9162_xcvr CONFIG.QPLL_ENABLE 1
-ad_ip_parameter axi_ad9162_xcvr CONFIG.TX_OR_RX_N 1
+ad_ip_instance axi_adxcvr axi_ad9162_xcvr [list \
+  NUM_OF_LANES 8 \
+  QPLL_ENABLE 1 \
+  TX_OR_RX_N 1 \
+]
 
 adi_axi_jesd204_tx_create axi_ad9162_jesd 8
 
@@ -50,26 +51,28 @@ ad_ip_instance util_upack2 util_ad9162_upack [list \
   SAMPLE_DATA_WIDTH $TX_SAMPLE_WIDTH \
 ]
 
-ad_ip_instance axi_dmac axi_ad9162_dma
-ad_ip_parameter axi_ad9162_dma CONFIG.DMA_TYPE_SRC 0
-ad_ip_parameter axi_ad9162_dma CONFIG.DMA_TYPE_DEST 1
-ad_ip_parameter axi_ad9162_dma CONFIG.ID 1
-ad_ip_parameter axi_ad9162_dma CONFIG.AXI_SLICE_SRC 0
-ad_ip_parameter axi_ad9162_dma CONFIG.AXI_SLICE_DEST 0
-ad_ip_parameter axi_ad9162_dma CONFIG.DMA_LENGTH_WIDTH 24
-ad_ip_parameter axi_ad9162_dma CONFIG.DMA_2D_TRANSFER 0
-ad_ip_parameter axi_ad9162_dma CONFIG.CYCLIC 0
-ad_ip_parameter axi_ad9162_dma CONFIG.DMA_DATA_WIDTH_SRC 256
-ad_ip_parameter axi_ad9162_dma CONFIG.DMA_DATA_WIDTH_DEST 256
+ad_ip_instance axi_dmac axi_ad9162_dma [list \
+  DMA_TYPE_SRC 0 \
+  DMA_TYPE_DEST 1 \
+  ID 1 \
+  AXI_SLICE_SRC 0 \
+  AXI_SLICE_DEST 0 \
+  DMA_LENGTH_WIDTH 24 \
+  DMA_2D_TRANSFER 0 \
+  CYCLIC 0 \
+  DMA_DATA_WIDTH_SRC 256 \
+  DMA_DATA_WIDTH_DEST 256 \
+]
 
 ad_dacfifo_create $dac_fifo_name $dac_data_width $dac_dma_data_width $dac_fifo_address_width
 
 # adc peripherals
 
-ad_ip_instance axi_adxcvr axi_ad9625_xcvr
-ad_ip_parameter axi_ad9625_xcvr CONFIG.NUM_OF_LANES 8
-ad_ip_parameter axi_ad9625_xcvr CONFIG.QPLL_ENABLE 0
-ad_ip_parameter axi_ad9625_xcvr CONFIG.TX_OR_RX_N 0
+ad_ip_instance axi_adxcvr axi_ad9625_xcvr [list \
+  NUM_OF_LANES 8 \
+  QPLL_ENABLE 0 \
+  TX_OR_RX_N 0 \
+]
 
 adi_tpl_jesd204_rx_create axi_ad9625_core $RX_NUM_OF_LANES \
                                           $RX_NUM_OF_CONVERTERS \
@@ -78,32 +81,34 @@ adi_tpl_jesd204_rx_create axi_ad9625_core $RX_NUM_OF_LANES \
 
 adi_axi_jesd204_rx_create axi_ad9625_jesd 8
 
-ad_ip_instance axi_dmac axi_ad9625_dma
-ad_ip_parameter axi_ad9625_dma CONFIG.DMA_TYPE_SRC 1
-ad_ip_parameter axi_ad9625_dma CONFIG.DMA_TYPE_DEST 0
-ad_ip_parameter axi_ad9625_dma CONFIG.ID 0
-ad_ip_parameter axi_ad9625_dma CONFIG.AXI_SLICE_SRC 0
-ad_ip_parameter axi_ad9625_dma CONFIG.AXI_SLICE_DEST 0
-ad_ip_parameter axi_ad9625_dma CONFIG.SYNC_TRANSFER_START 0
-ad_ip_parameter axi_ad9625_dma CONFIG.DMA_LENGTH_WIDTH 24
-ad_ip_parameter axi_ad9625_dma CONFIG.DMA_2D_TRANSFER 0
-ad_ip_parameter axi_ad9625_dma CONFIG.CYCLIC 0
-ad_ip_parameter axi_ad9625_dma CONFIG.DMA_DATA_WIDTH_SRC 64
-ad_ip_parameter axi_ad9625_dma CONFIG.DMA_DATA_WIDTH_DEST 64
+ad_ip_instance axi_dmac axi_ad9625_dma [list \
+  DMA_TYPE_SRC 1 \
+  DMA_TYPE_DEST 0 \
+  ID 0 \
+  AXI_SLICE_SRC 0 \
+  AXI_SLICE_DEST 0 \
+  SYNC_TRANSFER_START 0 \
+  DMA_LENGTH_WIDTH 24 \
+  DMA_2D_TRANSFER 0 \
+  CYCLIC 0 \
+  DMA_DATA_WIDTH_SRC 64 \
+  DMA_DATA_WIDTH_DEST 64 \
+]
 
 ad_adcfifo_create $adc_fifo_name $adc_data_width $adc_dma_data_width $adc_fifo_address_width
 
 # shared transceiver core
 
-ad_ip_instance util_adxcvr util_fmcomms11_xcvr
-ad_ip_parameter util_fmcomms11_xcvr CONFIG.QPLL_FBDIV 0x120
-ad_ip_parameter util_fmcomms11_xcvr CONFIG.CPLL_FBDIV 4
-ad_ip_parameter util_fmcomms11_xcvr CONFIG.TX_NUM_OF_LANES 8
-ad_ip_parameter util_fmcomms11_xcvr CONFIG.TX_CLK25_DIV 7
-ad_ip_parameter util_fmcomms11_xcvr CONFIG.RX_NUM_OF_LANES 8
-ad_ip_parameter util_fmcomms11_xcvr CONFIG.RX_CLK25_DIV 7
-ad_ip_parameter util_fmcomms11_xcvr CONFIG.RX_DFE_LPM_CFG 0x0904
-ad_ip_parameter util_fmcomms11_xcvr CONFIG.RX_CDR_CFG 0x03000023ff10400020
+ad_ip_instance util_adxcvr util_fmcomms11_xcvr [list \
+  QPLL_FBDIV 0x120 \
+  CPLL_FBDIV 4 \
+  TX_NUM_OF_LANES 8 \
+  TX_CLK25_DIV 7 \
+  RX_NUM_OF_LANES 8 \
+  RX_CLK25_DIV 7 \
+  RX_DFE_LPM_CFG 0x0904 \
+  RX_CDR_CFG 0x03000023ff10400020 \
+]
 
 # reference clocks & resets
 

--- a/projects/fmcomms11/common/fmcomms11_bd.tcl
+++ b/projects/fmcomms11/common/fmcomms11_bd.tcl
@@ -124,7 +124,7 @@ ad_connect  sys_cpu_clk util_fmcomms11_xcvr/up_clk
 
 # connections (dac)
 
-ad_xcvrcon  util_fmcomms11_xcvr axi_ad9162_xcvr axi_ad9162_jesd
+ad_xcvrcon  util_fmcomms11_xcvr axi_ad9162_xcvr axi_ad9162_jesd {0 1 2 3 7 4 6 5}
 ad_connect  util_fmcomms11_xcvr/tx_out_clk_0 axi_ad9162_core/link_clk
 ad_connect  axi_ad9162_jesd/tx_data axi_ad9162_core/link
 
@@ -156,7 +156,7 @@ ad_connect  dac_fifo_bypass axi_ad9162_fifo/bypass
 
 # connections (adc)
 
-ad_xcvrcon  util_fmcomms11_xcvr axi_ad9625_xcvr axi_ad9625_jesd
+ad_xcvrcon  util_fmcomms11_xcvr axi_ad9625_xcvr axi_ad9625_jesd {0 1 2 3 7 4 6 5}
 ad_connect  util_fmcomms11_xcvr/rx_out_clk_0 axi_ad9625_core/link_clk
 
 ad_connect  axi_ad9625_jesd/rx_sof axi_ad9625_core/link_sof

--- a/projects/fmcomms11/zc706/system_bd.tcl
+++ b/projects/fmcomms11/zc706/system_bd.tcl
@@ -1,13 +1,19 @@
 
+# instantiate the base design
 source $ad_hdl_dir/projects/common/zc706/zc706_system_bd.tcl
+
+# load all the FIFO related proccesses
 source $ad_hdl_dir/projects/common/zc706/zc706_plddr3_adcfifo_bd.tcl
 source $ad_hdl_dir/projects/common/xilinx/dacfifo_bd.tcl
+# NOTE: to swap the resources comment the two lines above, and uncomment to two line below
+#source $ad_hdl_dir/projects/common/zc706/zc706_plddr3_dacfifo_bd.tcl
+#source $ad_hdl_dir/projects/common/xilinx/adcfifo_bd.tcl
 
 # the DAC FIFO has a 500KSMP depth - 1 Mbyte
 set dac_fifo_address_width 15
 
 # by default PLDDR is used (1 Gbyte), this varible should be ignored
-set adc_fifo_address_width 18
+set adc_fifo_address_width 15
 
 source ../common/fmcomms11_bd.tcl
 

--- a/projects/fmcomms11/zc706/system_bd.tcl
+++ b/projects/fmcomms11/zc706/system_bd.tcl
@@ -1,7 +1,13 @@
 
-
 source $ad_hdl_dir/projects/common/zc706/zc706_system_bd.tcl
 source $ad_hdl_dir/projects/common/zc706/zc706_plddr3_adcfifo_bd.tcl
 source $ad_hdl_dir/projects/common/xilinx/dacfifo_bd.tcl
+
+# the DAC FIFO has a 500KSMP depth - 1 Mbyte
+set dac_fifo_address_width 15
+
+# by default PLDDR is used (1 Gbyte), this varible should be ignored
+set adc_fifo_address_width 18
+
 source ../common/fmcomms11_bd.tcl
 

--- a/projects/fmcomms11/zc706/system_constr.xdc
+++ b/projects/fmcomms11/zc706/system_constr.xdc
@@ -61,6 +61,6 @@ set_property  -dict {PACKAGE_PIN  AD23  IOSTANDARD LVCMOS25} [get_ports ad9162_i
 
 # clocks
 
-create_clock -name rx_ref_clk   -period  6.40 [get_ports trx_ref_clk_p]
-create_clock -name tx_div_clk   -period  3.20 [get_pins i_system_wrapper/system_i/util_fmcomms11_xcvr/inst/i_xch_0/i_gtxe2_channel/TXOUTCLK]
-create_clock -name rx_div_clk   -period  6.40 [get_pins i_system_wrapper/system_i/util_fmcomms11_xcvr/inst/i_xch_0/i_gtxe2_channel/RXOUTCLK]
+create_clock -name rx_ref_clk   -period  8 [get_ports trx_ref_clk_p]
+create_clock -name tx_div_clk   -period  4 [get_pins i_system_wrapper/system_i/util_fmcomms11_xcvr/inst/i_xch_0/i_gtxe2_channel/TXOUTCLK]
+create_clock -name rx_div_clk   -period  8 [get_pins i_system_wrapper/system_i/util_fmcomms11_xcvr/inst/i_xch_0/i_gtxe2_channel/RXOUTCLK]

--- a/projects/fmcomms11/zc706/system_constr.xdc
+++ b/projects/fmcomms11/zc706/system_constr.xdc
@@ -9,14 +9,14 @@ set_property  -dict {PACKAGE_PIN  AG8 } [get_ports rx_data_p[2]]                
 set_property  -dict {PACKAGE_PIN  AG7 } [get_ports rx_data_n[2]]                                      ; ## A07  FMC_HPC_DP2_M2C_N
 set_property  -dict {PACKAGE_PIN  AE8 } [get_ports rx_data_p[3]]                                      ; ## A10  FMC_HPC_DP3_M2C_P
 set_property  -dict {PACKAGE_PIN  AE7 } [get_ports rx_data_n[3]]                                      ; ## A11  FMC_HPC_DP3_M2C_N
-set_property  -dict {PACKAGE_PIN  AD6 } [get_ports rx_data_p[4]]                                      ; ## B12  FMC_HPC_DP7_M2C_P
-set_property  -dict {PACKAGE_PIN  AD5 } [get_ports rx_data_n[4]]                                      ; ## B13  FMC_HPC_DP7_M2C_N
-set_property  -dict {PACKAGE_PIN  AH6 } [get_ports rx_data_p[5]]                                      ; ## A14  FMC_HPC_DP4_M2C_P
-set_property  -dict {PACKAGE_PIN  AH5 } [get_ports rx_data_n[5]]                                      ; ## A15  FMC_HPC_DP4_M2C_N
+set_property  -dict {PACKAGE_PIN  AH6 } [get_ports rx_data_p[4]]                                      ; ## A14  FMC_HPC_DP4_M2C_P
+set_property  -dict {PACKAGE_PIN  AH5 } [get_ports rx_data_n[4]]                                      ; ## A15  FMC_HPC_DP4_M2C_N
+set_property  -dict {PACKAGE_PIN  AG4 } [get_ports rx_data_p[5]]                                      ; ## A18  FMC_HPC_DP5_M2C_P
+set_property  -dict {PACKAGE_PIN  AG3 } [get_ports rx_data_n[5]]                                      ; ## A19  FMC_HPC_DP5_M2C_N
 set_property  -dict {PACKAGE_PIN  AF6 } [get_ports rx_data_p[6]]                                      ; ## B16  FMC_HPC_DP6_M2C_P
 set_property  -dict {PACKAGE_PIN  AF5 } [get_ports rx_data_n[6]]                                      ; ## B17  FMC_HPC_DP6_M2C_N
-set_property  -dict {PACKAGE_PIN  AG4 } [get_ports rx_data_p[7]]                                      ; ## A18  FMC_HPC_DP5_M2C_P
-set_property  -dict {PACKAGE_PIN  AG3 } [get_ports rx_data_n[7]]                                      ; ## A19  FMC_HPC_DP5_M2C_N
+set_property  -dict {PACKAGE_PIN  AD6 } [get_ports rx_data_p[7]]                                      ; ## B12  FMC_HPC_DP7_M2C_P
+set_property  -dict {PACKAGE_PIN  AD5 } [get_ports rx_data_n[7]]                                      ; ## B13  FMC_HPC_DP7_M2C_N
 set_property  -dict {PACKAGE_PIN  AK17  IOSTANDARD LVDS_25} [get_ports rx_sync_p]                     ; ## H07  FMC_HPC_LA02_P
 set_property  -dict {PACKAGE_PIN  AK18  IOSTANDARD LVDS_25} [get_ports rx_sync_n]                     ; ## H08  FMC_HPC_LA02_N
 
@@ -30,14 +30,14 @@ set_property  -dict {PACKAGE_PIN  AJ4 } [get_ports tx_data_p[2]]                
 set_property  -dict {PACKAGE_PIN  AJ3 } [get_ports tx_data_n[2]]                                      ; ## A27  FMC_HPC_DP2_C2M_N
 set_property  -dict {PACKAGE_PIN  AK2 } [get_ports tx_data_p[3]]                                      ; ## A30  FMC_HPC_DP3_C2M_P
 set_property  -dict {PACKAGE_PIN  AK1 } [get_ports tx_data_n[3]]                                      ; ## A31  FMC_HPC_DP3_C2M_N
-set_property  -dict {PACKAGE_PIN  AD2 } [get_ports tx_data_p[4]]                                      ; ## B32  FMC_HPC_DP7_C2M_P
-set_property  -dict {PACKAGE_PIN  AD1 } [get_ports tx_data_n[4]]                                      ; ## B33  FMC_HPC_DP7_C2M_N
-set_property  -dict {PACKAGE_PIN  AH2 } [get_ports tx_data_p[5]]                                      ; ## A34  FMC_HPC_DP4_C2M_P
-set_property  -dict {PACKAGE_PIN  AH1 } [get_ports tx_data_n[5]]                                      ; ## A35  FMC_HPC_DP4_C2M_N
+set_property  -dict {PACKAGE_PIN  AH2 } [get_ports tx_data_p[4]]                                      ; ## A34  FMC_HPC_DP4_C2M_P
+set_property  -dict {PACKAGE_PIN  AH1 } [get_ports tx_data_n[4]]                                      ; ## A35  FMC_HPC_DP4_C2M_N
+set_property  -dict {PACKAGE_PIN  AF2 } [get_ports tx_data_p[5]]                                      ; ## A38  FMC_HPC_DP5_C2M_P
+set_property  -dict {PACKAGE_PIN  AF1 } [get_ports tx_data_n[5]]                                      ; ## A39  FMC_HPC_DP5_C2M_N
 set_property  -dict {PACKAGE_PIN  AE4 } [get_ports tx_data_p[6]]                                      ; ## B36  FMC_HPC_DP6_C2M_P
 set_property  -dict {PACKAGE_PIN  AE3 } [get_ports tx_data_n[6]]                                      ; ## B37  FMC_HPC_DP6_C2M_N
-set_property  -dict {PACKAGE_PIN  AF2 } [get_ports tx_data_p[7]]                                      ; ## A38  FMC_HPC_DP5_C2M_P
-set_property  -dict {PACKAGE_PIN  AF1 } [get_ports tx_data_n[7]]                                      ; ## A39  FMC_HPC_DP5_C2M_N
+set_property  -dict {PACKAGE_PIN  AD2 } [get_ports tx_data_p[7]]                                      ; ## B32  FMC_HPC_DP7_C2M_P
+set_property  -dict {PACKAGE_PIN  AD1 } [get_ports tx_data_n[7]]                                      ; ## B33  FMC_HPC_DP7_C2M_N
 set_property  -dict {PACKAGE_PIN  AH19  IOSTANDARD LVDS_25 DIFF_TERM TRUE} [get_ports tx_sync_p]      ; ## G09  FMC_HPC_LA03_P
 set_property  -dict {PACKAGE_PIN  AJ19  IOSTANDARD LVDS_25 DIFF_TERM TRUE} [get_ports tx_sync_n]      ; ## G10  FMC_HPC_LA03_N
 

--- a/projects/fmcomms11/zc706/system_top.v
+++ b/projects/fmcomms11/zc706/system_top.v
@@ -306,7 +306,8 @@ module system_top (
     .tx_data_7_p (tx_data_p[7]),
     .tx_ref_clk_0 (trx_ref_clk),
     .tx_sync_0 (tx_sync),
-    .tx_sysref_0 (1'b0));
+    .tx_sysref_0 (1'b0),
+    .dac_fifo_bypass (gpio_o[60]));
 
 endmodule
 


### PR DESCRIPTION
A few minor patch for FMCOMMS11:
  - connect dac_fifo_bypass to GPIO[60]
  - fix the DAC data path (define connections between upack and FIFO)