### PR TITLE
SPI Engine Interconnect: Fixed assignment type

### DIFF
--- a/library/spi_engine/spi_engine_interconnect/spi_engine_interconnect.v
+++ b/library/spi_engine/spi_engine_interconnect/spi_engine_interconnect.v
@@ -133,7 +133,7 @@ end
 
 always @(posedge clk) begin
   if (resetn == 1'b0) begin
-    idle = 1'b1;
+    idle <= 1'b1;
   end else begin
     if (m_sync_valid == 1'b1 && m_sync_ready == 1'b1) begin
       idle <= 1'b1;


### PR DESCRIPTION
Always construct should not contains blocking and non-blocking assignment at the same time.