### PR TITLE
SPI Engine Offload add incremental sync_id

### DIFF
--- a/library/spi_engine/axi_spi_engine/axi_spi_engine_constr.ttcl
+++ b/library/spi_engine/axi_spi_engine/axi_spi_engine_constr.ttcl
@@ -12,18 +12,16 @@ set_property ASYNC_REG TRUE \
   [get_cells -quiet -hierarchical *cdc_sync_stage2_reg*]
 
 set_false_path -quiet \
-  -from [get_cells -quiet -hierarchical -filter {NAME =~ *cdc_sync_stage0_reg* && IS_SEQUENTIAL}] \
-  -to [get_cells -quiet -hierarchical -filter {NAME =~ *cdc_sync_stage1_reg* && IS_SEQUENTIAL}]
+ -from [get_cells -quiet -hierarchical -filter {NAME =~ *i_address_gray/*cdc_sync_stage0_reg* && IS_SEQUENTIAL}] \
+ -to [get_cells -quiet -hierarchical -filter {NAME =~ *i_address_gray/*cdc_sync_stage1_reg* && IS_SEQUENTIAL}]
 
 set_false_path -quiet \
-  -from [get_cells -quiet -hierarchical -filter {NAME =~ *offload0_enable_reg* && IS_SEQUENTIAL}] \
-  -to [get_cells -quiet -hierarchical -filter {NAME =~ *cdc_sync_stage1_reg* && IS_SEQUENTIAL}]
+  -to [get_cells -quiet -hierarchical -filter {NAME =~ *i_offload_enable_sync/cdc_sync_stage1_reg* && IS_SEQUENTIAL}]
 
 set_false_path -quiet \
   -to [get_cells -quiet -hierarchical -filter {NAME =~ *i_offload_enabled_sync/cdc_sync_stage1_reg* && IS_SEQUENTIAL}]
 
 set_false_path -quiet \
-  -from [get_cells -quiet -hierarchical -filter {NAME =~ *offload0_mem_reset_reg* && IS_SEQUENTIAL}] \
-  -to [get_cells -quiet -hierarchical -filter {NAME =~ *cdc_sync_stage1_reg* && IS_SEQUENTIAL}]
+  -to [get_cells -quiet -hierarchical -filter {NAME =~ *i_offload_mem_reset_sync/cdc_sync_stage1_reg* && IS_SEQUENTIAL}]
 
 <: } :>

--- a/library/spi_engine/axi_spi_engine/axi_spi_engine_ip.tcl
+++ b/library/spi_engine/axi_spi_engine/axi_spi_engine_ip.tcl
@@ -50,6 +50,9 @@ adi_add_bus "spi_engine_offload_ctrl0" "master" \
 		{ "offload0_enable" "ENABLE"} \
 		{ "offload0_enabled" "ENABLED"} \
 		{ "offload0_mem_reset" "MEM_RESET"} \
+		{ "offload_sync_ready" "SYNC_READY"} \
+		{ "offload_sync_valid" "SYNC_VALID"} \
+		{ "offload_sync_data" "SYNC_DATA"} \
 	}
 
 adi_add_bus_clock "s_axi_aclk" "spi_engine_offload_ctrl0:s_axi" "s_axi_aresetn"

--- a/library/spi_engine/interfaces/spi_engine_offload_ctrl_rtl.xml
+++ b/library/spi_engine/interfaces/spi_engine_offload_ctrl_rtl.xml
@@ -109,5 +109,50 @@
 				</spirit:onSlave>
 			</spirit:wire>
 		</spirit:port>
+		<spirit:port>
+			<spirit:logicalName>SYNC_READY</spirit:logicalName>
+			<spirit:wire>
+				<spirit:onMaster>
+					<spirit:presence>required</spirit:presence>
+					<spirit:width>1</spirit:width>
+					<spirit:direction>out</spirit:direction>
+				</spirit:onMaster>
+				<spirit:onSlave>
+					<spirit:presence>required</spirit:presence>
+					<spirit:width>1</spirit:width>
+					<spirit:direction>in</spirit:direction>
+				</spirit:onSlave>
+			</spirit:wire>
+		</spirit:port>
+		<spirit:port>
+			<spirit:logicalName>SYNC_VALID</spirit:logicalName>
+			<spirit:wire>
+				<spirit:onMaster>
+					<spirit:presence>required</spirit:presence>
+					<spirit:width>1</spirit:width>
+					<spirit:direction>in</spirit:direction>
+				</spirit:onMaster>
+				<spirit:onSlave>
+					<spirit:presence>required</spirit:presence>
+					<spirit:width>1</spirit:width>
+					<spirit:direction>out</spirit:direction>
+				</spirit:onSlave>
+			</spirit:wire>
+		</spirit:port>
+		<spirit:port>
+			<spirit:logicalName>SYNC_DATA</spirit:logicalName>
+			<spirit:wire>
+				<spirit:onMaster>
+					<spirit:presence>required</spirit:presence>
+					<spirit:width>8</spirit:width>
+					<spirit:direction>in</spirit:direction>
+				</spirit:onMaster>
+				<spirit:onSlave>
+					<spirit:presence>required</spirit:presence>
+					<spirit:width>8</spirit:width>
+					<spirit:direction>out</spirit:direction>
+				</spirit:onSlave>
+			</spirit:wire>
+		</spirit:port>
 	</spirit:ports>
 </spirit:abstractionDefinition>

--- a/library/spi_engine/spi_engine_offload/spi_engine_offload.v
+++ b/library/spi_engine/spi_engine_offload/spi_engine_offload.v
@@ -56,6 +56,10 @@ module spi_engine_offload #(
   output ctrl_enabled,
   input ctrl_mem_reset,
 
+  output status_sync_valid,
+  input status_sync_ready,
+  output [7:0] status_sync_data,
+
   input spi_clk,
   input spi_resetn,
 
@@ -98,7 +102,6 @@ wire spi_enable;
 
 assign cmd_valid = spi_active;
 assign sdo_data_valid = spi_active;
-assign sync_ready = 1'b1;
 
 assign offload_sdi_valid = sdi_data_valid;
 
@@ -171,6 +174,15 @@ always @(posedge spi_clk) begin
 end
 
 assign cmd = (cmd_int_s[15:8] == 8'h30) ? {cmd_int_s[15:8], spi_sync_id_counter} : cmd_int_s;
+
+/* 
+ * Forwarded SYNC interface, this can be used to monitor the state of the 
+ * offload command sequence through SPI Engine regmap
+ */	
+
+assign status_sync_data = sync_data;
+assign status_sync_valid = sync_valid;
+assign sync_ready = status_sync_ready;
 
 generate if (ASYNC_SPI_CLK) begin
 

--- a/library/spi_engine/spi_engine_offload/spi_engine_offload_constr.ttcl
+++ b/library/spi_engine/spi_engine_offload/spi_engine_offload_constr.ttcl
@@ -1,0 +1,31 @@
+<: set ComponentName [getComponentNameString] :>
+<: setOutputDirectory "./" :>
+<: setFileName [ttcl_add $ComponentName "_constr"] :>
+<: setFileExtension ".xdc" :>
+<: setFileProcessingOrder late :>
+<: set async_spi_clk [getBooleanValue "ASYNC_SPI_CLK"] :>
+
+<: if { $async_spi_clk } { :>
+
+set_property ASYNC_REG TRUE \
+  [get_cells -quiet -hierarchical *cdc_sync_stage1_reg*] \
+  [get_cells -quiet -hierarchical *cdc_sync_stage2_reg*]
+
+set_false_path -quiet \
+  -to [get_cells -quiet -hierarchical -filter {NAME =~ *i_sync_sync_id_load/i_sync_out/cdc_sync_stage1_reg* && IS_SEQUENTIAL}]
+set_false_path -quiet \
+  -to [get_cells -quiet -hierarchical -filter {NAME =~ *i_sync_sync_id_load/i_sync_in/cdc_sync_stage1_reg* && IS_SEQUENTIAL}]
+
+set_false_path -quiet \
+  -to [get_cells -quiet -hierarchical -filter {NAME =~ *i_sync_sync_id/cdc_sync_stage1_reg* && IS_SEQUENTIAL}]
+
+set_false_path -quiet \
+  -to [get_cells -quiet -hierarchical -filter {NAME =~ *i_sync_enable/cdc_sync_stage1_reg* && IS_SEQUENTIAL}]
+
+set_false_path -quiet \
+  -to [get_cells -quiet -hierarchical -filter {NAME =~ *i_sync_enabled/cdc_sync_stage1_reg* && IS_SEQUENTIAL}]
+
+set_false_path -quiet \
+  -to [get_cells -quiet -hierarchical -filter {NAME =~ *i_sync_trigger/cdc_sync_stage1_reg* && IS_SEQUENTIAL}]
+
+<: } :>

--- a/library/spi_engine/spi_engine_offload/spi_engine_offload_ip.tcl
+++ b/library/spi_engine/spi_engine_offload/spi_engine_offload_ip.tcl
@@ -3,10 +3,13 @@ source $ad_hdl_dir/library/scripts/adi_ip_xilinx.tcl
 
 adi_ip_create spi_engine_offload
 adi_ip_files spi_engine_offload [list \
+  "spi_engine_offload_constr.ttcl" \
 	"spi_engine_offload.v" \
 ]
 
 adi_ip_properties_lite spi_engine_offload
+adi_ip_ttcl axi_spi_engine "spi_engine_offload_constr.ttcl"
+
 # Remove all inferred interfaces
 ipx::remove_all_bus_interface [ipx::current_core]
 

--- a/library/spi_engine/spi_engine_offload/spi_engine_offload_ip.tcl
+++ b/library/spi_engine/spi_engine_offload/spi_engine_offload_ip.tcl
@@ -46,6 +46,9 @@ adi_add_bus "spi_engine_offload_ctrl" "slave" \
 		{ "ctrl_enable" "ENABLE"} \
 		{ "ctrl_enabled" "ENABLED"} \
 		{ "ctrl_mem_reset" "MEM_RESET"} \
+		{ "status_sync_ready" "SYNC_READY"} \
+		{ "status_sync_valid" "SYNC_VALID"} \
+		{ "status_sync_data" "SYNC_DATA"} \
 	}
 
 adi_add_bus "offload_sdi" "master" \


### PR DESCRIPTION
Increment the sync_id value at each transfer. The initial value of the sync_id is the value of the last SYNC command loaded into the command buffer.

Add constraints ttcl for the data offload module.