### PR TITLE
adi_jesd204: Configure fPLL phase aligned mode

### DIFF
--- a/library/intel/adi_jesd204/adi_jesd204_hw.tcl
+++ b/library/intel/adi_jesd204/adi_jesd204_hw.tcl
@@ -386,9 +386,12 @@ proc jesd204_compose {} {
     add_instance link_pll altera_xcvr_fpll_a10 $version
     set_instance_parameter_value link_pll {gui_fpll_mode} {0}
     set_instance_parameter_value link_pll {gui_reference_clock_frequency} $refclk_frequency
-    set_instance_parameter_value link_pll {gui_number_of_output_clocks} 1
+    set_instance_parameter_value link_pll {gui_number_of_output_clocks} 2
+    set_instance_parameter_value link_pll {gui_enable_phase_alignment} 1
     set_instance_parameter_value link_pll {gui_desired_outclk0_frequency} $linkclk_frequency
     set_instance_parameter_value link_pll {enable_pll_reconfig} {1}
+    set pfdclk_frequency [get_instance_parameter_value link_pll gui_pfd_frequency]
+    set_instance_parameter_value link_pll {gui_desired_outclk1_frequency} $pfdclk_frequency
 
     set outclk_name "outclk0"
 


### PR DESCRIPTION
In phase aligned mode the fPLL uses an external feedback path to better
align the phase of the PLL output to the phase of the external reference
clock.

This mode is required for deterministic latency to be able to sample SYSREF
which is source synchronous to the external reference clock signal.

So far phase aligned mode had been disabled since manual PLL calibration
would fail in this mode under certain (unknown) circumstances and dynamic
reconfiguration of the PLL would not work.

The latest Intel Arria 10 transceiver datasheet contains instructions for
the proper calibration sequence to make it work when the PLL is configured
for phase aligned mode. Software has been updated accordingly, so enable
phase aligned mode.

Signed-off-by: Lars-Peter Clausen <lars@metafoo.de>