### PR TITLE
ad_rst_constr: Added the quiet option

### DIFF
--- a/library/xilinx/common/ad_rst_constr.xdc
+++ b/library/xilinx/common/ad_rst_constr.xdc
@@ -1,7 +1,9 @@
+# the "-quiet" option is added for the axi_spi_engine ip where the ad_rst.v 
+# module is not always inferred and this causes critical warnings
 
-set_property ASYNC_REG TRUE [get_cells -hierarchical -filter {name =~ *rst_async_d*_reg}]
-set_property ASYNC_REG TRUE [get_cells -hierarchical -filter {name =~ *rst_sync_reg}]
+set_property -quiet ASYNC_REG TRUE [get_cells -hierarchical -filter {name =~ *rst_async_d*_reg}]
+set_property -quiet ASYNC_REG TRUE [get_cells -hierarchical -filter {name =~ *rst_sync_reg}]
 
-set_false_path -to [get_pins -hierarchical *rst_sync_reg/PRE]
-set_false_path -to [get_pins -hierarchical *rst_async_d1_reg/PRE]
-set_false_path -to [get_pins -hierarchical *rst_async_d2_reg/PRE]
+set_false_path -quiet -to [get_pins -hierarchical *rst_sync_reg/PRE] 
+set_false_path -quiet -to [get_pins -hierarchical *rst_async_d1_reg/PRE]
+set_false_path -quiet -to [get_pins -hierarchical *rst_async_d2_reg/PRE]


### PR DESCRIPTION
critical warnings were caused by this file when the ad_rst.v instantiation
was done using generate depending on a parameter (i.e. axi_spi_engine)