### PR TITLE
dac_fmc_ebz: drive spi_en pin automatically based on FMC board selected

### DIFF
--- a/projects/dac_fmc_ebz/a10soc/system_top.v
+++ b/projects/dac_fmc_ebz/a10soc/system_top.v
@@ -167,7 +167,7 @@ module system_top #(
   // If you are planning to build a bitstream for just one of those boards you
   // can hardwire the logic level here.
   //
-  // assign spi_en = 1'bz;
+  assign spi_en = (DEVICE_CODE <= 2);
 
   assign spi_csn_clk = spi_csn_s[0];
   assign spi_csn_dac = spi_csn_s[1];
@@ -176,7 +176,6 @@ module system_top #(
 
   assign dac_fifo_bypass = gpio_o[40];
 
-  assign spi_en = gpio_o[36];
   assign dac_txen = gpio_o[35:32];
 
   assign gpio_i[63:32] = 'h0;

--- a/projects/dac_fmc_ebz/zc706/system_top.v
+++ b/projects/dac_fmc_ebz/zc706/system_top.v
@@ -88,7 +88,7 @@ module system_top #(
 
   inout       [ 4:0]      dac_ctrl,
 
-  inout                   spi_en,
+  output                  spi_en,
   output                  spi_csn_dac,
   output                  spi_csn_clk,
   output                  spi_csn_clk2,
@@ -128,7 +128,7 @@ module system_top #(
   // If you are planning to build a bitstream for just one of those boards you
   // can hardwire the logic level here.
   //
-  // assign spi_en = 1'bz;
+  assign spi_en = (DEVICE_CODE <= 2);
 
   //                                        9135/9144/9172    916(1,2,3,4)
   assign spi_csn_dac  = spi0_csn[1];
@@ -164,13 +164,12 @@ module system_top #(
 
   /* FMC GPIOs */
   ad_iobuf #(
-    .DATA_WIDTH(6)
+    .DATA_WIDTH(5)
   ) i_iobuf (
-    .dio_t (gpio_t[21+:6]),
-    .dio_i (gpio_o[21+:6]),
-    .dio_o (gpio_i[21+:6]),
+    .dio_t (gpio_t[21+:5]),
+    .dio_i (gpio_o[21+:5]),
+    .dio_o (gpio_i[21+:5]),
     .dio_p ({
-      spi_en,            /*      26 */
       dac_ctrl           /* 25 - 21 */
     })
   );
@@ -215,7 +214,7 @@ module system_top #(
   );
 
   assign gpio_i[63:52] = gpio_o[63:52];
-  assign gpio_i[47:27] = gpio_o[47:27];
+  assign gpio_i[47:26] = gpio_o[47:26];
   assign gpio_i[20:15] = gpio_o[20:15];
 
   system_wrapper i_system_wrapper (

--- a/projects/dac_fmc_ebz/zcu102/system_top.v
+++ b/projects/dac_fmc_ebz/zcu102/system_top.v
@@ -136,7 +136,7 @@ module system_top #(
   // If you are planning to build a bitstream for just one of those boards you
   // can hardwire the logic level here.
   //
-  // assign spi_en = 1'bz;
+  assign spi_en = (DEVICE_CODE <= 2);
 
   //                                        9135/9144/9172    916(1,2,3,4)
   assign spi_csn_dac  = spi0_csn[1];
@@ -172,13 +172,12 @@ module system_top #(
 
   /* FMC GPIOs */
   ad_iobuf #(
-    .DATA_WIDTH(6)
+    .DATA_WIDTH(5)
   ) i_iobuf (
-    .dio_t (gpio_t[21+:6]),
-    .dio_i (gpio_o[21+:6]),
-    .dio_o (gpio_i[21+:6]),
+    .dio_t (gpio_t[21+:5]),
+    .dio_i (gpio_o[21+:5]),
+    .dio_o (gpio_i[21+:5]),
     .dio_p ({
-      spi_en,            /*      26 */
       dac_ctrl           /* 25 - 21 */
     })
   );
@@ -215,7 +214,7 @@ module system_top #(
 
   assign gpio_i[94:52] = gpio_o[94:52];
   assign gpio_i[47:32] = gpio_o[47:32];
-  assign gpio_i[31:27] = gpio_o[31:27];
+  assign gpio_i[31:26] = gpio_o[31:26];
   assign gpio_i[ 7: 0] = gpio_o[7:0];
 
   system_wrapper i_system_wrapper (


### PR DESCRIPTION
spi_en is active ...
   ... high for AD9135-FMC-EBZ, AD9136-FMC-EBZ, AD9144-FMC-EBZ,
   ... low for AD9171-FMC-EBZ, AD9172-FMC-EBZ, AD9173-FMC-EBZ


Tested with AD9144 and ZCU102