### PR TITLE
scripts/adi_env.tcl: print in logs system variables are used

### DIFF
--- a/projects/scripts/adi_env.tcl
+++ b/projects/scripts/adi_env.tcl
@@ -22,6 +22,7 @@ if [info exists ::env(ADI_GHDL_DIR)] {
 #  default_value - returned vale in case environment variable does not exists
 proc get_env_param {name default_value} {
   if [info exists ::env($name)] {
+    puts "Getting from environment the parameter: $name=$::env($name) "
     return $::env($name)
   } else {
     return $default_value


### PR DESCRIPTION
When building parameterizable projects the value of the variables does not show up in the build log. 
This patch should fix that. 

