### PR TITLE
cn0506_rgmii/zcu102: Fix README typo

### DIFF
--- a/projects/cn0506_rgmii/zcu102/README.rst
+++ b/projects/cn0506_rgmii/zcu102/README.rst
@@ -1,3 +1,3 @@
-- Connect to FMC0
+- Connect to FMC1 (The FMC1 was chosen because of the global clock pin distribution on FMC0)
 - Voltage 1.8V
 - RGMII mode, using a GMII-to-RGMII converter. Connected to PS8's Ethernet 0(PHY 0) and Ethernet 1(PHY 1).


### PR DESCRIPTION
cn0506_rgmii/zcu102: Fix README typo.
The daughter card uses FMC1 because of the global clock pins distribution FMC0.