### PR TITLE
Fix SPI Engine execution

### DIFF
--- a/library/spi_engine/spi_engine_execution/spi_engine_execution.v
+++ b/library/spi_engine/spi_engine_execution/spi_engine_execution.v
@@ -141,7 +141,7 @@ wire sdi_enabled = cmd_d1[9];
 
 reg [(DATA_WIDTH-1):0] data_sdo_shift = 'h0;
 
-reg [4:0] trigger_rx_d = 5'b0;
+reg [SDI_DELAY+1:0] trigger_rx_d = {(SDI_DELAY+1){1'b0}};
 
 wire [1:0] inst = cmd[13:12];
 wire [1:0] inst_d1 = cmd_d1[13:12];
@@ -391,13 +391,10 @@ assign sdo_int_s = data_sdo_shift[DATA_WIDTH-1];
 
 always @(posedge clk) begin
   trigger_rx_d[0] <= trigger_rx;
-  trigger_rx_d[4:1] <= trigger_rx_d[3:0];
+  trigger_rx_d[SDI_DELAY+1:1] <= trigger_rx_d[SDI_DELAY:0];
 end
 
-assign trigger_rx_s = (SDI_DELAY == 2'b00) ? trigger_rx_d[1] :
-                      (SDI_DELAY == 2'b01) ? trigger_rx_d[2] :
-                      (SDI_DELAY == 2'b10) ? trigger_rx_d[3] :
-                      (SDI_DELAY == 2'b11) ? trigger_rx_d[4] : trigger_rx_d[1];
+assign trigger_rx_s = trigger_rx_d[SDI_DELAY+1];
 
 // Load the serial data into SDI shift register(s), then link it to the output
 // register of the module

--- a/library/spi_engine/spi_engine_execution/spi_engine_execution.v
+++ b/library/spi_engine/spi_engine_execution/spi_engine_execution.v
@@ -136,8 +136,8 @@ reg cpha = DEFAULT_SPI_CFG[0];
 reg cpol = DEFAULT_SPI_CFG[1];
 reg [7:0] clk_div = DEFAULT_CLK_DIV;
 
-wire sdo_enabled = cmd_d1[8];
-wire sdi_enabled = cmd_d1[9];
+reg sdo_enabled = 1'b0;
+reg sdi_enabled = 1'b0;
 
 reg [(DATA_WIDTH-1):0] data_sdo_shift = 'h0;
 
@@ -168,6 +168,13 @@ wire trigger_rx_s;
 wire last_sdi_bit;
 
 assign cmd_ready = idle;
+
+always @(posedge clk) begin
+  if (exec_transfer_cmd) begin
+    sdo_enabled <= cmd[8];
+    sdi_enabled <= cmd[9];
+  end
+end
 
 always @(posedge clk) begin
   if (cmd_ready)


### PR DESCRIPTION
The SDI (MISO) latching did not work correctly if SDI_DELAY was set to a higher value than zero.

The following patches fix the issue.