### PR TITLE
scripts/intel: Add message severity definition file

### DIFF
--- a/projects/scripts/adi_intel_msg.tcl
+++ b/projects/scripts/adi_intel_msg.tcl
@@ -1,0 +1,4 @@
+
+set_global_assignment -name MESSAGE_DISABLE 17951 ; ## unused RX channels
+set_global_assignment -name MESSAGE_DISABLE 18655 ; ## unused TX channels
+set_global_assignment -name MESSAGE_DISABLE 114001 ; ## Time value $x truncated to $y

--- a/projects/scripts/adi_project_intel.tcl
+++ b/projects/scripts/adi_project_intel.tcl
@@ -146,6 +146,10 @@ proc adi_project {project_name {parameter_list {}}} {
 
   }
 
+  # source MESSAGE-DISABLE definitions - to ignore invalid critical warnings
+
+  source $ad_hdl_dir/projects/scripts/adi_intel_msg.tcl
+
   # default assignments
 
   set_global_assignment -name QIP_FILE $system_qip_file


### PR DESCRIPTION
Trying to do the same thing as for Xilinx projects. This will downgrade the critical warning related to the unused TX high speed channel.