### PR TITLE
axi_fmcadc5_sync: rename generated spi clock

### DIFF
--- a/library/axi_fmcadc5_sync/axi_fmcadc5_sync_constr.xdc
+++ b/library/axi_fmcadc5_sync/axi_fmcadc5_sync_constr.xdc
@@ -41,6 +41,6 @@ set_false_path -to [get_cells -hier -filter {name =~ *rx_sync_disable_1* && IS_S
 set_false_path -to [get_cells -hier -filter {name =~ *rx_sync_disable_0* && IS_SEQUENTIAL}]
 
 # Define spi clock
-create_generated_clock -name spi_clk  \
+create_generated_clock -name forwarded_spi_clk  \
   -source [get_pins -hier up_spi_clk_int_reg/C] \
   -divide_by 2 [get_pins -hier up_spi_clk_int_reg/Q]


### PR DESCRIPTION
Rename the clock so it won't conflict with the main spi clock name.

Tested
Comiled VC707 project.