### PR TITLE
ad_fmclidar1_ebz/a10soc: Fix the comment about the carrier re-work

### DIFF
--- a/projects/ad_fmclidar1_ebz/a10soc/system_project.tcl
+++ b/projects/ad_fmclidar1_ebz/a10soc/system_project.tcl
@@ -19,9 +19,9 @@ set_global_assignment -name VERILOG_FILE ../../../library/util_cdc/sync_bits.v
 #
 # Changes required:
 #
-# REMOVE:   R575, R576, R621, R633, R361, R365
+# REMOVE:   R575, R576, R621, R633, R612, R613
 #
-# POPULATE: R574, R577, R620, R632, R360, R364
+# POPULATE: R574, R577, R620, R632, R610, R611
 #
 
 # ADC digital interface (JESD204B)


### PR DESCRIPTION
The project is using the FMCA connector of the board. Make sure that all
the carrier re-work is related to the FMCA connector.