### PR TITLE
ad7768-1evb: Remove ADC2 and update spi engine framework

### DIFF
--- a/library/spi_engine/spi_engine_execution/spi_engine_execution.v
+++ b/library/spi_engine/spi_engine_execution/spi_engine_execution.v
@@ -97,6 +97,9 @@ localparam REG_WORD_LENGTH = 2'b10;
 localparam BIT_COUNTER_WIDTH = DATA_WIDTH > 16 ? 5 :
                                DATA_WIDTH > 8  ? 4 : 3;
 
+localparam BIT_COUNTER_CARRY = 2** (BIT_COUNTER_WIDTH + 1);
+localparam BIT_COUNTER_CLEAR = {{8{1'b1}}, {BIT_COUNTER_WIDTH{1'b0}}, 1'b1};
+
 reg sclk_int = 1'b0;
 wire sdo_int_s;
 reg sdo_t_int = 1'b0;
@@ -130,7 +133,7 @@ wire end_of_word;
 
 reg [7:0] sdi_counter = 8'b0;
 
-assign first_bit = bit_counter == 'h0;
+assign first_bit = ((bit_counter == 'h0) ||  (bit_counter == word_length));
 assign last_bit = bit_counter == word_length - 1;
 assign end_of_word = last_bit == 1'b1 && ntx_rx == 1'b1 && clk_div_last == 1'b1;
 
@@ -142,20 +145,6 @@ reg [7:0] clk_div = DEFAULT_CLK_DIV;
 
 wire sdo_enabled = cmd_d1[8];
 wire sdi_enabled = cmd_d1[9];
-
-wire last_sdi_bit = (sdi_counter == word_length-1);
-
-wire trigger_tx = trigger == 1'b1 && ntx_rx == 1'b0;
-wire trigger_rx = trigger == 1'b1 && ntx_rx == 1'b1;
-
-reg trigger_rx_d1 = 1'b0;
-reg trigger_rx_d2 = 1'b0;
-reg trigger_rx_d3 = 1'b0;
-
-wire trigger_rx_s = (SDI_DELAY == 2'b00) ? trigger_rx :
-                    (SDI_DELAY == 2'b01) ? trigger_rx_d1 :
-                    (SDI_DELAY == 2'b10) ? trigger_rx_d2 :
-                    (SDI_DELAY == 2'b11) ? trigger_rx_d3 : trigger_rx;
 
 // supporting max 8 SDI channel
 reg [(DATA_WIDTH-1):0] data_sdo_shift = 'h0;
@@ -240,16 +229,23 @@ always @(posedge clk) begin
   end
 end
 
+wire trigger_tx = trigger == 1'b1 && ntx_rx == 1'b0;
+wire trigger_rx = trigger == 1'b1 && ntx_rx == 1'b1;
 
 wire sleep_counter_compare = sleep_counter == cmd_d1[7:0] && clk_div_last == 1'b1;
 wire cs_sleep_counter_compare = cs_sleep_counter == cmd_d1[9:8] && clk_div_last == 1'b1;
 wire cs_sleep_counter_compare2 = cs_sleep_counter2 == {cmd_d1[9:8],1'b1} && clk_div_last == 1'b1;
 
 always @(posedge clk) begin
-  if (idle == 1'b1)
+  if (idle == 1'b1) begin
     counter <= 'h00;
-  else if (clk_div_last == 1'b1 && wait_for_io == 1'b0)
-    counter <= counter + (transfer_active ? 'h1 : 'h10);
+  end else if (clk_div_last == 1'b1 && wait_for_io == 1'b0) begin
+    if (bit_counter == word_length) begin
+        counter <= (counter & BIT_COUNTER_CLEAR) + (transfer_active ? 'h1 : 'h10) + BIT_COUNTER_CARRY;
+    end else begin
+      counter <= counter + (transfer_active ? 'h1 : 'h10);
+    end
+  end
 end
 
 always @(posedge clk) begin
@@ -310,8 +306,7 @@ assign sync = cmd_d1[7:0];
 always @(posedge clk) begin
   if (resetn == 1'b0)
     sdo_data_ready <= 1'b0;
-  else if (sdo_enabled == 1'b1 && first_bit == 1'b1 && trigger_tx == 1'b1 &&
-    transfer_active == 1'b1)
+  else if (sdo_enabled == 1'b1 && first_bit == 1'b1 && trigger_tx == 1'b1 && transfer_active == 1'b1)
     sdo_data_ready <= 1'b1;
   else if (sdo_data_valid == 1'b1)
     sdo_data_ready <= 1'b0;
@@ -393,11 +388,20 @@ assign sdo_int_s = data_sdo_shift[DATA_WIDTH-1];
 // next SCLK edge must be used to flop the SDI line, to compensate the overall
 // delay of the read path
 
+reg trigger_rx_d1 = 1'b0;
+reg trigger_rx_d2 = 1'b0;
+reg trigger_rx_d3 = 1'b0;
+
 always @(posedge clk) begin
   trigger_rx_d1 <= trigger_rx;
   trigger_rx_d2 <= trigger_rx_d1;
   trigger_rx_d3 <= trigger_rx_d2;
 end
+
+wire trigger_rx_s = (SDI_DELAY == 2'b00) ? trigger_rx :
+                    (SDI_DELAY == 2'b01) ? trigger_rx_d1 :
+                    (SDI_DELAY == 2'b10) ? trigger_rx_d2 :
+                    (SDI_DELAY == 2'b11) ? trigger_rx_d3 : trigger_rx;
 
 always @(posedge clk) begin
   if (inst_d1 == CMD_CHIPSELECT) begin
@@ -442,6 +446,7 @@ assign sdi_data = (NUM_OF_SDI == 1) ? data_sdi_shift :
                                        data_sdi_shift_3, data_sdi_shift_2,
                                        data_sdi_shift_1, data_sdi_shift} : data_sdi_shift;
 
+wire last_sdi_bit = (sdi_counter == word_length-1);
 always @(posedge clk) begin
   if (resetn == 1'b0) begin
     sdi_counter <= 8'b0;
@@ -460,7 +465,7 @@ always @(posedge clk) begin
   end
 end
 
-// Additional register stage to improve timing
+// Additional register stage to imrpove timing
 always @(posedge clk) begin
   sclk <= sclk_int;
   sdo <= sdo_int_s;

--- a/projects/ad77681evb/common/ad77681evb_bd.tcl
+++ b/projects/ad77681evb/common/ad77681evb_bd.tcl
@@ -1,14 +1,12 @@
 
-create_bd_intf_port -mode Master -vlnv analog.com:interface:spi_master_rtl:1.0 adc1_spi
-create_bd_intf_port -mode Master -vlnv analog.com:interface:spi_master_rtl:1.0 adc2_spi
+create_bd_intf_port -mode Master -vlnv analog.com:interface:spi_master_rtl:1.0 adc_spi
 
-create_bd_port -dir I adc1_data_ready
-create_bd_port -dir I adc2_data_ready
+create_bd_port -dir I adc_data_ready
 
-# create a SPI Engine architecture for both ADCs
+# create a SPI Engine architecture for ADC
 
-create_bd_cell -type hier spi_adc1
-current_bd_instance /spi_adc1
+create_bd_cell -type hier spi_adc
+current_bd_instance /spi_adc
 
   create_bd_pin -dir I -type clk clk
   create_bd_pin -dir I -type rst resetn
@@ -17,204 +15,86 @@ current_bd_instance /spi_adc1
   create_bd_intf_pin -mode Master -vlnv analog.com:interface:spi_master_rtl:1.0 m_spi
   create_bd_intf_pin -mode Master -vlnv xilinx.com:interface:axis_rtl:1.0 M_AXIS_SAMPLE
 
-  # DATA_WIDTH is set to 8, so the granularity of the transaction will be 8 bit
-  # So we can to support 16bit 24bit and 32bit transfers
+  # DATA_WIDTH is set to 32
 
   ad_ip_instance spi_engine_execution execution
-  ad_ip_parameter execution CONFIG.DATA_WIDTH 8
+  ad_ip_parameter execution CONFIG.DATA_WIDTH 32
   ad_ip_parameter execution CONFIG.NUM_OF_CS 1
 
-  ad_ip_instance axi_spi_engine axi_1
-  ad_ip_parameter axi_1 CONFIG.DATA_WIDTH 8
-  ad_ip_parameter axi_1 CONFIG.NUM_OFFLOAD 1
+  ad_ip_instance axi_spi_engine axi_regmap
+  ad_ip_parameter axi_regmap CONFIG.DATA_WIDTH 32
+  ad_ip_parameter axi_regmap CONFIG.NUM_OFFLOAD 1
 
   ad_ip_instance spi_engine_offload offload
-  ad_ip_parameter offload CONFIG.DATA_WIDTH 8
+  ad_ip_parameter offload CONFIG.DATA_WIDTH 32
   ad_ip_parameter offload CONFIG.ASYNC_TRIG 1
 
   ad_ip_instance spi_engine_interconnect interconnect
-  ad_ip_parameter interconnect CONFIG.DATA_WIDTH 8
-
-  # to convert the 8bit AXI stream to 24bit AXI stream
-  ad_ip_instance axis_dwidth_converter m_axis_samples_24
-  ad_ip_parameter m_axis_samples_24 CONFIG.M_TDATA_NUM_BYTES 3
-
-  # upscale the data to 32bit, samples should be multiple of 16bit
-  ad_ip_instance util_axis_upscale axis_upscaler
-  ad_ip_parameter axis_upscaler CONFIG.NUM_OF_CHANNELS 1
-  ad_ip_parameter axis_upscaler CONFIG.DATA_WIDTH 24
-  ad_ip_parameter axis_upscaler CONFIG.UDATA_WIDTH 32
-  ad_connect axis_upscaler/dfmt_enable GND
-  ad_connect axis_upscaler/dfmt_type GND
-  ad_connect axis_upscaler/dfmt_se GND
-
-  ad_connect axi_1/spi_engine_offload_ctrl0 offload/spi_engine_offload_ctrl
+  ad_ip_parameter interconnect CONFIG.DATA_WIDTH 32
+  
+  ad_connect axi_regmap/spi_engine_offload_ctrl0 offload/spi_engine_offload_ctrl
   ad_connect offload/spi_engine_ctrl interconnect/s0_ctrl
-  ad_connect axi_1/spi_engine_ctrl interconnect/s1_ctrl
+  ad_connect axi_regmap/spi_engine_ctrl interconnect/s1_ctrl
   ad_connect interconnect/m_ctrl execution/ctrl
-  ad_connect offload/offload_sdi m_axis_samples_24/S_AXIS
-  ad_connect m_axis_samples_24/M_AXIS axis_upscaler/s_axis
-  ad_connect axis_upscaler/m_axis M_AXIS_SAMPLE
-
+  ad_connect offload/offload_sdi M_AXIS_SAMPLE
+ 
   ad_connect execution/spi m_spi
 
   ad_connect clk offload/spi_clk
   ad_connect clk offload/ctrl_clk
   ad_connect clk execution/clk
-  ad_connect clk axi_1/s_axi_aclk
-  ad_connect clk axi_1/spi_clk
+  ad_connect clk axi_regmap/s_axi_aclk
+  ad_connect clk axi_regmap/spi_clk
   ad_connect clk interconnect/clk
-  ad_connect clk m_axis_samples_24/aclk
-  ad_connect clk axis_upscaler/clk
-
-  ad_connect axi_1/spi_resetn offload/spi_resetn
-  ad_connect axi_1/spi_resetn execution/resetn
-  ad_connect axi_1/spi_resetn interconnect/resetn
-  ad_connect axi_1/spi_resetn m_axis_samples_24/aresetn
-  ad_connect axi_1/spi_resetn axis_upscaler/resetn
-
+  
+  ad_connect axi_regmap/spi_resetn offload/spi_resetn
+  ad_connect axi_regmap/spi_resetn execution/resetn
+  ad_connect axi_regmap/spi_resetn interconnect/resetn
+ 
   ad_connect drdy offload/trigger
 
-  ad_connect resetn axi_1/s_axi_aresetn
-  ad_connect irq axi_1/irq
+  ad_connect resetn axi_regmap/s_axi_aresetn
+  ad_connect irq axi_regmap/irq
+
 
 current_bd_instance /
 
-create_bd_cell -type hier spi_adc2
-current_bd_instance /spi_adc2
+ad_connect adc_data_ready spi_adc/drdy
 
-  create_bd_pin -dir I -type clk clk
-  create_bd_pin -dir I -type rst resetn
-  create_bd_pin -dir I drdy
-  create_bd_pin -dir O irq
-  create_bd_intf_pin -mode Master -vlnv analog.com:interface:spi_master_rtl:1.0 m_spi
-  create_bd_intf_pin -mode Master -vlnv xilinx.com:interface:axis_rtl:1.0 M_AXIS_SAMPLE
+# dma for the ADC
 
-  ad_ip_instance spi_engine_execution execution
-  ad_ip_parameter execution CONFIG.DATA_WIDTH 8
-  ad_ip_parameter execution CONFIG.NUM_OF_CS 1
+ad_ip_instance axi_dmac axi_ad77681_dma
+ad_ip_parameter axi_ad77681_dma CONFIG.DMA_TYPE_SRC 1
+ad_ip_parameter axi_ad77681_dma CONFIG.DMA_TYPE_DEST 0
+ad_ip_parameter axi_ad77681_dma CONFIG.CYCLIC 0
+ad_ip_parameter axi_ad77681_dma CONFIG.SYNC_TRANSFER_START 0
+ad_ip_parameter axi_ad77681_dma CONFIG.AXI_SLICE_SRC 0
+ad_ip_parameter axi_ad77681_dma CONFIG.AXI_SLICE_DEST 1
+ad_ip_parameter axi_ad77681_dma CONFIG.DMA_2D_TRANSFER 0
+ad_ip_parameter axi_ad77681_dma CONFIG.DMA_DATA_WIDTH_SRC 32
+ad_ip_parameter axi_ad77681_dma CONFIG.DMA_DATA_WIDTH_DEST 64
 
-  ad_ip_instance axi_spi_engine axi_2
-  ad_ip_parameter axi_2 CONFIG.DATA_WIDTH 8
-  ad_ip_parameter axi_2 CONFIG.NUM_OFFLOAD 1
+ad_connect  sys_cpu_clk spi_adc/clk
+ad_connect  sys_cpu_resetn spi_adc/resetn
+ad_connect  sys_cpu_resetn axi_ad77681_dma/m_dest_axi_aresetn
 
-  ad_ip_instance spi_engine_offload offload
-  ad_ip_parameter offload CONFIG.DATA_WIDTH 8
-  ad_ip_parameter offload CONFIG.ASYNC_TRIG 1
+ad_connect  spi_adc/m_spi adc_spi
+ad_connect  axi_ad77681_dma/s_axis spi_adc/M_AXIS_SAMPLE
 
-  ad_ip_instance spi_engine_interconnect interconnect
-  ad_ip_parameter interconnect CONFIG.DATA_WIDTH 8
-
-  # to convert the 8bit AXI stream to 24bit AXI stream
-  ad_ip_instance axis_dwidth_converter m_axis_samples_24
-  ad_ip_parameter m_axis_samples_24 CONFIG.M_TDATA_NUM_BYTES 3
-
-  # upscale the data to 32bit, samples should be multiple of 16bit
-  ad_ip_instance util_axis_upscale axis_upscaler
-  ad_ip_parameter axis_upscaler CONFIG.NUM_OF_CHANNELS 1
-  ad_ip_parameter axis_upscaler CONFIG.DATA_WIDTH 24
-  ad_ip_parameter axis_upscaler CONFIG.UDATA_WIDTH 32
-  ad_connect axis_upscaler/dfmt_enable GND
-  ad_connect axis_upscaler/dfmt_type GND
-  ad_connect axis_upscaler/dfmt_se GND
-
-  ad_connect axi_2/spi_engine_offload_ctrl0 offload/spi_engine_offload_ctrl
-  ad_connect offload/spi_engine_ctrl interconnect/s0_ctrl
-  ad_connect axi_2/spi_engine_ctrl interconnect/s1_ctrl
-  ad_connect interconnect/m_ctrl execution/ctrl
-  ad_connect offload/offload_sdi m_axis_samples_24/S_AXIS
-  ad_connect m_axis_samples_24/M_AXIS axis_upscaler/s_axis
-  ad_connect axis_upscaler/m_axis M_AXIS_SAMPLE
-
-  ad_connect execution/spi m_spi
-
-  ad_connect clk offload/spi_clk
-  ad_connect clk offload/ctrl_clk
-  ad_connect clk execution/clk
-  ad_connect clk axi_2/s_axi_aclk
-  ad_connect clk axi_2/spi_clk
-  ad_connect clk interconnect/clk
-  ad_connect clk m_axis_samples_24/aclk
-  ad_connect clk axis_upscaler/clk
-
-  ad_connect axi_2/spi_resetn offload/spi_resetn
-  ad_connect axi_2/spi_resetn execution/resetn
-  ad_connect axi_2/spi_resetn interconnect/resetn
-  ad_connect axi_2/spi_resetn m_axis_samples_24/aresetn
-  ad_connect axi_2/spi_resetn axis_upscaler/resetn
-
-  ad_connect drdy offload/trigger
-
-  ad_connect resetn axi_2/s_axi_aresetn
-  ad_connect irq axi_2/irq
-
-current_bd_instance /
-
-ad_connect adc1_data_ready spi_adc1/drdy
-ad_connect adc2_data_ready spi_adc2/drdy
-
-# dma for the ADC1
-
-ad_ip_instance axi_dmac axi_ad77681_dma_1
-ad_ip_parameter axi_ad77681_dma_1 CONFIG.DMA_TYPE_SRC 1
-ad_ip_parameter axi_ad77681_dma_1 CONFIG.DMA_TYPE_DEST 0
-ad_ip_parameter axi_ad77681_dma_1 CONFIG.CYCLIC 0
-ad_ip_parameter axi_ad77681_dma_1 CONFIG.SYNC_TRANSFER_START 0
-ad_ip_parameter axi_ad77681_dma_1 CONFIG.AXI_SLICE_SRC 0
-ad_ip_parameter axi_ad77681_dma_1 CONFIG.AXI_SLICE_DEST 1
-ad_ip_parameter axi_ad77681_dma_1 CONFIG.DMA_2D_TRANSFER 0
-ad_ip_parameter axi_ad77681_dma_1 CONFIG.DMA_DATA_WIDTH_SRC 32
-ad_ip_parameter axi_ad77681_dma_1 CONFIG.DMA_DATA_WIDTH_DEST 64
-
-ad_connect  sys_cpu_clk spi_adc1/clk
-ad_connect  sys_cpu_resetn spi_adc1/resetn
-ad_connect  sys_cpu_resetn axi_ad77681_dma_1/m_dest_axi_aresetn
-
-ad_connect  spi_adc1/m_spi adc1_spi
-ad_connect  axi_ad77681_dma_1/s_axis spi_adc1/M_AXIS_SAMPLE
-
-# dma for the ADC2
-
-ad_ip_instance axi_dmac axi_ad77681_dma_2
-ad_ip_parameter axi_ad77681_dma_2 CONFIG.DMA_TYPE_SRC 1
-ad_ip_parameter axi_ad77681_dma_2 CONFIG.DMA_TYPE_DEST 0
-ad_ip_parameter axi_ad77681_dma_2 CONFIG.CYCLIC 0
-ad_ip_parameter axi_ad77681_dma_2 CONFIG.SYNC_TRANSFER_START 0
-ad_ip_parameter axi_ad77681_dma_2 CONFIG.AXI_SLICE_SRC 0
-ad_ip_parameter axi_ad77681_dma_2 CONFIG.AXI_SLICE_DEST 1
-ad_ip_parameter axi_ad77681_dma_2 CONFIG.DMA_2D_TRANSFER 0
-ad_ip_parameter axi_ad77681_dma_2 CONFIG.DMA_DATA_WIDTH_SRC 32
-ad_ip_parameter axi_ad77681_dma_2 CONFIG.DMA_DATA_WIDTH_DEST 64
-
-ad_connect  sys_cpu_clk spi_adc2/clk
-ad_connect  sys_cpu_resetn spi_adc2/resetn
-ad_connect  sys_cpu_resetn axi_ad77681_dma_2/m_dest_axi_aresetn
-
-ad_connect  spi_adc2/m_spi adc2_spi
-ad_connect  axi_ad77681_dma_2/s_axis spi_adc2/M_AXIS_SAMPLE
 
 # AXI address definitions
 
-ad_cpu_interconnect 0x44a00000 spi_adc1/axi_1
-ad_cpu_interconnect 0x44b00000 spi_adc2/axi_2
-ad_cpu_interconnect 0x44a30000 axi_ad77681_dma_1
-ad_cpu_interconnect 0x44b30000 axi_ad77681_dma_2
+ad_cpu_interconnect 0x44a00000 spi_adc/axi_regmap
+ad_cpu_interconnect 0x44a30000 axi_ad77681_dma
 
-ad_connect sys_cpu_clk axi_ad77681_dma_1/s_axis_aclk
-ad_connect sys_cpu_clk axi_ad77681_dma_2/s_axis_aclk
+ad_connect sys_cpu_clk axi_ad77681_dma/s_axis_aclk
 
 # interrupts
 
-ad_cpu_interrupt "ps-13" "mb-13" axi_ad77681_dma_1/irq
-ad_cpu_interrupt "ps-12" "mb-12" axi_ad77681_dma_2/irq
-ad_cpu_interrupt "ps-11" "mb-11" spi_adc1/irq
-ad_cpu_interrupt "ps-10" "mb-10" spi_adc2/irq
+ad_cpu_interrupt "ps-13" "mb-13" axi_ad77681_dma/irq
+ad_cpu_interrupt "ps-11" "mb-11" spi_adc/irq
 
 # memory interconnects
 
-ad_mem_hp2_interconnect sys_cpu_clk sys_ps7/S_AXI_HP2
-ad_mem_hp2_interconnect sys_cpu_clk axi_ad77681_dma_1/m_dest_axi
-
-ad_mem_hp3_interconnect sys_cpu_clk sys_ps7/S_AXI_HP3
-ad_mem_hp3_interconnect sys_cpu_clk axi_ad77681_dma_2/m_dest_axi
-
+ad_mem_hp2_interconnect sys_cpu_clk sys_ps7/S_AXI_HP0
+ad_mem_hp2_interconnect sys_cpu_clk axi_ad77681_dma/m_dest_axi

--- a/projects/ad77681evb/zed/system_constr.xdc
+++ b/projects/ad77681evb/zed/system_constr.xdc
@@ -1,41 +1,25 @@
 
 # SPI interface
 
-set_property -dict {PACKAGE_PIN  N19 IOSTANDARD LVCMOS25 IOB TRUE}                  [get_ports ad7768_0_spi_sclk]    ; ## FMC_LPC_LA01_CC_P
-set_property -dict {PACKAGE_PIN  P17 IOSTANDARD LVCMOS25 IOB TRUE PULLTYPE PULLUP}  [get_ports ad7768_0_spi_miso]    ; ## FMC_LPC_LA02_P
-set_property -dict {PACKAGE_PIN  N22 IOSTANDARD LVCMOS25}                           [get_ports ad7768_0_spi_mosi]    ; ## FMC_LPC_LA03_P
-set_property -dict {PACKAGE_PIN  M21 IOSTANDARD LVCMOS25}                           [get_ports ad7768_0_spi_cs]      ; ## FMC_LPC_LA04_P
-
-set_property -dict {PACKAGE_PIN  N20 IOSTANDARD LVCMOS25 IOB TRUE}                  [get_ports ad7768_1_spi_sclk]    ; ## FMC_LPC_LA01_CC_N
-set_property -dict {PACKAGE_PIN  P18 IOSTANDARD LVCMOS25 IOB TRUE PULLTYPE PULLUP}  [get_ports ad7768_1_spi_miso]    ; ## FMC_LPC_LA02_N
-set_property -dict {PACKAGE_PIN  P22 IOSTANDARD LVCMOS25}                           [get_ports ad7768_1_spi_mosi]    ; ## FMC_LPC_LA03_N
-set_property -dict {PACKAGE_PIN  M22 IOSTANDARD LVCMOS25}                           [get_ports ad7768_1_spi_cs]      ; ## FMC_LPC_LA04_N
+set_property -dict {PACKAGE_PIN  N19 IOSTANDARD LVCMOS25 IOB TRUE}                  [get_ports ad7768_spi_sclk]    ; ## FMC_LPC_LA01_CC_P
+set_property -dict {PACKAGE_PIN  P17 IOSTANDARD LVCMOS25 IOB TRUE PULLTYPE PULLUP}  [get_ports ad7768_spi_miso]    ; ## FMC_LPC_LA02_P
+set_property -dict {PACKAGE_PIN  N22 IOSTANDARD LVCMOS25}                           [get_ports ad7768_spi_mosi]    ; ## FMC_LPC_LA03_P
+set_property -dict {PACKAGE_PIN  M21 IOSTANDARD LVCMOS25}                           [get_ports ad7768_spi_cs]      ; ## FMC_LPC_LA04_P
 
 # reset and GPIO signals
 
-set_property -dict {PACKAGE_PIN  P20 IOSTANDARD LVCMOS25}                           [get_ports ad7768_0_reset]       ; ## FMC_LPC_LA12_P
-set_property -dict {PACKAGE_PIN  J21 IOSTANDARD LVCMOS25}                           [get_ports ad7768_0_gpio[0]]     ; ## FMC_LPC_LA08_P
-set_property -dict {PACKAGE_PIN  R20 IOSTANDARD LVCMOS25}                           [get_ports ad7768_0_gpio[1]]     ; ## FMC_LPC_LA09_P
-set_property -dict {PACKAGE_PIN  R19 IOSTANDARD LVCMOS25}                           [get_ports ad7768_0_gpio[2]]     ; ## FMC_LPC_LA10_P
-set_property -dict {PACKAGE_PIN  N17 IOSTANDARD LVCMOS25}                           [get_ports ad7768_0_gpio[3]]     ; ## FMC_LPC_LA11_P
-
-set_property -dict {PACKAGE_PIN  P21 IOSTANDARD LVCMOS25}                           [get_ports ad7768_1_reset]       ; ## FMC_LPC_LA12_N
-set_property -dict {PACKAGE_PIN  J22 IOSTANDARD LVCMOS25}                           [get_ports ad7768_1_gpio[0]]     ; ## FMC_LPC_LA08_N
-set_property -dict {PACKAGE_PIN  R21 IOSTANDARD LVCMOS25}                           [get_ports ad7768_1_gpio[1]]     ; ## FMC_LPC_LA09_N
-set_property -dict {PACKAGE_PIN  T19 IOSTANDARD LVCMOS25}                           [get_ports ad7768_1_gpio[2]]     ; ## FMC_LPC_LA10_N
-set_property -dict {PACKAGE_PIN  N18 IOSTANDARD LVCMOS25}                           [get_ports ad7768_1_gpio[3]]     ; ## FMC_LPC_LA11_N
+set_property -dict {PACKAGE_PIN  P20 IOSTANDARD LVCMOS25}                           [get_ports ad7768_reset]       ; ## FMC_LPC_LA12_P
+set_property -dict {PACKAGE_PIN  J21 IOSTANDARD LVCMOS25}                           [get_ports ad7768_gpio[0]]     ; ## FMC_LPC_LA08_P
+set_property -dict {PACKAGE_PIN  R20 IOSTANDARD LVCMOS25}                           [get_ports ad7768_gpio[1]]     ; ## FMC_LPC_LA09_P
+set_property -dict {PACKAGE_PIN  R19 IOSTANDARD LVCMOS25}                           [get_ports ad7768_gpio[2]]     ; ## FMC_LPC_LA10_P
+set_property -dict {PACKAGE_PIN  N17 IOSTANDARD LVCMOS25}                           [get_ports ad7768_gpio[3]]     ; ## FMC_LPC_LA11_P
 
 # syncronization and timing
 
-set_property -dict {PACKAGE_PIN  J18 IOSTANDARD LVCMOS25 IOB TRUE}                  [get_ports ad7768_0_drdy]        ; ## FMC_LPC_LA05_P
-set_property -dict {PACKAGE_PIN  L19 IOSTANDARD LVCMOS25}                           [get_ports ad7768_0_sync_out]    ; ## FMC_LPC_CLK0_M2C_N
-set_property -dict {PACKAGE_PIN  L21 IOSTANDARD LVCMOS25}                           [get_ports ad7768_0_sync_in]     ; ## FMC_LPC_LA06_P
-set_property -dict {PACKAGE_PIN  M19 IOSTANDARD LVCMOS25}                           [get_ports ad7768_0_mclk]        ; ## FMC_LPC_LA00_CC_P
+set_property -dict {PACKAGE_PIN  J18 IOSTANDARD LVCMOS25 IOB TRUE}                  [get_ports ad7768_drdy]        ; ## FMC_LPC_LA05_P
+set_property -dict {PACKAGE_PIN  L19 IOSTANDARD LVCMOS25}                           [get_ports ad7768_sync_out]    ; ## FMC_LPC_CLK0_M2C_N
+set_property -dict {PACKAGE_PIN  L21 IOSTANDARD LVCMOS25}                           [get_ports ad7768_sync_in]     ; ## FMC_LPC_LA06_P
+set_property -dict {PACKAGE_PIN  M19 IOSTANDARD LVCMOS25}                           [get_ports ad7768_mclk]        ; ## FMC_LPC_LA00_CC_P
 
-set_property -dict {PACKAGE_PIN  K18 IOSTANDARD LVCMOS25 IOB TRUE}                  [get_ports ad7768_1_drdy]        ; ## FMC_LPC_LA05_N
-set_property -dict {PACKAGE_PIN  T16 IOSTANDARD LVCMOS25}                           [get_ports ad7768_1_sync_out]    ; ## FMC_LPC_LA07_P
-set_property -dict {PACKAGE_PIN  L22 IOSTANDARD LVCMOS25}                           [get_ports ad7768_1_sync_in]     ; ## FMC_LPC_LA06_N
-set_property -dict {PACKAGE_PIN  M20 IOSTANDARD LVCMOS25}                           [get_ports ad7768_1_mclk]        ; ## FMC_LPC_LA00_CC_N
-
-set_property -dict {PACKAGE_PIN  L18 IOSTANDARD LVCMOS25}                           [get_ports ad7768_mclk_return]   ; ## FMC_LPC_LA00_CC_P
+set_property -dict {PACKAGE_PIN  L18 IOSTANDARD LVCMOS25}                           [get_ports ad7768_mclk_return]   ; ## FMC_LPC_CLK0_M2C_P
 

--- a/projects/ad77681evb/zed/system_top.v
+++ b/projects/ad77681evb/zed/system_top.v
@@ -84,31 +84,19 @@ module system_top (
 
   input           otg_vbusoc,
 
-  inout           ad7768_0_reset,
-  inout           ad7768_0_sync_out,
-  inout           ad7768_0_sync_in,
-  inout   [ 3:0]  ad7768_0_gpio,
+  inout           ad7768_reset,
+  inout           ad7768_sync_out,
+  inout           ad7768_sync_in,
+  inout   [ 3:0]  ad7768_gpio,
 
-  inout           ad7768_1_reset,
-  inout           ad7768_1_sync_out,
-  inout           ad7768_1_sync_in,
-  inout   [ 3:0]  ad7768_1_gpio,
-
-  input           ad7768_0_mclk,
-  input           ad7768_1_mclk,
+  input           ad7768_mclk,
   output          ad7768_mclk_return,
 
-  input           ad7768_0_spi_miso,
-  output          ad7768_0_spi_mosi,
-  output          ad7768_0_spi_sclk,
-  output          ad7768_0_spi_cs,
-  input           ad7768_0_drdy,
-
-  input           ad7768_1_spi_miso,
-  output          ad7768_1_spi_mosi,
-  output          ad7768_1_spi_sclk,
-  output          ad7768_1_spi_cs,
-  input           ad7768_1_drdy);
+  input           ad7768_spi_miso,
+  output          ad7768_spi_mosi,
+  output          ad7768_spi_sclk,
+  output          ad7768_spi_cs,
+  input           ad7768_drdy);
 
   // internal signals
 
@@ -121,51 +109,31 @@ module system_top (
   wire    [ 1:0]  iic_mux_sda_i_s;
   wire    [ 1:0]  iic_mux_sda_o_s;
   wire            iic_mux_sda_t_s;
-  wire            ad7768_0_mclk_s;
-  wire            ad7768_1_mclk_s;
+  wire            ad7768_mclk_s;
 
   // instantiations
 
-  ad_data_clk #(.SINGLE_ENDED (1)) i_ad7768_0_mclk_receiver(
+  ad_data_clk #(.SINGLE_ENDED (1)) i_ad7768_mclk_receiver(
     .rst (1'b1),
     .locked (),
     .clk_in_p (ad7768_0_mclk),
     .clk_in_n (1'd0),
-    .clk(ad7768_0_mclk_s));
-
-  ad_data_clk #(.SINGLE_ENDED (1)) i_ad7768_1_mclk_receiver(
-    .rst (1'b1),
-    .locked (),
-    .clk_in_p (ad7768_1_mclk),
-    .clk_in_n (1'd0),
-    .clk(ad7768_1_mclk_s));
-
-  assign ad7768_mclk_return = ad7768_0_mclk_s;
+    .clk(ad7768_mclk_s));
+  
+  assign ad7768_mclk_return = ad7768_mclk_s;
 
   ad_iobuf #(
     .DATA_WIDTH(7)
-  ) i_iobuf_ad7768_1_gpio (
-    .dio_t(gpio_t[54:48]),
-    .dio_i(gpio_o[54:48]),
-    .dio_o(gpio_i[54:48]),
-    .dio_p({ad7768_1_gpio,
-            ad7768_1_sync_in,
-            ad7768_1_sync_out,
-            ad7768_1_reset}));
-
-  ad_iobuf #(
-    .DATA_WIDTH(7)
-  ) i_iobuf_ad7768_0_gpio (
+  ) i_iobuf_ad7768_gpio (
     .dio_t(gpio_t[38:32]),
     .dio_i(gpio_o[38:32]),
     .dio_o(gpio_i[38:32]),
-    .dio_p({ad7768_0_gpio,
-            ad7768_0_sync_in,
-            ad7768_0_sync_out,
-            ad7768_0_reset}));
+    .dio_p({ad7768_gpio,
+            ad7768_sync_in,
+            ad7768_sync_out,
+            ad7768_reset}));
 
-  assign gpio_i[47:39] = gpio_o[47:39];
-  assign gpio_i[63:55] = gpio_o[63:55];
+  assign gpio_i[63:39] = gpio_o[63:39];
 
   ad_iobuf #(
     .DATA_WIDTH(32)
@@ -175,8 +143,7 @@ module system_top (
     .dio_o(gpio_i[31:0]),
     .dio_p(gpio_bd));
 
-  assign gpio_i[47:39] = gpio_o[47:39];
-  assign gpio_i[63:55] = gpio_o[63:55];
+  assign gpio_i[63:39] = gpio_o[63:39];
 
   ad_iobuf #(
     .DATA_WIDTH(2)
@@ -239,18 +206,30 @@ module system_top (
     .iic_mux_sda_t (iic_mux_sda_t_s),
     .otg_vbusoc (otg_vbusoc),
     .spdif (spdif),
-    .adc1_spi_sdo (ad7768_0_spi_mosi),
-    .adc1_spi_sdo_t (),
-    .adc1_spi_sdi (ad7768_0_spi_miso),
-    .adc1_spi_cs (ad7768_0_spi_cs),
-    .adc1_spi_sclk (ad7768_0_spi_sclk),
-    .adc1_data_ready (ad7768_0_drdy),
-    .adc2_spi_sdo (ad7768_1_spi_mosi),
-    .adc2_spi_sdo_t (),
-    .adc2_spi_sdi (ad7768_1_spi_miso),
-    .adc2_spi_cs (ad7768_1_spi_cs),
-    .adc2_spi_sclk (ad7768_1_spi_sclk),
-    .adc2_data_ready (ad7768_1_drdy));
+    .spi0_clk_i (1'b0),
+    .spi0_clk_o (),
+    .spi0_csn_0_o (),
+    .spi0_csn_1_o (),
+    .spi0_csn_2_o (),
+    .spi0_csn_i (1'b1),
+    .spi0_sdi_i (1'b0),
+    .spi0_sdo_i (1'b0),
+    .spi0_sdo_o (),
+    .spi1_clk_i (1'b0),
+    .spi1_clk_o (),
+    .spi1_csn_0_o (),
+    .spi1_csn_1_o (),
+    .spi1_csn_2_o (),
+    .spi1_csn_i (1'b1),
+    .spi1_sdi_i (1'b0),
+    .spi1_sdo_i (1'b0),
+    .spi1_sdo_o (),
+    .adc_spi_sdo (ad7768_spi_mosi),
+    .adc_spi_sdo_t (),
+    .adc_spi_sdi (ad7768_spi_miso),
+    .adc_spi_cs (ad7768_spi_cs),
+    .adc_spi_sclk (ad7768_spi_sclk),
+    .adc_data_ready (ad7768_drdy));
 
 endmodule
 


### PR DESCRIPTION
The second ADC was removed from the project, as the EV-AD7768-1FMCZ evaluation
board contains only one ADC. Therefore, all the IPs related to the
second ADC have been removed, too.