### PR TITLE
util_clkdiv: fix for multiple instances

### DIFF
--- a/library/util_clkdiv/util_clkdiv_constr.xdc
+++ b/library/util_clkdiv/util_clkdiv_constr.xdc
@@ -1,2 +1,5 @@
-set_clock_groups -group [get_clocks clk_div_sel_0_s] -group [get_clocks clk_div_sel_1_s] -logically_exclusive
+set_clock_groups \
+  -group [get_clocks -of_objects [get_pins clk_divide_sel_0/O]] \
+  -group [get_clocks -of_objects [get_pins clk_divide_sel_1/O]] \
+  -logically_exclusive
 set_false_path -to [get_pins i_div_clk_gbuf/S*]


### PR DESCRIPTION
Vivado propagates and auto derives the clocks, however if multiple
instances of this components are used the names of the propagated clock
change while the constraint file has fixed name which will match only
the clocks from the first instance letting the second instance of the
clock div without exception.

Tested on Zed + fmcomms2