### PR TITLE
Bugfixes for dac_fmc_ebz; unused lanes and bypassing FIFO 

### DIFF
--- a/projects/dac_fmc_ebz/common/dac_fmc_ebz_bd.tcl
+++ b/projects/dac_fmc_ebz/common/dac_fmc_ebz_bd.tcl
@@ -165,7 +165,7 @@ ad_cpu_interrupt ps-12 mb-13 dac_dma/irq
 ad_connect axi_dac_fifo/bypass dac_fifo_bypass
 
 # Create dummy outputs for unused Tx lanes
-for {set i $JESD_L} {$i < 8} {incr i} {
+for {set i $NUM_OF_LANES} {$i < 8} {incr i} {
   create_bd_port -dir O tx_data_${i}_n
   create_bd_port -dir O tx_data_${i}_p
 }

--- a/projects/dac_fmc_ebz/zcu102/system_top.v
+++ b/projects/dac_fmc_ebz/zcu102/system_top.v
@@ -221,6 +221,7 @@ module system_top #(
   system_wrapper i_system_wrapper (
     .gpio_i (gpio_i),
     .gpio_o (gpio_o),
+    .dac_fifo_bypass(dac_fifo_bypass),
     .spi0_csn (spi0_csn),
     .spi0_miso (spi_miso),
     .spi0_mosi (spi_mosi),


### PR DESCRIPTION
:bug: Pass through FIFO bypass GPIO signal
:bug: Create dummy ports only for unused lanes