### PR TITLE
adrv9009_zu11eg_som: i2s fix

### DIFF
--- a/projects/adrv9009_zu11eg_som/carrier_bd.tcl
+++ b/projects/adrv9009_zu11eg_som/carrier_bd.tcl
@@ -7,17 +7,6 @@ create_bd_intf_port -mode Master -vlnv analog.com:interface:i2s_rtl:1.0 i2s
 create_bd_port -dir I axi_fan_tacho_i
 create_bd_port -dir O axi_fan_pwm_o
 
-# 12.288MHz clk
-ad_ip_instance axi_clkgen sys_audio_clkgen
-ad_ip_parameter sys_audio_clkgen CONFIG.ID 6
-ad_ip_parameter sys_audio_clkgen CONFIG.CLKIN_PERIOD 10
-ad_ip_parameter sys_audio_clkgen CONFIG.VCO_DIV 2
-ad_ip_parameter sys_audio_clkgen CONFIG.VCO_MUL 21
-ad_ip_parameter sys_audio_clkgen CONFIG.CLK0_DIV 85.5
-
-ad_connect sys_cpu_clk sys_audio_clkgen/clk
-ad_connect sys_i2s_mclk sys_audio_clkgen/clk_0
-
 # i2s ip
 ad_ip_instance axi_i2s_adi axi_i2s_adi
 ad_ip_parameter axi_i2s_adi CONFIG.DMA_TYPE 0
@@ -63,8 +52,8 @@ ad_connect i2s_rx_dma/s_axis_data axi_i2s_adi/m_axis_tdata
 ad_connect i2s_rx_dma/s_axis_valid axi_i2s_adi/m_axis_tvalid
 ad_connect i2s_rx_dma/s_axis_ready axi_i2s_adi/m_axis_tready
 ad_connect i2s axi_i2s_adi/I2S
-ad_connect sys_i2s_mclk axi_i2s_adi/data_clk_i
-ad_connect sys_i2s_mclk i2s_mclk
+ad_connect i2s_m_clk axi_i2s_adi/data_clk_i
+ad_connect i2s_m_clk i2s_mclk
 
 ad_connect sys_cpu_clk i2s_tx_dma/s_axi_aclk
 ad_connect sys_cpu_clk i2s_tx_dma/m_src_axi_aclk
@@ -92,7 +81,6 @@ ad_connect axi_fan_pwm_o axi_fan_control_0/pwm
 ad_cpu_interconnect 0x40000000 axi_fan_control_0
 ad_cpu_interconnect 0x41000000 i2s_rx_dma
 ad_cpu_interconnect 0x41001000 i2s_tx_dma
-ad_cpu_interconnect 0x41010000 sys_audio_clkgen
 ad_cpu_interconnect 0x42000000 axi_i2s_adi
 
 ad_mem_hp0_interconnect sys_cpu_clk i2s_tx_dma/m_src_axi

--- a/projects/adrv9009_zu11eg_som/system_bd.tcl
+++ b/projects/adrv9009_zu11eg_som/system_bd.tcl
@@ -24,6 +24,9 @@ ad_ip_parameter sys_ps8 CONFIG.PSU__CRL_APB__PL0_REF_CTRL__FREQMHZ 100
 ad_ip_parameter sys_ps8 CONFIG.PSU__FPGA_PL1_ENABLE 1
 ad_ip_parameter sys_ps8 CONFIG.PSU__CRL_APB__PL1_REF_CTRL__SRCSEL {IOPLL}
 ad_ip_parameter sys_ps8 CONFIG.PSU__CRL_APB__PL1_REF_CTRL__FREQMHZ 200
+ad_ip_parameter sys_ps8 CONFIG.PSU__FPGA_PL2_ENABLE 1
+ad_ip_parameter sys_ps8 CONFIG.PSU__CRL_APB__PL2_REF_CTRL__SRCSEL {IOPLL}
+ad_ip_parameter sys_ps8 CONFIG.PSU__CRL_APB__PL2_REF_CTRL__FREQMHZ 12.288
 ad_ip_parameter sys_ps8 CONFIG.PSU__USE__IRQ0 1
 ad_ip_parameter sys_ps8 CONFIG.PSU__USE__IRQ1 1
 ad_ip_parameter sys_ps8 CONFIG.PSU__GPIO_EMIO__PERIPHERAL__ENABLE 1
@@ -79,6 +82,7 @@ ad_ip_parameter sys_rstgen CONFIG.C_EXT_RST_WIDTH 1
 
 ad_connect  sys_cpu_clk sys_ps8/pl_clk0
 ad_connect  sys_200m_clk sys_ps8/pl_clk1
+ad_connect  i2s_m_clk sys_ps8/pl_clk2
 ad_connect  sys_cpu_reset sys_rstgen/peripheral_reset
 ad_connect  sys_cpu_resetn sys_rstgen/peripheral_aresetn
 ad_connect  sys_cpu_clk sys_rstgen/slowest_sync_clk


### PR DESCRIPTION
i2s mclk generated by ps instead of axi clkgen ip. ADAU1761 expects a free running clock and the i2s driver was switching the axi clkgen ip off which was causing issues.


