### PR TITLE
dac_fmc_ebz config device and mode at build

### DIFF
--- a/projects/dac_fmc_ebz/common/config.tcl
+++ b/projects/dac_fmc_ebz/common/config.tcl
@@ -1,7 +1,23 @@
-# Select the device and mode you want the project synthesise for:
+# Select the device and mode you want the project synthesise for, by setting the
+# ADI_DAC_DEVICE and ADI_DAC_MODE environment variables:
+#
+# make ADI_DAC_DEVICE=AD9172 ADI_DAC_MODE=04
 
-set device    AD9172
-set mode      04
+# Default:
+set device AD9172
+set mode   04
+
+if [info exists ::env(ADI_DAC_DEVICE)] {
+  set device $::env(ADI_DAC_DEVICE)
+} else {
+  set env(ADI_DAC_DEVICE) $device
+}
+
+if [info exists ::env(ADI_DAC_MODE)] {
+  set mode $::env(ADI_DAC_MODE)
+} else {
+  set env(ADI_DAC_MODE) $mode
+}
 
 #  1 - Single link
 #  2 - Dual link

--- a/projects/dac_fmc_ebz/zc706/system_bd.tcl
+++ b/projects/dac_fmc_ebz/zc706/system_bd.tcl
@@ -43,7 +43,9 @@ source ../common/dac_fmc_ebz_bd.tcl
 ad_ip_parameter axi_sysid_0 CONFIG.ROM_ADDR_BITS 9
 ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "[pwd]/mem_init_sys.txt"
 ad_ip_parameter rom_sys_0 CONFIG.ROM_ADDR_BITS 9
-set sys_cstring "sys rom custom string placeholder"
+set ADI_DAC_DEVICE $::env(ADI_DAC_DEVICE)
+set ADI_DAC_MODE $::env(ADI_DAC_MODE)
+set sys_cstring "$ADI_DAC_DEVICE - $ADI_DAC_MODE"
 sysid_gen_sys_init_file $sys_cstring
 
 ad_ip_parameter dac_jesd204_link/tx CONFIG.SYSREF_IOB false

--- a/projects/dac_fmc_ebz/zcu102/system_bd.tcl
+++ b/projects/dac_fmc_ebz/zcu102/system_bd.tcl
@@ -31,6 +31,8 @@ ad_ip_parameter dac_jesd204_link/tx CONFIG.SYSREF_IOB false
 ad_ip_parameter axi_sysid_0 CONFIG.ROM_ADDR_BITS 9
 ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "[pwd]/mem_init_sys.txt"
 ad_ip_parameter rom_sys_0 CONFIG.ROM_ADDR_BITS 9
-set sys_cstring "sys rom custom string placeholder"
+set ADI_DAC_DEVICE $::env(ADI_DAC_DEVICE)
+set ADI_DAC_MODE $::env(ADI_DAC_MODE)
+set sys_cstring "$ADI_DAC_DEVICE - $ADI_DAC_MODE"
 sysid_gen_sys_init_file $sys_cstring
 


### PR DESCRIPTION
A configuration can be selected when calling make e.g.:
make ADi_DAC_DEVICE=AD9144 ADI_DAC_MODE=04

Build tested on zcu102.