### PR TITLE
jesd204/ad_ip_jesd204_tpl_dac: Fix Intel dependencies

### DIFF
--- a/library/axi_ad9144/Makefile
+++ b/library/axi_ad9144/Makefile
@@ -17,6 +17,7 @@ INTEL_DEPS += ../common/ad_dds_2.v
 INTEL_DEPS += ../common/ad_dds_cordic_pipe.v
 INTEL_DEPS += ../common/ad_dds_sine.v
 INTEL_DEPS += ../common/ad_dds_sine_cordic.v
+INTEL_DEPS += ../common/ad_iqcor.v
 INTEL_DEPS += ../common/ad_perfect_shuffle.v
 INTEL_DEPS += ../common/ad_rst.v
 INTEL_DEPS += ../common/up_axi.v

--- a/library/axi_ad9144/axi_ad9144_hw.tcl
+++ b/library/axi_ad9144/axi_ad9144_hw.tcl
@@ -23,6 +23,7 @@ ad_ip_files axi_ad9144 [list \
   $ad_hdl_dir/library/common/ad_dds_2.v \
   $ad_hdl_dir/library/common/ad_dds_1.v \
   $ad_hdl_dir/library/common/ad_dds.v \
+  $ad_hdl_dir/library/common/ad_iqcor.v \
   $ad_hdl_dir/library/common/ad_perfect_shuffle.v \
   $ad_hdl_dir/library/common/ad_rst.v \
   $ad_hdl_dir/library/common/up_axi.v \

--- a/library/axi_ad9152/Makefile
+++ b/library/axi_ad9152/Makefile
@@ -17,6 +17,7 @@ INTEL_DEPS += ../common/ad_dds_2.v
 INTEL_DEPS += ../common/ad_dds_cordic_pipe.v
 INTEL_DEPS += ../common/ad_dds_sine.v
 INTEL_DEPS += ../common/ad_dds_sine_cordic.v
+INTEL_DEPS += ../common/ad_iqcor.v
 INTEL_DEPS += ../common/ad_perfect_shuffle.v
 INTEL_DEPS += ../common/ad_rst.v
 INTEL_DEPS += ../common/up_axi.v

--- a/library/axi_ad9152/axi_ad9152_hw.tcl
+++ b/library/axi_ad9152/axi_ad9152_hw.tcl
@@ -23,6 +23,7 @@ ad_ip_files axi_ad9152 [list \
   $ad_hdl_dir/library/common/ad_dds_2.v \
   $ad_hdl_dir/library/common/ad_dds_1.v \
   $ad_hdl_dir/library/common/ad_dds.v \
+  $ad_hdl_dir/library/common/ad_iqcor.v \
   $ad_hdl_dir/library/common/ad_perfect_shuffle.v \
   $ad_hdl_dir/library/common/ad_rst.v \
   $ad_hdl_dir/library/common/up_axi.v \

--- a/library/jesd204/ad_ip_jesd204_tpl_dac/ad_ip_jesd204_tpl_dac_hw.tcl
+++ b/library/jesd204/ad_ip_jesd204_tpl_dac/ad_ip_jesd204_tpl_dac_hw.tcl
@@ -35,6 +35,7 @@ ad_ip_files ad_ip_jesd204_tpl_dac [list \
   $ad_hdl_dir/library/common/ad_dds_2.v \
   $ad_hdl_dir/library/common/ad_dds_1.v \
   $ad_hdl_dir/library/common/ad_dds.v \
+  $ad_hdl_dir/library/common/ad_iqcor.v \
   $ad_hdl_dir/library/common/ad_perfect_shuffle.v \
   $ad_hdl_dir/library/common/ad_rst.v \
   $ad_hdl_dir/library/common/up_axi.v \


### PR DESCRIPTION
Even if the IQ rotation is disabled in the projects all modules has to be
added to the list of dependencies to avoid compilation errors.

Tested compilation on: 
daq2 a10soc
daq3 a10gx
dac_fmc_ebz a10soc