### PR TITLE
Dev m2k equal data delay

### DIFF
--- a/library/axi_adc_trigger/axi_adc_trigger.v
+++ b/library/axi_adc_trigger/axi_adc_trigger.v
@@ -62,7 +62,7 @@ module axi_adc_trigger #(
   output                data_valid_a_trig,
   output                data_valid_b_trig,
   output                trigger_out,
-  output reg            trigger_out_la,
+  output                trigger_out_la,
 
   output      [31:0]    fifo_depth,
 
@@ -198,6 +198,7 @@ module axi_adc_trigger #(
   reg        [31:0]     trigger_delay_counter;
   reg                   triggered;
   reg                   trigger_out_m1;
+  reg                   trigger_out_m2;
 
   reg                   streaming_on;
   reg                   trigger_out_hold;
@@ -275,6 +276,7 @@ module axi_adc_trigger #(
   // The data goes through and it is delayed with 4 clock cycles)
   always @(posedge clk) begin
     trigger_out_m1 <= trigger_out_s;
+    trigger_out_m2 <= trigger_out_m1;
     if (trigger_out_m1 & ~trigger_out_s) begin
       trigger_out_hold <= 1'b1;
     end
@@ -285,10 +287,10 @@ module axi_adc_trigger #(
     trigger_out_ack <= trigger_out_hold & (data_valid_a | data_valid_b);
 
     // triggers logic analyzer
-    trigger_out_la <= trigger_out_mixed;
   end
 
-  assign trigger_out = trigger_out_hold | trigger_out_m1;
+  assign trigger_out_la = trigger_out_mixed;
+  assign trigger_out = trigger_out_hold | trigger_out_m2;
 
   // the embedded trigger does not require any extra delay, since the util_extract
   // present in this case, delays the trigger with 2 clock cycles

--- a/library/axi_logic_analyzer/axi_logic_analyzer.v
+++ b/library/axi_logic_analyzer/axi_logic_analyzer.v
@@ -35,7 +35,13 @@
 
 `timescale 1ns/100ps
 
-module axi_logic_analyzer (
+module axi_logic_analyzer #(
+
+  // add sample delays on LA to compensate for adc path delay
+
+  parameter ADC_PATH_DELAY = 19) (
+
+  // interface
 
   input                 clk,
   output                clk_out,
@@ -45,7 +51,7 @@ module axi_logic_analyzer (
   output      [15:0]    data_t,
   input       [ 1:0]    trigger_i,
 
-  output reg            adc_valid,
+  output                adc_valid,
   output      [15:0]    adc_data,
 
   input       [15:0]    dac_data,
@@ -83,7 +89,6 @@ module axi_logic_analyzer (
 
   // internal registers
 
-  reg     [15:0]    data_m1 = 'd0;
   reg     [15:0]    data_r = 'd0;
   reg     [ 1:0]    trigger_m1 = 'd0;
   reg     [31:0]    downsampler_counter_la = 'd0;
@@ -107,7 +112,7 @@ module axi_logic_analyzer (
 
   reg               streaming_on;
 
-  reg     [15:0]    adc_data_m2 = 'd0;
+  reg     [15:0]    adc_data_mn = 'd0;
 
   // internal signals
 
@@ -156,7 +161,7 @@ module axi_logic_analyzer (
   assign trigger_out = trigger_delay == 32'h0 ? trigger_out_s | streaming_on : trigger_out_delayed | streaming_on;
   assign trigger_out_delayed = delay_counter == 32'h0 ? 1 : 0;
 
-  assign adc_data = adc_data_m2;
+  assign adc_data = adc_data_mn;
 
  always @(posedge clk_out) begin
     if (trigger_delay == 0) begin
@@ -218,26 +223,38 @@ module axi_logic_analyzer (
     .I1 (data_i[0]),
     .S (clock_select));
 
-  // synchronization
+  // - synchronization
+  // - compensate for m2k adc path delay
+  // - transfer data at clock frequency if capture is enabled
 
-  always @(posedge clk_out) begin
-    if (sample_valid_la == 1'b1) begin
-      data_m1 <= data_i;
-      trigger_m1 <= trigger_i;
+  genvar j;
+
+  generate
+
+    reg [15:0] data_m[ADC_PATH_DELAY-2:0];
+
+    always @(posedge clk_out) begin
+      if (sample_valid_la == 1'b1) begin
+        data_m[0] <= data_i;
+      end
     end
-  end
 
-  // transfer data at clock frequency
-  // if capture is enabled
-
-  always @(posedge clk_out) begin
-    if (sample_valid_la == 1'b1) begin
-      adc_data_m2  <= data_m1;
-      adc_valid <= 1'b1;
-    end else begin
-      adc_valid <= 1'b0;
+    for (j = 0; j < ADC_PATH_DELAY - 2; j = j + 1) begin
+      always @(posedge clk_out) begin
+        if (sample_valid_la == 1'b1) begin
+          data_m[j+1] <= data_m[j];
+        end
+      end
     end
-  end
+
+    always @(posedge clk_out) begin
+      if (sample_valid_la == 1'b1) begin
+        adc_data_mn <= data_m[ADC_PATH_DELAY-2];
+      end
+    end
+  endgenerate
+
+  assign adc_valid = sample_valid_la;
 
   // downsampler logic analyzer
 
@@ -295,7 +312,7 @@ module axi_logic_analyzer (
     .clk (clk_out),
     .reset (reset),
 
-    .data (adc_data_m2),
+    .data (adc_data_mn),
     .data_valid(sample_valid_la),
     .trigger_i (trigger_m1),
     .trigger_in (trigger_in),
@@ -329,7 +346,7 @@ module axi_logic_analyzer (
     .clock_select (clock_select),
     .overwrite_enable (overwrite_enable),
     .overwrite_data (overwrite_data),
-    .input_data (adc_data_m2),
+    .input_data (adc_data_mn),
     .od_pp_n (od_pp_n),
 
     .triggered (up_triggered),

--- a/library/axi_logic_analyzer/axi_logic_analyzer_trigger.v
+++ b/library/axi_logic_analyzer/axi_logic_analyzer_trigger.v
@@ -66,13 +66,11 @@ module axi_logic_analyzer_trigger (
   reg              trigger_active;
   reg              trigger_active_mux;
   reg              trigger_active_d1;
-  reg              trigger_active_d2;
 
   always @(posedge clk) begin
     if (data_valid == 1'b1) begin
       trigger_active_d1 <= trigger_active_mux;
-      trigger_active_d2 <= trigger_active_d1;
-      trigger_out <= trigger_active_d2;
+      trigger_out <= trigger_active_d1;
       trigger_out_adc <= trigger_active_mux;
     end
   end
@@ -82,20 +80,22 @@ module axi_logic_analyzer_trigger (
   // 0 OR
   // 1 AND
 
-  always @(*) begin
-    case (trigger_logic[0])
-      0: trigger_active = |((edge_detect & edge_detect_enable) |
-                            (rise_edge & rise_edge_enable) |
-                            (fall_edge & fall_edge_enable) |
-                            (low_level & low_level_enable) |
-                            (high_level & high_level_enable));
-      1: trigger_active = &((edge_detect | ~edge_detect_enable) &
-                            (rise_edge | ~rise_edge_enable) &
-                            (fall_edge | ~fall_edge_enable) &
-                            (low_level | ~low_level_enable) &
-                            (high_level | ~high_level_enable));
-      default: trigger_active = 1'b1;
-    endcase
+  always @(posedge clk) begin
+    if (data_valid == 1'b1) begin
+      case (trigger_logic[0])
+        0: trigger_active <= |((edge_detect & edge_detect_enable) |
+                               (rise_edge & rise_edge_enable) |
+                               (fall_edge & fall_edge_enable) |
+                               (low_level & low_level_enable) |
+                               (high_level & high_level_enable));
+        1: trigger_active <= &((edge_detect | ~edge_detect_enable) &
+                               (rise_edge | ~rise_edge_enable) &
+                               (fall_edge | ~fall_edge_enable) &
+                               (low_level | ~low_level_enable) &
+                               (high_level | ~high_level_enable));
+        default: trigger_active = 1'b1;
+      endcase
+    end
   end
 
   always @(*) begin

--- a/projects/m2k/standalone/system_constr.xdc
+++ b/projects/m2k/standalone/system_constr.xdc
@@ -70,7 +70,7 @@ create_clock -name clk_fpga_0 -period 36 [get_pins "i_system_wrapper/system_i/sy
 create_clock -name clk_fpga_1 -period  5 [get_pins "i_system_wrapper/system_i/sys_ps7/inst/PS7_i/FCLKCLK[1]"]
 create_clock -name clk_fpga_3 -period 18 [get_pins "i_system_wrapper/system_i/sys_ps7/inst/PS7_i/FCLKCLK[3]"]
 
-set_false_path -from [get_clocks data_clk] -to [get_pins {i_system_wrapper/system_i/logic_analyzer/inst/data_m1_reg[0]/D}]
+set_false_path -from [get_clocks data_clk] -to [get_cells {i_system_wrapper/system_i/logic_analyzer/inst/genblk*data_m*}]
 
 set_clock_groups -name exclusive_ -physically_exclusive \
 -group  [get_clocks data_clk] -group  [get_clocks rx_clk]


### PR DESCRIPTION
Equalize the delay paths for data and trigger between the axi_adc trigger and axi_logic_analyzer.
This will increase a bit the utilization, gaining reduced the trigger source delay uncertainty and reduce the software effort in compensating for that delay.

Tested on M2k.