### PR TITLE
SPI Engine: Add echoed SCLK support

### DIFF
--- a/library/spi_engine/scripts/spi_engine.tcl
+++ b/library/spi_engine/scripts/spi_engine.tcl
@@ -1,4 +1,4 @@
-proc spi_engine_create {{name "hier_spi_engine"} {data_width 32} {async_spi_clk 1} {num_cs 1} {num_sdi 1} {sdi_delay 2}} {
+proc spi_engine_create {{name "spi_engine"} {data_width 32} {async_spi_clk 1} {num_cs 1} {num_sdi 1} {sdi_delay 0}} {
 
   create_bd_cell -type hier $name
   current_bd_instance /$name

--- a/library/spi_engine/spi_axis_reorder/Makefile
+++ b/library/spi_engine/spi_axis_reorder/Makefile
@@ -1,0 +1,12 @@
+####################################################################################
+## Copyright 2020(c) Analog Devices, Inc.
+## Auto-generated, do not modify!
+####################################################################################
+
+LIBRARY_NAME := spi_axis_reorder
+
+GENERIC_DEPS += spi_axis_reorder.v
+
+XILINX_DEPS += spi_axis_reorder_ip.tcl
+
+include ../../scripts/library.mk

--- a/library/spi_engine/spi_axis_reorder/spi_axis_reorder.v
+++ b/library/spi_engine/spi_axis_reorder/spi_axis_reorder.v
@@ -1,0 +1,140 @@
+// ***************************************************************************
+// ***************************************************************************
+// Copyright 2014 - 2017 (c) Analog Devices, Inc. All rights reserved.
+//
+// In this HDL repository, there are many different and unique modules, consisting
+// of various HDL (Verilog or VHDL) components. The individual modules are
+// developed independently, and may be accompanied by separate and unique license
+// terms.
+//
+// The user should read each of these license terms, and understand the
+// freedoms and responsibilities that he or she has by using this source/core.
+//
+// This core is distributed in the hope that it will be useful, but WITHOUT ANY
+// WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+// A PARTICULAR PURPOSE.
+//
+// Redistribution and use of source or resulting binaries, with or without modification
+// of this file, are permitted under one of the following two license terms:
+//
+//   1. The GNU General Public License version 2 as published by the
+//      Free Software Foundation, which can be found in the top level directory
+//      of this repository (LICENSE_GPL2), and also online at:
+//      <https://www.gnu.org/licenses/old-licenses/gpl-2.0.html>
+//
+// OR
+//
+//   2. An ADI specific BSD license, which can be found in the top level directory
+//      of this repository (LICENSE_ADIBSD), and also on-line at:
+//      https://github.com/analogdevicesinc/hdl/blob/master/LICENSE_ADIBSD
+//      This will allow to generate bit files and not release the source code,
+//      as long as it attaches to an ADI device.
+//
+// ***************************************************************************
+// ***************************************************************************
+
+`timescale 1ns/100ps
+
+// Re-ordering module for ad463x devices (Flexi-SPI)
+//
+module ad463x_axis_reorder #(
+
+  parameter [3:0] NUM_OF_SDI = 2) (
+
+  input                          axis_aclk,
+  input                          axis_aresetn,
+
+  input                          s_axis_valid,
+  output                         s_axis_ready,
+  input [(NUM_OF_SDI * 32)-1:0]  s_axis_data,
+
+  output                         m_axis_valid,
+  input                          m_axis_ready,
+  output     [63:0]              m_axis_data
+);
+
+  // re-packager is always ready
+  assign s_axis_ready = 1'b1;
+
+  genvar i, j;
+  generate
+  if (NUM_OF_SDI == 1) begin : g_reorder_1_lane_interleaved
+
+    reg wr_addr = 0;
+    reg [63:0] axis_data_int;
+    reg mem_is_full;
+
+    // address control
+    // NOTE: ready is ignored, taking the fact that the module is always ready
+    always @(posedge axis_aclk) begin
+      if (axis_aresetn == 1'b0) begin
+        wr_addr <= 1'b0;
+        axis_data_int <= 64'b0;
+      end else begin
+        if ((s_axis_valid == 1'b1) && (s_axis_ready == 1'b1)) begin
+          wr_addr <= wr_addr + 1'b1;
+          axis_data_int <= (wr_addr) ? {s_axis_data, axis_data_int[31:0]} :
+                                       {axis_data_int[63:32], s_axis_data};
+        end
+      end
+    end
+
+    // latch the state of the memory
+    always @(posedge axis_aclk) begin
+      if (axis_aresetn == 1'b0) begin
+        mem_is_full <= 1'b0;
+      end else begin
+        if ((wr_addr == 1'b1) && (s_axis_valid == 1'b1)) begin
+          mem_is_full <= 1'b1;
+        end else begin
+          mem_is_full <= 1'b0;
+        end
+      end
+    end
+
+    // reorder the interleaved data
+    assign m_axis_valid = mem_is_full;
+    for (i=0; i<32; i=i+1) begin
+      assign m_axis_data[   i] = axis_data_int[2*i+1];
+      assign m_axis_data[32+i] = axis_data_int[2*i];
+    end
+
+  end else if (NUM_OF_SDI == 2) begin : g_reorder_2_lanes
+
+    assign m_axis_valid = s_axis_valid;
+    assign m_axis_data = s_axis_data;
+
+  end else if (NUM_OF_SDI == 4) begin : g_reorder_4_lanes
+
+    assign m_axis_valid = s_axis_valid;
+    for (i=0; i<16; i=i+1) begin
+      // first channel
+      assign m_axis_data[2*i  ]  = s_axis_data[32+i];
+      assign m_axis_data[2*i+1]  = s_axis_data[   i];
+      // second channel
+      assign m_axis_data[2*i+32] = s_axis_data[96+i];
+      assign m_axis_data[2*i+33] = s_axis_data[64+i];
+    end
+
+  end else if (NUM_OF_SDI == 8) begin : g_reorder_8_lanes
+
+    assign m_axis_valid = s_axis_valid;
+    for (i=0; i<8; i=i+1) begin
+      // first channel
+      assign m_axis_data[4*i  ]  = s_axis_data[96+i];
+      assign m_axis_data[4*i+1]  = s_axis_data[64+i];
+      assign m_axis_data[4*i+2]  = s_axis_data[32+i];
+      assign m_axis_data[4*i+3]  = s_axis_data[   i];
+      // second channel
+      assign m_axis_data[4*i+32] = s_axis_data[224+i];
+      assign m_axis_data[4*i+33] = s_axis_data[192+i];
+      assign m_axis_data[4*i+34] = s_axis_data[160+i];
+      assign m_axis_data[4*i+35] = s_axis_data[128+i];
+    end
+
+  end else begin
+    // Invalid configuration, leave everybody in the air
+  end
+  endgenerate
+
+endmodule

--- a/library/spi_engine/spi_axis_reorder/spi_axis_reorder_ip.tcl
+++ b/library/spi_engine/spi_axis_reorder/spi_axis_reorder_ip.tcl
@@ -1,0 +1,33 @@
+
+source ../../scripts/adi_env.tcl
+source $ad_hdl_dir/library/scripts/adi_ip_xilinx.tcl
+
+adi_ip_create spi_axis_reorder
+adi_ip_files spi_axis_reorder [list \
+	"spi_axis_reorder.v" \
+]
+
+adi_ip_properties_lite spi_axis_reorder
+# Remove all inferred interfaces
+ipx::remove_all_bus_interface [ipx::current_core]
+
+# Interface definitions
+
+adi_add_bus "s_axis" "slave" \
+	"xilinx.com:interface:axis_rtl:1.0" \
+	"xilinx.com:interface:axis:1.0" \
+	[list {"s_axis_ready" "TREADY"} \
+	      {"s_axis_valid" "TVALID"} \
+	      {"s_axis_data" "TDATA"}]
+
+adi_add_bus "m_axis" "master" \
+	"xilinx.com:interface:axis_rtl:1.0" \
+	"xilinx.com:interface:axis:1.0" \
+	[list {"m_axis_ready" "TREADY"} \
+	      {"m_axis_valid" "TVALID"} \
+	      {"m_axis_data" "TDATA"}]
+
+adi_add_bus_clock "axis_aclk" "s_axis:m_axis" "axis_aresetn"
+
+ipx::save_core [ipx::current_core]
+

--- a/library/spi_engine/spi_engine_execution/spi_engine_execution.v
+++ b/library/spi_engine/spi_engine_execution/spi_engine_execution.v
@@ -269,7 +269,7 @@ always @(posedge clk) begin
           idle <= 1'b1;
       end
       CMD_CHIPSELECT: begin
-        if (cs_sleep_counter_compare2)
+        if (cs_sleep_counter_compare)
           idle <= 1'b1;
       end
       CMD_MISC: begin

--- a/library/spi_engine/spi_engine_execution/spi_engine_execution.v
+++ b/library/spi_engine/spi_engine_execution/spi_engine_execution.v
@@ -435,7 +435,7 @@ if (ECHO_SCLK == 1) begin : g_echo_sclk_miso_latch
   // sdi_data_valid is synchronous to SPI clock, so synchronize the
   // last_sdi_bit to SPI clock
 
-  reg [2:0] last_sdi_bit_m = 2'b0;
+  reg [2:0] last_sdi_bit_m = 3'b0;
   always @(posedge clk) begin
     last_sdi_bit_m = {last_sdi_bit_m, last_sdi_bit};
   end

--- a/library/spi_engine/spi_engine_execution/spi_engine_execution.v
+++ b/library/spi_engine/spi_engine_execution/spi_engine_execution.v
@@ -421,17 +421,18 @@ if (ECHO_SCLK == 1) begin : g_echo_sclk_miso_latch
 
   for (i=0; i<NUM_OF_SDI; i=i+1) begin: g_sdi_shift_reg
 
-    reg [DATA_WIDTH-1:0] data_sdi_shift_n;
+    reg [DATA_WIDTH-1:0] data_sdi_shift;
 
+    // TODO: Maybe define an asynchronous reset here
     always @(negedge echo_sclk) begin
       if (cs_active_s) begin
-        data_sdi_shift_n <= 0;
+        data_sdi_shift <= 0;
       end else begin
-          data_sdi_shift_n <= {data_sdi_shift_n, sdi[i]};
+        data_sdi_shift <= {data_sdi_shift, sdi[i]};
       end
     end
 
-    assign sdi_data[i*DATA_WIDTH+:DATA_WIDTH] = data_sdi_shift_n;
+    assign sdi_data[i*DATA_WIDTH+:DATA_WIDTH] = data_sdi_shift;
 
   end
 

--- a/library/spi_engine/spi_engine_execution/spi_engine_execution.v
+++ b/library/spi_engine/spi_engine_execution/spi_engine_execution.v
@@ -95,6 +95,18 @@ localparam BIT_COUNTER_WIDTH = DATA_WIDTH > 16 ? 5 :
 localparam BIT_COUNTER_CARRY = 2** (BIT_COUNTER_WIDTH + 1);
 localparam BIT_COUNTER_CLEAR = {{8{1'b1}}, {BIT_COUNTER_WIDTH{1'b0}}, 1'b1};
 
+// Debug
+(* mark_debug = "true" *)wire dbg_cmd_ready = cmd_ready;
+(* mark_debug = "true" *)wire dbg_cmd_valid = cmd_valid;
+(* mark_debug = "true" *)wire [15:0] dbg_cmd = cmd;
+(* mark_debug = "true" *)wire dbg_sdi_data_ready = sdi_data_ready;
+(* mark_debug = "true" *)wire dbg_sdi_data_valid = sdi_data_valid;
+(* mark_debug = "true" *)wire [NUM_OF_SDI*DATA_WIDTH-1:0] dbg_sdi_data = sdi_data;
+(* mark_debug = "true" *)wire dbg_sync_ready = sync_ready;
+(* mark_debug = "true" *)wire dbg_sync_valid = sync_valid;
+(* mark_debug = "true" *)wire [7:0] dbg_sync = sync;
+(* mark_debug = "true" *)wire dbg_sclk_int = sclk_int;
+
 reg sclk_int = 1'b0;
 wire sdo_int_s;
 reg sdo_t_int = 1'b0;

--- a/library/spi_engine/spi_engine_offload/spi_engine_offload.v
+++ b/library/spi_engine/spi_engine_offload/spi_engine_offload.v
@@ -240,7 +240,7 @@ end endgenerate
 
 assign spi_cmd_rd_addr_next = spi_cmd_rd_addr + 1;
 
-wire trigger_s;
+(* mark_debug = "true" *)wire trigger_s;
 sync_bits #(
   .NUM_OF_BITS(1),
   .ASYNC_CLK(ASYNC_TRIG)


### PR DESCRIPTION
There are boards, which takes the SCLK and echos back to
the FPGA through a level shifter - doing this removes the effect of
round-trip timing delays from the level shifter. This is commonly done
whenever isolators are used since they are very slow.

By setting the ECHO_SCLK parameter to 1, the IP will use the incoming
echoed SCLK clock to latch the SDI line(s).

The designer responsibility to time the SDI shift registers in a way
that respects the design requirements.