### PR TITLE
scripts/xilinx: Version mismatch is upgraded to ERROR

### DIFF
--- a/library/scripts/adi_ip_xilinx.tcl
+++ b/library/scripts/adi_ip_xilinx.tcl
@@ -264,10 +264,20 @@ proc adi_ip_create {ip_name} {
   global IGNORE_VERSION_CHECK
 
   set VIVADO_VERSION [version -short]
-  if {[string compare $VIVADO_VERSION $REQUIRED_VIVADO_VERSION] != 0} {
-    puts -nonewline "CRITICAL WARNING: vivado version mismatch; "
-    puts -nonewline "expected $REQUIRED_VIVADO_VERSION, "
-    puts -nonewline "got $VIVADO_VERSION.\n"
+  if {$IGNORE_VERSION_CHECK} {
+    if {[string compare $VIVADO_VERSION $REQUIRED_VIVADO_VERSION] != 0} {
+      puts -nonewline "CRITICAL WARNING: vivado version mismatch; "
+      puts -nonewline "expected $REQUIRED_VIVADO_VERSION, "
+      puts -nonewline "got $VIVADO_VERSION.\n"
+    }
+  } else {
+    if {[string compare $VIVADO_VERSION $REQUIRED_VIVADO_VERSION] != 0} {
+      puts -nonewline "ERROR: vivado version mismatch; "
+      puts -nonewline "expected $REQUIRED_VIVADO_VERSION, "
+      puts -nonewline "got $VIVADO_VERSION.\n"
+      puts -nonewline "This ERROR message can be down-graded to CRITICAL WARNING by setting ADI_IGNORE_VERSION_CHECK environment variable to 1. Be aware that ADI will not support you, if you are using a different tool version.\n"
+      exit 2
+    }
   }
 
   create_project $ip_name . -force

--- a/projects/scripts/adi_project_xilinx.tcl
+++ b/projects/scripts/adi_project_xilinx.tcl
@@ -119,10 +119,20 @@ proc adi_project {project_name {mode 0} {parameter_list {}} } {
   }
 
   set VIVADO_VERSION [version -short]
-  if {[string compare $VIVADO_VERSION $REQUIRED_VIVADO_VERSION] != 0} {
-    puts -nonewline "CRITICAL WARNING: vivado version mismatch; "
-    puts -nonewline "expected $REQUIRED_VIVADO_VERSION, "
-    puts -nonewline "got $VIVADO_VERSION.\n"
+  if {$IGNORE_VERSION_CHECK} {
+    if {[string compare $VIVADO_VERSION $REQUIRED_VIVADO_VERSION] != 0} {
+      puts -nonewline "CRITICAL WARNING: vivado version mismatch; "
+      puts -nonewline "expected $REQUIRED_VIVADO_VERSION, "
+      puts -nonewline "got $VIVADO_VERSION.\n"
+    }
+  } else {
+    if {[string compare $VIVADO_VERSION $REQUIRED_VIVADO_VERSION] != 0} {
+      puts -nonewline "ERROR: vivado version mismatch; "
+      puts -nonewline "expected $REQUIRED_VIVADO_VERSION, "
+      puts -nonewline "got $VIVADO_VERSION.\n"
+      puts -nonewline "This ERROR message can be down-graded to CRITICAL WARNING by setting ADI_IGNORE_VERSION_CHECK environment variable to 1. Be aware that ADI will not support you, if you are using a different tool version.\n"
+      exit 2
+    }
   }
 
   if {$mode == 0} {


### PR DESCRIPTION
There is a major compatibility issue between 2019.1 and 2019.2.

The file system_top.hdf got a different file extention. This will
cause a compilation failer in the end of the build. To save time
and fail earlier, upgrade the version mismatch message to ERROR.

If user still wants to build a branch with different tool version
the variable ADI_IGNORE_VERSION_CHECK should be set to 1.