### PR TITLE
common/vcu118: Balance clocks

### DIFF
--- a/projects/ad9208_dual_ebz/vcu118/system_bd.tcl
+++ b/projects/ad9208_dual_ebz/vcu118/system_bd.tcl
@@ -34,10 +34,3 @@ foreach i {0 1} {
 }
 
 
-# Set the smart interconnect to use a lower speed switch to meet timing
-set_property -dict [list CONFIG.ADVANCED_PROPERTIES {  __view__ { \
-    timing { M00_Buffer { AR_SLR_PIPE 1 AW_SLR_PIPE 1 B_SLR_PIPE 1 R_SLR_PIPE 1 W_SLR_PIPE 1 } } \
-    clocking { SW0 { ASSOCIATED_CLK aclk1 } } \
-  } }] [get_bd_cells axi_mem_interconnect]
-
-

--- a/projects/ad9208_dual_ebz/vcu118/system_constr.xdc
+++ b/projects/ad9208_dual_ebz/vcu118/system_constr.xdc
@@ -89,20 +89,3 @@ set_input_delay -clock [get_clocks global_clk_0] \
   [expr [get_property PERIOD [get_clocks global_clk_0]] / 2] \
   [get_ports {rx_sysref_*}]
 
-# Place the sysref capture FFs near Bank 43, they can't be placed into the IOB due pulse width violation.
-# Creating the pblock prevents the tool from placing the FFs on another SLR and not closing timing.
-create_pblock pblock_sysref
-resize_pblock pblock_sysref -add SLICE_X50Y254:SLICE_X50Y278
-add_cells_to_pblock pblock_sysref [get_cells \
-  [list i_system_wrapper/system_i/axi_ad9208_1_jesd/rx/inst/i_lmfc/sysref_r_reg \
-        i_system_wrapper/system_i/axi_ad9208_0_jesd/rx/inst/i_lmfc/sysref_r_reg]]
-
-# Place the data path in SLR1 for a better timing closure
-create_pblock adc_data_path
-resize_pblock adc_data_path -add CLOCKREGION_X0Y5:CLOCKREGION_X2Y9
-add_cells_to_pblock adc_data_path [get_cells \
-  [list i_system_wrapper/system_i/util_ad9208_cpack \
-        i_system_wrapper/system_i/rx_ad9208_0_tpl_core \
-        i_system_wrapper/system_i/rx_ad9208_1_tpl_core \
-        i_system_wrapper/system_i/axi_ad9208_dma \
-        i_system_wrapper/system_i/axi_ad9208_fifo]] -clear_locs

--- a/projects/common/vcu118/vcu118_system_constr.xdc
+++ b/projects/common/vcu118/vcu118_system_constr.xdc
@@ -57,3 +57,16 @@ set_property -dict  {PACKAGE_PIN  AL24  IOSTANDARD  LVCMOS18  DRIVE 8 SLEW SLOW}
 create_generated_clock -name spi_clk  \
   -source [get_pins i_system_wrapper/system_i/axi_spi/ext_spi_clk] \
   -divide_by 2 [get_pins i_system_wrapper/system_i/axi_spi/sck_o]
+
+
+# Balance clocks
+#
+# Minimize skew on synchronous CDC timing paths between clocks originating 
+# from the same MMCM source. (sys_mem_clk and sys_cpu_clk)
+# This is required mostly by the smart interconnect.
+# Property must be applied directly to the output net of BUFGs.
+set_property CLOCK_DELAY_GROUP BALANCE_CLOCKS \
+  [list [get_nets [get_property PARENT [get_nets {i_system_wrapper/system_i/sys_cpu_clk}]]] \
+        [get_nets [get_property PARENT [get_nets {i_system_wrapper/system_i/sys_mem_clk}]]] \
+  ]
+


### PR DESCRIPTION
Minimize skew on synchronous CDC timing paths between clocks originating
from the same MMCM source. (sys_mem_clk and sys_cpu_clk)
This is required mostly by the smart interconnect.
The CLOCK_DELAY_GROUP property must be applied directly to the output net of BUFGs.

See: https://forums.xilinx.com/t5/AXI-Infrastructure/Smartconnect-and-Synchronous-Clock-Domain-Crossing-Issues/td-p/904824

Tested with all VCU118 project. Compile only.
