### PR TITLE
ad77681evb: Set spi_clk to 40MHz

### DIFF
--- a/projects/ad77681evb/common/ad77681evb_bd.tcl
+++ b/projects/ad77681evb/common/ad77681evb_bd.tcl
@@ -9,6 +9,7 @@ create_bd_cell -type hier spi_adc
 current_bd_instance /spi_adc
 
   create_bd_pin -dir I -type clk clk
+  create_bd_pin -dir I -type clk spi_clk
   create_bd_pin -dir I -type rst resetn
   create_bd_pin -dir I drdy
   create_bd_pin -dir O irq
@@ -24,10 +25,12 @@ current_bd_instance /spi_adc
   ad_ip_instance axi_spi_engine axi_regmap
   ad_ip_parameter axi_regmap CONFIG.DATA_WIDTH 32
   ad_ip_parameter axi_regmap CONFIG.NUM_OFFLOAD 1
+  ad_ip_parameter axi_regmap CONFIG.ASYNC_SPI_CLK 1
 
   ad_ip_instance spi_engine_offload offload
   ad_ip_parameter offload CONFIG.DATA_WIDTH 32
   ad_ip_parameter offload CONFIG.ASYNC_TRIG 1
+  ad_ip_parameter offload CONFIG.ASYNC_SPI_CLK 1
 
   ad_ip_instance spi_engine_interconnect interconnect
   ad_ip_parameter interconnect CONFIG.DATA_WIDTH 32
@@ -40,12 +43,12 @@ current_bd_instance /spi_adc
  
   ad_connect execution/spi m_spi
 
-  ad_connect clk offload/spi_clk
-  ad_connect clk offload/ctrl_clk
-  ad_connect clk execution/clk
+  ad_connect spi_clk offload/spi_clk
+  ad_connect spi_clk offload/ctrl_clk
+  ad_connect spi_clk execution/clk
   ad_connect clk axi_regmap/s_axi_aclk
-  ad_connect clk axi_regmap/spi_clk
-  ad_connect clk interconnect/clk
+  ad_connect spi_clk axi_regmap/spi_clk
+  ad_connect spi_clk interconnect/clk
   
   ad_connect axi_regmap/spi_resetn offload/spi_resetn
   ad_connect axi_regmap/spi_resetn execution/resetn
@@ -74,20 +77,25 @@ ad_ip_parameter axi_ad77681_dma CONFIG.DMA_2D_TRANSFER 0
 ad_ip_parameter axi_ad77681_dma CONFIG.DMA_DATA_WIDTH_SRC 32
 ad_ip_parameter axi_ad77681_dma CONFIG.DMA_DATA_WIDTH_DEST 64
 
+ad_ip_parameter sys_ps7 CONFIG.PCW_EN_CLK2_PORT 1
+ad_ip_parameter sys_ps7 CONFIG.PCW_EN_RST2_PORT 1
+ad_ip_parameter sys_ps7 CONFIG.PCW_FPGA2_PERIPHERAL_FREQMHZ 40.0
+ad_connect sys_40m_clk sys_ps7/FCLK_CLK2
+
 ad_connect  sys_cpu_clk spi_adc/clk
+ad_connect  sys_40m_clk spi_adc/spi_clk
 ad_connect  sys_cpu_resetn spi_adc/resetn
 ad_connect  sys_cpu_resetn axi_ad77681_dma/m_dest_axi_aresetn
 
 ad_connect  spi_adc/m_spi adc_spi
 ad_connect  axi_ad77681_dma/s_axis spi_adc/M_AXIS_SAMPLE
 
-
 # AXI address definitions
 
 ad_cpu_interconnect 0x44a00000 spi_adc/axi_regmap
 ad_cpu_interconnect 0x44a30000 axi_ad77681_dma
 
-ad_connect sys_cpu_clk axi_ad77681_dma/s_axis_aclk
+ad_connect sys_40m_clk axi_ad77681_dma/s_axis_aclk
 
 # interrupts
 


### PR DESCRIPTION
The maximum accepted frequency for spi clock is 20MHz. In order to obtain this value, the clock connected to spi_clk will be set to 40MHz and the prescaler will be set to 0. This will produce a division by 2 of the spi_clk, thus resulting a 20MHz spi clock.