### PR TITLE
cn0506_rgmii: Fix no clock defined warnings

### DIFF
--- a/projects/cn0506_rgmii/zcu102/system_constr.xdc
+++ b/projects/cn0506_rgmii/zcu102/system_constr.xdc
@@ -61,3 +61,9 @@ set_property UNAVAILABLE_DURING_CALIBRATION TRUE [get_ports rgmii_txd_b]
 
 set_property UNAVAILABLE_DURING_CALIBRATION TRUE [get_ports link_st_b]
 
+create_clock -period 400.000 -name mdio_clk_a [get_pins i_system_wrapper/system_i/sys_ps8/inst/emio_enet0_mdio_mdc]
+create_clock -period 400.000 -name mdio_clk_b [get_pins i_system_wrapper/system_i/sys_ps8/inst/emio_enet1_mdio_mdc]
+
+set_false_path -setup -to [get_pins i_system_wrapper/system_i/sys_ps8/inst/PS8_i/EMIOENET0MDIOI]
+set_false_path -setup -to [get_pins i_system_wrapper/system_i/sys_ps8/inst/PS8_i/EMIOENET1MDIOI]
+


### PR DESCRIPTION
This commit fixes the critical warning regarding the missing clock
definitions.
- Defined MDC(MDIO) clocks
- Set false path on(to) the ps8 MDIO input pins. There are synchronization
stages in the GMII to RGMII converter for the CDC between the 375M refclk
and 2.5M MDC clock domains.

Tested on cn0506_zcu102.