### PR TITLE
Fix project names

### DIFF
--- a/projects/ad40xx_fmc/zed/Makefile
+++ b/projects/ad40xx_fmc/zed/Makefile
@@ -3,7 +3,7 @@
 ## Auto-generated, do not modify!
 ####################################################################################
 
-PROJECT_NAME := ad40xx_zed
+PROJECT_NAME := ad40xx_fmc_zed
 
 M_DEPS += system_constr_adaq400x.xdc
 M_DEPS += system_constr_ad40xx.xdc
@@ -23,7 +23,6 @@ LIB_DEPS += spi_engine/spi_engine_execution
 LIB_DEPS += spi_engine/spi_engine_interconnect
 LIB_DEPS += spi_engine/spi_engine_offload
 LIB_DEPS += sysid_rom
-LIB_DEPS += util_axis_upscale
 LIB_DEPS += util_i2c_mixer
 LIB_DEPS += util_pulse_gen
 

--- a/projects/ad9208_dual_ebz/vcu118/Makefile
+++ b/projects/ad9208_dual_ebz/vcu118/Makefile
@@ -3,7 +3,7 @@
 ## Auto-generated, do not modify!
 ####################################################################################
 
-PROJECT_NAME := ad9208_vcu118
+PROJECT_NAME := ad9208_dual_ebz_vcu118
 
 M_DEPS += ../common/dual_ad9208_bd.tcl
 M_DEPS += ../../daq3/common/daq3_spi.v

--- a/projects/ad9208_dual_ebz/vcu118/system_project.tcl
+++ b/projects/ad9208_dual_ebz/vcu118/system_project.tcl
@@ -3,8 +3,8 @@ source ../../scripts/adi_env.tcl
 source $ad_hdl_dir/projects/scripts/adi_project_xilinx.tcl
 source $ad_hdl_dir/projects/scripts/adi_board.tcl
 
-adi_project ad9208_vcu118
-adi_project_files ad9208_vcu118 [list \
+adi_project ad9208_dual_ebz_vcu118
+adi_project_files ad9208_dual_ebz_vcu118 [list \
   "system_top.v" \
   "system_constr.xdc"\
   "$ad_hdl_dir/library/xilinx/common/ad_iobuf.v" \
@@ -15,5 +15,5 @@ adi_project_files ad9208_vcu118 [list \
 #set_property strategy Performance_Retiming [get_runs impl_1]
 set_property strategy Performance_SpreadSLLs [get_runs impl_1]
 
-adi_project_run ad9208_vcu118
+adi_project_run ad9208_dual_ebz_vcu118
 


### PR DESCRIPTION
Project name should have the following form: <project_dir_name>_<carrier>.

Fix project name for ad40xx_fmc and ad9208_dual_ebz.