### PR TITLE
Fix Quartus critical warnings and timing issues

### DIFF
--- a/projects/common/s10soc/s10soc_system_assign.tcl
+++ b/projects/common/s10soc/s10soc_system_assign.tcl
@@ -76,8 +76,6 @@ set_instance_assignment -name IO_STANDARD "1.8 V"     -to hps_emac_tx[3]
 set_instance_assignment -name IO_STANDARD "1.8 V"     -to hps_emac_mdc
 set_instance_assignment -name IO_STANDARD "1.8 V"     -to hps_emac_mdio
 
-set_instance_assignment -name CURRENT_STRENGTH "4ma"  -to hps_emac_rx_clk
-set_instance_assignment -name CURRENT_STRENGTH "8ma"  -to hps_emac_rx_ctl
 set_instance_assignment -name CURRENT_STRENGTH "4ma"  -to hps_emac_tx_clk
 set_instance_assignment -name CURRENT_STRENGTH "8ma"  -to hps_emac_tx_ctl
 set_instance_assignment -name CURRENT_STRENGTH "8ma"  -to hps_emac_tx[0]
@@ -294,7 +292,6 @@ set_location_assignment PIN_F32 -to hps_uart_tx
 
 set_instance_assignment -name IO_STANDARD "1.8V" -to hps_uart_rx
 set_instance_assignment -name IO_STANDARD "1.8V" -to hps_uart_tx
-set_instance_assignment -name CURRENT_STRENGTH "8ma" -to hps_uart_rx
 set_instance_assignment -name CURRENT_STRENGTH "8ma" -to hps_uart_tx
 
 # hps-gpio OOBE daughter card

--- a/projects/daq2/a10soc/system_project.tcl
+++ b/projects/daq2/a10soc/system_project.tcl
@@ -130,4 +130,7 @@ set_instance_assignment -name IO_STANDARD "1.8 V" -to spi_clk
 set_instance_assignment -name IO_STANDARD "1.8 V" -to spi_sdio
 set_instance_assignment -name IO_STANDARD "1.8 V" -to spi_dir
 
+# set optimization to get a better timing closure
+set_global_assignment -name OPTIMIZATION_MODE "HIGH PERFORMANCE EFFORT"
+
 execute_flow -compile

--- a/projects/scripts/adi_intel_msg.tcl
+++ b/projects/scripts/adi_intel_msg.tcl
@@ -1,4 +1,9 @@
 
+# For Arria 10 architecture
 set_global_assignment -name MESSAGE_DISABLE 17951 ; ## unused RX channels
 set_global_assignment -name MESSAGE_DISABLE 18655 ; ## unused TX channels
+
+# For Stratix 10 architecture
+set_global_assignment -name MESSAGE_DISABLE 19527 ; ## unused TX/RX channels
+
 set_global_assignment -name MESSAGE_DISABLE 114001 ; ## Time value $x truncated to $y


### PR DESCRIPTION
Fix various critical warnings in Quartus designs and a timing violation:
  1) Disable "Unused TX/RX channel" critical warning for Stratix 10
  2) Fix critical warning related to wrong IO property constraints for input port for Startix 10 base design 
  3) Put a higher optimization effort for the implementation, for DAQ2_A10SOC