### PR TITLE
ad40xx: Remove redundant upscaler IP

### DIFF
--- a/projects/ad40xx_fmc/zed/system_constr_ad40xx.xdc
+++ b/projects/ad40xx_fmc/zed/system_constr_ad40xx.xdc
@@ -8,3 +8,5 @@ set_property -dict {PACKAGE_PIN M20 IOSTANDARD LVCMOS25 IOB TRUE} [get_ports ad4
 
 set_property -dict {PACKAGE_PIN P22 IOSTANDARD LVCMOS25} [get_ports ad40xx_amp_pd]        ; ## G10  FMC_LPC_LA03_N
 
+set_multicycle_path 2 -setup -from [get_pins -hierarchical -filter {NAME=~*/i_sdo_fifo/i_mem/m_ram_reg/CLKARDCLK}] -to [get_pins -hierarchical -filter {NAME=~*/data_sdo_shift_reg[*]/D} 
+set_multicycle_path 1 -hold -from [get_pins -hierarchical -filter {NAME=~*/i_sdo_fifo/i_mem/m_ram_reg/CLKARDCLK}] -to [get_pins -hierarchical -filter {NAME=~*/data_sdo_shift_reg[*]/D}] 

--- a/projects/ad40xx_fmc/zed/system_constr_adaq400x.xdc
+++ b/projects/ad40xx_fmc/zed/system_constr_adaq400x.xdc
@@ -6,3 +6,5 @@ set_property -dict {PACKAGE_PIN Y10  IOSTANDARD LVCMOS33} [get_ports adaq400x_sp
 set_property -dict {PACKAGE_PIN AA9  IOSTANDARD LVCMOS33} [get_ports adaq400x_spi_sclk]      ; ## JA4
 set_property -dict {PACKAGE_PIN Y11  IOSTANDARD LVCMOS33} [get_ports adaq400x_spi_cs]        ; ## JA1
 
+set_multicycle_path 2 -setup -from [get_pins -hierarchical -filter {NAME=~*/i_sdo_fifo/i_mem/m_ram_reg/CLKARDCLK}] -to [get_pins -hierarchical -filter {NAME=~*/data_sdo_shift_reg[*]/D} 
+set_multicycle_path 1 -hold -from [get_pins -hierarchical -filter {NAME=~*/i_sdo_fifo/i_mem/m_ram_reg/CLKARDCLK}] -to [get_pins -hierarchical -filter {NAME=~*/data_sdo_shift_reg[*]/D}] 


### PR DESCRIPTION
The upscaler IP is no more needed, as the SPI Engine framework supports data transfers larger than 16 bits. Also, the AXI SPI Engine IP has been renamed to axi_regmap, which is more suggestive. 

Because the SDO_SHIFT_REG is initialized once at the beginning of the SPI transfer, increase the timing margin for the REG so we can use higher spi_clk frequency. The corresponding multicycle path constraints have been added in both xdc.