### PR TITLE
Fix QPRO optimization mode

### DIFF
--- a/projects/adrv9371x/a10gx/system_project.tcl
+++ b/projects/adrv9371x/a10gx/system_project.tcl
@@ -133,4 +133,8 @@ set_instance_assignment -name IO_STANDARD "1.8 V" -to ad9371_gpio[16]
 set_instance_assignment -name IO_STANDARD "1.8 V" -to ad9371_gpio[17]
 set_instance_assignment -name IO_STANDARD "1.8 V" -to ad9371_gpio[18]
 
+## improve timing - there are occasional timing failure with a small negative slack
+#  at no-MMU configuration
+set_global_assignment -name OPTIMIZATION_MODE "AGGRESSIVE PERFORMANCE"
+
 execute_flow -compile

--- a/projects/daq2/a10gx/system_project.tcl
+++ b/projects/daq2/a10gx/system_project.tcl
@@ -93,4 +93,8 @@ set_location_assignment PIN_AW11  -to spi_clk               ; ## D12  FMCA_LA05_
 set_location_assignment PIN_AW13  -to spi_sdio              ; ## D14  FMCA_LA09_P
 set_location_assignment PIN_AN19  -to spi_dir               ; ## G13  FMCA_LA08_N
 
+## improve timing - there are occasional timing failure with a small negative slack
+#  at no-MMU configuration
+set_global_assignment -name OPTIMIZATION_MODE "AGGRESSIVE PERFORMANCE"
+
 execute_flow -compile


### PR DESCRIPTION
The ADRV9371/a10gx and daq2/a10gx fails timing with default optimization mode. Use aggressive performance to improve timing.