### PR TITLE
fmcomms5/zc702: Fix the sys_dma_clk connections

### DIFF
--- a/projects/fmcomms5/zc702/system_bd.tcl
+++ b/projects/fmcomms5/zc702/system_bd.tcl
@@ -10,7 +10,9 @@ sysid_gen_sys_init_file $sys_cstring
 
 ad_ip_parameter sys_ps7 CONFIG.PCW_EN_CLK2_PORT 1
 ad_ip_parameter sys_ps7 CONFIG.PCW_FPGA2_PERIPHERAL_FREQMHZ 150.0
-ad_connect  sys_dma_clk sys_ps7/FCLK_CLK2
+
+ad_connect sys_dma_clk sys_ps7/FCLK_CLK2
+set sys_dma_clk [get_bd_nets sys_dma_clk]
 source ../common/fmcomms5_bd.tcl
 
 ad_ip_parameter axi_ad9361_0 CONFIG.ADC_INIT_DELAY 24


### PR DESCRIPTION
The $sys_dma_clk variable is connected to 200 MHz by default. It's a variable that must contain a net name.
Fix the variable update, to be connected to the 150MHz clock source. This will add some timing margin for the HPS2 and HPS3 interconnects. 