### PR TITLE
Adrv9xxx add fir filters

### DIFF
--- a/library/common/ad_bus_mux.v
+++ b/library/common/ad_bus_mux.v
@@ -1,0 +1,61 @@
+// ***************************************************************************
+// ***************************************************************************
+// Copyright 2014 - 2017 (c) Analog Devices, Inc. All rights reserved.
+//
+// In this HDL repository, there are many different and unique modules, consisting
+// of various HDL (Verilog or VHDL) components. The individual modules are
+// developed independently, and may be accompanied by separate and unique license
+// terms.
+//
+// The user should read each of these license terms, and understand the
+// freedoms and responsibilities that he or she has by using this source/core.
+//
+// This core is distributed in the hope that it will be useful, but WITHOUT ANY
+// WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+// A PARTICULAR PURPOSE.
+//
+// Redistribution and use of source or resulting binaries, with or without modification
+// of this file, are permitted under one of the following two license terms:
+//
+//   1. The GNU General Public License version 2 as published by the
+//      Free Software Foundation, which can be found in the top level directory
+//      of this repository (LICENSE_GPL2), and also online at:
+//      <https://www.gnu.org/licenses/old-licenses/gpl-2.0.html>
+//
+// OR
+//
+//   2. An ADI specific BSD license, which can be found in the top level directory
+//      of this repository (LICENSE_ADIBSD), and also on-line at:
+//      https://github.com/analogdevicesinc/hdl/blob/master/LICENSE_ADIBSD
+//      This will allow to generate bit files and not release the source code,
+//      as long as it attaches to an ADI device.
+//
+// ***************************************************************************
+// ***************************************************************************
+
+`timescale 1ns/100ps
+
+module ad_bus_mux #(
+
+  // Channel data width
+  parameter DATA_WIDTH = 16) (
+
+  input                    select_path,
+
+  input                    valid_in_0,
+  input                    enable_in_0,
+  input  [DATA_WIDTH-1:0]  data_in_0,
+
+  input                    valid_in_1,
+  input                    enable_in_1,
+  input  [DATA_WIDTH-1:0]  data_in_1,
+
+  output                   valid_out,
+  output                   enable_out,
+  output [DATA_WIDTH-1:0]  data_out);
+
+  assign valid_out  = (select_path == 0) ? valid_in_0   : valid_in_1;
+  assign enable_out = (select_path == 0) ? enable_in_0  : enable_in_1;
+  assign data_out   = (select_path == 0) ? data_in_0    : data_in_1;
+
+endmodule

--- a/projects/adrv9009/common/adrv9009_bd.tcl
+++ b/projects/adrv9009/common/adrv9009_bd.tcl
@@ -28,6 +28,7 @@ set dac_data_width [expr 32*$TX_NUM_OF_LANES]
 set dac_dma_data_width 128
 
 source $ad_hdl_dir/library/jesd204/scripts/jesd204.tcl
+source $ad_hdl_dir/projects/common/xilinx/adi_fir_filter_bd.tcl
 
 # adrv9009
 

--- a/projects/adrv9009/common/adrv9009_bd.tcl
+++ b/projects/adrv9009/common/adrv9009_bd.tcl
@@ -33,6 +33,8 @@ source $ad_hdl_dir/projects/common/xilinx/adi_fir_filter_bd.tcl
 # adrv9009
 
 create_bd_port -dir I dac_fifo_bypass
+create_bd_port -dir I adc_fir_filter_active
+create_bd_port -dir I dac_fir_filter_active
 
 # dac peripherals
 
@@ -57,6 +59,10 @@ ad_ip_instance util_upack2 util_adrv9009_tx_upack [list \
   SAMPLES_PER_CHANNEL $TX_SAMPLES_PER_CHANNEL \
   SAMPLE_DATA_WIDTH $TX_SAMPLE_WIDTH \
 ]
+
+ad_add_interpolation_filter "tx_fir_interpolator" 8 $TX_NUM_OF_CONVERTERS 2 {122.88} {15.36} \
+                             "$ad_hdl_dir/library/util_fir_int/coefile_int.coe"
+
 
 adi_tpl_jesd204_tx_create tx_adrv9009_tpl_core $TX_NUM_OF_LANES \
                                                $TX_NUM_OF_CONVERTERS \
@@ -106,6 +112,9 @@ adi_tpl_jesd204_rx_create rx_adrv9009_tpl_core $RX_NUM_OF_LANES \
                                                $RX_NUM_OF_CONVERTERS \
                                                $RX_SAMPLES_PER_FRAME \
                                                $RX_SAMPLE_WIDTH
+
+ad_add_decimation_filter "rx_fir_decimator" 8 $RX_NUM_OF_CONVERTERS 1 {122.88} {122.88} \
+                          "$ad_hdl_dir/library/util_fir_int/coefile_int.coe"
 
 ad_ip_instance axi_dmac axi_adrv9009_rx_dma
 ad_ip_parameter axi_adrv9009_rx_dma CONFIG.DMA_TYPE_SRC 2
@@ -227,11 +236,26 @@ ad_connect  axi_adrv9009_tx_jesd/tx_data tx_adrv9009_tpl_core/link
 ad_connect  axi_adrv9009_tx_clkgen/clk_0 util_adrv9009_tx_upack/clk
 ad_connect  adrv9009_tx_device_clk_rstgen/peripheral_reset util_adrv9009_tx_upack/reset
 
-ad_connect  tx_adrv9009_tpl_core/dac_valid_0 util_adrv9009_tx_upack/fifo_rd_en
+ad_ip_instance util_vector_logic logic_or [list \
+  C_OPERATION {or} \
+  C_SIZE 1]
+
+ad_connect  logic_or/Op1  tx_fir_interpolator/valid_out_0
+ad_connect  logic_or/Op2  tx_fir_interpolator/valid_out_2
+ad_connect  logic_or/Res  util_adrv9009_tx_upack/fifo_rd_en
+
+ad_connect tx_fir_interpolator/aclk axi_adrv9009_tx_clkgen/clk_0
 for {set i 0} {$i < $TX_NUM_OF_CONVERTERS} {incr i} {
-  ad_connect  util_adrv9009_tx_upack/fifo_rd_data_$i tx_adrv9009_tpl_core/dac_data_$i
-  ad_connect  tx_adrv9009_tpl_core/dac_enable_$i  util_adrv9009_tx_upack/enable_$i
+  ad_connect  tx_adrv9009_tpl_core/dac_enable_$i  tx_fir_interpolator/dac_enable_$i
+  ad_connect  tx_adrv9009_tpl_core/dac_valid_$i  tx_fir_interpolator/dac_valid_$i
+
+  ad_connect  util_adrv9009_tx_upack/fifo_rd_data_$i  tx_fir_interpolator/data_in_${i}
+  ad_connect  util_adrv9009_tx_upack/enable_$i  tx_fir_interpolator/enable_out_${i}
+
+  ad_connect  tx_fir_interpolator/data_out_${i}  tx_adrv9009_tpl_core/dac_data_$i
 }
+
+ad_connect  tx_fir_interpolator/active dac_fir_filter_active
 
 ad_connect  axi_adrv9009_tx_clkgen/clk_0 axi_adrv9009_dacfifo/dac_clk
 ad_connect  adrv9009_tx_device_clk_rstgen/peripheral_reset axi_adrv9009_dacfifo/dac_rst
@@ -262,11 +286,20 @@ ad_connect  axi_adrv9009_rx_jesd/rx_data_tvalid rx_adrv9009_tpl_core/link_valid
 ad_connect  axi_adrv9009_rx_clkgen/clk_0 util_adrv9009_rx_cpack/clk
 ad_connect  adrv9009_rx_device_clk_rstgen/peripheral_reset util_adrv9009_rx_cpack/reset
 
-ad_connect rx_adrv9009_tpl_core/adc_valid_0 util_adrv9009_rx_cpack/fifo_wr_en
+ad_connect rx_fir_decimator/aclk axi_adrv9009_rx_clkgen/clk_0
+
 for {set i 0} {$i < $RX_NUM_OF_CONVERTERS} {incr i} {
-  ad_connect  rx_adrv9009_tpl_core/adc_enable_$i util_adrv9009_rx_cpack/enable_$i
-  ad_connect  rx_adrv9009_tpl_core/adc_data_$i util_adrv9009_rx_cpack/fifo_wr_data_$i
+  ad_connect  rx_adrv9009_tpl_core/adc_valid_$i rx_fir_decimator/valid_in_$i
+  ad_connect  rx_adrv9009_tpl_core/adc_enable_$i rx_fir_decimator/enable_in_$i
+  ad_connect  rx_adrv9009_tpl_core/adc_data_$i rx_fir_decimator/data_in_${i}
+
+  ad_connect  rx_fir_decimator/enable_out_$i util_adrv9009_rx_cpack/enable_$i
+  ad_connect  rx_fir_decimator/data_out_${i} util_adrv9009_rx_cpack/fifo_wr_data_$i
 }
+
+ad_connect rx_fir_decimator/active adc_fir_filter_active
+
+ad_connect  rx_fir_decimator/valid_out_0 util_adrv9009_rx_cpack/fifo_wr_en
 ad_connect  rx_adrv9009_tpl_core/adc_dovf util_adrv9009_rx_cpack/fifo_wr_overflow
 
 ad_connect  axi_adrv9009_rx_clkgen/clk_0 axi_adrv9009_rx_dma/fifo_wr_clk

--- a/projects/adrv9009/zc706/system_project.tcl
+++ b/projects/adrv9009/zc706/system_project.tcl
@@ -10,6 +10,8 @@ adi_project_files adrv9009_zc706 [list \
   "system_top.v" \
   "system_constr.xdc"\
   "$ad_hdl_dir/library/xilinx/common/ad_iobuf.v" \
+  "$ad_hdl_dir/library/common/ad_bus_mux.v" \
+  "$ad_hdl_dir/library/common/util_pulse_gen.v" \
   "$ad_hdl_dir/projects/common/zc706/zc706_plddr3_constr.xdc" \
   "$ad_hdl_dir/projects/common/zc706/zc706_system_constr.xdc" ]
 

--- a/projects/adrv9009/zc706/system_top.v
+++ b/projects/adrv9009/zc706/system_top.v
@@ -332,6 +332,8 @@ module system_top (
 
   system_wrapper i_system_wrapper (
     .dac_fifo_bypass (gpio_o[60]),
+    .adc_fir_filter_active (gpio_o[61]),
+    .dac_fir_filter_active (gpio_o[62]),
     .ddr3_addr (ddr3_addr),
     .ddr3_ba (ddr3_ba),
     .ddr3_cas_n (ddr3_cas_n),

--- a/projects/adrv9009/zcu102/system_project.tcl
+++ b/projects/adrv9009/zcu102/system_project.tcl
@@ -8,6 +8,8 @@ adi_project_files adrv9009_zcu102 [list \
   "system_top.v" \
   "system_constr.xdc"\
   "$ad_hdl_dir/library/xilinx/common/ad_iobuf.v" \
+  "$ad_hdl_dir/library/common/ad_bus_mux.v" \
+  "$ad_hdl_dir/library/common/util_pulse_gen.v" \
   "$ad_hdl_dir/projects/common/zcu102/zcu102_system_constr.xdc" ]
 
 ## To improve timing of the BRAM buffers

--- a/projects/adrv9009/zcu102/system_top.v
+++ b/projects/adrv9009/zcu102/system_top.v
@@ -208,6 +208,8 @@ module system_top (
 
   system_wrapper i_system_wrapper (
     .dac_fifo_bypass (gpio_o[60]),
+    .adc_fir_filter_active (gpio_o[61]),
+    .dac_fir_filter_active (gpio_o[62]),
     .gpio_i (gpio_i),
     .gpio_o (gpio_o),
     .gpio_t (gpio_t),

--- a/projects/adrv9371x/common/adrv9371x_bd.tcl
+++ b/projects/adrv9371x/common/adrv9371x_bd.tcl
@@ -28,6 +28,7 @@ set dac_data_width [expr 32*$TX_NUM_OF_LANES]
 set dac_dma_data_width 128
 
 source $ad_hdl_dir/library/jesd204/scripts/jesd204.tcl
+source $ad_hdl_dir/projects/common/xilinx/adi_fir_filter_bd.tcl
 
 # ad9371
 

--- a/projects/adrv9371x/kcu105/system_project.tcl
+++ b/projects/adrv9371x/kcu105/system_project.tcl
@@ -8,6 +8,8 @@ adi_project_files adrv9371x_kcu105 [list \
   "system_top.v" \
   "system_constr.xdc"\
   "$ad_hdl_dir/library/xilinx/common/ad_iobuf.v" \
+  "$ad_hdl_dir/library/common/ad_bus_mux.v" \
+  "$ad_hdl_dir/library/common/util_pulse_gen.v" \
   "$ad_hdl_dir/projects/common/kcu105/kcu105_system_constr.xdc" \
   "$ad_hdl_dir/projects/common/kcu105/kcu105_system_lutram_constr.xdc" ]
 

--- a/projects/adrv9371x/kcu105/system_top.v
+++ b/projects/adrv9371x/kcu105/system_top.v
@@ -229,6 +229,8 @@ module system_top (
 
   system_wrapper i_system_wrapper (
     .dac_fifo_bypass (gpio_o[60]),
+    .adc_fir_filter_active (gpio_o[61]),
+    .dac_fir_filter_active (gpio_o[62]),
     .c0_ddr4_act_n (ddr4_act_n),
     .c0_ddr4_adr (ddr4_addr),
     .c0_ddr4_ba (ddr4_ba),

--- a/projects/adrv9371x/zc706/system_project.tcl
+++ b/projects/adrv9371x/zc706/system_project.tcl
@@ -10,6 +10,8 @@ adi_project_files adrv9371x_zc706 [list \
   "system_top.v" \
   "system_constr.xdc"\
   "$ad_hdl_dir/library/xilinx/common/ad_iobuf.v" \
+  "$ad_hdl_dir/library/common/ad_bus_mux.v" \
+  "$ad_hdl_dir/library/common/util_pulse_gen.v" \
   "$ad_hdl_dir/projects/common/zc706/zc706_plddr3_constr.xdc" \
   "$ad_hdl_dir/projects/common/zc706/zc706_system_constr.xdc" ]
 

--- a/projects/adrv9371x/zc706/system_top.v
+++ b/projects/adrv9371x/zc706/system_top.v
@@ -238,6 +238,8 @@ module system_top (
 
   system_wrapper i_system_wrapper (
     .dac_fifo_bypass (gpio_o[60]),
+    .adc_fir_filter_active (gpio_o[61]),
+    .dac_fir_filter_active (gpio_o[62]),
     .ddr3_addr (ddr3_addr),
     .ddr3_ba (ddr3_ba),
     .ddr3_cas_n (ddr3_cas_n),

--- a/projects/adrv9371x/zcu102/system_project.tcl
+++ b/projects/adrv9371x/zcu102/system_project.tcl
@@ -8,6 +8,8 @@ adi_project_files adrv9371x_zcu102 [list \
   "system_top.v" \
   "system_constr.xdc"\
   "$ad_hdl_dir/library/xilinx/common/ad_iobuf.v" \
+  "$ad_hdl_dir/library/common/ad_bus_mux.v" \
+  "$ad_hdl_dir/library/common/util_pulse_gen.v" \
   "$ad_hdl_dir/projects/common/zcu102/zcu102_system_constr.xdc" ]
 
 adi_project_run adrv9371x_zcu102

--- a/projects/adrv9371x/zcu102/system_top.v
+++ b/projects/adrv9371x/zcu102/system_top.v
@@ -191,6 +191,8 @@ module system_top (
 
   system_wrapper i_system_wrapper (
     .dac_fifo_bypass (gpio_o[60]),
+    .adc_fir_filter_active (gpio_o[61]),
+    .dac_fir_filter_active (gpio_o[62]),
     .gpio_i (gpio_i),
     .gpio_o (gpio_o),
     .gpio_t (gpio_t),

--- a/projects/common/xilinx/adi_fir_filter_bd.tcl
+++ b/projects/common/xilinx/adi_fir_filter_bd.tcl
@@ -1,0 +1,189 @@
+
+###################################################################################################
+###################################################################################################
+##
+# ad_add_decimation_filter - Creates a subsystem based on the Xilinx fir_compiler IP.
+# \param[name] - Subsystem name
+# \param[filter_rate] - Filter rate. E.g., 8
+# \param[n_chan] - Number of channels to filter
+# \param[parallel_paths] - Number of paralell paths. For scenarios where
+# the sampling rate is x times the core clock.
+# \param[core_clk_mhz] - Core clock in MHz
+# \param[sampl_freq_mhz] - Sampling frequency in MHz
+proc ad_add_decimation_filter {name filter_rate n_chan parallel_paths \
+                              core_clk_mhz sampl_freq_mhz coe_file} {
+  global ad_hdl_dir
+
+  create_bd_cell -type hier $name
+  set filter_name "fir_decimation"
+
+  create_bd_pin -dir I $name/aclk
+  create_bd_pin -dir I $name/active
+
+    # Adding the ad_bus_axis.v file in the project fileset sources_1 will not work
+    add_files -norecurse $ad_hdl_dir/library/common/ad_bus_mux.v
+
+
+  # add filter instances for n channels
+  for {set i 0} {$i < $n_chan} {incr i} {
+    ad_ip_instance fir_compiler $name/${filter_name}_${i} [ list \
+      Decimation_Rate $filter_rate \
+      Filter_Type "Decimation" \
+      Interpolation_Rate 1 \
+      Number_Paths $parallel_paths \
+      Clock_Frequency $core_clk_mhz \
+      Sample_Frequency $sampl_freq_mhz \
+      CoefficientSource COE_File \
+      Coefficient_File $coe_file \
+      Coefficient_Fractional_Bits 0 \
+      Data_Fractional_Bits 15 \
+      Coefficient_Sets 1 \
+      Coefficient_Sign Signed \
+      Coefficient_Structure Inferred \
+      Coefficient_Width 16 \
+      ColumnConfig 5 \
+      Filter_Architecture Systolic_Multiply_Accumulate \
+      Number_Channels 1 \
+      Output_Rounding_Mode Symmetric_Rounding_to_Zero \
+      Output_Width 16 \
+      Quantization Integer_Coefficients \
+      RateSpecification Frequency_Specification \
+      Zero_Pack_Factor 1
+    ]
+
+    ad_connect $name/aclk $name/${filter_name}_${i}/aclk
+
+    create_bd_pin -dir I $name/valid_in_$i
+    create_bd_pin -dir I $name/enable_in_$i
+    create_bd_pin -dir O $name/valid_out_$i
+    create_bd_pin -dir O $name/enable_out_$i
+    create_bd_pin -dir I -from [expr 16*$parallel_paths-1] -to 0 $name/data_in_$i
+    create_bd_pin -dir O -from [expr 16*$parallel_paths-1] -to 0 $name/data_out_$i
+
+    create_bd_cell -type module -reference ad_bus_mux $name/out_mux_$i
+    set_property -dict [list \
+      CONFIG.DATA_WIDTH [expr 16 * $parallel_paths]] [get_bd_cells $name/out_mux_$i]
+
+    ad_connect  $name/valid_in_$i  $name/out_mux_${i}/valid_in_0
+    ad_connect  $name/enable_in_$i  $name/out_mux_${i}/enable_in_0
+    ad_connect  $name/data_in_$i  $name/out_mux_${i}/data_in_0
+
+    ad_connect  $name/valid_in_$i  $name/${filter_name}_${i}/s_axis_data_tvalid
+    ad_connect  $name/enable_in_$i  $name/out_mux_${i}/enable_in_1
+    ad_connect  $name/data_in_$i  $name/${filter_name}_${i}/s_axis_data_tdata
+
+    ad_connect  $name/${filter_name}_${i}/m_axis_data_tvalid  $name/out_mux_${i}/valid_in_1
+    ad_connect  $name/${filter_name}_${i}/m_axis_data_tdata  $name/out_mux_${i}/data_in_1
+
+    ad_connect  $name/valid_out_$i  $name/out_mux_${i}/valid_out
+    ad_connect  $name/enable_out_$i  $name/out_mux_${i}/enable_out
+    ad_connect  $name/data_out_$i  $name/out_mux_${i}/data_out
+
+    ad_connect  $name/out_mux_${i}/select_path  $name/active
+  }
+}
+
+
+###################################################################################################
+###################################################################################################
+##
+# ad_add_interpolation_filter - Creates a subsystem based on the Xilinx fir_compiler IP.
+# \param[name] - Subsystem name
+# \param[filter_rate] - Filter rate. E.g., 8
+# \param[n_chan] - Number of channels to filter
+# \param[parallel_paths] - Number of paralell paths. For scenarios where
+# the sampling rate is x times the core clock.
+# \param[core_clk_mhz] - Core clock in MHz
+# \param[sampl_freq_mhz] - Sampling frequency in MHz
+proc ad_add_interpolation_filter {name filter_rate n_chan parallel_paths \
+                                 core_clk_mhz sampl_freq_mhz coe_file} {
+  global ad_hdl_dir
+
+  create_bd_cell -type hier $name
+  set filter_name "fir_interpolation"
+
+  add_files -norecurse $ad_hdl_dir/library/common/ad_bus_mux.v
+  add_files -norecurse $ad_hdl_dir/library/common/util_pulse_gen.v
+
+  create_bd_pin -dir I $name/aclk
+  create_bd_pin -dir I $name/active
+
+  # Create pulse generator for ready/valid signals - This is required because
+  # there is only one clock domain for the slave and master data paths.
+  # The generator will give a 1 clock cycle pulse every N clock cycle periods.
+  # N = data  rate.
+  create_bd_cell -type module -reference util_pulse_gen $name/rate_gen
+  set_property -dict [list \
+    CONFIG.PULSE_WIDTH {1} \
+    CONFIG.PULSE_PERIOD [expr $filter_rate -1]] [get_bd_cells $name/rate_gen]
+
+  ad_connect  $name/aclk  $name/rate_gen/clk
+  ad_connect  $name/rate_gen/pulse_width  GND
+  ad_connect  $name/rate_gen/pulse_period  GND
+  ad_connect  $name/rate_gen/load_config  GND
+  ad_connect  $name/active  $name/rate_gen/rstn
+
+  # add filter instances for n channels
+  for {set i 0} {$i < $n_chan} {incr i} {
+    ad_ip_instance fir_compiler $name/${filter_name}_${i} [ list \
+      Decimation_Rate 1 \
+      Filter_Type "Interpolation" \
+      Interpolation_Rate $filter_rate \
+      Number_Paths $parallel_paths \
+      Clock_Frequency $core_clk_mhz \
+      Sample_Frequency $sampl_freq_mhz \
+      CoefficientSource COE_File \
+      Coefficient_File $coe_file \
+      Coefficient_Fractional_Bits 0 \
+      Data_Fractional_Bits 15 \
+      Coefficient_Sets 1 \
+      Coefficient_Sign Signed \
+      Coefficient_Structure Inferred \
+      Coefficient_Width 16 \
+      ColumnConfig 5 \
+      Filter_Architecture Systolic_Multiply_Accumulate \
+      Number_Channels 1 \
+      Output_Rounding_Mode Symmetric_Rounding_to_Zero \
+      Output_Width 16 \
+      Quantization Integer_Coefficients \
+      RateSpecification Frequency_Specification \
+      Zero_Pack_Factor 1
+    ]
+
+    ad_connect $name/aclk $name/${filter_name}_${i}/aclk
+
+    create_bd_pin -dir I $name/dac_valid_$i
+    create_bd_pin -dir I $name/dac_enable_$i
+    create_bd_pin -dir O $name/valid_out_$i
+    create_bd_pin -dir O $name/enable_out_$i
+    create_bd_pin -dir I -from [expr 16*$parallel_paths-1] -to 0 $name/data_in_$i
+    create_bd_pin -dir O -from [expr 16*$parallel_paths-1] -to 0 $name/data_out_$i
+
+    ad_ip_instance util_vector_logic $name/logic_and_$i [list \
+      C_SIZE 1]
+
+    create_bd_cell -type module -reference ad_bus_mux $name/out_mux_$i
+    set_property -dict [list \
+      CONFIG.DATA_WIDTH [expr 16 * $parallel_paths]] [get_bd_cells $name/out_mux_$i]
+
+    ad_connect  $name/rate_gen/pulse  $name/logic_and_$i/Op1
+    ad_connect  $name/dac_valid_$i  $name/logic_and_$i/Op2
+    ad_connect  $name/logic_and_$i/Res  $name/${filter_name}_${i}/s_axis_data_tvalid
+    ad_connect  $name/${filter_name}_${i}/s_axis_data_tdata  $name/data_in_$i
+
+    ad_connect  $name/rate_gen/pulse  $name/out_mux_${i}/valid_in_1
+    ad_connect  $name/dac_enable_$i  $name/out_mux_${i}/enable_in_1
+    ad_connect  $name/${filter_name}_${i}/m_axis_data_tdata  $name/out_mux_${i}/data_in_1
+
+    ad_connect  $name/dac_valid_$i  $name/out_mux_${i}/valid_in_0
+    ad_connect  $name/dac_enable_$i  $name/out_mux_${i}/enable_in_0
+    ad_connect  $name/data_in_$i  $name/out_mux_${i}/data_in_0
+
+    ad_connect  $name/out_mux_${i}/valid_out  $name/valid_out_$i
+    ad_connect  $name/out_mux_${i}/enable_out  $name/enable_out_$i
+    ad_connect  $name/out_mux_${i}/data_out  $name/data_out_$i
+
+    ad_connect  $name/active  $name/out_mux_${i}/select_path
+  }
+}
+

--- a/projects/scripts/adi_board.tcl
+++ b/projects/scripts/adi_board.tcl
@@ -335,6 +335,9 @@ proc ad_xcvrpll {m_src m_dst} {
   }
 }
 
+###################################################################################################
+###################################################################################################
+
 ## Create an memory mapped interface connection to a MIG or PS7/8 IP, using a
 #  HP0 high speed interface in case of PSx.
 #


### PR DESCRIPTION
Add generic fir filters(decimation/interpolation by a factor of 8) for adrv9371x and adrv9009.
The filters are bypassed by default. To activate them set:
- gpio[61](EMIO) - decimation filter
- gpio[62](EMIO) - interpolation filter

Tested on:
 - adrv9371 zc706 and zcu102
 - adrv9009 zcu102