### PR TITLE
Fix filter control GPIO

### DIFF
--- a/projects/common/xilinx/adi_fir_filter_constr.xdc
+++ b/projects/common/xilinx/adi_fir_filter_constr.xdc
@@ -1,0 +1,7 @@
+# constraints
+
+set_property ASYNC_REG TRUE [get_cells -hier -filter {name =~ */cdc_sync_active/inst/cdc_sync_stage1_reg*}]
+set_property ASYNC_REG TRUE [get_cells -hier -filter {name =~ */cdc_sync_active/inst/cdc_sync_stage2_reg*}]
+
+set_false_path  -to [get_cells -hierarchical -filter {name =~ */cdc_sync_active/inst/cdc_sync_stage1_reg** && IS_SEQUENTIAL}]
+set_false_path  -to [get_cells -hierarchical -filter {name =~ */cdc_sync_active/inst/cdc_sync_stage2_reg** && IS_SEQUENTIAL}]


### PR DESCRIPTION
The GPIO, which activates the decimation and interpolation filters was not synchronized to the filter core clock, causing timing violation on KCU105.