### PR TITLE
cn0506_mii Updates for Rev B board

### DIFF
--- a/projects/cn0506_mii/a10soc/system_project.tcl
+++ b/projects/cn0506_mii/a10soc/system_project.tcl
@@ -22,7 +22,7 @@ source $ad_hdl_dir/projects/common/a10soc/a10soc_system_assign.tcl
 #  R633: R0 -> DNI
 
 set_location_assignment PIN_G14    -to  mii_rx_clk_a            ; ## G06 FMCA_HPC_LA00_CC_P
-set_location_assignment PIN_E12    -to  mii_rx_er_a             ; ## D08 FMCA_HPC_LA01_CC_P
+set_location_assignment PIN_E13    -to  mii_rx_er_a             ; ## D09 FMCA_HPC_LA01_CC_N
 set_location_assignment PIN_B9     -to  mii_rx_dv_a             ; ## H14 FMCA_HPC_LA07_N
 set_location_assignment PIN_C13    -to  mii_rxd_a[0]            ; ## H07 FMCA_HPC_LA02_P
 set_location_assignment PIN_D13    -to  mii_rxd_a[1]            ; ## H08 FMCA_HPC_LA02_N
@@ -68,7 +68,7 @@ set_instance_assignment -name IO_STANDARD "1.8 V" -to led_al_c_c2m
 set_instance_assignment -name IO_STANDARD "1.8 V" -to led_al_a_c2m
 
 set_location_assignment PIN_G7     -to  mii_rx_clk_b            ; ## C22 FMCA_HPC_LA18_CC_P
-set_location_assignment PIN_F9     -to  mii_rx_er_b             ; ## D20 FMCA_HPC_LA17_CC_P
+set_location_assignment PIN_G9     -to  mii_rx_er_b             ; ## D21 FMCA_HPC_LA17_CC_N
 set_location_assignment PIN_E2     -to  mii_rx_dv_b             ; ## H29 FMCA_HPC_LA24_N
 set_location_assignment PIN_G5     -to  mii_rxd_b[0]            ; ## H22 FMCA_HPC_LA19_P
 set_location_assignment PIN_G6     -to  mii_rxd_b[1]            ; ## H23 FMCA_HPC_LA19_N

--- a/projects/cn0506_mii/zc706/system_constr.xdc
+++ b/projects/cn0506_mii/zc706/system_constr.xdc
@@ -1,6 +1,6 @@
 
 set_property -dict {PACKAGE_PIN AE13  IOSTANDARD LVCMOS25} [get_ports mii_rx_clk_a]                ; ## G06 FMC_LPC_LA00_CC_P
-set_property -dict {PACKAGE_PIN AF15  IOSTANDARD LVCMOS25} [get_ports mii_rx_er_a]                 ; ## D08 FMC_LPC_LA01_CC_P
+set_property -dict {PACKAGE_PIN AG15  IOSTANDARD LVCMOS25} [get_ports mii_rx_er_a]                 ; ## D09 FMC_LPC_LA01_CC_N
 set_property -dict {PACKAGE_PIN AA14  IOSTANDARD LVCMOS25} [get_ports mii_rx_dv_a]                 ; ## H14 FMC_LPC_LA07_N
 set_property -dict {PACKAGE_PIN AE12  IOSTANDARD LVCMOS25} [get_ports {mii_rxd_a[0]}]              ; ## H07 FMC_LPC_LA02_P
 set_property -dict {PACKAGE_PIN AF12  IOSTANDARD LVCMOS25} [get_ports {mii_rxd_a[1]}]              ; ## H08 FMC_LPC_LA02_N
@@ -26,7 +26,7 @@ set_property -dict {PACKAGE_PIN AH17  IOSTANDARD LVCMOS25} [get_ports led_al_c_c
 set_property -dict {PACKAGE_PIN AH16  IOSTANDARD LVCMOS25} [get_ports led_al_a_c2m]                ; ## D18 FMC_LPC_LA13_N
 
 set_property -dict {PACKAGE_PIN AE27  IOSTANDARD LVCMOS25} [get_ports mii_rx_clk_b]                ; ## C22 FMC_LPC_LA18_CC_P
-set_property -dict {PACKAGE_PIN AB27  IOSTANDARD LVCMOS25} [get_ports mii_rx_er_b]                 ; ## D20 FMC_LPC_LA17_CC_P
+set_property -dict {PACKAGE_PIN AC27  IOSTANDARD LVCMOS25} [get_ports mii_rx_er_b]                 ; ## D21 FMC_LPC_LA17_CC_N
 set_property -dict {PACKAGE_PIN AG30  IOSTANDARD LVCMOS25} [get_ports mii_rx_dv_b]                 ; ## H29 FMC_LPC_LA24_N
 set_property -dict {PACKAGE_PIN AH26  IOSTANDARD LVCMOS25} [get_ports {mii_rxd_b[0]}]              ; ## H22 FMC_LPC_LA19_P
 set_property -dict {PACKAGE_PIN AH27  IOSTANDARD LVCMOS25} [get_ports {mii_rxd_b[1]}]              ; ## H23 FMC_LPC_LA19_N

--- a/projects/cn0506_mii/zcu102/system_constr.xdc
+++ b/projects/cn0506_mii/zcu102/system_constr.xdc
@@ -1,6 +1,6 @@
 
 set_property -dict {PACKAGE_PIN AE5  IOSTANDARD LVCMOS18} [get_ports mii_rx_clk_a]                 ; ## G06 FMC_HPC1_LA00_CC_P
-set_property -dict {PACKAGE_PIN AJ6  IOSTANDARD LVCMOS18} [get_ports mii_rx_er_a]                  ; ## D08 FMC_HPC1_LA01_CC_P
+set_property -dict {PACKAGE_PIN AJ5  IOSTANDARD LVCMOS18} [get_ports mii_rx_er_a]                  ; ## D09 FMC_HPC1_LA01_CC_N
 set_property -dict {PACKAGE_PIN AE4  IOSTANDARD LVCMOS18} [get_ports mii_rx_dv_a]                  ; ## H14 FMC_HPC1_LA07_N
 set_property -dict {PACKAGE_PIN AD2  IOSTANDARD LVCMOS18} [get_ports {mii_rxd_a[0]}]               ; ## H07 FMC_HPC1_LA02_P
 set_property -dict {PACKAGE_PIN AD1  IOSTANDARD LVCMOS18} [get_ports {mii_rxd_a[1]}]               ; ## H08 FMC_HPC1_LA02_N
@@ -26,7 +26,7 @@ set_property -dict {PACKAGE_PIN AG8  IOSTANDARD LVCMOS18} [get_ports led_al_c_c2
 set_property -dict {PACKAGE_PIN AH8  IOSTANDARD LVCMOS18} [get_ports led_al_a_c2m]                 ; ## D18 FMC_HPC1_LA13_N
 
 set_property -dict {PACKAGE_PIN Y8   IOSTANDARD LVCMOS18} [get_ports mii_rx_clk_b]                 ; ## C22 FMC_HPC1_LA18_CC_P
-set_property -dict {PACKAGE_PIN Y5   IOSTANDARD LVCMOS18} [get_ports mii_rx_er_b]                  ; ## D20 FMC_HPC1_LA17_CC_P
+set_property -dict {PACKAGE_PIN AA5  IOSTANDARD LVCMOS18} [get_ports mii_rx_er_b]                  ; ## D21 FMC_HPC1_LA17_CC_N
 set_property -dict {PACKAGE_PIN AH11 IOSTANDARD LVCMOS18} [get_ports mii_rx_dv_b]                  ; ## H29 FMC_HPC1_LA24_N
 set_property -dict {PACKAGE_PIN AA11 IOSTANDARD LVCMOS18} [get_ports {mii_rxd_b[0]}]               ; ## H22 FMC_HPC1_LA19_P
 set_property -dict {PACKAGE_PIN AA10 IOSTANDARD LVCMOS18} [get_ports {mii_rxd_b[1]}]               ; ## H23 FMC_HPC1_LA19_N

--- a/projects/cn0506_mii/zed/system_constr.xdc
+++ b/projects/cn0506_mii/zed/system_constr.xdc
@@ -1,6 +1,6 @@
 
 set_property -dict {PACKAGE_PIN M19  IOSTANDARD LVCMOS25} [get_ports mii_rx_clk_a]                ; ## G06 FMC_LPC_LA00_CC_P
-set_property -dict {PACKAGE_PIN N19 IOSTANDARD LVCMOS25} [get_ports mii_rx_er_a]                  ; ## D08 FMC_LPC_LA01_CC_P
+set_property -dict {PACKAGE_PIN N20  IOSTANDARD LVCMOS25} [get_ports mii_rx_er_a]                 ; ## D09 FMC_LPC_LA01_CC_N
 set_property -dict {PACKAGE_PIN T17  IOSTANDARD LVCMOS25} [get_ports mii_rx_dv_a]                 ; ## H14 FMC_LPC_LA07_N
 set_property -dict {PACKAGE_PIN P17  IOSTANDARD LVCMOS25} [get_ports {mii_rxd_a[0]}]              ; ## H07 FMC_LPC_LA02_P
 set_property -dict {PACKAGE_PIN P18  IOSTANDARD LVCMOS25} [get_ports {mii_rxd_a[1]}]              ; ## H08 FMC_LPC_LA02_N
@@ -26,7 +26,7 @@ set_property -dict {PACKAGE_PIN L17  IOSTANDARD LVCMOS25} [get_ports led_al_c_c2
 set_property -dict {PACKAGE_PIN M17  IOSTANDARD LVCMOS25} [get_ports led_al_a_c2m]                ; ## D18 FMC_LPC_LA13_N
 
 set_property -dict {PACKAGE_PIN D20  IOSTANDARD LVCMOS25} [get_ports mii_rx_clk_b]                ; ## C22 FMC_LPC_LA18_CC_P
-set_property -dict {PACKAGE_PIN B19  IOSTANDARD LVCMOS25} [get_ports mii_rx_er_b]                 ; ## D20 FMC_LPC_LA17_CC_P
+set_property -dict {PACKAGE_PIN B20  IOSTANDARD LVCMOS25} [get_ports mii_rx_er_b]                 ; ## D21 FMC_LPC_LA17_CC_N
 set_property -dict {PACKAGE_PIN A19  IOSTANDARD LVCMOS25} [get_ports mii_rx_dv_b]                 ; ## H29 FMC_LPC_LA24_N
 set_property -dict {PACKAGE_PIN G15  IOSTANDARD LVCMOS25} [get_ports {mii_rxd_b[0]}]              ; ## H22 FMC_LPC_LA19_P
 set_property -dict {PACKAGE_PIN G16  IOSTANDARD LVCMOS25} [get_ports {mii_rxd_b[1]}]              ; ## H23 FMC_LPC_LA19_N


### PR DESCRIPTION
Because of the rmii mode requirements(external 50MHz clock), the board will have the rx_err signal replaced on the FMC connector by the 50MHz external clock (D08/D20).
The rx_er will be shifted to the D9/D21 pins.