### PR TITLE
Fixing resets for various projects

### DIFF
--- a/projects/ad9265_fmc/common/ad9265_bd.tcl
+++ b/projects/ad9265_fmc/common/ad9265_bd.tcl
@@ -50,7 +50,7 @@ ad_cpu_interconnect 0x44A30000 axi_ad9265_dma
 
 ad_mem_hp2_interconnect $sys_dma_clk sys_ps7/S_AXI_HP2
 ad_mem_hp2_interconnect $sys_dma_clk axi_ad9265_dma/m_dest_axi
-ad_connect  $sys_cpu_resetn axi_ad9265_dma/m_dest_axi_aresetn
+ad_connect  $sys_dma_resetn axi_ad9265_dma/m_dest_axi_aresetn
 
 # interrupts
 

--- a/projects/ad9434_fmc/common/ad9434_bd.tcl
+++ b/projects/ad9434_fmc/common/ad9434_bd.tcl
@@ -48,7 +48,7 @@ ad_cpu_interconnect 0x44A30000  axi_ad9434_dma
 
 ad_mem_hp1_interconnect $sys_dma_clk sys_ps7/S_AXI_HP1
 ad_mem_hp1_interconnect $sys_dma_clk axi_ad9434_dma/m_dest_axi
-ad_connect $sys_cpu_resetn axi_ad9434_dma/m_dest_axi_aresetn
+ad_connect $sys_dma_resetn axi_ad9434_dma/m_dest_axi_aresetn
 
 # interrupts
 

--- a/projects/ad9739a_fmc/common/ad9739a_fmc_bd.tcl
+++ b/projects/ad9739a_fmc/common/ad9739a_fmc_bd.tcl
@@ -51,7 +51,7 @@ ad_cpu_interconnect 0x7c420000 axi_ad9739a_dma
 
 ad_mem_hp2_interconnect $sys_dma_clk sys_ps7/S_AXI_HP2
 ad_mem_hp2_interconnect $sys_dma_clk axi_ad9739a_dma/m_src_axi
-ad_connect  $sys_cpu_resetn axi_ad9739a_dma/m_src_axi_aresetn
+ad_connect  $sys_dma_resetn axi_ad9739a_dma/m_src_axi_aresetn
 
 # interrupts
 


### PR DESCRIPTION
After the clock/reset restructuring, there were a couple of leftovers, the following projects are fixed with this patch:
  - AD9434
  - AD9625
  - AD9739A
