### PR TITLE
adi_xilinx_device_info_enc: Add new packages

### DIFF
--- a/library/scripts/adi_xilinx_device_info_enc.tcl
+++ b/library/scripts/adi_xilinx_device_info_enc.tcl
@@ -100,7 +100,10 @@ set dev_package_list { \
         { cl      14 } \
         { sf      15 } \
         { ba      16 } \
-        { fa      17 }}
+        { fa      17 } \
+        { fs      18 } \
+        { fi      19 }}
+
 
 set xcvr_type_list { \
         { Unknown             0 } \


### PR DESCRIPTION
Add definition for new ultrascale device packages.
The package information is used by software for xcvr calibration.
At the moment, the factors that are influencing the calibration for the new
packages are not clear.