### PR TITLE
Fix trigger to data alignment on ADC path 

### DIFF
--- a/library/axi_adc_trigger/axi_adc_trigger.v
+++ b/library/axi_adc_trigger/axi_adc_trigger.v
@@ -137,10 +137,6 @@ module axi_adc_trigger #(
 
   wire                  comp_low_a_s; // signal is over the limit
   wire                  comp_low_b_s; // signal is over the limit
-  wire                  passthrough_high_a_s; // trigger when rising through the limit
-  wire                  passthrough_low_a_s;  // trigger when fallingh thorugh the limit
-  wire                  passthrough_high_b_s; // trigger when rising through the limit
-  wire                  passthrough_low_b_s;  // trigger when fallingh thorugh the limit
   wire                  trigger_a_fall_edge;
   wire                  trigger_a_rise_edge;
   wire                  trigger_b_fall_edge;
@@ -164,16 +160,20 @@ module axi_adc_trigger #(
   reg                   trigger_b_d3;
   reg                   comp_high_a;  // signal is over the limit
   reg                   old_comp_high_a;   // t + 1 version of comp_high_a
-  reg                   first_a_h_trigger; // valid hysteresis range on passthrough high trigger limit
-  reg                   first_a_l_trigger; // valid hysteresis range on passthrough low trigger limit
+  reg                   hyst_high_limit_pass_a; // valid hysteresis range on passthrough high trigger limit
+  reg                   hyst_low_limit_pass_a; // valid hysteresis range on passthrough low trigger limit
   reg signed [DW:0]     hyst_a_high_limit;
   reg signed [DW:0]     hyst_a_low_limit;
   reg                   comp_high_b;       // signal is over the limit
   reg                   old_comp_high_b;   // t + 1 version of comp_high_b
-  reg                   first_b_h_trigger; // valid hysteresis range on passthrough high trigger limit
-  reg                   first_b_l_trigger; // valid hysteresis range on passthrough low trigger limit
+  reg                   hyst_high_limit_pass_b; // valid hysteresis range on passthrough high trigger limit
+  reg                   hyst_low_limit_pass_b; // valid hysteresis range on passthrough low trigger limit
   reg signed [DW:0]     hyst_b_high_limit;
   reg signed [DW:0]     hyst_b_low_limit;
+  reg                   passthrough_high_a; // trigger when rising through the limit
+  reg                   passthrough_low_a;  // trigger when fallingh thorugh the limit
+  reg                   passthrough_high_b; // trigger when rising through the limit
+  reg                   passthrough_low_b;  // trigger when fallingh thorugh the limit
 
   reg                   trigger_pin_a;
   reg                   trigger_pin_b;
@@ -422,22 +422,22 @@ module axi_adc_trigger #(
     endcase
   end
 
-  always @(posedge clk) begin
+  always @(*) begin
     case(function_a)
       2'h0: trigger_adc_a = comp_low_a_s;
       2'h1: trigger_adc_a = comp_high_a;
-      2'h2: trigger_adc_a = passthrough_high_a_s;
-      2'h3: trigger_adc_a = passthrough_low_a_s;
+      2'h2: trigger_adc_a = passthrough_high_a;
+      2'h3: trigger_adc_a = passthrough_low_a;
       default: trigger_adc_a = comp_low_a_s;
     endcase
   end
 
-  always @(posedge clk) begin
+  always @(*) begin
     case(function_b)
       2'h0: trigger_adc_b = comp_low_b_s;
       2'h1: trigger_adc_b = comp_high_b;
-      2'h2: trigger_adc_b = passthrough_high_b_s;
-      2'h3: trigger_adc_b = passthrough_low_b_s;
+      2'h2: trigger_adc_b = passthrough_high_b;
+      2'h3: trigger_adc_b = passthrough_low_b;
       default: trigger_adc_b = comp_low_b_s;
     endcase
   end
@@ -483,55 +483,85 @@ module axi_adc_trigger #(
   end
 
   always @(posedge clk) begin
-    if (data_valid_a == 1'b1) begin
-      hyst_a_high_limit <= limit_a_cmp + hysteresis_a[DW:0];
-      hyst_a_low_limit  <= limit_a_cmp - hysteresis_a[DW:0];
+    if (reset == 1'b1) begin
+      comp_high_a <= 1'b0;
+      old_comp_high_a <= 1'b0;
+      passthrough_high_a <= 1'b0;
+      passthrough_low_a <= 1'b0;
+      hyst_a_high_limit <= {DW{1'b0}};
+      hyst_a_low_limit  <= {DW{1'b0}};
+      hyst_high_limit_pass_a <= 1'b0;
+      hyst_low_limit_pass_a <= 1'b0;
+    end else begin
+      if (data_valid_a == 1'b1) begin
+        hyst_a_high_limit <= limit_a_cmp + hysteresis_a[DW:0];
+        hyst_a_low_limit  <= limit_a_cmp - hysteresis_a[DW:0];
 
-      if (data_a_cmp >= limit_a_cmp) begin
-        comp_high_a <= 1'b1;
-        first_a_h_trigger <= passthrough_high_a_s ? 0 : first_a_h_trigger;
+        if (data_a_cmp >= limit_a_cmp) begin
+          comp_high_a <= 1'b1;
+        end else begin
+          comp_high_a <= 1'b0;
+        end
+
         if (data_a_cmp > hyst_a_high_limit) begin
-          first_a_l_trigger <= 1'b1;
+          hyst_low_limit_pass_a <= 1'b1;
+        end else begin
+          hyst_low_limit_pass_a <= (passthrough_low_a) ? 1'b0 : hyst_low_limit_pass_a;
         end
-      end else begin
-        comp_high_a <= 1'b0;
-        first_a_l_trigger <= (passthrough_low_a_s) ? 0 : first_a_l_trigger;
         if (data_a_cmp < hyst_a_low_limit) begin
-          first_a_h_trigger <= 1'b1;
+          hyst_high_limit_pass_a <= 1'b1;
+        end else begin
+          hyst_high_limit_pass_a <= passthrough_high_a ? 1'b0 : hyst_high_limit_pass_a;
         end
+
+        old_comp_high_a <= comp_high_a;
+        passthrough_high_a <= !old_comp_high_a & comp_high_a & hyst_high_limit_pass_a;
+        passthrough_low_a <= old_comp_high_a & !comp_high_a & hyst_low_limit_pass_a;
       end
-      old_comp_high_a <= comp_high_a;
     end
   end
 
-  assign passthrough_high_a_s = !old_comp_high_a & comp_high_a & first_a_h_trigger;
-  assign passthrough_low_a_s = old_comp_high_a & !comp_high_a & first_a_l_trigger;
   assign comp_low_a_s = !comp_high_a;
 
   always @(posedge clk) begin
-    if (data_valid_b == 1'b1) begin
-      hyst_b_high_limit <= limit_b_cmp + hysteresis_b[DW:0];
-      hyst_b_low_limit  <= limit_b_cmp - hysteresis_b[DW:0];
+    if (reset == 1'b1) begin
+      comp_high_b <= 1'b0;
+      old_comp_high_b <= 1'b0;
+      passthrough_high_b <= 1'b0;
+      passthrough_low_b <= 1'b0;
+      hyst_b_high_limit <= {DW{1'b0}};
+      hyst_b_low_limit  <= {DW{1'b0}};
+      hyst_high_limit_pass_b <= 1'b0;
+      hyst_low_limit_pass_b <= 1'b0;
+    end else begin
+      if (data_valid_b == 1'b1) begin
+        hyst_b_high_limit <= limit_b_cmp + hysteresis_b[DW:0];
+        hyst_b_low_limit  <= limit_b_cmp - hysteresis_b[DW:0];
 
-      if (data_b_cmp >= limit_b_cmp) begin
-        comp_high_b <= 1'b1;
-        first_b_h_trigger <= (passthrough_high_b_s == 1) ? 0 : first_b_h_trigger;
+        if (data_b_cmp >= limit_b_cmp) begin
+          comp_high_b <= 1'b1;
+        end else begin
+          comp_high_b <= 1'b0;
+        end
+
         if (data_b_cmp > hyst_b_high_limit) begin
-          first_b_l_trigger <= 1'b1;
+          hyst_low_limit_pass_b <= 1'b1;
+        end else begin
+          hyst_low_limit_pass_b <= (passthrough_low_b) ? 1'b0 : hyst_low_limit_pass_b;
         end
-      end else begin
-        comp_high_b <= 1'b0;
-        first_b_l_trigger <= (passthrough_low_b_s == 1) ? 0 : first_b_l_trigger;
         if (data_b_cmp < hyst_b_low_limit) begin
-          first_b_h_trigger <= 1'b1;
+          hyst_high_limit_pass_b <= 1'b1;
+        end else begin
+          hyst_high_limit_pass_b <= passthrough_high_b ? 1'b0 : hyst_high_limit_pass_b;
         end
+
+        old_comp_high_b <= comp_high_b;
+        passthrough_high_b <= !old_comp_high_b & comp_high_b & hyst_high_limit_pass_b;
+        passthrough_low_b <= old_comp_high_b & !comp_high_b & hyst_low_limit_pass_b;
       end
-      old_comp_high_b <= comp_high_b;
     end
   end
 
-  assign passthrough_high_b_s = !old_comp_high_b & comp_high_b & first_b_h_trigger;
-  assign passthrough_low_b_s = old_comp_high_b & !comp_high_b & first_b_l_trigger;
   assign comp_low_b_s = !comp_high_b;
 
   axi_adc_trigger_reg adc_trigger_registers (

--- a/library/axi_adc_trigger/axi_adc_trigger.v
+++ b/library/axi_adc_trigger/axi_adc_trigger.v
@@ -278,23 +278,35 @@ module axi_adc_trigger #(
   end
 
 
-  // keep data in sync with the trigger. The trigger bypasses the variable fifo.
-  // The data goes through and it is delayed with 4 clock cycles)
+  // 1. keep data in sync with the trigger. The trigger bypasses the variable
+  // fifo. The data goes through and it is delayed with 4 clock cycles)
+  // 2. For non max sample rate of the ADC, the trigger signal that originates
+  // from an external source is stored until the valid acknowledges the trigger.
   always @(posedge clk) begin
-    trigger_out_m1 <= trigger_out_s;
-    trigger_out_m2 <= trigger_out_m1;
-    if (trigger_out_m1 & ~trigger_out_s) begin
-      trigger_out_hold <= 1'b1;
-    end
-    if (trigger_out_ack) begin
+    if (reset == 1'b1) begin
+      trigger_out_m1 <= 1'b0;
+      trigger_out_m2 <= 1'b0;
+      trigger_out_ack <= 1'b0;
       trigger_out_hold <= 1'b0;
+    end else begin
+      if (data_out_valid == 1'b1) begin
+        trigger_out_m1 <= trigger_out_s | trigger_out_hold;
+        trigger_out_m2 <= trigger_out_m1;
+        trigger_out_ack <= trigger_out_hold;
+      end
+      if (~trigger_out_m1 & trigger_out_s & ~data_out_valid) begin
+        trigger_out_hold <= 1'b1;
+      end
+      if (trigger_out_ack) begin
+        trigger_out_hold <= 1'b0;
+      end
     end
-
-    trigger_out_ack <= trigger_out_hold & (data_valid_a | data_valid_b);
   end
 
+  assign data_out_valid = data_valid_a | data_valid_b;
+
   assign trigger_out_la = trigger_out_mixed;
-  assign trigger_out = trigger_out_hold | trigger_out_m2;
+  assign trigger_out = trigger_out_m2;
 
   always @(posedge clk) begin
     data_a_trig <= (embedded_trigger == 1'h0) ? {data_a[14],data_a[14:0]} : {trigger_out_s,data_a[14:0]};

--- a/library/axi_adc_trigger/axi_adc_trigger_ip.tcl
+++ b/library/axi_adc_trigger/axi_adc_trigger_ip.tcl
@@ -15,6 +15,7 @@ adi_ip_files axi_adc_trigger [list \
 adi_ip_properties axi_adc_trigger
 
 ipx::infer_bus_interface clk xilinx.com:signal:clock_rtl:1.0 [ipx::current_core]
+ipx::infer_bus_interface reset xilinx.com:signal:reset_rtl:1.0 [ipx::current_core]
 
 ipx::save_core [ipx::current_core]
 

--- a/library/axi_adc_trigger/axi_adc_trigger_reg.v
+++ b/library/axi_adc_trigger/axi_adc_trigger_reg.v
@@ -62,6 +62,7 @@ module axi_adc_trigger_reg (
   output      [16:0]  trigger_out_control,
   output      [31:0]  fifo_depth,
   output      [31:0]  trigger_delay,
+  output      [31:0]  trigger_holdoff,
 
   output              streaming,
 
@@ -100,6 +101,7 @@ module axi_adc_trigger_reg (
   reg     [16:0]  up_trigger_out_control = 17'h0;
   reg     [31:0]  up_fifo_depth = 32'h0;
   reg     [31:0]  up_trigger_delay = 32'h0;
+  reg     [31:0]  up_trigger_holdoff = 32'h0;
   reg             up_triggered = 1'h0;
   reg             up_streaming = 1'h0;
 
@@ -129,6 +131,7 @@ module axi_adc_trigger_reg (
       up_trigger_out_control <= 'd0;
       up_triggered <= 1'd0;
       up_streaming <= 1'd0;
+      up_trigger_holdoff <= 32'h0;
     end else begin
       up_wack <= up_wreq;
       if ((up_wreq == 1'b1) && (up_waddr[4:0] == 5'h1)) begin
@@ -184,6 +187,9 @@ module axi_adc_trigger_reg (
       if ((up_wreq == 1'b1) && (up_waddr[4:0] == 5'h11)) begin
         up_streaming <= up_wdata[0];
       end
+      if ((up_wreq == 1'b1) && (up_waddr[4:0] == 5'h12)) begin
+        up_trigger_holdoff <= up_wdata[31:0];
+      end
     end
   end
 
@@ -215,6 +221,7 @@ module axi_adc_trigger_reg (
           5'hf: up_rdata <= {31'h0,up_triggered};
           5'h10: up_rdata <= up_trigger_delay;
           5'h11: up_rdata <= {31'h0,up_streaming};
+          5'h12: up_rdata <= up_trigger_holdoff;
           default: up_rdata <= 0;
         endcase
       end else begin
@@ -223,7 +230,7 @@ module axi_adc_trigger_reg (
     end
   end
 
-   up_xfer_cntrl #(.DATA_WIDTH(210)) i_xfer_cntrl (
+   up_xfer_cntrl #(.DATA_WIDTH(242)) i_xfer_cntrl (
     .up_rstn (up_rstn),
     .up_clk (up_clk),
     .up_data_cntrl ({ up_streaming,           // 1
@@ -240,6 +247,7 @@ module axi_adc_trigger_reg (
                       up_trigger_l_mix_b,     // 4
                       up_trigger_out_control, // 17
                       up_fifo_depth,          // 32
+                      up_trigger_holdoff,     // 32
                       up_trigger_delay}),     // 32
 
     .up_xfer_done (),
@@ -259,6 +267,7 @@ module axi_adc_trigger_reg (
                       trigger_l_mix_b,    // 4
                       trigger_out_control,// 17
                       fifo_depth,         // 32
+                      trigger_holdoff,    // 32
                       trigger_delay}));   // 32
 
 endmodule

--- a/projects/m2k/common/m2k_bd.tcl
+++ b/projects/m2k/common/m2k_bd.tcl
@@ -227,6 +227,7 @@ ad_connect adc_trigger/data_a_trig       ad9963_adc_concat/In0
 ad_connect adc_trigger/data_b_trig       ad9963_adc_concat/In1
 ad_connect adc_trigger/data_valid_a_trig adc_trigger_fifo/data_in_valid
 ad_connect ad9963_adc_concat/dout        adc_trigger_fifo/data_in
+ad_connect axi_ad9963/adc_rst            adc_trigger/reset
 
 ad_connect adc_trigger_fifo/depth        adc_trigger/fifo_depth
 


### PR DESCRIPTION
Waiting on trigger holdoff to be merged.

-Fix "trigger jitter"
-Fix data alignment" - The data was captured with two samples earlier than expected when using sampling frequencies slower than the maximum(100MSPS).

Tested on m2k.