### PR TITLE
adi_board.tcl:ad_xcvrcon: do not reorder common control

### DIFF
--- a/projects/scripts/adi_board.tcl
+++ b/projects/scripts/adi_board.tcl
@@ -280,8 +280,8 @@ proc ad_xcvrcon {u_xcvr a_xcvr a_jesd {lane_map {}} {device_clk {}}} {
       }
     }
 
-    if {(($phys_lane%4) == 0) && ($qpll_enable == 1)} {
-      ad_connect  ${a_xcvr}/up_cm_${n} ${u_xcvr}/up_cm_${phys_lane}
+    if {(($n%4) == 0) && ($qpll_enable == 1)} {
+      ad_connect  ${a_xcvr}/up_cm_${n} ${u_xcvr}/up_cm_${n}
     }
     ad_connect  ${a_xcvr}/up_ch_${n} ${u_xcvr}/up_${txrx}_${phys_lane}
     ad_connect  ${device_clk} ${u_xcvr}/${txrx}_clk_${phys_lane}


### PR DESCRIPTION
When channels are not swapped in groups of four but are completely out of order
the common control channel can't be reordered based on the index of the
channel.