### PR TITLE
M2k dac sample hold

### DIFF
--- a/library/axi_ad9963/axi_ad9963.v
+++ b/library/axi_ad9963/axi_ad9963.v
@@ -99,10 +99,14 @@ module axi_ad9963 #(
   output          dac_enable_i,
   output          dac_valid_i,
   input   [15:0]  dac_data_i,
+  input           dma_valid_i,
   output          dac_enable_q,
   output          dac_valid_q,
   input   [15:0]  dac_data_q,
+  input           dma_valid_q,
   input           dac_dunf,
+
+  input           hold_last_sample,
 
   // axi interface
 
@@ -145,7 +149,6 @@ module axi_ad9963 #(
   wire            adc_valid_s;
   wire    [23:0]  adc_data_s;
   wire            adc_status_s;
-  wire            dac_valid_s;
   wire    [23:0]  dac_data_s;
   wire    [12:0]  up_adc_dld_s;
   wire    [64:0]  up_adc_dwdata_s;
@@ -164,6 +167,8 @@ module axi_ad9963 #(
   wire            up_rack_tx_s;
   wire            up_adc_ce;
   wire            up_dac_ce;
+  wire            valid_out_q_s;
+  wire            valid_out_i_s;
 
   // signal name changes
 
@@ -200,9 +205,11 @@ module axi_ad9963 #(
     .adc_data (adc_data_s),
     .adc_status (adc_status_s),
     .up_adc_ce(up_adc_ce),
-    .dac_valid (dac_valid_s),
     .dac_data (dac_data_s),
+    .out_valid_q (valid_out_q_s),
+    .out_valid_i (valid_out_i_s),
     .up_dac_ce(up_dac_ce),
+    .tx_sample_hold (hold_last_sample),
     .up_clk (up_clk),
     .up_adc_dld (up_adc_dld_s),
     .up_adc_dwdata (up_adc_dwdata_s),
@@ -271,7 +278,6 @@ module axi_ad9963 #(
   i_tx (
     .dac_clk (dac_clk),
     .dac_rst (dac_rst),
-    .dac_valid (dac_valid_s),
     .dac_data (dac_data_s),
     .adc_data (adc_data_s),
     .dac_sync_in (dac_sync_in),
@@ -279,9 +285,13 @@ module axi_ad9963 #(
     .dac_enable_i (dac_enable_i),
     .dac_valid_i (dac_valid_i),
     .dac_data_i (dac_data_i),
+    .dma_valid_i (dma_valid_i),
+    .out_valid_i (valid_out_i_s),
     .dac_enable_q (dac_enable_q),
     .dac_valid_q (dac_valid_q),
     .dac_data_q (dac_data_q),
+    .dma_valid_q (dma_valid_q),
+    .out_valid_q (valid_out_q_s),
     .dac_dunf(dac_dunf),
     .up_dac_ce(up_dac_ce),
     .up_rstn (up_rstn),

--- a/library/axi_ad9963/axi_ad9963_tx.v
+++ b/library/axi_ad9963/axi_ad9963_tx.v
@@ -53,7 +53,6 @@ module axi_ad9963_tx #(
 
   input               dac_clk,
   output              dac_rst,
-  output reg          dac_valid,
   output      [23:0]  dac_data,
   input       [23:0]  adc_data,
 
@@ -67,9 +66,13 @@ module axi_ad9963_tx #(
   output              dac_enable_i,
   output reg          dac_valid_i,
   input       [15:0]  dac_data_i,
+  input               dma_valid_i,
+  output              out_valid_i,
   output              dac_enable_q,
   output reg          dac_valid_q,
   input       [15:0]  dac_data_q,
+  input               dma_valid_q,
+  output              out_valid_q,
   input               dac_dunf,
 
   output              up_dac_ce,
@@ -104,13 +107,11 @@ module axi_ad9963_tx #(
 
   always @(posedge dac_clk) begin
     if (dac_rst == 1'b1) begin
-      dac_valid <= 1'b0;
       dac_valid_i <= 1'b0;
       dac_valid_q <= 1'b0;
     end else begin
-      dac_valid <= 1'b1;
-      dac_valid_i <= dac_valid;
-      dac_valid_q <= dac_valid;
+      dac_valid_i <= 1'b1;
+      dac_valid_q <= 1'b1;
     end
   end
 
@@ -134,7 +135,7 @@ module axi_ad9963_tx #(
   i_tx_channel_0 (
     .dac_clk (dac_clk),
     .dac_rst (dac_rst),
-    .dac_valid (dac_valid),
+    .dac_valid (dac_valid_i),
     .dma_data (dac_data_i),
     .adc_data (adc_data[11:0]),
     .dac_data (dac_data[11:0]),
@@ -143,6 +144,8 @@ module axi_ad9963_tx #(
     .dac_enable (dac_enable_i),
     .dac_data_sync (dac_data_sync_s),
     .dac_dds_format (dac_dds_format_s),
+    .dma_valid (dma_valid_i),
+    .out_data_valid (out_valid_i),
     .up_rstn (up_rstn),
     .up_clk (up_clk),
     .up_wreq (up_wreq),
@@ -166,7 +169,7 @@ module axi_ad9963_tx #(
   i_tx_channel_1 (
     .dac_clk (dac_clk),
     .dac_rst (dac_rst),
-    .dac_valid (dac_valid),
+    .dac_valid (dac_valid_q),
     .dma_data (dac_data_q),
     .adc_data (adc_data[23:12]),
     .dac_data (dac_data[23:12]),
@@ -175,6 +178,8 @@ module axi_ad9963_tx #(
     .dac_enable (dac_enable_q),
     .dac_data_sync (dac_data_sync_s),
     .dac_dds_format (dac_dds_format_s),
+    .dma_valid (dma_valid_q),
+    .out_data_valid (out_valid_q),
     .up_rstn (up_rstn),
     .up_clk (up_clk),
     .up_wreq (up_wreq),

--- a/library/axi_dac_interpolate/axi_dac_interpolate_reg.v
+++ b/library/axi_dac_interpolate/axi_dac_interpolate_reg.v
@@ -50,6 +50,7 @@ module axi_dac_interpolate_reg(
   output      [15:0]  dac_correction_coefficient_a,
   output      [15:0]  dac_correction_coefficient_b,
   output      [19:0]  trigger_config,
+  output      [ 1:0]  lsample_hold_config,
  // bus interface
 
   input               up_rstn,
@@ -77,6 +78,7 @@ module axi_dac_interpolate_reg(
   reg     [15:0]  up_correction_coefficient_a = 16'h0;
   reg     [15:0]  up_correction_coefficient_b = 16'h0;
   reg     [19:0]  up_trigger_config = 20'h0;
+  reg     [ 1:0]  up_lsample_hold_config = 2'h0;
 
   wire    [ 1:0]  flags;
 
@@ -96,6 +98,7 @@ module axi_dac_interpolate_reg(
       up_correction_coefficient_a <= 'd0;
       up_correction_coefficient_b <= 'd0;
       up_trigger_config <= 'd0;
+      up_lsample_hold_config <= 'h0;
     end else begin
       up_wack <= up_wreq;
       if ((up_wreq == 1'b1) && (up_waddr[4:0] == 5'h1)) begin
@@ -128,6 +131,9 @@ module axi_dac_interpolate_reg(
       if ((up_wreq == 1'b1) && (up_waddr[4:0] == 5'h18)) begin
         up_trigger_config <= up_wdata[19:0];
       end
+      if ((up_wreq == 1'b1) && (up_waddr[4:0] == 5'h19)) begin
+        up_lsample_hold_config <= up_wdata[1:0];
+      end
     end
   end
 
@@ -152,6 +158,7 @@ module axi_dac_interpolate_reg(
           5'h16: up_rdata <= {16'h0,up_correction_coefficient_a};
           5'h17: up_rdata <= {16'h0,up_correction_coefficient_b};
           5'h18: up_rdata <= {12'h0,up_trigger_config};
+          5'h19: up_rdata <= {30'h0,up_lsample_hold_config};
           default: up_rdata <= 0;
         endcase
       end else begin
@@ -160,7 +167,7 @@ module axi_dac_interpolate_reg(
     end
   end
 
-   up_xfer_cntrl #(.DATA_WIDTH(126)) i_xfer_cntrl (
+   up_xfer_cntrl #(.DATA_WIDTH(128)) i_xfer_cntrl (
     .up_rstn (up_rstn),
     .up_clk (up_clk),
     .up_data_cntrl ({ up_config[1],               // 1
@@ -168,6 +175,7 @@ module axi_dac_interpolate_reg(
                       up_correction_coefficient_b,// 16
                       up_correction_coefficient_a,// 16
                       up_trigger_config,          // 20
+                      up_lsample_hold_config,     //  2
                       up_flags,                   //  2
                       up_interpolation_ratio_b,   // 32
                       up_interpolation_ratio_a,   // 32
@@ -182,6 +190,7 @@ module axi_dac_interpolate_reg(
                       dac_correction_coefficient_b, // 16
                       dac_correction_coefficient_a, // 16
                       trigger_config,               // 20
+                      lsample_hold_config,          // 2
                       flags,                        // 2
                       dac_interpolation_ratio_b,    // 32
                       dac_interpolation_ratio_a,    // 32

--- a/projects/m2k/common/m2k_bd.tcl
+++ b/projects/m2k/common/m2k_bd.tcl
@@ -259,6 +259,10 @@ ad_connect axi_dac_interpolate/trigger_i   trigger_i
 ad_connect axi_dac_interpolate/trigger_adc adc_trigger/trigger_out_la
 ad_connect axi_dac_interpolate/trigger_la  logic_analyzer/trigger_out_adc
 
+ad_connect axi_dac_interpolate/dac_valid_out_a  axi_ad9963/dma_valid_i
+ad_connect axi_dac_interpolate/dac_valid_out_b  axi_ad9963/dma_valid_q
+ad_connect axi_dac_interpolate/hold_last_sample  axi_ad9963/hold_last_sample
+
 ad_connect /axi_ad9963/tx_data    txd
 ad_connect /axi_ad9963/tx_iq      txiq
 ad_connect /axi_ad9963/tx_clk     tx_clk


### PR DESCRIPTION
Add DAC last sample hold support.

- add trigger start/stop options
- DMA sync stop option
- transmit last sample or zero option

Usually a transmission is achieved with cyclic buffers written in memory. One for each channel(DMA). When the transmission is halted, the software, will first stop the DMAs. Regarding the DMA sync stop option, if one DMA is stopped, the other one will still transfer data(software can’t stop them at the same time), but “the last sample” is stored and used(at the DAC interface level), in regards with the first stopped DMA

In order for this mechanism to function properly, the application should not go back to DDS source select at the DAC interface level(axi_ad9963) after the transmission ends.