### PR TITLE
 axi_adc_trigger: Fix trigger out glitches

### DIFF
--- a/library/axi_adc_trigger/axi_adc_trigger.v
+++ b/library/axi_adc_trigger/axi_adc_trigger.v
@@ -39,7 +39,8 @@ module axi_adc_trigger #(
 
   // parameters
 
-  parameter SIGN_BITS = 2) (
+  parameter SIGN_BITS = 2,
+  parameter OUT_PIN_HOLD_N = 100000) (
 
   // interface
 
@@ -171,13 +172,12 @@ module axi_adc_trigger #(
 
   reg                   trigger_pin_a;
   reg                   trigger_pin_b;
-  reg        [ 1:0]     trigger_o_m;
-  reg        [ 1:0]     trigger_o_m_1;
+  reg        [ 1:0]     trigger_o_m = 1'd0;
 
-  reg                   trig_o_hold_0;
-  reg                   trig_o_hold_1;
-  reg        [16:0]     trig_o_hold_cnt_0;
-  reg        [16:0]     trig_o_hold_cnt_1;
+  reg                   trig_o_hold_0 = 1'b0;
+  reg                   trig_o_hold_1 = 1'b0;
+  reg        [16:0]     trig_o_hold_cnt_0 = 17'd0;
+  reg        [16:0]     trig_o_hold_cnt_1 = 17'd0;
 
   reg                   trigger_adc_a;
   reg                   trigger_adc_b;
@@ -247,26 +247,23 @@ module axi_adc_trigger #(
   // trigger out is acknowledged by the hold counter will be disregarded for 1ms.
   // This was done to avoid noise created by high frequency switches on long
   // wires.
+
   always @(posedge clk) begin
     // trigger_o[0] hold start
-    if ((trigger_o_m[0] != trigger_o_m_1[0]) & (trig_o_hold_cnt_0 == 17'd0)) begin
-      trig_o_hold_cnt_0 <= 17'd100000;
-      trig_o_hold_0 <= trigger_o_m[0];
-    end
     if (trig_o_hold_cnt_0 != 17'd0) begin
       trig_o_hold_cnt_0 <= trig_o_hold_cnt_0 - 17'd1;
+    end else if (trig_o_hold_0 != trigger_o_m[0]) begin
+      trig_o_hold_cnt_0 <= OUT_PIN_HOLD_N;
+      trig_o_hold_0 <= trigger_o_m[0];
     end
-    trigger_o_m_1[0] <= trigger_o_m[0];
 
     // trigger_o[1] hold start
-    if ((trigger_o_m[1] != trigger_o_m_1[1]) & (trig_o_hold_cnt_1 == 17'd0)) begin
-      trig_o_hold_cnt_1 <= 17'd100000;
-      trig_o_hold_1 <= trigger_o_m[1];
-    end
     if (trig_o_hold_cnt_1 != 17'd0) begin
       trig_o_hold_cnt_1 <= trig_o_hold_cnt_1 - 17'd1;
+    end else if (trig_o_hold_1 != trigger_o_m[1]) begin
+      trig_o_hold_cnt_1 <= OUT_PIN_HOLD_N;
+      trig_o_hold_1 <= trigger_o_m[1];
     end
-    trigger_o_m_1[1] <= trigger_o_m[1];
 
     // hold
     trigger_o[0] <= (trig_o_hold_cnt_0 == 'd0) ? trigger_o_m[0] : trig_o_hold_0;


### PR DESCRIPTION
Currently trigger out pin is hold for 1ms in the next transition state(t+1) state(0 or 1), but not in the state that follows (t+2). This commit fixes this issue.

Tested on M2k.