### PR TITLE
ad_ip_jesd204_tpl_dac: Quick fix

### DIFF
--- a/library/jesd204/ad_ip_jesd204_tpl_dac/ad_ip_jesd204_tpl_dac_regmap.v
+++ b/library/jesd204/ad_ip_jesd204_tpl_dac/ad_ip_jesd204_tpl_dac_regmap.v
@@ -127,7 +127,7 @@ module ad_ip_jesd204_tpl_dac_regmap #(
     .up_rstn (up_rstn),
 
     .up_axi_awvalid (s_axi_awvalid),
-    .up_axi_awaddr ({4'b0,s_axi_awaddr}),
+    .up_axi_awaddr (s_axi_awaddr),
     .up_axi_awready (s_axi_awready),
     .up_axi_wvalid (s_axi_wvalid),
     .up_axi_wdata (s_axi_wdata),
@@ -137,7 +137,7 @@ module ad_ip_jesd204_tpl_dac_regmap #(
     .up_axi_bresp (s_axi_bresp),
     .up_axi_bready (s_axi_bready),
     .up_axi_arvalid (s_axi_arvalid),
-    .up_axi_araddr ({4'b0,s_axi_araddr}),
+    .up_axi_araddr (s_axi_araddr),
     .up_axi_arready (s_axi_arready),
     .up_axi_rvalid (s_axi_rvalid),
     .up_axi_rresp (s_axi_rresp),


### PR DESCRIPTION
This patch will fix the following warning:

[Synth 8-689] width (16) of port connection 'up_axi_awaddr'
does not match port width (12) of module 'up_axi'