### PR TITLE
Fix constraints for ad40xx

### DIFF
--- a/projects/ad40xx_fmc/zed/system_constr_ad40xx.xdc
+++ b/projects/ad40xx_fmc/zed/system_constr_ad40xx.xdc
@@ -8,5 +8,10 @@ set_property -dict {PACKAGE_PIN M20 IOSTANDARD LVCMOS25 IOB TRUE} [get_ports ad4
 
 set_property -dict {PACKAGE_PIN P22 IOSTANDARD LVCMOS25} [get_ports ad40xx_amp_pd]        ; ## G10  FMC_LPC_LA03_N
 
-set_multicycle_path 2 -setup -from [get_pins -hierarchical -filter {NAME=~*/i_sdo_fifo/i_mem/m_ram_reg/CLKARDCLK}] -to [get_pins -hierarchical -filter {NAME=~*/data_sdo_shift_reg[*]/D}] 
-set_multicycle_path 1 -hold -from [get_pins -hierarchical -filter {NAME=~*/i_sdo_fifo/i_mem/m_ram_reg/CLKARDCLK}] -to [get_pins -hierarchical -filter {NAME=~*/data_sdo_shift_reg[*]/D}] 
+## There is a multi-cycle path between the axi_spi_engine's SDO_FIFO and the
+# execution's shift register, because we load new data into the shift register
+# in every DATA_WIDTH's x 2 cycle. (worst case scenario)
+# Set a multi-cycle delay of 2 spi_clk cycle, slightly over constraining the path.
+set_multicycle_path 2 -setup -from [get_cells -hierarchical -filter {NAME=~*/i_sdo_fifo/i_mem/m_ram_reg}] -to [get_pins -hierarchical -filter {NAME=~*/data_sdo_shift_reg[*]/D}]
+set_multicycle_path 1 -hold  -from [get_cells -hierarchical -filter {NAME=~*/i_sdo_fifo/i_mem/m_ram_reg}] -to [get_pins -hierarchical -filter {NAME=~*/data_sdo_shift_reg[*]/D}]
+

--- a/projects/ad40xx_fmc/zed/system_constr_adaq400x.xdc
+++ b/projects/ad40xx_fmc/zed/system_constr_adaq400x.xdc
@@ -6,5 +6,10 @@ set_property -dict {PACKAGE_PIN Y10  IOSTANDARD LVCMOS33} [get_ports adaq400x_sp
 set_property -dict {PACKAGE_PIN AA9  IOSTANDARD LVCMOS33} [get_ports adaq400x_spi_sclk]      ; ## JA4
 set_property -dict {PACKAGE_PIN Y11  IOSTANDARD LVCMOS33} [get_ports adaq400x_spi_cs]        ; ## JA1
 
-set_multicycle_path 2 -setup -from [get_pins -hierarchical -filter {NAME=~*/i_sdo_fifo/i_mem/m_ram_reg/CLKARDCLK}] -to [get_pins -hierarchical -filter {NAME=~*/data_sdo_shift_reg[*]/D}]
-set_multicycle_path 1 -hold -from [get_pins -hierarchical -filter {NAME=~*/i_sdo_fifo/i_mem/m_ram_reg/CLKARDCLK}] -to [get_pins -hierarchical -filter {NAME=~*/data_sdo_shift_reg[*]/D}] 
+## There is a multi-cycle path between the axi_spi_engine's SDO_FIFO and the
+# execution's shift register, because we load new data into the shift register
+# in every DATA_WIDTH's x 2 cycle. (worst case scenario)
+# Set a multi-cycle delay of 2 spi_clk cycle, slightly over constraining the path.
+set_multicycle_path 2 -setup -from [get_cells -hierarchical -filter {NAME=~*/i_sdo_fifo/i_mem/m_ram_reg}] -to [get_pins -hierarchical -filter {NAME=~*/data_sdo_shift_reg[*]/D}]
+set_multicycle_path 1 -hold -from [get_cells -hierarchical -filter {NAME=~*/i_sdo_fifo/i_mem/m_ram_reg}] -to [get_pins -hierarchical -filter {NAME=~*/data_sdo_shift_reg[*]/D}]
+


### PR DESCRIPTION
ad40xx_fmc/zed: Fix constraints, to avoid critical warnings in synthesis