### PR TITLE
ad9361 latency fixes

### DIFF
--- a/library/axi_ad9361/axi_ad9361.v
+++ b/library/axi_ad9361/axi_ad9361.v
@@ -252,6 +252,7 @@ module axi_ad9361 #(
   wire            dac_data_q0_s;
   wire            dac_data_i1_s;
   wire            dac_data_q1_s;
+  wire            dac_sync_enable;
   wire    [12:0]  up_adc_dld_s;
   wire    [64:0]  up_adc_dwdata_s;
   wire    [64:0]  up_adc_drdata_s;
@@ -506,6 +507,7 @@ module axi_ad9361 #(
   assign up_wack_tdd_s  = 1'b0;
   assign up_rack_tdd_s  = 1'b0;
   assign up_rdata_tdd_s = 32'b0;
+  assign dac_sync_enable = adc_valid_s;
   end
   endgenerate
 
@@ -545,6 +547,9 @@ module axi_ad9361 #(
     .up_raddr (up_raddr_s),
     .up_rdata (up_rdata_tdd_s),
     .up_rack (up_rack_tdd_s));
+
+  assign dac_sync_enable = adc_valid_s || tdd_mode_s;
+
   end
   endgenerate
 
@@ -673,6 +678,7 @@ module axi_ad9361 #(
     .delay_clk (delay_clk),
     .delay_rst (),
     .delay_locked (delay_locked_s),
+    .dac_sync_enable (dac_sync_enable),
     .dac_sync_in (dac_sync_in),
     .dac_sync_out (dac_sync_out),
     .dac_enable_i0 (dac_enable_i0),

--- a/library/axi_ad9361/axi_ad9361.v
+++ b/library/axi_ad9361/axi_ad9361.v
@@ -66,6 +66,7 @@ module axi_ad9361 #(
   parameter   DAC_IQCORRECTION_DISABLE = 0,
   parameter   IO_DELAY_GROUP = "dev_if_delay_group",
   parameter   MIMO_ENABLE = 0,
+  parameter   USE_SSI_CLK = 1,
   parameter   DELAY_REFCLK_FREQUENCY = 200) (
 
   // physical interface (receive-lvds)
@@ -334,6 +335,7 @@ module axi_ad9361 #(
     .DAC_IODELAY_ENABLE (DAC_IODELAY_ENABLE),
     .IO_DELAY_GROUP (IO_DELAY_GROUP),
     .CLK_DESKEW (MIMO_ENABLE),
+    .USE_SSI_CLK (USE_SSI_CLK),
     .DELAY_REFCLK_FREQUENCY (DELAY_REFCLK_FREQUENCY))
   i_dev_if (
     .rx_clk_in (rx_clk_in),
@@ -397,6 +399,7 @@ module axi_ad9361 #(
     .DAC_IODELAY_ENABLE (DAC_IODELAY_ENABLE),
     .IO_DELAY_GROUP (IO_DELAY_GROUP),
     .CLK_DESKEW (MIMO_ENABLE),
+    .USE_SSI_CLK (USE_SSI_CLK),
     .DELAY_REFCLK_FREQUENCY (DELAY_REFCLK_FREQUENCY))
   i_dev_if (
     .rx_clk_in_p (rx_clk_in_p),

--- a/library/axi_ad9361/axi_ad9361_tx.v
+++ b/library/axi_ad9361/axi_ad9361_tx.v
@@ -77,6 +77,7 @@ module axi_ad9361_tx #(
 
   // master/slave
 
+  input           dac_sync_enable,
   input           dac_sync_in,
   output          dac_sync_out,
 
@@ -160,6 +161,7 @@ module axi_ad9361_tx #(
   // master/slave
 
   assign dac_data_sync_s = (ID == 0) ? dac_sync_out : dac_sync_in;
+  assign dac_sync_out = dac_sync & dac_sync_enable;
 
   always @(posedge dac_clk) begin
     dac_data_sync <= dac_data_sync_s;
@@ -371,7 +373,7 @@ module axi_ad9361_tx #(
     .mmcm_rst (),
     .dac_clk (dac_clk),
     .dac_rst (dac_rst),
-    .dac_sync (dac_sync_out),
+    .dac_sync (dac_sync),
     .dac_frame (),
     .dac_clksel (dac_clksel),
     .dac_par_type (),

--- a/library/axi_ad9361/intel/axi_ad9361_cmos_if.v
+++ b/library/axi_ad9361/intel/axi_ad9361_cmos_if.v
@@ -40,6 +40,7 @@ module axi_ad9361_cmos_if #(
   parameter   FPGA_TECHNOLOGY = 0,
   parameter   DAC_IODELAY_ENABLE = 0,
   parameter   CLK_DESKEW = 0,
+  parameter   USE_SSI_CLK = 1,
 
   // Dummy parameters, required keep the code consistency(used on Xilinx)
   parameter   IO_DELAY_GROUP = "dev_if_delay_group",

--- a/library/axi_ad9361/intel/axi_ad9361_lvds_if.v
+++ b/library/axi_ad9361/intel/axi_ad9361_lvds_if.v
@@ -42,6 +42,7 @@ module axi_ad9361_lvds_if #(
   parameter   CLK_DESKEW = 0,
 
   // Dummy parameters, required keep the code consistency(used on Xilinx)
+  parameter   USE_SSI_CLK = 1,
   parameter   IO_DELAY_GROUP = "dev_if_delay_group",
   parameter   DELAY_REFCLK_FREQUENCY = 0) (
 

--- a/library/axi_ad9361/xilinx/axi_ad9361_cmos_if.v
+++ b/library/axi_ad9361/xilinx/axi_ad9361_cmos_if.v
@@ -41,6 +41,7 @@ module axi_ad9361_cmos_if #(
   parameter   DAC_IODELAY_ENABLE = 0,
   parameter   IO_DELAY_GROUP = "dev_if_delay_group",
   parameter   CLK_DESKEW = 0,
+  parameter   USE_SSI_CLK = 1,
   parameter   DELAY_REFCLK_FREQUENCY = 200) (
 
   // physical interface (receive)
@@ -597,6 +598,7 @@ module axi_ad9361_cmos_if #(
 
   // device clock interface (receive clock)
 
+  generate if (USE_SSI_CLK == 1) begin
   ad_data_clk #(
     .SINGLE_ENDED (1))
   i_clk (
@@ -605,6 +607,10 @@ module axi_ad9361_cmos_if #(
     .clk_in_p (rx_clk_in),
     .clk_in_n (1'd0),
     .clk (l_clk));
+  end else begin
+    assign l_clk = clk;
+  end
+  endgenerate
 
 endmodule
 

--- a/library/axi_ad9361/xilinx/axi_ad9361_lvds_if.v
+++ b/library/axi_ad9361/xilinx/axi_ad9361_lvds_if.v
@@ -126,14 +126,9 @@ module axi_ad9361_lvds_if #(
   reg                 rx_r1_mode = 'd0;
   reg                 rx_locked_m1 = 'd0;
   reg                 rx_locked = 'd0;
-  reg                 rx_valid = 'd0;
   reg     [ 1:0]      rx_frame = 'd0;
   reg     [ 5:0]      rx_data_1 = 'd0;
   reg     [ 5:0]      rx_data_0 = 'd0;
-  reg     [ 3:0]      rx_frame_d = 'd0;
-  reg     [ 5:0]      rx_data_1_2d = 'd0;
-  reg     [ 5:0]      rx_data_0_2d = 'd0;
-  reg     [ 5:0]      rx_data_1_d = 'd0;
   reg                 adc_valid_p = 'd0;
   reg     [47:0]      adc_data_p = 'd0;
   reg                 adc_status_p = 'd0;
@@ -163,7 +158,6 @@ module axi_ad9361_lvds_if #(
 
   // internal signals
 
-  wire    [ 3:0]      rx_frame_d_s;
   wire    [ 5:0]      rx_data_1_s;
   wire    [ 5:0]      rx_data_0_s;
   wire    [ 1:0]      rx_frame_s;
@@ -210,7 +204,6 @@ module axi_ad9361_lvds_if #(
   // intel-equivalence
 
   always @(posedge l_clk) begin
-    rx_valid <= ~rx_valid;
     rx_frame <= rx_frame_s;
     rx_data_1 <= rx_data_1_s;
     rx_data_0 <= rx_data_0_s;
@@ -218,36 +211,21 @@ module axi_ad9361_lvds_if #(
 
   // frame check
 
-  assign rx_frame_d_s = {rx_frame_s, rx_frame};
-
-  always @(posedge l_clk) begin
-    if (rx_valid == 1'd1) begin
-      if (rx_r1_mode == 1'd1) begin
-        rx_frame_d <= rx_frame_d_s;
-      end else begin
-        rx_frame_d <= ~rx_frame_d_s;
-      end
-    end
-  end
-
-  // data hold
-
-  always @(posedge l_clk) begin
-    if (rx_valid == 1'd1) begin
-      rx_data_1_2d <= rx_data_1_s;
-      rx_data_0_2d <= rx_data_0_s;
-      rx_data_1_d <= rx_data_1;
-    end
-  end
 
   // delineation
+  reg             rx_error_r1 = 'd0;
+  reg             rx_error_r2 = 'd0;
 
   always @(posedge l_clk) begin
-    if (rx_valid == 1'b1) begin
+    rx_error_r1 <= ~((rx_frame_s == 4'b1100) || (rx_frame_s == 4'b0011));
+    rx_error_r2 <= ~((rx_frame_s == 4'b1111) || (rx_frame_s == 4'b1100) ||
+                     (rx_frame_s == 4'b0000) || (rx_frame_s == 4'b0011));
+  end
+
+  always @(posedge l_clk) begin
       case ({rx_r1_mode, rx_frame_s, rx_frame})
         5'b01111: begin
           adc_valid_p <= 1'b0;
-          adc_data_p[47:24] <= 24'd0;
           adc_data_p[23:12] <= {rx_data_1, rx_data_1_s};
           adc_data_p[11: 0] <= {rx_data_0, rx_data_0_s};
         end
@@ -255,43 +233,6 @@ module axi_ad9361_lvds_if #(
           adc_valid_p <= 1'b1;
           adc_data_p[47:36] <= {rx_data_1, rx_data_1_s};
           adc_data_p[35:24] <= {rx_data_0, rx_data_0_s};
-          adc_data_p[23: 0] <= adc_data_p[23:0];
-        end
-        5'b00111: begin
-          adc_valid_p <= 1'b0;
-          adc_data_p[47:24] <= 24'd0;
-          adc_data_p[23:12] <= {rx_data_0, rx_data_0_s};
-          adc_data_p[11: 0] <= {rx_data_1_2d, rx_data_1};
-        end
-        5'b01000: begin
-          adc_valid_p <= 1'b1;
-          adc_data_p[47:36] <= {rx_data_0, rx_data_0_s};
-          adc_data_p[35:24] <= {rx_data_1_2d, rx_data_1};
-          adc_data_p[23: 0] <= adc_data_p[23:0];
-        end
-        5'b00011: begin
-          adc_valid_p <= 1'b0;
-          adc_data_p[47:24] <= 24'd0;
-          adc_data_p[23:12] <= {rx_data_1_2d, rx_data_1};
-          adc_data_p[11: 0] <= {rx_data_0_2d, rx_data_0};
-        end
-        5'b01100: begin
-          adc_valid_p <= 1'b1;
-          adc_data_p[47:36] <= {rx_data_1_2d, rx_data_1};
-          adc_data_p[35:24] <= {rx_data_0_2d, rx_data_0};
-          adc_data_p[23: 0] <= adc_data_p[23:0];
-        end
-        5'b00001: begin
-          adc_valid_p <= 1'b0;
-          adc_data_p[47:24] <= 24'd0;
-          adc_data_p[23:12] <= {rx_data_0_2d, rx_data_0};
-          adc_data_p[11: 0] <= {rx_data_1_d, rx_data_1_2d};
-        end
-        5'b01110: begin
-          adc_valid_p <= 1'b1;
-          adc_data_p[47:36] <= {rx_data_0_2d, rx_data_0};
-          adc_data_p[35:24] <= {rx_data_1_d, rx_data_1_2d};
-          adc_data_p[23: 0] <= adc_data_p[23:0];
         end
         5'b10011: begin
           adc_valid_p <= 1'b1;
@@ -299,44 +240,19 @@ module axi_ad9361_lvds_if #(
           adc_data_p[23:12] <= {rx_data_1, rx_data_1_s};
           adc_data_p[11: 0] <= {rx_data_0, rx_data_0_s};
         end
-        5'b11001: begin
-          adc_valid_p <= 1'b1;
-          adc_data_p[47:24] <= 24'd0;
-          adc_data_p[23:12] <= {rx_data_0, rx_data_0_s};
-          adc_data_p[11: 0] <= {rx_data_1_2d, rx_data_1};
-        end
-        5'b11100: begin
-          adc_valid_p <= 1'b1;
-          adc_data_p[47:24] <= 24'd0;
-          adc_data_p[23:12] <= {rx_data_1_2d, rx_data_1};
-          adc_data_p[11: 0] <= {rx_data_0_2d, rx_data_0};
-        end
-        5'b10110: begin
-          adc_valid_p <= 1'b1;
-          adc_data_p[47:24] <= 24'd0;
-          adc_data_p[23:12] <= {rx_data_0_2d, rx_data_0};
-          adc_data_p[11: 0] <= {rx_data_1_d, rx_data_1_2d};
-        end
         default: begin
           adc_valid_p <= 1'b0;
-          adc_data_p <= 48'd0;
         end
       endcase
-    end else begin
-      adc_valid_p <= 1'b0;
-      adc_data_p <= adc_data_p;
-    end
   end
 
   // adc-status
 
   always @(posedge l_clk) begin
-    if (rx_valid == 1'b1) begin
-      if (rx_frame_d == rx_frame_d_s) begin
-        adc_status_p <= rx_locked;
-      end else begin
-        adc_status_p <= 1'b0;
-      end
+    if (adc_r1_mode == 1'b1) begin
+      adc_status_p <= ~rx_error_r1 & rx_locked;
+    end else begin
+      adc_status_p <= ~rx_error_r2 & rx_locked;
     end
   end
 

--- a/library/axi_ad9361/xilinx/axi_ad9361_lvds_if.v
+++ b/library/axi_ad9361/xilinx/axi_ad9361_lvds_if.v
@@ -41,6 +41,7 @@ module axi_ad9361_lvds_if #(
   parameter   DAC_IODELAY_ENABLE = 0,
   parameter   IO_DELAY_GROUP = "dev_if_delay_group",
   parameter   CLK_DESKEW = 0,
+  parameter   USE_SSI_CLK = 1,
   parameter   DELAY_REFCLK_FREQUENCY = 200) (
 
   // physical interface (receive)
@@ -690,7 +691,7 @@ module axi_ad9361_lvds_if #(
     .delay_locked ());
 
   // device clock interface (receive clock)
-
+  generate if (USE_SSI_CLK == 1) begin
   ad_data_clk
   i_clk (
     .rst (1'd0),
@@ -698,6 +699,10 @@ module axi_ad9361_lvds_if #(
     .clk_in_p (rx_clk_in_p),
     .clk_in_n (rx_clk_in_n),
     .clk (l_clk));
+  end else begin
+    assign l_clk = clk;
+  end
+  endgenerate
 
 endmodule
 

--- a/projects/fmcomms5/common/fmcomms5_bd.tcl
+++ b/projects/fmcomms5/common/fmcomms5_bd.tcl
@@ -49,7 +49,6 @@ ad_connect $sys_cpu_resetn sys_100m_resetn
 ad_ip_instance axi_ad9361 axi_ad9361_0
 ad_ip_parameter axi_ad9361_0 CONFIG.ID 0
 ad_ip_parameter axi_ad9361_0 CONFIG.IO_DELAY_GROUP dev_0_if_delay_group
-ad_ip_parameter axi_ad9361_0 CONFIG.MIMO_ENABLE 1
 ad_connect $sys_iodelay_clk axi_ad9361_0/delay_clk
 ad_connect axi_ad9361_0/l_clk axi_ad9361_0/clk
 ad_connect axi_ad9361_0/dac_sync_out axi_ad9361_0/dac_sync_in
@@ -75,7 +74,7 @@ ad_connect up_txnrx_0 axi_ad9361_0/up_txnrx
 ad_ip_instance axi_ad9361 axi_ad9361_1
 ad_ip_parameter axi_ad9361_1 CONFIG.ID 1
 ad_ip_parameter axi_ad9361_1 CONFIG.IO_DELAY_GROUP dev_1_if_delay_group
-ad_ip_parameter axi_ad9361_1 CONFIG.MIMO_ENABLE 1
+ad_ip_parameter axi_ad9361_1 CONFIG.USE_SSI_CLK 0
 ad_connect $sys_iodelay_clk axi_ad9361_1/delay_clk
 ad_connect axi_ad9361_0/l_clk axi_ad9361_1/clk
 ad_connect axi_ad9361_0/dac_sync_out axi_ad9361_1/dac_sync_in


### PR DESCRIPTION
this commit allows the following:
- having fixed latency from Tx to Rx application layer interface of axi_ad9361  
- having synchronized Rx channels at sample level from both ad9361 in fmcomms5

Tested with: 
zc706 + fmcomms2
zc706 + fmcomms5
zcu102 + fmcomms2 
zcu102 + fmcomms5
