### PR TITLE
daq3:vcu118: Delete constraint related to smart connect

### DIFF
--- a/projects/daq3/vcu118/system_bd.tcl
+++ b/projects/daq3/vcu118/system_bd.tcl
@@ -32,5 +32,3 @@ ad_ip_parameter axi_ad9680_dma CONFIG.AXI_SLICE_SRC true
 ad_ip_parameter axi_ad9152_dma CONFIG.AXI_SLICE_DEST true
 ad_ip_parameter axi_ad9152_dma CONFIG.AXI_SLICE_SRC true
 
-set_property -dict [list CONFIG.ADVANCED_PROPERTIES { __view__ { clocking { SW0 { ASSOCIATED_CLK aclk1 } } }}] [get_bd_cells axi_mem_interconnect]
-


### PR DESCRIPTION
This patch should fix the timing issue on DAQ3 VCU118.

Apparently this constraint will cause more harm than good. The tool will
try to prevent an invalid hold violation by increasing the net delay,
causing a setup violation on the same path. (inside the smart connect)

See more info here:
https://forums.xilinx.com/t5/AXI-Infrastructure/Smartconnect-and-Synchronous-Clock-Domain-Crossing-Issues/td-p/904824