### PR TITLE
Rename projects for consistency

### DIFF
--- a/projects/ad40xx_fmc/zed/Makefile
+++ b/projects/ad40xx_fmc/zed/Makefile
@@ -3,7 +3,7 @@
 ## Auto-generated, do not modify!
 ####################################################################################
 
-PROJECT_NAME := ad40xx_zed
+PROJECT_NAME := ad40xx_fmc_zed
 
 M_DEPS += system_constr_adaq400x.xdc
 M_DEPS += system_constr_ad40xx.xdc
@@ -23,7 +23,6 @@ LIB_DEPS += spi_engine/spi_engine_execution
 LIB_DEPS += spi_engine/spi_engine_interconnect
 LIB_DEPS += spi_engine/spi_engine_offload
 LIB_DEPS += sysid_rom
-LIB_DEPS += util_axis_upscale
 LIB_DEPS += util_i2c_mixer
 LIB_DEPS += util_pulse_gen
 

--- a/projects/ad40xx_fmc/zed/system_project.tcl
+++ b/projects/ad40xx_fmc/zed/system_project.tcl
@@ -21,16 +21,16 @@ source $ad_hdl_dir/projects/scripts/adi_board.tcl
 ##
 set ad40xx_adaq400x_n 1
 
-adi_project ad40xx_zed
+adi_project ad40xx_fmc_zed
 
 if {$ad40xx_adaq400x_n == 1} {
-  adi_project_files ad40xx_zed [list \
+  adi_project_files ad40xx_fmc_zed [list \
       "$ad_hdl_dir/library/xilinx/common/ad_iobuf.v" \
       "system_top_ad40xx.v" \
       "system_constr_ad40xx.xdc" \
       "$ad_hdl_dir/projects/common/zed/zed_system_constr.xdc"]
 } elseif {$ad40xx_adaq400x_n == 0} {
-  adi_project_files ad40xx_zed [list \
+  adi_project_files ad40xx_fmc_zed [list \
       "$ad_hdl_dir/library/xilinx/common/ad_iobuf.v" \
       "system_top_adaq400x.v" \
       "system_constr_adaq400x.xdc" \
@@ -40,5 +40,5 @@ if {$ad40xx_adaq400x_n == 1} {
   return -code error [format "ERROR: Invalid eval board type! ..."]
 }
 
-adi_project_run ad40xx_zed
+adi_project_run ad40xx_fmc_zed
 

--- a/projects/ad9208_dual_ebz/vcu118/Makefile
+++ b/projects/ad9208_dual_ebz/vcu118/Makefile
@@ -3,7 +3,7 @@
 ## Auto-generated, do not modify!
 ####################################################################################
 
-PROJECT_NAME := ad9208_vcu118
+PROJECT_NAME := ad9208_dual_ebz_vcu118
 
 M_DEPS += ../common/dual_ad9208_bd.tcl
 M_DEPS += ../../daq3/common/daq3_spi.v

--- a/projects/ad9208_dual_ebz/vcu118/system_project.tcl
+++ b/projects/ad9208_dual_ebz/vcu118/system_project.tcl
@@ -3,8 +3,8 @@ source ../../scripts/adi_env.tcl
 source $ad_hdl_dir/projects/scripts/adi_project_xilinx.tcl
 source $ad_hdl_dir/projects/scripts/adi_board.tcl
 
-adi_project ad9208_vcu118
-adi_project_files ad9208_vcu118 [list \
+adi_project ad9208_dual_ebz_vcu118
+adi_project_files ad9208_dual_ebz_vcu118 [list \
   "system_top.v" \
   "system_constr.xdc"\
   "$ad_hdl_dir/library/xilinx/common/ad_iobuf.v" \
@@ -15,5 +15,5 @@ adi_project_files ad9208_vcu118 [list \
 #set_property strategy Performance_Retiming [get_runs impl_1]
 set_property strategy Performance_SpreadSLLs [get_runs impl_1]
 
-adi_project_run ad9208_vcu118
+adi_project_run ad9208_dual_ebz_vcu118
 

--- a/projects/cn0506_mii/a10soc/Makefile
+++ b/projects/cn0506_mii/a10soc/Makefile
@@ -3,7 +3,7 @@
 ## Auto-generated, do not modify!
 ####################################################################################
 
-PROJECT_NAME := cn0506_a10soc
+PROJECT_NAME := cn0506_mii_a10soc
 
 M_DEPS += ../common/cn0506_qsys.tcl
 M_DEPS += ../../common/a10soc/a10soc_system_qsys.tcl

--- a/projects/cn0506_mii/a10soc/system_project.tcl
+++ b/projects/cn0506_mii/a10soc/system_project.tcl
@@ -2,7 +2,7 @@
 source ../../scripts/adi_env.tcl
 source ../../scripts/adi_project_intel.tcl
 
-adi_project cn0506_a10soc
+adi_project cn0506_mii_a10soc
 
 source $ad_hdl_dir/projects/common/a10soc/a10soc_system_assign.tcl
 

--- a/projects/cn0506_mii/zc706/Makefile
+++ b/projects/cn0506_mii/zc706/Makefile
@@ -3,7 +3,7 @@
 ## Auto-generated, do not modify!
 ####################################################################################
 
-PROJECT_NAME := cn0506_zc706
+PROJECT_NAME := cn0506_mii_zc706
 
 M_DEPS += ../common/cn0506_bd.tcl
 M_DEPS += ../../common/zc706/zc706_system_constr.xdc

--- a/projects/cn0506_mii/zc706/system_project.tcl
+++ b/projects/cn0506_mii/zc706/system_project.tcl
@@ -3,12 +3,12 @@ source ../../scripts/adi_env.tcl
 source $ad_hdl_dir/projects/scripts/adi_project_xilinx.tcl
 source $ad_hdl_dir/projects/scripts/adi_board.tcl
 
-adi_project cn0506_zc706
-adi_project_files  cn0506_zc706 [list \
+adi_project cn0506_mii_zc706
+adi_project_files  cn0506_mii_zc706 [list \
   "system_top.v" \
   "system_constr.xdc"\
   "$ad_hdl_dir/projects/common/zc706/zc706_system_constr.xdc" \
   "$ad_hdl_dir/library/xilinx/common/ad_iobuf.v"]
 
-adi_project_run cn0506_zc706
+adi_project_run cn0506_mii_zc706
 

--- a/projects/cn0506_mii/zcu102/Makefile
+++ b/projects/cn0506_mii/zcu102/Makefile
@@ -3,7 +3,7 @@
 ## Auto-generated, do not modify!
 ####################################################################################
 
-PROJECT_NAME := cn0506_zcu102
+PROJECT_NAME := cn0506_mii_zcu102
 
 M_DEPS += ../common/cn0506_bd.tcl
 M_DEPS += ../../common/zcu102/zcu102_system_constr.xdc

--- a/projects/cn0506_mii/zcu102/system_project.tcl
+++ b/projects/cn0506_mii/zcu102/system_project.tcl
@@ -3,11 +3,11 @@ source ../../scripts/adi_env.tcl
 source $ad_hdl_dir/projects/scripts/adi_project_xilinx.tcl
 source $ad_hdl_dir/projects/scripts/adi_board.tcl
 
-adi_project cn0506_zcu102
-adi_project_files  cn0506_zcu102 [list \
+adi_project cn0506_mii_zcu102
+adi_project_files  cn0506_mii_zcu102 [list \
   "system_top.v" \
   "system_constr.xdc"\
   "$ad_hdl_dir/projects/common/zcu102/zcu102_system_constr.xdc" ]
 
-adi_project_run cn0506_zcu102
+adi_project_run cn0506_mii_zcu102
 

--- a/projects/cn0506_mii/zed/Makefile
+++ b/projects/cn0506_mii/zed/Makefile
@@ -3,7 +3,7 @@
 ## Auto-generated, do not modify!
 ####################################################################################
 
-PROJECT_NAME := cn0506_zed
+PROJECT_NAME := cn0506_mii_zed
 
 M_DEPS += ../common/cn0506_bd.tcl
 M_DEPS += ../../common/zed/zed_system_constr.xdc

--- a/projects/cn0506_mii/zed/system_project.tcl
+++ b/projects/cn0506_mii/zed/system_project.tcl
@@ -3,12 +3,12 @@ source ../../scripts/adi_env.tcl
 source $ad_hdl_dir/projects/scripts/adi_project_xilinx.tcl
 source $ad_hdl_dir/projects/scripts/adi_board.tcl
 
-adi_project cn0506_zed
-adi_project_files  cn0506_zed [list \
+adi_project cn0506_mii_zed
+adi_project_files  cn0506_mii_zed [list \
   "system_top.v" \
   "system_constr.xdc"\
   "$ad_hdl_dir/projects/common/zed/zed_system_constr.xdc" \
   "$ad_hdl_dir/library/xilinx/common/ad_iobuf.v"]
 
-adi_project_run cn0506_zed
+adi_project_run cn0506_mii_zed
 

--- a/projects/cn0506_rgmii/a10soc/Makefile
+++ b/projects/cn0506_rgmii/a10soc/Makefile
@@ -3,7 +3,7 @@
 ## Auto-generated, do not modify!
 ####################################################################################
 
-PROJECT_NAME := cn0506_a10soc
+PROJECT_NAME := cn0506_rgmii_a10soc
 
 M_DEPS += ../common/cn0506_qsys.tcl
 M_DEPS += ../../common/a10soc/a10soc_system_qsys.tcl

--- a/projects/cn0506_rgmii/a10soc/system_project.tcl
+++ b/projects/cn0506_rgmii/a10soc/system_project.tcl
@@ -2,7 +2,7 @@
 source ../../scripts/adi_env.tcl
 source ../../scripts/adi_project_intel.tcl
 
-adi_project cn0506_a10soc
+adi_project cn0506_rgmii_a10soc
 
 source $ad_hdl_dir/projects/common/a10soc/a10soc_system_assign.tcl
 

--- a/projects/cn0506_rgmii/zc706/Makefile
+++ b/projects/cn0506_rgmii/zc706/Makefile
@@ -3,7 +3,7 @@
 ## Auto-generated, do not modify!
 ####################################################################################
 
-PROJECT_NAME := cn0506_zc706
+PROJECT_NAME := cn0506_rgmii_zc706
 
 M_DEPS += ../common/cn0506_bd.tcl
 M_DEPS += ../../common/zc706/zc706_system_constr.xdc

--- a/projects/cn0506_rgmii/zc706/system_project.tcl
+++ b/projects/cn0506_rgmii/zc706/system_project.tcl
@@ -3,12 +3,12 @@ source ../../scripts/adi_env.tcl
 source $ad_hdl_dir/projects/scripts/adi_project_xilinx.tcl
 source $ad_hdl_dir/projects/scripts/adi_board.tcl
 
-adi_project cn0506_zc706
-adi_project_files  cn0506_zc706 [list \
+adi_project cn0506_rgmii_zc706
+adi_project_files  cn0506_rgmii_zc706 [list \
   "system_top.v" \
   "system_constr.xdc"\
   "$ad_hdl_dir/projects/common/zc706/zc706_system_constr.xdc" \
   "$ad_hdl_dir/library/xilinx/common/ad_iobuf.v"]
 
-adi_project_run cn0506_zc706
+adi_project_run cn0506_rgmii_zc706
 

--- a/projects/cn0506_rgmii/zcu102/Makefile
+++ b/projects/cn0506_rgmii/zcu102/Makefile
@@ -3,7 +3,7 @@
 ## Auto-generated, do not modify!
 ####################################################################################
 
-PROJECT_NAME := cn0506_zcu102
+PROJECT_NAME := cn0506_rgmii_zcu102
 
 M_DEPS += ../common/cn0506_bd.tcl
 M_DEPS += ../../common/zcu102/zcu102_system_constr.xdc

--- a/projects/cn0506_rgmii/zcu102/system_project.tcl
+++ b/projects/cn0506_rgmii/zcu102/system_project.tcl
@@ -3,11 +3,11 @@ source ../../scripts/adi_env.tcl
 source $ad_hdl_dir/projects/scripts/adi_project_xilinx.tcl
 source $ad_hdl_dir/projects/scripts/adi_board.tcl
 
-adi_project cn0506_zcu102
-adi_project_files  cn0506_zcu102 [list \
+adi_project cn0506_rgmii_zcu102
+adi_project_files  cn0506_rgmii_zcu102 [list \
   "system_top.v" \
   "system_constr.xdc"\
   "$ad_hdl_dir/projects/common/zcu102/zcu102_system_constr.xdc" ]
 
-adi_project_run cn0506_zcu102
+adi_project_run cn0506_rgmii_zcu102
 

--- a/projects/cn0506_rgmii/zed/Makefile
+++ b/projects/cn0506_rgmii/zed/Makefile
@@ -3,7 +3,7 @@
 ## Auto-generated, do not modify!
 ####################################################################################
 
-PROJECT_NAME := cn0506_zed
+PROJECT_NAME := cn0506_rgmii_zed
 
 M_DEPS += ../common/cn0506_bd.tcl
 M_DEPS += ../../common/zed/zed_system_constr.xdc

--- a/projects/cn0506_rgmii/zed/system_project.tcl
+++ b/projects/cn0506_rgmii/zed/system_project.tcl
@@ -3,12 +3,12 @@ source ../../scripts/adi_env.tcl
 source $ad_hdl_dir/projects/scripts/adi_project_xilinx.tcl
 source $ad_hdl_dir/projects/scripts/adi_board.tcl
 
-adi_project cn0506_zed
-adi_project_files  cn0506_zed [list \
+adi_project cn0506_rgmii_zed
+adi_project_files  cn0506_rgmii_zed [list \
   "system_top.v" \
   "system_constr.xdc"\
   "$ad_hdl_dir/projects/common/zed/zed_system_constr.xdc" \
   "$ad_hdl_dir/library/xilinx/common/ad_iobuf.v"]
 
-adi_project_run cn0506_zed
+adi_project_run cn0506_rgmii_zed
 


### PR DESCRIPTION
The name of the project generated by system_project.tcl should be the same with the name of the project folder. 