### PR TITLE
ad9081_fmca_ebz: Fix device clocks termination

### DIFF
--- a/projects/ad9081_fmca_ebz/vcu118/system_constr.xdc
+++ b/projects/ad9081_fmca_ebz/vcu118/system_constr.xdc
@@ -2,93 +2,93 @@
 ## mxfe
 #
 
-set_property         -dict {PACKAGE_PIN R34  IOSTANDARD LVCMOS18                       } [get_ports agc0[0]                   ]    ; ## IO_L13P_T2L_N0_GC_QBC_45
-set_property         -dict {PACKAGE_PIN P34  IOSTANDARD LVCMOS18                       } [get_ports agc0[1]                   ]    ; ## IO_L13N_T2L_N1_GC_QBC_45
-set_property         -dict {PACKAGE_PIN R31  IOSTANDARD LVCMOS18                       } [get_ports agc1[0]                   ]    ; ## IO_L10P_T1U_N6_QBC_AD4P_45
-set_property         -dict {PACKAGE_PIN P31  IOSTANDARD LVCMOS18                       } [get_ports agc1[1]                   ]    ; ## IO_L10N_T1U_N7_QBC_AD4N_45
-set_property         -dict {PACKAGE_PIN N32  IOSTANDARD LVCMOS18                       } [get_ports agc2[0]                   ]    ; ## IO_L23P_T3U_N8_45
-set_property         -dict {PACKAGE_PIN M32  IOSTANDARD LVCMOS18                       } [get_ports agc2[1]                   ]    ; ## IO_L23N_T3U_N9_45
-set_property         -dict {PACKAGE_PIN M35  IOSTANDARD LVCMOS18                       } [get_ports agc3[0]                   ]    ; ## IO_L24P_T3U_N10_45
-set_property         -dict {PACKAGE_PIN L35  IOSTANDARD LVCMOS18                       } [get_ports agc3[1]                   ]    ; ## IO_L24N_T3U_N11_45
-set_property         -dict {PACKAGE_PIN P36  IOSTANDARD LVDS                           } [get_ports clkin6_n                  ]    ; ## IO_L14N_T2L_N3_GC_45
-set_property         -dict {PACKAGE_PIN P35  IOSTANDARD LVDS                           } [get_ports clkin6_p                  ]    ; ## IO_L14P_T2L_N2_GC_45
-set_property         -dict {PACKAGE_PIN AM39                                           } [get_ports clkin8_n                  ]    ; ## MGTREFCLK1N_120 
-set_property         -dict {PACKAGE_PIN AM38                                           } [get_ports clkin8_p                  ]    ; ## MGTREFCLK1P_120 
-set_property         -dict {PACKAGE_PIN AK39                                           } [get_ports fpga_refclk_in_n          ]    ; ## MGTREFCLK0N_121 
-set_property         -dict {PACKAGE_PIN AK38                                           } [get_ports fpga_refclk_in_p          ]    ; ## MGTREFCLK0P_121 
-set_property         -dict {PACKAGE_PIN V39                                            } [get_ports fpga_refclk_in_replica_n  ]    ; ## MGTREFCLK0N_126 
-set_property         -dict {PACKAGE_PIN V38                                            } [get_ports fpga_refclk_in_replica_p  ]    ; ## MGTREFCLK0P_126
-set_property  -quiet -dict {PACKAGE_PIN AL46                                           } [get_ports rx_data_n[2]              ]    ; ## MGTYRXN2_121               FPGA_SERDIN_0_N
-set_property  -quiet -dict {PACKAGE_PIN AL45                                           } [get_ports rx_data_p[2]              ]    ; ## MGTYRXP2_121               FPGA_SERDIN_0_P
-set_property  -quiet -dict {PACKAGE_PIN AR46                                           } [get_ports rx_data_n[0]              ]    ; ## MGTYRXN0_121               FPGA_SERDIN_1_N
-set_property  -quiet -dict {PACKAGE_PIN AR45                                           } [get_ports rx_data_p[0]              ]    ; ## MGTYRXP0_121               FPGA_SERDIN_1_P
-set_property  -quiet -dict {PACKAGE_PIN N46                                            } [get_ports rx_data_n[7]              ]    ; ## MGTYRXN3_126               FPGA_SERDIN_2_N
-set_property  -quiet -dict {PACKAGE_PIN N45                                            } [get_ports rx_data_p[7]              ]    ; ## MGTYRXP3_126               FPGA_SERDIN_2_P
-set_property  -quiet -dict {PACKAGE_PIN R46                                            } [get_ports rx_data_n[6]              ]    ; ## MGTYRXN2_126               FPGA_SERDIN_3_N
-set_property  -quiet -dict {PACKAGE_PIN R45                                            } [get_ports rx_data_p[6]              ]    ; ## MGTYRXP2_126               FPGA_SERDIN_3_P
-set_property  -quiet -dict {PACKAGE_PIN U46                                            } [get_ports rx_data_n[5]              ]    ; ## MGTYRXN1_126               FPGA_SERDIN_4_N
-set_property  -quiet -dict {PACKAGE_PIN U45                                            } [get_ports rx_data_p[5]              ]    ; ## MGTYRXP1_126               FPGA_SERDIN_4_P
-set_property  -quiet -dict {PACKAGE_PIN W46                                            } [get_ports rx_data_n[4]              ]    ; ## MGTYRXN0_126               FPGA_SERDIN_5_N
-set_property  -quiet -dict {PACKAGE_PIN W45                                            } [get_ports rx_data_p[4]              ]    ; ## MGTYRXP0_126               FPGA_SERDIN_5_P
-set_property  -quiet -dict {PACKAGE_PIN AJ46                                           } [get_ports rx_data_n[3]              ]    ; ## MGTYRXN3_121               FPGA_SERDIN_6_N
-set_property  -quiet -dict {PACKAGE_PIN AJ45                                           } [get_ports rx_data_p[3]              ]    ; ## MGTYRXP3_121               FPGA_SERDIN_6_P
-set_property  -quiet -dict {PACKAGE_PIN AN46                                           } [get_ports rx_data_n[1]              ]    ; ## MGTYRXN1_121               FPGA_SERDIN_7_N
-set_property  -quiet -dict {PACKAGE_PIN AN45                                           } [get_ports rx_data_p[1]              ]    ; ## MGTYRXP1_121               FPGA_SERDIN_7_P
-set_property  -quiet -dict {PACKAGE_PIN AT43                                           } [get_ports tx_data_n[0]              ]    ; ## MGTYTXN0_121               FPGA_SERDOUT_0_N
-set_property  -quiet -dict {PACKAGE_PIN AT42                                           } [get_ports tx_data_p[0]              ]    ; ## MGTYTXP0_121               FPGA_SERDOUT_0_P
-set_property  -quiet -dict {PACKAGE_PIN AM43                                           } [get_ports tx_data_n[2]              ]    ; ## MGTYTXN2_121               FPGA_SERDOUT_1_N
-set_property  -quiet -dict {PACKAGE_PIN AM42                                           } [get_ports tx_data_p[2]              ]    ; ## MGTYTXP2_121               FPGA_SERDOUT_1_P
-set_property  -quiet -dict {PACKAGE_PIN K43                                            } [get_ports tx_data_n[7]              ]    ; ## MGTYTXN3_126               FPGA_SERDOUT_2_N
-set_property  -quiet -dict {PACKAGE_PIN K42                                            } [get_ports tx_data_p[7]              ]    ; ## MGTYTXP3_126               FPGA_SERDOUT_2_P
-set_property  -quiet -dict {PACKAGE_PIN M43                                            } [get_ports tx_data_n[6]              ]    ; ## MGTYTXN2_126               FPGA_SERDOUT_3_N
-set_property  -quiet -dict {PACKAGE_PIN M42                                            } [get_ports tx_data_p[6]              ]    ; ## MGTYTXP2_126               FPGA_SERDOUT_3_P
-set_property  -quiet -dict {PACKAGE_PIN AP43                                           } [get_ports tx_data_n[1]              ]    ; ## MGTYTXN1_121               FPGA_SERDOUT_4_N
-set_property  -quiet -dict {PACKAGE_PIN AP42                                           } [get_ports tx_data_p[1]              ]    ; ## MGTYTXP1_121               FPGA_SERDOUT_4_P
-set_property  -quiet -dict {PACKAGE_PIN P43                                            } [get_ports tx_data_n[5]              ]    ; ## MGTYTXN1_126               FPGA_SERDOUT_5_N
-set_property  -quiet -dict {PACKAGE_PIN P42                                            } [get_ports tx_data_p[5]              ]    ; ## MGTYTXP1_126               FPGA_SERDOUT_5_P
-set_property  -quiet -dict {PACKAGE_PIN T43                                            } [get_ports tx_data_n[4]              ]    ; ## MGTYTXN0_126               FPGA_SERDOUT_6_N
-set_property  -quiet -dict {PACKAGE_PIN T42                                            } [get_ports tx_data_p[4]              ]    ; ## MGTYTXP0_126               FPGA_SERDOUT_6_P
-set_property  -quiet -dict {PACKAGE_PIN AL41                                           } [get_ports tx_data_n[3]              ]    ; ## MGTYTXN3_121               FPGA_SERDOUT_7_N
-set_property  -quiet -dict {PACKAGE_PIN AL40                                           } [get_ports tx_data_p[3]              ]    ; ## MGTYTXP3_121               FPGA_SERDOUT_7_P
-set_property  -quiet -dict {PACKAGE_PIN AK32 IOSTANDARD LVDS     DIFF_TERM_ADV TERM_100} [get_ports fpga_syncin_n[0]          ]    ; ## IO_L14N_T2L_N3_GC_43       
-set_property  -quiet -dict {PACKAGE_PIN AJ32 IOSTANDARD LVDS     DIFF_TERM_ADV TERM_100} [get_ports fpga_syncin_p[0]          ]    ; ## IO_L14P_T2L_N2_GC_43
-set_property  -quiet -dict {PACKAGE_PIN AT40 IOSTANDARD LVDS     DIFF_TERM_ADV TERM_100} [get_ports fpga_syncin_n[1]          ]    ; ## IO_L4N_T0U_N7_DBC_AD7N_43
-set_property  -quiet -dict {PACKAGE_PIN AT39 IOSTANDARD LVDS     DIFF_TERM_ADV TERM_100} [get_ports fpga_syncin_p[1]          ]    ; ## IO_L4P_T0U_N6_DBC_AD7P_43
-set_property  -quiet -dict {PACKAGE_PIN AL31 IOSTANDARD LVDS                           } [get_ports fpga_syncout_n[0]         ]    ; ## IO_L16N_T2U_N7_QBC_AD3N_43
-set_property  -quiet -dict {PACKAGE_PIN AL30 IOSTANDARD LVDS                           } [get_ports fpga_syncout_p[0]         ]    ; ## IO_L16P_T2U_N6_QBC_AD3P_43
-set_property  -quiet -dict {PACKAGE_PIN AT36 IOSTANDARD LVDS                           } [get_ports fpga_syncout_n[1]         ]    ; ## IO_L2N_T0L_N3_43
-set_property  -quiet -dict {PACKAGE_PIN AT35 IOSTANDARD LVDS                           } [get_ports fpga_syncout_p[1]         ]    ; ## IO_L2P_T0L_N2_43
-set_property         -dict {PACKAGE_PIN AG32 IOSTANDARD LVCMOS18                       } [get_ports gpio[0]                   ]    ; ## IO_L24P_T3U_N10_43
-set_property         -dict {PACKAGE_PIN AG33 IOSTANDARD LVCMOS18                       } [get_ports gpio[1]                   ]    ; ## IO_L24N_T3U_N11_43
-set_property         -dict {PACKAGE_PIN N33  IOSTANDARD LVCMOS18                       } [get_ports gpio[2]                   ]    ; ## IO_L22P_T3U_N6_DBC_AD0P_45
-set_property         -dict {PACKAGE_PIN M33  IOSTANDARD LVCMOS18                       } [get_ports gpio[3]                   ]    ; ## IO_L22N_T3U_N7_DBC_AD0N_45
-set_property         -dict {PACKAGE_PIN AJ35 IOSTANDARD LVCMOS18                       } [get_ports gpio[4]                   ]    ; ## IO_L20P_T3L_N2_AD1P_43
-set_property         -dict {PACKAGE_PIN AJ36 IOSTANDARD LVCMOS18                       } [get_ports gpio[5]                   ]    ; ## IO_L20N_T3L_N3_AD1N_43
-set_property         -dict {PACKAGE_PIN AG31 IOSTANDARD LVCMOS18                       } [get_ports gpio[6]                   ]    ; ## IO_L23P_T3U_N8_43
-set_property         -dict {PACKAGE_PIN AH31 IOSTANDARD LVCMOS18                       } [get_ports gpio[7]                   ]    ; ## IO_L23N_T3U_N9_43
-set_property         -dict {PACKAGE_PIN AG34 IOSTANDARD LVCMOS18                       } [get_ports gpio[8]                   ]    ; ## IO_L22P_T3U_N6_DBC_AD0P_43
-set_property         -dict {PACKAGE_PIN AH35 IOSTANDARD LVCMOS18                       } [get_ports gpio[9]                   ]    ; ## IO_L22N_T3U_N7_DBC_AD0N_43
-set_property         -dict {PACKAGE_PIN N35  IOSTANDARD LVCMOS18                       } [get_ports gpio[10]                  ]    ; ## IO_L20N_T3L_N3_AD1N_45
-set_property         -dict {PACKAGE_PIN AJ31 IOSTANDARD LVCMOS18                       } [get_ports hmc_gpio1                 ]    ; ## IO_L17N_T2U_N9_AD10N_43
-set_property         -dict {PACKAGE_PIN AP37 IOSTANDARD LVCMOS18                       } [get_ports hmc_sync                  ]    ; ## IO_L5N_T0U_N9_AD14N_43
-set_property         -dict {PACKAGE_PIN AK29 IOSTANDARD LVCMOS18                       } [get_ports irqb[0]                   ]    ; ## IO_L18P_T2U_N10_AD2P_43
-set_property         -dict {PACKAGE_PIN AK30 IOSTANDARD LVCMOS18                       } [get_ports irqb[1]                   ]    ; ## IO_L18N_T2U_N11_AD2N_43
-set_property         -dict {PACKAGE_PIN AP36 IOSTANDARD LVCMOS18                       } [get_ports rstb                      ]    ; ## IO_L5P_T0U_N8_AD14P_43
-set_property         -dict {PACKAGE_PIN AP35 IOSTANDARD LVCMOS18                       } [get_ports rxen[0]                   ]    ; ## IO_L3P_T0L_N4_AD15P_43
-set_property         -dict {PACKAGE_PIN AR35 IOSTANDARD LVCMOS18                       } [get_ports rxen[1]                   ]    ; ## IO_L3N_T0L_N5_AD15N_43
-set_property         -dict {PACKAGE_PIN AP38 IOSTANDARD LVCMOS18                       } [get_ports spi0_csb                  ]    ; ## IO_L1P_T0L_N0_DBC_43
-set_property         -dict {PACKAGE_PIN AR38 IOSTANDARD LVCMOS18                       } [get_ports spi0_miso                 ]    ; ## IO_L1N_T0L_N1_DBC_43
-set_property         -dict {PACKAGE_PIN AR37 IOSTANDARD LVCMOS18                       } [get_ports spi0_mosi                 ]    ; ## IO_L6P_T0U_N10_AD6P_43
-set_property         -dict {PACKAGE_PIN AT37 IOSTANDARD LVCMOS18                       } [get_ports spi0_sclk                 ]    ; ## IO_L6N_T0U_N11_AD6N_43
-set_property         -dict {PACKAGE_PIN AH33 IOSTANDARD LVCMOS18                       } [get_ports spi1_csb                  ]    ; ## IO_L21P_T3L_N4_AD8P_43
-set_property         -dict {PACKAGE_PIN AJ30 IOSTANDARD LVCMOS18                       } [get_ports spi1_sclk                 ]    ; ## IO_L17P_T2U_N8_AD10P_43
-set_property         -dict {PACKAGE_PIN AH34 IOSTANDARD LVCMOS18                       } [get_ports spi1_sdio                 ]    ; ## IO_L21N_T3L_N5_AD8N_43
-set_property         -dict {PACKAGE_PIN AM32 IOSTANDARD LVDS     DIFF_TERM_ADV TERM_100} [get_ports sysref2_n                 ]    ; ## IO_L13N_T2L_N1_GC_QBC_43
-set_property         -dict {PACKAGE_PIN AL32 IOSTANDARD LVDS     DIFF_TERM_ADV TERM_100} [get_ports sysref2_p                 ]    ; ## IO_L13P_T2L_N0_GC_QBC_43
-set_property         -dict {PACKAGE_PIN AJ33 IOSTANDARD LVCMOS18                       } [get_ports txen[0]                   ]    ; ## IO_L19P_T3L_N0_DBC_AD9P_43
-set_property         -dict {PACKAGE_PIN AK33 IOSTANDARD LVCMOS18                       } [get_ports txen[1]                   ]    ; ## IO_L19N_T3L_N1_DBC_AD9N_43
+set_property         -dict {PACKAGE_PIN R34  IOSTANDARD LVCMOS18                                     } [get_ports agc0[0]                   ]    ; ## IO_L13P_T2L_N0_GC_QBC_45
+set_property         -dict {PACKAGE_PIN P34  IOSTANDARD LVCMOS18                                     } [get_ports agc0[1]                   ]    ; ## IO_L13N_T2L_N1_GC_QBC_45
+set_property         -dict {PACKAGE_PIN R31  IOSTANDARD LVCMOS18                                     } [get_ports agc1[0]                   ]    ; ## IO_L10P_T1U_N6_QBC_AD4P_45
+set_property         -dict {PACKAGE_PIN P31  IOSTANDARD LVCMOS18                                     } [get_ports agc1[1]                   ]    ; ## IO_L10N_T1U_N7_QBC_AD4N_45
+set_property         -dict {PACKAGE_PIN N32  IOSTANDARD LVCMOS18                                     } [get_ports agc2[0]                   ]    ; ## IO_L23P_T3U_N8_45
+set_property         -dict {PACKAGE_PIN M32  IOSTANDARD LVCMOS18                                     } [get_ports agc2[1]                   ]    ; ## IO_L23N_T3U_N9_45
+set_property         -dict {PACKAGE_PIN M35  IOSTANDARD LVCMOS18                                     } [get_ports agc3[0]                   ]    ; ## IO_L24P_T3U_N10_45
+set_property         -dict {PACKAGE_PIN L35  IOSTANDARD LVCMOS18                                     } [get_ports agc3[1]                   ]    ; ## IO_L24N_T3U_N11_45
+set_property         -dict {PACKAGE_PIN P36  IOSTANDARD LVDS     DIFF_TERM_ADV TERM_100 DQS_BIAS TRUE} [get_ports clkin6_n                  ]    ; ## IO_L14N_T2L_N3_GC_45
+set_property         -dict {PACKAGE_PIN P35  IOSTANDARD LVDS     DIFF_TERM_ADV TERM_100 DQS_BIAS TRUE} [get_ports clkin6_p                  ]    ; ## IO_L14P_T2L_N2_GC_45
+set_property         -dict {PACKAGE_PIN AM39                                                         } [get_ports clkin8_n                  ]    ; ## MGTREFCLK1N_120 
+set_property         -dict {PACKAGE_PIN AM38                                                         } [get_ports clkin8_p                  ]    ; ## MGTREFCLK1P_120 
+set_property         -dict {PACKAGE_PIN AK39                                                         } [get_ports fpga_refclk_in_n          ]    ; ## MGTREFCLK0N_121 
+set_property         -dict {PACKAGE_PIN AK38                                                         } [get_ports fpga_refclk_in_p          ]    ; ## MGTREFCLK0P_121 
+set_property         -dict {PACKAGE_PIN V39                                                          } [get_ports fpga_refclk_in_replica_n  ]    ; ## MGTREFCLK0N_126 
+set_property         -dict {PACKAGE_PIN V38                                                          } [get_ports fpga_refclk_in_replica_p  ]    ; ## MGTREFCLK0P_126
+set_property  -quiet -dict {PACKAGE_PIN AL46                                                         } [get_ports rx_data_n[2]              ]    ; ## MGTYRXN2_121               FPGA_SERDIN_0_N
+set_property  -quiet -dict {PACKAGE_PIN AL45                                                         } [get_ports rx_data_p[2]              ]    ; ## MGTYRXP2_121               FPGA_SERDIN_0_P
+set_property  -quiet -dict {PACKAGE_PIN AR46                                                         } [get_ports rx_data_n[0]              ]    ; ## MGTYRXN0_121               FPGA_SERDIN_1_N
+set_property  -quiet -dict {PACKAGE_PIN AR45                                                         } [get_ports rx_data_p[0]              ]    ; ## MGTYRXP0_121               FPGA_SERDIN_1_P
+set_property  -quiet -dict {PACKAGE_PIN N46                                                          } [get_ports rx_data_n[7]              ]    ; ## MGTYRXN3_126               FPGA_SERDIN_2_N
+set_property  -quiet -dict {PACKAGE_PIN N45                                                          } [get_ports rx_data_p[7]              ]    ; ## MGTYRXP3_126               FPGA_SERDIN_2_P
+set_property  -quiet -dict {PACKAGE_PIN R46                                                          } [get_ports rx_data_n[6]              ]    ; ## MGTYRXN2_126               FPGA_SERDIN_3_N
+set_property  -quiet -dict {PACKAGE_PIN R45                                                          } [get_ports rx_data_p[6]              ]    ; ## MGTYRXP2_126               FPGA_SERDIN_3_P
+set_property  -quiet -dict {PACKAGE_PIN U46                                                          } [get_ports rx_data_n[5]              ]    ; ## MGTYRXN1_126               FPGA_SERDIN_4_N
+set_property  -quiet -dict {PACKAGE_PIN U45                                                          } [get_ports rx_data_p[5]              ]    ; ## MGTYRXP1_126               FPGA_SERDIN_4_P
+set_property  -quiet -dict {PACKAGE_PIN W46                                                          } [get_ports rx_data_n[4]              ]    ; ## MGTYRXN0_126               FPGA_SERDIN_5_N
+set_property  -quiet -dict {PACKAGE_PIN W45                                                          } [get_ports rx_data_p[4]              ]    ; ## MGTYRXP0_126               FPGA_SERDIN_5_P
+set_property  -quiet -dict {PACKAGE_PIN AJ46                                                         } [get_ports rx_data_n[3]              ]    ; ## MGTYRXN3_121               FPGA_SERDIN_6_N
+set_property  -quiet -dict {PACKAGE_PIN AJ45                                                         } [get_ports rx_data_p[3]              ]    ; ## MGTYRXP3_121               FPGA_SERDIN_6_P
+set_property  -quiet -dict {PACKAGE_PIN AN46                                                         } [get_ports rx_data_n[1]              ]    ; ## MGTYRXN1_121               FPGA_SERDIN_7_N
+set_property  -quiet -dict {PACKAGE_PIN AN45                                                         } [get_ports rx_data_p[1]              ]    ; ## MGTYRXP1_121               FPGA_SERDIN_7_P
+set_property  -quiet -dict {PACKAGE_PIN AT43                                                         } [get_ports tx_data_n[0]              ]    ; ## MGTYTXN0_121               FPGA_SERDOUT_0_N
+set_property  -quiet -dict {PACKAGE_PIN AT42                                                         } [get_ports tx_data_p[0]              ]    ; ## MGTYTXP0_121               FPGA_SERDOUT_0_P
+set_property  -quiet -dict {PACKAGE_PIN AM43                                                         } [get_ports tx_data_n[2]              ]    ; ## MGTYTXN2_121               FPGA_SERDOUT_1_N
+set_property  -quiet -dict {PACKAGE_PIN AM42                                                         } [get_ports tx_data_p[2]              ]    ; ## MGTYTXP2_121               FPGA_SERDOUT_1_P
+set_property  -quiet -dict {PACKAGE_PIN K43                                                          } [get_ports tx_data_n[7]              ]    ; ## MGTYTXN3_126               FPGA_SERDOUT_2_N
+set_property  -quiet -dict {PACKAGE_PIN K42                                                          } [get_ports tx_data_p[7]              ]    ; ## MGTYTXP3_126               FPGA_SERDOUT_2_P
+set_property  -quiet -dict {PACKAGE_PIN M43                                                          } [get_ports tx_data_n[6]              ]    ; ## MGTYTXN2_126               FPGA_SERDOUT_3_N
+set_property  -quiet -dict {PACKAGE_PIN M42                                                          } [get_ports tx_data_p[6]              ]    ; ## MGTYTXP2_126               FPGA_SERDOUT_3_P
+set_property  -quiet -dict {PACKAGE_PIN AP43                                                         } [get_ports tx_data_n[1]              ]    ; ## MGTYTXN1_121               FPGA_SERDOUT_4_N
+set_property  -quiet -dict {PACKAGE_PIN AP42                                                         } [get_ports tx_data_p[1]              ]    ; ## MGTYTXP1_121               FPGA_SERDOUT_4_P
+set_property  -quiet -dict {PACKAGE_PIN P43                                                          } [get_ports tx_data_n[5]              ]    ; ## MGTYTXN1_126               FPGA_SERDOUT_5_N
+set_property  -quiet -dict {PACKAGE_PIN P42                                                          } [get_ports tx_data_p[5]              ]    ; ## MGTYTXP1_126               FPGA_SERDOUT_5_P
+set_property  -quiet -dict {PACKAGE_PIN T43                                                          } [get_ports tx_data_n[4]              ]    ; ## MGTYTXN0_126               FPGA_SERDOUT_6_N
+set_property  -quiet -dict {PACKAGE_PIN T42                                                          } [get_ports tx_data_p[4]              ]    ; ## MGTYTXP0_126               FPGA_SERDOUT_6_P
+set_property  -quiet -dict {PACKAGE_PIN AL41                                                         } [get_ports tx_data_n[3]              ]    ; ## MGTYTXN3_121               FPGA_SERDOUT_7_N
+set_property  -quiet -dict {PACKAGE_PIN AL40                                                         } [get_ports tx_data_p[3]              ]    ; ## MGTYTXP3_121               FPGA_SERDOUT_7_P
+set_property  -quiet -dict {PACKAGE_PIN AK32 IOSTANDARD LVDS     DIFF_TERM_ADV TERM_100              } [get_ports fpga_syncin_n[0]          ]    ; ## IO_L14N_T2L_N3_GC_43       
+set_property  -quiet -dict {PACKAGE_PIN AJ32 IOSTANDARD LVDS     DIFF_TERM_ADV TERM_100              } [get_ports fpga_syncin_p[0]          ]    ; ## IO_L14P_T2L_N2_GC_43
+set_property  -quiet -dict {PACKAGE_PIN AT40 IOSTANDARD LVDS     DIFF_TERM_ADV TERM_100              } [get_ports fpga_syncin_n[1]          ]    ; ## IO_L4N_T0U_N7_DBC_AD7N_43
+set_property  -quiet -dict {PACKAGE_PIN AT39 IOSTANDARD LVDS     DIFF_TERM_ADV TERM_100              } [get_ports fpga_syncin_p[1]          ]    ; ## IO_L4P_T0U_N6_DBC_AD7P_43
+set_property  -quiet -dict {PACKAGE_PIN AL31 IOSTANDARD LVDS                                         } [get_ports fpga_syncout_n[0]         ]    ; ## IO_L16N_T2U_N7_QBC_AD3N_43
+set_property  -quiet -dict {PACKAGE_PIN AL30 IOSTANDARD LVDS                                         } [get_ports fpga_syncout_p[0]         ]    ; ## IO_L16P_T2U_N6_QBC_AD3P_43
+set_property  -quiet -dict {PACKAGE_PIN AT36 IOSTANDARD LVDS                                         } [get_ports fpga_syncout_n[1]         ]    ; ## IO_L2N_T0L_N3_43
+set_property  -quiet -dict {PACKAGE_PIN AT35 IOSTANDARD LVDS                                         } [get_ports fpga_syncout_p[1]         ]    ; ## IO_L2P_T0L_N2_43
+set_property         -dict {PACKAGE_PIN AG32 IOSTANDARD LVCMOS18                                     } [get_ports gpio[0]                   ]    ; ## IO_L24P_T3U_N10_43
+set_property         -dict {PACKAGE_PIN AG33 IOSTANDARD LVCMOS18                                     } [get_ports gpio[1]                   ]    ; ## IO_L24N_T3U_N11_43
+set_property         -dict {PACKAGE_PIN N33  IOSTANDARD LVCMOS18                                     } [get_ports gpio[2]                   ]    ; ## IO_L22P_T3U_N6_DBC_AD0P_45
+set_property         -dict {PACKAGE_PIN M33  IOSTANDARD LVCMOS18                                     } [get_ports gpio[3]                   ]    ; ## IO_L22N_T3U_N7_DBC_AD0N_45
+set_property         -dict {PACKAGE_PIN AJ35 IOSTANDARD LVCMOS18                                     } [get_ports gpio[4]                   ]    ; ## IO_L20P_T3L_N2_AD1P_43
+set_property         -dict {PACKAGE_PIN AJ36 IOSTANDARD LVCMOS18                                     } [get_ports gpio[5]                   ]    ; ## IO_L20N_T3L_N3_AD1N_43
+set_property         -dict {PACKAGE_PIN AG31 IOSTANDARD LVCMOS18                                     } [get_ports gpio[6]                   ]    ; ## IO_L23P_T3U_N8_43
+set_property         -dict {PACKAGE_PIN AH31 IOSTANDARD LVCMOS18                                     } [get_ports gpio[7]                   ]    ; ## IO_L23N_T3U_N9_43
+set_property         -dict {PACKAGE_PIN AG34 IOSTANDARD LVCMOS18                                     } [get_ports gpio[8]                   ]    ; ## IO_L22P_T3U_N6_DBC_AD0P_43
+set_property         -dict {PACKAGE_PIN AH35 IOSTANDARD LVCMOS18                                     } [get_ports gpio[9]                   ]    ; ## IO_L22N_T3U_N7_DBC_AD0N_43
+set_property         -dict {PACKAGE_PIN N35  IOSTANDARD LVCMOS18                                     } [get_ports gpio[10]                  ]    ; ## IO_L20N_T3L_N3_AD1N_45
+set_property         -dict {PACKAGE_PIN AJ31 IOSTANDARD LVCMOS18                                     } [get_ports hmc_gpio1                 ]    ; ## IO_L17N_T2U_N9_AD10N_43
+set_property         -dict {PACKAGE_PIN AP37 IOSTANDARD LVCMOS18                                     } [get_ports hmc_sync                  ]    ; ## IO_L5N_T0U_N9_AD14N_43
+set_property         -dict {PACKAGE_PIN AK29 IOSTANDARD LVCMOS18                                     } [get_ports irqb[0]                   ]    ; ## IO_L18P_T2U_N10_AD2P_43
+set_property         -dict {PACKAGE_PIN AK30 IOSTANDARD LVCMOS18                                     } [get_ports irqb[1]                   ]    ; ## IO_L18N_T2U_N11_AD2N_43
+set_property         -dict {PACKAGE_PIN AP36 IOSTANDARD LVCMOS18                                     } [get_ports rstb                      ]    ; ## IO_L5P_T0U_N8_AD14P_43
+set_property         -dict {PACKAGE_PIN AP35 IOSTANDARD LVCMOS18                                     } [get_ports rxen[0]                   ]    ; ## IO_L3P_T0L_N4_AD15P_43
+set_property         -dict {PACKAGE_PIN AR35 IOSTANDARD LVCMOS18                                     } [get_ports rxen[1]                   ]    ; ## IO_L3N_T0L_N5_AD15N_43
+set_property         -dict {PACKAGE_PIN AP38 IOSTANDARD LVCMOS18                                     } [get_ports spi0_csb                  ]    ; ## IO_L1P_T0L_N0_DBC_43
+set_property         -dict {PACKAGE_PIN AR38 IOSTANDARD LVCMOS18                                     } [get_ports spi0_miso                 ]    ; ## IO_L1N_T0L_N1_DBC_43
+set_property         -dict {PACKAGE_PIN AR37 IOSTANDARD LVCMOS18                                     } [get_ports spi0_mosi                 ]    ; ## IO_L6P_T0U_N10_AD6P_43
+set_property         -dict {PACKAGE_PIN AT37 IOSTANDARD LVCMOS18                                     } [get_ports spi0_sclk                 ]    ; ## IO_L6N_T0U_N11_AD6N_43
+set_property         -dict {PACKAGE_PIN AH33 IOSTANDARD LVCMOS18                                     } [get_ports spi1_csb                  ]    ; ## IO_L21P_T3L_N4_AD8P_43
+set_property         -dict {PACKAGE_PIN AJ30 IOSTANDARD LVCMOS18                                     } [get_ports spi1_sclk                 ]    ; ## IO_L17P_T2U_N8_AD10P_43
+set_property         -dict {PACKAGE_PIN AH34 IOSTANDARD LVCMOS18                                     } [get_ports spi1_sdio                 ]    ; ## IO_L21N_T3L_N5_AD8N_43
+set_property         -dict {PACKAGE_PIN AM32 IOSTANDARD LVDS     DIFF_TERM_ADV TERM_100 DQS_BIAS TRUE} [get_ports sysref2_n                 ]    ; ## IO_L13N_T2L_N1_GC_QBC_43
+set_property         -dict {PACKAGE_PIN AL32 IOSTANDARD LVDS     DIFF_TERM_ADV TERM_100 DQS_BIAS TRUE} [get_ports sysref2_p                 ]    ; ## IO_L13P_T2L_N0_GC_QBC_43
+set_property         -dict {PACKAGE_PIN AJ33 IOSTANDARD LVCMOS18                                     } [get_ports txen[0]                   ]    ; ## IO_L19P_T3L_N0_DBC_AD9P_43
+set_property         -dict {PACKAGE_PIN AK33 IOSTANDARD LVCMOS18                                     } [get_ports txen[1]                   ]    ; ## IO_L19N_T3L_N1_DBC_AD9N_43
 
-set_property         -dict {PACKAGE_PIN AK35 IOSTANDARD LVCMOS18 PULLTYPE PULLUP       } [get_ports vadj_1v8_pgood            ]    ; ## IO_T1U_N12_43_AK35 
+set_property         -dict {PACKAGE_PIN AK35 IOSTANDARD LVCMOS18 PULLTYPE PULLUP                     } [get_ports vadj_1v8_pgood            ]    ; ## IO_T1U_N12_43_AK35 
 
 
 

--- a/projects/ad9081_fmca_ebz/zcu102/system_constr.xdc
+++ b/projects/ad9081_fmca_ebz/zcu102/system_constr.xdc
@@ -2,87 +2,87 @@
 ## mxfe
 #
 
-set_property         -dict {PACKAGE_PIN P11   IOSTANDARD LVCMOS18                       } [get_ports agc0[0]          ]    ; ## FMC0_LA17_CC_P      IO_L13P_T2L_N0_GC_QBC_67   
-set_property         -dict {PACKAGE_PIN N11   IOSTANDARD LVCMOS18                       } [get_ports agc0[1]          ]    ; ## FMC0_LA17_CC_N      IO_L13N_T2L_N1_GC_QBC_67
-set_property         -dict {PACKAGE_PIN N9    IOSTANDARD LVCMOS18                       } [get_ports agc1[0]          ]    ; ## FMC0_LA18_CC_P      IO_L16P_T2U_N6_QBC_AD3P_67
-set_property         -dict {PACKAGE_PIN N8    IOSTANDARD LVCMOS18                       } [get_ports agc1[1]          ]    ; ## FMC0_LA18_CC_N      IO_L16N_T2U_N7_QBC_AD3N_67
-set_property         -dict {PACKAGE_PIN N13   IOSTANDARD LVCMOS18                       } [get_ports agc2[0]          ]    ; ## FMC0_LA20_P         IO_L22P_T3U_N6_DBC_AD0P_67
-set_property         -dict {PACKAGE_PIN M13   IOSTANDARD LVCMOS18                       } [get_ports agc2[1]          ]    ; ## FMC0_LA20_N         IO_L22N_T3U_N7_DBC_AD0N_67
-set_property         -dict {PACKAGE_PIN P12   IOSTANDARD LVCMOS18                       } [get_ports agc3[0]          ]    ; ## FMC0_LA21_P         IO_L21P_T3L_N4_AD8P_67
-set_property         -dict {PACKAGE_PIN N12   IOSTANDARD LVCMOS18                       } [get_ports agc3[1]          ]    ; ## FMC0_LA21_N         IO_L21N_T3L_N5_AD8N_67
-set_property         -dict {PACKAGE_PIN Y3    IOSTANDARD LVDS                           } [get_ports clkin10_n        ]    ; ## FMC0_CLK2_IO_N      IO_L13N_T2L_N1_GC_QBC_66 
-set_property         -dict {PACKAGE_PIN Y4    IOSTANDARD LVDS                           } [get_ports clkin10_p        ]    ; ## FMC0_CLK2_IO_P      IO_L13P_T2L_N0_GC_QBC_66 
-set_property         -dict {PACKAGE_PIN R8    IOSTANDARD LVDS                           } [get_ports clkin6_n         ]    ; ## FMC0_CLK1_M2C_N     IO_L12N_T1U_N11_GC_67
-set_property         -dict {PACKAGE_PIN T8    IOSTANDARD LVDS                           } [get_ports clkin6_p         ]    ; ## FMC0_CLK1_M2C_P     IO_L12P_T1U_N10_GC_67
-set_property         -dict {PACKAGE_PIN G7                                              } [get_ports fpga_refclk_in_n ]    ; ## FMC0_GBTCLK0_M2C_N  MGTREFCLK0N_229
-set_property         -dict {PACKAGE_PIN G8                                              } [get_ports fpga_refclk_in_p ]    ; ## FMC0_GBTCLK0_M2C_P  MGTREFCLK0P_229
-set_property  -quiet -dict {PACKAGE_PIN F1                                              } [get_ports rx_data_n[2]     ]    ; ## FMC0_DP2_M2C_N      MGTHRXN3_229    FPGA_SERDIN_0_N
-set_property  -quiet -dict {PACKAGE_PIN F2                                              } [get_ports rx_data_p[2]     ]    ; ## FMC0_DP2_M2C_P      MGTHRXP3_229    FPGA_SERDIN_0_P
-set_property  -quiet -dict {PACKAGE_PIN H1                                              } [get_ports rx_data_n[0]     ]    ; ## FMC0_DP0_M2C_N      MGTHRXN2_229    FPGA_SERDIN_1_N
-set_property  -quiet -dict {PACKAGE_PIN H2                                              } [get_ports rx_data_p[0]     ]    ; ## FMC0_DP0_M2C_P      MGTHRXP2_229    FPGA_SERDIN_1_P
-set_property  -quiet -dict {PACKAGE_PIN M1                                              } [get_ports rx_data_n[7]     ]    ; ## FMC0_DP7_M2C_N      MGTHRXN2_228    FPGA_SERDIN_2_N
-set_property  -quiet -dict {PACKAGE_PIN M2                                              } [get_ports rx_data_p[7]     ]    ; ## FMC0_DP7_M2C_P      MGTHRXP2_228    FPGA_SERDIN_2_P
-set_property  -quiet -dict {PACKAGE_PIN T1                                              } [get_ports rx_data_n[6]     ]    ; ## FMC0_DP6_M2C_N      MGTHRXN0_228    FPGA_SERDIN_3_N
-set_property  -quiet -dict {PACKAGE_PIN T2                                              } [get_ports rx_data_p[6]     ]    ; ## FMC0_DP6_M2C_P      MGTHRXP0_228    FPGA_SERDIN_3_P
-set_property  -quiet -dict {PACKAGE_PIN P1                                              } [get_ports rx_data_n[5]     ]    ; ## FMC0_DP5_M2C_N      MGTHRXN1_228    FPGA_SERDIN_4_N
-set_property  -quiet -dict {PACKAGE_PIN P2                                              } [get_ports rx_data_p[5]     ]    ; ## FMC0_DP5_M2C_P      MGTHRXP1_228    FPGA_SERDIN_4_P
-set_property  -quiet -dict {PACKAGE_PIN L3                                              } [get_ports rx_data_n[4]     ]    ; ## FMC0_DP4_M2C_N      MGTHRXN3_228    FPGA_SERDIN_5_N
-set_property  -quiet -dict {PACKAGE_PIN L4                                              } [get_ports rx_data_p[4]     ]    ; ## FMC0_DP4_M2C_P      MGTHRXP3_228    FPGA_SERDIN_5_P
-set_property  -quiet -dict {PACKAGE_PIN K1                                              } [get_ports rx_data_n[3]     ]    ; ## FMC0_DP3_M2C_N      MGTHRXN0_229    FPGA_SERDIN_6_N
-set_property  -quiet -dict {PACKAGE_PIN K2                                              } [get_ports rx_data_p[3]     ]    ; ## FMC0_DP3_M2C_P      MGTHRXP0_229    FPGA_SERDIN_6_P
-set_property  -quiet -dict {PACKAGE_PIN J3                                              } [get_ports rx_data_n[1]     ]    ; ## FMC0_DP1_M2C_N      MGTHRXN1_229    FPGA_SERDIN_7_N
-set_property  -quiet -dict {PACKAGE_PIN J4                                              } [get_ports rx_data_p[1]     ]    ; ## FMC0_DP1_M2C_P      MGTHRXP1_229    FPGA_SERDIN_7_P
-set_property  -quiet -dict {PACKAGE_PIN G3                                              } [get_ports tx_data_n[0]     ]    ; ## FMC0_DP0_C2M_N      MGTHTXN2_229    FPGA_SERDOUT_0_N
-set_property  -quiet -dict {PACKAGE_PIN G4                                              } [get_ports tx_data_p[0]     ]    ; ## FMC0_DP0_C2M_P      MGTHTXP2_229    FPGA_SERDOUT_0_P
-set_property  -quiet -dict {PACKAGE_PIN F5                                              } [get_ports tx_data_n[2]     ]    ; ## FMC0_DP2_C2M_N      MGTHTXN3_229    FPGA_SERDOUT_1_N
-set_property  -quiet -dict {PACKAGE_PIN F6                                              } [get_ports tx_data_p[2]     ]    ; ## FMC0_DP2_C2M_P      MGTHTXP3_229    FPGA_SERDOUT_1_P
-set_property  -quiet -dict {PACKAGE_PIN N3                                              } [get_ports tx_data_n[7]     ]    ; ## FMC0_DP7_C2M_N      MGTHTXN2_228    FPGA_SERDOUT_2_N
-set_property  -quiet -dict {PACKAGE_PIN N4                                              } [get_ports tx_data_p[7]     ]    ; ## FMC0_DP7_C2M_P      MGTHTXP2_228    FPGA_SERDOUT_2_P
-set_property  -quiet -dict {PACKAGE_PIN R3                                              } [get_ports tx_data_n[6]     ]    ; ## FMC0_DP6_C2M_N      MGTHTXN0_228    FPGA_SERDOUT_3_N
-set_property  -quiet -dict {PACKAGE_PIN R4                                              } [get_ports tx_data_p[6]     ]    ; ## FMC0_DP6_C2M_P      MGTHTXP0_228    FPGA_SERDOUT_3_P
-set_property  -quiet -dict {PACKAGE_PIN H5                                              } [get_ports tx_data_n[1]     ]    ; ## FMC0_DP1_C2M_N      MGTHTXN1_229    FPGA_SERDOUT_4_N
-set_property  -quiet -dict {PACKAGE_PIN H6                                              } [get_ports tx_data_p[1]     ]    ; ## FMC0_DP1_C2M_P      MGTHTXP1_229    FPGA_SERDOUT_4_P
-set_property  -quiet -dict {PACKAGE_PIN P5                                              } [get_ports tx_data_n[5]     ]    ; ## FMC0_DP5_C2M_N      MGTHTXN1_228    FPGA_SERDOUT_5_N
-set_property  -quiet -dict {PACKAGE_PIN P6                                              } [get_ports tx_data_p[5]     ]    ; ## FMC0_DP5_C2M_P      MGTHTXP1_228    FPGA_SERDOUT_5_P
-set_property  -quiet -dict {PACKAGE_PIN M5                                              } [get_ports tx_data_n[4]     ]    ; ## FMC0_DP4_C2M_N      MGTHTXN3_228    FPGA_SERDOUT_6_N
-set_property  -quiet -dict {PACKAGE_PIN M6                                              } [get_ports tx_data_p[4]     ]    ; ## FMC0_DP4_C2M_P      MGTHTXP3_228    FPGA_SERDOUT_6_P
-set_property  -quiet -dict {PACKAGE_PIN K5                                              } [get_ports tx_data_n[3]     ]    ; ## FMC0_DP3_C2M_N      MGTHTXN0_229    FPGA_SERDOUT_7_N
-set_property  -quiet -dict {PACKAGE_PIN K6                                              } [get_ports tx_data_p[3]     ]    ; ## FMC0_DP3_C2M_P      MGTHTXP0_229    FPGA_SERDOUT_7_P
-set_property  -quiet -dict {PACKAGE_PIN V1    IOSTANDARD LVDS     DIFF_TERM_ADV TERM_100} [get_ports fpga_syncin_n[0] ]    ; ## FMC0_LA02_N         IO_L23N_T3U_N9_66
-set_property  -quiet -dict {PACKAGE_PIN V2    IOSTANDARD LVDS     DIFF_TERM_ADV TERM_100} [get_ports fpga_syncin_p[0] ]    ; ## FMC0_LA02_P         IO_L23P_T3U_N8_66
-set_property  -quiet -dict {PACKAGE_PIN Y1    IOSTANDARD LVDS     DIFF_TERM_ADV TERM_100} [get_ports fpga_syncin_n[1] ]    ; ## FMC0_LA03_N         IO_L22N_T3U_N7_DBC_AD0N_66
-set_property  -quiet -dict {PACKAGE_PIN Y2    IOSTANDARD LVDS     DIFF_TERM_ADV TERM_100} [get_ports fpga_syncin_p[1] ]    ; ## FMC0_LA03_P         IO_L22P_T3U_N6_DBC_AD0P_66
-set_property  -quiet -dict {PACKAGE_PIN AC4   IOSTANDARD LVDS                           } [get_ports fpga_syncout_n[0]]    ; ## FMC0_LA01_CC_N      IO_L16N_T2U_N7_QBC_AD3N_66
-set_property  -quiet -dict {PACKAGE_PIN AB4   IOSTANDARD LVDS                           } [get_ports fpga_syncout_p[0]]    ; ## FMC0_LA01_CC_P      IO_L16P_T2U_N6_QBC_AD3P_66
-set_property  -quiet -dict {PACKAGE_PIN AC1   IOSTANDARD LVDS                           } [get_ports fpga_syncout_n[1]]    ; ## FMC0_LA06_N         IO_L19N_T3L_N1_DBC_AD9N_66
-set_property  -quiet -dict {PACKAGE_PIN AC2   IOSTANDARD LVDS                           } [get_ports fpga_syncout_p[1]]    ; ## FMC0_LA06_P         IO_L19P_T3L_N0_DBC_AD9P_66
-set_property         -dict {PACKAGE_PIN Y10   IOSTANDARD LVCMOS18                       } [get_ports gpio[0]          ]    ; ## FMC0_LA15_P         IO_L6P_T0U_N10_AD6P_66
-set_property         -dict {PACKAGE_PIN Y9    IOSTANDARD LVCMOS18                       } [get_ports gpio[1]          ]    ; ## FMC0_LA15_N         IO_L6N_T0U_N11_AD6N_66
-set_property         -dict {PACKAGE_PIN L13   IOSTANDARD LVCMOS18                       } [get_ports gpio[2]          ]    ; ## FMC0_LA19_P         IO_L23P_T3U_N8_67
-set_property         -dict {PACKAGE_PIN K13   IOSTANDARD LVCMOS18                       } [get_ports gpio[3]          ]    ; ## FMC0_LA19_N         IO_L23N_T3U_N9_67
-set_property         -dict {PACKAGE_PIN AB8   IOSTANDARD LVCMOS18                       } [get_ports gpio[4]          ]    ; ## FMC0_LA13_P         IO_L8P_T1L_N2_AD5P_66
-set_property         -dict {PACKAGE_PIN AC8   IOSTANDARD LVCMOS18                       } [get_ports gpio[5]          ]    ; ## FMC0_LA13_N         IO_L8N_T1L_N3_AD5N_66
-set_property         -dict {PACKAGE_PIN AC7   IOSTANDARD LVCMOS18                       } [get_ports gpio[6]          ]    ; ## FMC0_LA14_P         IO_L7P_T1L_N0_QBC_AD13P_66
-set_property         -dict {PACKAGE_PIN AC6   IOSTANDARD LVCMOS18                       } [get_ports gpio[7]          ]    ; ## FMC0_LA14_N         IO_L7N_T1L_N1_QBC_AD13N_66
-set_property         -dict {PACKAGE_PIN Y12   IOSTANDARD LVCMOS18                       } [get_ports gpio[8]          ]    ; ## FMC0_LA16_P         IO_L5P_T0U_N8_AD14P_66
-set_property         -dict {PACKAGE_PIN AA12  IOSTANDARD LVCMOS18                       } [get_ports gpio[9]          ]    ; ## FMC0_LA16_N         IO_L5N_T0U_N9_AD14N_66
-set_property         -dict {PACKAGE_PIN M14   IOSTANDARD LVCMOS18                       } [get_ports gpio[10]         ]    ; ## FMC0_LA22_N         IO_L20N_T3L_N3_AD1N_67
-set_property         -dict {PACKAGE_PIN AB5   IOSTANDARD LVCMOS18                       } [get_ports hmc_gpio1        ]    ; ## FMC0_LA11_N         IO_L10N_T1U_N7_QBC_AD4N_66
-set_property         -dict {PACKAGE_PIN U4    IOSTANDARD LVCMOS18                       } [get_ports hmc_sync         ]    ; ## FMC0_LA07_N         IO_L18N_T2U_N11_AD2N_66
-set_property         -dict {PACKAGE_PIN V4    IOSTANDARD LVCMOS18                       } [get_ports irqb[0]          ]    ; ## FMC0_LA08_P         IO_L17P_T2U_N8_AD10P_66
-set_property         -dict {PACKAGE_PIN V3    IOSTANDARD LVCMOS18                       } [get_ports irqb[1]          ]    ; ## FMC0_LA08_N         IO_L17N_T2U_N9_AD10N_66
-set_property         -dict {PACKAGE_PIN U5    IOSTANDARD LVCMOS18                       } [get_ports rstb             ]    ; ## FMC0_LA07_P         IO_L18P_T2U_N10_AD2P_66
-set_property         -dict {PACKAGE_PIN W5    IOSTANDARD LVCMOS18                       } [get_ports rxen[0]          ]    ; ## FMC0_LA10_P         IO_L15P_T2L_N4_AD11P_66
-set_property         -dict {PACKAGE_PIN W4    IOSTANDARD LVCMOS18                       } [get_ports rxen[1]          ]    ; ## FMC0_LA10_N         IO_L15N_T2L_N5_AD11N_66
-set_property         -dict {PACKAGE_PIN AB3   IOSTANDARD LVCMOS18                       } [get_ports spi0_csb         ]    ; ## FMC0_LA05_P         IO_L20P_T3L_N2_AD1P_66
-set_property         -dict {PACKAGE_PIN AC3   IOSTANDARD LVCMOS18                       } [get_ports spi0_miso        ]    ; ## FMC0_LA05_N         IO_L20N_T3L_N3_AD1N_66
-set_property         -dict {PACKAGE_PIN AA2   IOSTANDARD LVCMOS18                       } [get_ports spi0_mosi        ]    ; ## FMC0_LA04_P         IO_L21P_T3L_N4_AD8P_66
-set_property         -dict {PACKAGE_PIN AA1   IOSTANDARD LVCMOS18                       } [get_ports spi0_sclk        ]    ; ## FMC0_LA04_N         IO_L21N_T3L_N5_AD8N_66
-set_property         -dict {PACKAGE_PIN W7    IOSTANDARD LVCMOS18                       } [get_ports spi1_csb         ]    ; ## FMC0_LA12_P         IO_L9P_T1L_N4_AD12P_66
-set_property         -dict {PACKAGE_PIN AB6   IOSTANDARD LVCMOS18                       } [get_ports spi1_sclk        ]    ; ## FMC0_LA11_P         IO_L10P_T1U_N6_QBC_AD4P_66
-set_property         -dict {PACKAGE_PIN W6    IOSTANDARD LVCMOS18                       } [get_ports spi1_sdio        ]    ; ## FMC0_LA12_N         IO_L9N_T1L_N5_AD12N_66
-set_property         -dict {PACKAGE_PIN AA6   IOSTANDARD LVDS     DIFF_TERM_ADV TERM_100} [get_ports sysref2_n        ]    ; ## FMC0_CLK0_M2C_N     IO_L12N_T1U_N11_GC_66
-set_property         -dict {PACKAGE_PIN AA7   IOSTANDARD LVDS     DIFF_TERM_ADV TERM_100} [get_ports sysref2_p        ]    ; ## FMC0_CLK0_M2C_P     IO_L12P_T1U_N10_GC_66
-set_property         -dict {PACKAGE_PIN W2    IOSTANDARD LVCMOS18                       } [get_ports txen[0]          ]    ; ## FMC0_LA09_P         IO_L24P_T3U_N10_66
-set_property         -dict {PACKAGE_PIN W1    IOSTANDARD LVCMOS18                       } [get_ports txen[1]          ]    ; ## FMC0_LA09_N         IO_L24N_T3U_N11_66
+set_property         -dict {PACKAGE_PIN P11   IOSTANDARD LVCMOS18                                     } [get_ports agc0[0]          ]    ; ## FMC0_LA17_CC_P      IO_L13P_T2L_N0_GC_QBC_67   
+set_property         -dict {PACKAGE_PIN N11   IOSTANDARD LVCMOS18                                     } [get_ports agc0[1]          ]    ; ## FMC0_LA17_CC_N      IO_L13N_T2L_N1_GC_QBC_67
+set_property         -dict {PACKAGE_PIN N9    IOSTANDARD LVCMOS18                                     } [get_ports agc1[0]          ]    ; ## FMC0_LA18_CC_P      IO_L16P_T2U_N6_QBC_AD3P_67
+set_property         -dict {PACKAGE_PIN N8    IOSTANDARD LVCMOS18                                     } [get_ports agc1[1]          ]    ; ## FMC0_LA18_CC_N      IO_L16N_T2U_N7_QBC_AD3N_67
+set_property         -dict {PACKAGE_PIN N13   IOSTANDARD LVCMOS18                                     } [get_ports agc2[0]          ]    ; ## FMC0_LA20_P         IO_L22P_T3U_N6_DBC_AD0P_67
+set_property         -dict {PACKAGE_PIN M13   IOSTANDARD LVCMOS18                                     } [get_ports agc2[1]          ]    ; ## FMC0_LA20_N         IO_L22N_T3U_N7_DBC_AD0N_67
+set_property         -dict {PACKAGE_PIN P12   IOSTANDARD LVCMOS18                                     } [get_ports agc3[0]          ]    ; ## FMC0_LA21_P         IO_L21P_T3L_N4_AD8P_67
+set_property         -dict {PACKAGE_PIN N12   IOSTANDARD LVCMOS18                                     } [get_ports agc3[1]          ]    ; ## FMC0_LA21_N         IO_L21N_T3L_N5_AD8N_67
+set_property         -dict {PACKAGE_PIN Y3    IOSTANDARD LVDS     DIFF_TERM_ADV TERM_100 DQS_BIAS TRUE} [get_ports clkin10_n        ]    ; ## FMC0_CLK2_IO_N      IO_L13N_T2L_N1_GC_QBC_66 
+set_property         -dict {PACKAGE_PIN Y4    IOSTANDARD LVDS     DIFF_TERM_ADV TERM_100 DQS_BIAS TRUE} [get_ports clkin10_p        ]    ; ## FMC0_CLK2_IO_P      IO_L13P_T2L_N0_GC_QBC_66 
+set_property         -dict {PACKAGE_PIN R8    IOSTANDARD LVDS     DIFF_TERM_ADV TERM_100 DQS_BIAS TRUE} [get_ports clkin6_n         ]    ; ## FMC0_CLK1_M2C_N     IO_L12N_T1U_N11_GC_67
+set_property         -dict {PACKAGE_PIN T8    IOSTANDARD LVDS     DIFF_TERM_ADV TERM_100 DQS_BIAS TRUE} [get_ports clkin6_p         ]    ; ## FMC0_CLK1_M2C_P     IO_L12P_T1U_N10_GC_67
+set_property         -dict {PACKAGE_PIN G7                                                            } [get_ports fpga_refclk_in_n ]    ; ## FMC0_GBTCLK0_M2C_N  MGTREFCLK0N_229
+set_property         -dict {PACKAGE_PIN G8                                                            } [get_ports fpga_refclk_in_p ]    ; ## FMC0_GBTCLK0_M2C_P  MGTREFCLK0P_229
+set_property  -quiet -dict {PACKAGE_PIN F1                                                            } [get_ports rx_data_n[2]     ]    ; ## FMC0_DP2_M2C_N      MGTHRXN3_229    FPGA_SERDIN_0_N
+set_property  -quiet -dict {PACKAGE_PIN F2                                                            } [get_ports rx_data_p[2]     ]    ; ## FMC0_DP2_M2C_P      MGTHRXP3_229    FPGA_SERDIN_0_P
+set_property  -quiet -dict {PACKAGE_PIN H1                                                            } [get_ports rx_data_n[0]     ]    ; ## FMC0_DP0_M2C_N      MGTHRXN2_229    FPGA_SERDIN_1_N
+set_property  -quiet -dict {PACKAGE_PIN H2                                                            } [get_ports rx_data_p[0]     ]    ; ## FMC0_DP0_M2C_P      MGTHRXP2_229    FPGA_SERDIN_1_P
+set_property  -quiet -dict {PACKAGE_PIN M1                                                            } [get_ports rx_data_n[7]     ]    ; ## FMC0_DP7_M2C_N      MGTHRXN2_228    FPGA_SERDIN_2_N
+set_property  -quiet -dict {PACKAGE_PIN M2                                                            } [get_ports rx_data_p[7]     ]    ; ## FMC0_DP7_M2C_P      MGTHRXP2_228    FPGA_SERDIN_2_P
+set_property  -quiet -dict {PACKAGE_PIN T1                                                            } [get_ports rx_data_n[6]     ]    ; ## FMC0_DP6_M2C_N      MGTHRXN0_228    FPGA_SERDIN_3_N
+set_property  -quiet -dict {PACKAGE_PIN T2                                                            } [get_ports rx_data_p[6]     ]    ; ## FMC0_DP6_M2C_P      MGTHRXP0_228    FPGA_SERDIN_3_P
+set_property  -quiet -dict {PACKAGE_PIN P1                                                            } [get_ports rx_data_n[5]     ]    ; ## FMC0_DP5_M2C_N      MGTHRXN1_228    FPGA_SERDIN_4_N
+set_property  -quiet -dict {PACKAGE_PIN P2                                                            } [get_ports rx_data_p[5]     ]    ; ## FMC0_DP5_M2C_P      MGTHRXP1_228    FPGA_SERDIN_4_P
+set_property  -quiet -dict {PACKAGE_PIN L3                                                            } [get_ports rx_data_n[4]     ]    ; ## FMC0_DP4_M2C_N      MGTHRXN3_228    FPGA_SERDIN_5_N
+set_property  -quiet -dict {PACKAGE_PIN L4                                                            } [get_ports rx_data_p[4]     ]    ; ## FMC0_DP4_M2C_P      MGTHRXP3_228    FPGA_SERDIN_5_P
+set_property  -quiet -dict {PACKAGE_PIN K1                                                            } [get_ports rx_data_n[3]     ]    ; ## FMC0_DP3_M2C_N      MGTHRXN0_229    FPGA_SERDIN_6_N
+set_property  -quiet -dict {PACKAGE_PIN K2                                                            } [get_ports rx_data_p[3]     ]    ; ## FMC0_DP3_M2C_P      MGTHRXP0_229    FPGA_SERDIN_6_P
+set_property  -quiet -dict {PACKAGE_PIN J3                                                            } [get_ports rx_data_n[1]     ]    ; ## FMC0_DP1_M2C_N      MGTHRXN1_229    FPGA_SERDIN_7_N
+set_property  -quiet -dict {PACKAGE_PIN J4                                                            } [get_ports rx_data_p[1]     ]    ; ## FMC0_DP1_M2C_P      MGTHRXP1_229    FPGA_SERDIN_7_P
+set_property  -quiet -dict {PACKAGE_PIN G3                                                            } [get_ports tx_data_n[0]     ]    ; ## FMC0_DP0_C2M_N      MGTHTXN2_229    FPGA_SERDOUT_0_N
+set_property  -quiet -dict {PACKAGE_PIN G4                                                            } [get_ports tx_data_p[0]     ]    ; ## FMC0_DP0_C2M_P      MGTHTXP2_229    FPGA_SERDOUT_0_P
+set_property  -quiet -dict {PACKAGE_PIN F5                                                            } [get_ports tx_data_n[2]     ]    ; ## FMC0_DP2_C2M_N      MGTHTXN3_229    FPGA_SERDOUT_1_N
+set_property  -quiet -dict {PACKAGE_PIN F6                                                            } [get_ports tx_data_p[2]     ]    ; ## FMC0_DP2_C2M_P      MGTHTXP3_229    FPGA_SERDOUT_1_P
+set_property  -quiet -dict {PACKAGE_PIN N3                                                            } [get_ports tx_data_n[7]     ]    ; ## FMC0_DP7_C2M_N      MGTHTXN2_228    FPGA_SERDOUT_2_N
+set_property  -quiet -dict {PACKAGE_PIN N4                                                            } [get_ports tx_data_p[7]     ]    ; ## FMC0_DP7_C2M_P      MGTHTXP2_228    FPGA_SERDOUT_2_P
+set_property  -quiet -dict {PACKAGE_PIN R3                                                            } [get_ports tx_data_n[6]     ]    ; ## FMC0_DP6_C2M_N      MGTHTXN0_228    FPGA_SERDOUT_3_N
+set_property  -quiet -dict {PACKAGE_PIN R4                                                            } [get_ports tx_data_p[6]     ]    ; ## FMC0_DP6_C2M_P      MGTHTXP0_228    FPGA_SERDOUT_3_P
+set_property  -quiet -dict {PACKAGE_PIN H5                                                            } [get_ports tx_data_n[1]     ]    ; ## FMC0_DP1_C2M_N      MGTHTXN1_229    FPGA_SERDOUT_4_N
+set_property  -quiet -dict {PACKAGE_PIN H6                                                            } [get_ports tx_data_p[1]     ]    ; ## FMC0_DP1_C2M_P      MGTHTXP1_229    FPGA_SERDOUT_4_P
+set_property  -quiet -dict {PACKAGE_PIN P5                                                            } [get_ports tx_data_n[5]     ]    ; ## FMC0_DP5_C2M_N      MGTHTXN1_228    FPGA_SERDOUT_5_N
+set_property  -quiet -dict {PACKAGE_PIN P6                                                            } [get_ports tx_data_p[5]     ]    ; ## FMC0_DP5_C2M_P      MGTHTXP1_228    FPGA_SERDOUT_5_P
+set_property  -quiet -dict {PACKAGE_PIN M5                                                            } [get_ports tx_data_n[4]     ]    ; ## FMC0_DP4_C2M_N      MGTHTXN3_228    FPGA_SERDOUT_6_N
+set_property  -quiet -dict {PACKAGE_PIN M6                                                            } [get_ports tx_data_p[4]     ]    ; ## FMC0_DP4_C2M_P      MGTHTXP3_228    FPGA_SERDOUT_6_P
+set_property  -quiet -dict {PACKAGE_PIN K5                                                            } [get_ports tx_data_n[3]     ]    ; ## FMC0_DP3_C2M_N      MGTHTXN0_229    FPGA_SERDOUT_7_N
+set_property  -quiet -dict {PACKAGE_PIN K6                                                            } [get_ports tx_data_p[3]     ]    ; ## FMC0_DP3_C2M_P      MGTHTXP0_229    FPGA_SERDOUT_7_P
+set_property  -quiet -dict {PACKAGE_PIN V1    IOSTANDARD LVDS     DIFF_TERM_ADV TERM_100              } [get_ports fpga_syncin_n[0] ]    ; ## FMC0_LA02_N         IO_L23N_T3U_N9_66
+set_property  -quiet -dict {PACKAGE_PIN V2    IOSTANDARD LVDS     DIFF_TERM_ADV TERM_100              } [get_ports fpga_syncin_p[0] ]    ; ## FMC0_LA02_P         IO_L23P_T3U_N8_66
+set_property  -quiet -dict {PACKAGE_PIN Y1    IOSTANDARD LVDS     DIFF_TERM_ADV TERM_100              } [get_ports fpga_syncin_n[1] ]    ; ## FMC0_LA03_N         IO_L22N_T3U_N7_DBC_AD0N_66
+set_property  -quiet -dict {PACKAGE_PIN Y2    IOSTANDARD LVDS     DIFF_TERM_ADV TERM_100              } [get_ports fpga_syncin_p[1] ]    ; ## FMC0_LA03_P         IO_L22P_T3U_N6_DBC_AD0P_66
+set_property  -quiet -dict {PACKAGE_PIN AC4   IOSTANDARD LVDS                                         } [get_ports fpga_syncout_n[0]]    ; ## FMC0_LA01_CC_N      IO_L16N_T2U_N7_QBC_AD3N_66
+set_property  -quiet -dict {PACKAGE_PIN AB4   IOSTANDARD LVDS                                         } [get_ports fpga_syncout_p[0]]    ; ## FMC0_LA01_CC_P      IO_L16P_T2U_N6_QBC_AD3P_66
+set_property  -quiet -dict {PACKAGE_PIN AC1   IOSTANDARD LVDS                                         } [get_ports fpga_syncout_n[1]]    ; ## FMC0_LA06_N         IO_L19N_T3L_N1_DBC_AD9N_66
+set_property  -quiet -dict {PACKAGE_PIN AC2   IOSTANDARD LVDS                                         } [get_ports fpga_syncout_p[1]]    ; ## FMC0_LA06_P         IO_L19P_T3L_N0_DBC_AD9P_66
+set_property         -dict {PACKAGE_PIN Y10   IOSTANDARD LVCMOS18                                     } [get_ports gpio[0]          ]    ; ## FMC0_LA15_P         IO_L6P_T0U_N10_AD6P_66
+set_property         -dict {PACKAGE_PIN Y9    IOSTANDARD LVCMOS18                                     } [get_ports gpio[1]          ]    ; ## FMC0_LA15_N         IO_L6N_T0U_N11_AD6N_66
+set_property         -dict {PACKAGE_PIN L13   IOSTANDARD LVCMOS18                                     } [get_ports gpio[2]          ]    ; ## FMC0_LA19_P         IO_L23P_T3U_N8_67
+set_property         -dict {PACKAGE_PIN K13   IOSTANDARD LVCMOS18                                     } [get_ports gpio[3]          ]    ; ## FMC0_LA19_N         IO_L23N_T3U_N9_67
+set_property         -dict {PACKAGE_PIN AB8   IOSTANDARD LVCMOS18                                     } [get_ports gpio[4]          ]    ; ## FMC0_LA13_P         IO_L8P_T1L_N2_AD5P_66
+set_property         -dict {PACKAGE_PIN AC8   IOSTANDARD LVCMOS18                                     } [get_ports gpio[5]          ]    ; ## FMC0_LA13_N         IO_L8N_T1L_N3_AD5N_66
+set_property         -dict {PACKAGE_PIN AC7   IOSTANDARD LVCMOS18                                     } [get_ports gpio[6]          ]    ; ## FMC0_LA14_P         IO_L7P_T1L_N0_QBC_AD13P_66
+set_property         -dict {PACKAGE_PIN AC6   IOSTANDARD LVCMOS18                                     } [get_ports gpio[7]          ]    ; ## FMC0_LA14_N         IO_L7N_T1L_N1_QBC_AD13N_66
+set_property         -dict {PACKAGE_PIN Y12   IOSTANDARD LVCMOS18                                     } [get_ports gpio[8]          ]    ; ## FMC0_LA16_P         IO_L5P_T0U_N8_AD14P_66
+set_property         -dict {PACKAGE_PIN AA12  IOSTANDARD LVCMOS18                                     } [get_ports gpio[9]          ]    ; ## FMC0_LA16_N         IO_L5N_T0U_N9_AD14N_66
+set_property         -dict {PACKAGE_PIN M14   IOSTANDARD LVCMOS18                                     } [get_ports gpio[10]         ]    ; ## FMC0_LA22_N         IO_L20N_T3L_N3_AD1N_67
+set_property         -dict {PACKAGE_PIN AB5   IOSTANDARD LVCMOS18                                     } [get_ports hmc_gpio1        ]    ; ## FMC0_LA11_N         IO_L10N_T1U_N7_QBC_AD4N_66
+set_property         -dict {PACKAGE_PIN U4    IOSTANDARD LVCMOS18                                     } [get_ports hmc_sync         ]    ; ## FMC0_LA07_N         IO_L18N_T2U_N11_AD2N_66
+set_property         -dict {PACKAGE_PIN V4    IOSTANDARD LVCMOS18                                     } [get_ports irqb[0]          ]    ; ## FMC0_LA08_P         IO_L17P_T2U_N8_AD10P_66
+set_property         -dict {PACKAGE_PIN V3    IOSTANDARD LVCMOS18                                     } [get_ports irqb[1]          ]    ; ## FMC0_LA08_N         IO_L17N_T2U_N9_AD10N_66
+set_property         -dict {PACKAGE_PIN U5    IOSTANDARD LVCMOS18                                     } [get_ports rstb             ]    ; ## FMC0_LA07_P         IO_L18P_T2U_N10_AD2P_66
+set_property         -dict {PACKAGE_PIN W5    IOSTANDARD LVCMOS18                                     } [get_ports rxen[0]          ]    ; ## FMC0_LA10_P         IO_L15P_T2L_N4_AD11P_66
+set_property         -dict {PACKAGE_PIN W4    IOSTANDARD LVCMOS18                                     } [get_ports rxen[1]          ]    ; ## FMC0_LA10_N         IO_L15N_T2L_N5_AD11N_66
+set_property         -dict {PACKAGE_PIN AB3   IOSTANDARD LVCMOS18                                     } [get_ports spi0_csb         ]    ; ## FMC0_LA05_P         IO_L20P_T3L_N2_AD1P_66
+set_property         -dict {PACKAGE_PIN AC3   IOSTANDARD LVCMOS18                                     } [get_ports spi0_miso        ]    ; ## FMC0_LA05_N         IO_L20N_T3L_N3_AD1N_66
+set_property         -dict {PACKAGE_PIN AA2   IOSTANDARD LVCMOS18                                     } [get_ports spi0_mosi        ]    ; ## FMC0_LA04_P         IO_L21P_T3L_N4_AD8P_66
+set_property         -dict {PACKAGE_PIN AA1   IOSTANDARD LVCMOS18                                     } [get_ports spi0_sclk        ]    ; ## FMC0_LA04_N         IO_L21N_T3L_N5_AD8N_66
+set_property         -dict {PACKAGE_PIN W7    IOSTANDARD LVCMOS18                                     } [get_ports spi1_csb         ]    ; ## FMC0_LA12_P         IO_L9P_T1L_N4_AD12P_66
+set_property         -dict {PACKAGE_PIN AB6   IOSTANDARD LVCMOS18                                     } [get_ports spi1_sclk        ]    ; ## FMC0_LA11_P         IO_L10P_T1U_N6_QBC_AD4P_66
+set_property         -dict {PACKAGE_PIN W6    IOSTANDARD LVCMOS18                                     } [get_ports spi1_sdio        ]    ; ## FMC0_LA12_N         IO_L9N_T1L_N5_AD12N_66
+set_property         -dict {PACKAGE_PIN AA6   IOSTANDARD LVDS     DIFF_TERM_ADV TERM_100 DQS_BIAS TRUE} [get_ports sysref2_n        ]    ; ## FMC0_CLK0_M2C_N     IO_L12N_T1U_N11_GC_66
+set_property         -dict {PACKAGE_PIN AA7   IOSTANDARD LVDS     DIFF_TERM_ADV TERM_100 DQS_BIAS TRUE} [get_ports sysref2_p        ]    ; ## FMC0_CLK0_M2C_P     IO_L12P_T1U_N10_GC_66
+set_property         -dict {PACKAGE_PIN W2    IOSTANDARD LVCMOS18                                     } [get_ports txen[0]          ]    ; ## FMC0_LA09_P         IO_L24P_T3U_N10_66
+set_property         -dict {PACKAGE_PIN W1    IOSTANDARD LVCMOS18                                     } [get_ports txen[1]          ]    ; ## FMC0_LA09_N         IO_L24N_T3U_N11_66
 


### PR DESCRIPTION
The device clocks are AC coupled LVDS lines without external termination.
For proper operation internal differential termination must be enabled,
the DQS_BIAS will DC bias the AC coupled signal to VCCO/2 (1.8/2) 0.9V

Tested on MxFE and ZCU102