### PR TITLE
projects: cn0540: coraz7s: Add XADC support

### DIFF
--- a/projects/cn0540/common/cn0540_bd.tcl
+++ b/projects/cn0540/common/cn0540_bd.tcl
@@ -1,6 +1,13 @@
 
 create_bd_intf_port -mode Master -vlnv analog.com:interface:spi_master_rtl:1.0 adc_spi
 create_bd_intf_port -mode Master -vlnv xilinx.com:interface:iic_rtl:1.0 iic_cn0540
+create_bd_intf_port -mode Slave -vlnv xilinx.com:interface:diff_analog_io_rtl:1.0 xadc_mux
+create_bd_intf_port -mode Slave -vlnv xilinx.com:interface:diff_analog_io_rtl:1.0 xadc_vaux1
+create_bd_intf_port -mode Slave -vlnv xilinx.com:interface:diff_analog_io_rtl:1.0 xadc_vaux9
+create_bd_intf_port -mode Slave -vlnv xilinx.com:interface:diff_analog_io_rtl:1.0 xadc_vaux6
+create_bd_intf_port -mode Slave -vlnv xilinx.com:interface:diff_analog_io_rtl:1.0 xadc_vaux15
+create_bd_intf_port -mode Slave -vlnv xilinx.com:interface:diff_analog_io_rtl:1.0 xadc_vaux5
+create_bd_intf_port -mode Slave -vlnv xilinx.com:interface:diff_analog_io_rtl:1.0 xadc_vaux13
 
 create_bd_port -dir I adc_data_ready
 
@@ -99,11 +106,43 @@ ad_connect  spi_adc/m_spi adc_spi
 ad_connect  spi_clk spi_adc/spi_clk
 ad_connect  axi_cn0540_dma/s_axis spi_adc/M_AXIS_SAMPLE
 
+# Xilinx's XADC
+
+ad_ip_instance xadc_wiz xadc_in
+
+ad_ip_parameter xadc_in CONFIG.XADC_STARUP_SELECTION channel_sequencer
+ad_ip_parameter xadc_in CONFIG.SEQUENCER_MODE Continuous
+ad_ip_parameter xadc_in CONFIG.CHANNEL_ENABLE_VP_VN true
+ad_ip_parameter xadc_in CONFIG.CHANNEL_ENABLE_VAUXP1_VAUXN1 true
+ad_ip_parameter xadc_in CONFIG.CHANNEL_ENABLE_VAUXP5_VAUXN5 true
+ad_ip_parameter xadc_in CONFIG.CHANNEL_ENABLE_VAUXP6_VAUXN6 true
+ad_ip_parameter xadc_in CONFIG.CHANNEL_ENABLE_VAUXP9_VAUXN9 true
+ad_ip_parameter xadc_in CONFIG.CHANNEL_ENABLE_VAUXP13_VAUXN13 true
+ad_ip_parameter xadc_in CONFIG.CHANNEL_ENABLE_VAUXP15_VAUXN15 true
+ad_ip_parameter xadc_in CONFIG.ENABLE_VCCDDRO_ALARM false
+ad_ip_parameter xadc_in CONFIG.ENABLE_VCCPAUX_ALARM false
+ad_ip_parameter xadc_in CONFIG.ENABLE_VCCPINT_ALARM false
+ad_ip_parameter xadc_in CONFIG.EXTERNAL_MUX_CHANNEL VP_VN
+ad_ip_parameter xadc_in CONFIG.OT_ALARM false
+ad_ip_parameter xadc_in CONFIG.SINGLE_CHANNEL_SELECTION TEMPERATURE
+ad_ip_parameter xadc_in CONFIG.USER_TEMP_ALARM false
+ad_ip_parameter xadc_in CONFIG.VCCAUX_ALARM false
+ad_ip_parameter xadc_in CONFIG.VCCINT_ALARM false
+
+ad_connect xadc_in/Vp_Vn xadc_mux
+ad_connect xadc_in/Vaux1 xadc_vaux1
+ad_connect xadc_in/Vaux5 xadc_vaux5
+ad_connect xadc_in/Vaux6 xadc_vaux6
+ad_connect xadc_in/Vaux9 xadc_vaux9
+ad_connect xadc_in/Vaux13 xadc_vaux13
+ad_connect xadc_in/Vaux15 xadc_vaux15
+
 # AXI address definitions
 
 ad_cpu_interconnect 0x44a00000 spi_adc/axi_regmap
 ad_cpu_interconnect 0x44a30000 axi_cn0540_dma
 ad_cpu_interconnect 0x44a40000 axi_iic_cn0540
+ad_cpu_interconnect 0x44a50000 xadc_in
 ad_cpu_interconnect 0x44a70000 spi_clkgen
 
 ad_connect spi_clk axi_cn0540_dma/s_axis_aclk

--- a/projects/cn0540/coraz7s/system_constr.xdc
+++ b/projects/cn0540/coraz7s/system_constr.xdc
@@ -38,3 +38,23 @@ create_generated_clock -name SCLK_clk -source [get_pins -hier -filter name=~*scl
 set_input_delay -clock [get_clocks spi_clk] [get_property PERIOD [get_clocks spi_clk]] \
 		[get_ports -filter {NAME =~ "cn0540_spi_miso"}]
 
+## Dedicated Analog Inputs
+set_property -dict { PACKAGE_PIN K9    IOSTANDARD LVCMOS33 } [get_ports { cn0540_xadc_mux_p }]; #VP_0 Sch=xadc_v_p
+set_property -dict { PACKAGE_PIN L10   IOSTANDARD LVCMOS33 } [get_ports { cn0540_xadc_mux_n }]; #VN_0 Sch=xadc_v_n
+
+## ChipKit Outer Analog Header - as Single-Ended Analog Inputs
+## NOTE: These ports can be used as single-ended analog inputs with voltages from 0-3.3V (ChipKit analog pins A0-A5) or as digital I/O.
+## WARNING: Do not use both sets of constraints at the same time!
+set_property -dict { PACKAGE_PIN E17   IOSTANDARD LVCMOS33 } [get_ports { cn0540_ck_an0_p }]; #IO_L3P_T0_DQS_AD1P_35 Sch=ck_an_p[0]
+set_property -dict { PACKAGE_PIN D18   IOSTANDARD LVCMOS33 } [get_ports { cn0540_ck_an0_n }]; #IO_L3N_T0_DQS_AD1N_35 Sch=ck_an_n[0]
+set_property -dict { PACKAGE_PIN E18   IOSTANDARD LVCMOS33 } [get_ports { cn0540_ck_an1_p }]; #IO_L5P_T0_AD9P_35 Sch=ck_an_p[1]
+set_property -dict { PACKAGE_PIN E19   IOSTANDARD LVCMOS33 } [get_ports { cn0540_ck_an1_n }]; #IO_L5N_T0_AD9N_35 Sch=ck_an_n[1]
+set_property -dict { PACKAGE_PIN K14   IOSTANDARD LVCMOS33 } [get_ports { cn0540_ck_an2_p }]; #IO_L20P_T3_AD6P_35 Sch=ck_an_p[2]
+set_property -dict { PACKAGE_PIN J14   IOSTANDARD LVCMOS33 } [get_ports { cn0540_ck_an2_n }]; #IO_L20N_T3_AD6N_35 Sch=ck_an_n[2]
+set_property -dict { PACKAGE_PIN K16   IOSTANDARD LVCMOS33 } [get_ports { cn0540_ck_an3_p }]; #IO_L24P_T3_AD15P_35 Sch=ck_an_p[3]
+set_property -dict { PACKAGE_PIN J16   IOSTANDARD LVCMOS33 } [get_ports { cn0540_ck_an3_n }]; #IO_L24N_T3_AD15N_35 Sch=ck_an_n[3]
+set_property -dict { PACKAGE_PIN J20   IOSTANDARD LVCMOS33 } [get_ports { cn0540_ck_an4_p }]; #IO_L17P_T2_AD5P_35 Sch=ck_an_p[4]
+set_property -dict { PACKAGE_PIN H20   IOSTANDARD LVCMOS33 } [get_ports { cn0540_ck_an4_n }]; #IO_L17N_T2_AD5N_35 Sch=ck_an_n[4]
+set_property -dict { PACKAGE_PIN G19   IOSTANDARD LVCMOS33 } [get_ports { cn0540_ck_an5_p }]; #IO_L18P_T2_AD13P_35 Sch=ck_an_p[5]
+set_property -dict { PACKAGE_PIN G20   IOSTANDARD LVCMOS33 } [get_ports { cn0540_ck_an5_n }]; #IO_L18N_T2_AD13N_35 Sch=ck_an_n[5]
+

--- a/projects/cn0540/coraz7s/system_top.v
+++ b/projects/cn0540/coraz7s/system_top.v
@@ -63,6 +63,21 @@ module system_top (
   inout   [1:0]   btn,
   inout   [5:0]   led,
 
+  input           cn0540_xadc_mux_p,
+  input           cn0540_xadc_mux_n,
+  input           cn0540_ck_an0_p,
+  input           cn0540_ck_an0_n,
+  input           cn0540_ck_an1_p,
+  input           cn0540_ck_an1_n,
+  input           cn0540_ck_an2_p,
+  input           cn0540_ck_an2_n,
+  input           cn0540_ck_an3_p,
+  input           cn0540_ck_an3_n,
+  input           cn0540_ck_an4_p,
+  input           cn0540_ck_an4_n,
+  input           cn0540_ck_an5_p,
+  input           cn0540_ck_an5_n,
+
   inout           cn0540_scl,
   inout           cn0540_sda,
 
@@ -176,7 +191,21 @@ module system_top (
     .spi1_csn_i (1'b1),
     .spi1_sdi_i (1'b0),
     .spi1_sdo_i (1'b0),
-    .spi1_sdo_o());
+    .spi1_sdo_o(),
+    .xadc_mux_v_p  (cn0540_xadc_mux_p),
+    .xadc_mux_v_n  (cn0540_xadc_mux_n),
+    .xadc_vaux1_v_p  (cn0540_ck_an0_p),
+    .xadc_vaux1_v_n  (cn0540_ck_an0_n),
+    .xadc_vaux5_v_p  (cn0540_ck_an4_p),
+    .xadc_vaux5_v_n  (cn0540_ck_an4_n),
+    .xadc_vaux6_v_p  (cn0540_ck_an2_p),
+    .xadc_vaux6_v_n  (cn0540_ck_an2_n),
+    .xadc_vaux9_v_p  (cn0540_ck_an1_p),
+    .xadc_vaux9_v_n  (cn0540_ck_an1_n),
+    .xadc_vaux13_v_p (cn0540_ck_an5_p),
+    .xadc_vaux13_v_n (cn0540_ck_an5_n),
+    .xadc_vaux15_v_p (cn0540_ck_an3_p),
+    .xadc_vaux15_v_n (cn0540_ck_an3_n));
 
 endmodule
 


### PR DESCRIPTION
The coraz7s has an Arduino/chipKIT Shield connector with 6 Single-ended
and 8 Differential Analog inputs tied to Xilinx's XADC.
The CN0540 uses the A0-5 pins as single-ended adc channels to monitor
the differential input, ADC driver, and buffer voltages.

Signed-off-by: Sergiu Cuciurean <sergiu.cuciurean@analog.com>