### PR TITLE
Fix port definition for some common modules

### DIFF
--- a/library/common/ad_csc_CrYCb2RGB.v
+++ b/library/common/ad_csc_CrYCb2RGB.v
@@ -47,14 +47,14 @@ module ad_csc_CrYCb2RGB #(
 
   // Cr-Y-Cb inputs
 
-  input                   clk,
-  input       [DW:0]      CrYCb_sync,
-  input       [23:0]      CrYCb_data,
+  input                               clk,
+  input       [DELAY_DATA_WIDTH-1:0]  CrYCb_sync,
+  input       [23:0]                  CrYCb_data,
 
   // R-G-B outputs
 
-  output      [DW:0]      RGB_sync,
-  output      [23:0]      RGB_data);
+  output      [DELAY_DATA_WIDTH-1:0]  RGB_sync,
+  output      [23:0]                  RGB_data);
 
   localparam  DW = DELAY_DATA_WIDTH - 1;
 

--- a/library/common/ad_csc_RGB2CrYCb.v
+++ b/library/common/ad_csc_RGB2CrYCb.v
@@ -47,14 +47,14 @@ module ad_csc_RGB2CrYCb #(
 
   // R-G-B inputs
 
-  input                   clk,
-  input       [DW:0]      RGB_sync,
-  input       [23:0]      RGB_data,
+  input                               clk,
+  input       [DELAY_DATA_WIDTH-1:0]  RGB_sync,
+  input       [23:0]                  RGB_data,
 
   // Cr-Y-Cb outputs
 
-  output      [DW:0]      CrYCb_sync,
-  output      [23:0]      CrYCb_data);
+  output      [DELAY_DATA_WIDTH-1:0]  CrYCb_sync,
+  output      [23:0]                  CrYCb_data);
 
   localparam  DW = DELAY_DATA_WIDTH - 1;
 

--- a/library/common/ad_ss_444to422.v
+++ b/library/common/ad_ss_444to422.v
@@ -43,15 +43,15 @@ module ad_ss_444to422 #(
 
   // 444 inputs
 
-  input                   clk,
-  input                   s444_de,
-  input       [DW:0]      s444_sync,
-  input       [23:0]      s444_data,
+  input                               clk,
+  input                               s444_de,
+  input       [DELAY_DATA_WIDTH-1:0]  s444_sync,
+  input       [23:0]                  s444_data,
 
   // 422 outputs
 
-  output  reg [DW:0]      s422_sync,
-  output  reg [15:0]      s422_data);
+  output  reg [DELAY_DATA_WIDTH-1:0]  s422_sync,
+  output  reg [15:0]                  s422_data);
 
   localparam  DW = DELAY_DATA_WIDTH - 1;
 


### PR DESCRIPTION
Local parameters can not be used in port definitions. Various synthesizers do not support this and can generate errors.