### PR TITLE
Fix m2k warnings

### DIFF
--- a/library/axi_logic_analyzer/axi_logic_analyzer.v
+++ b/library/axi_logic_analyzer/axi_logic_analyzer.v
@@ -126,7 +126,7 @@ module axi_logic_analyzer (
   reg    [ 1:0]     low_level_trigger = 1'd0;
 
   reg    [31:0]     trigger_holdoff_counter = 32'd0;
-  reg    [ 4:0]     adc_data_delay = 5'd0;
+  reg    [ 3:0]     adc_data_delay = 4'd0;
 
   reg    [16:0]     data_fixed_delay [0:15];
   reg    [15:0]     data_dynamic_delay [0:15];
@@ -183,8 +183,8 @@ module axi_logic_analyzer (
 
   wire              streaming;
 
-  wire    [ 4:0]    in_data_delay;
-  wire    [ 4:0]    up_data_delay;
+  wire    [ 3:0]    in_data_delay;
+  wire    [ 3:0]    up_data_delay;
   wire              master_delay_ctrl;
   wire    [ 9:0]    data_delay_control;
   wire    [15:0]    adc_data_mn;
@@ -290,19 +290,19 @@ module axi_logic_analyzer (
   // adc path 'rate delay' given by axi_adc_decimate
   always @(posedge clk_out) begin
     case (external_rate)
-      3'd0:    adc_data_delay <= 5'd1; // 100MSPS
-      3'd1:    adc_data_delay <= 5'd3; // 10MSPS
-      default: adc_data_delay <= 5'd1; // <= 1MSPS
+      3'd0:    adc_data_delay <= 4'd1; // 100MSPS
+      3'd1:    adc_data_delay <= 4'd3; // 10MSPS
+      default: adc_data_delay <= 4'd1; // <= 1MSPS
     endcase
   end
 
-  assign up_data_delay = data_delay_control[4:0];
+  assign up_data_delay = data_delay_control[3:0];
   assign rate_gen_select = data_delay_control[8];
 
   // select if the delay taps number is chosen by the user or automatically
   assign master_delay_ctrl = data_delay_control[9];
   assign in_data_delay = master_delay_ctrl ? up_data_delay :
-                         external_decimation_en ? 5'd0 : adc_data_delay;
+                         external_decimation_en ? 4'd0 : adc_data_delay;
 
   always @(posedge clk_out) begin
     if (sample_valid_la == 1'b1) begin

--- a/projects/m2k/common/m2k_bd.tcl
+++ b/projects/m2k/common/m2k_bd.tcl
@@ -46,7 +46,6 @@ ad_ip_parameter bram_la CONFIG.Algorithm {Low_Power}
 ad_ip_parameter bram_la CONFIG.Use_Byte_Write_Enable {false}
 ad_ip_parameter bram_la CONFIG.Operating_Mode_A {NO_CHANGE}
 ad_ip_parameter bram_la CONFIG.Register_PortB_Output_of_Memory_Primitives {true}
-ad_ip_parameter bram_la CONFIG.Use_RSTA_Pin {false}
 ad_ip_parameter bram_la CONFIG.Port_B_Clock {100}
 ad_ip_parameter bram_la CONFIG.Port_B_Enable_Rate {100}
 ad_ip_parameter bram_la CONFIG.Write_Width_A {16}
@@ -91,7 +90,6 @@ ad_ip_parameter bram_adc CONFIG.Enable_32bit_Address false
 ad_ip_parameter bram_adc CONFIG.Use_Byte_Write_Enable false
 ad_ip_parameter bram_adc CONFIG.Operating_Mode_A {NO_CHANGE}
 ad_ip_parameter bram_adc CONFIG.Register_PortB_Output_of_Memory_Primitives true
-ad_ip_parameter bram_adc CONFIG.Use_RSTA_Pin {false}
 ad_ip_parameter bram_adc CONFIG.Port_B_Clock 100
 ad_ip_parameter bram_adc CONFIG.Port_B_Enable_Rate 100
 ad_ip_parameter bram_adc CONFIG.Write_Width_A 32


### PR DESCRIPTION
Fix warnings regarding the use of a localparam in a port declaration and unused registers.

Build tested.