### PR TITLE
fmcomms8: Fix SPI timing

### DIFF
--- a/projects/fmcomms8/zcu102/system_constr.xdc
+++ b/projects/fmcomms8/zcu102/system_constr.xdc
@@ -127,3 +127,5 @@ set_input_delay -clock rx_fmc_dev_clk -min 4    [get_ports sysref_c_p];
 
 set_input_delay -clock tx_fmc_dev_clk -max 4    [get_ports sysref_d_p];
 set_input_delay -clock tx_fmc_dev_clk -min 4    [get_ports sysref_d_p];
+
+create_clock -name spi0_clk      -period 100   [get_pins -hier */EMIOSPI0SCLKO]


### PR DESCRIPTION
The maximum SPI rate set to 10MHz, as at 40 MHz it doesn't meet timing