### PR TITLE
dac_fmc_ebz/common/config.tcl: fix typo

### DIFF
--- a/projects/dac_fmc_ebz/common/config.tcl
+++ b/projects/dac_fmc_ebz/common/config.tcl
@@ -86,7 +86,7 @@ set params(AD9161,02) {2 2 2 2 1 16 16}
 set params(AD9161,03) {2 3 3 4 1 16 16}
 set params(AD9161,04) {2 4 1 1 1 16 16}
 set params(AD9161,06) {2 6 3 2 1 16 16}
-set params(AD9161,08) {2 8 2 2 1 16 16}
+set params(AD9161,08) {2 8 2 1 1 16 16}
 set params(AD9161,device_code) 3
 #                 Mode M L S F HD N NP
 set params(AD9162,01) {2 1 1 4 1 16 16}
@@ -94,7 +94,7 @@ set params(AD9162,02) {2 2 2 2 1 16 16}
 set params(AD9162,03) {2 3 3 4 1 16 16}
 set params(AD9162,04) {2 4 1 1 1 16 16}
 set params(AD9162,06) {2 6 3 2 1 16 16}
-set params(AD9162,08) {2 8 2 2 1 16 16}
+set params(AD9162,08) {2 8 2 1 1 16 16}
 set params(AD9162,device_code) 3
 #                 Mode M L S F HD N NP
 set params(AD9163,01) {2 1 1 4 1 16 16}
@@ -102,7 +102,7 @@ set params(AD9163,02) {2 2 2 2 1 16 16}
 set params(AD9163,03) {2 3 3 4 1 16 16}
 set params(AD9163,04) {2 4 1 1 1 16 16}
 set params(AD9163,06) {2 6 3 2 1 16 16}
-set params(AD9163,08) {2 8 2 2 1 16 16}
+set params(AD9163,08) {2 8 2 1 1 16 16}
 set params(AD9163,device_code) 3
 #                 Mode M L S F HD N NP
 set params(AD9164,01) {2 1 1 4 1 16 16}
@@ -110,7 +110,7 @@ set params(AD9164,02) {2 2 2 2 1 16 16}
 set params(AD9164,03) {2 3 3 4 1 16 16}
 set params(AD9164,04) {2 4 1 1 1 16 16}
 set params(AD9164,06) {2 6 3 2 1 16 16}
-set params(AD9164,08) {2 8 2 2 1 16 16}
+set params(AD9164,08) {2 8 2 1 1 16 16}
 set params(AD9164,device_code) 3
 
 # AD9171


### PR DESCRIPTION
Fix typo for 916x family.

Tested compile only.