### PR TITLE
Fix cn0540 with coraz7s

### DIFF
--- a/projects/cn0540/common/cn0540_bd.tcl
+++ b/projects/cn0540/common/cn0540_bd.tcl
@@ -8,6 +8,15 @@ create_bd_port -dir I adc_data_ready
 ad_ip_instance axi_iic axi_iic_cn0540
 ad_connect iic_cn0540 axi_iic_cn0540/iic
 
+# Generate a 80MHz spi_clk for the SPI Engine (targeted SCLK is 20MHz)
+
+ad_ip_instance axi_clkgen spi_clkgen
+ad_ip_parameter spi_clkgen CONFIG.CLK0_DIV 10
+ad_ip_parameter spi_clkgen CONFIG.VCO_DIV 1
+ad_ip_parameter spi_clkgen CONFIG.VCO_MUL 8
+ad_connect $sys_cpu_clk spi_clkgen/clk
+ad_connect spi_clk spi_clkgen/clk_0
+
 # create a SPI Engine architecture for ADC
 
 create_bd_cell -type hier spi_adc
@@ -87,7 +96,7 @@ ad_connect  $sys_cpu_resetn spi_adc/resetn
 ad_connect  $sys_cpu_resetn axi_cn0540_dma/m_dest_axi_aresetn
 
 ad_connect  spi_adc/m_spi adc_spi
-ad_connect  $sys_dma_clk spi_adc/spi_clk
+ad_connect  spi_clk spi_adc/spi_clk
 ad_connect  axi_cn0540_dma/s_axis spi_adc/M_AXIS_SAMPLE
 
 # AXI address definitions
@@ -95,8 +104,9 @@ ad_connect  axi_cn0540_dma/s_axis spi_adc/M_AXIS_SAMPLE
 ad_cpu_interconnect 0x44a00000 spi_adc/axi_regmap
 ad_cpu_interconnect 0x44a30000 axi_cn0540_dma
 ad_cpu_interconnect 0x44a40000 axi_iic_cn0540
+ad_cpu_interconnect 0x44a70000 spi_clkgen
 
-ad_connect $sys_dma_clk axi_cn0540_dma/s_axis_aclk
+ad_connect spi_clk axi_cn0540_dma/s_axis_aclk
 
 # interrupts
 

--- a/projects/cn0540/coraz7s/system_constr.xdc
+++ b/projects/cn0540/coraz7s/system_constr.xdc
@@ -28,8 +28,8 @@ set_property -dict {PACKAGE_PIN  P15 IOSTANDARD LVCMOS33}                       
 set_multicycle_path 2 -setup -from [get_cells -hierarchical -filter {NAME=~*/i_sdo_fifo/i_mem/m_ram_reg}] -to [get_pins -hierarchical -filter {NAME=~*/data_sdo_shift_reg[*]/D}]
 set_multicycle_path 1 -hold  -from [get_cells -hierarchical -filter {NAME=~*/i_sdo_fifo/i_mem/m_ram_reg}] -to [get_pins -hierarchical -filter {NAME=~*/data_sdo_shift_reg[*]/D}]
 
-# rename auto-generated clock for SPI Engine to spi_clk - 40MHz
-create_generated_clock -name spi_clk [get_pins -hier -filter {name=~*PS7_i/FCLKCLK1}]
+# rename auto-generated clock for SPI Engine to spi_clk - 80MHz
+create_generated_clock -name spi_clk -source [get_pins -filter name=~*CLKIN1 -of [get_cells -hier -filter name=~*spi_clkgen*i_mmcm]] -master_clock clk_fpga_0 [get_pins -filter name=~*CLKOUT0 -of [get_cells -hier -filter name=~*spi_clkgen*i_mmcm]]
 
 # create a generated clock for SCLK - fSCLK=spi_clk/2 - 20MHz
 create_generated_clock -name SCLK_clk -source [get_pins -hier -filter name=~*sclk_reg/C] -edges {1 3 5} [get_ports cn0540_spi_sclk]

--- a/projects/cn0540/coraz7s/system_constr.xdc
+++ b/projects/cn0540/coraz7s/system_constr.xdc
@@ -35,6 +35,6 @@ create_generated_clock -name spi_clk -source [get_pins -filter name=~*CLKIN1 -of
 create_generated_clock -name SCLK_clk -source [get_pins -hier -filter name=~*sclk_reg/C] -edges {1 3 5} [get_ports cn0540_spi_sclk]
 
 # input delays for MISO lines (SDO for the device)
-set_input_delay -clock [get_clocks SCLK_clk] -max  0.6 [get_ports cn0540_spi_miso] -clock_fall
-set_input_delay -clock [get_clocks SCLK_clk] -min  0.1 [get_ports cn0540_spi_miso] -clock_fall
+set_input_delay -clock [get_clocks spi_clk] [get_property PERIOD [get_clocks spi_clk]] \
+		[get_ports -filter {NAME =~ "cn0540_spi_miso"}]
 


### PR DESCRIPTION
Increase the spi_clk frequency to 80MHz. This way we do not lose the last bit in the SPI interface. 