### PR TITLE
jesd204_tx: add output pipeline stage

### DIFF
--- a/library/jesd204/jesd204_tx/jesd204_tx.v
+++ b/library/jesd204/jesd204_tx/jesd204_tx.v
@@ -46,7 +46,8 @@
 
 module jesd204_tx #(
   parameter NUM_LANES = 1,
-  parameter NUM_LINKS = 1
+  parameter NUM_LINKS = 1,
+  parameter NUM_OUTPUT_PIPELINE = 0
 ) (
   input clk,
   input reset,
@@ -109,6 +110,7 @@ localparam LMFC_COUNTER_WIDTH = MAX_BEATS_PER_MULTIFRAME > 256 ? 9 :
   MAX_BEATS_PER_MULTIFRAME > 2 ? 2 : 1;
 
 localparam DW = DATA_PATH_WIDTH * 8 * NUM_LANES;
+localparam CW = DATA_PATH_WIDTH * NUM_LANES;
 
 wire eof_gen_reset;
 wire [DATA_PATH_WIDTH-1:0] eof;
@@ -120,6 +122,9 @@ wire [DW-1:0] ilas_data;
 wire [DATA_PATH_WIDTH-1:0] ilas_charisk;
 
 wire cfg_generate_eomf = 1'b1;
+
+wire [DW-1:0] phy_data_r;
+wire [CW-1:0] phy_charisk_r;
 
 jesd204_lmfc i_lmfc (
   .clk(clk),
@@ -193,6 +198,21 @@ jesd204_eof_generator #(
   .eomf(eomf)
 );
 
+pipeline_stage #(
+  .WIDTH(CW + DW),
+  .REGISTERED(NUM_OUTPUT_PIPELINE)
+) i_output_pipeline_stage (
+  .clk(clk),
+  .in({
+    phy_data_r,
+    phy_charisk_r
+  }),
+  .out({
+    phy_data,
+    phy_charisk
+  })
+);
+
 generate
 genvar i;
 for (i = 0; i < NUM_LANES; i = i + 1) begin: gen_lane
@@ -218,8 +238,8 @@ for (i = 0; i < NUM_LANES; i = i + 1) begin: gen_lane
     .tx_data(tx_data[D_STOP:D_START]),
     .tx_ready(tx_ready),
 
-    .phy_data(phy_data[D_STOP:D_START]),
-    .phy_charisk(phy_charisk[C_STOP:C_START]),
+    .phy_data(phy_data_r[D_STOP:D_START]),
+    .phy_charisk(phy_charisk_r[C_STOP:C_START]),
 
     .cfg_disable_scrambler(cfg_disable_scrambler)
   );

--- a/library/jesd204/jesd204_tx/jesd204_tx_hw.tcl
+++ b/library/jesd204/jesd204_tx/jesd204_tx_hw.tcl
@@ -61,6 +61,7 @@ ad_ip_files jesd204_tx [list \
   ../jesd204_common/jesd204_eof_generator.v \
   ../jesd204_common/jesd204_lmfc.v \
   ../jesd204_common/jesd204_scrambler.v \
+  ../jesd204_common/pipeline_stage.v \
   $ad_hdl_dir/library/util_cdc/sync_bits.v \
   $ad_hdl_dir/library/util_cdc/util_cdc_constr.tcl \
 ]
@@ -76,6 +77,11 @@ add_parameter NUM_LINKS INTEGER 1
 set_parameter_property NUM_LINKS DISPLAY_NAME "Number of Links"
 set_parameter_property NUM_LINKS ALLOWED_RANGES 1:8
 set_parameter_property NUM_LINKS HDL_PARAMETER true
+
+add_parameter NUM_OUTPUT_PIPELINE INTEGER 0
+set_parameter_property NUM_OUTPUT_PIPELINE DISPLAY_NAME "Number of output pipeline stages"
+set_parameter_property NUM_OUTPUT_PIPELINE ALLOWED_RANGES 0:3
+set_parameter_property NUM_OUTPUT_PIPELINE HDL_PARAMETER true
 
 # clock
 


### PR DESCRIPTION
This change adds an option for pipe-lining the Tx link layer towards physical layer for better timing closure on multi SLR devices.

Tested on non-public hardware.