### PR TITLE
adi_project_xilinx.tcl: Add commands to generate extra resource utilization files

### DIFF
--- a/projects/scripts/project-xilinx.mk
+++ b/projects/scripts/project-xilinx.mk
@@ -25,6 +25,7 @@ CLEAN_TARGET += .Xil
 CLEAN_TARGET += *.ip_user_files
 CLEAN_TARGET += *.str
 CLEAN_TARGET += mem_init_sys.txt
+CLEAN_TARGET += *.csv
 
 # Common dependencies that all projects have
 M_DEPS += system_project.tcl


### PR DESCRIPTION
Add commands to generate one extra resource utilization file, in CSV format.
New commands are executed only if ADI_GENERATE_UTILIZATION environment variable is set.