### PR TITLE
Add channel crossbar to DAC TPL

### DIFF
--- a/library/common/ad_mux.v
+++ b/library/common/ad_mux.v
@@ -57,7 +57,8 @@ module ad_mux #(
 localparam MUX_SZ = CH_CNT < REQ_MUX_SZ ? CH_CNT : REQ_MUX_SZ;
 localparam CLOG2_CH_CNT = $clog2(CH_CNT);
 localparam CLOG2_MUX_SZ = $clog2(MUX_SZ);
-localparam NUM_STAGES = $clog2(CH_CNT) / $clog2(MUX_SZ);
+localparam NUM_STAGES = ($clog2(CH_CNT) / $clog2(MUX_SZ)) + // divide and round up
+                       |($clog2(CH_CNT) % $clog2(MUX_SZ));
 
 wire [NUM_STAGES*DW+CH_W-1:0] mux_in;
 wire [NUM_STAGES*CLOG2_CH_CNT-1:0] ch_sel_pln;

--- a/library/common/ad_mux.v
+++ b/library/common/ad_mux.v
@@ -54,6 +54,8 @@ module ad_mux #(
   output [CH_W-1:0] data_out
 );
 
+`define MIN(A,B) (A<B?A:B)
+
 localparam MUX_SZ = CH_CNT < REQ_MUX_SZ ? CH_CNT : REQ_MUX_SZ;
 localparam CLOG2_CH_CNT = $clog2(CH_CNT);
 localparam CLOG2_MUX_SZ = $clog2(MUX_SZ);
@@ -95,7 +97,9 @@ generate
       end
     end
 
-    for (j = 0; j < MUX_SZ**(NUM_STAGES-i); j = j + MUX_SZ) begin: g_mux
+    localparam MAX_RANGE_PER_STAGE=MUX_SZ**(NUM_STAGES-i);
+
+    for (j = 0; j < `MIN(MAX_RANGE_PER_STAGE,CH_CNT); j = j + MUX_SZ) begin: g_mux
 
       ad_mux_core #(
         .CH_W (CH_W),

--- a/library/common/ad_mux.v
+++ b/library/common/ad_mux.v
@@ -1,0 +1,118 @@
+// ***************************************************************************
+// ***************************************************************************
+// Copyright 2014 - 2017 (c) Analog Devices, Inc. All rights reserved.
+//
+// In this HDL repository, there are many different and unique modules, consisting
+// of various HDL (Verilog or VHDL) components. The individual modules are
+// developed independently, and may be accompanied by separate and unique license
+// terms.
+//
+// The user should read each of these license terms, and understand the
+// freedoms and responsibilities that he or she has by using this source/core.
+//
+// This core is distributed in the hope that it will be useful, but WITHOUT ANY
+// WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+// A PARTICULAR PURPOSE.
+//
+// Redistribution and use of source or resulting binaries, with or without modification
+// of this file, are permitted under one of the following two license terms:
+//
+//   1. The GNU General Public License version 2 as published by the
+//      Free Software Foundation, which can be found in the top level directory
+//      of this repository (LICENSE_GPL2), and also online at:
+//      <https://www.gnu.org/licenses/old-licenses/gpl-2.0.html>
+//
+// OR
+//
+//   2. An ADI specific BSD license, which can be found in the top level directory
+//      of this repository (LICENSE_ADIBSD), and also on-line at:
+//      https://github.com/analogdevicesinc/hdl/blob/master/LICENSE_ADIBSD
+//      This will allow to generate bit files and not release the source code,
+//      as long as it attaches to an ADI device.
+//
+// ***************************************************************************
+// ***************************************************************************
+
+`timescale 1ns/100ps
+
+// Constraints :  CH_CNT must be power of 2
+//  Build a large mux from smaller ones defined by the MUX_SZ parameter
+//  Use EN_REG to add a register at the output of the small muxes to  help
+//  timing closure.
+
+module ad_mux #(
+  parameter CH_W = 16,   // Width of input channel
+  parameter CH_CNT = 64,  // Number of input channels
+  parameter REQ_MUX_SZ = 8,  // Size of mux which acts as a building block
+  parameter EN_REG = 1,  // Enable register at output of each mux
+  parameter DW = CH_W*CH_CNT
+
+) (
+  input clk,
+  input [DW-1:0] data_in,
+  input [$clog2(CH_CNT)-1:0] ch_sel,
+  output [CH_W-1:0] data_out
+);
+
+localparam MUX_SZ = CH_CNT < REQ_MUX_SZ ? CH_CNT : REQ_MUX_SZ;
+localparam CLOG2_CH_CNT = $clog2(CH_CNT);
+localparam CLOG2_MUX_SZ = $clog2(MUX_SZ);
+localparam NUM_STAGES = $clog2(CH_CNT) / $clog2(MUX_SZ);
+
+wire [NUM_STAGES*DW+CH_W-1:0] mux_in;
+wire [NUM_STAGES*CLOG2_CH_CNT-1:0] ch_sel_pln;
+
+
+assign mux_in[DW-1:0] = data_in;
+assign ch_sel_pln[CLOG2_CH_CNT-1:0] = ch_sel;
+
+genvar i;
+genvar j;
+
+generate
+
+
+  for (i = 0; i < NUM_STAGES; i = i + 1) begin: g_stage
+
+    wire [CLOG2_CH_CNT-1:0] ch_sel_cur;
+    assign ch_sel_cur = ch_sel_pln[i*CLOG2_CH_CNT+:CLOG2_CH_CNT];
+
+    wire [CLOG2_MUX_SZ-1:0] ch_sel_w;
+    assign ch_sel_w = ch_sel_cur >> i*CLOG2_MUX_SZ;
+
+    if (EN_REG) begin
+      reg [CLOG2_CH_CNT-1:0] ch_sel_d;
+      always @(posedge clk) begin
+        ch_sel_d <= ch_sel_cur;
+      end
+      if (i<NUM_STAGES-1) begin
+        assign ch_sel_pln[(i+1)*CLOG2_CH_CNT+:CLOG2_CH_CNT] = ch_sel_d;
+      end
+    end else begin
+      if (i<NUM_STAGES-1) begin
+        assign ch_sel_pln[(i+1)*CLOG2_CH_CNT+:CLOG2_CH_CNT] = ch_sel_cur;
+      end
+    end
+
+    for (j = 0; j < MUX_SZ**(NUM_STAGES-i); j = j + MUX_SZ) begin: g_mux
+
+      ad_mux_core #(
+        .CH_W (CH_W),
+        .CH_CNT (MUX_SZ),
+        .EN_REG (EN_REG)
+      ) i_mux (
+        .clk (clk),
+        .data_in (mux_in[i*DW+j*CH_W+:MUX_SZ*CH_W]),
+        .ch_sel (ch_sel_w),
+        .data_out (mux_in[(i+1)*DW+(j/MUX_SZ)*CH_W+:CH_W])
+      );
+
+    end
+  end
+
+endgenerate
+
+assign data_out = mux_in[NUM_STAGES*DW+:CH_W];
+
+endmodule
+

--- a/library/common/ad_mux_core.v
+++ b/library/common/ad_mux_core.v
@@ -1,0 +1,66 @@
+// ***************************************************************************
+// ***************************************************************************
+// Copyright 2014 - 2017 (c) Analog Devices, Inc. All rights reserved.
+//
+// In this HDL repository, there are many different and unique modules, consisting
+// of various HDL (Verilog or VHDL) components. The individual modules are
+// developed independently, and may be accompanied by separate and unique license
+// terms.
+//
+// The user should read each of these license terms, and understand the
+// freedoms and responsibilities that he or she has by using this source/core.
+//
+// This core is distributed in the hope that it will be useful, but WITHOUT ANY
+// WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+// A PARTICULAR PURPOSE.
+//
+// Redistribution and use of source or resulting binaries, with or without modification
+// of this file, are permitted under one of the following two license terms:
+//
+//   1. The GNU General Public License version 2 as published by the
+//      Free Software Foundation, which can be found in the top level directory
+//      of this repository (LICENSE_GPL2), and also online at:
+//      <https://www.gnu.org/licenses/old-licenses/gpl-2.0.html>
+//
+// OR
+//
+//   2. An ADI specific BSD license, which can be found in the top level directory
+//      of this repository (LICENSE_ADIBSD), and also on-line at:
+//      https://github.com/analogdevicesinc/hdl/blob/master/LICENSE_ADIBSD
+//      This will allow to generate bit files and not release the source code,
+//      as long as it attaches to an ADI device.
+//
+// ***************************************************************************
+// ***************************************************************************
+
+`timescale 1ns/100ps
+
+module ad_mux_core #(
+  parameter CH_W = 16,
+  parameter CH_CNT = 8,
+  parameter EN_REG = 0
+) (
+  input clk,
+  input [CH_W*CH_CNT-1:0] data_in,
+  input [$clog2(CH_CNT)-1:0] ch_sel,
+  output [CH_W-1:0] data_out
+);
+
+wire [CH_W-1:0] data_out_loc;
+
+assign data_out_loc = data_in >> CH_W*ch_sel;
+
+generate if (EN_REG) begin
+  reg [CH_W-1:0] data_out_reg;
+  always @(posedge clk) begin
+    data_out_reg <= data_out_loc;
+  end
+  assign data_out = data_out_reg;
+end else begin
+  assign data_out = data_out_loc;
+end
+endgenerate
+
+endmodule
+
+

--- a/library/common/tb/ad_mux_tb
+++ b/library/common/tb/ad_mux_tb
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+SOURCE="ad_mux_tb.v"
+SOURCE+=" ../ad_mux.v"
+SOURCE+=" ../ad_mux_core.v"
+
+cd `dirname $0`
+source run_tb.sh

--- a/library/common/tb/ad_mux_tb.v
+++ b/library/common/tb/ad_mux_tb.v
@@ -9,7 +9,7 @@ module ad_mux_tb;
   parameter EN_REG = 1;   // Enable register at output of each mux
 
   localparam MUX_SZ = CH_CNT < REQ_MUX_SZ ? CH_CNT : REQ_MUX_SZ;
-  localparam NUM_STAGES = $clog2(CH_CNT) / $clog2(MUX_SZ);
+  localparam NUM_STAGES = $clog2(CH_CNT) / $clog2(MUX_SZ) + |($clog2(CH_CNT) % $clog2(MUX_SZ));
   localparam DW = CH_W*CH_CNT;
 
   `include "tb_base.v"

--- a/library/common/tb/ad_mux_tb.v
+++ b/library/common/tb/ad_mux_tb.v
@@ -1,0 +1,71 @@
+`timescale 1ns/100ps
+
+module ad_mux_tb;
+  parameter VCD_FILE = "ad_mux_tb.vcd";
+
+  parameter CH_W = 16;   // Width of input channel
+  parameter CH_CNT = 64;  // Number of input channels
+  parameter REQ_MUX_SZ = 8;  // Size of mux which acts as a building block
+  parameter EN_REG = 1;   // Enable register at output of each mux
+
+  localparam MUX_SZ = CH_CNT < REQ_MUX_SZ ? CH_CNT : REQ_MUX_SZ;
+  localparam NUM_STAGES = $clog2(CH_CNT) / $clog2(MUX_SZ);
+  localparam DW = CH_W*CH_CNT;
+
+  `include "tb_base.v"
+
+  reg [CH_W*CH_CNT-1:0] data_in = 'h0;
+  reg [$clog2(CH_CNT)-1:0] ch_sel = 'h0;
+  wire [CH_W-1:0] data_out;
+
+  ad_mux #(
+    .CH_W(CH_W),
+    .CH_CNT(CH_CNT),
+    .REQ_MUX_SZ(REQ_MUX_SZ),
+    .EN_REG(EN_REG)
+  ) DUT (
+    .clk(clk),
+    .data_in(data_in),
+    .ch_sel(ch_sel),
+    .data_out(data_out)
+  );
+
+  wire [CH_W-1:0] ref_data;
+  generate
+  if (EN_REG) begin
+    integer ii;
+    reg [CH_W*CH_CNT-1:0] mux_pln [1:NUM_STAGES];
+    always @(posedge clk) begin
+      mux_pln[1] <= data_in >> ch_sel*CH_W;
+      for (ii=2; ii<=NUM_STAGES; ii=ii+1) begin
+        mux_pln[ii] <= mux_pln[ii-1];
+      end
+    end
+    assign ref_data = mux_pln[NUM_STAGES];
+  end else begin
+    assign ref_data = data_in >> ch_sel*CH_W;
+  end
+  endgenerate
+
+  integer i;
+  initial begin
+    for (i=0; i<CH_W*CH_CNT/8; i=i+1) begin
+      data_in[i*8+:8] = i[7:0];
+    end
+
+    for (i=0; i<CH_CNT; i=i+1) begin
+      @(posedge clk);
+      ch_sel <= ch_sel + 1;
+    end
+  end
+
+  wire mismatch;
+  assign mismatch = ref_data !== data_out;
+
+  always @(posedge clk) begin
+    if (mismatch) begin
+      failed <= 1'b1;
+    end
+  end
+
+endmodule

--- a/library/common/tb/run_tb.sh
+++ b/library/common/tb/run_tb.sh
@@ -1,0 +1,24 @@
+NAME=`basename $0`
+
+case "$SIMULATOR" in
+	  modelsim)
+  		# ModelSim flow
+  		vlib work
+  		vlog ${SOURCE} || exit 1
+  		vsim ${NAME} -do "add log /* -r; run -a" -gui || exit 1
+		;;
+  	xsim)
+  		# xsim flow
+  		xvlog -log ${NAME}_xvlog.log --sourcelibdir . ${SOURCE}
+  		xelab -log ${NAME}_xelab.log -debug all ${NAME}
+  		xsim work.${NAME} -R
+		;;
+	  *)
+      mkdir -p run
+      mkdir -p vcd
+      iverilog ${SOURCE} -o run/run_${NAME} $1 || exit 1
+  
+      cd vcd
+      ../run/run_${NAME}
+	  ;;
+esac

--- a/library/common/tb/tb_base.v
+++ b/library/common/tb/tb_base.v
@@ -1,0 +1,86 @@
+//
+// The ADI JESD204 Core is released under the following license, which is
+// different than all other HDL cores in this repository.
+//
+// Please read this, and understand the freedoms and responsibilities you have
+// by using this source code/core.
+//
+// The JESD204 HDL, is copyright © 2016-2017 Analog Devices Inc.
+//
+// This core is free software, you can use run, copy, study, change, ask
+// questions about and improve this core. Distribution of source, or resulting
+// binaries (including those inside an FPGA or ASIC) require you to release the
+// source of the entire project (excluding the system libraries provide by the
+// tools/compiler/FPGA vendor). These are the terms of the GNU General Public
+// License version 2 as published by the Free Software Foundation.
+//
+// This core  is distributed in the hope that it will be useful, but WITHOUT ANY
+// WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+// A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License version 2
+// along with this source code, and binary.  If not, see
+// <http://www.gnu.org/licenses/>.
+//
+// Commercial licenses (with commercial support) of this JESD204 core are also
+// available under terms different than the General Public License. (e.g. they
+// do not require you to accompany any image (FPGA or ASIC) using the JESD204
+// core with any corresponding source code.) For these alternate terms you must
+// purchase a license from Analog Devices Technology Licensing Office. Users
+// interested in such a license should contact jesd204-licensing@analog.com for
+// more information. This commercial license is sub-licensable (if you purchase
+// chips from Analog Devices, incorporate them into your PCB level product, and
+// purchase a JESD204 license, end users of your product will also have a
+// license to use this core in a commercial setting without releasing their
+// source code).
+//
+// In addition, we kindly ask you to acknowledge ADI in any program, application
+// or publication in which you use this JESD204 HDL core. (You are not required
+// to do so; it is up to your common sense to decide whether you want to comply
+// with this request or not.) For general publications, we suggest referencing :
+// “The design and implementation of the JESD204 HDL Core used in this project
+// is copyright © 2016-2017, Analog Devices, Inc.”
+//
+
+  reg clk = 1'b0;
+  reg [3:0] reset_shift = 4'b1111;
+  reg trigger_reset = 1'b0;
+  wire reset;
+
+  reg failed = 1'b0;
+
+  initial
+  begin
+    $dumpfile (VCD_FILE);
+    $dumpvars;
+`ifdef TIMEOUT
+    #`TIMEOUT
+`else
+    #100000
+`endif
+    if (failed == 1'b0)
+      $display("SUCCESS");
+    else
+      $display("FAILED");
+    $finish;
+  end
+
+  always @(*) #10 clk <= ~clk;
+  always @(posedge clk) begin
+    if (trigger_reset == 1'b1) begin
+      reset_shift <= 3'b111;
+    end else begin
+      reset_shift <= {reset_shift[2:0],1'b0};
+    end
+  end
+
+  assign reset = reset_shift[3];
+
+
+
+  task do_trigger_reset;
+  begin
+    @(posedge clk) trigger_reset <= 1'b1;
+    @(posedge clk) trigger_reset <= 1'b0;
+  end
+  endtask

--- a/library/jesd204/ad_ip_jesd204_tpl_dac/Makefile
+++ b/library/jesd204/ad_ip_jesd204_tpl_dac/Makefile
@@ -5,6 +5,8 @@
 
 LIBRARY_NAME := ad_ip_jesd204_tpl_dac
 
+GENERIC_DEPS += ../../common/ad_mux.v
+GENERIC_DEPS += ../../common/ad_mux_core.v
 GENERIC_DEPS += ../../common/ad_dds.v
 GENERIC_DEPS += ../../common/ad_dds_1.v
 GENERIC_DEPS += ../../common/ad_dds_2.v

--- a/library/jesd204/ad_ip_jesd204_tpl_dac/ad_ip_jesd204_tpl_dac.v
+++ b/library/jesd204/ad_ip_jesd204_tpl_dac/ad_ip_jesd204_tpl_dac.v
@@ -40,7 +40,8 @@ module ad_ip_jesd204_tpl_dac #(
   parameter DDS_CORDIC_PHASE_DW = 16,
   parameter DATAPATH_DISABLE = 0,
   parameter IQCORRECTION_DISABLE = 1,
-  parameter EXT_SYNC = 0
+  parameter EXT_SYNC = 0,
+  parameter XBAR_ENABLE = 0
 ) (
   // jesd interface
   // link_clk is (line-rate/40)
@@ -112,9 +113,11 @@ module ad_ip_jesd204_tpl_dac #(
   wire [NUM_CHANNELS*16-1:0] dac_pat_data_0_s;
   wire [NUM_CHANNELS*16-1:0] dac_pat_data_1_s;
   wire [NUM_CHANNELS*4-1:0] dac_data_sel_s;
+  wire [NUM_CHANNELS-1:0] dac_mask_enable_s;
   wire [NUM_CHANNELS-1:0]  dac_iqcor_enb;
   wire [NUM_CHANNELS*16-1:0] dac_iqcor_coeff_1;
   wire [NUM_CHANNELS*16-1:0] dac_iqcor_coeff_2;
+  wire [NUM_CHANNELS*8-1:0] dac_src_chan_sel;
 
   // regmap
 
@@ -122,6 +125,7 @@ module ad_ip_jesd204_tpl_dac #(
     .ID (ID),
     .DATAPATH_DISABLE (DATAPATH_DISABLE),
     .IQCORRECTION_DISABLE (IQCORRECTION_DISABLE),
+    .XBAR_ENABLE (XBAR_ENABLE),
     .FPGA_TECHNOLOGY (FPGA_TECHNOLOGY),
     .FPGA_FAMILY (FPGA_FAMILY),
     .SPEED_GRADE (SPEED_GRADE),
@@ -170,10 +174,13 @@ module ad_ip_jesd204_tpl_dac #(
     .dac_pat_data_0 (dac_pat_data_0_s),
     .dac_pat_data_1 (dac_pat_data_1_s),
     .dac_data_sel (dac_data_sel_s),
+    .dac_mask_enable (dac_mask_enable_s),
 
     .dac_iqcor_enb (dac_iqcor_enb),
     .dac_iqcor_coeff_1 (dac_iqcor_coeff_1),
     .dac_iqcor_coeff_2 (dac_iqcor_coeff_2),
+
+    .dac_src_chan_sel (dac_src_chan_sel),
 
     .jesd_m (NUM_CHANNELS),
     .jesd_l (NUM_LANES),
@@ -189,6 +196,7 @@ module ad_ip_jesd204_tpl_dac #(
   ad_ip_jesd204_tpl_dac_core #(
     .DATAPATH_DISABLE (DATAPATH_DISABLE),
     .IQCORRECTION_DISABLE (IQCORRECTION_DISABLE),
+    .XBAR_ENABLE (XBAR_ENABLE),
     .NUM_LANES (NUM_LANES),
     .NUM_CHANNELS (NUM_CHANNELS),
     .BITS_PER_SAMPLE (BITS_PER_SAMPLE),
@@ -228,10 +236,13 @@ module ad_ip_jesd204_tpl_dac #(
     .dac_pat_data_0 (dac_pat_data_0_s),
     .dac_pat_data_1 (dac_pat_data_1_s),
     .dac_data_sel (dac_data_sel_s),
+    .dac_mask_enable (dac_mask_enable_s),
 
     .dac_iqcor_enb (dac_iqcor_enb),
     .dac_iqcor_coeff_1 (dac_iqcor_coeff_1),
-    .dac_iqcor_coeff_2 (dac_iqcor_coeff_2)
+    .dac_iqcor_coeff_2 (dac_iqcor_coeff_2),
+
+    .dac_src_chan_sel (dac_src_chan_sel)
 
   );
 

--- a/library/jesd204/ad_ip_jesd204_tpl_dac/ad_ip_jesd204_tpl_dac_channel.v
+++ b/library/jesd204/ad_ip_jesd204_tpl_dac/ad_ip_jesd204_tpl_dac_channel.v
@@ -52,6 +52,7 @@ module ad_ip_jesd204_tpl_dac_channel #(
   input dac_dds_format,
 
   input [3:0] dac_data_sel,
+  input       dac_mask_enable,
 
   input [15:0] dac_dds_scale_0,
   input [15:0] dac_dds_init_0,
@@ -127,15 +128,16 @@ module ad_ip_jesd204_tpl_dac_channel #(
   // dac data select
 
   always @(posedge clk) begin
-    dac_enable <= (dac_data_sel == 4'h2) ? 1'b1 : 1'b0;
-    case (dac_data_sel)
-      4'h7: dac_data <= pn15_data;
-      4'h6: dac_data <= pn7_data;
-      4'h5: dac_data <= ~pn15_data;
-      4'h4: dac_data <= ~pn7_data;
-      4'h3: dac_data <= 'h00;
-      4'h2: dac_data <= dac_iqcor_data_s;
-      4'h1: dac_data <= dac_pat_data_s;
+    dac_enable <= dac_mask_enable ? 1'b0 : (dac_data_sel == 4'h2);
+    casex ({dac_mask_enable,dac_data_sel})
+      5'h07: dac_data <= pn15_data;
+      5'h06: dac_data <= pn7_data;
+      5'h05: dac_data <= ~pn15_data;
+      5'h04: dac_data <= ~pn7_data;
+      5'h03: dac_data <= 'h00;
+      5'h02: dac_data <= dac_iqcor_data_s;
+      5'h01: dac_data <= dac_pat_data_s;
+      5'h1x: dac_data <= dac_iqcor_data_s;
       default: dac_data <= dac_dds_data_s;
     endcase
   end

--- a/library/jesd204/ad_ip_jesd204_tpl_dac/ad_ip_jesd204_tpl_dac_core.v
+++ b/library/jesd204/ad_ip_jesd204_tpl_dac/ad_ip_jesd204_tpl_dac_core.v
@@ -26,6 +26,7 @@
 module ad_ip_jesd204_tpl_dac_core #(
   parameter DATAPATH_DISABLE = 0,
   parameter IQCORRECTION_DISABLE = 1,
+  parameter XBAR_ENABLE = 1,
   parameter NUM_LANES = 1,
   parameter NUM_CHANNELS = 1,
   parameter BITS_PER_SAMPLE = 16,
@@ -62,6 +63,7 @@ module ad_ip_jesd204_tpl_dac_core #(
   input dac_dds_format,
 
   input [NUM_CHANNELS*4-1:0] dac_data_sel,
+  input [NUM_CHANNELS-1:0]   dac_mask_enable,
 
   input [NUM_CHANNELS*16-1:0] dac_dds_scale_0,
   input [NUM_CHANNELS*16-1:0] dac_dds_init_0,
@@ -77,6 +79,8 @@ module ad_ip_jesd204_tpl_dac_core #(
   input [NUM_CHANNELS*16-1:0] dac_iqcor_coeff_1,
   input [NUM_CHANNELS*16-1:0] dac_iqcor_coeff_2,
 
+  input [NUM_CHANNELS*8-1:0] dac_src_chan_sel,
+
   output [NUM_CHANNELS-1:0] enable
 );
 
@@ -86,6 +90,7 @@ module ad_ip_jesd204_tpl_dac_core #(
 
 
   wire [DAC_DATA_WIDTH-1:0] dac_data_s;
+  wire [DMA_DATA_WIDTH-1:0] dac_ddata_muxed;
 
   wire [DAC_CDW-1:0] pn7_data;
   wire [DAC_CDW-1:0] pn15_data;
@@ -151,6 +156,25 @@ module ad_ip_jesd204_tpl_dac_core #(
     localparam IQ_PAIR_CH_INDEX = (NUM_CHANNELS%2) ? i :
                                   (i%2) ? i-1 : i+1;
 
+
+    if (XBAR_ENABLE == 1) begin
+
+      // NUM_CHANNELS : 1  mux
+      ad_mux #(
+        .CH_W (DMA_CDW),
+        .CH_CNT (NUM_CHANNELS),
+        .EN_REG (1)
+      ) channel_mux (
+        .clk (clk),
+        .data_in (dac_ddata),
+        .ch_sel (dac_src_chan_sel[8*i+:8]),
+        .data_out (dac_ddata_muxed[DMA_CDW*i+:DMA_CDW])
+      );
+
+    end else begin
+      assign dac_ddata_muxed[DMA_CDW*i+:DMA_CDW] = dac_ddata[DMA_CDW*i+:DMA_CDW];
+    end
+
     ad_ip_jesd204_tpl_dac_channel #(
       .DATA_PATH_WIDTH (DATA_PATH_WIDTH),
       .CONVERTER_RESOLUTION (CONVERTER_RESOLUTION),
@@ -165,7 +189,7 @@ module ad_ip_jesd204_tpl_dac_core #(
       .clk (clk),
       .dac_enable (enable[i]),
       .dac_data (dac_data_s[DAC_CDW*i+:DAC_CDW]),
-      .dma_data (dac_ddata[DMA_CDW*i+:DMA_CDW]),
+      .dma_data (dac_ddata_muxed[DMA_CDW*i+:DMA_CDW]),
 
       .pn7_data (pn7_data),
       .pn15_data (pn15_data),
@@ -174,6 +198,7 @@ module ad_ip_jesd204_tpl_dac_core #(
       .dac_dds_format (dac_dds_format),
 
       .dac_data_sel (dac_data_sel[4*i+:4]),
+      .dac_mask_enable (dac_mask_enable[i]),
 
       .dac_dds_scale_0 (dac_dds_scale_0[16*i+:16]),
       .dac_dds_init_0 (dac_dds_init_0[16*i+:16]),
@@ -188,7 +213,7 @@ module ad_ip_jesd204_tpl_dac_core #(
       .dac_iqcor_enb (dac_iqcor_enb[i]),
       .dac_iqcor_coeff_1 (dac_iqcor_coeff_1[16*i+:16]),
       .dac_iqcor_coeff_2 (dac_iqcor_coeff_2[16*i+:16]),
-      .dac_iqcor_data_in (dac_ddata[DMA_CDW*IQ_PAIR_CH_INDEX+:DMA_CDW])
+      .dac_iqcor_data_in (dac_ddata_muxed[DMA_CDW*IQ_PAIR_CH_INDEX+:DMA_CDW])
 
     );
   end

--- a/library/jesd204/ad_ip_jesd204_tpl_dac/ad_ip_jesd204_tpl_dac_hw.tcl
+++ b/library/jesd204/ad_ip_jesd204_tpl_dac/ad_ip_jesd204_tpl_dac_hw.tcl
@@ -29,6 +29,8 @@ ad_ip_create ad_ip_jesd204_tpl_dac "JESD204 Transport Layer for DACs" p_ad_ip_je
 set_module_property VALIDATION_CALLBACK p_ad_ip_jesd204_tpl_dac_validate
 ad_ip_files ad_ip_jesd204_tpl_dac [list \
   $ad_hdl_dir/library/intel/common/ad_mul.v \
+  $ad_hdl_dir/library/common/ad_mux.v \
+  $ad_hdl_dir/library/common/ad_mux_core.v \
   $ad_hdl_dir/library/common/ad_dds_sine.v \
   $ad_hdl_dir/library/common/ad_dds_cordic_pipe.v \
   $ad_hdl_dir/library/common/ad_dds_sine_cordic.v \
@@ -198,6 +200,11 @@ ad_ip_parameter DDS_CORDIC_PHASE_DW INTEGER 16 true [list \
   DISPLAY_NAME "CORDIC DDS Phase Width" \
   ALLOWED_RANGES {8:20} \
   UNITS bits \
+  GROUP $group \
+]
+
+ad_ip_parameter XBAR_ENABLE boolean 0 true [list \
+  DISPLAY_NAME "Channel Crossbar Enable" \
   GROUP $group \
 ]
 

--- a/library/jesd204/ad_ip_jesd204_tpl_dac/ad_ip_jesd204_tpl_dac_ip.tcl
+++ b/library/jesd204/ad_ip_jesd204_tpl_dac/ad_ip_jesd204_tpl_dac_ip.tcl
@@ -27,6 +27,8 @@ source $ad_hdl_dir/library/scripts/adi_ip_xilinx.tcl
 adi_ip_create ad_ip_jesd204_tpl_dac
 adi_ip_files ad_ip_jesd204_tpl_dac [list \
   "$ad_hdl_dir/library/xilinx/common/ad_mul.v" \
+  "$ad_hdl_dir/library/common/ad_mux.v" \
+  "$ad_hdl_dir/library/common/ad_mux_core.v" \
   "$ad_hdl_dir/library/common/ad_dds_sine.v" \
   "$ad_hdl_dir/library/common/ad_dds_cordic_pipe.v" \
   "$ad_hdl_dir/library/common/ad_dds_sine_cordic.v" \
@@ -147,6 +149,7 @@ foreach {k v w} {
   "DATAPATH_DISABLE" "Disable Datapath" "checkBox" \
   "EXT_SYNC" "Enable external SYNC" "checkBox" \
   "IQCORRECTION_DISABLE" "Disable IQ Correction" "checkBox" \
+  "XBAR_ENABLE" "Enable user data XBAR" "checkBox" \
   "DDS_TYPE" "DDS Type" "comboBox" \
   "DDS_CORDIC_DW" "CORDIC DDS Data Width" "text" \
   "DDS_CORDIC_PHASE_DW" "CORDIC DDS Phase Width" "text" \

--- a/library/jesd204/ad_ip_jesd204_tpl_dac/ad_ip_jesd204_tpl_dac_regmap.v
+++ b/library/jesd204/ad_ip_jesd204_tpl_dac/ad_ip_jesd204_tpl_dac_regmap.v
@@ -27,6 +27,7 @@ module ad_ip_jesd204_tpl_dac_regmap #(
   parameter ID = 0,
   parameter DATAPATH_DISABLE = 0,
   parameter IQCORRECTION_DISABLE = 1,
+  parameter XBAR_ENABLE = 0,
   parameter FPGA_TECHNOLOGY = 0,
   parameter FPGA_FAMILY = 0,
   parameter SPEED_GRADE = 0,
@@ -71,6 +72,7 @@ module ad_ip_jesd204_tpl_dac_regmap #(
   input dac_sync_in_status,
 
   output [NUM_CHANNELS*4-1:0] dac_data_sel,
+  output [NUM_CHANNELS-1:0] dac_mask_enable,
   output dac_dds_format,
 
   output [NUM_CHANNELS*16-1:0] dac_dds_scale_0,
@@ -86,6 +88,8 @@ module ad_ip_jesd204_tpl_dac_regmap #(
   output [NUM_CHANNELS-1:0]  dac_iqcor_enb,
   output [NUM_CHANNELS*16-1:0] dac_iqcor_coeff_1,
   output [NUM_CHANNELS*16-1:0] dac_iqcor_coeff_2,
+
+  output [NUM_CHANNELS*8-1:0] dac_src_chan_sel,
 
   // Framer interface
   input [NUM_PROFILES*8-1: 0] jesd_m,
@@ -183,11 +187,15 @@ module ad_ip_jesd204_tpl_dac_regmap #(
   end
 
   // dac common processor interface
+  //
+  localparam CONFIG = (XBAR_ENABLE << 10) ||
+                      (DATAPATH_DISABLE << 6) ||
+                      (IQCORRECTION_DISABLE << 0);
 
   up_dac_common #(
     .COMMON_ID(6'h0),
     .ID (ID),
-    .CONFIG((DATAPATH_DISABLE << 6) | (IQCORRECTION_DISABLE << 0)),
+    .CONFIG(CONFIG),
     .FPGA_TECHNOLOGY (FPGA_TECHNOLOGY),
     .FPGA_FAMILY (FPGA_FAMILY),
     .SPEED_GRADE (SPEED_GRADE),
@@ -246,8 +254,10 @@ module ad_ip_jesd204_tpl_dac_regmap #(
     up_dac_channel #(
       .COMMON_ID(6'h1 + i/16),
       .CHANNEL_ID (i % 16),
+      .CHANNEL_NUMBER (i),
       .USERPORTS_DISABLE (1),
-      .IQCORRECTION_DISABLE (IQCORRECTION_DISABLE)
+      .IQCORRECTION_DISABLE (IQCORRECTION_DISABLE),
+      .XBAR_ENABLE (XBAR_ENABLE)
     ) i_up_dac_channel (
       .dac_clk (link_clk),
       .dac_rst (dac_rst),
@@ -260,10 +270,12 @@ module ad_ip_jesd204_tpl_dac_regmap #(
       .dac_pat_data_1 (dac_pat_data_0[16*i+:16]),
       .dac_pat_data_2 (dac_pat_data_1[16*i+:16]),
       .dac_data_sel (dac_data_sel[4*i+:4]),
+      .dac_mask_enable (dac_mask_enable[i]),
       .dac_iq_mode (),
       .dac_iqcor_enb (dac_iqcor_enb[i]),
       .dac_iqcor_coeff_1 (dac_iqcor_coeff_1[16*i+:16]),
       .dac_iqcor_coeff_2 (dac_iqcor_coeff_2[16*i+:16]),
+      .dac_src_chan_sel (dac_src_chan_sel[8*i+:8]),
       .up_usr_datatype_be (),
       .up_usr_datatype_signed (),
       .up_usr_datatype_shift (),

--- a/projects/ad9081_fmca_ebz/common/ad9081_fmca_ebz_bd.tcl
+++ b/projects/ad9081_fmca_ebz/common/ad9081_fmca_ebz_bd.tcl
@@ -230,6 +230,7 @@ adi_tpl_jesd204_tx_create tx_mxfe_tpl_core $TX_NUM_OF_LANES \
                                            $DATAPATH_WIDTH
 
 ad_ip_parameter tx_mxfe_tpl_core/dac_tpl_core CONFIG.IQCORRECTION_DISABLE 0
+ad_ip_parameter tx_mxfe_tpl_core/dac_tpl_core CONFIG.XBAR_ENABLE 1
 
 ad_ip_instance util_upack2 util_mxfe_upack [list \
   NUM_OF_CHANNELS $TX_NUM_OF_CONVERTERS \


### PR DESCRIPTION
This series of changed adds channel crossbar to DAC TPL selectable through synthesis parameter. 
The capability is discoverable by the software through the config register. 

The crossbar is an N to N mux,  implemented with pipelined muxes. 

Allows routing any channel to any, or one to many to broadcast the same channel to all converters.
Each converter has a register which defines the source of the data from the DMA interface, 

Tested with MxFE. 
Tested compile only DAQ2/A10SOC
