### PR TITLE
Fix sysid cstring

### DIFF
--- a/projects/ad40xx_fmc/zed/system_bd.tcl
+++ b/projects/ad40xx_fmc/zed/system_bd.tcl
@@ -19,6 +19,6 @@ source ../common/ad40xx_bd.tcl
 ad_ip_parameter axi_sysid_0 CONFIG.ROM_ADDR_BITS 9
 ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "[pwd]/mem_init_sys.txt"
 ad_ip_parameter rom_sys_0 CONFIG.ROM_ADDR_BITS 9
-set sys_cstring "sys rom custom string placeholder"
-sysid_gen_sys_init_file $sys_cstring
+
+sysid_gen_sys_init_file
 

--- a/projects/ad5758_sdz/zed/system_bd.tcl
+++ b/projects/ad5758_sdz/zed/system_bd.tcl
@@ -5,6 +5,6 @@ source $ad_hdl_dir/projects/common/zed/zed_system_bd.tcl
 ad_ip_parameter axi_sysid_0 CONFIG.ROM_ADDR_BITS 9
 ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "[pwd]/mem_init_sys.txt"
 ad_ip_parameter rom_sys_0 CONFIG.ROM_ADDR_BITS 9
-set sys_cstring "sys rom custom string placeholder"
-sysid_gen_sys_init_file $sys_cstring
+
+sysid_gen_sys_init_file
 

--- a/projects/ad5766_sdz/zed/system_bd.tcl
+++ b/projects/ad5766_sdz/zed/system_bd.tcl
@@ -5,8 +5,8 @@ source $ad_hdl_dir/projects/common/zed/zed_system_bd.tcl
 ad_ip_parameter axi_sysid_0 CONFIG.ROM_ADDR_BITS 9
 ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "[pwd]/mem_init_sys.txt"
 ad_ip_parameter rom_sys_0 CONFIG.ROM_ADDR_BITS 9
-set sys_cstring "sys rom custom string placeholder"
-sysid_gen_sys_init_file $sys_cstring
+
+sysid_gen_sys_init_file
 
 source ../common/ad5766_bd.tcl
 

--- a/projects/ad6676evb/vc707/system_bd.tcl
+++ b/projects/ad6676evb/vc707/system_bd.tcl
@@ -6,5 +6,5 @@ source ../common/ad6676evb_bd.tcl
 ad_ip_parameter axi_sysid_0 CONFIG.ROM_ADDR_BITS 9
 ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "[pwd]/mem_init_sys.txt"
 ad_ip_parameter rom_sys_0 CONFIG.ROM_ADDR_BITS 9
-set sys_cstring "sys rom custom string placeholder"
-sysid_gen_sys_init_file $sys_cstring
+
+sysid_gen_sys_init_file

--- a/projects/ad6676evb/zc706/system_bd.tcl
+++ b/projects/ad6676evb/zc706/system_bd.tcl
@@ -6,5 +6,5 @@ source ../common/ad6676evb_bd.tcl
 ad_ip_parameter axi_sysid_0 CONFIG.ROM_ADDR_BITS 9
 ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "[pwd]/mem_init_sys.txt"
 ad_ip_parameter rom_sys_0 CONFIG.ROM_ADDR_BITS 9
-set sys_cstring "sys rom custom string placeholder"
-sysid_gen_sys_init_file $sys_cstring
+
+sysid_gen_sys_init_file

--- a/projects/ad7134_fmc/zed/system_bd.tcl
+++ b/projects/ad7134_fmc/zed/system_bd.tcl
@@ -5,8 +5,8 @@ source $ad_hdl_dir/projects/common/zed/zed_system_bd.tcl
 ad_ip_parameter axi_sysid_0 CONFIG.ROM_ADDR_BITS 9
 ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "[pwd]/mem_init_sys.txt"
 ad_ip_parameter rom_sys_0 CONFIG.ROM_ADDR_BITS 9
-set sys_cstring "sys rom custom string placeholder"
-sysid_gen_sys_init_file $sys_cstring
+
+sysid_gen_sys_init_file
 
 # specify ADC resolution -- the design supports 16/24/32 bit resolutions
 

--- a/projects/ad738x_fmc/zed/system_bd.tcl
+++ b/projects/ad738x_fmc/zed/system_bd.tcl
@@ -5,8 +5,8 @@ source $ad_hdl_dir/projects/common/zed/zed_system_bd.tcl
 ad_ip_parameter axi_sysid_0 CONFIG.ROM_ADDR_BITS 9
 ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "[pwd]/mem_init_sys.txt"
 ad_ip_parameter rom_sys_0 CONFIG.ROM_ADDR_BITS 9
-set sys_cstring "sys rom custom string placeholder"
-sysid_gen_sys_init_file $sys_cstring
+
+sysid_gen_sys_init_file
 
 # specify ADC resolution -- the design supports 16/14/12 bit resolutions
 

--- a/projects/ad7405_fmc/zed/system_bd.tcl
+++ b/projects/ad7405_fmc/zed/system_bd.tcl
@@ -5,8 +5,8 @@ source $ad_hdl_dir/projects/common/zed/zed_system_bd.tcl
 ad_ip_parameter axi_sysid_0 CONFIG.ROM_ADDR_BITS 9
 ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "[pwd]/mem_init_sys.txt"
 ad_ip_parameter rom_sys_0 CONFIG.ROM_ADDR_BITS 9
-set sys_cstring "sys rom custom string placeholder"
-sysid_gen_sys_init_file $sys_cstring
+
+sysid_gen_sys_init_file
 
 # System clock is 100 MHz for this base design
 

--- a/projects/ad7616_sdz/zc706/system_bd.tcl
+++ b/projects/ad7616_sdz/zc706/system_bd.tcl
@@ -5,8 +5,8 @@ source $ad_hdl_dir/projects/common/zc706/zc706_system_bd.tcl
 ad_ip_parameter axi_sysid_0 CONFIG.ROM_ADDR_BITS 9
 ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "[pwd]/mem_init_sys.txt"
 ad_ip_parameter rom_sys_0 CONFIG.ROM_ADDR_BITS 9
-set sys_cstring "sys rom custom string placeholder"
-sysid_gen_sys_init_file $sys_cstring
+
+sysid_gen_sys_init_file
 
 source ../common/ad7616_bd.tcl
 

--- a/projects/ad7616_sdz/zed/system_bd.tcl
+++ b/projects/ad7616_sdz/zed/system_bd.tcl
@@ -5,8 +5,8 @@ source $ad_hdl_dir/projects/common/zed/zed_system_bd.tcl
 ad_ip_parameter axi_sysid_0 CONFIG.ROM_ADDR_BITS 9
 ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "[pwd]/mem_init_sys.txt"
 ad_ip_parameter rom_sys_0 CONFIG.ROM_ADDR_BITS 9
-set sys_cstring "sys rom custom string placeholder"
-sysid_gen_sys_init_file $sys_cstring
+
+sysid_gen_sys_init_file
 
 source ../common/ad7616_bd.tcl
 

--- a/projects/ad77681evb/zed/system_bd.tcl
+++ b/projects/ad77681evb/zed/system_bd.tcl
@@ -5,8 +5,8 @@ source $ad_hdl_dir/projects/common/zed/zed_system_bd.tcl
 ad_ip_parameter axi_sysid_0 CONFIG.ROM_ADDR_BITS 9
 ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "[pwd]/mem_init_sys.txt"
 ad_ip_parameter rom_sys_0 CONFIG.ROM_ADDR_BITS 9
-set sys_cstring "sys rom custom string placeholder"
-sysid_gen_sys_init_file $sys_cstring
+
+sysid_gen_sys_init_file
 
 source ../common/ad77681evb_bd.tcl
 

--- a/projects/ad7768evb/zed/system_bd.tcl
+++ b/projects/ad7768evb/zed/system_bd.tcl
@@ -5,8 +5,8 @@ source $ad_hdl_dir/projects/common/zed/zed_system_bd.tcl
 ad_ip_parameter axi_sysid_0 CONFIG.ROM_ADDR_BITS 9
 ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "[pwd]/mem_init_sys.txt"
 ad_ip_parameter rom_sys_0 CONFIG.ROM_ADDR_BITS 9
-set sys_cstring "sys rom custom string placeholder"
-sysid_gen_sys_init_file $sys_cstring
+
+sysid_gen_sys_init_file
 
 source ../common/ad7768evb_bd.tcl
 

--- a/projects/ad9081_fmca_ebz/vcu118/system_bd.tcl
+++ b/projects/ad9081_fmca_ebz/vcu118/system_bd.tcl
@@ -17,8 +17,8 @@ ad_ip_parameter axi_mxfe_tx_jesd/tx CONFIG.NUM_OUTPUT_PIPELINE 1
 ad_ip_parameter axi_sysid_0 CONFIG.ROM_ADDR_BITS 9
 ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "[pwd]/mem_init_sys.txt"
 ad_ip_parameter rom_sys_0 CONFIG.ROM_ADDR_BITS 9
-set sys_cstring "sys rom custom string placeholder"
-sysid_gen_sys_init_file $sys_cstring
+
+sysid_gen_sys_init_file
 
 if {$ad_project_params(JESD_MODE) == "8B10B"} {
 # Parameters for 15.5Gpbs lane rate

--- a/projects/ad9081_fmca_ebz/zcu102/system_bd.tcl
+++ b/projects/ad9081_fmca_ebz/zcu102/system_bd.tcl
@@ -14,8 +14,8 @@ source ../common/ad9081_fmca_ebz_bd.tcl
 ad_ip_parameter axi_sysid_0 CONFIG.ROM_ADDR_BITS 9
 ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "[pwd]/mem_init_sys.txt"
 ad_ip_parameter rom_sys_0 CONFIG.ROM_ADDR_BITS 9
-set sys_cstring "sys rom custom string placeholder"
-sysid_gen_sys_init_file $sys_cstring
+
+sysid_gen_sys_init_file
 
 # Parameters for 15.5Gpbs lane rate
 

--- a/projects/ad9208_dual_ebz/vcu118/system_bd.tcl
+++ b/projects/ad9208_dual_ebz/vcu118/system_bd.tcl
@@ -10,8 +10,8 @@ source ../common/dual_ad9208_bd.tcl
 ad_ip_parameter axi_sysid_0 CONFIG.ROM_ADDR_BITS 9
 ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "[pwd]/mem_init_sys.txt"
 ad_ip_parameter rom_sys_0 CONFIG.ROM_ADDR_BITS 9
-set sys_cstring "sys rom custom string placeholder"
-sysid_gen_sys_init_file $sys_cstring
+
+sysid_gen_sys_init_file
 
 foreach i {0 1} {
 

--- a/projects/ad9265_fmc/zc706/system_bd.tcl
+++ b/projects/ad9265_fmc/zc706/system_bd.tcl
@@ -6,5 +6,5 @@ source ../common/ad9265_bd.tcl
 ad_ip_parameter axi_sysid_0 CONFIG.ROM_ADDR_BITS 9
 ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "[pwd]/mem_init_sys.txt"
 ad_ip_parameter rom_sys_0 CONFIG.ROM_ADDR_BITS 9
-set sys_cstring "sys rom custom string placeholder"
-sysid_gen_sys_init_file $sys_cstring
+
+sysid_gen_sys_init_file

--- a/projects/ad9434_fmc/zc706/system_bd.tcl
+++ b/projects/ad9434_fmc/zc706/system_bd.tcl
@@ -6,5 +6,5 @@ source ../common/ad9434_bd.tcl
 ad_ip_parameter axi_sysid_0 CONFIG.ROM_ADDR_BITS 9
 ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "[pwd]/mem_init_sys.txt"
 ad_ip_parameter rom_sys_0 CONFIG.ROM_ADDR_BITS 9
-set sys_cstring "sys rom custom string placeholder"
-sysid_gen_sys_init_file $sys_cstring
+
+sysid_gen_sys_init_file

--- a/projects/ad9467_fmc/kc705/system_bd.tcl
+++ b/projects/ad9467_fmc/kc705/system_bd.tcl
@@ -6,5 +6,5 @@ source ../common/ad9467_bd.tcl
 ad_ip_parameter axi_sysid_0 CONFIG.ROM_ADDR_BITS 9
 ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "[pwd]/mem_init_sys.txt"
 ad_ip_parameter rom_sys_0 CONFIG.ROM_ADDR_BITS 9
-set sys_cstring "sys rom custom string placeholder"
-sysid_gen_sys_init_file $sys_cstring
+
+sysid_gen_sys_init_file

--- a/projects/ad9467_fmc/zed/system_bd.tcl
+++ b/projects/ad9467_fmc/zed/system_bd.tcl
@@ -6,5 +6,5 @@ source ../common/ad9467_bd.tcl
 ad_ip_parameter axi_sysid_0 CONFIG.ROM_ADDR_BITS 9
 ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "[pwd]/mem_init_sys.txt"
 ad_ip_parameter rom_sys_0 CONFIG.ROM_ADDR_BITS 9
-set sys_cstring "sys rom custom string placeholder"
-sysid_gen_sys_init_file $sys_cstring
+
+sysid_gen_sys_init_file

--- a/projects/ad9739a_fmc/zc706/system_bd.tcl
+++ b/projects/ad9739a_fmc/zc706/system_bd.tcl
@@ -6,5 +6,5 @@ source ../common/ad9739a_fmc_bd.tcl
 ad_ip_parameter axi_sysid_0 CONFIG.ROM_ADDR_BITS 9
 ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "[pwd]/mem_init_sys.txt"
 ad_ip_parameter rom_sys_0 CONFIG.ROM_ADDR_BITS 9
-set sys_cstring "sys rom custom string placeholder"
-sysid_gen_sys_init_file $sys_cstring
+
+sysid_gen_sys_init_file

--- a/projects/ad_fmclidar1_ebz/a10soc/system_qsys.tcl
+++ b/projects/ad_fmclidar1_ebz/a10soc/system_qsys.tcl
@@ -18,6 +18,5 @@ set_instance_parameter_value rom_sys_0 {ROM_ADDR_BITS} {9}
 
 set_instance_parameter_value rom_sys_0 {PATH_TO_FILE} "[pwd]/mem_init_sys.txt"
 
-set sys_cstring "sys rom custom string placeholder";
-sysid_gen_sys_init_file $sys_cstring;
+sysid_gen_sys_init_file;
 

--- a/projects/ad_fmclidar1_ebz/zc706/system_bd.tcl
+++ b/projects/ad_fmclidar1_ebz/zc706/system_bd.tcl
@@ -39,6 +39,6 @@ ad_connect iic_dac sys_ps7/IIC_1
 ad_ip_parameter axi_sysid_0 CONFIG.ROM_ADDR_BITS 9
 ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "[pwd]/mem_init_sys.txt"
 ad_ip_parameter rom_sys_0 CONFIG.ROM_ADDR_BITS 9
-set sys_cstring "sys rom custom string placeholder"
-sysid_gen_sys_init_file $sys_cstring
+
+sysid_gen_sys_init_file
 

--- a/projects/ad_fmclidar1_ebz/zcu102/system_bd.tcl
+++ b/projects/ad_fmclidar1_ebz/zcu102/system_bd.tcl
@@ -41,6 +41,6 @@ ad_cpu_interrupt ps-12  mb-14  afe_dac_iic/iic2intc_irpt
 ad_ip_parameter axi_sysid_0 CONFIG.ROM_ADDR_BITS 9
 ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "[pwd]/mem_init_sys.txt"
 ad_ip_parameter rom_sys_0 CONFIG.ROM_ADDR_BITS 9
-set sys_cstring "sys rom custom string placeholder"
-sysid_gen_sys_init_file $sys_cstring
+
+sysid_gen_sys_init_file
 

--- a/projects/adaq7980_sdz/zed/system_bd.tcl
+++ b/projects/adaq7980_sdz/zed/system_bd.tcl
@@ -5,8 +5,8 @@ source $ad_hdl_dir/projects/common/zed/zed_system_bd.tcl
 ad_ip_parameter axi_sysid_0 CONFIG.ROM_ADDR_BITS 9
 ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "[pwd]/mem_init_sys.txt"
 ad_ip_parameter rom_sys_0 CONFIG.ROM_ADDR_BITS 9
-set sys_cstring "sys rom custom string placeholder"
-sysid_gen_sys_init_file $sys_cstring
+
+sysid_gen_sys_init_file
 
 # specify ADC sampling rate in samples/seconds -- default is 1 MSPS
 set adc_sampling_rate 1000000

--- a/projects/adrv9001/zed/system_bd.tcl
+++ b/projects/adrv9001/zed/system_bd.tcl
@@ -6,6 +6,6 @@ source ../common/adrv9001_bd.tcl
 ad_ip_parameter axi_sysid_0 CONFIG.ROM_ADDR_BITS 9
 ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "[pwd]/mem_init_sys.txt"
 ad_ip_parameter rom_sys_0 CONFIG.ROM_ADDR_BITS 9
-set sys_cstring "sys rom custom string placeholder"
-sysid_gen_sys_init_file $sys_cstring
+
+sysid_gen_sys_init_file
 

--- a/projects/adrv9009/a10gx/system_qsys.tcl
+++ b/projects/adrv9009/a10gx/system_qsys.tcl
@@ -12,6 +12,5 @@ set_instance_parameter_value rom_sys_0 {ROM_ADDR_BITS} {9}
 
 set_instance_parameter_value rom_sys_0 {PATH_TO_FILE} "[pwd]/mem_init_sys.txt"
 
-set sys_cstring "sys rom custom string placeholder";
-sysid_gen_sys_init_file $sys_cstring;
+sysid_gen_sys_init_file;
 

--- a/projects/adrv9009/a10soc/system_qsys.tcl
+++ b/projects/adrv9009/a10soc/system_qsys.tcl
@@ -12,6 +12,5 @@ set_instance_parameter_value rom_sys_0 {ROM_ADDR_BITS} {9}
 
 set_instance_parameter_value rom_sys_0 {PATH_TO_FILE} "[pwd]/mem_init_sys.txt"
 
-set sys_cstring "sys rom custom string placeholder";
-sysid_gen_sys_init_file $sys_cstring;
+sysid_gen_sys_init_file;
 

--- a/projects/adrv9009/zc706/system_bd.tcl
+++ b/projects/adrv9009/zc706/system_bd.tcl
@@ -8,8 +8,8 @@ source $ad_hdl_dir/projects/common/zc706/zc706_plddr3_dacfifo_bd.tcl
 ad_ip_parameter axi_sysid_0 CONFIG.ROM_ADDR_BITS 9
 ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "[pwd]/mem_init_sys.txt"
 ad_ip_parameter rom_sys_0 CONFIG.ROM_ADDR_BITS 9
-set sys_cstring "sys rom custom string placeholder"
-sysid_gen_sys_init_file $sys_cstring
+
+sysid_gen_sys_init_file
 
 ad_ip_parameter sys_ps7 CONFIG.PCW_FPGA2_PERIPHERAL_FREQMHZ 250
 

--- a/projects/adrv9009/zcu102/system_bd.tcl
+++ b/projects/adrv9009/zcu102/system_bd.tcl
@@ -11,8 +11,8 @@ source $ad_hdl_dir/projects/common/xilinx/dacfifo_bd.tcl
 ad_ip_parameter axi_sysid_0 CONFIG.ROM_ADDR_BITS 9
 ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "[pwd]/mem_init_sys.txt"
 ad_ip_parameter rom_sys_0 CONFIG.ROM_ADDR_BITS 9
-set sys_cstring "sys rom custom string placeholder"
-sysid_gen_sys_init_file $sys_cstring
+
+sysid_gen_sys_init_file
 
 ad_mem_hp0_interconnect sys_cpu_clk sys_ps8/S_AXI_HP0
 

--- a/projects/adrv9009zu11eg/adrv2crr_fmc/system_bd.tcl
+++ b/projects/adrv9009zu11eg/adrv2crr_fmc/system_bd.tcl
@@ -5,5 +5,5 @@ source ../common/adrv2crr_fmc_bd.tcl
 ad_ip_parameter axi_sysid_0 CONFIG.ROM_ADDR_BITS 9
 ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "[pwd]/mem_init_sys.txt"
 ad_ip_parameter rom_sys_0 CONFIG.ROM_ADDR_BITS 9
-set sys_cstring "sys rom custom string placeholder"
-sysid_gen_sys_init_file $sys_cstring
+
+sysid_gen_sys_init_file

--- a/projects/adrv9009zu11eg/adrv2crr_fmcomms8/system_bd.tcl
+++ b/projects/adrv9009zu11eg/adrv2crr_fmcomms8/system_bd.tcl
@@ -76,8 +76,8 @@ ad_xcvrpll  axi_adrv9009_som_obs_xcvr/up_pll_rst util_adrv9009_som_xcvr/up_cpll_
 ad_ip_parameter axi_sysid_0 CONFIG.ROM_ADDR_BITS 9
 ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "[pwd]/mem_init_sys.txt"
 ad_ip_parameter rom_sys_0 CONFIG.ROM_ADDR_BITS 9
-set sys_cstring "sys rom custom string placeholder"
-sysid_gen_sys_init_file $sys_cstring
+
+sysid_gen_sys_init_file
 
 ad_cpu_interconnect 0x46000000 axi_fmcomms8_gpio
 

--- a/projects/adrv9361z7035/ccbob_cmos/system_bd.tcl
+++ b/projects/adrv9361z7035/ccbob_cmos/system_bd.tcl
@@ -13,5 +13,5 @@ ad_ip_parameter axi_ad9361 CONFIG.ADC_INIT_DELAY 29
 ad_ip_parameter axi_sysid_0 CONFIG.ROM_ADDR_BITS 9
 ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "[pwd]/mem_init_sys.txt"
 ad_ip_parameter rom_sys_0 CONFIG.ROM_ADDR_BITS 9
-set sys_cstring "sys rom custom string placeholder"
-sysid_gen_sys_init_file $sys_cstring
+
+sysid_gen_sys_init_file

--- a/projects/adrv9361z7035/ccbob_lvds/system_bd.tcl
+++ b/projects/adrv9361z7035/ccbob_lvds/system_bd.tcl
@@ -10,5 +10,5 @@ ad_ip_parameter axi_ad9361 CONFIG.ADC_INIT_DELAY 29
 ad_ip_parameter axi_sysid_0 CONFIG.ROM_ADDR_BITS 9
 ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "[pwd]/mem_init_sys.txt"
 ad_ip_parameter rom_sys_0 CONFIG.ROM_ADDR_BITS 9
-set sys_cstring "sys rom custom string placeholder"
-sysid_gen_sys_init_file $sys_cstring
+
+sysid_gen_sys_init_file

--- a/projects/adrv9361z7035/ccfmc_lvds/system_bd.tcl
+++ b/projects/adrv9361z7035/ccfmc_lvds/system_bd.tcl
@@ -13,5 +13,5 @@ ad_ip_parameter axi_ad9361 CONFIG.ADC_INIT_DELAY 29
 ad_ip_parameter axi_sysid_0 CONFIG.ROM_ADDR_BITS 9
 ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "[pwd]/mem_init_sys.txt"
 ad_ip_parameter rom_sys_0 CONFIG.ROM_ADDR_BITS 9
-set sys_cstring "sys rom custom string placeholder"
-sysid_gen_sys_init_file $sys_cstring
+
+sysid_gen_sys_init_file

--- a/projects/adrv9361z7035/ccpackrf_lvds/system_bd.tcl
+++ b/projects/adrv9361z7035/ccpackrf_lvds/system_bd.tcl
@@ -13,5 +13,5 @@ set_property CONFIG.ADC_INIT_DELAY 29 [get_bd_cells axi_ad9361]
 ad_ip_parameter axi_sysid_0 CONFIG.ROM_ADDR_BITS 9
 ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "[pwd]/mem_init_sys.txt"
 ad_ip_parameter rom_sys_0 CONFIG.ROM_ADDR_BITS 9
-set sys_cstring "sys rom custom string placeholder"
-sysid_gen_sys_init_file $sys_cstring
+
+sysid_gen_sys_init_file

--- a/projects/adrv9364z7020/ccbob_cmos/system_bd.tcl
+++ b/projects/adrv9364z7020/ccbob_cmos/system_bd.tcl
@@ -13,5 +13,5 @@ set_property CONFIG.ADC_INIT_DELAY 30 [get_bd_cells axi_ad9361]
 ad_ip_parameter axi_sysid_0 CONFIG.ROM_ADDR_BITS 9
 ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "[pwd]/mem_init_sys.txt"
 ad_ip_parameter rom_sys_0 CONFIG.ROM_ADDR_BITS 9
-set sys_cstring "sys rom custom string placeholder"
-sysid_gen_sys_init_file $sys_cstring
+
+sysid_gen_sys_init_file

--- a/projects/adrv9364z7020/ccbob_lvds/system_bd.tcl
+++ b/projects/adrv9364z7020/ccbob_lvds/system_bd.tcl
@@ -10,5 +10,5 @@ set_property CONFIG.ADC_INIT_DELAY 30 [get_bd_cells axi_ad9361]
 ad_ip_parameter axi_sysid_0 CONFIG.ROM_ADDR_BITS 9
 ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "[pwd]/mem_init_sys.txt"
 ad_ip_parameter rom_sys_0 CONFIG.ROM_ADDR_BITS 9
-set sys_cstring "sys rom custom string placeholder"
-sysid_gen_sys_init_file $sys_cstring
+
+sysid_gen_sys_init_file

--- a/projects/adrv9364z7020/ccpackrf_lvds/system_bd.tcl
+++ b/projects/adrv9364z7020/ccpackrf_lvds/system_bd.tcl
@@ -13,5 +13,5 @@ set_property CONFIG.ADC_INIT_DELAY 30 [get_bd_cells axi_ad9361]
 ad_ip_parameter axi_sysid_0 CONFIG.ROM_ADDR_BITS 9
 ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "[pwd]/mem_init_sys.txt"
 ad_ip_parameter rom_sys_0 CONFIG.ROM_ADDR_BITS 9
-set sys_cstring "sys rom custom string placeholder"
-sysid_gen_sys_init_file $sys_cstring
+
+sysid_gen_sys_init_file

--- a/projects/adrv9371x/a10gx/system_qsys.tcl
+++ b/projects/adrv9371x/a10gx/system_qsys.tcl
@@ -13,6 +13,5 @@ set_instance_parameter_value rom_sys_0 {ROM_ADDR_BITS} {9}
 
 set_instance_parameter_value rom_sys_0 {PATH_TO_FILE} "[pwd]/mem_init_sys.txt"
 
-set sys_cstring "sys rom custom string placeholder";
-sysid_gen_sys_init_file $sys_cstring;
+sysid_gen_sys_init_file;
 

--- a/projects/adrv9371x/a10soc/system_qsys.tcl
+++ b/projects/adrv9371x/a10soc/system_qsys.tcl
@@ -12,6 +12,5 @@ set_instance_parameter_value rom_sys_0 {ROM_ADDR_BITS} {9}
 
 set_instance_parameter_value rom_sys_0 {PATH_TO_FILE} "[pwd]/mem_init_sys.txt"
 
-set sys_cstring "sys rom custom string placeholder";
-sysid_gen_sys_init_file $sys_cstring;
+sysid_gen_sys_init_file;
 

--- a/projects/adrv9371x/kcu105/system_bd.tcl
+++ b/projects/adrv9371x/kcu105/system_bd.tcl
@@ -12,8 +12,8 @@ source $ad_hdl_dir/projects/common/xilinx/dacfifo_bd.tcl
 ad_ip_parameter axi_sysid_0 CONFIG.ROM_ADDR_BITS 9
 ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "[pwd]/mem_init_sys.txt"
 ad_ip_parameter rom_sys_0 CONFIG.ROM_ADDR_BITS 9
-set sys_cstring "sys rom custom string placeholder"
-sysid_gen_sys_init_file $sys_cstring
+
+sysid_gen_sys_init_file
 
 ad_ip_parameter axi_ddr_cntrl CONFIG.ADDN_UI_CLKOUT3_FREQ_HZ 200
 

--- a/projects/adrv9371x/zc706/system_bd.tcl
+++ b/projects/adrv9371x/zc706/system_bd.tcl
@@ -8,8 +8,8 @@ source $ad_hdl_dir/projects/common/zc706/zc706_plddr3_dacfifo_bd.tcl
 ad_ip_parameter axi_sysid_0 CONFIG.ROM_ADDR_BITS 9
 ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "[pwd]/mem_init_sys.txt"
 ad_ip_parameter rom_sys_0 CONFIG.ROM_ADDR_BITS 9
-set sys_cstring "sys rom custom string placeholder"
-sysid_gen_sys_init_file $sys_cstring
+
+sysid_gen_sys_init_file
 
 ad_ip_parameter sys_ps7 CONFIG.PCW_FPGA2_PERIPHERAL_FREQMHZ 200
 

--- a/projects/adrv9371x/zcu102/system_bd.tcl
+++ b/projects/adrv9371x/zcu102/system_bd.tcl
@@ -11,8 +11,8 @@ source $ad_hdl_dir/projects/common/xilinx/dacfifo_bd.tcl
 ad_ip_parameter axi_sysid_0 CONFIG.ROM_ADDR_BITS 9
 ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "[pwd]/mem_init_sys.txt"
 ad_ip_parameter rom_sys_0 CONFIG.ROM_ADDR_BITS 9
-set sys_cstring "sys rom custom string placeholder"
-sysid_gen_sys_init_file $sys_cstring
+
+sysid_gen_sys_init_file
 
 ad_ip_parameter sys_ps8 CONFIG.PSU__FPGA_PL2_ENABLE 1
 ad_ip_parameter sys_ps8 CONFIG.PSU__CRL_APB__PL2_REF_CTRL__SRCSEL {IOPLL}

--- a/projects/adv7511/zc702/system_bd.tcl
+++ b/projects/adv7511/zc702/system_bd.tcl
@@ -5,5 +5,5 @@ source $ad_hdl_dir/projects/common/zc702/zc702_system_bd.tcl
 ad_ip_parameter axi_sysid_0 CONFIG.ROM_ADDR_BITS 9
 ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "[pwd]/mem_init_sys.txt"
 ad_ip_parameter rom_sys_0 CONFIG.ROM_ADDR_BITS 9
-set sys_cstring "sys rom custom string placeholder"
-sysid_gen_sys_init_file $sys_cstring
+
+sysid_gen_sys_init_file

--- a/projects/adv7511/zc706/system_bd.tcl
+++ b/projects/adv7511/zc706/system_bd.tcl
@@ -5,5 +5,5 @@ source $ad_hdl_dir/projects/common/zc706/zc706_system_bd.tcl
 ad_ip_parameter axi_sysid_0 CONFIG.ROM_ADDR_BITS 9
 ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "[pwd]/mem_init_sys.txt"
 ad_ip_parameter rom_sys_0 CONFIG.ROM_ADDR_BITS 9
-set sys_cstring "sys rom custom string placeholder"
-sysid_gen_sys_init_file $sys_cstring
+
+sysid_gen_sys_init_file

--- a/projects/adv7511/zed/system_bd.tcl
+++ b/projects/adv7511/zed/system_bd.tcl
@@ -5,6 +5,6 @@ source $ad_hdl_dir/projects/common/zed/zed_system_bd.tcl
 ad_ip_parameter axi_sysid_0 CONFIG.ROM_ADDR_BITS 9
 ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "[pwd]/mem_init_sys.txt"
 ad_ip_parameter rom_sys_0 CONFIG.ROM_ADDR_BITS 9
-set sys_cstring "sys rom custom string placeholder"
-sysid_gen_sys_init_file $sys_cstring
+
+sysid_gen_sys_init_file
 

--- a/projects/arradio/c5soc/system_qsys.tcl
+++ b/projects/arradio/c5soc/system_qsys.tcl
@@ -9,6 +9,5 @@ set_instance_parameter_value rom_sys_0 {ROM_ADDR_BITS} {9}
 
 set_instance_parameter_value rom_sys_0 {PATH_TO_FILE} "[pwd]/mem_init_sys.txt"
 
-set sys_cstring "sys rom custom string placeholder";
-sysid_gen_sys_init_file $sys_cstring;
+sysid_gen_sys_init_file;
 

--- a/projects/cn0363/zed/system_bd.tcl
+++ b/projects/cn0363/zed/system_bd.tcl
@@ -6,8 +6,8 @@ source ../common/cn0363_bd.tcl
 ad_ip_parameter axi_sysid_0 CONFIG.ROM_ADDR_BITS 9
 ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "[pwd]/mem_init_sys.txt"
 ad_ip_parameter rom_sys_0 CONFIG.ROM_ADDR_BITS 9
-set sys_cstring "sys rom custom string placeholder"
-sysid_gen_sys_init_file $sys_cstring
+
+sysid_gen_sys_init_file
 
 ad_ip_parameter sys_ps7 CONFIG.PCW_GPIO_EMIO_GPIO_IO 35
 

--- a/projects/cn0506_mii/a10soc/system_qsys.tcl
+++ b/projects/cn0506_mii/a10soc/system_qsys.tcl
@@ -9,6 +9,5 @@ set_instance_parameter_value rom_sys_0 {ROM_ADDR_BITS} {9}
 
 set_instance_parameter_value rom_sys_0 {PATH_TO_FILE} "[pwd]/mem_init_sys.txt"
 
-set sys_cstring "sys rom custom string placeholder";
-sysid_gen_sys_init_file $sys_cstring;
+sysid_gen_sys_init_file;
 

--- a/projects/cn0506_rgmii/a10soc/system_qsys.tcl
+++ b/projects/cn0506_rgmii/a10soc/system_qsys.tcl
@@ -9,6 +9,5 @@ set_instance_parameter_value rom_sys_0 {ROM_ADDR_BITS} {9}
 
 set_instance_parameter_value rom_sys_0 {PATH_TO_FILE} "[pwd]/mem_init_sys.txt"
 
-set sys_cstring "sys rom custom string placeholder";
-sysid_gen_sys_init_file $sys_cstring;
+sysid_gen_sys_init_file;
 

--- a/projects/cn0506_rmii/zc706/system_bd.tcl
+++ b/projects/cn0506_rmii/zc706/system_bd.tcl
@@ -55,6 +55,6 @@ ad_connect proc_sys_reset_eth1/peripheral_aresetn  mii_to_rmii_1/rst_n
 ad_ip_parameter axi_sysid_0 CONFIG.ROM_ADDR_BITS 9
 ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "[pwd]/mem_init_sys.txt"
 ad_ip_parameter rom_sys_0 CONFIG.ROM_ADDR_BITS 9
-set sys_cstring "sys rom custom string placeholder"
-sysid_gen_sys_init_file $sys_cstring
+
+sysid_gen_sys_init_file
 

--- a/projects/cn0506_rmii/zcu102/system_bd.tcl
+++ b/projects/cn0506_rmii/zcu102/system_bd.tcl
@@ -60,6 +60,6 @@ ad_connect proc_sys_reset_eth1/peripheral_aresetn  mii_to_rmii_1/rst_n
 ad_ip_parameter axi_sysid_0 CONFIG.ROM_ADDR_BITS 9
 ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "[pwd]/mem_init_sys.txt"
 ad_ip_parameter rom_sys_0 CONFIG.ROM_ADDR_BITS 9
-set sys_cstring "sys rom custom string placeholder"
-sysid_gen_sys_init_file $sys_cstring
+
+sysid_gen_sys_init_file
 

--- a/projects/cn0506_rmii/zed/system_bd.tcl
+++ b/projects/cn0506_rmii/zed/system_bd.tcl
@@ -54,6 +54,6 @@ ad_connect proc_sys_reset_eth1/peripheral_aresetn  mii_to_rmii_1/rst_n
 ad_ip_parameter axi_sysid_0 CONFIG.ROM_ADDR_BITS 9
 ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "[pwd]/mem_init_sys.txt"
 ad_ip_parameter rom_sys_0 CONFIG.ROM_ADDR_BITS 9
-set sys_cstring "sys rom custom string placeholder"
-sysid_gen_sys_init_file $sys_cstring
+
+sysid_gen_sys_init_file
 

--- a/projects/cn0540/coraz7s/system_bd.tcl
+++ b/projects/cn0540/coraz7s/system_bd.tcl
@@ -5,8 +5,8 @@ source $ad_hdl_dir/projects/common/coraz7s/coraz7s_system_bd.tcl
 ad_ip_parameter axi_sysid_0 CONFIG.ROM_ADDR_BITS 9
 ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "[pwd]/mem_init_sys.txt"
 ad_ip_parameter rom_sys_0 CONFIG.ROM_ADDR_BITS 9
-set sys_cstring "sys rom custom string placeholder"
-sysid_gen_sys_init_file $sys_cstring
+
+sysid_gen_sys_init_file
 
 set sys_dma_clk [get_bd_nets sys_dma_clk]
 

--- a/projects/dac_fmc_ebz/a10soc/system_qsys.tcl
+++ b/projects/dac_fmc_ebz/a10soc/system_qsys.tcl
@@ -43,6 +43,5 @@ set_instance_parameter_value rom_sys_0 {ROM_ADDR_BITS} {9}
 
 set_instance_parameter_value rom_sys_0 {PATH_TO_FILE} "[pwd]/mem_init_sys.txt"
 
-set sys_cstring "sys rom custom string placeholder";
-sysid_gen_sys_init_file $sys_cstring;
+sysid_gen_sys_init_file;
 

--- a/projects/daq2/a10gx/system_qsys.tcl
+++ b/projects/daq2/a10gx/system_qsys.tcl
@@ -13,6 +13,5 @@ set_instance_parameter_value rom_sys_0 {ROM_ADDR_BITS} {9}
 
 set_instance_parameter_value rom_sys_0 {PATH_TO_FILE} "[pwd]/mem_init_sys.txt"
 
-set sys_cstring "sys rom custom string placeholder";
-sysid_gen_sys_init_file $sys_cstring;
+sysid_gen_sys_init_file;
 

--- a/projects/daq2/a10soc/system_qsys.tcl
+++ b/projects/daq2/a10soc/system_qsys.tcl
@@ -12,6 +12,5 @@ set_instance_parameter_value rom_sys_0 {ROM_ADDR_BITS} {9}
 
 set_instance_parameter_value rom_sys_0 {PATH_TO_FILE} "[pwd]/mem_init_sys.txt"
 
-set sys_cstring "sys rom custom string placeholder";
-sysid_gen_sys_init_file $sys_cstring;
+sysid_gen_sys_init_file;
 

--- a/projects/daq2/kc705/system_bd.tcl
+++ b/projects/daq2/kc705/system_bd.tcl
@@ -16,5 +16,5 @@ source ../common/daq2_bd.tcl
 ad_ip_parameter axi_sysid_0 CONFIG.ROM_ADDR_BITS 9
 ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "[pwd]/mem_init_sys.txt"
 ad_ip_parameter rom_sys_0 CONFIG.ROM_ADDR_BITS 9
-set sys_cstring "sys rom custom string placeholder"
-sysid_gen_sys_init_file $sys_cstring
+
+sysid_gen_sys_init_file

--- a/projects/daq2/kcu105/system_bd.tcl
+++ b/projects/daq2/kcu105/system_bd.tcl
@@ -16,8 +16,8 @@ source ../common/daq2_bd.tcl
 ad_ip_parameter axi_sysid_0 CONFIG.ROM_ADDR_BITS 9
 ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "[pwd]/mem_init_sys.txt"
 ad_ip_parameter rom_sys_0 CONFIG.ROM_ADDR_BITS 9
-set sys_cstring "sys rom custom string placeholder"
-sysid_gen_sys_init_file $sys_cstring
+
+sysid_gen_sys_init_file
 
 ad_ip_parameter util_daq2_xcvr CONFIG.QPLL_FBDIV 20
 ad_ip_parameter util_daq2_xcvr CONFIG.QPLL_REFCLK_DIV 1

--- a/projects/daq2/zc706/system_bd.tcl
+++ b/projects/daq2/zc706/system_bd.tcl
@@ -16,5 +16,5 @@ source ../common/daq2_bd.tcl
 ad_ip_parameter axi_sysid_0 CONFIG.ROM_ADDR_BITS 9
 ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "[pwd]/mem_init_sys.txt"
 ad_ip_parameter rom_sys_0 CONFIG.ROM_ADDR_BITS 9
-set sys_cstring "sys rom custom string placeholder"
-sysid_gen_sys_init_file $sys_cstring
+
+sysid_gen_sys_init_file

--- a/projects/daq2/zcu102/system_bd.tcl
+++ b/projects/daq2/zcu102/system_bd.tcl
@@ -16,8 +16,8 @@ source ../common/daq2_bd.tcl
 ad_ip_parameter axi_sysid_0 CONFIG.ROM_ADDR_BITS 9
 ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "[pwd]/mem_init_sys.txt"
 ad_ip_parameter rom_sys_0 CONFIG.ROM_ADDR_BITS 9
-set sys_cstring "sys rom custom string placeholder"
-sysid_gen_sys_init_file $sys_cstring
+
+sysid_gen_sys_init_file
 
 ad_ip_parameter util_daq2_xcvr CONFIG.QPLL_FBDIV 20
 ad_ip_parameter util_daq2_xcvr CONFIG.QPLL_REFCLK_DIV 1

--- a/projects/daq3/a10gx/system_qsys.tcl
+++ b/projects/daq3/a10gx/system_qsys.tcl
@@ -12,6 +12,5 @@ set_instance_parameter_value rom_sys_0 {ROM_ADDR_BITS} {9}
 
 set_instance_parameter_value rom_sys_0 {PATH_TO_FILE} "[pwd]/mem_init_sys.txt"
 
-set sys_cstring "sys rom custom string placeholder";
-sysid_gen_sys_init_file $sys_cstring;
+sysid_gen_sys_init_file;
 

--- a/projects/daq3/kcu105/system_bd.tcl
+++ b/projects/daq3/kcu105/system_bd.tcl
@@ -16,8 +16,8 @@ source ../common/daq3_bd.tcl
 ad_ip_parameter axi_sysid_0 CONFIG.ROM_ADDR_BITS 9
 ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "[pwd]/mem_init_sys.txt"
 ad_ip_parameter rom_sys_0 CONFIG.ROM_ADDR_BITS 9
-set sys_cstring "sys rom custom string placeholder"
-sysid_gen_sys_init_file $sys_cstring
+
+sysid_gen_sys_init_file
 
 ad_ip_parameter util_daq3_xcvr CONFIG.QPLL_FBDIV 20
 ad_ip_parameter util_daq3_xcvr CONFIG.QPLL_REFCLK_DIV 1

--- a/projects/daq3/vcu118/system_bd.tcl
+++ b/projects/daq3/vcu118/system_bd.tcl
@@ -15,8 +15,8 @@ source ../common/daq3_bd.tcl
 ad_ip_parameter axi_sysid_0 CONFIG.ROM_ADDR_BITS 9
 ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "[pwd]/mem_init_sys.txt"
 ad_ip_parameter rom_sys_0 CONFIG.ROM_ADDR_BITS 9
-set sys_cstring "sys rom custom string placeholder"
-sysid_gen_sys_init_file $sys_cstring
+
+sysid_gen_sys_init_file
 
 ad_ip_parameter util_daq3_xcvr CONFIG.QPLL_FBDIV 20
 ad_ip_parameter util_daq3_xcvr CONFIG.QPLL_REFCLK_DIV 1

--- a/projects/daq3/zc706/system_bd.tcl
+++ b/projects/daq3/zc706/system_bd.tcl
@@ -16,5 +16,5 @@ source ../common/daq3_bd.tcl
 ad_ip_parameter axi_sysid_0 CONFIG.ROM_ADDR_BITS 9
 ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "[pwd]/mem_init_sys.txt"
 ad_ip_parameter rom_sys_0 CONFIG.ROM_ADDR_BITS 9
-set sys_cstring "sys rom custom string placeholder"
-sysid_gen_sys_init_file $sys_cstring
+
+sysid_gen_sys_init_file

--- a/projects/daq3/zcu102/system_bd.tcl
+++ b/projects/daq3/zcu102/system_bd.tcl
@@ -12,8 +12,8 @@ source ../common/daq3_bd.tcl
 ad_ip_parameter axi_sysid_0 CONFIG.ROM_ADDR_BITS 9
 ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "[pwd]/mem_init_sys.txt"
 ad_ip_parameter rom_sys_0 CONFIG.ROM_ADDR_BITS 9
-set sys_cstring "sys rom custom string placeholder"
-sysid_gen_sys_init_file $sys_cstring
+
+sysid_gen_sys_init_file
 
 # configure the CPLL's to support 12.33Gbps
 ad_ip_parameter util_daq3_xcvr CONFIG.CPLL_CFG0 0x03fe

--- a/projects/fmcadc2/vc707/system_bd.tcl
+++ b/projects/fmcadc2/vc707/system_bd.tcl
@@ -12,5 +12,5 @@ source ../common/fmcadc2_bd.tcl
 ad_ip_parameter axi_sysid_0 CONFIG.ROM_ADDR_BITS 9
 ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "[pwd]/mem_init_sys.txt"
 ad_ip_parameter rom_sys_0 CONFIG.ROM_ADDR_BITS 9
-set sys_cstring "sys rom custom string placeholder"
-sysid_gen_sys_init_file $sys_cstring
+
+sysid_gen_sys_init_file

--- a/projects/fmcadc2/zc706/system_bd.tcl
+++ b/projects/fmcadc2/zc706/system_bd.tcl
@@ -9,5 +9,5 @@ source ../common/fmcadc2_bd.tcl
 ad_ip_parameter axi_sysid_0 CONFIG.ROM_ADDR_BITS 9
 ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "[pwd]/mem_init_sys.txt"
 ad_ip_parameter rom_sys_0 CONFIG.ROM_ADDR_BITS 9
-set sys_cstring "sys rom custom string placeholder"
-sysid_gen_sys_init_file $sys_cstring
+
+sysid_gen_sys_init_file

--- a/projects/fmcadc5/vc707/system_bd.tcl
+++ b/projects/fmcadc5/vc707/system_bd.tcl
@@ -12,8 +12,8 @@ source ../common/fmcadc5_bd.tcl
 ad_ip_parameter axi_sysid_0 CONFIG.ROM_ADDR_BITS 9
 ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "[pwd]/mem_init_sys.txt"
 ad_ip_parameter rom_sys_0 CONFIG.ROM_ADDR_BITS 9
-set sys_cstring "sys rom custom string placeholder"
-sysid_gen_sys_init_file $sys_cstring
+
+sysid_gen_sys_init_file
 
 # ila
 

--- a/projects/fmcjesdadc1/kc705/system_bd.tcl
+++ b/projects/fmcjesdadc1/kc705/system_bd.tcl
@@ -6,8 +6,8 @@ source ../common/fmcjesdadc1_bd.tcl
 ad_ip_parameter axi_sysid_0 CONFIG.ROM_ADDR_BITS 9
 ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "[pwd]/mem_init_sys.txt"
 ad_ip_parameter rom_sys_0 CONFIG.ROM_ADDR_BITS 9
-set sys_cstring "sys rom custom string placeholder"
-sysid_gen_sys_init_file $sys_cstring
+
+sysid_gen_sys_init_file
 
 ad_ip_parameter axi_ad9250_0_dma CONFIG.DMA_DATA_WIDTH_DEST 512
 ad_ip_parameter axi_ad9250_0_dma CONFIG.FIFO_SIZE 32

--- a/projects/fmcjesdadc1/vc707/system_bd.tcl
+++ b/projects/fmcjesdadc1/vc707/system_bd.tcl
@@ -6,8 +6,8 @@ source ../common/fmcjesdadc1_bd.tcl
 ad_ip_parameter axi_sysid_0 CONFIG.ROM_ADDR_BITS 9
 ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "[pwd]/mem_init_sys.txt"
 ad_ip_parameter rom_sys_0 CONFIG.ROM_ADDR_BITS 9
-set sys_cstring "sys rom custom string placeholder"
-sysid_gen_sys_init_file $sys_cstring
+
+sysid_gen_sys_init_file
 
 ad_ip_parameter axi_ad9250_0_dma CONFIG.DMA_DATA_WIDTH_DEST 256
 ad_ip_parameter axi_ad9250_0_dma CONFIG.FIFO_SIZE 32

--- a/projects/fmcjesdadc1/zc706/system_bd.tcl
+++ b/projects/fmcjesdadc1/zc706/system_bd.tcl
@@ -6,5 +6,5 @@ source ../common/fmcjesdadc1_bd.tcl
 ad_ip_parameter axi_sysid_0 CONFIG.ROM_ADDR_BITS 9
 ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "[pwd]/mem_init_sys.txt"
 ad_ip_parameter rom_sys_0 CONFIG.ROM_ADDR_BITS 9
-set sys_cstring "sys rom custom string placeholder"
-sysid_gen_sys_init_file $sys_cstring
+
+sysid_gen_sys_init_file

--- a/projects/fmcomms11/zc706/system_bd.tcl
+++ b/projects/fmcomms11/zc706/system_bd.tcl
@@ -21,5 +21,5 @@ source ../common/fmcomms11_bd.tcl
 ad_ip_parameter axi_sysid_0 CONFIG.ROM_ADDR_BITS 9
 ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "[pwd]/mem_init_sys.txt"
 ad_ip_parameter rom_sys_0 CONFIG.ROM_ADDR_BITS 9
-set sys_cstring "sys rom custom string placeholder"
-sysid_gen_sys_init_file $sys_cstring
+
+sysid_gen_sys_init_file

--- a/projects/fmcomms2/kc705/system_bd.tcl
+++ b/projects/fmcomms2/kc705/system_bd.tcl
@@ -6,8 +6,8 @@ source ../common/fmcomms2_bd.tcl
 ad_ip_parameter axi_sysid_0 CONFIG.ROM_ADDR_BITS 9
 ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "[pwd]/mem_init_sys.txt"
 ad_ip_parameter rom_sys_0 CONFIG.ROM_ADDR_BITS 9
-set sys_cstring "sys rom custom string placeholder"
-sysid_gen_sys_init_file $sys_cstring
+
+sysid_gen_sys_init_file
 
 ad_ip_parameter axi_ad9361 CONFIG.ADC_INIT_DELAY 31
 

--- a/projects/fmcomms2/kcu105/system_bd.tcl
+++ b/projects/fmcomms2/kcu105/system_bd.tcl
@@ -7,8 +7,8 @@ source ../common/fmcomms2_bd.tcl
 ad_ip_parameter axi_sysid_0 CONFIG.ROM_ADDR_BITS 9
 ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "[pwd]/mem_init_sys.txt"
 ad_ip_parameter rom_sys_0 CONFIG.ROM_ADDR_BITS 9
-set sys_cstring "sys rom custom string placeholder"
-sysid_gen_sys_init_file $sys_cstring
+
+sysid_gen_sys_init_file
 
 ad_ip_parameter util_ad9361_divclk CONFIG.SIM_DEVICE ULTRASCALE
 

--- a/projects/fmcomms2/vc707/system_bd.tcl
+++ b/projects/fmcomms2/vc707/system_bd.tcl
@@ -6,8 +6,8 @@ source ../common/fmcomms2_bd.tcl
 ad_ip_parameter axi_sysid_0 CONFIG.ROM_ADDR_BITS 9
 ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "[pwd]/mem_init_sys.txt"
 ad_ip_parameter rom_sys_0 CONFIG.ROM_ADDR_BITS 9
-set sys_cstring "sys rom custom string placeholder"
-sysid_gen_sys_init_file $sys_cstring
+
+sysid_gen_sys_init_file
 
 ad_ip_parameter axi_ad9361 CONFIG.ADC_INIT_DELAY 22
 

--- a/projects/fmcomms2/zc702/system_bd.tcl
+++ b/projects/fmcomms2/zc702/system_bd.tcl
@@ -6,8 +6,8 @@ source ../common/fmcomms2_bd.tcl
 ad_ip_parameter axi_sysid_0 CONFIG.ROM_ADDR_BITS 9
 ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "[pwd]/mem_init_sys.txt"
 ad_ip_parameter rom_sys_0 CONFIG.ROM_ADDR_BITS 9
-set sys_cstring "sys rom custom string placeholder"
-sysid_gen_sys_init_file $sys_cstring
+
+sysid_gen_sys_init_file
 
 ad_ip_parameter axi_ad9361 CONFIG.ADC_INIT_DELAY 23
 

--- a/projects/fmcomms2/zc706/system_bd.tcl
+++ b/projects/fmcomms2/zc706/system_bd.tcl
@@ -6,8 +6,8 @@ source ../common/fmcomms2_bd.tcl
 ad_ip_parameter axi_sysid_0 CONFIG.ROM_ADDR_BITS 9
 ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "[pwd]/mem_init_sys.txt"
 ad_ip_parameter rom_sys_0 CONFIG.ROM_ADDR_BITS 9
-set sys_cstring "sys rom custom string placeholder"
-sysid_gen_sys_init_file $sys_cstring
+
+sysid_gen_sys_init_file
 
 ad_ip_parameter axi_ad9361 CONFIG.ADC_INIT_DELAY 20
 

--- a/projects/fmcomms2/zcu102/system_bd.tcl
+++ b/projects/fmcomms2/zcu102/system_bd.tcl
@@ -6,8 +6,8 @@ source ../common/fmcomms2_bd.tcl
 ad_ip_parameter axi_sysid_0 CONFIG.ROM_ADDR_BITS 9
 ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "[pwd]/mem_init_sys.txt"
 ad_ip_parameter rom_sys_0 CONFIG.ROM_ADDR_BITS 9
-set sys_cstring "sys rom custom string placeholder"
-sysid_gen_sys_init_file $sys_cstring
+
+sysid_gen_sys_init_file
 
 ad_ip_parameter util_ad9361_divclk CONFIG.SIM_DEVICE ULTRASCALE
 

--- a/projects/fmcomms2/zed/system_bd.tcl
+++ b/projects/fmcomms2/zed/system_bd.tcl
@@ -6,8 +6,8 @@ source ../common/fmcomms2_bd.tcl
 ad_ip_parameter axi_sysid_0 CONFIG.ROM_ADDR_BITS 9
 ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "[pwd]/mem_init_sys.txt"
 ad_ip_parameter rom_sys_0 CONFIG.ROM_ADDR_BITS 9
-set sys_cstring "sys rom custom string placeholder"
-sysid_gen_sys_init_file $sys_cstring
+
+sysid_gen_sys_init_file
 
 ad_ip_parameter axi_ad9361 CONFIG.ADC_INIT_DELAY 23
 

--- a/projects/fmcomms5/zc702/system_bd.tcl
+++ b/projects/fmcomms5/zc702/system_bd.tcl
@@ -5,8 +5,8 @@ source $ad_hdl_dir/projects/common/zc702/zc702_system_bd.tcl
 ad_ip_parameter axi_sysid_0 CONFIG.ROM_ADDR_BITS 9
 ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "[pwd]/mem_init_sys.txt"
 ad_ip_parameter rom_sys_0 CONFIG.ROM_ADDR_BITS 9
-set sys_cstring "sys rom custom string placeholder"
-sysid_gen_sys_init_file $sys_cstring
+
+sysid_gen_sys_init_file
 
 ad_ip_parameter sys_ps7 CONFIG.PCW_EN_CLK2_PORT 1
 ad_ip_parameter sys_ps7 CONFIG.PCW_FPGA2_PERIPHERAL_FREQMHZ 150.0

--- a/projects/fmcomms5/zc706/system_bd.tcl
+++ b/projects/fmcomms5/zc706/system_bd.tcl
@@ -5,8 +5,8 @@ source $ad_hdl_dir/projects/common/zc706/zc706_system_bd.tcl
 ad_ip_parameter axi_sysid_0 CONFIG.ROM_ADDR_BITS 9
 ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "[pwd]/mem_init_sys.txt"
 ad_ip_parameter rom_sys_0 CONFIG.ROM_ADDR_BITS 9
-set sys_cstring "sys rom custom string placeholder"
-sysid_gen_sys_init_file $sys_cstring
+
+sysid_gen_sys_init_file
 
 ad_ip_parameter sys_ps7 CONFIG.PCW_EN_CLK2_PORT 1
 ad_ip_parameter sys_ps7 CONFIG.PCW_FPGA2_PERIPHERAL_FREQMHZ 200.0

--- a/projects/fmcomms5/zcu102/system_bd.tcl
+++ b/projects/fmcomms5/zcu102/system_bd.tcl
@@ -6,8 +6,8 @@ source ../common/fmcomms5_bd.tcl
 ad_ip_parameter axi_sysid_0 CONFIG.ROM_ADDR_BITS 9
 ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "[pwd]/mem_init_sys.txt"
 ad_ip_parameter rom_sys_0 CONFIG.ROM_ADDR_BITS 9
-set sys_cstring "sys rom custom string placeholder"
-sysid_gen_sys_init_file $sys_cstring
+
+sysid_gen_sys_init_file
 
 ad_ip_parameter axi_ad9361_0 CONFIG.ADC_INIT_DELAY 8
 ad_ip_parameter axi_ad9361_0 CONFIG.DELAY_REFCLK_FREQUENCY 500

--- a/projects/fmcomms8/zcu102/system_bd.tcl
+++ b/projects/fmcomms8/zcu102/system_bd.tcl
@@ -9,8 +9,8 @@ set dac_fifo_address_width 16
 ad_ip_parameter axi_sysid_0 CONFIG.ROM_ADDR_BITS 9
 ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "[pwd]/mem_init_sys.txt"
 ad_ip_parameter rom_sys_0 CONFIG.ROM_ADDR_BITS 9
-set sys_cstring "sys rom custom string placeholder"
-sysid_gen_sys_init_file $sys_cstring
+
+sysid_gen_sys_init_file
 
 source ../common/fmcomms8_bd.tcl
 ad_ip_parameter sys_ps8 CONFIG.PSU__CRL_APB__PL1_REF_CTRL__FREQMHZ 300

--- a/projects/imageon/zed/system_bd.tcl
+++ b/projects/imageon/zed/system_bd.tcl
@@ -6,5 +6,5 @@ source ../common/imageon_bd.tcl
 ad_ip_parameter axi_sysid_0 CONFIG.ROM_ADDR_BITS 9
 ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "[pwd]/mem_init_sys.txt"
 ad_ip_parameter rom_sys_0 CONFIG.ROM_ADDR_BITS 9
-set sys_cstring "sys rom custom string placeholder"
-sysid_gen_sys_init_file $sys_cstring
+
+sysid_gen_sys_init_file

--- a/projects/scripts/adi_board.tcl
+++ b/projects/scripts/adi_board.tcl
@@ -859,7 +859,7 @@ proc hexstr_flip {str} {
 # \param[custom_string] - string input
 #
 
-proc sysid_gen_sys_init_file {custom_string} {
+proc sysid_gen_sys_init_file {{custom_string {}}} {
 
   # git sha
   if {[catch {exec git rev-parse HEAD} gitsha_string] != 0} {

--- a/projects/scripts/adi_pd_intel.tcl
+++ b/projects/scripts/adi_pd_intel.tcl
@@ -95,7 +95,7 @@ proc rev_by_string {str} {
 # \param[custom_string] - string input
 #
 
-proc sysid_gen_sys_init_file {custom_string} {
+proc sysid_gen_sys_init_file {{custom_string {}}} {
 
   global project_name;
   puts "project_name: $project_name";


### PR DESCRIPTION
because the software will start printing the contents of the "custom string" the default "placeholder" had to be removed.