### PR TITLE
fmcjesdadc1: Change rx_div_clk to 125MHz

### DIFF
--- a/projects/fmcjesdadc1/kc705/system_constr.xdc
+++ b/projects/fmcjesdadc1/kc705/system_constr.xdc
@@ -21,7 +21,7 @@ set_property  -dict {PACKAGE_PIN  D21   IOSTANDARD LVCMOS25} [get_ports spi_sdio
 # clocks
 
 create_clock -name rx_ref_clk   -period  4.00 [get_ports rx_ref_clk_p]
-create_clock -name rx_div_clk   -period  6.40 [get_pins i_system_wrapper/system_i/util_fmcjesdadc1_xcvr/inst/i_xch_0/i_gtxe2_channel/RXOUTCLK]
+create_clock -name rx_div_clk   -period  8.00 [get_pins i_system_wrapper/system_i/util_fmcjesdadc1_xcvr/inst/i_xch_0/i_gtxe2_channel/RXOUTCLK]
 
 set_property ASYNC_REG TRUE [get_cells -hier -filter {name =~ *sysref_en_m*}]
 set_false_path -to [get_cells -hier -filter {name =~ *sysref_en_m1*  && IS_SEQUENTIAL}]

--- a/projects/fmcjesdadc1/vc707/system_constr.xdc
+++ b/projects/fmcjesdadc1/vc707/system_constr.xdc
@@ -21,7 +21,7 @@ set_property  -dict {PACKAGE_PIN  V29   IOSTANDARD LVCMOS18} [get_ports spi_sdio
 # clocks
 
 create_clock -name rx_ref_clk   -period  4.00 [get_ports rx_ref_clk_p]
-create_clock -name rx_div_clk   -period  6.40 [get_pins i_system_wrapper/system_i/util_fmcjesdadc1_xcvr/inst/i_xch_0/i_gtxe2_channel/RXOUTCLK]
+create_clock -name rx_div_clk   -period  8.00 [get_pins i_system_wrapper/system_i/util_fmcjesdadc1_xcvr/inst/i_xch_0/i_gtxe2_channel/RXOUTCLK]
 
 set_property ASYNC_REG TRUE [get_cells -hier -filter {name =~ *sysref_en_m*}]
 set_false_path -to [get_cells -hier -filter {name =~ *sysref_en_m1*  && IS_SEQUENTIAL}]

--- a/projects/fmcjesdadc1/zc706/system_constr.xdc
+++ b/projects/fmcjesdadc1/zc706/system_constr.xdc
@@ -21,7 +21,7 @@ set_property  -dict {PACKAGE_PIN  P21   IOSTANDARD LVCMOS25} [get_ports spi_sdio
 # clocks
 
 create_clock -name rx_ref_clk   -period  4.00 [get_ports rx_ref_clk_p]
-create_clock -name rx_div_clk   -period  6.40 [get_pins i_system_wrapper/system_i/util_fmcjesdadc1_xcvr/inst/i_xch_0/i_gtxe2_channel/RXOUTCLK]
+create_clock -name rx_div_clk   -period  8.00 [get_pins i_system_wrapper/system_i/util_fmcjesdadc1_xcvr/inst/i_xch_0/i_gtxe2_channel/RXOUTCLK]
 
 set_property ASYNC_REG TRUE [get_cells -hier -filter {name =~ *sysref_en_m*}]
 set_false_path -to [get_cells -hier -filter {name =~ *sysref_en_m1*  && IS_SEQUENTIAL}]


### PR DESCRIPTION
The rx_div_clk should have a frequency of 125MHz, as the maximum lane
rate is 5Gbpsb (5Gbps/40=125MHz). Therefore, the period of rx_div_clk
needs to be changed from 6.40, which corresponds to a frequency of
156.25 MHz, to 8.00 in order to obtain a 125MHz frequency. 