### PR TITLE
Fix SPI Engine framework

### DIFF
--- a/library/spi_engine/axi_spi_engine/axi_spi_engine_ip.tcl
+++ b/library/spi_engine/axi_spi_engine/axi_spi_engine_ip.tcl
@@ -96,7 +96,7 @@ set cc [ipx::current_core]
 ## ID
 set_property -dict [list \
   "value_validation_type" "range_long" \
-  "value_validation_range_minimum" "1" \
+  "value_validation_range_minimum" "0" \
   "value_validation_range_maximum" "255" \
  ] \
  [ipx::get_user_parameters ID -of_objects $cc]

--- a/library/spi_engine/axi_spi_engine/axi_spi_engine_ip.tcl
+++ b/library/spi_engine/axi_spi_engine/axi_spi_engine_ip.tcl
@@ -149,6 +149,11 @@ set_property -dict [list \
   "value" "false" \
  ] \
  [ipx::get_user_parameters ASYNC_SPI_CLK -of_objects $cc]
+set_property -dict [list \
+  "value_format" "bool" \
+  "value" "false" \
+ ] \
+ [ipx::get_hdl_parameters ASYNC_SPI_CLK -of_objects $cc]
 
 ## NUM_OFFLOAD
 set_property -dict [list \

--- a/library/spi_engine/spi_engine_execution/spi_engine_execution_ip.tcl
+++ b/library/spi_engine/spi_engine_execution/spi_engine_execution_ip.tcl
@@ -101,6 +101,11 @@ set_property -dict [list \
   "value" "false" \
  ] \
  [ipx::get_user_parameters SDI_DELAY -of_objects $cc]
+set_property -dict [list \
+  "value_format" "bool" \
+  "value" "false" \
+ ] \
+ [ipx::get_hdl_parameters SDI_DELAY -of_objects $cc]
 
 ## Customize IP Layout
 

--- a/library/spi_engine/spi_engine_offload/spi_engine_offload_ip.tcl
+++ b/library/spi_engine/spi_engine_offload/spi_engine_offload_ip.tcl
@@ -75,6 +75,11 @@ set_property -dict [list \
   "value" "false" \
  ] \
  [ipx::get_user_parameters ASYNC_SPI_CLK -of_objects $cc]
+set_property -dict [list \
+  "value_format" "bool" \
+  "value" "false" \
+ ] \
+ [ipx::get_hdl_parameters ASYNC_SPI_CLK -of_objects $cc]
 
 ## ASYNC_TRIG
 set_property -dict [list \
@@ -82,6 +87,11 @@ set_property -dict [list \
   "value" "false" \
  ] \
  [ipx::get_user_parameters ASYNC_TRIG -of_objects $cc]
+set_property -dict [list \
+  "value_format" "bool" \
+  "value" "false" \
+ ] \
+ [ipx::get_hdl_parameters ASYNC_TRIG -of_objects $cc]
 
 ## NUM_OF_SDI
 set_property -dict [list \

--- a/projects/cn0540/coraz7s/system_constr.xdc
+++ b/projects/cn0540/coraz7s/system_constr.xdc
@@ -23,3 +23,7 @@ set_property -dict {PACKAGE_PIN  T14 IOSTANDARD LVCMOS33}                       
 
 set_property -dict {PACKAGE_PIN  P16 IOSTANDARD LVCMOS33}                           [get_ports cn0540_scl]         ; ## CK_SCL
 set_property -dict {PACKAGE_PIN  P15 IOSTANDARD LVCMOS33}                           [get_ports cn0540_sda]         ; ## CK_SDA
+
+# relax the timing between the SDO FIFO and shift-register
+set_multicycle_path 2 -setup -from [get_pins -hierarchical -filter {NAME=~*/i_sdo_fifo/i_mem/m_ram_reg/CLKARDCLK}] -to [get_pins -hierarchical -filter {NAME=~*/data_sdo_shift_reg[*]/D}]
+set_multicycle_path 1 -hold -from [get_pins -hierarchical -filter {NAME=~*/i_sdo_fifo/i_mem/m_ram_reg/CLKARDCLK}] -to [get_pins -hierarchical -filter {NAME=~*/data_sdo_shift_reg[*]/D}]


### PR DESCRIPTION
The IPXACT updates introduced a bug into the SPI Engine framework. This patch fix it.

Also improved the timing constraint for cn0540/coraz7.