### PR TITLE
spi_engine: Update pulse generation

### DIFF
--- a/library/spi_engine/axi_spi_engine/axi_spi_engine.v
+++ b/library/spi_engine/axi_spi_engine/axi_spi_engine.v
@@ -121,8 +121,9 @@ module axi_spi_engine #(
 
   output offload0_mem_reset,
   output offload0_enable,
-  input offload0_enabled
-  );
+  input offload0_enabled,
+  output reg [31:0] pulse_gen_period,
+  output reg pulse_gen_load);
 
   localparam PCORE_VERSION = 'h010071;
   localparam S_AXI = 0;
@@ -281,18 +282,29 @@ module axi_spi_engine #(
   reg offload0_mem_reset_reg;
   wire offload0_enabled_s;
 
+  
+  always @(posedge clk) begin
+    if ((up_waddr_s == 8'h48) && (up_wreq_s == 1'b1)) begin
+      pulse_gen_load <= 1'b1;
+    end else begin
+      pulse_gen_load <= 1'b0;
+    end
+  end
+
   // the software reset should reset all the registers
   always @(posedge clk) begin
     if (up_sw_resetn == 1'b0) begin
       up_irq_mask <= 'h00;
       offload0_enable_reg <= 1'b0;
       offload0_mem_reset_reg <= 1'b0;
+      pulse_gen_period <= 'h00;
     end else begin
       if (up_wreq_s) begin
         case (up_waddr_s)
           8'h20: up_irq_mask <= up_wdata_s;
           8'h40: offload0_enable_reg <= up_wdata_s[0];
           8'h42: offload0_mem_reset_reg <= up_wdata_s[0];
+          8'h48: pulse_gen_period <= up_wdata_s;
         endcase
       end
     end
@@ -324,6 +336,7 @@ module axi_spi_engine #(
       8'h3c: up_rdata_ff <= sdi_fifo_out_data; /* PEEK register */
       8'h40: up_rdata_ff <= {offload0_enable_reg};
       8'h41: up_rdata_ff <= {offload0_enabled_s};
+      8'h48: up_rdata_ff <= pulse_gen_period;
       default: up_rdata_ff <= 'h00;
     endcase
   end

--- a/projects/adaq7980_sdz/common/adaq7980_bd.tcl
+++ b/projects/adaq7980_sdz/common/adaq7980_bd.tcl
@@ -17,12 +17,15 @@ current_bd_instance /spi
   ad_ip_instance spi_engine_offload offload
   ad_ip_instance spi_engine_interconnect interconnect
   ad_ip_instance util_pulse_gen trigger_gen
+  ad_ip_instance xlconstant trigger_gen_pulse_width
 
   ad_ip_parameter offload CONFIG.DATA_WIDTH 16
   ad_ip_parameter axi CONFIG.DATA_WIDTH 16
   ad_ip_parameter interconnect CONFIG.DATA_WIDTH 16
   ad_ip_parameter execution CONFIG.DATA_WIDTH 16
-
+  ad_ip_parameter trigger_gen_pulse_width CONFIG.CONST_WIDTH 32
+  ad_ip_parameter trigger_gen_pulse_width CONFIG.CONST_VAL 1
+  
   ## to setup the sample rate of the system change the PULSE_PERIOD value
   ## the acutal sample rate will be PULSE_PERIOD * (1/sys_cpu_clk)
   set cycle_per_sec_100mhz 100000000
@@ -53,12 +56,10 @@ current_bd_instance /spi
   ad_connect axi/spi_resetn execution/resetn
   ad_connect axi/spi_resetn interconnect/resetn
   ad_connect axi/spi_resetn trigger_gen/rstn
-  ad_connect trigger_gen/load_config GND
-  ad_connect trigger_gen/pulse_width GND
-  ad_connect trigger_gen/pulse_period GND
-
+  ad_connect trigger_gen/load_config axi/pulse_gen_load
+  ad_connect trigger_gen/pulse_period axi/pulse_gen_period
+  ad_connect trigger_gen_pulse_width/dout trigger_gen/pulse_width
   ad_connect trigger_gen/pulse offload/trigger
-
   ad_connect resetn axi/s_axi_aresetn
   ad_connect irq axi/irq
 


### PR DESCRIPTION
The pulse period had a fixed value. Therefore, in order to be able
to configure it from the software, a 32b register pulse_period_reg
was added in axi_spi_engine. Also, to generate the pulse, the
output register pulse_gen_loadc was added.