### PR TITLE
Dev mxfe iq rotation

### DIFF
--- a/library/common/ad_iqcor.v
+++ b/library/common/ad_iqcor.v
@@ -36,6 +36,8 @@
 // if SCALE_ONLY is set to 1, b*(q+y) is set to 0, and the module is used for
 // scale correction of channel I
 
+// Assumption CR smaller or equal to 16
+
 `timescale 1ns/100ps
 
 module ad_iqcor #(
@@ -44,43 +46,36 @@ module ad_iqcor #(
 
   parameter   Q_OR_I_N = 0,
   parameter   SCALE_ONLY = 0,
-  parameter   DISABLE = 0) (
+  parameter   DISABLE = 0,
+  parameter   CR = 16,   // Converter Resolution
+  parameter   DPW = 1    // Data Path Width
+) (
 
   // data interface
 
   input           clk,
   input           valid,
-  input   [15:0]  data_in,
-  input   [15:0]  data_iq,
+  input   [DPW*CR-1:0]  data_in,
+  input   [DPW*CR-1:0]  data_iq,
   output          valid_out,
-  output  [15:0]  data_out,
+  output  [DPW*CR-1:0]  data_out,
 
   // control interface
 
   input           iqcor_enable,
   input   [15:0]  iqcor_coeff_1,
-  input   [15:0]  iqcor_coeff_2);
+  input   [15:0]  iqcor_coeff_2
+);
 
   // internal registers
 
-  reg             p1_valid = 'd0;
-  reg     [33:0]  p1_data_p = 'd0;
-  reg             valid_int = 'd0;
-  reg     [15:0]  data_int = 'd0;
   reg     [15:0]  iqcor_coeff_1_r = 'd0;
   reg     [15:0]  iqcor_coeff_2_r = 'd0;
 
   // internal signals
+  wire [DPW-1:0]    valid_int_loc;
+  wire [DPW*CR-1:0] data_int_loc;
 
-  wire    [15:0]  data_i_s;
-  wire    [15:0]  data_q_s;
-  wire    [33:0]  p1_data_p_i_s;
-  wire            p1_valid_s;
-  wire    [15:0]  p1_data_i_s;
-  wire    [33:0]  p1_data_p_q_s;
-  wire    [15:0]  p1_data_q_s;
-  wire    [15:0]  p1_data_i_int;
-  wire    [15:0]  p1_data_q_int;
 
   // data-path disable
 
@@ -89,15 +84,11 @@ module ad_iqcor #(
     assign valid_out = valid;
     assign data_out = data_in;
   end else begin
-    assign valid_out = valid_int;
-    assign data_out = data_int;
+    assign valid_out = valid_int_loc;
+    assign data_out = data_int_loc;
   end
   endgenerate
 
-  // swap i & q
-
-  assign data_i_s = (Q_OR_I_N == 1 && SCALE_ONLY == 1'b0) ? data_iq : data_in;
-  assign data_q_s = (Q_OR_I_N == 1) ? data_in : data_iq;
 
   // coefficients are flopped to remove warnings from vivado
 
@@ -106,63 +97,85 @@ module ad_iqcor #(
     iqcor_coeff_2_r <= iqcor_coeff_2;
   end
 
+  genvar i;
+  generate 
+  for (i=0; i<DPW; i=i+1) begin
+
+  wire    [CR-1:0]  data_i_s;
+  wire    [CR-1:0]  data_q_s;
+  wire    [CR-1:0]  p1_data_i_s;
+  wire              p1_valid_s;
+  wire    [33:0]  p1_data_p_i_s;
+  wire    [33:0]  p1_data_p_q_s;
+
+  wire    [CR-1:0]  p1_data_q_s;
+  wire    [CR-1:0]  p1_data_i_int;
+  wire    [CR-1:0]  p1_data_q_int;
+
+  reg             p1_valid = 'd0;
+  reg     [33:0]  p1_data_p = 'd0;
+  reg             valid_int = 'd0;
+  reg     [15:0]  data_int = 'd0;
+ 
+  // swap i & q
+  assign data_i_s = (Q_OR_I_N == 1 && SCALE_ONLY == 1'b0) ? data_iq[i*CR+:CR] : data_in[i*CR+:CR];
+  assign data_q_s = (Q_OR_I_N == 1) ? data_in[i*CR+:CR] : data_iq[i*CR+:CR];
+
   // scaling functions - i
 
-  ad_mul #(.DELAY_DATA_WIDTH(17)) i_mul_i (
+  ad_mul #(.DELAY_DATA_WIDTH(CR+1)) i_mul_i (
     .clk (clk),
-    .data_a ({data_i_s[15], data_i_s}),
+    .data_a ({data_i_s[CR-1], data_i_s, {16-CR{1'b0}}}),
     .data_b ({iqcor_coeff_1_r[15], iqcor_coeff_1_r}),
     .data_p (p1_data_p_i_s),
     .ddata_in ({valid, data_i_s}),
     .ddata_out ({p1_valid_s, p1_data_i_s}));
 
-  generate
   if (SCALE_ONLY == 0) begin
     // scaling functions - q
-
-    ad_mul #(.DELAY_DATA_WIDTH(16)) i_mul_q (
+  
+    ad_mul #(.DELAY_DATA_WIDTH(CR)) i_mul_q (
       .clk (clk),
-      .data_a ({data_q_s[15], data_q_s}),
+      .data_a ({data_q_s[CR-1], data_q_s, {16-CR{1'b0}}}),
       .data_b ({iqcor_coeff_2_r[15], iqcor_coeff_2_r}),
       .data_p (p1_data_p_q_s),
       .ddata_in (data_q_s),
       .ddata_out (p1_data_q_s));
-
+  
   // sum
   end else begin
     assign p1_data_p_q_s = 34'h0;
-    assign p1_data_q_s = 16'h0;
+    assign p1_data_q_s = {CR{1'b0}};
   end
 
-  endgenerate
-  generate
+
   if (Q_OR_I_N == 1 && SCALE_ONLY == 0) begin
-    reg [15:0]  p1_data_q = 'd0;
+    reg [CR-1:0]  p1_data_q = 'd0;
 
     always @(posedge clk) begin
       p1_data_q <= p1_data_q_s;
     end
 
-    assign p1_data_i_int = 16'h0;
+    assign p1_data_i_int = {CR{1'b0}};
     assign p1_data_q_int = p1_data_q;
 
   // sum
   end else begin
-    reg [15:0]  p1_data_i = 'd0;
+    reg [CR-1:0]  p1_data_i = 'd0;
 
     always @(posedge clk) begin
       p1_data_i <= p1_data_i_s;
     end
 
     assign p1_data_i_int = p1_data_i;
-    assign p1_data_q_int = 16'h0;
+    assign p1_data_q_int = {CR{1'b0}};
   end
-  endgenerate
 
   always @(posedge clk) begin
     p1_valid <= p1_valid_s;
     p1_data_p <= p1_data_p_i_s + p1_data_p_q_s;
   end
+
   // output registers
 
   always @(posedge clk) begin
@@ -175,7 +188,12 @@ module ad_iqcor #(
       data_int <= p1_data_i_int;
     end
   end
+  
+  assign valid_int_loc[i] = valid_int;
+  assign data_int_loc[i*CR+:CR] = data_int[15-:CR];
 
+  end
+  endgenerate
 
 endmodule
 

--- a/library/common/ad_iqcor.v
+++ b/library/common/ad_iqcor.v
@@ -99,100 +99,99 @@ module ad_iqcor #(
 
   genvar i;
   generate 
-  for (i=0; i<DPW; i=i+1) begin
+    for (i=0; i<DPW; i=i+1) begin
+      wire    [CR-1:0]  data_i_s;
+      wire    [CR-1:0]  data_q_s;
+      wire    [CR-1:0]  p1_data_i_s;
+      wire              p1_valid_s;
+      wire    [33:0]  p1_data_p_i_s;
+      wire    [33:0]  p1_data_p_q_s;
 
-  wire    [CR-1:0]  data_i_s;
-  wire    [CR-1:0]  data_q_s;
-  wire    [CR-1:0]  p1_data_i_s;
-  wire              p1_valid_s;
-  wire    [33:0]  p1_data_p_i_s;
-  wire    [33:0]  p1_data_p_q_s;
+      wire    [CR-1:0]  p1_data_q_s;
+      wire    [CR-1:0]  p1_data_i_int;
+      wire    [CR-1:0]  p1_data_q_int;
 
-  wire    [CR-1:0]  p1_data_q_s;
-  wire    [CR-1:0]  p1_data_i_int;
-  wire    [CR-1:0]  p1_data_q_int;
-
-  reg             p1_valid = 'd0;
-  reg     [33:0]  p1_data_p = 'd0;
-  reg             valid_int = 'd0;
-  reg     [15:0]  data_int = 'd0;
+      reg             p1_valid = 'd0;
+      reg     [33:0]  p1_data_p = 'd0;
+      reg             valid_int = 'd0;
+      reg     [15:0]  data_int = 'd0;
  
-  // swap i & q
-  assign data_i_s = (Q_OR_I_N == 1 && SCALE_ONLY == 1'b0) ? data_iq[i*CR+:CR] : data_in[i*CR+:CR];
-  assign data_q_s = (Q_OR_I_N == 1) ? data_in[i*CR+:CR] : data_iq[i*CR+:CR];
+      // swap i & q
+      assign data_i_s = (Q_OR_I_N == 1 && SCALE_ONLY == 1'b0) ? data_iq[i*CR+:CR] : data_in[i*CR+:CR];
+      assign data_q_s = (Q_OR_I_N == 1) ? data_in[i*CR+:CR] : data_iq[i*CR+:CR];
 
-  // scaling functions - i
+      // scaling functions - i
 
-  ad_mul #(.DELAY_DATA_WIDTH(CR+1)) i_mul_i (
-    .clk (clk),
-    .data_a ({data_i_s[CR-1], data_i_s, {16-CR{1'b0}}}),
-    .data_b ({iqcor_coeff_1_r[15], iqcor_coeff_1_r}),
-    .data_p (p1_data_p_i_s),
-    .ddata_in ({valid, data_i_s}),
-    .ddata_out ({p1_valid_s, p1_data_i_s}));
+      ad_mul #(.DELAY_DATA_WIDTH(CR+1)) i_mul_i (
+        .clk (clk),
+        .data_a ({data_i_s[CR-1], data_i_s, {16-CR{1'b0}}}),
+        .data_b ({iqcor_coeff_1_r[15], iqcor_coeff_1_r}),
+        .data_p (p1_data_p_i_s),
+        .ddata_in ({valid, data_i_s}),
+        .ddata_out ({p1_valid_s, p1_data_i_s}));
 
-  if (SCALE_ONLY == 0) begin
-    // scaling functions - q
-  
-    ad_mul #(.DELAY_DATA_WIDTH(CR)) i_mul_q (
-      .clk (clk),
-      .data_a ({data_q_s[CR-1], data_q_s, {16-CR{1'b0}}}),
-      .data_b ({iqcor_coeff_2_r[15], iqcor_coeff_2_r}),
-      .data_p (p1_data_p_q_s),
-      .ddata_in (data_q_s),
-      .ddata_out (p1_data_q_s));
-  
-  // sum
-  end else begin
-    assign p1_data_p_q_s = 34'h0;
-    assign p1_data_q_s = {CR{1'b0}};
-  end
+      if (SCALE_ONLY == 0) begin
+        // scaling functions - q
+    
+        ad_mul #(.DELAY_DATA_WIDTH(CR)) i_mul_q (
+          .clk (clk),
+          .data_a ({data_q_s[CR-1], data_q_s, {16-CR{1'b0}}}),
+          .data_b ({iqcor_coeff_2_r[15], iqcor_coeff_2_r}),
+          .data_p (p1_data_p_q_s),
+          .ddata_in (data_q_s),
+          .ddata_out (p1_data_q_s));
+    
+      // sum
+      end else begin
+        assign p1_data_p_q_s = 34'h0;
+        assign p1_data_q_s = {CR{1'b0}};
+      end
 
 
-  if (Q_OR_I_N == 1 && SCALE_ONLY == 0) begin
-    reg [CR-1:0]  p1_data_q = 'd0;
+      if (Q_OR_I_N == 1 && SCALE_ONLY == 0) begin
+        reg [CR-1:0]  p1_data_q = 'd0;
 
-    always @(posedge clk) begin
-      p1_data_q <= p1_data_q_s;
+        always @(posedge clk) begin
+          p1_data_q <= p1_data_q_s;
+        end
+
+        assign p1_data_i_int = {CR{1'b0}};
+        assign p1_data_q_int = p1_data_q;
+
+      // sum
+      end else begin
+        reg [CR-1:0]  p1_data_i = 'd0;
+
+        always @(posedge clk) begin
+          p1_data_i <= p1_data_i_s;
+        end
+
+        assign p1_data_i_int = p1_data_i;
+        assign p1_data_q_int = {CR{1'b0}};
+      end
+
+      always @(posedge clk) begin
+        p1_valid <= p1_valid_s;
+        p1_data_p <= p1_data_p_i_s + p1_data_p_q_s;
+      end
+
+      // output registers
+
+      always @(posedge clk) begin
+        valid_int <= p1_valid;
+        if (iqcor_enable == 1'b1) begin
+          data_int <= p1_data_p[29:14];
+        end else if (Q_OR_I_N == 1 && SCALE_ONLY == 0) begin
+          data_int <= p1_data_q_int;
+        end else begin
+          data_int <= p1_data_i_int;
+        end
+      end
+      
+      assign valid_int_loc[i] = valid_int;
+      assign data_int_loc[i*CR+:CR] = data_int[15-:CR];
+
     end
-
-    assign p1_data_i_int = {CR{1'b0}};
-    assign p1_data_q_int = p1_data_q;
-
-  // sum
-  end else begin
-    reg [CR-1:0]  p1_data_i = 'd0;
-
-    always @(posedge clk) begin
-      p1_data_i <= p1_data_i_s;
-    end
-
-    assign p1_data_i_int = p1_data_i;
-    assign p1_data_q_int = {CR{1'b0}};
-  end
-
-  always @(posedge clk) begin
-    p1_valid <= p1_valid_s;
-    p1_data_p <= p1_data_p_i_s + p1_data_p_q_s;
-  end
-
-  // output registers
-
-  always @(posedge clk) begin
-    valid_int <= p1_valid;
-    if (iqcor_enable == 1'b1) begin
-      data_int <= p1_data_p[29:14];
-    end else if (Q_OR_I_N == 1 && SCALE_ONLY == 0) begin
-      data_int <= p1_data_q_int;
-    end else begin
-      data_int <= p1_data_i_int;
-    end
-  end
-  
-  assign valid_int_loc[i] = valid_int;
-  assign data_int_loc[i*CR+:CR] = data_int[15-:CR];
-
-  end
   endgenerate
 
 endmodule

--- a/library/jesd204/ad_ip_jesd204_tpl_dac/Makefile
+++ b/library/jesd204/ad_ip_jesd204_tpl_dac/Makefile
@@ -11,6 +11,7 @@ GENERIC_DEPS += ../../common/ad_dds_2.v
 GENERIC_DEPS += ../../common/ad_dds_cordic_pipe.v
 GENERIC_DEPS += ../../common/ad_dds_sine.v
 GENERIC_DEPS += ../../common/ad_dds_sine_cordic.v
+GENERIC_DEPS += ../../common/ad_iqcor.v
 GENERIC_DEPS += ../../common/ad_perfect_shuffle.v
 GENERIC_DEPS += ../../common/ad_rst.v
 GENERIC_DEPS += ../../common/up_axi.v

--- a/library/jesd204/ad_ip_jesd204_tpl_dac/ad_ip_jesd204_tpl_dac.v
+++ b/library/jesd204/ad_ip_jesd204_tpl_dac/ad_ip_jesd204_tpl_dac.v
@@ -38,7 +38,8 @@ module ad_ip_jesd204_tpl_dac #(
   parameter DDS_TYPE = 1,
   parameter DDS_CORDIC_DW = 16,
   parameter DDS_CORDIC_PHASE_DW = 16,
-  parameter DATAPATH_DISABLE = 0
+  parameter DATAPATH_DISABLE = 0,
+  parameter IQCORRECTION_DISABLE = 1
 ) (
   // jesd interface
   // link_clk is (line-rate/40)
@@ -105,11 +106,16 @@ module ad_ip_jesd204_tpl_dac #(
   wire [NUM_CHANNELS*16-1:0] dac_pat_data_0_s;
   wire [NUM_CHANNELS*16-1:0] dac_pat_data_1_s;
   wire [NUM_CHANNELS*4-1:0] dac_data_sel_s;
+  wire [NUM_CHANNELS-1:0]  dac_iqcor_enb;
+  wire [NUM_CHANNELS*16-1:0] dac_iqcor_coeff_1;
+  wire [NUM_CHANNELS*16-1:0] dac_iqcor_coeff_2;
 
   // regmap
 
   ad_ip_jesd204_tpl_dac_regmap #(
     .ID (ID),
+    .DATAPATH_DISABLE (DATAPATH_DISABLE),
+    .IQCORRECTION_DISABLE (IQCORRECTION_DISABLE),
     .FPGA_TECHNOLOGY (FPGA_TECHNOLOGY),
     .FPGA_FAMILY (FPGA_FAMILY),
     .SPEED_GRADE (SPEED_GRADE),
@@ -158,6 +164,10 @@ module ad_ip_jesd204_tpl_dac #(
     .dac_pat_data_1 (dac_pat_data_1_s),
     .dac_data_sel (dac_data_sel_s),
 
+    .dac_iqcor_enb (dac_iqcor_enb),
+    .dac_iqcor_coeff_1 (dac_iqcor_coeff_1),
+    .dac_iqcor_coeff_2 (dac_iqcor_coeff_2),
+
     .jesd_m (NUM_CHANNELS),
     .jesd_l (NUM_LANES),
     .jesd_s (SAMPLES_PER_FRAME),
@@ -171,6 +181,7 @@ module ad_ip_jesd204_tpl_dac #(
 
   ad_ip_jesd204_tpl_dac_core #(
     .DATAPATH_DISABLE (DATAPATH_DISABLE),
+    .IQCORRECTION_DISABLE (IQCORRECTION_DISABLE),
     .NUM_LANES (NUM_LANES),
     .NUM_CHANNELS (NUM_CHANNELS),
     .BITS_PER_SAMPLE (BITS_PER_SAMPLE),
@@ -206,7 +217,12 @@ module ad_ip_jesd204_tpl_dac #(
     .dac_dds_incr_1 (dac_dds_incr_1_s),
     .dac_pat_data_0 (dac_pat_data_0_s),
     .dac_pat_data_1 (dac_pat_data_1_s),
-    .dac_data_sel (dac_data_sel_s)
+    .dac_data_sel (dac_data_sel_s),
+
+    .dac_iqcor_enb (dac_iqcor_enb),
+    .dac_iqcor_coeff_1 (dac_iqcor_coeff_1),
+    .dac_iqcor_coeff_2 (dac_iqcor_coeff_2)
+
   );
 
 endmodule

--- a/library/jesd204/ad_ip_jesd204_tpl_dac/ad_ip_jesd204_tpl_dac_ip.tcl
+++ b/library/jesd204/ad_ip_jesd204_tpl_dac/ad_ip_jesd204_tpl_dac_ip.tcl
@@ -33,6 +33,7 @@ adi_ip_files ad_ip_jesd204_tpl_dac [list \
   "$ad_hdl_dir/library/common/ad_dds_2.v" \
   "$ad_hdl_dir/library/common/ad_dds_1.v" \
   "$ad_hdl_dir/library/common/ad_dds.v" \
+  "$ad_hdl_dir/library/common/ad_iqcor.v" \
   "$ad_hdl_dir/library/common/ad_perfect_shuffle.v" \
   "$ad_hdl_dir/library/common/ad_rst.v" \
   "$ad_hdl_dir/library/common/up_axi.v" \
@@ -144,6 +145,7 @@ set i 0
 
 foreach {k v w} {
   "DATAPATH_DISABLE" "Disable Datapath" "checkBox" \
+  "IQCORRECTION_DISABLE" "Disable IQ Correction" "checkBox" \
   "DDS_TYPE" "DDS Type" "comboBox" \
   "DDS_CORDIC_DW" "CORDIC DDS Data Width" "text" \
   "DDS_CORDIC_PHASE_DW" "CORDIC DDS Phase Width" "text" \

--- a/library/jesd204/ad_ip_jesd204_tpl_dac/ad_ip_jesd204_tpl_dac_regmap.v
+++ b/library/jesd204/ad_ip_jesd204_tpl_dac/ad_ip_jesd204_tpl_dac_regmap.v
@@ -25,6 +25,8 @@
 
 module ad_ip_jesd204_tpl_dac_regmap #(
   parameter ID = 0,
+  parameter DATAPATH_DISABLE = 0,
+  parameter IQCORRECTION_DISABLE = 1,
   parameter FPGA_TECHNOLOGY = 0,
   parameter FPGA_FAMILY = 0,
   parameter SPEED_GRADE = 0,
@@ -78,6 +80,10 @@ module ad_ip_jesd204_tpl_dac_regmap #(
 
   output [NUM_CHANNELS*16-1:0] dac_pat_data_0,
   output [NUM_CHANNELS*16-1:0] dac_pat_data_1,
+
+  output [NUM_CHANNELS-1:0]  dac_iqcor_enb,
+  output [NUM_CHANNELS*16-1:0] dac_iqcor_coeff_1,
+  output [NUM_CHANNELS*16-1:0] dac_iqcor_coeff_2,
 
   // Framer interface
   input [NUM_PROFILES*8-1: 0] jesd_m,
@@ -179,6 +185,7 @@ module ad_ip_jesd204_tpl_dac_regmap #(
   up_dac_common #(
     .COMMON_ID(6'h0),
     .ID (ID),
+    .CONFIG((DATAPATH_DISABLE << 6) | (IQCORRECTION_DISABLE << 0)),
     .FPGA_TECHNOLOGY (FPGA_TECHNOLOGY),
     .FPGA_FAMILY (FPGA_FAMILY),
     .SPEED_GRADE (SPEED_GRADE),
@@ -237,7 +244,7 @@ module ad_ip_jesd204_tpl_dac_regmap #(
       .COMMON_ID(6'h1 + i/16),
       .CHANNEL_ID (i % 16),
       .USERPORTS_DISABLE (1),
-      .IQCORRECTION_DISABLE (1)
+      .IQCORRECTION_DISABLE (IQCORRECTION_DISABLE)
     ) i_up_dac_channel (
       .dac_clk (link_clk),
       .dac_rst (dac_rst),
@@ -251,9 +258,9 @@ module ad_ip_jesd204_tpl_dac_regmap #(
       .dac_pat_data_2 (dac_pat_data_1[16*i+:16]),
       .dac_data_sel (dac_data_sel[4*i+:4]),
       .dac_iq_mode (),
-      .dac_iqcor_enb (),
-      .dac_iqcor_coeff_1 (),
-      .dac_iqcor_coeff_2 (),
+      .dac_iqcor_enb (dac_iqcor_enb[i]),
+      .dac_iqcor_coeff_1 (dac_iqcor_coeff_1[16*i+:16]),
+      .dac_iqcor_coeff_2 (dac_iqcor_coeff_2[16*i+:16]),
       .up_usr_datatype_be (),
       .up_usr_datatype_signed (),
       .up_usr_datatype_shift (),

--- a/projects/ad9081_fmca_ebz/common/ad9081_fmca_ebz_bd.tcl
+++ b/projects/ad9081_fmca_ebz/common/ad9081_fmca_ebz_bd.tcl
@@ -216,6 +216,8 @@ adi_tpl_jesd204_tx_create tx_mxfe_tpl_core $TX_NUM_OF_LANES \
                                            $TX_SAMPLE_WIDTH \
                                            $DATAPATH_WIDTH
 
+ad_ip_parameter tx_mxfe_tpl_core/tpl_core CONFIG.IQCORRECTION_DISABLE 0
+
 ad_ip_instance util_upack2 util_mxfe_upack [list \
   NUM_OF_CHANNELS $TX_NUM_OF_CONVERTERS \
   SAMPLES_PER_CHANNEL $TX_SAMPLES_PER_CHANNEL \


### PR DESCRIPTION
The IQ rotation is ported from the FMCOMMS2. See the algorithm 
https://wiki.analog.com/resources/eval/user-guides/ad-fmcomms2-ebz/iq_rotation

Integrated into TPL. 
Updated to support multiple samples on a clock cycle. 

Tested on MxFE
