### PR TITLE
adrv9371/daq2/daq3:kcu105: patch GTH3 CPLL parameters

### DIFF
--- a/projects/adrv9371x/kcu105/system_bd.tcl
+++ b/projects/adrv9371x/kcu105/system_bd.tcl
@@ -21,4 +21,7 @@ source ../common/adrv9371x_bd.tcl
 
 ad_ip_parameter util_ad9371_xcvr CONFIG.QPLL_FBDIV 80
 ad_ip_parameter util_ad9371_xcvr CONFIG.QPLL_REFCLK_DIV 1
+ad_ip_parameter util_ad9371_xcvr CONFIG.CPLL_CFG0 0x67f8
+ad_ip_parameter util_ad9371_xcvr CONFIG.CPLL_CFG1 0xa4ac
+ad_ip_parameter util_ad9371_xcvr CONFIG.CPLL_CFG2 0x0007
 

--- a/projects/daq2/kcu105/system_bd.tcl
+++ b/projects/daq2/kcu105/system_bd.tcl
@@ -21,5 +21,6 @@ sysid_gen_sys_init_file $sys_cstring
 
 ad_ip_parameter util_daq2_xcvr CONFIG.QPLL_FBDIV 20
 ad_ip_parameter util_daq2_xcvr CONFIG.QPLL_REFCLK_DIV 1
-
-
+ad_ip_parameter util_daq2_xcvr CONFIG.CPLL_CFG0 0x67f8
+ad_ip_parameter util_daq2_xcvr CONFIG.CPLL_CFG1 0xa4ac
+ad_ip_parameter util_daq2_xcvr CONFIG.CPLL_CFG2 0x0007

--- a/projects/daq3/kcu105/system_bd.tcl
+++ b/projects/daq3/kcu105/system_bd.tcl
@@ -21,4 +21,6 @@ sysid_gen_sys_init_file $sys_cstring
 
 ad_ip_parameter util_daq3_xcvr CONFIG.QPLL_FBDIV 20
 ad_ip_parameter util_daq3_xcvr CONFIG.QPLL_REFCLK_DIV 1
-
+ad_ip_parameter util_daq3_xcvr CONFIG.CPLL_CFG0 0x67f8
+ad_ip_parameter util_daq3_xcvr CONFIG.CPLL_CFG1 0xa4ac
+ad_ip_parameter util_daq3_xcvr CONFIG.CPLL_CFG2 0x0007


### PR DESCRIPTION
Update GTH3 parameters according to a 10Gbps link from the Transceiver
Wizard.

Without this fix none of the JESD projects Tx side is working (ADRV9371, DAQ2, DAQ3)
2018_r2 already had this fix but was not ported to master: https://github.com/analogdevicesinc/hdl/commit/482933bc49c578411a8eb35e62bfcf7e9be6029e

Tested on KCU105  + DAQ2