### PR TITLE
daq2:a10gx:Solve timming issue

### DIFF
--- a/projects/daq2/a10gx/system_project.tcl
+++ b/projects/daq2/a10gx/system_project.tcl
@@ -95,6 +95,6 @@ set_location_assignment PIN_AN19  -to spi_dir               ; ## G13  FMCA_LA08_
 
 ## improve timing - there are occasional timing failure with a small negative slack
 #  at no-MMU configuration
-set_global_assignment -name OPTIMIZATION_MODE "AGGRESSIVE PERFORMANCE"
+set_global_assignment -name OPTIMIZATION_MODE "SUPERIOR PERFORMANCE"
 
 execute_flow -compile


### PR DESCRIPTION
Solved negative slack timming issue by modifying the optimization mode parameter.

Signed-off-by: Dan Hotoleanu <dan.hotoleanu@analog.com>