### PR TITLE
zynq:all: fix SPI clock constraint

### DIFF
--- a/projects/common/zc702/zc702_system_constr.xdc
+++ b/projects/common/zc702/zc702_system_constr.xdc
@@ -44,5 +44,5 @@ set_property  -dict {PACKAGE_PIN  G22   IOSTANDARD LVCMOS25} [get_ports gpio_bd[
 set_property  -dict {PACKAGE_PIN  H18   IOSTANDARD LVCMOS25} [get_ports gpio_bd[7]]   ; ## XADC_GPIO_3
 
 # Define SPI clock
-create_clock -name spi0_clk      -period 20   [get_pins -hier */EMIOSPI0SCLKO]
-create_clock -name spi1_clk      -period 20   [get_pins -hier */EMIOSPI1SCLKO]
+create_clock -name spi0_clk      -period 40   [get_pins -hier */EMIOSPI0SCLKO]
+create_clock -name spi1_clk      -period 40   [get_pins -hier */EMIOSPI1SCLKO]

--- a/projects/common/zc706/zc706_system_constr.xdc
+++ b/projects/common/zc706/zc706_system_constr.xdc
@@ -62,5 +62,5 @@ set_property  -dict {PACKAGE_PIN  J16   IOSTANDARD LVCMOS15} [get_ports gpio_bd[
 set_property  -dict {PACKAGE_PIN  J14   IOSTANDARD LVCMOS15} [get_ports gpio_bd[14]]          ; ## XADC_GPIO_3
 
 # Define SPI clock
-create_clock -name spi0_clk      -period 20   [get_pins -hier */EMIOSPI0SCLKO]
-create_clock -name spi1_clk      -period 20   [get_pins -hier */EMIOSPI1SCLKO]
+create_clock -name spi0_clk      -period 40   [get_pins -hier */EMIOSPI0SCLKO]
+create_clock -name spi1_clk      -period 40   [get_pins -hier */EMIOSPI1SCLKO]

--- a/projects/common/zcu102/zcu102_system_constr.xdc
+++ b/projects/common/zcu102/zcu102_system_constr.xdc
@@ -26,5 +26,5 @@ set_property  -dict {PACKAGE_PIN  AH14  IOSTANDARD LVCMOS33} [get_ports gpio_bd_
 set_property  -dict {PACKAGE_PIN  AL12  IOSTANDARD LVCMOS33} [get_ports gpio_bd_o[7]]           ; ## GPIO_LED_7
 
 # Define SPI clock
-create_clock -name spi0_clk      -period 20   [get_pins -hier */EMIOSPI0SCLKO]
-create_clock -name spi1_clk      -period 20   [get_pins -hier */EMIOSPI1SCLKO]
+create_clock -name spi0_clk      -period 40   [get_pins -hier */EMIOSPI0SCLKO]
+create_clock -name spi1_clk      -period 40   [get_pins -hier */EMIOSPI1SCLKO]

--- a/projects/common/zed/zed_system_constr.xdc
+++ b/projects/common/zed/zed_system_constr.xdc
@@ -88,5 +88,5 @@ set_property  -dict {PACKAGE_PIN  J15   IOSTANDARD LVCMOS25} [get_ports gpio_bd[
 set_property  -dict {PACKAGE_PIN  G17   IOSTANDARD LVCMOS25} [get_ports gpio_bd[31]]      ; ## OTG-RESETN
 
 # Define SPI clock
-create_clock -name spi0_clk      -period 20   [get_pins -hier */EMIOSPI0SCLKO]
-create_clock -name spi1_clk      -period 20   [get_pins -hier */EMIOSPI1SCLKO]
+create_clock -name spi0_clk      -period 40   [get_pins -hier */EMIOSPI0SCLKO]
+create_clock -name spi1_clk      -period 40   [get_pins -hier */EMIOSPI1SCLKO]

--- a/projects/m2k/standalone/system_constr.xdc
+++ b/projects/m2k/standalone/system_constr.xdc
@@ -210,5 +210,5 @@ set_switching_activity -static_probability 1 -toggle_rate 0 [get_nets i_system_w
 set_switching_activity -static_probability 0 -toggle_rate 0 [get_nets i_system_wrapper/system_i/logic_analyzer_reset_bus_struct_reset]
 
 # Define SPI clock
-create_clock -name spi0_clk      -period 20   [get_pins -hier */EMIOSPI0SCLKO]
+create_clock -name spi0_clk      -period 40   [get_pins -hier */EMIOSPI0SCLKO]
 

--- a/projects/pluto/system_constr.xdc
+++ b/projects/pluto/system_constr.xdc
@@ -69,6 +69,8 @@ create_clock -name rx_clk -period  16.27 [get_ports rx_clk_in]
 create_clock -name clk_fpga_0 -period 10 [get_pins "i_system_wrapper/system_i/sys_ps7/inst/PS7_i/FCLKCLK[0]"]
 create_clock -name clk_fpga_1 -period  5 [get_pins "i_system_wrapper/system_i/sys_ps7/inst/PS7_i/FCLKCLK[1]"]
 
+create_clock -name spi0_clk      -period 40   [get_pins -hier */EMIOSPI0SCLKO]
+
 set_input_jitter clk_fpga_0 0.3
 set_input_jitter clk_fpga_1 0.15
 


### PR DESCRIPTION
According to data sheets the EMIO SPI controller maximum frequency is
just 25MHz. Constrain the SPI clock accordingly.