### PR TITLE
axi_gpreg: Add ttcl for clock_mon  constraints

### DIFF
--- a/library/axi_gpreg/Makefile
+++ b/library/axi_gpreg/Makefile
@@ -13,7 +13,7 @@ GENERIC_DEPS += axi_gpreg_clock_mon.v
 GENERIC_DEPS += axi_gpreg_io.v
 
 XILINX_DEPS += ../xilinx/common/ad_rst_constr.xdc
-XILINX_DEPS += ../xilinx/common/up_clock_mon_constr.xdc
 XILINX_DEPS += axi_gpreg_ip.tcl
+XILINX_DEPS += axi_gpreg_constr.ttcl
 
 include ../scripts/library.mk

--- a/library/axi_gpreg/axi_gpreg_constr.ttcl
+++ b/library/axi_gpreg/axi_gpreg_constr.ttcl
@@ -1,0 +1,18 @@
+<: set ComponentName [getComponentNameString] :>
+<: setOutputDirectory "./" :>
+<: setFileName [ttcl_add $ComponentName "_constr"] :>
+<: setFileExtension ".xdc" :>
+<: setFileProcessingOrder late :>
+<: set num_of_clk_mons [getBooleanValue "NUM_OF_CLK_MONS"] :>
+
+<: if { $num_of_clk_mons > 0 } { :>
+
+set_property ASYNC_REG true [get_cells -hierarchical -filter {name =~ *up_count_running_m*}]
+set_property ASYNC_REG true [get_cells -hierarchical -filter {name =~ *d_count_run_m*}]
+set_property ASYNC_REG true [get_cells -hierarchical -filter {name =~ *up_d_count_reg*}]
+
+set_false_path -from [get_cells -hierarchical -filter {name =~ *d_count_run_m3_reg*  && IS_SEQUENTIAL}] -to [get_cells -hierarchical -filter {name =~ *up_count_running_m1_reg* && IS_SEQUENTIAL}]
+set_false_path -from [get_cells -hierarchical -filter {name =~ *up_count_run_reg*    && IS_SEQUENTIAL}] -to [get_cells -hierarchical -filter {name =~ *d_count_run_m1_reg* && IS_SEQUENTIAL}]
+set_false_path -from [get_cells -hierarchical -filter {name =~ *d_count_reg*         && IS_SEQUENTIAL}] -to [get_cells -hierarchical -filter {name =~ *up_d_count_reg* && IS_SEQUENTIAL}]
+
+<: } :>

--- a/library/axi_gpreg/axi_gpreg_ip.tcl
+++ b/library/axi_gpreg/axi_gpreg_ip.tcl
@@ -9,12 +9,13 @@ adi_ip_files axi_gpreg [list \
   "$ad_hdl_dir/library/common/up_clock_mon.v" \
   "$ad_hdl_dir/library/common/up_axi.v" \
   "$ad_hdl_dir/library/xilinx/common/ad_rst_constr.xdc" \
-  "$ad_hdl_dir/library/xilinx/common/up_clock_mon_constr.xdc" \
   "axi_gpreg_io.v" \
+  "axi_gpreg_constr.ttcl" \
   "axi_gpreg_clock_mon.v" \
   "axi_gpreg.v" ]
 
 adi_ip_properties axi_gpreg
+adi_ip_ttcl axi_gpreg "axi_gpreg_constr.ttcl"
 
 set_property enablement_dependency {spirit:decode(id('MODELPARAM_VALUE.NUM_OF_IO')) > 0} \
   [ipx::get_ports up_gp_*_0 -of_objects [ipx::current_core]]


### PR DESCRIPTION
fixed critical warnings generated when the NUM_OF_CLK_MONS parameter
is set to 0 and the constraints written in up_clock_mon_constr.xdc
cannot be applied; removed up_clock_mon_constr.xdc from ip core.