### PR TITLE
Add DE10nano support for ad77681evb

### DIFF
--- a/library/spi_engine/axi_spi_engine/axi_spi_engine.v
+++ b/library/spi_engine/axi_spi_engine/axi_spi_engine.v
@@ -55,7 +55,7 @@ module axi_spi_engine #(
   input         s_axi_aclk,
   input         s_axi_aresetn,
   input         s_axi_awvalid,
-  input  [15:0] s_axi_awaddr,
+  input   [9:0] s_axi_awaddr,
   output        s_axi_awready,
   input   [2:0] s_axi_awprot,
   input         s_axi_wvalid,
@@ -66,7 +66,7 @@ module axi_spi_engine #(
   output [ 1:0] s_axi_bresp,
   input         s_axi_bready,
   input         s_axi_arvalid,
-  input  [15:0] s_axi_araddr,
+  input   [9:0] s_axi_araddr,
   output        s_axi_arready,
   input   [2:0] s_axi_arprot,
   output        s_axi_rvalid,
@@ -79,11 +79,11 @@ module axi_spi_engine #(
   input                           up_clk,
   input                           up_rstn,
   input                           up_wreq,
-  input  [13:0]                   up_waddr,
+  input  [7:0]                   up_waddr,
   input  [31:0]                   up_wdata,
   output                          up_wack,
   input                           up_rreq,
-  input  [13:0]                   up_raddr,
+  input  [7:0]                   up_raddr,
   output [31:0]                   up_rdata,
   output                          up_rack,
 
@@ -176,8 +176,8 @@ module axi_spi_engine #(
   wire                            up_wreq_s;
   wire                            up_rreq_s;
   wire [31:0]                     up_wdata_s;
-  wire [13:0]                     up_waddr_s;
-  wire [13:0]                     up_raddr_s;
+  wire [7:0]                      up_waddr_s;
+  wire [7:0]                      up_raddr_s;
 
   // Scratch register
   reg [31:0] up_scratch = 'h00;
@@ -198,7 +198,7 @@ module axi_spi_engine #(
     // interface wrapper
 
     up_axi #(
-      .AXI_ADDRESS_WIDTH (16)
+      .AXI_ADDRESS_WIDTH (10)
     ) i_up_axi (
       .up_rstn(rstn),
       .up_clk(clk),

--- a/library/spi_engine/axi_spi_engine/axi_spi_engine_hw.tcl
+++ b/library/spi_engine/axi_spi_engine/axi_spi_engine_hw.tcl
@@ -5,7 +5,11 @@ source ../../scripts/adi_ip_intel.tcl
 
 ad_ip_create axi_spi_engine {AXI SPI Engine} p_elaboration
 ad_ip_files axi_spi_engine [list\
+  $ad_hdl_dir/library/util_axis_fifo/util_axis_fifo.v \
+  $ad_hdl_dir/library/util_axis_fifo/address_sync.v \
   $ad_hdl_dir/library/common/up_axi.v \
+  $ad_hdl_dir/library/common/ad_rst.v \
+  $ad_hdl_dir/library/xilinx/common/ad_rst_constr.xdc \
   axi_spi_engine.v]
 
 # parameters

--- a/library/spi_engine/axi_spi_engine/axi_spi_engine_hw.tcl
+++ b/library/spi_engine/axi_spi_engine/axi_spi_engine_hw.tcl
@@ -1,0 +1,126 @@
+
+package require qsys
+source ../../scripts/adi_env.tcl
+source ../../scripts/adi_ip_intel.tcl
+
+ad_ip_create axi_spi_engine {AXI SPI Engine} p_elaboration
+ad_ip_files axi_spi_engine [list\
+  $ad_hdl_dir/library/common/up_axi.v \
+  axi_spi_engine.v]
+
+# parameters
+
+ad_ip_parameter CMD_FIFO_ADDRESS_WIDTH INTEGER 4
+ad_ip_parameter SYNC_FIFO_ADDRESS_WIDTH INTEGER 4
+ad_ip_parameter SDO_FIFO_ADDRESS_WIDTH INTEGER 5
+ad_ip_parameter SDI_FIFO_ADDRESS_WIDTH INTEGER 5
+ad_ip_parameter MM_IF_TYPE INTEGER 1
+ad_ip_parameter ASYNC_SPI_CLK INTEGER 0
+ad_ip_parameter NUM_OFFLOAD INTEGER 1
+ad_ip_parameter OFFLOAD0_CMD_MEM_ADDRESS_WIDTH INTEGER 4
+ad_ip_parameter OFFLOAD0_SDO_MEM_ADDRESS_WIDTH INTEGER 4
+ad_ip_parameter ID INTEGER 0
+ad_ip_parameter DATA_WIDTH INTEGER 8
+ad_ip_parameter NUM_OF_SDI INTEGER 1
+
+proc p_elaboration {} {
+
+  # read parameters
+
+  set mm_if_type [get_parameter_value "MM_IF_TYPE"]
+
+  set num_of_sdi [get_parameter_value NUM_OF_SDI]
+  set data_width [get_parameter_value DATA_WIDTH]
+
+  # interrupt
+
+  add_interface interrupt_sender interrupt end
+  add_interface_port interrupt_sender irq irq Output 1
+
+  if {$mm_if_type} {
+
+    # Microprocessor interface
+
+    ad_interface clock   up_clk    input                  1
+    ad_interface reset-n up_rstn   input                  1   if_up_clk
+    ad_interface signal  up_wreq   input                  1
+    ad_interface signal  up_wack   output                 1
+    ad_interface signal  up_waddr  input                 14
+    ad_interface signal  up_wdata  input                 31
+    ad_interface signal  up_rreq   input                  1
+    ad_interface signal  up_rack   output                 1
+    ad_interface signal  up_raddr  output                14
+    ad_interface signal  up_rdata  output                31
+
+  } else {
+
+    # AXI Memory Mapped interface
+
+    ad_ip_intf_s_axi s_axi_aclk s_axi_aresetn 15
+
+    set_interface_property interrupt_sender associatedAddressablePoint s_axi
+    set_interface_property interrupt_sender associatedClock s_axi_clock
+    set_interface_property interrupt_sender associatedReset s_axi_reset
+    set_interface_property interrupt_sender ENABLED true
+
+  }
+
+  # SPI Engine interfaces
+
+  ad_interface clock spi_clk     input 1
+  ad_interface reset spi_resetn  output 1 if_spi_clk
+
+  add_interface cmd axi4stream start
+  add_interface_port cmd cmd_ready tready   input  1
+  add_interface_port cmd cmd_valid tvalid   output 1
+  add_interface_port cmd cmd_data  tdata    output 16
+
+  set_interface_property cmd associatedClock if_spi_clk
+  set_interface_property cmd associatedReset if_spi_resetn
+
+  add_interface sdo_data axi4stream start
+  add_interface_port sdo_data sdo_data_ready tready input  1
+  add_interface_port sdo_data sdo_data_valid tvalid output 1
+  add_interface_port sdo_data sdo_data       tdata  output $data_width
+
+  set_interface_property sdo_data associatedClock if_spi_clk
+  set_interface_property sdo_data associatedReset if_spi_resetn
+
+  add_interface sdi_data axi4stream end
+  add_interface_port sdi_data sdi_data_ready  tready output 1
+  add_interface_port sdi_data sdi_data_valid  tvalid input  1
+  add_interface_port sdi_data sdi_data        tdata  input [expr $num_of_sdi * $data_width]
+
+  set_interface_property sdi_data associatedClock if_spi_clk
+  set_interface_property sdi_data associatedReset if_spi_resetn
+
+  add_interface sync axi4stream end
+  add_interface_port sync sync_valid  tvalid input   1
+  add_interface_port sync sync_ready  tready output  1
+  add_interface_port sync sync_data   tdata  input   8
+
+  set_interface_property sync associatedClock if_spi_clk
+  set_interface_property sync associatedReset if_spi_resetn
+
+  # Offload interfaces
+
+  add_interface offload0_cmd conduit end
+  add_interface_port offload0_cmd offload0_cmd_wr_en    wre   output  1
+  add_interface_port offload0_cmd offload0_cmd_wr_data  data  output  16
+
+  set_interface_property offload0_cmd associatedClock if_spi_clk
+  set_interface_property offload0_cmd associatedReset none
+
+  add_interface offload0_sdo conduit end
+  add_interface_port offload0_sdo offload0_sdo_wr_en    wre   output  1
+  add_interface_port offload0_sdo offload0_sdo_wr_data  data  output  $data_width
+
+  set_interface_property offload0_sdo associatedClock if_spi_clk
+  set_interface_property offload0_sdo associatedReset none
+
+  ad_interface signal  offload0_mem_reset  output  1   reset
+  ad_interface signal  offload0_enable     output  1   enable
+  ad_interface signal  offload0_enabled    input   1   enabled
+
+}
+

--- a/library/spi_engine/axi_spi_engine/axi_spi_engine_hw.tcl
+++ b/library/spi_engine/axi_spi_engine/axi_spi_engine_hw.tcl
@@ -46,21 +46,21 @@ proc p_elaboration {} {
     # Microprocessor interface
 
     ad_interface clock   up_clk    input                  1
-    ad_interface reset-n up_rstn   input                  1   if_up_clk
+    ad_interface reset   up_rstn   input                  1   if_up_clk
     ad_interface signal  up_wreq   input                  1
     ad_interface signal  up_wack   output                 1
-    ad_interface signal  up_waddr  input                 14
+    ad_interface signal  up_waddr  input                  8
     ad_interface signal  up_wdata  input                 31
     ad_interface signal  up_rreq   input                  1
     ad_interface signal  up_rack   output                 1
-    ad_interface signal  up_raddr  output                14
+    ad_interface signal  up_raddr  output                 8
     ad_interface signal  up_rdata  output                31
 
   } else {
 
     # AXI Memory Mapped interface
 
-    ad_ip_intf_s_axi s_axi_aclk s_axi_aresetn 15
+    ad_ip_intf_s_axi s_axi_aclk s_axi_aresetn 10
 
     set_interface_property interrupt_sender associatedAddressablePoint s_axi
     set_interface_property interrupt_sender associatedClock s_axi_clock

--- a/library/spi_engine/spi_engine_execution/spi_engine_execution_hw.tcl
+++ b/library/spi_engine/spi_engine_execution/spi_engine_execution_hw.tcl
@@ -25,7 +25,7 @@ proc p_elaboration {} {
   # clock and reset interface
 
   ad_interface clock   clk     input 1
-  ad_interface reset-n resetn  input 1 if_clk
+  ad_interface reset   resetn  input 1 if_clk
 
   ad_interface signal active output 1
 

--- a/library/spi_engine/spi_engine_execution/spi_engine_execution_hw.tcl
+++ b/library/spi_engine/spi_engine_execution/spi_engine_execution_hw.tcl
@@ -1,0 +1,108 @@
+
+package require qsys
+source ../../scripts/adi_env.tcl
+source ../../scripts/adi_ip_intel.tcl
+
+ad_ip_create spi_engine_execution {SPI Engine Execution}
+set_module_property ELABORATION_CALLBACK p_elaboration
+ad_ip_files spi_engine_execution [list\
+  spi_engine_execution.v]
+
+# parameters
+
+ad_ip_parameter NUM_OF_CS INTEGER 1
+ad_ip_parameter DEFAULT_SPI_CFG INTEGER 0
+ad_ip_parameter DEFAULT_CLK_DIV INTEGER 0
+ad_ip_parameter DATA_WIDTH INTEGER 8
+ad_ip_parameter NUM_OF_SDI INTEGER 1
+
+proc p_elaboration {} {
+
+  set data_width [get_parameter_value DATA_WIDTH]
+  set num_of_sdi [get_parameter_value NUM_OF_SDI]
+  set num_of_cs [get_parameter_value NUM_OF_CS]
+
+  # clock and reset interface
+
+  ad_interface clock   clk     input 1
+  ad_interface reset-n resetn  input 1 if_clk
+
+  ad_interface signal active output 1
+
+  # command interface
+
+  add_interface cmd axi4stream end
+  add_interface_port cmd cmd_ready tready output 1
+  add_interface_port cmd cmd_valid tvalid input  1
+  add_interface_port cmd cmd       tdata  input  16
+
+  set_interface_property cmd associatedClock if_clk
+  set_interface_property cmd associatedReset if_resetn
+
+  # SDO data interface
+
+  add_interface sdo_data axi4stream end
+  add_interface_port sdo_data sdo_data_ready  tready output 1
+  add_interface_port sdo_data sdo_data_valid  tvalid input  1
+  add_interface_port sdo_data sdo_data        tdata  input  $data_width
+
+  set_interface_property sdo_data associatedClock if_clk
+  set_interface_property sdo_data associatedReset if_resetn
+
+  # SDI data interface
+
+  add_interface sdi_data axi4stream start
+  add_interface_port sdi_data sdi_data_ready  tready input  1
+  add_interface_port sdi_data sdi_data_valid  tvalid output 1
+  add_interface_port sdi_data sdi_data        tdata  output [expr $num_of_sdi * $data_width]
+
+  set_interface_property sdi_data associatedClock if_clk
+  set_interface_property sdi_data associatedReset if_resetn
+
+  # SYNC data interface
+
+  add_interface sync axi4stream start
+  add_interface_port sync sync_valid  tvalid output  1
+  add_interface_port sync sync_ready  tready input 1
+  add_interface_port sync sync        tdata  output  8
+
+  set_interface_property sync associatedClock if_clk
+  set_interface_property sync associatedReset if_resetn
+
+  ## physical SPI interface
+
+  ad_interface clock sclk output 1
+
+  ad_interface signal sdo output 1
+  ad_interface signal sdo_t output 1
+
+  ad_interface signal sdi   input 1
+  ad_interface signal sdi_1 input 1
+  ad_interface signal sdi_2 input 1
+  ad_interface signal sdi_3 input 1
+  ad_interface signal sdi_4 input 1
+  ad_interface signal sdi_5 input 1
+  ad_interface signal sdi_6 input 1
+  ad_interface signal sdi_7 input 1
+
+  ad_interface signal cs output 1
+  ad_interface signal three_wire output 1
+
+  if {$num_of_sdi < 8} {
+    set_interface_property if_sdi_7 ENABLED false
+  } elseif {$num_of_sdi < 7} {
+    set_interface_property if_sdi_6 ENABLED false
+  } elseif {$num_of_sdi < 6} {
+    set_interface_property if_sdi_5 ENABLED false
+  } elseif {$num_of_sdi < 5} {
+    set_interface_property if_sdi_4 ENABLED false
+  } elseif {$num_of_sdi < 4} {
+    set_interface_property if_sdi_3 ENABLED false
+  } elseif {$num_of_sdi < 3} {
+    set_interface_property if_sdi_2 ENABLED false
+  } elseif {$num_of_sdi < 2} {
+    set_interface_property if_sdi_1 ENABLED false
+  }
+
+}
+

--- a/library/spi_engine/spi_engine_execution/spi_engine_execution_hw.tcl
+++ b/library/spi_engine/spi_engine_execution/spi_engine_execution_hw.tcl
@@ -69,40 +69,16 @@ proc p_elaboration {} {
   set_interface_property sync associatedClock if_clk
   set_interface_property sync associatedReset if_resetn
 
-  ## physical SPI interface
+  # physical SPI interface
 
   ad_interface clock sclk output 1
 
-  ad_interface signal sdo output 1
+  ad_interface signal sdo   output 1
   ad_interface signal sdo_t output 1
-
-  ad_interface signal sdi   input 1
-  ad_interface signal sdi_1 input 1
-  ad_interface signal sdi_2 input 1
-  ad_interface signal sdi_3 input 1
-  ad_interface signal sdi_4 input 1
-  ad_interface signal sdi_5 input 1
-  ad_interface signal sdi_6 input 1
-  ad_interface signal sdi_7 input 1
+  ad_interface signal sdi   input  $num_of_sdi
 
   ad_interface signal cs output 1
   ad_interface signal three_wire output 1
-
-  if {$num_of_sdi < 8} {
-    set_interface_property if_sdi_7 ENABLED false
-  } elseif {$num_of_sdi < 7} {
-    set_interface_property if_sdi_6 ENABLED false
-  } elseif {$num_of_sdi < 6} {
-    set_interface_property if_sdi_5 ENABLED false
-  } elseif {$num_of_sdi < 5} {
-    set_interface_property if_sdi_4 ENABLED false
-  } elseif {$num_of_sdi < 4} {
-    set_interface_property if_sdi_3 ENABLED false
-  } elseif {$num_of_sdi < 3} {
-    set_interface_property if_sdi_2 ENABLED false
-  } elseif {$num_of_sdi < 2} {
-    set_interface_property if_sdi_1 ENABLED false
-  }
 
 }
 

--- a/library/spi_engine/spi_engine_interconnect/spi_engine_interconnect_hw.tcl
+++ b/library/spi_engine/spi_engine_interconnect/spi_engine_interconnect_hw.tcl
@@ -1,0 +1,146 @@
+
+package require qsys
+source ../../scripts/adi_env.tcl
+source ../../scripts/adi_ip_intel.tcl
+
+ad_ip_create spi_engine_interconnect {SPI Engine Interconnect} p_elaboration
+ad_ip_files spi_engine_interconnect [list\
+  spi_engine_interconnect.v]
+
+# parameters
+
+ad_ip_parameter DATA_WIDTH INTEGER 8
+ad_ip_parameter NUM_OF_SDI INTEGER 1
+
+proc p_elaboration {} {
+
+  set data_width [get_parameter_value DATA_WIDTH]
+  set num_of_sdi [get_parameter_value NUM_OF_SDI]
+
+  # clock and reset interface
+
+  ad_interface clock clk     input 1 
+  ad_interface reset resetn  input 1 if_clk
+
+  # command master interface
+
+  add_interface m_cmd axi4stream start
+  add_interface_port m_cmd m_cmd_ready tready input  1
+  add_interface_port m_cmd m_cmd_valid tvalid output 1
+  add_interface_port m_cmd m_cmd_data  tdata  output 16
+
+  set_interface_property m_cmd associatedClock if_clk
+  set_interface_property m_cmd associatedReset if_resetn
+
+  # SDO data master interface
+
+  add_interface m_sdo axi4stream start
+  add_interface_port m_sdo m_sdo_ready tready input  1
+  add_interface_port m_sdo m_sdo_valid tvalid output 1
+  add_interface_port m_sdo m_sdo_data  tdata  output $data_width
+
+  set_interface_property m_sdo associatedClock if_clk
+  set_interface_property m_sdo associatedReset if_resetn
+
+  # SDI data master interface
+
+  add_interface m_sdi axi4stream end
+  add_interface_port m_sdi m_sdi_ready tready output 1
+  add_interface_port m_sdi m_sdi_valid tvalid input  1
+  add_interface_port m_sdi m_sdi_data  tdata  input  [expr $num_of_sdi * $data_width]
+
+  set_interface_property m_sdi associatedClock if_clk
+  set_interface_property m_sdi associatedReset if_resetn
+
+  # SYNC master interface
+
+  add_interface m_sync axi4stream end
+  add_interface_port m_sync m_sync_valid tvalid input  1
+  add_interface_port m_sync m_sync_ready tready output 1
+  add_interface_port m_sync m_sync       tdata  input  8
+
+  set_interface_property m_sync associatedClock if_clk
+  set_interface_property m_sync associatedReset if_resetn
+
+  # command slave0 interface
+
+  add_interface s0_cmd axi4stream end
+  add_interface_port s0_cmd s0_cmd_ready tready output 1
+  add_interface_port s0_cmd s0_cmd_valid tvalid input  1
+  add_interface_port s0_cmd s0_cmd_data  tdata  input  16
+
+  set_interface_property s0_cmd associatedClock if_clk
+  set_interface_property s0_cmd associatedReset if_resetn
+
+  # SDO data slave0 interface
+
+  add_interface s0_sdo axi4stream end
+  add_interface_port s0_sdo s0_sdo_ready tready output 1
+  add_interface_port s0_sdo s0_sdo_valid tvalid input  1
+  add_interface_port s0_sdo s0_sdo_data  tdata  input  $data_width
+
+  set_interface_property s0_sdo associatedClock if_clk
+  set_interface_property s0_sdo associatedReset if_resetn
+
+  # SDI data slave0 interface
+
+  add_interface s0_sdi axi4stream start
+  add_interface_port s0_sdi s0_sdi_ready tready input  1
+  add_interface_port s0_sdi s0_sdi_valid tvalid output 1
+  add_interface_port s0_sdi s0_sdi_data  tdata  output [expr $num_of_sdi * $data_width]
+
+  set_interface_property s0_sdi associatedClock if_clk
+  set_interface_property s0_sdi associatedReset if_resetn
+
+  # SYNC slave0 interface
+
+  add_interface s0_sync axi4stream start
+  add_interface_port s0_sync s0_sync_valid tvalid output 1
+  add_interface_port s0_sync s0_sync_ready tready input  1
+  add_interface_port s0_sync s0_sync       tdata  output 8
+
+  set_interface_property s0_sync associatedClock if_clk
+  set_interface_property s0_sync associatedReset if_resetn
+
+  # command slave1 interface
+
+  add_interface s1_cmd axi4stream end
+  add_interface_port s1_cmd s1_cmd_ready tready output 1
+  add_interface_port s1_cmd s1_cmd_valid tvalid input  1
+  add_interface_port s1_cmd s1_cmd_data  tdata  input  16
+
+  set_interface_property s1_cmd associatedClock if_clk
+  set_interface_property s1_cmd associatedReset if_resetn
+
+  # SDO data slave1 interface
+
+  add_interface s1_sdo axi4stream end
+  add_interface_port s1_sdo s1_sdo_ready tready output 1
+  add_interface_port s1_sdo s1_sdo_valid tvalid input  1
+  add_interface_port s1_sdo s1_sdo_data  tdata  input  $data_width
+
+  set_interface_property s1_sdo associatedClock if_clk
+  set_interface_property s1_sdo associatedReset if_resetn
+
+  # SDI data slave1 interface
+
+  add_interface s1_sdi axi4stream start
+  add_interface_port s1_sdi s1_sdi_ready tready input  1
+  add_interface_port s1_sdi s1_sdi_valid tvalid output 1
+  add_interface_port s1_sdi s1_sdi_data  tdata  output [expr $num_of_sdi * $data_width]
+
+  set_interface_property s1_sdi associatedClock if_clk
+  set_interface_property s1_sdi associatedReset if_resetn
+
+  # SYNC slave1 interface
+
+  add_interface s1_sync axi4stream start
+  add_interface_port s1_sync s1_sync_valid tvalid output 1
+  add_interface_port s1_sync s1_sync_ready tready input  1
+  add_interface_port s1_sync s1_sync       tdata  output 8
+
+  set_interface_property s1_sync associatedClock if_clk
+  set_interface_property s1_sync associatedReset if_resetn
+
+}
+

--- a/library/spi_engine/spi_engine_offload/spi_engine_offload_hw.tcl
+++ b/library/spi_engine/spi_engine_offload/spi_engine_offload_hw.tcl
@@ -1,0 +1,105 @@
+
+package require qsys
+source ../../scripts/adi_env.tcl
+source ../../scripts/adi_ip_intel.tcl
+
+ad_ip_create spi_engine_offload {SPI Engine Offload} p_elaboration
+ad_ip_files spi_engine_offload [list\
+  $ad_hdl_dir/library/util_cdc/sync_bits.v \
+  spi_engine_offload.v]
+
+# parameters
+
+ad_ip_parameter ASYNC_SPI_CLK INTEGER 0
+ad_ip_parameter ASYNC_TRIG INTEGER 0
+ad_ip_parameter CMD_MEM_ADDRESS_WIDTH INTEGER 4
+ad_ip_parameter SDO_MEM_ADDRESS_WIDTH INTEGER 4
+ad_ip_parameter DATA_WIDTH INTEGER 8
+ad_ip_parameter NUM_OF_SDI INTEGER 1
+
+proc p_elaboration {} {
+
+  set data_width [get_parameter_value DATA_WIDTH]
+  set num_of_sdi [get_parameter_value NUM_OF_SDI]
+
+  # control interface
+
+  ad_interface clock ctrl_clk input 1
+  ad_interface reset spi_resetn  input 1 if_spi_clk
+
+  add_interface ctrl_cmd_wr conduit end
+  add_interface_port ctrl_cmd_wr ctrl_cmd_wr_en    wre   input  1
+  add_interface_port ctrl_cmd_wr ctrl_cmd_wr_data  data  input 16
+
+  set_interface_property ctrl_cmd_wr associatedClock if_ctrl_clk
+  set_interface_property ctrl_cmd_wr associatedReset none
+
+  add_interface ctrl_sdo_wr conduit end
+  add_interface_port ctrl_sdo_wr ctrl_sdo_wr_en    wre   input  1
+  add_interface_port ctrl_sdo_wr ctrl_sdo_wr_data  data  input $data_width
+
+  set_interface_property ctrl_sdo_wr associatedClock if_ctrl_clk
+  set_interface_property ctrl_sdo_wr associatedReset none
+
+  ad_interface signal  ctrl_enable     input  1   enable
+  ad_interface signal  ctrl_enabled    output 1   enabled
+  ad_interface signal  ctrl_mem_reset  input  1   reset
+
+  # SPI Engine interfaces
+
+  ad_interface clock   spi_clk     input 1
+  ad_interface reset-n spi_resetn  input 1 if_spi_clk
+
+  ad_interface signal  trigger     input 1
+
+  ## command interface
+
+  add_interface cmd axi4stream start
+  add_interface_port cmd cmd_valid tvalid   output   1
+  add_interface_port cmd cmd_ready tready   input    1
+  add_interface_port cmd cmd       tdata    output   16
+
+  set_interface_property cmd associatedClock if_spi_clk
+  set_interface_property cmd associatedReset if_spi_resetn
+
+  ## SDO data interface
+
+  add_interface sdo_data axi4stream start
+  add_interface_port sdo_data sdo_data_valid  tvalid   output  1
+  add_interface_port sdo_data sdo_data_ready  tready   input   1
+  add_interface_port sdo_data sdo_data        tdata    output  $data_width
+
+  set_interface_property sdo_data associatedClock if_spi_clk
+  set_interface_property sdo_data associatedReset if_spi_resetn
+
+  ## SDI data interface
+
+  add_interface sdi_data axi4stream end
+  add_interface_port sdi_data sdi_data_valid  tvalid  input   1
+  add_interface_port sdi_data sdi_data_ready  tready  output  1
+  add_interface_port sdi_data sdi_data        tdata   input   [expr $num_of_sdi * $data_width]
+
+  set_interface_property sdi_data associatedClock if_spi_clk
+  set_interface_property sdi_data associatedReset if_spi_resetn
+
+  ## SYNC data interface
+
+  add_interface sync axi4stream end
+  add_interface_port sync sync_valid  tvalid input   1
+  add_interface_port sync sync_ready  tready output  1
+  add_interface_port sync sync_data   tdata  input   8
+
+  set_interface_property sync associatedClock if_spi_clk
+  set_interface_property sync associatedReset if_spi_resetn
+
+  ## Offload SDI data interface
+  
+  add_interface offload_sdi axi4stream start
+  add_interface_port offload_sdi offload_sdi_valid tvalid  output  1
+  add_interface_port offload_sdi offload_sdi_ready tready  input   1
+  add_interface_port offload_sdi offload_sdi_data  tdata   output  [expr $num_of_sdi * $data_width]
+
+  set_interface_property offload_sdi associatedClock if_spi_clk
+  set_interface_property offload_sdi associatedReset if_spi_resetn
+
+}

--- a/library/spi_engine/spi_engine_offload/spi_engine_offload_hw.tcl
+++ b/library/spi_engine/spi_engine_offload/spi_engine_offload_hw.tcl
@@ -48,7 +48,7 @@ proc p_elaboration {} {
   # SPI Engine interfaces
 
   ad_interface clock   spi_clk     input 1
-  ad_interface reset-n spi_resetn  input 1 if_spi_clk
+  ad_interface resetn  spi_resetn  input 1 if_spi_clk
 
   ad_interface signal  trigger     input 1
 

--- a/projects/ad77681evb/common/ad77681evb_qsys.tcl
+++ b/projects/ad77681evb/common/ad77681evb_qsys.tcl
@@ -1,0 +1,111 @@
+    
+    # dma
+
+    add_instance axi_dmac_0 axi_dmac
+    set_instance_parameter_value axi_dmac_0 {DMA_DATA_WIDTH_SRC} {32}
+    set_instance_parameter_value axi_dmac_0 {DMA_DATA_WIDTH_DEST} {64}
+    set_instance_parameter_value axi_dmac_0 {DMA_2D_TRANSFER} {0}
+    set_instance_parameter_value axi_dmac_0 {DMA_LENGTH_WIDTH} {24}
+    set_instance_parameter_value axi_dmac_0 {AXI_SLICE_DEST} {0}
+    set_instance_parameter_value axi_dmac_0 {AXI_SLICE_SRC} {0}
+    set_instance_parameter_value axi_dmac_0 {SYNC_TRANSFER_START} {0}
+    set_instance_parameter_value axi_dmac_0 {CYCLIC} {1}
+    set_instance_parameter_value axi_dmac_0 {DMA_TYPE_DEST} {0}
+    set_instance_parameter_value axi_dmac_0 {DMA_TYPE_SRC} {1}
+    set_instance_parameter_value axi_dmac_0 {FIFO_SIZE} {8}
+    set_instance_parameter_value axi_dmac_0 {HAS_AXIS_TLAST} {0}
+
+    add_connection axi_dmac_0.m_dest_axi sys_hps.f2h_sdram0_data
+    add_connection sys_clk.clk axi_dmac_0.if_s_axis_aclk
+    add_connection sys_clk.clk axi_dmac_0.s_axi_clock
+    add_connection sys_clk.clk_reset axi_dmac_0.m_dest_axi_reset
+    add_connection sys_clk.clk_reset axi_dmac_0.s_axi_reset
+    add_connection sys_dma_clk.clk axi_dmac_0.m_dest_axi_clock
+    add_connection sys_dma_clk.clk_reset axi_dmac_0.m_dest_axi_reset
+   	
+	# create a SPI Engine architecture for ADC
+	
+    # axi_spi_engine
+
+    add_instance axi_spi_engine_0 axi_spi_engine
+    set_instance_parameter_value axi_spi_engine_0 {DATA_WIDTH}  {32}
+    set_instance_parameter_value axi_spi_engine_0 {MM_IF_TYPE}  {0}
+    set_instance_parameter_value axi_spi_engine_0 {NUM_OF_SDI}  {1}
+    set_instance_parameter_value axi_spi_engine_0 {NUM_OFFLOAD} {1}
+
+    add_connection sys_clk.clk axi_spi_engine_0.if_spi_clk
+    add_connection sys_clk.clk axi_spi_engine_0.s_axi_clock
+    add_connection sys_clk.clk_reset axi_spi_engine_0.s_axi_reset	
+
+    # spi_engine_execution
+
+    add_instance spi_engine_execution_0 spi_engine_execution
+    set_instance_parameter_value spi_engine_execution_0 {DATA_WIDTH} {32}
+    set_instance_parameter_value spi_engine_execution_0 {NUM_OF_SDI} {1}
+
+    add_connection sys_clk.clk spi_engine_execution_0.if_clk
+    add_connection axi_spi_engine_0.if_spi_resetn spi_engine_execution_0.if_resetn
+    add_interface spi_engine_execution_0_if_cs conduit end
+    set_interface_property spi_engine_cs EXPORT_OF spi_engine_execution_0.if_cs
+    add_interface spi_engine_execution_0_if_sclk clock source
+    set_interface_property spi_engine_sclk EXPORT_OF spi_engine_execution_0.if_sclk
+    add_interface spi_engine_execution_0_if_sdi conduit end
+    set_interface_property spi_engine_sdi EXPORT_OF spi_engine_execution_0.if_sdi
+    add_interface spi_engine_execution_0_if_sdo conduit end
+    set_interface_property spi_engine_sdo EXPORT_OF spi_engine_execution_0.if_sdo
+    add_interface spi_engine_sdo_t conduit end
+    set_interface_property spi_engine_sdo_t EXPORT_OF spi_engine_execution_0.if_sdo_t
+   
+    # spi_engine_interconnect
+
+    add_instance spi_engine_interconnect_0 spi_engine_interconnect
+    set_instance_parameter_value spi_engine_interconnect_0 {DATA_WIDTH} {32}
+    set_instance_parameter_value spi_engine_interconnect_0 {NUM_OF_SDI} {1}
+
+    add_connection sys_clk.clk spi_engine_interconnect_0.if_clk
+    add_connection axi_spi_engine_0.if_spi_resetn spi_engine_interconnect_0.if_resetn
+
+    # spi_engine_offload
+
+    add_instance spi_engine_offload_0 spi_engine_offload
+    set_instance_parameter_value spi_engine_offload_0 {ASYNC_TRIG} {1}
+    set_instance_parameter_value spi_engine_offload_0 {DATA_WIDTH} {32}
+    set_instance_parameter_value spi_engine_offload_0 {NUM_OF_SDI} {1}
+
+    add_connection sys_clk.clk spi_engine_offload_0.if_ctrl_clk
+    add_connection sys_clk.clk spi_engine_offload_0.if_spi_clk
+    add_connection axi_spi_engine_0.if_spi_resetn spi_engine_offload_0.if_spi_resetn
+    add_interface spi_engine_offload_0_if_trigger conduit end
+    set_interface_property spi_engine_trigger EXPORT_OF spi_engine_offload_0.if_trigger
+
+    # SPI Engine connections
+
+    add_connection axi_spi_engine_0.cmd spi_engine_interconnect_0.s0_cmd
+    add_connection axi_spi_engine_0.sdo_data spi_engine_interconnect_0.s0_sdo 
+    add_connection spi_engine_execution_0.sdi_data spi_engine_interconnect_0.m_sdi 
+    add_connection spi_engine_execution_0.sync spi_engine_interconnect_0.m_sync
+    add_connection spi_engine_interconnect_0.m_cmd spi_engine_execution_0.cmd 
+    add_connection spi_engine_interconnect_0.m_sdo spi_engine_execution_0.sdo_data 
+    add_connection spi_engine_interconnect_0.s0_sdi axi_spi_engine_0.sdi_data 
+    add_connection spi_engine_interconnect_0.s0_sync axi_spi_engine_0.sync 
+    add_connection spi_engine_interconnect_0.s1_sdi spi_engine_offload_0.sdi_data 
+    add_connection spi_engine_interconnect_0.s1_sync spi_engine_offload_0.sync
+    add_connection spi_engine_offload_0.cmd spi_engine_interconnect_0.s1_cmd 
+    add_connection spi_engine_offload_0.ctrl_cmd_wr axi_spi_engine_0.offload0_cmd
+    add_connection spi_engine_offload_0.ctrl_sdo_wr axi_spi_engine_0.offload0_sdo
+    add_connection spi_engine_offload_0.if_ctrl_enable axi_spi_engine_0.if_offload0_enable
+    add_connection spi_engine_offload_0.if_ctrl_enabled axi_spi_engine_0.if_offload0_enabled
+    add_connection spi_engine_offload_0.if_ctrl_mem_reset axi_spi_engine_0.if_offload0_mem_reset
+    add_connection spi_engine_offload_0.sdo_data spi_engine_interconnect_0.s1_sdo
+    add_connection spi_engine_offload_0.offload_sdi axi_dmac_0.s_axis	
+	
+    # cpu interconnects
+
+    ad_cpu_interconnect 0x00020000 axi_dmac_0.s_axi
+    ad_cpu_interconnect 0x00028000 axi_spi_engine_0.s_axi
+
+    #interrupts
+
+    ad_cpu_interrupt 3 axi_dmac_0.interrupt_sender
+    ad_cpu_interrupt 4 axi_spi_engine_0.interrupt_sender
+

--- a/projects/ad77681evb/de10nano/Makefile
+++ b/projects/ad77681evb/de10nano/Makefile
@@ -1,0 +1,14 @@
+####################################################################################
+## Copyright 2019 - 2020(c) Analog Devices, Inc.
+## Auto-generated, do not modify!
+####################################################################################
+
+PROJECT_NAME := ad77681evb_de10nano
+
+M_DEPS += ../common/ad77681evb_qsys.tcl
+M_DEPS += ../../common/de10nano/de10nano_system_assign.tcl
+M_DEPS += ../../common/de10nano/de10nano_system_qsys.tcl
+
+LIB_DEPS += axi_dmac
+
+include ../../scripts/project-intel.mk

--- a/projects/ad77681evb/de10nano/system_constr.sdc
+++ b/projects/ad77681evb/de10nano/system_constr.sdc
@@ -1,0 +1,6 @@
+
+create_clock -period "20.000 ns"  -name sys_clk_50mhz      [get_ports {sys_clk}]
+
+derive_pll_clocks
+derive_clock_uncertainty
+

--- a/projects/ad77681evb/de10nano/system_project.tcl
+++ b/projects/ad77681evb/de10nano/system_project.tcl
@@ -11,7 +11,7 @@ source $ad_hdl_dir/projects/common/de10nano/de10nano_system_assign.tcl
 
 # SPI interface
 
-set_location_assignment PIN_AH12 -to ad77681_spi_sclk       ; ##   Arduino_IO13
+set_location_assignment PIN_AH12 -to ad77681_spi_sclk      ; ##   Arduino_IO13
 set_location_assignment PIN_AH11 -to ad77681_spi_miso      ; ##   Arduino_IO12
 set_location_assignment PIN_AG16 -to ad77681_spi_mosi      ; ##   Arduino_IO11
 set_location_assignment PIN_AF15 -to ad77681_spi_cs        ; ##   Arduino_IO10
@@ -44,8 +44,7 @@ set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to ad77681_drdy
 set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to ad77681_sync_in
 
 
-#
 # set optimization to get a better timing closure
-set_global_assignment -name OPTIMIZATION_MODE "HIGH PERFORMANCE EFFORT"
+#set_global_assignment -name OPTIMIZATION_MODE "HIGH PERFORMANCE EFFORT"
 
 execute_flow -compile

--- a/projects/ad77681evb/de10nano/system_project.tcl
+++ b/projects/ad77681evb/de10nano/system_project.tcl
@@ -1,0 +1,51 @@
+
+source ../../scripts/adi_env.tcl
+source ../../scripts/adi_project_intel.tcl
+
+adi_project ad77681evb_de10nano
+
+source $ad_hdl_dir/projects/common/de10nano/de10nano_system_assign.tcl
+
+# files
+
+
+# SPI interface
+
+set_location_assignment PIN_AH12 -to ad77681_spi_sclk       ; ##   Arduino_IO13
+set_location_assignment PIN_AH11 -to ad77681_spi_miso      ; ##   Arduino_IO12
+set_location_assignment PIN_AG16 -to ad77681_spi_mosi      ; ##   Arduino_IO11
+set_location_assignment PIN_AF15 -to ad77681_spi_cs        ; ##   Arduino_IO10
+
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to ad77681_spi_sclk
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to ad77681_spi_miso
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to ad77681_spi_mosi
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to ad77681_spi_cs
+
+# reset and GPIO signals
+
+set_location_assignment PIN_AG9  -to ad77681_reset         ; ##   Arduino_IO3
+set_location_assignment PIN_AE15 -to ad77681_fda_dis       ; ##   Arduino_IO9
+set_location_assignment PIN_AF17 -to ad77681_fda_mode      ; ##   Arduino_IO8
+set_location_assignment PIN_U13  -to ad77681_dac_buf_en    ; ##   Arduino_IO5
+set_location_assignment PIN_U14  -to ad77681_io_int        ; ##   Arduino_IO4
+
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to ad77681_reset
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to ad77681_fda_dis
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to ad77681_fda_mode
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to ad77681_dac_buf_en
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to ad77681_io_int
+
+# synchronization and timing
+
+set_location_assignment PIN_AG10 -to ad77681_drdy          ; ##   Arduino_IO2
+set_location_assignment PIN_AG8  -to ad77681_sync_in       ; ##   Arduino_IO6
+
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to ad77681_drdy
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to ad77681_sync_in
+
+
+#
+# set optimization to get a better timing closure
+set_global_assignment -name OPTIMIZATION_MODE "HIGH PERFORMANCE EFFORT"
+
+execute_flow -compile

--- a/projects/ad77681evb/de10nano/system_qsys.tcl
+++ b/projects/ad77681evb/de10nano/system_qsys.tcl
@@ -1,0 +1,6 @@
+
+set dac_fifo_address_width 10
+
+source $ad_hdl_dir/projects/common/de10nano/de10nano_system_qsys.tcl
+source ../common/ad77681evb_qsys.tcl
+

--- a/projects/ad77681evb/de10nano/system_top.v
+++ b/projects/ad77681evb/de10nano/system_top.v
@@ -77,7 +77,7 @@ module system_top (
   inout             sdio_cmd,
   inout   [  3:0]   sdio_d,
 
-  // hps-spim1-lcd
+  // hps-spim1
 
   output            spim1_ss0,
   output            spim1_clk,
@@ -115,14 +115,7 @@ module system_top (
   input            ad77681_fda_dis,
   input            ad77681_fda_mode,
   input            ad77681_dac_buf_en,
-  inout            ad77681_io_int,
-
-  // spi interface
-
-  output           spi_csn,
-  output           spi_clk,
-  output           spi_mosi,
-  input            spi_miso);
+  inout            ad77681_io_int);
 
   // internal signals
 
@@ -206,10 +199,6 @@ module system_top (
     .sys_gpio_bd_out_port (gpio_o[31:0]),
     .sys_gpio_in_export (gpio_i[63:32]),
     .sys_gpio_out_export (gpio_o[63:32]),
-    .sys_spi_MISO (spi_miso),
-    .sys_spi_MOSI (spi_mosi),
-    .sys_spi_SCLK (spi_clk),
-    .sys_spi_SS_n (spi_csn),
     .spi_engine_sdo_sdo (ad77681_spi_mosi),
     .spi_engine_sdo_t_sdo_t (),
     .spi_engine_sdi_sdi (ad77681_spi_miso),

--- a/projects/ad77681evb/de10nano/system_top.v
+++ b/projects/ad77681evb/de10nano/system_top.v
@@ -135,7 +135,10 @@ module system_top (
   assign gpio_i[33] = ad77681_sync_in;
   assign ad77681_reset = gpio_o[32];
 
-  assign gpio_i[31:0] = gpio_o[31:0];
+  assign gpio_i[11:4] = gpio_bd_i[7:0];
+  assign gpio_bd_o[3:0] = gpio_o[3:0];
+
+  assign gpio_i[31:12] = gpio_o[31:12];
 
   system_bd i_system_bd (
     .sys_clk_clk (sys_clk),

--- a/projects/ad77681evb/de10nano/system_top.v
+++ b/projects/ad77681evb/de10nano/system_top.v
@@ -1,0 +1,223 @@
+// ***************************************************************************
+// ***************************************************************************
+// Copyright 2019 - 2020 (c) Analog Devices, Inc. All rights reserved.
+//
+// In this HDL repository, there are many different and unique modules, consisting
+// of various HDL (Verilog or VHDL) components. The individual modules are
+// developed independently, and may be accompanied by separate and unique license
+// terms.
+//
+// The user should read each of these license terms, and understand the
+// freedoms and responsabilities that he or she has by using this source/core.
+//
+// This core is distributed in the hope that it will be useful, but WITHOUT ANY
+// WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+// A PARTICULAR PURPOSE.
+//
+// Redistribution and use of source or resulting binaries, with or without modification
+// of this file, are permitted under one of the following two license terms:
+//
+//   1. The GNU General Public License version 2 as published by the
+//      Free Software Foundation, which can be found in the top level directory
+//      of this repository (LICENSE_GPL2), and also online at:
+//      <https://www.gnu.org/licenses/old-licenses/gpl-2.0.html>
+//
+// OR
+//
+//   2. An ADI specific BSD license, which can be found in the top level directory
+//      of this repository (LICENSE_ADIBSD), and also on-line at:
+//      https://github.com/analogdevicesinc/hdl/blob/master/LICENSE_ADIBSD
+//      This will allow to generate bit files and not release the source code,
+//      as long as it attaches to an ADI device.
+//
+// ***************************************************************************
+// ***************************************************************************
+
+`timescale 1ns/100ps
+
+module system_top (
+
+  // clock and resets
+
+  input            sys_clk,
+
+  // hps-ddr
+
+  output  [14:0]   ddr3_a,
+  output  [ 2:0]   ddr3_ba,
+  output           ddr3_reset_n,
+  output           ddr3_ck_p,
+  output           ddr3_ck_n,
+  output           ddr3_cke,
+  output           ddr3_cs_n,
+  output           ddr3_ras_n,
+  output           ddr3_cas_n,
+  output           ddr3_we_n,
+  inout   [31:0]   ddr3_dq,
+  inout   [ 3:0]   ddr3_dqs_p,
+  inout   [ 3:0]   ddr3_dqs_n,
+  output  [ 3:0]   ddr3_dm,
+  output           ddr3_odt,
+  input            ddr3_rzq,
+
+  // hps-ethernet
+
+  output            eth1_tx_clk,
+  output            eth1_tx_ctl,
+  output  [  3:0]   eth1_tx_d,
+  input             eth1_rx_clk,
+  input             eth1_rx_ctl,
+  input   [  3:0]   eth1_rx_d,
+  output            eth1_mdc,
+  inout             eth1_mdio,
+
+  // hps-sdio
+
+  output            sdio_clk,
+  inout             sdio_cmd,
+  inout   [  3:0]   sdio_d,
+
+  // hps-spim1-lcd
+
+  output            spim1_ss0,
+  output            spim1_clk,
+  output            spim1_mosi,
+  input             spim1_miso,
+
+  // hps-usb
+
+  input             usb1_clk,
+  output            usb1_stp,
+  input             usb1_dir,
+  input             usb1_nxt,
+  inout   [  7:0]   usb1_d,
+
+  // hps-uart
+
+  input             uart0_rx,
+  output            uart0_tx,
+
+  // board gpio
+
+  output  [  3:0]   gpio_bd_o,
+  input   [  7:0]   gpio_bd_i,
+
+  // ad77681
+
+  input            ad77681_spi_miso,
+  output           ad77681_spi_mosi,
+  output           ad77681_spi_sclk,
+  output           ad77681_spi_cs,
+  input            ad77681_drdy,
+
+  output           ad77681_reset,
+  inout            ad77681_sync_in,
+  input            ad77681_fda_dis,
+  input            ad77681_fda_mode,
+  input            ad77681_dac_buf_en,
+  inout            ad77681_io_int,
+
+  // spi interface
+
+  output           spi_csn,
+  output           spi_clk,
+  output           spi_mosi,
+  input            spi_miso);
+
+  // internal signals
+
+  wire             sys_resetn;
+  wire    [63:0]   gpio_i;
+  wire    [63:0]   gpio_o;
+
+  // instantiations
+
+  assign gpio_i[63:39] = gpio_o[63:39];
+  
+  assign gpio_i[38] = ad77681_io_int;
+  assign gpio_i[37] = ad77681_drdy;
+  assign gpio_i[36] = ad77681_fda_dis;
+  assign gpio_i[35] = ad77681_fda_mode;
+  assign gpio_i[34] = ad77681_dac_buf_en;
+  assign gpio_i[33] = ad77681_sync_in;
+  assign ad77681_reset = gpio_o[32];
+
+  assign gpio_i[31:0] = gpio_o[31:0];
+
+  system_bd i_system_bd (
+    .sys_clk_clk (sys_clk),
+    .sys_hps_h2f_reset_reset_n (sys_resetn), 
+    .sys_hps_memory_mem_a (ddr3_a),
+    .sys_hps_memory_mem_ba (ddr3_ba),
+    .sys_hps_memory_mem_ck (ddr3_ck_p),
+    .sys_hps_memory_mem_ck_n (ddr3_ck_n),
+    .sys_hps_memory_mem_cke (ddr3_cke),
+    .sys_hps_memory_mem_cs_n (ddr3_cs_n),
+    .sys_hps_memory_mem_ras_n (ddr3_ras_n),
+    .sys_hps_memory_mem_cas_n (ddr3_cas_n),
+    .sys_hps_memory_mem_we_n (ddr3_we_n),
+    .sys_hps_memory_mem_reset_n (ddr3_reset_n),
+    .sys_hps_memory_mem_dq (ddr3_dq),
+    .sys_hps_memory_mem_dqs (ddr3_dqs_p),
+    .sys_hps_memory_mem_dqs_n (ddr3_dqs_n),
+    .sys_hps_memory_mem_odt (ddr3_odt),
+    .sys_hps_memory_mem_dm (ddr3_dm),
+    .sys_hps_memory_oct_rzqin (ddr3_rzq),
+    .sys_rst_reset_n (sys_resetn),
+    .sys_hps_hps_io_hps_io_emac1_inst_TX_CLK (eth1_tx_clk),
+    .sys_hps_hps_io_hps_io_emac1_inst_TXD0 (eth1_tx_d[0]),
+    .sys_hps_hps_io_hps_io_emac1_inst_TXD1 (eth1_tx_d[1]),
+    .sys_hps_hps_io_hps_io_emac1_inst_TXD2 (eth1_tx_d[2]),
+    .sys_hps_hps_io_hps_io_emac1_inst_TXD3 (eth1_tx_d[3]),
+    .sys_hps_hps_io_hps_io_emac1_inst_RXD0 (eth1_rx_d[0]),
+    .sys_hps_hps_io_hps_io_emac1_inst_MDIO (eth1_mdio),
+    .sys_hps_hps_io_hps_io_emac1_inst_MDC (eth1_mdc),
+    .sys_hps_hps_io_hps_io_emac1_inst_RX_CTL (eth1_rx_ctl),
+    .sys_hps_hps_io_hps_io_emac1_inst_TX_CTL (eth1_tx_ctl),
+    .sys_hps_hps_io_hps_io_emac1_inst_RX_CLK (eth1_rx_clk),
+    .sys_hps_hps_io_hps_io_emac1_inst_RXD1 (eth1_rx_d[1]),
+    .sys_hps_hps_io_hps_io_emac1_inst_RXD2 (eth1_rx_d[2]),
+    .sys_hps_hps_io_hps_io_emac1_inst_RXD3 (eth1_rx_d[3]),
+    .sys_hps_hps_io_hps_io_sdio_inst_CMD (sdio_cmd),
+    .sys_hps_hps_io_hps_io_sdio_inst_D0 (sdio_d[0]),
+    .sys_hps_hps_io_hps_io_sdio_inst_D1 (sdio_d[1]),
+    .sys_hps_hps_io_hps_io_sdio_inst_CLK (sdio_clk),
+    .sys_hps_hps_io_hps_io_sdio_inst_D2 (sdio_d[2]),
+    .sys_hps_hps_io_hps_io_sdio_inst_D3 (sdio_d[3]),
+    .sys_hps_hps_io_hps_io_usb1_inst_D0 (usb1_d[0]),
+    .sys_hps_hps_io_hps_io_usb1_inst_D1 (usb1_d[1]),
+    .sys_hps_hps_io_hps_io_usb1_inst_D2 (usb1_d[2]),
+    .sys_hps_hps_io_hps_io_usb1_inst_D3 (usb1_d[3]),
+    .sys_hps_hps_io_hps_io_usb1_inst_D4 (usb1_d[4]),
+    .sys_hps_hps_io_hps_io_usb1_inst_D5 (usb1_d[5]),
+    .sys_hps_hps_io_hps_io_usb1_inst_D6 (usb1_d[6]),
+    .sys_hps_hps_io_hps_io_usb1_inst_D7 (usb1_d[7]),
+    .sys_hps_hps_io_hps_io_usb1_inst_CLK (usb1_clk),
+    .sys_hps_hps_io_hps_io_usb1_inst_STP (usb1_stp),
+    .sys_hps_hps_io_hps_io_usb1_inst_DIR (usb1_dir),
+    .sys_hps_hps_io_hps_io_usb1_inst_NXT (usb1_nxt),
+    .sys_hps_hps_io_hps_io_uart0_inst_RX (uart0_rx),
+    .sys_hps_hps_io_hps_io_uart0_inst_TX (uart0_tx),
+    .sys_hps_hps_io_hps_io_spim1_inst_CLK (spim1_clk),
+    .sys_hps_hps_io_hps_io_spim1_inst_MOSI (spim1_mosi),
+    .sys_hps_hps_io_hps_io_spim1_inst_MISO (spim1_miso),
+    .sys_hps_hps_io_hps_io_spim1_inst_SS0 (spim1_ss0),
+    .sys_gpio_bd_in_port (gpio_i[31:0]),
+    .sys_gpio_bd_out_port (gpio_o[31:0]),
+    .sys_gpio_in_export (gpio_i[63:32]),
+    .sys_gpio_out_export (gpio_o[63:32]),
+    .sys_spi_MISO (spi_miso),
+    .sys_spi_MOSI (spi_mosi),
+    .sys_spi_SCLK (spi_clk),
+    .sys_spi_SS_n (spi_csn),
+    .spi_engine_sdo_sdo (ad77681_spi_mosi),
+    .spi_engine_sdo_t_sdo_t (),
+    .spi_engine_sdi_sdi (ad77681_spi_miso),
+    .spi_engine_cs_cs (ad77681_spi_cs),
+    .spi_engine_sclk_clk (ad77681_spi_sclk),
+    .spi_engine_trigger_trigger (ad77681_drdy));
+
+endmodule
+
+// ***************************************************************************
+// ***************************************************************************

--- a/projects/common/de10nano/de10nano_system_assign.tcl
+++ b/projects/common/de10nano/de10nano_system_assign.tcl
@@ -1,0 +1,704 @@
+# de10nano
+# clocks (V11, Y13, E11 - PL 50MHz)
+# clocks (E20, D20 - HPS 25MHz)
+
+set_location_assignment PIN_V11 -to sys_clk
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to sys_clk
+
+# Switches
+
+set_location_assignment PIN_Y24  -to gpio_bd_o[0]
+set_location_assignment PIN_W24  -to gpio_bd_o[1]
+set_location_assignment PIN_W21  -to gpio_bd_o[2]
+set_location_assignment PIN_W20  -to gpio_bd_o[3]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to gpio_bd_o[0]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to gpio_bd_o[1]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to gpio_bd_o[2]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to gpio_bd_o[3]
+
+# LEDs
+
+set_location_assignment PIN_W15   -to gpio_bd_i[0]
+set_location_assignment PIN_AA24  -to gpio_bd_i[1]
+set_location_assignment PIN_V16   -to gpio_bd_i[2]
+set_location_assignment PIN_V15   -to gpio_bd_i[3]
+set_location_assignment PIN_AF26  -to gpio_bd_i[4]
+set_location_assignment PIN_AE26  -to gpio_bd_i[5]
+set_location_assignment PIN_Y16   -to gpio_bd_i[6]
+set_location_assignment PIN_AA23  -to gpio_bd_i[7]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to gpio_bd_i[0]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to gpio_bd_i[1]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to gpio_bd_i[2]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to gpio_bd_i[3]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to gpio_bd_i[4]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to gpio_bd_i[5]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to gpio_bd_i[6]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to gpio_bd_i[7]
+
+# push-buttons
+
+# set_location_assignment PIN_AH17 -to gpio_bd_i[0]
+# set_location_assignment PIN_AH16 -to gpio_bd_i[1]
+# set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to gpio_bd_i[0]
+# set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to gpio_bd_i[1]
+
+# UART
+
+set_location_assignment PIN_A22 -to uart0_rx
+set_location_assignment PIN_B21 -to uart0_tx
+
+# set_instance_assignment -name IO_STANDARD "3.3-V LVCMOS" -to uart0_rx
+# set_instance_assignment -name IO_STANDARD "3.3-V LVCMOS" -to uart0_tx
+
+# USB
+
+set_location_assignment PIN_G4    -to usb1_clk
+set_location_assignment PIN_C5    -to usb1_stp
+set_location_assignment PIN_E5    -to usb1_dir
+set_location_assignment PIN_D5    -to usb1_nxt
+set_location_assignment PIN_C10   -to usb1_d[0]
+set_location_assignment PIN_F5    -to usb1_d[1]
+set_location_assignment PIN_C9    -to usb1_d[2]
+set_location_assignment PIN_C4    -to usb1_d[3]
+set_location_assignment PIN_C8    -to usb1_d[4]
+set_location_assignment PIN_D4    -to usb1_d[5]
+set_location_assignment PIN_C7    -to usb1_d[6]
+set_location_assignment PIN_F4    -to usb1_d[7]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to usb1_clk
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to usb1_stp
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to usb1_dir
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to usb1_nxt
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to usb1_d[0]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to usb1_d[1]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to usb1_d[2]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to usb1_d[3]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to usb1_d[4]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to usb1_d[5]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to usb1_d[6]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to usb1_d[7]
+set_instance_assignment -name CURRENT_STRENGTH_NEW 4MA -to usb1_clk
+set_instance_assignment -name CURRENT_STRENGTH_NEW 4MA -to usb1_stp
+set_instance_assignment -name CURRENT_STRENGTH_NEW 4MA -to usb1_dir
+set_instance_assignment -name CURRENT_STRENGTH_NEW 4MA -to usb1_nxt
+set_instance_assignment -name CURRENT_STRENGTH_NEW 4MA -to usb1_d[0]
+set_instance_assignment -name CURRENT_STRENGTH_NEW 4MA -to usb1_d[1]
+set_instance_assignment -name CURRENT_STRENGTH_NEW 4MA -to usb1_d[2]
+set_instance_assignment -name CURRENT_STRENGTH_NEW 4MA -to usb1_d[3]
+set_instance_assignment -name CURRENT_STRENGTH_NEW 4MA -to usb1_d[4]
+set_instance_assignment -name CURRENT_STRENGTH_NEW 4MA -to usb1_d[5]
+set_instance_assignment -name CURRENT_STRENGTH_NEW 4MA -to usb1_d[6]
+set_instance_assignment -name CURRENT_STRENGTH_NEW 4MA -to usb1_d[7]
+
+set_location_assignment PIN_B8   -to sdio_clk
+set_location_assignment PIN_D14  -to sdio_cmd
+set_location_assignment PIN_C13  -to sdio_d[0]
+set_location_assignment PIN_B6   -to sdio_d[1]
+set_location_assignment PIN_B11  -to sdio_d[2]
+set_location_assignment PIN_B9   -to sdio_d[3]
+
+set_instance_assignment -name IO_STANDARD "3.3-V LVCMOS" -to sdio_clk
+set_instance_assignment -name IO_STANDARD "3.3-V LVCMOS" -to sdio_cmd
+set_instance_assignment -name IO_STANDARD "3.3-V LVCMOS" -to sdio_d[0]
+set_instance_assignment -name IO_STANDARD "3.3-V LVCMOS" -to sdio_d[1]
+set_instance_assignment -name IO_STANDARD "3.3-V LVCMOS" -to sdio_d[2]
+set_instance_assignment -name IO_STANDARD "3.3-V LVCMOS" -to sdio_d[3]
+
+# ETHERNET
+
+set_location_assignment PIN_J15   -to eth1_tx_clk
+set_location_assignment PIN_A12   -to eth1_tx_ctl
+set_location_assignment PIN_A16   -to eth1_tx_d[0]
+set_location_assignment PIN_J14   -to eth1_tx_d[1]
+set_location_assignment PIN_A15   -to eth1_tx_d[2]
+set_location_assignment PIN_D17   -to eth1_tx_d[3]
+set_location_assignment PIN_J12   -to eth1_rx_clk
+set_location_assignment PIN_J13   -to eth1_rx_ctl
+set_location_assignment PIN_A14   -to eth1_rx_d[0]
+set_location_assignment PIN_A11   -to eth1_rx_d[1]
+set_location_assignment PIN_C15   -to eth1_rx_d[2]
+set_location_assignment PIN_A9    -to eth1_rx_d[3]
+set_location_assignment PIN_A13   -to eth1_mdc
+set_location_assignment PIN_E16   -to eth1_mdio
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to eth1_tx_clk
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to eth1_tx_ctl
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to eth1_tx_d[0]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to eth1_tx_d[1]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to eth1_tx_d[2]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to eth1_tx_d[3]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to eth1_rx_clk
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to eth1_rx_ctl
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to eth1_rx_d[0]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to eth1_rx_d[1]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to eth1_rx_d[2]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to eth1_rx_d[3]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to eth1_mdc
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to eth1_mdio
+set_instance_assignment -name CURRENT_STRENGTH_NEW 4MA -to eth1_tx_clk
+set_instance_assignment -name CURRENT_STRENGTH_NEW 4MA -to eth1_tx_ctl
+set_instance_assignment -name CURRENT_STRENGTH_NEW 4MA -to eth1_tx_d[0]
+set_instance_assignment -name CURRENT_STRENGTH_NEW 4MA -to eth1_tx_d[1]
+set_instance_assignment -name CURRENT_STRENGTH_NEW 4MA -to eth1_tx_d[2]
+set_instance_assignment -name CURRENT_STRENGTH_NEW 4MA -to eth1_tx_d[3]
+set_instance_assignment -name CURRENT_STRENGTH_NEW 4MA -to eth1_rx_clk
+set_instance_assignment -name CURRENT_STRENGTH_NEW 4MA -to eth1_rx_ctl
+set_instance_assignment -name CURRENT_STRENGTH_NEW 4MA -to eth1_rx_d[0]
+set_instance_assignment -name CURRENT_STRENGTH_NEW 4MA -to eth1_rx_d[1]
+set_instance_assignment -name CURRENT_STRENGTH_NEW 4MA -to eth1_rx_d[2]
+set_instance_assignment -name CURRENT_STRENGTH_NEW 4MA -to eth1_rx_d[3]
+set_instance_assignment -name CURRENT_STRENGTH_NEW 4MA -to eth1_mdc
+set_instance_assignment -name CURRENT_STRENGTH_NEW 4MA -to eth1_mdio
+
+# DDR
+
+set_instance_assignment -name D5_DELAY 2 -to ddr3_ck_p
+set_instance_assignment -name D5_DELAY 2 -to ddr3_ck_n
+
+set_instance_assignment -name CURRENT_STRENGTH_NEW "MAXIMUM CURRENT" -to ddr3_a[0]
+set_instance_assignment -name CURRENT_STRENGTH_NEW "MAXIMUM CURRENT" -to ddr3_a[1]
+set_instance_assignment -name CURRENT_STRENGTH_NEW "MAXIMUM CURRENT" -to ddr3_a[2]
+set_instance_assignment -name CURRENT_STRENGTH_NEW "MAXIMUM CURRENT" -to ddr3_a[3]
+set_instance_assignment -name CURRENT_STRENGTH_NEW "MAXIMUM CURRENT" -to ddr3_a[4]
+set_instance_assignment -name CURRENT_STRENGTH_NEW "MAXIMUM CURRENT" -to ddr3_a[5]
+set_instance_assignment -name CURRENT_STRENGTH_NEW "MAXIMUM CURRENT" -to ddr3_a[6]
+set_instance_assignment -name CURRENT_STRENGTH_NEW "MAXIMUM CURRENT" -to ddr3_a[7]
+set_instance_assignment -name CURRENT_STRENGTH_NEW "MAXIMUM CURRENT" -to ddr3_a[8]
+set_instance_assignment -name CURRENT_STRENGTH_NEW "MAXIMUM CURRENT" -to ddr3_a[9]
+set_instance_assignment -name CURRENT_STRENGTH_NEW "MAXIMUM CURRENT" -to ddr3_a[10]
+set_instance_assignment -name CURRENT_STRENGTH_NEW "MAXIMUM CURRENT" -to ddr3_a[11]
+set_instance_assignment -name CURRENT_STRENGTH_NEW "MAXIMUM CURRENT" -to ddr3_a[12]
+set_instance_assignment -name CURRENT_STRENGTH_NEW "MAXIMUM CURRENT" -to ddr3_a[13]
+set_instance_assignment -name CURRENT_STRENGTH_NEW "MAXIMUM CURRENT" -to ddr3_a[14]
+set_instance_assignment -name CURRENT_STRENGTH_NEW "MAXIMUM CURRENT" -to ddr3_ba[0]
+set_instance_assignment -name CURRENT_STRENGTH_NEW "MAXIMUM CURRENT" -to ddr3_ba[1]
+set_instance_assignment -name CURRENT_STRENGTH_NEW "MAXIMUM CURRENT" -to ddr3_ba[2]
+set_instance_assignment -name CURRENT_STRENGTH_NEW "MAXIMUM CURRENT" -to ddr3_cas_n
+set_instance_assignment -name CURRENT_STRENGTH_NEW "MAXIMUM CURRENT" -to ddr3_cke
+set_instance_assignment -name CURRENT_STRENGTH_NEW "MAXIMUM CURRENT" -to ddr3_cs_n
+set_instance_assignment -name CURRENT_STRENGTH_NEW "MAXIMUM CURRENT" -to ddr3_odt
+set_instance_assignment -name CURRENT_STRENGTH_NEW "MAXIMUM CURRENT" -to ddr3_ras_n
+set_instance_assignment -name CURRENT_STRENGTH_NEW "MAXIMUM CURRENT" -to ddr3_reset_n
+set_instance_assignment -name CURRENT_STRENGTH_NEW "MAXIMUM CURRENT" -to ddr3_we_n
+
+set_instance_assignment -name GLOBAL_SIGNAL OFF -to i_system_bd|sys_hps|hps_io|border|hps_sdram_inst|p0|umemphy|uio_pads|dq_ddio[0].read_capture_clk_buffer
+set_instance_assignment -name GLOBAL_SIGNAL OFF -to i_system_bd|sys_hps|hps_io|border|hps_sdram_inst|p0|umemphy|uio_pads|dq_ddio[1].read_capture_clk_buffer
+set_instance_assignment -name GLOBAL_SIGNAL OFF -to i_system_bd|sys_hps|hps_io|border|hps_sdram_inst|p0|umemphy|uio_pads|dq_ddio[2].read_capture_clk_buffer
+set_instance_assignment -name GLOBAL_SIGNAL OFF -to i_system_bd|sys_hps|hps_io|border|hps_sdram_inst|p0|umemphy|uio_pads|dq_ddio[3].read_capture_clk_buffer
+set_instance_assignment -name GLOBAL_SIGNAL OFF -to i_system_bd|sys_hps|hps_io|border|hps_sdram_inst|p0|umemphy|uread_datapath|reset_n_fifo_wraddress[0]
+set_instance_assignment -name GLOBAL_SIGNAL OFF -to i_system_bd|sys_hps|hps_io|border|hps_sdram_inst|p0|umemphy|uread_datapath|reset_n_fifo_wraddress[1]
+set_instance_assignment -name GLOBAL_SIGNAL OFF -to i_system_bd|sys_hps|hps_io|border|hps_sdram_inst|p0|umemphy|uread_datapath|reset_n_fifo_wraddress[2]
+set_instance_assignment -name GLOBAL_SIGNAL OFF -to i_system_bd|sys_hps|hps_io|border|hps_sdram_inst|p0|umemphy|uread_datapath|reset_n_fifo_wraddress[3]
+set_instance_assignment -name GLOBAL_SIGNAL OFF -to i_system_bd|sys_hps|hps_io|border|hps_sdram_inst|p0|umemphy|uread_datapath|reset_n_fifo_write_side[0]
+set_instance_assignment -name GLOBAL_SIGNAL OFF -to i_system_bd|sys_hps|hps_io|border|hps_sdram_inst|p0|umemphy|uread_datapath|reset_n_fifo_write_side[1]
+set_instance_assignment -name GLOBAL_SIGNAL OFF -to i_system_bd|sys_hps|hps_io|border|hps_sdram_inst|p0|umemphy|uread_datapath|reset_n_fifo_write_side[2]
+set_instance_assignment -name GLOBAL_SIGNAL OFF -to i_system_bd|sys_hps|hps_io|border|hps_sdram_inst|p0|umemphy|uread_datapath|reset_n_fifo_write_side[3]
+set_instance_assignment -name GLOBAL_SIGNAL OFF -to i_system_bd|sys_hps|hps_io|border|hps_sdram_inst|p0|umemphy|ureset|phy_reset_mem_stable_n
+set_instance_assignment -name GLOBAL_SIGNAL OFF -to i_system_bd|sys_hps|hps_io|border|hps_sdram_inst|p0|umemphy|ureset|phy_reset_n
+
+set_instance_assignment -name INPUT_TERMINATION "PARALLEL 50 OHM WITH CALIBRATION" -to ddr3_dq[0]
+set_instance_assignment -name INPUT_TERMINATION "PARALLEL 50 OHM WITH CALIBRATION" -to ddr3_dq[1]
+set_instance_assignment -name INPUT_TERMINATION "PARALLEL 50 OHM WITH CALIBRATION" -to ddr3_dq[2]
+set_instance_assignment -name INPUT_TERMINATION "PARALLEL 50 OHM WITH CALIBRATION" -to ddr3_dq[3]
+set_instance_assignment -name INPUT_TERMINATION "PARALLEL 50 OHM WITH CALIBRATION" -to ddr3_dq[4]
+set_instance_assignment -name INPUT_TERMINATION "PARALLEL 50 OHM WITH CALIBRATION" -to ddr3_dq[5]
+set_instance_assignment -name INPUT_TERMINATION "PARALLEL 50 OHM WITH CALIBRATION" -to ddr3_dq[6]
+set_instance_assignment -name INPUT_TERMINATION "PARALLEL 50 OHM WITH CALIBRATION" -to ddr3_dq[7]
+set_instance_assignment -name INPUT_TERMINATION "PARALLEL 50 OHM WITH CALIBRATION" -to ddr3_dq[8]
+set_instance_assignment -name INPUT_TERMINATION "PARALLEL 50 OHM WITH CALIBRATION" -to ddr3_dq[9]
+set_instance_assignment -name INPUT_TERMINATION "PARALLEL 50 OHM WITH CALIBRATION" -to ddr3_dq[10]
+set_instance_assignment -name INPUT_TERMINATION "PARALLEL 50 OHM WITH CALIBRATION" -to ddr3_dq[11]
+set_instance_assignment -name INPUT_TERMINATION "PARALLEL 50 OHM WITH CALIBRATION" -to ddr3_dq[12]
+set_instance_assignment -name INPUT_TERMINATION "PARALLEL 50 OHM WITH CALIBRATION" -to ddr3_dq[13]
+set_instance_assignment -name INPUT_TERMINATION "PARALLEL 50 OHM WITH CALIBRATION" -to ddr3_dq[14]
+set_instance_assignment -name INPUT_TERMINATION "PARALLEL 50 OHM WITH CALIBRATION" -to ddr3_dq[15]
+set_instance_assignment -name INPUT_TERMINATION "PARALLEL 50 OHM WITH CALIBRATION" -to ddr3_dq[16]
+set_instance_assignment -name INPUT_TERMINATION "PARALLEL 50 OHM WITH CALIBRATION" -to ddr3_dq[17]
+set_instance_assignment -name INPUT_TERMINATION "PARALLEL 50 OHM WITH CALIBRATION" -to ddr3_dq[18]
+set_instance_assignment -name INPUT_TERMINATION "PARALLEL 50 OHM WITH CALIBRATION" -to ddr3_dq[19]
+set_instance_assignment -name INPUT_TERMINATION "PARALLEL 50 OHM WITH CALIBRATION" -to ddr3_dq[20]
+set_instance_assignment -name INPUT_TERMINATION "PARALLEL 50 OHM WITH CALIBRATION" -to ddr3_dq[21]
+set_instance_assignment -name INPUT_TERMINATION "PARALLEL 50 OHM WITH CALIBRATION" -to ddr3_dq[22]
+set_instance_assignment -name INPUT_TERMINATION "PARALLEL 50 OHM WITH CALIBRATION" -to ddr3_dq[23]
+set_instance_assignment -name INPUT_TERMINATION "PARALLEL 50 OHM WITH CALIBRATION" -to ddr3_dq[24]
+set_instance_assignment -name INPUT_TERMINATION "PARALLEL 50 OHM WITH CALIBRATION" -to ddr3_dq[25]
+set_instance_assignment -name INPUT_TERMINATION "PARALLEL 50 OHM WITH CALIBRATION" -to ddr3_dq[26]
+set_instance_assignment -name INPUT_TERMINATION "PARALLEL 50 OHM WITH CALIBRATION" -to ddr3_dq[27]
+set_instance_assignment -name INPUT_TERMINATION "PARALLEL 50 OHM WITH CALIBRATION" -to ddr3_dq[28]
+set_instance_assignment -name INPUT_TERMINATION "PARALLEL 50 OHM WITH CALIBRATION" -to ddr3_dq[29]
+set_instance_assignment -name INPUT_TERMINATION "PARALLEL 50 OHM WITH CALIBRATION" -to ddr3_dq[30]
+set_instance_assignment -name INPUT_TERMINATION "PARALLEL 50 OHM WITH CALIBRATION" -to ddr3_dq[31]
+set_instance_assignment -name INPUT_TERMINATION "PARALLEL 50 OHM WITH CALIBRATION" -to ddr3_dqs_p[0]
+set_instance_assignment -name INPUT_TERMINATION "PARALLEL 50 OHM WITH CALIBRATION" -to ddr3_dqs_p[1]
+set_instance_assignment -name INPUT_TERMINATION "PARALLEL 50 OHM WITH CALIBRATION" -to ddr3_dqs_p[2]
+set_instance_assignment -name INPUT_TERMINATION "PARALLEL 50 OHM WITH CALIBRATION" -to ddr3_dqs_p[3]
+set_instance_assignment -name INPUT_TERMINATION "PARALLEL 50 OHM WITH CALIBRATION" -to ddr3_dqs_n[0]
+set_instance_assignment -name INPUT_TERMINATION "PARALLEL 50 OHM WITH CALIBRATION" -to ddr3_dqs_n[1]
+set_instance_assignment -name INPUT_TERMINATION "PARALLEL 50 OHM WITH CALIBRATION" -to ddr3_dqs_n[2]
+set_instance_assignment -name INPUT_TERMINATION "PARALLEL 50 OHM WITH CALIBRATION" -to ddr3_dqs_n[3]
+
+set_instance_assignment -name IO_STANDARD "DIFFERENTIAL 1.5-V SSTL CLASS I" -to ddr3_ck_p
+set_instance_assignment -name IO_STANDARD "DIFFERENTIAL 1.5-V SSTL CLASS I" -to ddr3_ck_n
+set_instance_assignment -name IO_STANDARD "DIFFERENTIAL 1.5-V SSTL CLASS I" -to ddr3_dqs_p[0]
+set_instance_assignment -name IO_STANDARD "DIFFERENTIAL 1.5-V SSTL CLASS I" -to ddr3_dqs_p[1]
+set_instance_assignment -name IO_STANDARD "DIFFERENTIAL 1.5-V SSTL CLASS I" -to ddr3_dqs_p[2]
+set_instance_assignment -name IO_STANDARD "DIFFERENTIAL 1.5-V SSTL CLASS I" -to ddr3_dqs_p[3]
+set_instance_assignment -name IO_STANDARD "DIFFERENTIAL 1.5-V SSTL CLASS I" -to ddr3_dqs_n[0]
+set_instance_assignment -name IO_STANDARD "DIFFERENTIAL 1.5-V SSTL CLASS I" -to ddr3_dqs_n[1]
+set_instance_assignment -name IO_STANDARD "DIFFERENTIAL 1.5-V SSTL CLASS I" -to ddr3_dqs_n[2]
+set_instance_assignment -name IO_STANDARD "DIFFERENTIAL 1.5-V SSTL CLASS I" -to ddr3_dqs_n[3]
+
+set_instance_assignment -name IO_STANDARD "SSTL-15 CLASS I" -to ddr3_a[0]
+set_instance_assignment -name IO_STANDARD "SSTL-15 CLASS I" -to ddr3_a[1]
+set_instance_assignment -name IO_STANDARD "SSTL-15 CLASS I" -to ddr3_a[2]
+set_instance_assignment -name IO_STANDARD "SSTL-15 CLASS I" -to ddr3_a[3]
+set_instance_assignment -name IO_STANDARD "SSTL-15 CLASS I" -to ddr3_a[4]
+set_instance_assignment -name IO_STANDARD "SSTL-15 CLASS I" -to ddr3_a[5]
+set_instance_assignment -name IO_STANDARD "SSTL-15 CLASS I" -to ddr3_a[6]
+set_instance_assignment -name IO_STANDARD "SSTL-15 CLASS I" -to ddr3_a[7]
+set_instance_assignment -name IO_STANDARD "SSTL-15 CLASS I" -to ddr3_a[8]
+set_instance_assignment -name IO_STANDARD "SSTL-15 CLASS I" -to ddr3_a[9]
+set_instance_assignment -name IO_STANDARD "SSTL-15 CLASS I" -to ddr3_a[10]
+set_instance_assignment -name IO_STANDARD "SSTL-15 CLASS I" -to ddr3_a[11]
+set_instance_assignment -name IO_STANDARD "SSTL-15 CLASS I" -to ddr3_a[12]
+set_instance_assignment -name IO_STANDARD "SSTL-15 CLASS I" -to ddr3_a[13]
+set_instance_assignment -name IO_STANDARD "SSTL-15 CLASS I" -to ddr3_a[14]
+set_instance_assignment -name IO_STANDARD "SSTL-15 CLASS I" -to ddr3_ba[0]
+set_instance_assignment -name IO_STANDARD "SSTL-15 CLASS I" -to ddr3_ba[1]
+set_instance_assignment -name IO_STANDARD "SSTL-15 CLASS I" -to ddr3_ba[2]
+set_instance_assignment -name IO_STANDARD "SSTL-15 CLASS I" -to ddr3_cas_n
+set_instance_assignment -name IO_STANDARD "SSTL-15 CLASS I" -to ddr3_cke
+set_instance_assignment -name IO_STANDARD "SSTL-15 CLASS I" -to ddr3_cs_n
+set_instance_assignment -name IO_STANDARD "SSTL-15 CLASS I" -to ddr3_dm[0]
+set_instance_assignment -name IO_STANDARD "SSTL-15 CLASS I" -to ddr3_dm[1]
+set_instance_assignment -name IO_STANDARD "SSTL-15 CLASS I" -to ddr3_dm[2]
+set_instance_assignment -name IO_STANDARD "SSTL-15 CLASS I" -to ddr3_dm[3]
+set_instance_assignment -name IO_STANDARD "SSTL-15 CLASS I" -to ddr3_dq[0]
+set_instance_assignment -name IO_STANDARD "SSTL-15 CLASS I" -to ddr3_dq[1]
+set_instance_assignment -name IO_STANDARD "SSTL-15 CLASS I" -to ddr3_dq[2]
+set_instance_assignment -name IO_STANDARD "SSTL-15 CLASS I" -to ddr3_dq[3]
+set_instance_assignment -name IO_STANDARD "SSTL-15 CLASS I" -to ddr3_dq[4]
+set_instance_assignment -name IO_STANDARD "SSTL-15 CLASS I" -to ddr3_dq[5]
+set_instance_assignment -name IO_STANDARD "SSTL-15 CLASS I" -to ddr3_dq[6]
+set_instance_assignment -name IO_STANDARD "SSTL-15 CLASS I" -to ddr3_dq[7]
+set_instance_assignment -name IO_STANDARD "SSTL-15 CLASS I" -to ddr3_dq[8]
+set_instance_assignment -name IO_STANDARD "SSTL-15 CLASS I" -to ddr3_dq[9]
+set_instance_assignment -name IO_STANDARD "SSTL-15 CLASS I" -to ddr3_dq[10]
+set_instance_assignment -name IO_STANDARD "SSTL-15 CLASS I" -to ddr3_dq[11]
+set_instance_assignment -name IO_STANDARD "SSTL-15 CLASS I" -to ddr3_dq[12]
+set_instance_assignment -name IO_STANDARD "SSTL-15 CLASS I" -to ddr3_dq[13]
+set_instance_assignment -name IO_STANDARD "SSTL-15 CLASS I" -to ddr3_dq[14]
+set_instance_assignment -name IO_STANDARD "SSTL-15 CLASS I" -to ddr3_dq[15]
+set_instance_assignment -name IO_STANDARD "SSTL-15 CLASS I" -to ddr3_dq[16]
+set_instance_assignment -name IO_STANDARD "SSTL-15 CLASS I" -to ddr3_dq[17]
+set_instance_assignment -name IO_STANDARD "SSTL-15 CLASS I" -to ddr3_dq[18]
+set_instance_assignment -name IO_STANDARD "SSTL-15 CLASS I" -to ddr3_dq[19]
+set_instance_assignment -name IO_STANDARD "SSTL-15 CLASS I" -to ddr3_dq[20]
+set_instance_assignment -name IO_STANDARD "SSTL-15 CLASS I" -to ddr3_dq[21]
+set_instance_assignment -name IO_STANDARD "SSTL-15 CLASS I" -to ddr3_dq[22]
+set_instance_assignment -name IO_STANDARD "SSTL-15 CLASS I" -to ddr3_dq[23]
+set_instance_assignment -name IO_STANDARD "SSTL-15 CLASS I" -to ddr3_dq[24]
+set_instance_assignment -name IO_STANDARD "SSTL-15 CLASS I" -to ddr3_dq[25]
+set_instance_assignment -name IO_STANDARD "SSTL-15 CLASS I" -to ddr3_dq[26]
+set_instance_assignment -name IO_STANDARD "SSTL-15 CLASS I" -to ddr3_dq[27]
+set_instance_assignment -name IO_STANDARD "SSTL-15 CLASS I" -to ddr3_dq[28]
+set_instance_assignment -name IO_STANDARD "SSTL-15 CLASS I" -to ddr3_dq[29]
+set_instance_assignment -name IO_STANDARD "SSTL-15 CLASS I" -to ddr3_dq[30]
+set_instance_assignment -name IO_STANDARD "SSTL-15 CLASS I" -to ddr3_dq[31]
+set_instance_assignment -name IO_STANDARD "SSTL-15 CLASS I" -to ddr3_odt
+set_instance_assignment -name IO_STANDARD "SSTL-15 CLASS I" -to ddr3_ras_n
+set_instance_assignment -name IO_STANDARD "SSTL-15 CLASS I" -to ddr3_reset_n
+set_instance_assignment -name IO_STANDARD "SSTL-15 CLASS I" -to ddr3_we_n
+set_instance_assignment -name IO_STANDARD "SSTL-15 CLASS I" -to ddr3_rzq
+
+set_instance_assignment -name OUTPUT_TERMINATION "SERIES 50 OHM WITH CALIBRATION" -to ddr3_dm[0]
+set_instance_assignment -name OUTPUT_TERMINATION "SERIES 50 OHM WITH CALIBRATION" -to ddr3_dm[1]
+set_instance_assignment -name OUTPUT_TERMINATION "SERIES 50 OHM WITH CALIBRATION" -to ddr3_dm[2]
+set_instance_assignment -name OUTPUT_TERMINATION "SERIES 50 OHM WITH CALIBRATION" -to ddr3_dm[3]
+set_instance_assignment -name OUTPUT_TERMINATION "SERIES 50 OHM WITH CALIBRATION" -to ddr3_dq[0]
+set_instance_assignment -name OUTPUT_TERMINATION "SERIES 50 OHM WITH CALIBRATION" -to ddr3_dq[1]
+set_instance_assignment -name OUTPUT_TERMINATION "SERIES 50 OHM WITH CALIBRATION" -to ddr3_dq[2]
+set_instance_assignment -name OUTPUT_TERMINATION "SERIES 50 OHM WITH CALIBRATION" -to ddr3_dq[3]
+set_instance_assignment -name OUTPUT_TERMINATION "SERIES 50 OHM WITH CALIBRATION" -to ddr3_dq[4]
+set_instance_assignment -name OUTPUT_TERMINATION "SERIES 50 OHM WITH CALIBRATION" -to ddr3_dq[5]
+set_instance_assignment -name OUTPUT_TERMINATION "SERIES 50 OHM WITH CALIBRATION" -to ddr3_dq[6]
+set_instance_assignment -name OUTPUT_TERMINATION "SERIES 50 OHM WITH CALIBRATION" -to ddr3_dq[7]
+set_instance_assignment -name OUTPUT_TERMINATION "SERIES 50 OHM WITH CALIBRATION" -to ddr3_dq[8]
+set_instance_assignment -name OUTPUT_TERMINATION "SERIES 50 OHM WITH CALIBRATION" -to ddr3_dq[9]
+set_instance_assignment -name OUTPUT_TERMINATION "SERIES 50 OHM WITH CALIBRATION" -to ddr3_dq[10]
+set_instance_assignment -name OUTPUT_TERMINATION "SERIES 50 OHM WITH CALIBRATION" -to ddr3_dq[11]
+set_instance_assignment -name OUTPUT_TERMINATION "SERIES 50 OHM WITH CALIBRATION" -to ddr3_dq[12]
+set_instance_assignment -name OUTPUT_TERMINATION "SERIES 50 OHM WITH CALIBRATION" -to ddr3_dq[13]
+set_instance_assignment -name OUTPUT_TERMINATION "SERIES 50 OHM WITH CALIBRATION" -to ddr3_dq[14]
+set_instance_assignment -name OUTPUT_TERMINATION "SERIES 50 OHM WITH CALIBRATION" -to ddr3_dq[15]
+set_instance_assignment -name OUTPUT_TERMINATION "SERIES 50 OHM WITH CALIBRATION" -to ddr3_dq[16]
+set_instance_assignment -name OUTPUT_TERMINATION "SERIES 50 OHM WITH CALIBRATION" -to ddr3_dq[17]
+set_instance_assignment -name OUTPUT_TERMINATION "SERIES 50 OHM WITH CALIBRATION" -to ddr3_dq[18]
+set_instance_assignment -name OUTPUT_TERMINATION "SERIES 50 OHM WITH CALIBRATION" -to ddr3_dq[19]
+set_instance_assignment -name OUTPUT_TERMINATION "SERIES 50 OHM WITH CALIBRATION" -to ddr3_dq[20]
+set_instance_assignment -name OUTPUT_TERMINATION "SERIES 50 OHM WITH CALIBRATION" -to ddr3_dq[21]
+set_instance_assignment -name OUTPUT_TERMINATION "SERIES 50 OHM WITH CALIBRATION" -to ddr3_dq[22]
+set_instance_assignment -name OUTPUT_TERMINATION "SERIES 50 OHM WITH CALIBRATION" -to ddr3_dq[23]
+set_instance_assignment -name OUTPUT_TERMINATION "SERIES 50 OHM WITH CALIBRATION" -to ddr3_dq[24]
+set_instance_assignment -name OUTPUT_TERMINATION "SERIES 50 OHM WITH CALIBRATION" -to ddr3_dq[25]
+set_instance_assignment -name OUTPUT_TERMINATION "SERIES 50 OHM WITH CALIBRATION" -to ddr3_dq[26]
+set_instance_assignment -name OUTPUT_TERMINATION "SERIES 50 OHM WITH CALIBRATION" -to ddr3_dq[27]
+set_instance_assignment -name OUTPUT_TERMINATION "SERIES 50 OHM WITH CALIBRATION" -to ddr3_dq[28]
+set_instance_assignment -name OUTPUT_TERMINATION "SERIES 50 OHM WITH CALIBRATION" -to ddr3_dq[29]
+set_instance_assignment -name OUTPUT_TERMINATION "SERIES 50 OHM WITH CALIBRATION" -to ddr3_dq[30]
+set_instance_assignment -name OUTPUT_TERMINATION "SERIES 50 OHM WITH CALIBRATION" -to ddr3_dq[31]
+set_instance_assignment -name OUTPUT_TERMINATION "SERIES 50 OHM WITH CALIBRATION" -to ddr3_dqs_p[0]
+set_instance_assignment -name OUTPUT_TERMINATION "SERIES 50 OHM WITH CALIBRATION" -to ddr3_dqs_p[1]
+set_instance_assignment -name OUTPUT_TERMINATION "SERIES 50 OHM WITH CALIBRATION" -to ddr3_dqs_p[2]
+set_instance_assignment -name OUTPUT_TERMINATION "SERIES 50 OHM WITH CALIBRATION" -to ddr3_dqs_p[3]
+set_instance_assignment -name OUTPUT_TERMINATION "SERIES 50 OHM WITH CALIBRATION" -to ddr3_dqs_n[0]
+set_instance_assignment -name OUTPUT_TERMINATION "SERIES 50 OHM WITH CALIBRATION" -to ddr3_dqs_n[1]
+set_instance_assignment -name OUTPUT_TERMINATION "SERIES 50 OHM WITH CALIBRATION" -to ddr3_dqs_n[2]
+set_instance_assignment -name OUTPUT_TERMINATION "SERIES 50 OHM WITH CALIBRATION" -to ddr3_dqs_n[3]
+set_instance_assignment -name OUTPUT_TERMINATION "SERIES 50 OHM WITHOUT CALIBRATION" -to ddr3_ck_p
+set_instance_assignment -name OUTPUT_TERMINATION "SERIES 50 OHM WITHOUT CALIBRATION" -to ddr3_ck_n
+
+set_instance_assignment -name PACKAGE_SKEW_COMPENSATION OFF -to ddr3_a[0]
+set_instance_assignment -name PACKAGE_SKEW_COMPENSATION OFF -to ddr3_a[1]
+set_instance_assignment -name PACKAGE_SKEW_COMPENSATION OFF -to ddr3_a[2]
+set_instance_assignment -name PACKAGE_SKEW_COMPENSATION OFF -to ddr3_a[3]
+set_instance_assignment -name PACKAGE_SKEW_COMPENSATION OFF -to ddr3_a[4]
+set_instance_assignment -name PACKAGE_SKEW_COMPENSATION OFF -to ddr3_a[5]
+set_instance_assignment -name PACKAGE_SKEW_COMPENSATION OFF -to ddr3_a[6]
+set_instance_assignment -name PACKAGE_SKEW_COMPENSATION OFF -to ddr3_a[7]
+set_instance_assignment -name PACKAGE_SKEW_COMPENSATION OFF -to ddr3_a[8]
+set_instance_assignment -name PACKAGE_SKEW_COMPENSATION OFF -to ddr3_a[9]
+set_instance_assignment -name PACKAGE_SKEW_COMPENSATION OFF -to ddr3_a[10]
+set_instance_assignment -name PACKAGE_SKEW_COMPENSATION OFF -to ddr3_a[11]
+set_instance_assignment -name PACKAGE_SKEW_COMPENSATION OFF -to ddr3_a[12]
+set_instance_assignment -name PACKAGE_SKEW_COMPENSATION OFF -to ddr3_a[13]
+set_instance_assignment -name PACKAGE_SKEW_COMPENSATION OFF -to ddr3_a[14]
+set_instance_assignment -name PACKAGE_SKEW_COMPENSATION OFF -to ddr3_ba[0]
+set_instance_assignment -name PACKAGE_SKEW_COMPENSATION OFF -to ddr3_ba[1]
+set_instance_assignment -name PACKAGE_SKEW_COMPENSATION OFF -to ddr3_ba[2]
+set_instance_assignment -name PACKAGE_SKEW_COMPENSATION OFF -to ddr3_cas_n
+set_instance_assignment -name PACKAGE_SKEW_COMPENSATION OFF -to ddr3_ck_p
+set_instance_assignment -name PACKAGE_SKEW_COMPENSATION OFF -to ddr3_ck_n
+set_instance_assignment -name PACKAGE_SKEW_COMPENSATION OFF -to ddr3_cke
+set_instance_assignment -name PACKAGE_SKEW_COMPENSATION OFF -to ddr3_cs_n
+set_instance_assignment -name PACKAGE_SKEW_COMPENSATION OFF -to ddr3_dm[0]
+set_instance_assignment -name PACKAGE_SKEW_COMPENSATION OFF -to ddr3_dm[1]
+set_instance_assignment -name PACKAGE_SKEW_COMPENSATION OFF -to ddr3_dm[2]
+set_instance_assignment -name PACKAGE_SKEW_COMPENSATION OFF -to ddr3_dm[3]
+set_instance_assignment -name PACKAGE_SKEW_COMPENSATION OFF -to ddr3_dq[0]
+set_instance_assignment -name PACKAGE_SKEW_COMPENSATION OFF -to ddr3_dq[1]
+set_instance_assignment -name PACKAGE_SKEW_COMPENSATION OFF -to ddr3_dq[2]
+set_instance_assignment -name PACKAGE_SKEW_COMPENSATION OFF -to ddr3_dq[3]
+set_instance_assignment -name PACKAGE_SKEW_COMPENSATION OFF -to ddr3_dq[4]
+set_instance_assignment -name PACKAGE_SKEW_COMPENSATION OFF -to ddr3_dq[5]
+set_instance_assignment -name PACKAGE_SKEW_COMPENSATION OFF -to ddr3_dq[6]
+set_instance_assignment -name PACKAGE_SKEW_COMPENSATION OFF -to ddr3_dq[7]
+set_instance_assignment -name PACKAGE_SKEW_COMPENSATION OFF -to ddr3_dq[8]
+set_instance_assignment -name PACKAGE_SKEW_COMPENSATION OFF -to ddr3_dq[9]
+set_instance_assignment -name PACKAGE_SKEW_COMPENSATION OFF -to ddr3_dq[10]
+set_instance_assignment -name PACKAGE_SKEW_COMPENSATION OFF -to ddr3_dq[11]
+set_instance_assignment -name PACKAGE_SKEW_COMPENSATION OFF -to ddr3_dq[12]
+set_instance_assignment -name PACKAGE_SKEW_COMPENSATION OFF -to ddr3_dq[13]
+set_instance_assignment -name PACKAGE_SKEW_COMPENSATION OFF -to ddr3_dq[14]
+set_instance_assignment -name PACKAGE_SKEW_COMPENSATION OFF -to ddr3_dq[15]
+set_instance_assignment -name PACKAGE_SKEW_COMPENSATION OFF -to ddr3_dq[16]
+set_instance_assignment -name PACKAGE_SKEW_COMPENSATION OFF -to ddr3_dq[17]
+set_instance_assignment -name PACKAGE_SKEW_COMPENSATION OFF -to ddr3_dq[18]
+set_instance_assignment -name PACKAGE_SKEW_COMPENSATION OFF -to ddr3_dq[19]
+set_instance_assignment -name PACKAGE_SKEW_COMPENSATION OFF -to ddr3_dq[20]
+set_instance_assignment -name PACKAGE_SKEW_COMPENSATION OFF -to ddr3_dq[21]
+set_instance_assignment -name PACKAGE_SKEW_COMPENSATION OFF -to ddr3_dq[22]
+set_instance_assignment -name PACKAGE_SKEW_COMPENSATION OFF -to ddr3_dq[23]
+set_instance_assignment -name PACKAGE_SKEW_COMPENSATION OFF -to ddr3_dq[24]
+set_instance_assignment -name PACKAGE_SKEW_COMPENSATION OFF -to ddr3_dq[25]
+set_instance_assignment -name PACKAGE_SKEW_COMPENSATION OFF -to ddr3_dq[26]
+set_instance_assignment -name PACKAGE_SKEW_COMPENSATION OFF -to ddr3_dq[27]
+set_instance_assignment -name PACKAGE_SKEW_COMPENSATION OFF -to ddr3_dq[28]
+set_instance_assignment -name PACKAGE_SKEW_COMPENSATION OFF -to ddr3_dq[29]
+set_instance_assignment -name PACKAGE_SKEW_COMPENSATION OFF -to ddr3_dq[30]
+set_instance_assignment -name PACKAGE_SKEW_COMPENSATION OFF -to ddr3_dq[31]
+set_instance_assignment -name PACKAGE_SKEW_COMPENSATION OFF -to ddr3_dqs_p[0]
+set_instance_assignment -name PACKAGE_SKEW_COMPENSATION OFF -to ddr3_dqs_p[1]
+set_instance_assignment -name PACKAGE_SKEW_COMPENSATION OFF -to ddr3_dqs_p[2]
+set_instance_assignment -name PACKAGE_SKEW_COMPENSATION OFF -to ddr3_dqs_p[3]
+set_instance_assignment -name PACKAGE_SKEW_COMPENSATION OFF -to ddr3_dqs_n[0]
+set_instance_assignment -name PACKAGE_SKEW_COMPENSATION OFF -to ddr3_dqs_n[1]
+set_instance_assignment -name PACKAGE_SKEW_COMPENSATION OFF -to ddr3_dqs_n[2]
+set_instance_assignment -name PACKAGE_SKEW_COMPENSATION OFF -to ddr3_dqs_n[3]
+set_instance_assignment -name PACKAGE_SKEW_COMPENSATION OFF -to ddr3_odt
+set_instance_assignment -name PACKAGE_SKEW_COMPENSATION OFF -to ddr3_ras_n
+set_instance_assignment -name PACKAGE_SKEW_COMPENSATION OFF -to ddr3_reset_n
+set_instance_assignment -name PACKAGE_SKEW_COMPENSATION OFF -to ddr3_we_n
+
+set_instance_assignment -name ENABLE_BENEFICIAL_SKEW_OPTIMIZATION_FOR_NON_GLOBAL_CLOCKS ON -to i_system_bd|sys_hps|hps_io|border|hps_sdram_inst
+set_instance_assignment -name PLL_COMPENSATION_MODE DIRECT -to i_system_bd|sys_hps|hps_io|border|hps_sdram_inst|pll0|fbout
+
+# DDR3 pin locations
+
+set_location_assignment PIN_C28   -to ddr3_a[0]
+set_location_assignment PIN_B28   -to ddr3_a[1]
+set_location_assignment PIN_E26   -to ddr3_a[2]
+set_location_assignment PIN_D26   -to ddr3_a[3]
+set_location_assignment PIN_J21   -to ddr3_a[4]
+set_location_assignment PIN_J20   -to ddr3_a[5]
+set_location_assignment PIN_C26   -to ddr3_a[6]
+set_location_assignment PIN_B26   -to ddr3_a[7]
+set_location_assignment PIN_F26   -to ddr3_a[8]
+set_location_assignment PIN_F25   -to ddr3_a[9]
+set_location_assignment PIN_A24   -to ddr3_a[10]
+set_location_assignment PIN_B24   -to ddr3_a[11]
+set_location_assignment PIN_D24   -to ddr3_a[12]
+set_location_assignment PIN_C24   -to ddr3_a[13]
+set_location_assignment PIN_G23   -to ddr3_a[14]
+set_location_assignment PIN_A27   -to ddr3_ba[0]
+set_location_assignment PIN_H25   -to ddr3_ba[1]
+set_location_assignment PIN_G25   -to ddr3_ba[2]
+set_location_assignment PIN_A26   -to ddr3_cas_n
+set_location_assignment PIN_N21   -to ddr3_ck_p
+set_location_assignment PIN_N20   -to ddr3_ck_n
+set_location_assignment PIN_L28   -to ddr3_cke
+set_location_assignment PIN_L21   -to ddr3_cs_n
+set_location_assignment PIN_G28   -to ddr3_dm[0]
+set_location_assignment PIN_P28   -to ddr3_dm[1]
+set_location_assignment PIN_W28   -to ddr3_dm[2]
+set_location_assignment PIN_AB28  -to ddr3_dm[3]
+set_location_assignment PIN_J25   -to ddr3_dq[0]
+set_location_assignment PIN_J24   -to ddr3_dq[1]
+set_location_assignment PIN_E28   -to ddr3_dq[2]
+set_location_assignment PIN_D27   -to ddr3_dq[3]
+set_location_assignment PIN_J26   -to ddr3_dq[4]
+set_location_assignment PIN_K26   -to ddr3_dq[5]
+set_location_assignment PIN_G27   -to ddr3_dq[6]
+set_location_assignment PIN_F28   -to ddr3_dq[7]
+set_location_assignment PIN_K25   -to ddr3_dq[8]
+set_location_assignment PIN_L25   -to ddr3_dq[9]
+set_location_assignment PIN_J27   -to ddr3_dq[10]
+set_location_assignment PIN_J28   -to ddr3_dq[11]
+set_location_assignment PIN_M27   -to ddr3_dq[12]
+set_location_assignment PIN_M26   -to ddr3_dq[13]
+set_location_assignment PIN_M28   -to ddr3_dq[14]
+set_location_assignment PIN_N28   -to ddr3_dq[15]
+set_location_assignment PIN_N24   -to ddr3_dq[16]
+set_location_assignment PIN_N25   -to ddr3_dq[17]
+set_location_assignment PIN_T28   -to ddr3_dq[18]
+set_location_assignment PIN_U28   -to ddr3_dq[19]
+set_location_assignment PIN_N26   -to ddr3_dq[20]
+set_location_assignment PIN_N27   -to ddr3_dq[21]
+set_location_assignment PIN_R27   -to ddr3_dq[22]
+set_location_assignment PIN_V27   -to ddr3_dq[23]
+set_location_assignment PIN_R26   -to ddr3_dq[24]
+set_location_assignment PIN_R25   -to ddr3_dq[25]
+set_location_assignment PIN_AA28  -to ddr3_dq[26]
+set_location_assignment PIN_W26   -to ddr3_dq[27]
+set_location_assignment PIN_R24   -to ddr3_dq[28]
+set_location_assignment PIN_T24   -to ddr3_dq[29]
+set_location_assignment PIN_Y27   -to ddr3_dq[30]
+set_location_assignment PIN_AA27  -to ddr3_dq[31]
+set_location_assignment PIN_R17   -to ddr3_dqs_p[0]
+set_location_assignment PIN_R16   -to ddr3_dqs_n[0]
+set_location_assignment PIN_R19   -to ddr3_dqs_p[1]
+set_location_assignment PIN_R18   -to ddr3_dqs_n[1]
+set_location_assignment PIN_T19   -to ddr3_dqs_p[2]
+set_location_assignment PIN_T18   -to ddr3_dqs_n[2]
+set_location_assignment PIN_U19   -to ddr3_dqs_p[3]
+set_location_assignment PIN_T20   -to ddr3_dqs_n[3]
+set_location_assignment PIN_D28   -to ddr3_odt
+set_location_assignment PIN_A25   -to ddr3_ras_n
+set_location_assignment PIN_V28   -to ddr3_reset_n
+set_location_assignment PIN_E25   -to ddr3_we_n
+set_location_assignment PIN_D25   -to ddr3_rzq
+
+# gpio-0 (JP1)
+
+# set_location_assignment PIN_V12  -to gpio_0[0]
+# set_location_assignment PIN_E8   -to gpio_0[1]
+# set_location_assignment PIN_W12  -to gpio_0[2]
+# set_location_assignment PIN_D11  -to gpio_0[3]
+# set_location_assignment PIN_D8   -to gpio_0[4]
+# set_location_assignment PIN_AH13 -to gpio_0[5]
+# set_location_assignment PIN_AF7  -to gpio_0[6]
+# set_location_assignment PIN_AH14 -to gpio_0[7]
+# set_location_assignment PIN_AF4  -to gpio_0[8]
+# set_location_assignment PIN_AH3  -to gpio_0[9]
+# set_location_assignment PIN_AD5  -to gpio_0[10]
+# set_location_assignment PIN_AG14 -to gpio_0[11]
+# set_location_assignment PIN_AE23 -to gpio_0[12]
+# set_location_assignment PIN_AE6  -to gpio_0[13]
+# set_location_assignment PIN_AD23 -to gpio_0[14]
+# set_location_assignment PIN_AE24 -to gpio_0[15]
+# set_location_assignment PIN_D12  -to gpio_0[16]
+# set_location_assignment PIN_AD20 -to gpio_0[17]
+# set_location_assignment PIN_C12  -to gpio_0[18]
+# set_location_assignment PIN_AD17 -to gpio_0[19]
+# set_location_assignment PIN_AC23 -to gpio_0[20]
+# set_location_assignment PIN_AC22 -to gpio_0[21]
+# set_location_assignment PIN_Y19  -to gpio_0[22]
+# set_location_assignment PIN_AB23 -to gpio_0[23]
+# set_location_assignment PIN_AA19 -to gpio_0[24]
+# set_location_assignment PIN_W11  -to gpio_0[25]
+# set_location_assignment PIN_AA18 -to gpio_0[26]
+# set_location_assignment PIN_W14  -to gpio_0[27]
+# set_location_assignment PIN_Y18  -to gpio_0[28]
+# set_location_assignment PIN_Y17  -to gpio_0[29]
+# set_location_assignment PIN_AB25 -to gpio_0[30]
+# set_location_assignment PIN_AB26 -to gpio_0[31]
+# set_location_assignment PIN_Y11  -to gpio_0[32]
+# set_location_assignment PIN_AA26 -to gpio_0[33]
+# set_location_assignment PIN_AA13 -to gpio_0[34]
+# set_location_assignment PIN_AA11 -to gpio_0[35]
+# set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to gpio_0[0]
+# set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to gpio_0[1]
+# set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to gpio_0[2]
+# set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to gpio_0[3]
+# set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to gpio_0[4]
+# set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to gpio_0[5]
+# set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to gpio_0[6]
+# set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to gpio_0[7]
+# set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to gpio_0[8]
+# set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to gpio_0[9]
+# set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to gpio_0[10]
+# set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to gpio_0[11]
+# set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to gpio_0[12]
+# set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to gpio_0[13]
+# set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to gpio_0[14]
+# set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to gpio_0[15]
+# set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to gpio_0[16]
+# set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to gpio_0[17]
+# set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to gpio_0[18]
+# set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to gpio_0[19]
+# set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to gpio_0[20]
+# set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to gpio_0[21]
+# set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to gpio_0[22]
+# set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to gpio_0[23]
+# set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to gpio_0[24]
+# set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to gpio_0[25]
+# set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to gpio_0[26]
+# set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to gpio_0[27]
+# set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to gpio_0[28]
+# set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to gpio_0[29]
+# set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to gpio_0[30]
+# set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to gpio_0[31]
+# set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to gpio_0[32]
+# set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to gpio_0[33]
+# set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to gpio_0[34]
+# set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to gpio_0[35]
+
+# gpio-1 (JP7)
+
+# set_location_assignment PIN_Y15  -to gpio_1[0]
+# set_location_assignment PIN_AC24 -to gpio_1[1]
+# set_location_assignment PIN_AA15 -to gpio_1[2]
+# set_location_assignment PIN_AD26 -to gpio_1[3]
+# set_location_assignment PIN_AG28 -to gpio_1[4]
+# set_location_assignment PIN_AF28 -to gpio_1[5]
+# set_location_assignment PIN_AE25 -to gpio_1[6]
+# set_location_assignment PIN_AF27 -to gpio_1[7]
+# set_location_assignment PIN_AG26 -to gpio_1[8]
+# set_location_assignment PIN_AH27 -to gpio_1[9]
+# set_location_assignment PIN_AG25 -to gpio_1[10]
+# set_location_assignment PIN_AH26 -to gpio_1[11]
+# set_location_assignment PIN_AH24 -to gpio_1[12]
+# set_location_assignment PIN_AF25 -to gpio_1[13]
+# set_location_assignment PIN_AG23 -to gpio_1[14]
+# set_location_assignment PIN_AF23 -to gpio_1[15]
+# set_location_assignment PIN_AG24 -to gpio_1[16]
+# set_location_assignment PIN_AH22 -to gpio_1[17]
+# set_location_assignment PIN_AH21 -to gpio_1[18]
+# set_location_assignment PIN_AG21 -to gpio_1[19]
+# set_location_assignment PIN_AH23 -to gpio_1[20]
+# set_location_assignment PIN_AA20 -to gpio_1[21]
+# set_location_assignment PIN_AF22 -to gpio_1[22]
+# set_location_assignment PIN_AE22 -to gpio_1[23]
+# set_location_assignment PIN_AG20 -to gpio_1[24]
+# set_location_assignment PIN_AF21 -to gpio_1[25]
+# set_location_assignment PIN_AG19 -to gpio_1[26]
+# set_location_assignment PIN_AH19 -to gpio_1[27]
+# set_location_assignment PIN_AG18 -to gpio_1[28]
+# set_location_assignment PIN_AH18 -to gpio_1[29]
+# set_location_assignment PIN_AF18 -to gpio_1[30]
+# set_location_assignment PIN_AF20 -to gpio_1[31]
+# set_location_assignment PIN_AG15 -to gpio_1[32]
+# set_location_assignment PIN_AE20 -to gpio_1[33]
+# set_location_assignment PIN_AE19 -to gpio_1[34]
+# set_location_assignment PIN_AE17 -to gpio_1[35]
+# set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to gpio_1[0]
+# set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to gpio_1[1]
+# set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to gpio_1[2]
+# set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to gpio_1[3]
+# set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to gpio_1[4]
+# set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to gpio_1[5]
+# set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to gpio_1[6]
+# set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to gpio_1[7]
+# set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to gpio_1[8]
+# set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to gpio_1[9]
+# set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to gpio_1[10]
+# set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to gpio_1[11]
+# set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to gpio_1[12]
+# set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to gpio_1[13]
+# set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to gpio_1[14]
+# set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to gpio_1[15]
+# set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to gpio_1[16]
+# set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to gpio_1[17]
+# set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to gpio_1[18]
+# set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to gpio_1[19]
+# set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to gpio_1[20]
+# set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to gpio_1[21]
+# set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to gpio_1[22]
+# set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to gpio_1[23]
+# set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to gpio_1[24]
+# set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to gpio_1[25]
+# set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to gpio_1[26]
+# set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to gpio_1[27]
+# set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to gpio_1[28]
+# set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to gpio_1[29]
+# set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to gpio_1[30]
+# set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to gpio_1[31]
+# set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to gpio_1[32]
+# set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to gpio_1[33]
+# set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to gpio_1[34]
+# set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to gpio_1[35]
+
+# arduino (JP7)
+
+# set_location_assignment PIN_AG13 -to arduino_io[0]
+# set_location_assignment PIN_AF13 -to arduino_io[1]
+# set_location_assignment PIN_AG10 -to arduino_io[2]
+# set_location_assignment PIN_AG9  -to arduino_io[3]
+# set_location_assignment PIN_U14  -to arduino_io[4]
+# set_location_assignment PIN_U13  -to arduino_io[5]
+# set_location_assignment PIN_AG8  -to arduino_io[6]
+# set_location_assignment PIN_AH8  -to arduino_io[7]
+# set_location_assignment PIN_AF17 -to arduino_io[8]
+# set_location_assignment PIN_AE15 -to arduino_io[9]
+# set_location_assignment PIN_AF15 -to arduino_io[10]
+# set_location_assignment PIN_AG16 -to arduino_io[11]
+# set_location_assignment PIN_AH11 -to arduino_io[12]
+# set_location_assignment PIN_AH12 -to arduino_io[13]
+# set_location_assignment PIN_AH9  -to arduino_io[14]
+# set_location_assignment PIN_AG11 -to arduino_io[15]
+# set_location_assignment PIN_AH7  -to arduino_reset_n
+# set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to arduino_io[0]
+# set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to arduino_io[1]
+# set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to arduino_io[2]
+# set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to arduino_io[3]
+# set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to arduino_io[4]
+# set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to arduino_io[5]
+# set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to arduino_io[6]
+# set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to arduino_io[7]
+# set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to arduino_io[8]
+# set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to arduino_io[9]
+# set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to arduino_io[10]
+# set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to arduino_io[11]
+# set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to arduino_io[12]
+# set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to arduino_io[13]
+# set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to arduino_io[14]
+# set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to arduino_io[15]
+# set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to arduino_reset_n
+
+# globals
+
+set_global_assignment -name USE_DLL_FREQUENCY_FOR_DQS_DELAY_CHAIN ON
+set_global_assignment -name UNIPHY_SEQUENCER_DQS_CONFIG_ENABLE ON
+set_global_assignment -name OPTIMIZE_MULTI_CORNER_TIMING ON
+set_global_assignment -name OPTIMIZE_HOLD_TIMING "ALL PATHS"
+set_global_assignment -name ECO_REGENERATE_REPORT ON
+set_global_assignment -name SYNTH_TIMING_DRIVEN_SYNTHESIS ON
+

--- a/projects/common/de10nano/de10nano_system_qsys.tcl
+++ b/projects/common/de10nano/de10nano_system_qsys.tcl
@@ -1,0 +1,221 @@
+# de10nano carrier qsys
+# system clock
+
+add_instance sys_clk clock_source
+set_instance_parameter_value sys_clk {clockFrequency} {50000000.0}
+set_instance_parameter_value sys_clk {clockFrequencyKnown} {1}
+set_instance_parameter_value sys_clk {resetSynchronousEdges} {NONE}
+add_interface sys_clk clock sink
+add_interface sys_rst reset sink
+set_interface_property sys_clk EXPORT_OF sys_clk.clk_in
+set_interface_property sys_rst EXPORT_OF sys_clk.clk_in_reset
+
+# hps
+
+add_instance sys_hps altera_hps
+set_instance_parameter_value sys_hps {MPU_EVENTS_Enable} {0}
+set_instance_parameter_value sys_hps {F2SDRAM_Type} {Avalon-MM\ Bidirectional AXI-3 AXI-3}
+set_instance_parameter_value sys_hps {F2SDRAM_Width} {64 64 64}
+set_instance_parameter_value sys_hps {F2SINTERRUPT_Enable} {1}
+set_instance_parameter_value sys_hps {EMAC0_PinMuxing} {Unused}
+set_instance_parameter_value sys_hps {EMAC0_Mode} {N/A}
+set_instance_parameter_value sys_hps {EMAC1_PinMuxing} {HPS I/O Set 0}
+set_instance_parameter_value sys_hps {EMAC1_Mode} {RGMII}
+set_instance_parameter_value sys_hps {SDIO_PinMuxing} {HPS I/O Set 0}
+set_instance_parameter_value sys_hps {SDIO_Mode} {4-bit Data}
+set_instance_parameter_value sys_hps {USB0_PinMuxing} {Unused}
+set_instance_parameter_value sys_hps {USB0_Mode} {N/A}
+set_instance_parameter_value sys_hps {USB1_PinMuxing} {HPS I/O Set 0}
+set_instance_parameter_value sys_hps {USB1_Mode} {SDR}
+set_instance_parameter_value sys_hps {SPIM0_PinMuxing} {Unused}
+set_instance_parameter_value sys_hps {SPIM0_Mode} {N/A}
+set_instance_parameter_value sys_hps {SPIM1_PinMuxing} {HPS I/O Set 0}
+set_instance_parameter_value sys_hps {SPIM1_Mode} {Single Slave Select}
+set_instance_parameter_value sys_hps {UART0_PinMuxing} {HPS I/O Set 0}
+set_instance_parameter_value sys_hps {UART0_Mode} {No Flow Control}
+set_instance_parameter_value sys_hps {UART1_PinMuxing} {Unused}
+set_instance_parameter_value sys_hps {UART1_Mode} {N/A}
+set_instance_parameter_value sys_hps {I2C0_PinMuxing} {FPGA}
+set_instance_parameter_value sys_hps {I2C0_Mode} {Full}
+set_instance_parameter_value sys_hps {desired_cfg_clk_mhz} {80.0}
+set_instance_parameter_value sys_hps {S2FCLK_USER0CLK_Enable} {1}
+set_instance_parameter_value sys_hps {S2FCLK_USER1CLK_Enable} {0}
+set_instance_parameter_value sys_hps {S2FCLK_USER1CLK_FREQ} {100.0}
+set_instance_parameter_value sys_hps {S2FCLK_USER2CLK_FREQ} {100.0}
+set_instance_parameter_value sys_hps {HPS_PROTOCOL} {DDR3}
+set_instance_parameter_value sys_hps {MEM_CLK_FREQ} {400.0}
+set_instance_parameter_value sys_hps {REF_CLK_FREQ} {25.0}
+set_instance_parameter_value sys_hps {MEM_VOLTAGE} {1.5V DDR3}
+set_instance_parameter_value sys_hps {MEM_CLK_FREQ_MAX} {800.0}
+set_instance_parameter_value sys_hps {MEM_DQ_WIDTH} {32}
+set_instance_parameter_value sys_hps {MEM_ROW_ADDR_WIDTH} {15}
+set_instance_parameter_value sys_hps {MEM_COL_ADDR_WIDTH} {10}
+set_instance_parameter_value sys_hps {MEM_BANKADDR_WIDTH} {3}
+set_instance_parameter_value sys_hps {MEM_TCL} {7}
+set_instance_parameter_value sys_hps {MEM_DRV_STR} {RZQ/6}
+set_instance_parameter_value sys_hps {MEM_RTT_NOM} {RZQ/6}
+set_instance_parameter_value sys_hps {MEM_WTCL} {7}
+set_instance_parameter_value sys_hps {MEM_RTT_WR} {Dynamic ODT off}
+set_instance_parameter_value sys_hps {TIMING_TIS} {175}
+set_instance_parameter_value sys_hps {TIMING_TIH} {250}
+set_instance_parameter_value sys_hps {TIMING_TDS} {50}
+set_instance_parameter_value sys_hps {TIMING_TDH} {125}
+set_instance_parameter_value sys_hps {TIMING_TDQSQ} {120}
+set_instance_parameter_value sys_hps {TIMING_TQH} {0.38}
+set_instance_parameter_value sys_hps {TIMING_TDQSCK} {400}
+set_instance_parameter_value sys_hps {TIMING_TDQSS} {0.25}
+set_instance_parameter_value sys_hps {TIMING_TQSH} {0.38}
+set_instance_parameter_value sys_hps {TIMING_TDSH} {0.2}
+set_instance_parameter_value sys_hps {TIMING_TDSS} {0.2}
+set_instance_parameter_value sys_hps {MEM_TINIT_US} {500}
+set_instance_parameter_value sys_hps {MEM_TMRD_CK} {4}
+set_instance_parameter_value sys_hps {MEM_TRAS_NS} {35.0}
+set_instance_parameter_value sys_hps {MEM_TRCD_NS} {13.75}
+set_instance_parameter_value sys_hps {MEM_TRP_NS} {13.75}
+set_instance_parameter_value sys_hps {MEM_TREFI_US} {7.8}
+set_instance_parameter_value sys_hps {MEM_TRFC_NS} {300.0}
+set_instance_parameter_value sys_hps {MEM_TWR_NS} {15.0}
+set_instance_parameter_value sys_hps {MEM_TWTR} {4}
+set_instance_parameter_value sys_hps {MEM_TFAW_NS} {37.5}
+set_instance_parameter_value sys_hps {MEM_TRRD_NS} {7.5}
+set_instance_parameter_value sys_hps {MEM_TRTP_NS} {7.5}
+set_instance_parameter_value sys_hps {TIMING_BOARD_MAX_CK_DELAY} {0.6}
+set_instance_parameter_value sys_hps {TIMING_BOARD_MAX_DQS_DELAY} {0.6}
+set_instance_parameter_value sys_hps {TIMING_BOARD_SKEW_CKDQS_DIMM_MIN} {-0.01}
+set_instance_parameter_value sys_hps {TIMING_BOARD_SKEW_CKDQS_DIMM_MAX} {0.01}
+set_instance_parameter_value sys_hps {TIMING_BOARD_SKEW_WITHIN_DQS} {0.02}
+set_instance_parameter_value sys_hps {TIMING_BOARD_SKEW_BETWEEN_DQS} {0.02}
+set_instance_parameter_value sys_hps {TIMING_BOARD_DQ_TO_DQS_SKEW} {0.0}
+set_instance_parameter_value sys_hps {TIMING_BOARD_AC_SKEW} {0.02}
+set_instance_parameter_value sys_hps {TIMING_BOARD_AC_TO_CK_SKEW} {0.0}
+add_interface sys_hps_memory conduit end
+set_interface_property sys_hps_memory EXPORT_OF sys_hps.memory
+add_interface sys_hps_hps_io conduit end
+set_interface_property sys_hps_hps_io EXPORT_OF sys_hps.hps_io
+add_interface sys_hps_h2f_reset reset source
+set_interface_property sys_hps_h2f_reset EXPORT_OF sys_hps.h2f_reset
+add_connection sys_clk.clk sys_hps.f2h_sdram0_clock
+add_connection sys_clk.clk sys_hps.h2f_axi_clock
+add_connection sys_clk.clk sys_hps.f2h_axi_clock
+add_connection sys_clk.clk sys_hps.h2f_lw_axi_clock
+add_interface sys_hps_i2c0 conduit end
+set_interface_property sys_hps_i2c0 EXPORT_OF sys_hps.i2c0
+add_interface sys_hps_i2c0_clk clock source
+set_interface_property sys_hps_i2c0_clk EXPORT_OF sys_hps.i2c0_clk
+add_interface sys_hps_i2c0_scl_in clock sink
+set_interface_property sys_hps_i2c0_scl_in EXPORT_OF sys_hps.i2c0_scl_in
+
+# cpu/hps handling
+
+proc ad_cpu_interrupt {m_irq m_port} {
+
+  add_connection sys_hps.f2h_irq0 ${m_port}
+  set_connection_parameter_value sys_hps.f2h_irq0/${m_port} irqNumber ${m_irq}
+}
+
+proc ad_cpu_interconnect {m_base m_port} {
+
+  add_connection sys_hps.h2f_lw_axi_master ${m_port}
+  set_connection_parameter_value sys_hps.h2f_lw_axi_master/${m_port} baseAddress ${m_base}
+}
+
+proc ad_dma_interconnect {m_port m_id} {
+
+  if {${m_id} == 1} {
+    add_connection ${m_port} sys_hps.f2h_sdram1_data
+    set_connection_parameter_value ${m_port}/sys_hps.f2h_sdram1_data baseAddress {0x0000}
+    return
+  }
+
+  add_connection ${m_port} sys_hps.f2h_sdram2_data
+  set_connection_parameter_value ${m_port}/sys_hps.f2h_sdram2_data baseAddress {0x0000}
+}
+
+# common dma interfaces
+
+add_instance sys_dma_clk clock_source
+add_connection sys_clk.clk sys_dma_clk.clk_in
+add_connection sys_clk.clk_reset sys_dma_clk.clk_in_reset
+add_connection sys_dma_clk.clk sys_hps.f2h_sdram1_clock
+add_connection sys_dma_clk.clk sys_hps.f2h_sdram2_clock
+
+# internal memory
+
+add_instance sys_int_mem altera_avalon_onchip_memory2
+set_instance_parameter_value sys_int_mem {dualPort} {0}
+set_instance_parameter_value sys_int_mem {dataWidth} {64}
+set_instance_parameter_value sys_int_mem {memorySize} {65536.0}
+set_instance_parameter_value sys_int_mem {initMemContent} {0}
+add_connection sys_clk.clk sys_int_mem.clk1
+add_connection sys_clk.clk_reset sys_int_mem.reset1
+add_connection sys_hps.h2f_axi_master sys_int_mem.s1
+set_connection_parameter_value sys_hps.h2f_axi_master/sys_int_mem.s1 baseAddress {0x0000}
+
+# id
+
+add_instance sys_id altera_avalon_sysid_qsys
+set_instance_parameter_value sys_id {id} {-1395322110}
+add_connection sys_clk.clk sys_id.clk
+add_connection sys_clk.clk_reset sys_id.reset
+
+# gpio-bd
+
+add_instance sys_gpio_bd altera_avalon_pio
+set_instance_parameter_value sys_gpio_bd {direction} {InOut}
+set_instance_parameter_value sys_gpio_bd {generateIRQ} {1}
+set_instance_parameter_value sys_gpio_bd {width} {32}
+add_connection sys_clk.clk sys_gpio_bd.clk
+add_connection sys_clk.clk_reset sys_gpio_bd.reset
+add_interface sys_gpio_bd conduit end
+set_interface_property sys_gpio_bd EXPORT_OF sys_gpio_bd.external_connection
+
+# gpio-in
+
+add_instance sys_gpio_in altera_avalon_pio
+set_instance_parameter_value sys_gpio_in {direction} {Input}
+set_instance_parameter_value sys_gpio_in {generateIRQ} {1}
+set_instance_parameter_value sys_gpio_in {width} {32}
+add_connection sys_clk.clk_reset sys_gpio_in.reset
+add_connection sys_clk.clk sys_gpio_in.clk
+add_interface sys_gpio_in conduit end
+set_interface_property sys_gpio_in EXPORT_OF sys_gpio_in.external_connection
+
+# gpio-out
+
+add_instance sys_gpio_out altera_avalon_pio
+set_instance_parameter_value sys_gpio_out {direction} {Output}
+set_instance_parameter_value sys_gpio_out {generateIRQ} {0}
+set_instance_parameter_value sys_gpio_out {width} {32}
+add_connection sys_clk.clk_reset sys_gpio_out.reset
+add_connection sys_clk.clk sys_gpio_out.clk
+add_interface sys_gpio_out conduit end
+set_interface_property sys_gpio_out EXPORT_OF sys_gpio_out.external_connection
+
+# spi
+
+add_instance sys_spi altera_avalon_spi
+set_instance_parameter_value sys_spi {clockPhase} {0}
+set_instance_parameter_value sys_spi {clockPolarity} {1}
+set_instance_parameter_value sys_spi {dataWidth} {8}
+set_instance_parameter_value sys_spi {masterSPI} {1}
+set_instance_parameter_value sys_spi {numberOfSlaves} {1}
+set_instance_parameter_value sys_spi {targetClockRate} {50000000.0}
+add_connection sys_clk.clk sys_spi.clk
+add_connection sys_clk.clk_reset sys_spi.reset
+add_interface sys_spi conduit end
+set_interface_property sys_spi EXPORT_OF sys_spi.external
+
+# interrupts
+
+ad_cpu_interrupt 0 sys_gpio_bd.irq
+ad_cpu_interrupt 1 sys_spi.irq
+ad_cpu_interrupt 2 sys_gpio_in.irq 
+
+# cpu interconnects
+
+ad_cpu_interconnect 0x00108000 sys_spi.spi_control_port
+ad_cpu_interconnect 0x00010000 sys_id.control_slave
+ad_cpu_interconnect 0x00010080 sys_gpio_bd.s1
+ad_cpu_interconnect 0x00010100 sys_gpio_in.s1
+ad_cpu_interconnect 0x00109000 sys_gpio_out.s1
+

--- a/projects/scripts/adi_project_intel.tcl
+++ b/projects/scripts/adi_project_intel.tcl
@@ -39,7 +39,7 @@ proc adi_project {project_name {parameter_list {}}} {
     set system_qip_file system_bd/synthesis/system_bd.qip
   }
 
-  if [regexp "de10nano$" $project_name] {
+  if [regexp "_de10nano$" $project_name] {
     set family "Cyclone V"
     set device 5CSEBA6U23I7DK
     set system_qip_file system_bd/synthesis/system_bd.qip


### PR DESCRIPTION
This project is the reference design for the ad77681evb and Intel carriers such as DE10nano board. The new introduced feature is the integration of SPI Engine Framework for Intel projects.