### PR TITLE
SPI Engine improvements

### DIFF
--- a/library/spi_engine/axi_spi_engine/axi_spi_engine.v
+++ b/library/spi_engine/axi_spi_engine/axi_spi_engine.v
@@ -333,6 +333,7 @@ module axi_spi_engine #(
       8'h35: up_rdata_ff <= sdo_fifo_room;
       8'h36: up_rdata_ff <= sdi_fifo_level;
       8'h3a: up_rdata_ff <= sdi_fifo_out_data;
+      8'h3b: up_rdata_ff <= (NUM_OF_SDI*DATA_WIDTH > 32) ? sdi_fifo_out_data[NUM_OF_SDI*DATA_WIDTH-1:32] : sdi_fifo_out_data; /* store SDI's 32 bits MSB, if exists */
       8'h3c: up_rdata_ff <= sdi_fifo_out_data; /* PEEK register */
       8'h40: up_rdata_ff <= {offload0_enable_reg};
       8'h41: up_rdata_ff <= {offload0_enabled_s};

--- a/library/spi_engine/axi_spi_engine/axi_spi_engine.v
+++ b/library/spi_engine/axi_spi_engine/axi_spi_engine.v
@@ -47,8 +47,8 @@ module axi_spi_engine #(
   parameter OFFLOAD0_CMD_MEM_ADDRESS_WIDTH = 4,
   parameter OFFLOAD0_SDO_MEM_ADDRESS_WIDTH = 4,
   parameter ID = 0,
-  parameter DATA_WIDTH = 8,
-  parameter NUM_OF_SDI = 1 ) (
+  parameter [15:0] DATA_WIDTH = 8,
+  parameter [ 7:0] NUM_OF_SDI = 1 ) (
 
   // Slave AXI interface
 
@@ -282,7 +282,7 @@ module axi_spi_engine #(
   reg offload0_mem_reset_reg;
   wire offload0_enabled_s;
 
-  
+
   always @(posedge clk) begin
     if ((up_waddr_s == 8'h48) && (up_wreq_s == 1'b1)) begin
       pulse_gen_load <= 1'b1;
@@ -323,7 +323,7 @@ module axi_spi_engine #(
       8'h00: up_rdata_ff <= PCORE_VERSION;
       8'h01: up_rdata_ff <= ID;
       8'h02: up_rdata_ff <= up_scratch;
-      8'h03: up_rdata_ff <= DATA_WIDTH;
+      8'h03: up_rdata_ff <= {8'b0, NUM_OF_SDI, DATA_WIDTH};
       8'h10: up_rdata_ff <= up_sw_reset;
       8'h20: up_rdata_ff <= up_irq_mask;
       8'h21: up_rdata_ff <= up_irq_pending;


### PR DESCRIPTION
Two minor SPI Engine improvement:
 - the value of NUM_OF_SDI is accessible from register 0xC
 - FIFO read support data widths up to 64 bits