### PR TITLE
M2k trigger disable condition

### DIFF
--- a/library/axi_adc_trigger/axi_adc_trigger.v
+++ b/library/axi_adc_trigger/axi_adc_trigger.v
@@ -479,7 +479,8 @@ module axi_adc_trigger #(
       4'h6: trigger_out_mixed = trigger_a | trigger_in;
       4'h7: trigger_out_mixed = trigger_b | trigger_in;
       4'h8: trigger_out_mixed = trigger_a | trigger_b | trigger_in;
-      default: trigger_out_mixed = trigger_a;
+      4'hf: trigger_out_mixed = 1'b0; // trigger disable
+      default: trigger_out_mixed = 1'b0;
     endcase
   end
 

--- a/library/axi_logic_analyzer/axi_logic_analyzer_trigger.v
+++ b/library/axi_logic_analyzer/axi_logic_analyzer_trigger.v
@@ -121,7 +121,8 @@ module axi_logic_analyzer_trigger (
       3'd2: trigger_active_mux = trigger_active & trigger_in;
       3'd3: trigger_active_mux = trigger_active | trigger_in;
       3'd4: trigger_active_mux = trigger_active ^ trigger_in;
-      default: trigger_active_mux = 1'b1;
+      3'd7: trigger_active_mux = 1'b0; // trigger disable
+      default: trigger_active_mux = 1'b0;
     endcase
   end
 


### PR DESCRIPTION
Add trigger disable option for both ADC and Logic Analyzer instruments.
Tested on m2k.