### PR TITLE
AXI SPI Engine: revert pulse period

### DIFF
--- a/library/spi_engine/axi_spi_engine/axi_spi_engine.v
+++ b/library/spi_engine/axi_spi_engine/axi_spi_engine.v
@@ -125,13 +125,7 @@ module axi_spi_engine #(
 
   output offload_sync_ready,
   input offload_sync_valid,
-  input [7:0] offload_sync_data,
-
-  // Configuration interface conversion start generator (PWM)
-
-  output reg [31:0] pulse_gen_period,
-  output reg [31:0] pulse_gen_width,
-  output reg pulse_gen_load);
+  input [7:0] offload_sync_data);
 
   localparam PCORE_VERSION = 'h010071;
   localparam S_AXI = 0;
@@ -297,31 +291,18 @@ module axi_spi_engine #(
   reg offload0_mem_reset_reg;
   wire offload0_enabled_s;
 
-
-  always @(posedge clk) begin
-    if ((up_waddr_s == 8'h48) && (up_wreq_s == 1'b1)) begin
-      pulse_gen_load <= 1'b1;
-    end else begin
-      pulse_gen_load <= 1'b0;
-    end
-  end
-
   // the software reset should reset all the registers
   always @(posedge clk) begin
     if (up_sw_resetn == 1'b0) begin
       up_irq_mask <= 'h00;
       offload0_enable_reg <= 1'b0;
       offload0_mem_reset_reg <= 1'b0;
-      pulse_gen_period <= 32'h0;
-      pulse_gen_width <= 32'h0;
     end else begin
       if (up_wreq_s) begin
         case (up_waddr_s)
           8'h20: up_irq_mask <= up_wdata_s;
           8'h40: offload0_enable_reg <= up_wdata_s[0];
           8'h42: offload0_mem_reset_reg <= up_wdata_s[0];
-          8'h48: pulse_gen_period <= up_wdata_s;
-          8'h49: pulse_gen_width <= up_wdata_s;
         endcase
       end
     end
@@ -355,8 +336,6 @@ module axi_spi_engine #(
       8'h3c: up_rdata_ff <= sdi_fifo_out_data; /* PEEK register */
       8'h40: up_rdata_ff <= {offload0_enable_reg};
       8'h41: up_rdata_ff <= {offload0_enabled_s};
-      8'h48: up_rdata_ff <= pulse_gen_period;
-      8'h49: up_rdata_ff <= pulse_gen_width;
       default: up_rdata_ff <= 'h00;
     endcase
   end

--- a/projects/adaq7980_sdz/zed/Makefile
+++ b/projects/adaq7980_sdz/zed/Makefile
@@ -22,6 +22,6 @@ LIB_DEPS += spi_engine/spi_engine_interconnect
 LIB_DEPS += spi_engine/spi_engine_offload
 LIB_DEPS += sysid_rom
 LIB_DEPS += util_i2c_mixer
-LIB_DEPS += util_pulse_gen
+LIB_DEPS += axi_pulse_gen
 
 include ../../scripts/project-xilinx.mk


### PR DESCRIPTION
Controlling the offload trigger (in case of an internal trigger) from AXI SPI Engine module is a wrong approach, and it can generate tightly coupled solutions which are hard to maintain and debug. The best approach is to control and generate the internal trigger from outside of the framework, taking the fact that the source of the trigger can vary in function of the application.

The only project that uses these "AXI SPI Engine" offload trigger generator registers is the ADAQ7980.

Revert all the commits that add the control register for the trigger generator. Update the ADAQ7980 project to use an axi_utile_pulsegen for offload trigger generation. 

Note: software needs to be updated to support the new trigger generation scheme. This PR will be merge after testing the solution.