### PR TITLE
Fix hdmi tx warnings

### DIFF
--- a/library/axi_hdmi_tx/axi_hdmi_tx_core.v
+++ b/library/axi_hdmi_tx/axi_hdmi_tx_core.v
@@ -295,7 +295,6 @@ module axi_hdmi_tx_core #(
   always @(posedge hdmi_clk) begin
     if (EMBEDDED_SYNC == 1) begin
       hdmi_hs <= 1'b0;
-      hdmi_vs <= 1'b0;
       if (hdmi_hs_count <= hdmi_he_width_s) begin
         hdmi_hs_de <= 1'b0;
       end else begin

--- a/library/common/ad_csc.v
+++ b/library/common/ad_csc.v
@@ -79,7 +79,6 @@ module ad_csc #(
   reg         [DELAY_DW-1:0]  sync_2_m;
   reg         [DELAY_DW-1:0]  sync_3_m;
   reg         [DELAY_DW-1:0]  sync_4_m;
-  reg         [DELAY_DW-1:0]  sync_5_m;
   reg         [         7:0]  csc_data_d;
 
 
@@ -96,7 +95,6 @@ module ad_csc #(
     sync_2_m <= sync_1_m;
     sync_3_m <= sync_2_m;
     sync_4_m <= sync_3_m;
-    sync_5_m <= sync_4_m;
   end
 
   assign color1 = {1'd0,    data[23:16]};
@@ -120,6 +118,7 @@ module ad_csc #(
   generate
     // in RGB to YCbCr there are no overflows or underflows
     if (YCbCr_2_RGB) begin
+      reg  [DELAY_DW-1:0]  sync_5_m;
       // output registers, output is unsigned (0 if sum is < 0) and saturated.
       // the inputs are expected to be 1.4.20 format (output is 8bits).
 
@@ -131,6 +130,7 @@ module ad_csc #(
         end else begin
           csc_data_d <= s_data_3[22:15];
         end
+        sync_5_m <= sync_4_m;
       end
       assign csc_data = csc_data_d;
       assign csc_sync = sync_5_m;

--- a/library/common/ad_ss_422to444.v
+++ b/library/common/ad_ss_422to444.v
@@ -43,15 +43,15 @@ module ad_ss_422to444 #(
 
   // 422 inputs
 
-  input                   clk,
-  input                   s422_de,
-  input       [DW:0]      s422_sync,
-  input       [15:0]      s422_data,
+  input                               clk,
+  input                               s422_de,
+  input       [DELAY_DATA_WIDTH-1:0]  s422_sync,
+  input       [                15:0]  s422_data,
 
   // 444 outputs
 
-  output  reg [DW:0]      s444_sync,
-  output  reg [23:0]      s444_data);
+  output  reg [DELAY_DATA_WIDTH-1:0]  s444_sync,
+  output  reg [                23:0]  s444_data);
 
   localparam  DW = DELAY_DATA_WIDTH - 1;
 


### PR DESCRIPTION
Fix warnings regarding the use of a localparam in a port declaration and unused registers.

Build tested.