### PR TITLE
Lidar: update the IO constraints to revB

### DIFF
--- a/projects/ad_fmclidar1_ebz/a10soc/system_project.tcl
+++ b/projects/ad_fmclidar1_ebz/a10soc/system_project.tcl
@@ -116,21 +116,21 @@ set_location_assignment  PIN_G7  -to  laser_driver           ; ## C22  FMCA_HPC_
 set_location_assignment  PIN_H7  -to  "laser_driver(n)"      ; ## C23  FMCA_HPC_LA18_CC_N
 
 set_location_assignment  PIN_G1  -to  laser_driver_en_n      ; ## C26  FMCA_HPC_LA27_P
-set_location_assignment  PIN_H2  -to  laser_driver_otw_n     ; ## C27  FMCA_HPC_LA27_N
+set_location_assignment  PIN_P8  -to  laser_driver_otw_n     ; ## G33  FMCA_HPC_LA31_P
 
-set_location_assignment  PIN_F9  -to  laser_gpio[0]          ; ## D20  FMCA_HPC_LA17_CC_P
-set_location_assignment  PIN_G9  -to  laser_gpio[1]          ; ## D21  FMCA_HPC_LA17_CC_N
-set_location_assignment  PIN_C1  -to  laser_gpio[2]          ; ## D23  FMCA_HPC_LA23_P
-set_location_assignment  PIN_D1  -to  laser_gpio[3]          ; ## D24  FMCA_HPC_LA23_N
-set_location_assignment  PIN_F2  -to  laser_gpio[4]          ; ## D26  FMCA_HPC_LA26_P
-set_location_assignment  PIN_G2  -to  laser_gpio[5]          ; ## D27  FMCA_HPC_LA26_N
-set_location_assignment  PIN_F4  -to  laser_gpio[6]          ; ## G24  FMCA_HPC_LA22_P
-set_location_assignment  PIN_G4  -to  laser_gpio[7]          ; ## G25  FMCA_HPC_LA22_N
-set_location_assignment  PIN_E3  -to  laser_gpio[8]          ; ## G27  FMCA_HPC_LA25_P
-set_location_assignment  PIN_F3  -to  laser_gpio[9]          ; ## G28  FMCA_HPC_LA25_N
-set_location_assignment  PIN_N9  -to  laser_gpio[10]         ; ## G30  FMCA_HPC_LA29_P
-set_location_assignment  PIN_P10 -to  laser_gpio[11]         ; ## G31  FMCA_HPC_LA29_N
-set_location_assignment  PIN_P8  -to  laser_gpio[12]         ; ## G33  FMCA_HPC_LA31_P
+set_location_assignment  PIN_H2  -to  laser_gpio[0]          ; ## C27  FMCA_HPC_LA27_N
+set_location_assignment  PIN_F9  -to  laser_gpio[1]          ; ## D20  FMCA_HPC_LA17_CC_P
+set_location_assignment  PIN_G9  -to  laser_gpio[2]          ; ## D21  FMCA_HPC_LA17_CC_N
+set_location_assignment  PIN_C1  -to  laser_gpio[3]          ; ## D23  FMCA_HPC_LA23_P
+set_location_assignment  PIN_D1  -to  laser_gpio[4]          ; ## D24  FMCA_HPC_LA23_N
+set_location_assignment  PIN_F2  -to  laser_gpio[5]          ; ## D26  FMCA_HPC_LA26_P
+set_location_assignment  PIN_G2  -to  laser_gpio[6]          ; ## D27  FMCA_HPC_LA26_N
+set_location_assignment  PIN_F4  -to  laser_gpio[7]          ; ## G24  FMCA_HPC_LA22_P
+set_location_assignment  PIN_G4  -to  laser_gpio[8]          ; ## G25  FMCA_HPC_LA22_N
+set_location_assignment  PIN_E3  -to  laser_gpio[9]          ; ## G27  FMCA_HPC_LA25_P
+set_location_assignment  PIN_F3  -to  laser_gpio[10]         ; ## G28  FMCA_HPC_LA25_N
+set_location_assignment  PIN_N9  -to  laser_gpio[11]         ; ## G30  FMCA_HPC_LA29_P
+set_location_assignment  PIN_P10 -to  laser_gpio[12]         ; ## G31  FMCA_HPC_LA29_N
 set_location_assignment  PIN_R8  -to  laser_gpio[13]         ; ## G34  FMCA_HPC_LA31_N
 
 set_instance_assignment -name IO_STANDARD LVDS -to  laser_driver

--- a/projects/ad_fmclidar1_ebz/zc706/system_constr.xdc
+++ b/projects/ad_fmclidar1_ebz/zc706/system_constr.xdc
@@ -51,21 +51,21 @@ set_property  -dict {PACKAGE_PIN  W25   IOSTANDARD LVDS_25 DIFF_TERM TRUE}  [get
 set_property  -dict {PACKAGE_PIN  W26   IOSTANDARD LVDS_25 DIFF_TERM TRUE}  [get_ports laser_driver_n]  ; ## C23  FMC_HPC_LA18_CC_N
 
 set_property  -dict {PACKAGE_PIN  V28   IOSTANDARD LVCMOS25} [get_ports laser_driver_en_n]        ; ## C26  FMC_HPC_LA27_P
-set_property  -dict {PACKAGE_PIN  V29   IOSTANDARD LVCMOS25} [get_ports laser_driver_otw_n]       ; ## C27  FMC_HPC_LA27_N
+set_property  -dict {PACKAGE_PIN  N29   IOSTANDARD LVCMOS25} [get_ports laser_driver_otw_n]       ; ## G33  FMC_HPC_LA31_P
 
-set_property  -dict {PACKAGE_PIN  V23   IOSTANDARD LVCMOS25} [get_ports laser_gpio[0]]          ; ## D20  FMC_HPC_LA17_CC_P
-set_property  -dict {PACKAGE_PIN  W24   IOSTANDARD LVCMOS25} [get_ports laser_gpio[1]]          ; ## D21  FMC_HPC_LA17_CC_N
-set_property  -dict {PACKAGE_PIN  P25   IOSTANDARD LVCMOS25} [get_ports laser_gpio[2]]          ; ## D23  FMC_HPC_LA23_P
-set_property  -dict {PACKAGE_PIN  P26   IOSTANDARD LVCMOS25} [get_ports laser_gpio[3]]          ; ## D24  FMC_HPC_LA23_N
-set_property  -dict {PACKAGE_PIN  R28   IOSTANDARD LVCMOS25} [get_ports laser_gpio[4]]          ; ## D26  FMC_HPC_LA26_P
-set_property  -dict {PACKAGE_PIN  T28   IOSTANDARD LVCMOS25} [get_ports laser_gpio[5]]          ; ## D27  FMC_HPC_LA26_N
-set_property  -dict {PACKAGE_PIN  V27   IOSTANDARD LVCMOS25} [get_ports laser_gpio[6]]          ; ## G24  FMC_HPC_LA22_P
-set_property  -dict {PACKAGE_PIN  W28   IOSTANDARD LVCMOS25} [get_ports laser_gpio[7]]          ; ## G25  FMC_HPC_LA22_N
-set_property  -dict {PACKAGE_PIN  T29   IOSTANDARD LVCMOS25} [get_ports laser_gpio[8]]          ; ## G27  FMC_HPC_LA25_P
-set_property  -dict {PACKAGE_PIN  U29   IOSTANDARD LVCMOS25} [get_ports laser_gpio[9]]          ; ## G28  FMC_HPC_LA25_N
-set_property  -dict {PACKAGE_PIN  R25   IOSTANDARD LVCMOS25} [get_ports laser_gpio[10]]         ; ## G30  FMC_HPC_LA29_P
-set_property  -dict {PACKAGE_PIN  R26   IOSTANDARD LVCMOS25} [get_ports laser_gpio[11]]         ; ## G31  FMC_HPC_LA29_N
-set_property  -dict {PACKAGE_PIN  N29   IOSTANDARD LVCMOS25} [get_ports laser_gpio[12]]         ; ## G33  FMC_HPC_LA31_P
+set_property  -dict {PACKAGE_PIN  V29   IOSTANDARD LVCMOS25} [get_ports laser_gpio[0]]          ; ## C27  FMC_HPC_LA27_N
+set_property  -dict {PACKAGE_PIN  V23   IOSTANDARD LVCMOS25} [get_ports laser_gpio[1]]          ; ## D20  FMC_HPC_LA17_CC_P
+set_property  -dict {PACKAGE_PIN  W24   IOSTANDARD LVCMOS25} [get_ports laser_gpio[2]]          ; ## D21  FMC_HPC_LA17_CC_N
+set_property  -dict {PACKAGE_PIN  P25   IOSTANDARD LVCMOS25} [get_ports laser_gpio[3]]          ; ## D23  FMC_HPC_LA23_P
+set_property  -dict {PACKAGE_PIN  P26   IOSTANDARD LVCMOS25} [get_ports laser_gpio[4]]          ; ## D24  FMC_HPC_LA23_N
+set_property  -dict {PACKAGE_PIN  R28   IOSTANDARD LVCMOS25} [get_ports laser_gpio[5]]          ; ## D26  FMC_HPC_LA26_P
+set_property  -dict {PACKAGE_PIN  T28   IOSTANDARD LVCMOS25} [get_ports laser_gpio[6]]          ; ## D27  FMC_HPC_LA26_N
+set_property  -dict {PACKAGE_PIN  V27   IOSTANDARD LVCMOS25} [get_ports laser_gpio[7]]          ; ## G24  FMC_HPC_LA22_P
+set_property  -dict {PACKAGE_PIN  W28   IOSTANDARD LVCMOS25} [get_ports laser_gpio[8]]          ; ## G25  FMC_HPC_LA22_N
+set_property  -dict {PACKAGE_PIN  T29   IOSTANDARD LVCMOS25} [get_ports laser_gpio[9]]          ; ## G27  FMC_HPC_LA25_P
+set_property  -dict {PACKAGE_PIN  U29   IOSTANDARD LVCMOS25} [get_ports laser_gpio[10]]         ; ## G28  FMC_HPC_LA25_N
+set_property  -dict {PACKAGE_PIN  R25   IOSTANDARD LVCMOS25} [get_ports laser_gpio[11]]         ; ## G30  FMC_HPC_LA29_P
+set_property  -dict {PACKAGE_PIN  R26   IOSTANDARD LVCMOS25} [get_ports laser_gpio[12]]         ; ## G31  FMC_HPC_LA29_N
 set_property  -dict {PACKAGE_PIN  P29   IOSTANDARD LVCMOS25} [get_ports laser_gpio[13]]         ; ## G34  FMC_HPC_LA31_N
 
 # TIA channel selection

--- a/projects/ad_fmclidar1_ebz/zcu102/system_constr.xdc
+++ b/projects/ad_fmclidar1_ebz/zcu102/system_constr.xdc
@@ -51,21 +51,21 @@ set_property  -dict {PACKAGE_PIN  N9   IOSTANDARD LVDS}  [get_ports laser_driver
 set_property  -dict {PACKAGE_PIN  N8   IOSTANDARD LVDS}  [get_ports laser_driver_n]          ; ## C23  FMC_HPC_LA18_CC_N
 
 set_property  -dict {PACKAGE_PIN  M10   IOSTANDARD LVCMOS18} [get_ports laser_driver_en_n]   ; ## C26  FMC_HPC_LA27_P
-set_property  -dict {PACKAGE_PIN  L10   IOSTANDARD LVCMOS18} [get_ports laser_driver_otw_n]  ; ## C27  FMC_HPC_LA27_N
+set_property  -dict {PACKAGE_PIN  V8    IOSTANDARD LVCMOS18} [get_ports laser_driver_otw_n]  ; ## G33  FMC_HPC_LA31_P
 
-set_property  -dict {PACKAGE_PIN  P11   IOSTANDARD LVCMOS18} [get_ports laser_gpio[0]]       ; ## D20  FMC_HPC_LA17_CC_P
-set_property  -dict {PACKAGE_PIN  N11   IOSTANDARD LVCMOS18} [get_ports laser_gpio[1]]       ; ## D21  FMC_HPC_LA17_CC_N
-set_property  -dict {PACKAGE_PIN  L16   IOSTANDARD LVCMOS18} [get_ports laser_gpio[2]]       ; ## D23  FMC_HPC_LA23_P
-set_property  -dict {PACKAGE_PIN  K16   IOSTANDARD LVCMOS18} [get_ports laser_gpio[3]]       ; ## D24  FMC_HPC_LA23_N
-set_property  -dict {PACKAGE_PIN  L15   IOSTANDARD LVCMOS18} [get_ports laser_gpio[4]]       ; ## D26  FMC_HPC_LA26_P
-set_property  -dict {PACKAGE_PIN  K15   IOSTANDARD LVCMOS18} [get_ports laser_gpio[5]]       ; ## D27  FMC_HPC_LA26_N
-set_property  -dict {PACKAGE_PIN  M15   IOSTANDARD LVCMOS18} [get_ports laser_gpio[6]]       ; ## G24  FMC_HPC_LA22_P
-set_property  -dict {PACKAGE_PIN  M14   IOSTANDARD LVCMOS18} [get_ports laser_gpio[7]]       ; ## G25  FMC_HPC_LA22_N
-set_property  -dict {PACKAGE_PIN  M11   IOSTANDARD LVCMOS18} [get_ports laser_gpio[8]]       ; ## G27  FMC_HPC_LA25_P
-set_property  -dict {PACKAGE_PIN  L11   IOSTANDARD LVCMOS18} [get_ports laser_gpio[9]]       ; ## G28  FMC_HPC_LA25_N
-set_property  -dict {PACKAGE_PIN  U9    IOSTANDARD LVCMOS18} [get_ports laser_gpio[10]]      ; ## G30  FMC_HPC_LA29_P
-set_property  -dict {PACKAGE_PIN  U8    IOSTANDARD LVCMOS18} [get_ports laser_gpio[11]]      ; ## G31  FMC_HPC_LA29_N
-set_property  -dict {PACKAGE_PIN  V8    IOSTANDARD LVCMOS18} [get_ports laser_gpio[12]]      ; ## G33  FMC_HPC_LA31_P
+set_property  -dict {PACKAGE_PIN  L10   IOSTANDARD LVCMOS18} [get_ports laser_gpio[0]]       ; ## C27  FMC_HPC_LA27_N
+set_property  -dict {PACKAGE_PIN  P11   IOSTANDARD LVCMOS18} [get_ports laser_gpio[1]]       ; ## D20  FMC_HPC_LA17_CC_P
+set_property  -dict {PACKAGE_PIN  N11   IOSTANDARD LVCMOS18} [get_ports laser_gpio[2]]       ; ## D21  FMC_HPC_LA17_CC_N
+set_property  -dict {PACKAGE_PIN  L16   IOSTANDARD LVCMOS18} [get_ports laser_gpio[3]]       ; ## D23  FMC_HPC_LA23_P
+set_property  -dict {PACKAGE_PIN  K16   IOSTANDARD LVCMOS18} [get_ports laser_gpio[4]]       ; ## D24  FMC_HPC_LA23_N
+set_property  -dict {PACKAGE_PIN  L15   IOSTANDARD LVCMOS18} [get_ports laser_gpio[5]]       ; ## D26  FMC_HPC_LA26_P
+set_property  -dict {PACKAGE_PIN  K15   IOSTANDARD LVCMOS18} [get_ports laser_gpio[6]]       ; ## D27  FMC_HPC_LA26_N
+set_property  -dict {PACKAGE_PIN  M15   IOSTANDARD LVCMOS18} [get_ports laser_gpio[7]]       ; ## G24  FMC_HPC_LA22_P
+set_property  -dict {PACKAGE_PIN  M14   IOSTANDARD LVCMOS18} [get_ports laser_gpio[8]]       ; ## G25  FMC_HPC_LA22_N
+set_property  -dict {PACKAGE_PIN  M11   IOSTANDARD LVCMOS18} [get_ports laser_gpio[9]]       ; ## G27  FMC_HPC_LA25_P
+set_property  -dict {PACKAGE_PIN  L11   IOSTANDARD LVCMOS18} [get_ports laser_gpio[10]]      ; ## G28  FMC_HPC_LA25_N
+set_property  -dict {PACKAGE_PIN  U9    IOSTANDARD LVCMOS18} [get_ports laser_gpio[11]]      ; ## G30  FMC_HPC_LA29_P
+set_property  -dict {PACKAGE_PIN  U8    IOSTANDARD LVCMOS18} [get_ports laser_gpio[12]]      ; ## G31  FMC_HPC_LA29_N
 set_property  -dict {PACKAGE_PIN  V7    IOSTANDARD LVCMOS18} [get_ports laser_gpio[13]]      ; ## G34  FMC_HPC_LA31_N
 
 # TIA channel selection


### PR DESCRIPTION
The IO location of the laser_driver_otw_n was moved from FMC_HPC_LA27_N
to FMC_HPC_LA31 (laser_gpio[12]).
laser_gpio[11:0] assignments were shifted with one bit to MSB, and laser_gpio[0]
got the old location of the laser_driver_otw_n.