### PR TITLE
ADRV9001 refactor VADJ monitoring

### DIFF
--- a/projects/adrv9001/zcu102/system_constr.xdc
+++ b/projects/adrv9001/zcu102/system_constr.xdc
@@ -36,8 +36,8 @@ set_property  -dict {PACKAGE_PIN Y10   IOSTANDARD LVCMOS18}  [get_ports spi_en] 
 set_property  -dict {PACKAGE_PIN W2    IOSTANDARD LVCMOS18}  [get_ports tx1_enable]                        ; #FMC_HPC0_LA09_P      IO_L24P_T3U_N10_66
 set_property  -dict {PACKAGE_PIN U9    IOSTANDARD LVCMOS18}  [get_ports tx2_enable]                        ; #FMC_HPC0_LA29_P      IO_L9P_T1L_N4_AD12P_67
 
-set_property  -dict {PACKAGE_PIN V8    IOSTANDARD LVCMOS18}  [get_ports vadj_test_1]                       ; #FMC_HPC0_LA31_P      IO_L7P_T1L_N0_QBC_AD13P_67
-set_property  -dict {PACKAGE_PIN V7    IOSTANDARD LVCMOS18}  [get_ports vadj_test_2]                       ; #FMC_HPC0_LA31_N      IO_L7N_T1L_N1_QBC_AD13N_67
+set_property  -dict {PACKAGE_PIN V8    IOSTANDARD LVCMOS18}  [get_ports vadj_err]                          ; #FMC_HPC0_LA31_P      IO_L7P_T1L_N0_QBC_AD13P_67
+set_property  -dict {PACKAGE_PIN V7    IOSTANDARD LVCMOS18}  [get_ports platform_status]                   ; #FMC_HPC0_LA31_N      IO_L7N_T1L_N1_QBC_AD13N_67
 
 set_property UNAVAILABLE_DURING_CALIBRATION TRUE [get_ports tx1_strobe_out_p]
 set_property UNAVAILABLE_DURING_CALIBRATION TRUE [get_ports tx2_idata_out_p]

--- a/projects/adrv9001/zcu102/system_top.v
+++ b/projects/adrv9001/zcu102/system_top.v
@@ -121,8 +121,8 @@ module system_top (
   output                  tx2_strobe_out_p,
 
   inout                   sm_fan_tach,
-  output                  vadj_test_1,
-  output                  vadj_test_2
+  input                   vadj_err,
+  output                  platform_status
 );
   // internal registers
   reg         [  2:0] mcs_sync_m = 'd0;
@@ -165,7 +165,7 @@ module system_top (
   //
   assign mssi_sync = gpio_o[54];
 
-  assign {vadj_test_2,vadj_test_1} = 2'b11;
+  assign platform_status = vadj_err;
 
   ad_iobuf #(.DATA_WIDTH(20)) i_iobuf (
     .dio_t ({gpio_t[51:32]}),
@@ -196,7 +196,9 @@ module system_top (
   assign gpio_i[20: 8] = gpio_bd_i;
   assign gpio_bd_o = gpio_o[ 7: 0];
 
-  assign gpio_i[94:52] = gpio_o[94:52];
+  assign gpio_i[54:52] = gpio_o[54:52];
+  assign gpio_i[55] = vadj_err;
+  assign gpio_i[94:56] = gpio_o[94:56];
   assign gpio_i[31:21] = gpio_o[31:21];
 
   assign spi_en = spi_csn[0];

--- a/projects/adrv9001/zed/system_constr.xdc
+++ b/projects/adrv9001/zed/system_constr.xdc
@@ -34,8 +34,8 @@ set_property  -dict {PACKAGE_PIN J16  IOSTANDARD LVCMOS18}  [get_ports spi_en]  
 set_property  -dict {PACKAGE_PIN R20  IOSTANDARD LVCMOS18}  [get_ports tx1_enable]        ; # D14 FMC_HPC0_LA09_P      IO_L17P_T2_34
 set_property  -dict {PACKAGE_PIN C17  IOSTANDARD LVCMOS18}  [get_ports tx2_enable]        ; # G30 FMC_HPC0_LA29_P      IO_L11P_T1_SRCC_35
 
-set_property  -dict {PACKAGE_PIN B16  IOSTANDARD LVCMOS18}  [get_ports vadj_test_1]       ; # G33 FMC_HPC0_LA31_P      IO_L8P_T1_AD10P_35
-set_property  -dict {PACKAGE_PIN B17  IOSTANDARD LVCMOS18}  [get_ports vadj_test_2]       ; # G34 FMC_HPC0_LA31_N      IO_L8N_T1_AD10N_35
+set_property  -dict {PACKAGE_PIN B16  IOSTANDARD LVCMOS18}  [get_ports vadj_err]          ; # G33 FMC_HPC0_LA31_P      IO_L8P_T1_AD10P_35
+set_property  -dict {PACKAGE_PIN B17  IOSTANDARD LVCMOS18}  [get_ports platform_status]   ; # G34 FMC_HPC0_LA31_N      IO_L8N_T1_AD10N_35
 
 # redefine contraints from common file for VADJ 1.8V
 set_property  -dict {PACKAGE_PIN  L16   IOSTANDARD LVCMOS18} [get_ports otg_vbusoc]

--- a/projects/adrv9001/zed/system_top.v
+++ b/projects/adrv9001/zed/system_top.v
@@ -154,8 +154,8 @@ module system_top (
   output                  tx2_strobe_out_p,
 
   inout                   sm_fan_tach,
-  output                  vadj_test_1,
-  output                  vadj_test_2
+  input                   vadj_err,
+  output                  platform_status
 );
 
   // internal registers
@@ -171,6 +171,9 @@ module system_top (
   wire    [ 1:0]  iic_mux_sda_i_s;
   wire    [ 1:0]  iic_mux_sda_o_s;
   wire            iic_mux_sda_t_s;
+  wire            spi_clk_s;
+  wire            spi_en_s;
+  wire            spi_dio_s;
 
   // instantiations
 
@@ -178,7 +181,7 @@ module system_top (
   //
   assign mssi_sync = gpio_o[54];
 
-  assign {vadj_test_2,vadj_test_1} = 2'b11;
+  assign platform_status = vadj_err;
 
   ad_iobuf #(
     .DATA_WIDTH(32)
@@ -189,7 +192,7 @@ module system_top (
     .dio_p(gpio_bd));
 
   ad_iobuf #(.DATA_WIDTH(20)) i_iobuf (
-    .dio_t ({gpio_t[51:32]}),
+    .dio_t (vadj_err ? {20{1'b1}} : gpio_t[51:32]),
     .dio_i ({gpio_o[51:32]}),
     .dio_o ({gpio_i[51:32]}),
     .dio_p ({tx2_enable,  // 51
@@ -213,7 +216,9 @@ module system_top (
              dgpio_1,     // 33
              dgpio_0 })); // 32
 
-  assign gpio_i[63:52] = gpio_o[63:52];
+  assign gpio_i[54:52] = gpio_o[54:52];
+  assign gpio_i[55] = vadj_err;
+  assign gpio_i[63:56] = gpio_o[63:56];
 
    ad_iobuf #(.DATA_WIDTH(2)) i_iobuf_iic_scl (
     .dio_t ({iic_mux_scl_t_s,iic_mux_scl_t_s}),
@@ -276,7 +281,7 @@ module system_top (
     .ref_clk (1'b0),
     .mssi_sync (mssi_sync),
 
-    .tx_output_enable (1'b1),
+    .tx_output_enable (~vadj_err),
 
     .rx1_dclk_in_n (rx1_dclk_in_n),
     .rx1_dclk_in_p (rx1_dclk_in_p),
@@ -319,14 +324,14 @@ module system_top (
     .tx2_strobe_out_p (tx2_strobe_out_p),
 
     .spi0_clk_i (1'b0),
-    .spi0_clk_o (spi_clk),
-    .spi0_csn_0_o (spi_en),
+    .spi0_clk_o (spi_clk_s),
+    .spi0_csn_0_o (spi_en_s),
     .spi0_csn_1_o (),
     .spi0_csn_2_o (),
     .spi0_csn_i (1'b1),
     .spi0_sdi_i (spi_do),
     .spi0_sdo_i (1'b0),
-    .spi0_sdo_o (spi_dio),
+    .spi0_sdo_o (spi_dio_s),
     .spi1_clk_i (1'b0),
     .spi1_clk_o (),
     .spi1_csn_0_o (),
@@ -337,6 +342,11 @@ module system_top (
     .spi1_sdo_i (1'b0),
     .spi1_sdo_o ()
   );
+
+ assign spi_clk = vadj_err ? 1'bz : spi_clk_s;
+ assign spi_en  = vadj_err ? 1'bz : spi_en_s;
+ assign spi_dio = vadj_err ? 1'bz : spi_dio_s;
+
 endmodule
 
 // ***************************************************************************


### PR DESCRIPTION
VADJ on Zedboard can be higher than 1.8V the 9001 supports. The evaluation board has a circuitry built to detect higher voltage levels than 1.8V  asserting VADJ_ERR in this case.   A status LED on the evaluation board indicated good operation.  

For Zedboard all outputs are kept high-z in case VAD_ERR is set. 
For ZCU102 only the status led is driven. 

Tested on Zed