### PR TITLE
spi_engine: Add SPI Engine Intel Support

### DIFF
--- a/library/spi_engine/axi_spi_engine/axi_spi_engine_constr.sdc
+++ b/library/spi_engine/axi_spi_engine/axi_spi_engine_constr.sdc
@@ -1,0 +1,4 @@
+
+set_false_path  \
+  -to [get_registers  *cdc_sync_stage1*]
+

--- a/library/spi_engine/axi_spi_engine/axi_spi_engine_hw.tcl
+++ b/library/spi_engine/axi_spi_engine/axi_spi_engine_hw.tcl
@@ -1,0 +1,136 @@
+
+package require qsys
+source ../../scripts/adi_env.tcl
+source ../../scripts/adi_ip_intel.tcl
+
+ad_ip_create axi_spi_engine {AXI SPI Engine} p_elaboration
+ad_ip_files axi_spi_engine [list\
+  $ad_hdl_dir/library/util_axis_fifo/util_axis_fifo.v \
+  $ad_hdl_dir/library/util_axis_fifo/address_sync.v \
+  $ad_hdl_dir/library/util_axis_fifo/address_gray_pipelined.v \
+  $ad_hdl_dir/library/util_axis_fifo/address_gray.v \
+  $ad_hdl_dir/library/util_cdc/sync_bits.v \
+  $ad_hdl_dir/library/util_cdc/sync_gray.v \
+  $ad_hdl_dir/library/common/ad_mem.v \
+  $ad_hdl_dir/library/common/up_axi.v \
+  $ad_hdl_dir/library/common/ad_rst.v \
+  $ad_hdl_dir/library/intel/common/up_rst_constr.sdc \
+  axi_spi_engine_constr.sdc \
+  axi_spi_engine.v]
+
+# parameters
+
+ad_ip_parameter CMD_FIFO_ADDRESS_WIDTH INTEGER 4
+ad_ip_parameter SYNC_FIFO_ADDRESS_WIDTH INTEGER 4
+ad_ip_parameter SDO_FIFO_ADDRESS_WIDTH INTEGER 5
+ad_ip_parameter SDI_FIFO_ADDRESS_WIDTH INTEGER 5
+ad_ip_parameter MM_IF_TYPE INTEGER 1
+ad_ip_parameter ASYNC_SPI_CLK INTEGER 0
+ad_ip_parameter NUM_OFFLOAD INTEGER 1
+ad_ip_parameter OFFLOAD0_CMD_MEM_ADDRESS_WIDTH INTEGER 4
+ad_ip_parameter OFFLOAD0_SDO_MEM_ADDRESS_WIDTH INTEGER 4
+ad_ip_parameter ID INTEGER 0
+ad_ip_parameter DATA_WIDTH INTEGER 8
+ad_ip_parameter NUM_OF_SDI INTEGER 1
+
+proc p_elaboration {} {
+
+  # read parameters
+
+  set mm_if_type [get_parameter_value "MM_IF_TYPE"]
+
+  set num_of_sdi [get_parameter_value NUM_OF_SDI]
+  set data_width [get_parameter_value DATA_WIDTH]
+
+  # interrupt
+
+  add_interface interrupt_sender interrupt end
+  add_interface_port interrupt_sender irq irq Output 1
+
+  if {$mm_if_type} {
+
+    # Microprocessor interface
+
+    ad_interface clock   up_clk    input                  1
+    ad_interface reset   up_rstn   input                  1   if_up_clk
+    ad_interface signal  up_wreq   input                  1
+    ad_interface signal  up_wack   output                 1
+    ad_interface signal  up_waddr  input                 14
+    ad_interface signal  up_wdata  input                 32
+    ad_interface signal  up_rreq   input                  1
+    ad_interface signal  up_rack   output                 1
+    ad_interface signal  up_raddr  output                14
+    ad_interface signal  up_rdata  output                32
+
+  } else {
+
+    # AXI Memory Mapped interface
+
+    ad_ip_intf_s_axi s_axi_aclk s_axi_aresetn 16
+
+    set_interface_property interrupt_sender associatedAddressablePoint s_axi
+    set_interface_property interrupt_sender associatedClock s_axi_clock
+    set_interface_property interrupt_sender associatedReset s_axi_reset
+    set_interface_property interrupt_sender ENABLED true
+
+  }
+
+  # SPI Engine interfaces
+
+  ad_interface clock spi_clk     input 1
+  ad_interface reset spi_resetn  output 1 if_spi_clk
+
+  add_interface cmd axi4stream start
+  add_interface_port cmd cmd_ready tready   input  1
+  add_interface_port cmd cmd_valid tvalid   output 1
+  add_interface_port cmd cmd_data  tdata    output 16
+
+  set_interface_property cmd associatedClock if_spi_clk
+  set_interface_property cmd associatedReset if_spi_resetn
+
+  add_interface sdo_data axi4stream start
+  add_interface_port sdo_data sdo_data_ready tready input  1
+  add_interface_port sdo_data sdo_data_valid tvalid output 1
+  add_interface_port sdo_data sdo_data       tdata  output $data_width
+
+  set_interface_property sdo_data associatedClock if_spi_clk
+  set_interface_property sdo_data associatedReset if_spi_resetn
+
+  add_interface sdi_data axi4stream end
+  add_interface_port sdi_data sdi_data_ready  tready output 1
+  add_interface_port sdi_data sdi_data_valid  tvalid input  1
+  add_interface_port sdi_data sdi_data        tdata  input [expr $num_of_sdi * $data_width]
+
+  set_interface_property sdi_data associatedClock if_spi_clk
+  set_interface_property sdi_data associatedReset if_spi_resetn
+
+  add_interface sync axi4stream end
+  add_interface_port sync sync_valid  tvalid input   1
+  add_interface_port sync sync_ready  tready output  1
+  add_interface_port sync sync_data   tdata  input   8
+
+  set_interface_property sync associatedClock if_spi_clk
+  set_interface_property sync associatedReset if_spi_resetn
+
+  # Offload interfaces
+
+  add_interface offload0_cmd conduit end
+  add_interface_port offload0_cmd offload0_cmd_wr_en    wre   output  1
+  add_interface_port offload0_cmd offload0_cmd_wr_data  data  output  16
+
+  set_interface_property offload0_cmd associatedClock if_spi_clk
+  set_interface_property offload0_cmd associatedReset none
+
+  add_interface offload0_sdo conduit end
+  add_interface_port offload0_sdo offload0_sdo_wr_en    wre   output  1
+  add_interface_port offload0_sdo offload0_sdo_wr_data  data  output  $data_width
+
+  set_interface_property offload0_sdo associatedClock if_spi_clk
+  set_interface_property offload0_sdo associatedReset none
+
+  ad_interface signal  offload0_mem_reset  output  1   reset
+  ad_interface signal  offload0_enable     output  1   enable
+  ad_interface signal  offload0_enabled    input   1   enabled
+
+}
+

--- a/library/spi_engine/spi_engine_execution/spi_engine_execution_hw.tcl
+++ b/library/spi_engine/spi_engine_execution/spi_engine_execution_hw.tcl
@@ -1,0 +1,84 @@
+
+package require qsys
+source ../../scripts/adi_env.tcl
+source ../../scripts/adi_ip_intel.tcl
+
+ad_ip_create spi_engine_execution {SPI Engine Execution}
+set_module_property ELABORATION_CALLBACK p_elaboration
+ad_ip_files spi_engine_execution [list\
+  spi_engine_execution.v]
+
+# parameters
+
+ad_ip_parameter NUM_OF_CS INTEGER 1
+ad_ip_parameter DEFAULT_SPI_CFG INTEGER 0
+ad_ip_parameter DEFAULT_CLK_DIV INTEGER 0
+ad_ip_parameter DATA_WIDTH INTEGER 8
+ad_ip_parameter NUM_OF_SDI INTEGER 1
+
+proc p_elaboration {} {
+
+  set data_width [get_parameter_value DATA_WIDTH]
+  set num_of_sdi [get_parameter_value NUM_OF_SDI]
+  set num_of_cs [get_parameter_value NUM_OF_CS]
+
+  # clock and reset interface
+
+  ad_interface clock   clk     input 1
+  ad_interface reset   resetn  input 1 if_clk
+
+  ad_interface signal active output 1
+
+  # command interface
+
+  add_interface cmd axi4stream end
+  add_interface_port cmd cmd_ready tready output 1
+  add_interface_port cmd cmd_valid tvalid input  1
+  add_interface_port cmd cmd       tdata  input  16
+
+  set_interface_property cmd associatedClock if_clk
+  set_interface_property cmd associatedReset if_resetn
+
+  # SDO data interface
+
+  add_interface sdo_data axi4stream end
+  add_interface_port sdo_data sdo_data_ready  tready output 1
+  add_interface_port sdo_data sdo_data_valid  tvalid input  1
+  add_interface_port sdo_data sdo_data        tdata  input  $data_width
+
+  set_interface_property sdo_data associatedClock if_clk
+  set_interface_property sdo_data associatedReset if_resetn
+
+  # SDI data interface
+
+  add_interface sdi_data axi4stream start
+  add_interface_port sdi_data sdi_data_ready  tready input  1
+  add_interface_port sdi_data sdi_data_valid  tvalid output 1
+  add_interface_port sdi_data sdi_data        tdata  output [expr $num_of_sdi * $data_width]
+
+  set_interface_property sdi_data associatedClock if_clk
+  set_interface_property sdi_data associatedReset if_resetn
+
+  # SYNC data interface
+
+  add_interface sync axi4stream start
+  add_interface_port sync sync_valid  tvalid output  1
+  add_interface_port sync sync_ready  tready input 1
+  add_interface_port sync sync        tdata  output  8
+
+  set_interface_property sync associatedClock if_clk
+  set_interface_property sync associatedReset if_resetn
+
+  # physical SPI interface
+
+  ad_interface clock sclk output 1
+
+  ad_interface signal sdo   output 1
+  ad_interface signal sdo_t output 1
+  ad_interface signal sdi   input  $num_of_sdi
+
+  ad_interface signal cs output 1
+  ad_interface signal three_wire output 1
+
+}
+

--- a/library/spi_engine/spi_engine_interconnect/spi_engine_interconnect_hw.tcl
+++ b/library/spi_engine/spi_engine_interconnect/spi_engine_interconnect_hw.tcl
@@ -1,0 +1,146 @@
+
+package require qsys
+source ../../scripts/adi_env.tcl
+source ../../scripts/adi_ip_intel.tcl
+
+ad_ip_create spi_engine_interconnect {SPI Engine Interconnect} p_elaboration
+ad_ip_files spi_engine_interconnect [list\
+  spi_engine_interconnect.v]
+
+# parameters
+
+ad_ip_parameter DATA_WIDTH INTEGER 8
+ad_ip_parameter NUM_OF_SDI INTEGER 1
+
+proc p_elaboration {} {
+
+  set data_width [get_parameter_value DATA_WIDTH]
+  set num_of_sdi [get_parameter_value NUM_OF_SDI]
+
+  # clock and reset interface
+
+  ad_interface clock clk     input 1 
+  ad_interface reset resetn  input 1 if_clk
+
+  # command master interface
+
+  add_interface m_cmd axi4stream start
+  add_interface_port m_cmd m_cmd_ready tready input  1
+  add_interface_port m_cmd m_cmd_valid tvalid output 1
+  add_interface_port m_cmd m_cmd_data  tdata  output 16
+
+  set_interface_property m_cmd associatedClock if_clk
+  set_interface_property m_cmd associatedReset if_resetn
+
+  # SDO data master interface
+
+  add_interface m_sdo axi4stream start
+  add_interface_port m_sdo m_sdo_ready tready input  1
+  add_interface_port m_sdo m_sdo_valid tvalid output 1
+  add_interface_port m_sdo m_sdo_data  tdata  output $data_width
+
+  set_interface_property m_sdo associatedClock if_clk
+  set_interface_property m_sdo associatedReset if_resetn
+
+  # SDI data master interface
+
+  add_interface m_sdi axi4stream end
+  add_interface_port m_sdi m_sdi_ready tready output 1
+  add_interface_port m_sdi m_sdi_valid tvalid input  1
+  add_interface_port m_sdi m_sdi_data  tdata  input  [expr $num_of_sdi * $data_width]
+
+  set_interface_property m_sdi associatedClock if_clk
+  set_interface_property m_sdi associatedReset if_resetn
+
+  # SYNC master interface
+
+  add_interface m_sync axi4stream end
+  add_interface_port m_sync m_sync_valid tvalid input  1
+  add_interface_port m_sync m_sync_ready tready output 1
+  add_interface_port m_sync m_sync       tdata  input  8
+
+  set_interface_property m_sync associatedClock if_clk
+  set_interface_property m_sync associatedReset if_resetn
+
+  # command slave0 interface
+
+  add_interface s0_cmd axi4stream end
+  add_interface_port s0_cmd s0_cmd_ready tready output 1
+  add_interface_port s0_cmd s0_cmd_valid tvalid input  1
+  add_interface_port s0_cmd s0_cmd_data  tdata  input  16
+
+  set_interface_property s0_cmd associatedClock if_clk
+  set_interface_property s0_cmd associatedReset if_resetn
+
+  # SDO data slave0 interface
+
+  add_interface s0_sdo axi4stream end
+  add_interface_port s0_sdo s0_sdo_ready tready output 1
+  add_interface_port s0_sdo s0_sdo_valid tvalid input  1
+  add_interface_port s0_sdo s0_sdo_data  tdata  input  $data_width
+
+  set_interface_property s0_sdo associatedClock if_clk
+  set_interface_property s0_sdo associatedReset if_resetn
+
+  # SDI data slave0 interface
+
+  add_interface s0_sdi axi4stream start
+  add_interface_port s0_sdi s0_sdi_ready tready input  1
+  add_interface_port s0_sdi s0_sdi_valid tvalid output 1
+  add_interface_port s0_sdi s0_sdi_data  tdata  output [expr $num_of_sdi * $data_width]
+
+  set_interface_property s0_sdi associatedClock if_clk
+  set_interface_property s0_sdi associatedReset if_resetn
+
+  # SYNC slave0 interface
+
+  add_interface s0_sync axi4stream start
+  add_interface_port s0_sync s0_sync_valid tvalid output 1
+  add_interface_port s0_sync s0_sync_ready tready input  1
+  add_interface_port s0_sync s0_sync       tdata  output 8
+
+  set_interface_property s0_sync associatedClock if_clk
+  set_interface_property s0_sync associatedReset if_resetn
+
+  # command slave1 interface
+
+  add_interface s1_cmd axi4stream end
+  add_interface_port s1_cmd s1_cmd_ready tready output 1
+  add_interface_port s1_cmd s1_cmd_valid tvalid input  1
+  add_interface_port s1_cmd s1_cmd_data  tdata  input  16
+
+  set_interface_property s1_cmd associatedClock if_clk
+  set_interface_property s1_cmd associatedReset if_resetn
+
+  # SDO data slave1 interface
+
+  add_interface s1_sdo axi4stream end
+  add_interface_port s1_sdo s1_sdo_ready tready output 1
+  add_interface_port s1_sdo s1_sdo_valid tvalid input  1
+  add_interface_port s1_sdo s1_sdo_data  tdata  input  $data_width
+
+  set_interface_property s1_sdo associatedClock if_clk
+  set_interface_property s1_sdo associatedReset if_resetn
+
+  # SDI data slave1 interface
+
+  add_interface s1_sdi axi4stream start
+  add_interface_port s1_sdi s1_sdi_ready tready input  1
+  add_interface_port s1_sdi s1_sdi_valid tvalid output 1
+  add_interface_port s1_sdi s1_sdi_data  tdata  output [expr $num_of_sdi * $data_width]
+
+  set_interface_property s1_sdi associatedClock if_clk
+  set_interface_property s1_sdi associatedReset if_resetn
+
+  # SYNC slave1 interface
+
+  add_interface s1_sync axi4stream start
+  add_interface_port s1_sync s1_sync_valid tvalid output 1
+  add_interface_port s1_sync s1_sync_ready tready input  1
+  add_interface_port s1_sync s1_sync       tdata  output 8
+
+  set_interface_property s1_sync associatedClock if_clk
+  set_interface_property s1_sync associatedReset if_resetn
+
+}
+

--- a/library/spi_engine/spi_engine_offload/spi_engine_offload_hw.tcl
+++ b/library/spi_engine/spi_engine_offload/spi_engine_offload_hw.tcl
@@ -1,0 +1,105 @@
+
+package require qsys
+source ../../scripts/adi_env.tcl
+source ../../scripts/adi_ip_intel.tcl
+
+ad_ip_create spi_engine_offload {SPI Engine Offload} p_elaboration
+ad_ip_files spi_engine_offload [list\
+  $ad_hdl_dir/library/util_cdc/sync_bits.v \
+  spi_engine_offload.v]
+
+# parameters
+
+ad_ip_parameter ASYNC_SPI_CLK INTEGER 0
+ad_ip_parameter ASYNC_TRIG INTEGER 0
+ad_ip_parameter CMD_MEM_ADDRESS_WIDTH INTEGER 4
+ad_ip_parameter SDO_MEM_ADDRESS_WIDTH INTEGER 4
+ad_ip_parameter DATA_WIDTH INTEGER 8
+ad_ip_parameter NUM_OF_SDI INTEGER 1
+
+proc p_elaboration {} {
+
+  set data_width [get_parameter_value DATA_WIDTH]
+  set num_of_sdi [get_parameter_value NUM_OF_SDI]
+
+  # control interface
+
+  ad_interface clock ctrl_clk input 1
+  ad_interface reset spi_resetn  input 1 if_spi_clk
+
+  add_interface ctrl_cmd_wr conduit end
+  add_interface_port ctrl_cmd_wr ctrl_cmd_wr_en    wre   input  1
+  add_interface_port ctrl_cmd_wr ctrl_cmd_wr_data  data  input 16
+
+  set_interface_property ctrl_cmd_wr associatedClock if_ctrl_clk
+  set_interface_property ctrl_cmd_wr associatedReset none
+
+  add_interface ctrl_sdo_wr conduit end
+  add_interface_port ctrl_sdo_wr ctrl_sdo_wr_en    wre   input  1
+  add_interface_port ctrl_sdo_wr ctrl_sdo_wr_data  data  input $data_width
+
+  set_interface_property ctrl_sdo_wr associatedClock if_ctrl_clk
+  set_interface_property ctrl_sdo_wr associatedReset none
+
+  ad_interface signal  ctrl_enable     input  1   enable
+  ad_interface signal  ctrl_enabled    output 1   enabled
+  ad_interface signal  ctrl_mem_reset  input  1   reset
+
+  # SPI Engine interfaces
+
+  ad_interface clock   spi_clk     input 1
+  ad_interface resetn  spi_resetn  input 1 if_spi_clk
+
+  ad_interface signal  trigger     input 1
+
+  ## command interface
+
+  add_interface cmd axi4stream start
+  add_interface_port cmd cmd_valid tvalid   output   1
+  add_interface_port cmd cmd_ready tready   input    1
+  add_interface_port cmd cmd       tdata    output   16
+
+  set_interface_property cmd associatedClock if_spi_clk
+  set_interface_property cmd associatedReset if_spi_resetn
+
+  ## SDO data interface
+
+  add_interface sdo_data axi4stream start
+  add_interface_port sdo_data sdo_data_valid  tvalid   output  1
+  add_interface_port sdo_data sdo_data_ready  tready   input   1
+  add_interface_port sdo_data sdo_data        tdata    output  $data_width
+
+  set_interface_property sdo_data associatedClock if_spi_clk
+  set_interface_property sdo_data associatedReset if_spi_resetn
+
+  ## SDI data interface
+
+  add_interface sdi_data axi4stream end
+  add_interface_port sdi_data sdi_data_valid  tvalid  input   1
+  add_interface_port sdi_data sdi_data_ready  tready  output  1
+  add_interface_port sdi_data sdi_data        tdata   input   [expr $num_of_sdi * $data_width]
+
+  set_interface_property sdi_data associatedClock if_spi_clk
+  set_interface_property sdi_data associatedReset if_spi_resetn
+
+  ## SYNC data interface
+
+  add_interface sync axi4stream end
+  add_interface_port sync sync_valid  tvalid input   1
+  add_interface_port sync sync_ready  tready output  1
+  add_interface_port sync sync_data   tdata  input   8
+
+  set_interface_property sync associatedClock if_spi_clk
+  set_interface_property sync associatedReset if_spi_resetn
+
+  ## Offload SDI data interface
+  
+  add_interface offload_sdi axi4stream start
+  add_interface_port offload_sdi offload_sdi_valid tvalid  output  1
+  add_interface_port offload_sdi offload_sdi_ready tready  input   1
+  add_interface_port offload_sdi offload_sdi_data  tdata   output  [expr $num_of_sdi * $data_width]
+
+  set_interface_property offload_sdi associatedClock if_spi_clk
+  set_interface_property offload_sdi associatedReset if_spi_resetn
+
+}


### PR DESCRIPTION
This commit contains the *_hw.tcl files for building the SPI Engine modules
for Intel projects. Also, a new set of constraints is added for the regmap module,
in order to meet timing.