### PR TITLE
SPI Engine Intel support

### DIFF
--- a/library/spi_engine/axi_spi_engine/axi_spi_engine_hw.tcl
+++ b/library/spi_engine/axi_spi_engine/axi_spi_engine_hw.tcl
@@ -1,0 +1,127 @@
+
+package require qsys
+source ../../scripts/adi_env.tcl
+source ../../scripts/adi_ip_intel.tcl
+
+ad_ip_create axi_spi_engine {AXI SPI Engine} p_elaboration
+ad_ip_files axi_spi_engine [list\
+  $ad_hdl_dir/library/common/up_axi.v \
+  axi_spi_engine.v]
+
+# parameters
+
+ad_ip_parameter ID INTEGER 0
+ad_ip_parameter DATA_WIDTH INTEGER 8
+ad_ip_parameter NUM_OF_SDI INTEGER 1
+ad_ip_parameter CMD_FIFO_ADDRESS_WIDTH INTEGER 4
+ad_ip_parameter SDO_FIFO_ADDRESS_WIDTH INTEGER 5
+ad_ip_parameter SDI_FIFO_ADDRESS_WIDTH INTEGER 5
+ad_ip_parameter MM_IF_TYPE INTEGER 1
+ad_ip_parameter UP_ADDRESS_WIDTH INTEGER 14
+ad_ip_parameter ASYNC_SPI_CLK INTEGER 0
+ad_ip_parameter NUM_OFFLOAD INTEGER 1
+ad_ip_parameter OFFLOAD0_CMD_MEM_ADDRESS_WIDTH INTEGER 4
+ad_ip_parameter OFFLOAD0_SDO_MEM_ADDRESS_WIDTH INTEGER 4
+
+proc p_elaboration {} {
+
+  # read parameters
+
+  set mm_if_type [get_parameter_value "MM_IF_TYPE"]
+
+  set up_address_width [get_parameter_value UP_ADDRESS_WIDTH]
+  set num_of_sdi [get_parameter_value NUM_OF_SDI]
+  set data_width [get_parameter_value DATA_WIDTH]
+
+  # interrupt
+
+  add_interface interrupt_sender interrupt end
+  add_interface_port interrupt_sender irq irq Output 1
+
+  if {$mm_if_type} {
+
+    # Microprocessor interface
+
+    ad_interface clock   up_clk    input                  1
+    ad_interface reset-n up_rstn   input                  1   if_up_clk
+    ad_interface signal  up_wreq   input                  1
+    ad_interface signal  up_wack   output                 1
+    ad_interface signal  up_waddr  input  $up_address_width
+    ad_interface signal  up_wdata  input                 31
+    ad_interface signal  up_rreq   input                  1
+    ad_interface signal  up_rack   output                 1
+    ad_interface signal  up_raddr  output $up_address_width
+    ad_interface signal  up_rdata  output                31
+
+  } else {
+
+    # AXI Memory Mapped interface
+
+    ad_ip_intf_s_axi s_axi_aclk s_axi_aresetn 15
+
+    set_interface_property interrupt_sender associatedAddressablePoint s_axi
+    set_interface_property interrupt_sender associatedClock s_axi_clock
+    set_interface_property interrupt_sender associatedReset s_axi_reset
+    set_interface_property interrupt_sender ENABLED true
+
+  }
+
+  # SPI Engine interfaces
+
+  ad_interface clock spi_clk     input 1
+  ad_interface reset spi_resetn  input 1 if_spi_clk
+
+  add_interface cmd_if conduit end
+  add_interface_port cmd_if cmd_ready enable  input   1
+  add_interface_port cmd_if cmd_valid valid   output  1
+  add_interface_port cmd_if cmd       data    output 16
+
+  set_interface_property cmd_if associatedClock if_spi_clk
+  set_interface_property cmd_if associatedReset if_spi_resetn
+
+  add_interface sdo_if conduit end
+  add_interface_port sdo_if sdo_data_ready  enable  input           1
+  add_interface_port sdo_if sdo_data_valid  valid   output          1
+  add_interface_port sdo_if sdo_data        data    output $data_width
+
+  set_interface_property sdo_if associatedClock if_spi_clk
+  set_interface_property sdo_if associatedReset if_spi_resetn
+
+  add_interface sdi_if conduit end
+  add_interface_port sdi_if sdi_data_ready  ready output                      1
+  add_interface_port sdi_if sdi_data_valid  valid input                       1
+  add_interface_port sdi_if sdi_data        data  input [expr $num_of_sdi * $data_width]
+
+  set_interface_property sdo_if associatedClock if_spi_clk
+  set_interface_property sdo_if associatedReset if_spi_resetn
+
+  add_interface sync_if conduit end
+  add_interface_port sync_if sync_data_valid  valid input   1
+  add_interface_port sync_if sync_data_ready  ready output  1
+  add_interface_port sync_if sync_data        data  input   8
+
+  set_interface_property sync_if associatedClock if_spi_clk
+  set_interface_property sync_if associatedReset if_spi_resetn
+
+  # Offload interfaces
+
+  add_interface offload0_cmd_if conduit end
+  add_interface_port offload0_cmd_if cmd_wre    wre   output  1
+  add_interface_port offload0_cmd_if cmd_data   data  output 16
+
+  set_interface_property offload0_cmd_if associatedClock if_spi_clk
+  set_interface_property offload0_cmd_if associatedReset if_spi_resetn
+
+  add_interface offload0_sdo_if conduit end
+  add_interface_port offload0_sdo_if sdo_wre    wre   output  1
+  add_interface_port offload0_sdo_if sdo_data   data  output  $data_width
+
+  set_interface_property offload0_sdo_if associatedClock if_spi_clk
+  set_interface_property offload0_sdo_if associatedReset if_spi_resetn
+
+  ad_interface signal  offload0_mem_reset  output  1   reset
+  ad_interface signal  offload0_enable     output  1   enable
+  ad_interface signal  offload0_enabled    input   1   enabled
+
+}
+

--- a/library/spi_engine/spi_engine_execution/spi_engine_execution_hw.tcl
+++ b/library/spi_engine/spi_engine_execution/spi_engine_execution_hw.tcl
@@ -1,0 +1,91 @@
+
+package require qsys
+source ../../scripts/adi_env.tcl
+source ../../scripts/adi_ip_intel.tcl
+
+ad_ip_create spi_engine_execution {SPI Engine Execution} p_elaboration
+ad_ip_files spi_engine_execution [list\
+  spi_engine_execution.v]
+
+# parameters
+
+ad_ip_parameter NUM_OF_CS INTEGER 1
+ad_ip_parameter DEFAULT_SPI_CFG INTEGER 0
+ad_ip_parameter DEFAULT_SPI_DIV INTEGER 0
+ad_ip_parameter DATA_WIDTH INTEGER 8
+ad_ip_parameter NUM_OF_SDI INTEGER 1
+
+proc p_elaboration {} {
+
+  set data_width [get_parameter_value DATA_WIDTH]
+  set num_of_sdi [get_parameter_value NUM_OF_SDI]
+  set num_of_cs [get_parameter_value NUM_OF_CS]
+
+  # clock and reset interface
+
+  ad_interface clock   clk     input 1
+  ad_interface reset-n resetn  input 1 if_clk
+
+  ad_interface signal active output 1
+
+  # command interface
+
+  add_interface cmd_if conduit end
+  add_interface_port cmd_if cmd_ready ready output 1
+  add_interface_port cmd_if cmd_valid valid input 1
+  add_interface_port cmd_if cmd       data  input 16
+
+  set_interface_property cmd_if associatedClock if_clk
+  set_interface_property cmd_if associatedReset if_resetn
+
+  # SDO data interface
+
+  add_interface sdo_if conduit end
+  add_interface_port sdo_if sdo_data_ready ready output 1
+  add_interface_port sdo_if sdo_data_valid valid input  1
+  add_interface_port sdo_if sdo_data        data input  $data_width
+
+  set_interface_property sdo_if associatedClock if_clk
+  set_interface_property sdo_if associatedReset if_resetn
+
+  # SDI data interface
+
+  add_interface sdi_if conduit end
+  add_interface_port sdi_if sdi_data_ready  ready input  1
+  add_interface_port sdi_if sdi_data_valid  valid output 1
+  add_interface_port sdi_if sdi_data        data  output [expr $num_of_sdi * $data_width]
+
+  set_interface_property sdi_if associatedClock if_clk
+  set_interface_property sdi_if associatedReset if_resetn
+
+  # SYNC data interface
+
+  add_interface sync_if conduit end
+  add_interface_port sync_if sync_data_valid  valid input  1
+  add_interface_port sync_if sync_data_ready  ready output 1
+  add_interface_port sync_if sync_data        data  input  8
+
+  set_interface_property sync_if associatedClock if_clk
+  set_interface_property sync_if associatedReset if_resetn
+
+  ## physical SPI interface
+
+  ad_interface clock sclk output 1
+
+  ad_interface signal sdo output 1
+  ad_interface signal sdo_t output 1
+
+  ad_interface signal sdi   input 1
+  ad_interface signal sdi_1 input 1
+  ad_interface signal sdi_2 input 1
+  ad_interface signal sdi_3 input 1
+  ad_interface signal sdi_4 input 1
+  ad_interface signal sdi_5 input 1
+  ad_interface signal sdi_6 input 1
+  ad_interface signal sdi_7 input 1
+
+  ad_interface signal cs output 1
+  ad_interface signal three_wire output 1
+
+}
+

--- a/library/spi_engine/spi_engine_interconnect/spi_engine_interconnect_hw.tcl
+++ b/library/spi_engine/spi_engine_interconnect/spi_engine_interconnect_hw.tcl
@@ -1,0 +1,146 @@
+
+package require qsys
+source ../../scripts/adi_env.tcl
+source ../../scripts/adi_ip_intel.tcl
+
+ad_ip_create spi_engine_interconnect {SPI Engine Interconnect} p_elaboration
+ad_ip_files spi_engine_execution [list\
+  spi_engine_interconnect.v]
+
+# parameters
+
+ad_ip_parameter DATA_WIDTH INTEGER 8
+ad_ip_parameter NUM_OF_SDI INTEGER 1
+
+proc p_elaboration {} {
+
+  set data_width [get_parameter_value DATA_WIDTH]
+  set num_of_sdi [get_parameter_value NUM_OF_SDI]
+
+  # clock and reset interface
+
+  ad_interface clock clk input 1
+  ad_interface reset resestn input 1 if_clk
+
+  # command master interface
+
+  add_interface m_cmd_if conduit end
+  add_interface_port m_cmd_if m_cmd_ready enable input 1
+  add_interface_port m_cmd_if m_cmd_valid valid output 1
+  add_interface_port m_cmd_if m_cmd data output 16
+
+  set_interface_property m_cmd_if associatedClock if_clk
+  set_interface_property m_cmd_if associatedReset none
+
+  # SDO data master interface
+
+  add_interface m_sdo_if conduit end
+  add_interface_port m_sdo_if m_sdo_data_ready enable input 1
+  add_interface_port m_sdo_if m_sdo_data_valid valid output 1
+  add_interface_port m_sdo_if m_sdo_data data output $data_width
+
+  set_interface_property m_sdo_if associatedClock if_clk
+  set_interface_property m_sdo_if associatedReset none
+
+  # SDI data master interface
+
+  add_interface m_sdi_if conduit end
+  add_interface_port m_sdi_if m_sdi_data_ready ready output 1
+  add_interface_port m_sdi_if m_sdi_data_valid valid input 1
+  add_interface_port m_sdi_if m_sdi_data data input [expr $num_of_sdi * $data_width]
+
+  set_interface_property m_sdo_if associatedClock if_clk
+  set_interface_property m_sdo_if associatedReset none
+
+  # SYNC master interface
+
+  add_interface m_sync_if conduit end
+  add_interface_port m_sync_if m_sync_data_valid valid input 1
+  add_interface_port m_sync_if m_sync_data_ready ready output 1
+  add_interface_port m_sync_if m_sync_data data input 8
+
+  set_interface_property m_sync_if associatedClock if_clk
+  set_interface_property m_sync_if associatedReset none
+
+  # command slave0 interface
+
+  add_interface s0_cmd_if conduit end
+  add_interface_port s0_cmd_if s0_cmd_ready enable output 1
+  add_interface_port s0_cmd_if s0_cmd_valid valid input 1
+  add_interface_port s0_cmd_if s0_cmd data input 16
+
+  set_interface_property s0_cmd_if associatedClock if_clk
+  set_interface_property s0_cmd_if associatedReset none
+
+  # SDO data slave0 interface
+
+  add_interface s0_sdo_if conduit end
+  add_interface_port s0_sdo_if s0_sdo_data_ready enable output 1
+  add_interface_port s0_sdo_if s0_sdo_data_valid valid input 1
+  add_interface_port s0_sdo_if s0_sdo_data data input $data_width
+
+  set_interface_property s0_sdo_if associatedClock if_clk
+  set_interface_property s0_sdo_if associatedReset none
+
+  # SDI data slave0 interface
+
+  add_interface s0_sdi_if conduit end
+  add_interface_port s0_sdi_if s0_sdi_data_ready ready input 1
+  add_interface_port s0_sdi_if s0_sdi_data_valid valid output 1
+  add_interface_port s0_sdi_if s0_sdi_data data output [expr $num_of_sdi * $data_width]
+
+  set_interface_property s0_sdo_if associatedClock if_clk
+  set_interface_property s0_sdo_if associatedReset none
+
+  # SYNC slave0 interface
+
+  add_interface s0_sync_if conduit end
+  add_interface_port s0_sync_if s0_sync_data_valid valid output 1
+  add_interface_port s0_sync_if s0_sync_data_ready ready input 1
+  add_interface_port s0_sync_if s0_sync_data data output 8
+
+  set_interface_property s0_sync_if associatedClock if_clk
+  set_interface_property s0_sync_if associatedReset none
+
+  # command slave1 interface
+
+  add_interface s1_cmd_if conduit end
+  add_interface_port s1_cmd_if s1_cmd_ready enable output 1
+  add_interface_port s1_cmd_if s1_cmd_valid valid input 1
+  add_interface_port s1_cmd_if s1_cmd data input 16
+
+  set_interface_property s1_cmd_if associatedClock if_clk
+  set_interface_property s1_cmd_if associatedReset none
+
+  # SDO data slave1 interface
+
+  add_interface s1_sdo_if conduit end
+  add_interface_port s1_sdo_if s1_sdo_data_ready enable output 1
+  add_interface_port s1_sdo_if s1_sdo_data_valid valid input 1
+  add_interface_port s1_sdo_if s1_sdo_data data input $data_width
+
+  set_interface_property s1_sdo_if associatedClock if_clk
+  set_interface_property s1_sdo_if associatedReset none
+
+  # SDI data slave1 interface
+
+  add_interface s1_sdi_if conduit end
+  add_interface_port s1_sdi_if s1_sdi_data_ready ready input 1
+  add_interface_port s1_sdi_if s1_sdi_data_valid valid output 1
+  add_interface_port s1_sdi_if s1_sdi_data data output [expr $num_of_sdi * $data_width]
+
+  set_interface_property s1_sdo_if associatedClock if_clk
+  set_interface_property s1_sdo_if associatedReset none
+
+  # SYNC slave1 interface
+
+  add_interface s1_sync_if conduit end
+  add_interface_port s1_sync_if s1_sync_data_valid valid output 1
+  add_interface_port s1_sync_if s1_sync_data_ready ready input 1
+  add_interface_port s1_sync_if s1_sync_data data output 8
+
+  set_interface_property s1_sync_if associatedClock if_clk
+  set_interface_property s1_sync_if associatedReset none
+
+}
+

--- a/library/spi_engine/spi_engine_offload/spi_engine_offload_hw.tcl
+++ b/library/spi_engine/spi_engine_offload/spi_engine_offload_hw.tcl
@@ -1,0 +1,104 @@
+
+package require qsys
+source ../../scripts/adi_env.tcl
+source ../../scripts/adi_ip_intel.tcl
+
+ad_ip_create spi_engine_offload {SPI Engine Offload} p_elaboration
+ad_ip_files spi_engine_offload [list\
+  $ad_hdl_dir/library/util_cdc/sync_bits.v \
+  spi_engine_offload.v]
+
+# parameters
+
+ad_ip_parameter ASYNC_SPI_CLK INTEGER 0
+ad_ip_parameter ASYNC_TRIG INTEGER 0
+ad_ip_parameter CMD_MEM_ADDRESS_WIDTH INTEGER 4
+ad_ip_parameter SDO_MEM_ADDRESS_WIDTH INTEGER 4
+ad_ip_parameter DATA_WIDTH INTEGER 8
+ad_ip_parameter NUM_OF_SDI INTEGER 1
+
+proc p_elaboration {} {
+
+  set data_width [get_parameter_value DATA_WIDTH]
+  set num_of_sdi [get_parameter_value NUM_OF_SDI]
+
+  # control interface
+
+  ad_interface clock ctrl_clk input 1
+
+  add_interface ctrl_cmd_if conduit end
+  add_interface_port ctrl_cmd_if ctrl_cmd_wr_en    wre   output  1
+  add_interface_port ctrl_cmd_if ctrl_cmd_wr_data  data  output 16
+
+  set_interface_property ctrl_cmd_if associatedClock if_ctrl_clk
+  set_interface_property ctrl_cmd_if associatedReset none
+
+  add_interface ctrl_sdo_if conduit end
+  add_interface_port ctrl_sdo_if ctrl_sdo_wr_en    wre   output  1
+  add_interface_port ctrl_sdo_if ctrl_sdo_wr_data  data  output $data_width
+
+  set_interface_property ctrl_sdo_if associatedClock if_ctrl_clk
+  set_interface_property ctrl_sdo_if associatedReset none
+
+  ad_interface signal  ctrl_enable     input  1   enable
+  ad_interface signal  ctrl_enabled    output 1   enabled
+  ad_interface signal  ctrl_mem_reset  input  1   reset
+
+  # SPI Engine interfaces
+
+  ad_interface clock   spi_clk     input 1
+  ad_interface reset-n spi_resetn  input 1 if_spi_clk
+
+  ad_interface signal  trigger     input 1
+
+  ## command interface
+
+  add_interface cmd_if conduit end
+  add_interface_port cmd_if cmd_valid valid   output    1
+  add_interface_port cmd_if cmd_ready ready   input     1
+  add_interface_port cmd_if cmd       data    output   16
+
+  set_interface_property cmd_if associatedClock if_spi_clk
+  set_interface_property cmd_if associatedReset if_spi_resetn
+
+  ## SDO data interface
+
+  add_interface sdo_if conduit end
+  add_interface_port sdo_if sdo_data_valid  valid   output 1
+  add_interface_port sdo_if sdo_data_ready  ready   input  1
+  add_interface_port sdo_if sdo_data        data    output $data_width
+
+  set_interface_property sdo_if associatedClock if_spi_clk
+  set_interface_property sdo_if associatedReset if_spi_resetn
+
+  ## SDI data interface
+
+  add_interface sdi_if conduit end
+  add_interface_port sdi_if sdi_data_valid  valid input   1
+  add_interface_port sdi_if sdi_data_ready  ready output  1
+  add_interface_port sdi_if sdi_data        data  input   [expr $num_of_sdi * $data_width]
+
+  set_interface_property sdi_if associatedClock if_spi_clk
+  set_interface_property sdi_if associatedReset if_spi_resetn
+
+  ## SYNC data interface
+
+  add_interface sync_if conduit end
+  add_interface_port sync_if sync_data_valid  valid input   1
+  add_interface_port sync_if sync_data_ready  ready output  1
+  add_interface_port sync_if sync_data        data  input   8
+
+  set_interface_property sync_if associatedClock if_spi_clk
+  set_interface_property sync_if associatedReset if_spi_resetn
+
+  ## Offload SDI data interface
+
+  add_interface offload_sdi_if conduit end
+  add_interface_port offload_sdi_if offload_sdi_valid  valid input   1
+  add_interface_port offload_sdi_if offload_sdi_ready  ready output  1
+  add_interface_port offload_sdi_if offload_sdi_data   data  input   [expr $num_of_sdi * $data_width]
+
+  set_interface_property offload_sdi_if associatedClock if_spi_clk
+  set_interface_property offload_sdi_if associatedReset if_spi_resetn
+
+}


### PR DESCRIPTION
Add Intel support for the SPI Engine framework.

Current status: 
  - IP catalog can see the IPs
  - All the IPs can be instantiated and the HDL generation pass without an error
  - It were never tested in an actual hardware