### PR TITLE
ad77681evb: Remove redundant ad_data_clk

### DIFF
--- a/projects/ad77681evb/zed/Makefile
+++ b/projects/ad77681evb/zed/Makefile
@@ -1,5 +1,5 @@
 ####################################################################################
-## Copyright 2018(c) Analog Devices, Inc.
+## Copyright 2020(c) Analog Devices, Inc.
 ## Auto-generated, do not modify!
 ####################################################################################
 
@@ -9,7 +9,6 @@ M_DEPS += ../common/ad77681evb_bd.tcl
 M_DEPS += ../../common/zed/zed_system_constr.xdc
 M_DEPS += ../../common/zed/zed_system_bd.tcl
 M_DEPS += ../../../library/xilinx/common/ad_iobuf.v
-M_DEPS += ../../../library/xilinx/common/ad_data_clk.v
 
 LIB_DEPS += axi_clkgen
 LIB_DEPS += axi_dmac

--- a/projects/ad77681evb/zed/system_constr.xdc
+++ b/projects/ad77681evb/zed/system_constr.xdc
@@ -19,7 +19,4 @@ set_property -dict {PACKAGE_PIN  N17 IOSTANDARD LVCMOS25}                       
 set_property -dict {PACKAGE_PIN  J18 IOSTANDARD LVCMOS25 IOB TRUE}                  [get_ports ad7768_drdy]        ; ## FMC_LPC_LA05_P
 set_property -dict {PACKAGE_PIN  L19 IOSTANDARD LVCMOS25}                           [get_ports ad7768_sync_out]    ; ## FMC_LPC_CLK0_M2C_N
 set_property -dict {PACKAGE_PIN  L21 IOSTANDARD LVCMOS25}                           [get_ports ad7768_sync_in]     ; ## FMC_LPC_LA06_P
-set_property -dict {PACKAGE_PIN  M19 IOSTANDARD LVCMOS25}                           [get_ports ad7768_mclk]        ; ## FMC_LPC_LA00_CC_P
-
-set_property -dict {PACKAGE_PIN  L18 IOSTANDARD LVCMOS25}                           [get_ports ad7768_mclk_return]   ; ## FMC_LPC_CLK0_M2C_P
 

--- a/projects/ad77681evb/zed/system_top.v
+++ b/projects/ad77681evb/zed/system_top.v
@@ -1,6 +1,6 @@
 // ***************************************************************************
 // ***************************************************************************
-// Copyright 2014 - 2017 (c) Analog Devices, Inc. All rights reserved.
+// Copyright 2014 - 2020 (c) Analog Devices, Inc. All rights reserved.
 //
 // In this HDL repository, there are many different and unique modules, consisting
 // of various HDL (Verilog or VHDL) components. The individual modules are
@@ -89,9 +89,6 @@ module system_top (
   inout           ad7768_sync_in,
   inout   [ 3:0]  ad7768_gpio,
 
-  input           ad7768_mclk,
-  output          ad7768_mclk_return,
-
   input           ad7768_spi_miso,
   output          ad7768_spi_mosi,
   output          ad7768_spi_sclk,
@@ -109,18 +106,8 @@ module system_top (
   wire    [ 1:0]  iic_mux_sda_i_s;
   wire    [ 1:0]  iic_mux_sda_o_s;
   wire            iic_mux_sda_t_s;
-  wire            ad7768_mclk_s;
 
   // instantiations
-
-  ad_data_clk #(.SINGLE_ENDED (1)) i_ad7768_mclk_receiver(
-    .rst (1'b1),
-    .locked (),
-    .clk_in_p (ad7768_0_mclk),
-    .clk_in_n (1'd0),
-    .clk(ad7768_mclk_s));
-  
-  assign ad7768_mclk_return = ad7768_mclk_s;
 
   ad_iobuf #(
     .DATA_WIDTH(7)


### PR DESCRIPTION
This commit will fix the warning caused by the redundant use of ad_data_clk.