### PR TITLE
common:vcu118: move system memory to DDR C2

### DIFF
--- a/projects/common/vcu118/vcu118_system_bd.tcl
+++ b/projects/common/vcu118/vcu118_system_bd.tcl
@@ -77,8 +77,8 @@ ad_ip_parameter sys_500m_rstgen CONFIG.C_EXT_RST_WIDTH 1
 # instance: ddr4
 
 ad_ip_instance ip:ddr4 axi_ddr_cntrl
-ad_ip_parameter axi_ddr_cntrl CONFIG.C0_CLOCK_BOARD_INTERFACE default_250mhz_clk1
-ad_ip_parameter axi_ddr_cntrl CONFIG.C0_DDR4_BOARD_INTERFACE ddr4_sdram_c1
+ad_ip_parameter axi_ddr_cntrl CONFIG.C0_CLOCK_BOARD_INTERFACE default_250mhz_clk2
+ad_ip_parameter axi_ddr_cntrl CONFIG.C0_DDR4_BOARD_INTERFACE ddr4_sdram_c2
 ad_ip_parameter axi_ddr_cntrl CONFIG.RESET_BOARD_INTERFACE reset
 ad_ip_parameter axi_ddr_cntrl CONFIG.ADDN_UI_CLKOUT2_FREQ_HZ 250
 ad_ip_parameter axi_ddr_cntrl CONFIG.ADDN_UI_CLKOUT3_FREQ_HZ 500

--- a/projects/common/vcu118/vcu118_system_constr.xdc
+++ b/projects/common/vcu118/vcu118_system_constr.xdc
@@ -5,8 +5,8 @@ set_property -dict  {PACKAGE_PIN  L19  IOSTANDARD  LVCMOS12} [get_ports sys_rst]
 
 # clocks
 
-set_property -dict  {PACKAGE_PIN  E12   IOSTANDARD  DIFF_SSTL12} [get_ports sys_clk_p]
-set_property -dict  {PACKAGE_PIN  D12   IOSTANDARD  DIFF_SSTL12} [get_ports sys_clk_n]
+set_property -dict  {PACKAGE_PIN  AW26   IOSTANDARD  LVDS} [get_ports sys_clk_p]
+set_property -dict  {PACKAGE_PIN  AW27   IOSTANDARD  LVDS} [get_ports sys_clk_n]
 
 # ethernet
 


### PR DESCRIPTION
The DDR controller for C2 for is much closer to the transceivers which
connect to the FMCp connector so designs does not have to span over all
three SLRs just over two reducing implementation and timing closure effort.

Tested compile only on dual_ad9208 and daq3. 
Tested on hardware with non hdl projects.