### PR TITLE
adrv9009_zu11eg_som: Add axi_sysid

### DIFF
--- a/projects/adrv9009zu11eg/adrv2crr_fmc/Makefile
+++ b/projects/adrv9009zu11eg/adrv2crr_fmc/Makefile
@@ -5,24 +5,25 @@
 
 PROJECT_NAME := adrv9009zu11eg
 
-M_DEPS += ../common/adrv2crr_fmc_bd.tcl
 M_DEPS += ../common/adrv9009zu11eg_spi.v
+M_DEPS += ../common/adrv9009zu11eg_constr.xdc
 M_DEPS += ../common/adrv9009zu11eg_bd.tcl
 M_DEPS += ../common/adrv2crr_fmc_constr.xdc
-M_DEPS += ../common/adrv9009zu11eg_constr.xdc
+M_DEPS += ../common/adrv2crr_fmc_bd.tcl
 M_DEPS += ../../../library/xilinx/common/ad_iobuf.v
 M_DEPS += ../../../library/jesd204/scripts/jesd204.tcl
 
-LIB_DEPS += axi_clkgen
 LIB_DEPS += axi_dmac
 LIB_DEPS += axi_fan_control
 LIB_DEPS += axi_i2s_adi
+LIB_DEPS += axi_sysid
 LIB_DEPS += jesd204/ad_ip_jesd204_tpl_adc
 LIB_DEPS += jesd204/ad_ip_jesd204_tpl_dac
 LIB_DEPS += jesd204/axi_jesd204_rx
 LIB_DEPS += jesd204/axi_jesd204_tx
 LIB_DEPS += jesd204/jesd204_rx
 LIB_DEPS += jesd204/jesd204_tx
+LIB_DEPS += sysid_rom
 LIB_DEPS += util_pack/util_cpack2
 LIB_DEPS += util_pack/util_upack2
 LIB_DEPS += xilinx/axi_adxcvr

--- a/projects/adrv9009zu11eg/adrv2crr_fmc/system_bd.tcl
+++ b/projects/adrv9009zu11eg/adrv2crr_fmc/system_bd.tcl
@@ -1,3 +1,9 @@
 
 source ../common/adrv9009zu11eg_bd.tcl
 source ../common/adrv2crr_fmc_bd.tcl
+
+ad_ip_parameter axi_sysid_0 CONFIG.ROM_ADDR_BITS 9
+ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "[pwd]/mem_init_sys.txt"
+ad_ip_parameter rom_sys_0 CONFIG.ROM_ADDR_BITS 9
+set sys_cstring "sys rom custom string placeholder"
+sysid_gen_sys_init_file $sys_cstring

--- a/projects/adrv9009zu11eg/common/adrv9009zu11eg_bd.tcl
+++ b/projects/adrv9009zu11eg/common/adrv9009zu11eg_bd.tcl
@@ -118,6 +118,15 @@ ad_connect  sys_ps8/emio_spi0_ss_i_n VCC
 ad_connect  sys_ps8/emio_spi0_sclk_i GND
 ad_connect  sys_ps8/emio_spi0_s_i GND
 
+#system ID
+
+ad_ip_instance axi_sysid axi_sysid_0
+ad_ip_instance sysid_rom rom_sys_0
+
+ad_connect  axi_sysid_0/rom_addr rom_sys_0/rom_addr
+ad_connect  axi_sysid_0/sys_rom_data rom_sys_0/rom_data
+ad_connect  sys_cpu_clk rom_sys_0/clk
+
 # interrupts
 
 ad_ip_instance xlconcat sys_concat_intc_0
@@ -443,6 +452,7 @@ ad_cpu_interconnect 0x44A70000 axi_adrv9009_som_obs_jesd
 ad_cpu_interconnect 0x7c400000 axi_adrv9009_som_tx_dma
 ad_cpu_interconnect 0x7c420000 axi_adrv9009_som_rx_dma
 ad_cpu_interconnect 0x7c440000 axi_adrv9009_som_obs_dma
+ad_cpu_interconnect 0x45000000 axi_sysid_0
 
 # gt uses hp0, and 100MHz clock for both DRP and AXI4
 

--- a/projects/adrv9009zu11eg/common/adrv9009zu11eg_constr.xdc
+++ b/projects/adrv9009zu11eg/common/adrv9009zu11eg_constr.xdc
@@ -218,4 +218,4 @@ set_property -dict {PACKAGE_PIN AN21 IOSTANDARD LVCMOS18}  [get_ports spi_clk]
 set_property -dict {PACKAGE_PIN AP21 IOSTANDARD LVCMOS18}  [get_ports spi_sdio]
 set_property -dict {PACKAGE_PIN AR9  IOSTANDARD LVCMOS18}  [get_ports spi_miso]
 
-create_clock -name spi0_clk      -period 40   [get_pins -hier */EMIOSPI0SCLKO]
+create_clock -name spi0_clk      -period 100   [get_pins -hier */EMIOSPI0SCLKO]


### PR DESCRIPTION
v2: Updated after name change. Decreased SPI clock speed to meet timing.