### PR TITLE
LiDAR A10SOC: Fix AFE's I2C interface

### DIFF
--- a/projects/ad_fmclidar1_ebz/a10soc/system_project.tcl
+++ b/projects/ad_fmclidar1_ebz/a10soc/system_project.tcl
@@ -191,6 +191,9 @@ set_instance_assignment -name IO_STANDARD "1.8V" -to afe_dac_scl
 set_instance_assignment -name IO_STANDARD "1.8V" -to afe_dac_clr_n
 set_instance_assignment -name IO_STANDARD "1.8V" -to afe_dac_load
 
+set_instance_assignment -name WEAK_PULL_UP_RESISTOR ON -to afe_dac_scl
+set_instance_assignment -name WEAK_PULL_UP_RESISTOR ON -to afe_dac_sda
+
 # AFE ADC SPI and control
 
 set_location_assignment  PIN_H14  -to afe_adc_sclk          ; ## G07  FMCA_HPC_LA00_CC_N

--- a/projects/ad_fmclidar1_ebz/a10soc/system_top.v
+++ b/projects/ad_fmclidar1_ebz/a10soc/system_top.v
@@ -233,6 +233,18 @@ module system_top (
     .ext_sync (laser_driver),
     .s_axis_sync (dma_sync_s));
 
+  // IO Buffers for I2C
+
+  wire i2c_0_scl_out;
+  wire i2c_0_scl_in;
+  wire i2c_0_sda_in;
+  wire i2c_0_sda_oe;
+
+  ALT_IOBUF scl_iobuf (.i(1'b0), .oe(i2c_0_scl_out), .o(i2c_0_scl_in), .io(afe_dac_scl));
+  ALT_IOBUF sda_iobuf (.i(1'b0), .oe(i2c_0_sda_oe), .o(i2c_0_sda_in), .io(afe_dac_sda));
+
+  // Block design instance
+
   system_bd i_system_bd (
     .sys_clk_clk (sys_clk),
     .sys_gpio_bd_in_port (gpio_i[31:0]),
@@ -305,6 +317,11 @@ module system_top (
     .sys_hps_out_rstn_reset_n (sys_hps_resetn),
     .sys_hps_rstn_reset_n (sys_resetn),
     .sys_rstn_reset_n (sys_resetn_s),
+    // AFE's DAC I2C interface
+    .sys_hps_i2c_0_sda_i (i2c_0_sda_in),
+    .sys_hps_i2c_0_sda_oe (i2c_0_sda_oe),
+    .sys_hps_i2c_0_scl_out_clk (i2c_0_scl_out),
+    .sys_hps_i2c_0_scl_in_clk (i2c_0_scl_in),
     // SPI interface for ADC (AD9694)
     .sys_spi_MISO (spi_adc_miso),
     .sys_spi_MOSI (spi_adc_mosi),

--- a/projects/ad_fmclidar1_ebz/common/ad_fmclidar1_ebz_qsys.tcl
+++ b/projects/ad_fmclidar1_ebz/common/ad_fmclidar1_ebz_qsys.tcl
@@ -35,9 +35,15 @@ set_interface_property sys_spi_vco EXPORT_OF sys_spi_vco.external
 
 # I2C interface for AFE's DAC chip - activate the second I2C HPS interface
 
-set_hps_io IO_SHARED_Q4_08 I2C0:SDA
-set_hps_io IO_SHARED_Q4_08 I2C0:SCL
-set_instance_parameter_value sys_hps {HPS_IO_Enable} $hps_io_list
+set_instance_parameter_value sys_hps {I2C0_PinMuxing} {FPGA}
+set_instance_parameter_value sys_hps {I2C0_Mode} {default}
+
+add_interface sys_hps_i2c_0 conduit end
+set_interface_property sys_hps_i2c_0 EXPORT_OF sys_hps.i2c0
+add_interface sys_hps_i2c_0_scl_out clock source
+set_interface_property sys_hps_i2c_0_scl_out EXPORT_OF sys_hps.i2c0_clk
+add_interface sys_hps_i2c_0_scl_in clock sink
+set_interface_property sys_hps_i2c_0_scl_in EXPORT_OF sys_hps.i2c0_scl_in
 
 # SPI interface for AFE's ADC chip - fSCLK = 10 MHz
 


### PR DESCRIPTION
The AFE's I2C interface should be pin-multiplexed to the FPGA. Also, add
a bidirectional IO buffer for the interface, and make sure it has weak
pull-up resistors.