### PR TITLE
Update adi_env.tcl scripts

### DIFF
--- a/library/scripts/adi_env.tcl
+++ b/library/scripts/adi_env.tcl
@@ -2,14 +2,16 @@
 # environment related stuff
 
 set ad_hdl_dir [file normalize [file join [file dirname [info script]] "../.."]]
-set ad_phdl_dir $ad_hdl_dir
+
+# assuming that ghdl is cloned next to hdl repository
+set ad_ghdl_dir [file normalize [file join [file dirname [info script]] "../../../ghdl"]]
 
 
 if [info exists ::env(ADI_HDL_DIR)] {
   set ad_hdl_dir [file normalize $::env(ADI_HDL_DIR)]
 }
 
-if [info exists ::env(ADI_PHDL_DIR)] {
-  set ad_phdl_dir [file normalize $::env(ADI_PHDL_DIR)]
+if [info exists ::env(ADI_GHDL_DIR)] {
+  set ad_ghdl_dir [file normalize $::env(ADI_GHDL_DIR)]
 }
 

--- a/projects/common/intel/sys_gen.tcl
+++ b/projects/common/intel/sys_gen.tcl
@@ -22,7 +22,7 @@ if {[string compare $QUARTUS_VERSION $REQUIRED_QUARTUS_VERSION] != 0} {
 
 # library paths
 
-set ad_lib_folders "$ad_hdl_dir/library/**/*;$ad_phdl_dir/library/**/*"
+set ad_lib_folders "$ad_hdl_dir/library/**/*;$ad_ghdl_dir/library/**/*"
 
 set_user_option -name USER_IP_SEARCH_PATHS $ad_lib_folders
 set_global_assignment -name IP_SEARCH_PATHS $ad_lib_folders
@@ -37,7 +37,7 @@ if [info exists ::env(NIOS_MMU_ENABLED)] {
 set QFILE [open "system_qsys_script.tcl" "w"]
 puts $QFILE "set mmu_enabled $mmu_enabled"
 puts $QFILE "set ad_hdl_dir $ad_hdl_dir"
-puts $QFILE "set ad_phdl_dir $ad_phdl_dir"
+puts $QFILE "set ad_ghdl_dir $ad_ghdl_dir"
 puts $QFILE "source system_qsys.tcl"
 puts $QFILE "set_interconnect_requirement {\$system} {qsys_mm.clockCrossingAdapter} {FIFO}"
 puts $QFILE "set_interconnect_requirement {\$system} {qsys_mm.maxAdditionalLatency} {2}"

--- a/projects/scripts/adi_env.tcl
+++ b/projects/scripts/adi_env.tcl
@@ -2,14 +2,16 @@
 # environment related stuff
 
 set ad_hdl_dir [file normalize [file join [file dirname [info script]] "../.."]]
-set ad_phdl_dir $ad_hdl_dir
+
+# assuming that ghdl is cloned next to hdl repository
+set ad_ghdl_dir [file normalize [file join [file dirname [info script]] "../../../ghdl"]]
 
 
 if [info exists ::env(ADI_HDL_DIR)] {
   set ad_hdl_dir [file normalize $::env(ADI_HDL_DIR)]
 }
 
-if [info exists ::env(ADI_PHDL_DIR)] {
-  set ad_phdl_dir [file normalize $::env(ADI_PHDL_DIR)]
+if [info exists ::env(ADI_GHDL_DIR)] {
+G set ad_ghdl_dir [file normalize $::env(ADI_GHDL_DIR)]
 }
 

--- a/projects/scripts/adi_project_intel.tcl
+++ b/projects/scripts/adi_project_intel.tcl
@@ -15,7 +15,7 @@ set version "18.1.0"
 proc adi_project {project_name {parameter_list {}}} {
 
   global ad_hdl_dir
-  global ad_phdl_dir
+  global ad_ghdl_dir
   global family
   global device
   global version
@@ -76,7 +76,7 @@ proc adi_project {project_name {parameter_list {}}} {
 
   # library paths
 
-  set ad_lib_folders "$ad_hdl_dir/library/**/*;$ad_phdl_dir/library/**/*"
+  set ad_lib_folders "$ad_hdl_dir/library/**/*;$ad_ghdl_dir/library/**/*"
 
   set_user_option -name USER_IP_SEARCH_PATHS $ad_lib_folders
   set_global_assignment -name IP_SEARCH_PATHS $ad_lib_folders
@@ -96,7 +96,7 @@ proc adi_project {project_name {parameter_list {}}} {
   set QFILE [open "system_qsys_script.tcl" "w"]
   puts $QFILE "set mmu_enabled $mmu_enabled"
   puts $QFILE "set ad_hdl_dir $ad_hdl_dir"
-  puts $QFILE "set ad_phdl_dir $ad_phdl_dir"
+  puts $QFILE "set ad_ghdl_dir $ad_ghdl_dir"
   puts $QFILE "package require qsys"
   puts $QFILE "set_module_property NAME {system_bd}"
   puts $QFILE "set_project_property DEVICE_FAMILY {$family}"


### PR DESCRIPTION
Our internal repository was changed from phdl to ghdl. Update the
adi_env.tcl scripts and other scripts, which depends on the $ad_ghdl_dir
variable. This way the tools will see all the internal IPs too.