### PR TITLE
sysid_intel: Fixed axi_sysid module name

### DIFF
--- a/library/axi_sysid/axi_sysid.v
+++ b/library/axi_sysid/axi_sysid.v
@@ -1,6 +1,6 @@
 `timescale 1ns / 1ps
 
-module sys_id #(
+module axi_sysid #(
   parameter ROM_WIDTH = 32,
   parameter ROM_ADDR_BITS = 9)(
 


### PR DESCRIPTION
fixes critical warning reported by lnagy