### PR TITLE
Fmcomms2 a10soc bring back

### DIFF
--- a/library/axi_ad9361/axi_ad9361_hw.tcl
+++ b/library/axi_ad9361/axi_ad9361_hw.tcl
@@ -202,13 +202,13 @@ proc axi_ad9361_elab {} {
     set_instance_parameter_value axi_ad9361_serdes_out {SERDES_FACTOR} {4}
     set_instance_parameter_value axi_ad9361_serdes_out {CLKIN_FREQUENCY} {250.0}
 
-    add_hdl_instance axi_ad9361_data_out altera_gpio 19.1
+    add_hdl_instance axi_ad9361_data_out altera_gpio 18.1
     set_instance_parameter_value axi_ad9361_data_out {DEVICE_FAMILY} {Arria 10}
     set_instance_parameter_value axi_ad9361_data_out {PIN_TYPE_GUI} {Output}
     set_instance_parameter_value axi_ad9361_data_out {SIZE} {1}
     set_instance_parameter_value axi_ad9361_data_out {gui_io_reg_mode} {DDIO}
 
-    add_hdl_instance clk_buffer altclkctrl 19.1
+    add_hdl_instance clk_buffer altclkctrl 18.1
     set_instance_parameter_value clk_buffer {DEVICE_FAMILY} {Arria 10}
 
   }

--- a/projects/fmcomms2/a10soc/Makefile
+++ b/projects/fmcomms2/a10soc/Makefile
@@ -1,0 +1,20 @@
+####################################################################################
+## Copyright 2018(c) Analog Devices, Inc.
+## Auto-generated, do not modify!
+####################################################################################
+
+PROJECT_NAME := fmcomms2_a10soc
+
+M_DEPS += ../common/fmcomms2_qsys.tcl
+M_DEPS += ../../common/a10soc/a10soc_system_qsys.tcl
+M_DEPS += ../../common/a10soc/a10soc_system_assign.tcl
+M_DEPS += ../../common/a10soc/a10soc_plddr4_assign.tcl
+
+LIB_DEPS += axi_ad9361
+LIB_DEPS += axi_dmac
+LIB_DEPS += util_pack/util_cpack2
+LIB_DEPS += util_pack/util_upack2
+LIB_DEPS += util_rfifo
+LIB_DEPS += util_wfifo
+
+include ../../scripts/project-intel.mk

--- a/projects/fmcomms2/a10soc/quartus.ini
+++ b/projects/fmcomms2/a10soc/quartus.ini
@@ -1,0 +1,1 @@
+disable_lvds_non_dedicated_refclk_error=on

--- a/projects/fmcomms2/a10soc/system_constr.sdc
+++ b/projects/fmcomms2/a10soc/system_constr.sdc
@@ -1,0 +1,9 @@
+
+create_clock -period "10.000 ns"  -name sys_clk_100mhz      [get_ports {sys_clk}]
+create_clock -period "4.000 ns"   -name rx_clk_250mhz       [get_ports {rx_clk_in}]
+
+derive_pll_clocks
+derive_clock_uncertainty
+
+set_false_path -from [get_registers *altera_reset_synchronizer:alt_rst_sync_uq1|altera_reset_synchronizer_int_chain_out*]
+set_false_path -from [get_registers system_bd:i_system_bd|axi_ad9361:axi_ad9361|axi_ad9361_lvds_if:i_dev_if|axi_ad9361_lvds_if_10:i_axi_ad9361_lvds_if_10|locked_int]

--- a/projects/fmcomms2/a10soc/system_project.tcl
+++ b/projects/fmcomms2/a10soc/system_project.tcl
@@ -1,0 +1,140 @@
+
+source ../../scripts/adi_env.tcl
+source ../../scripts/adi_project_intel.tcl
+
+adi_project fmcomms2_a10soc
+
+source $ad_hdl_dir/projects/common/a10soc/a10soc_system_assign.tcl
+source $ad_hdl_dir/projects/common/a10soc/a10soc_plddr4_assign.tcl
+
+# lane interface
+
+# Note: This projects requires a hardware rework to function correctly.
+# The rework connects FMC header pins directly to the FPGA so that they can be
+# accessed by the fabric.
+#
+# Changes required:
+#  R610: DNI -> R0
+#  R611: DNI -> R0
+#  R612: R0 -> DNI
+#  R613: R0 -> DNI
+#  R620: DNI -> R0
+#  R632: DNI -> R0
+#  R621: R0 -> DNI
+#  R633: R0 -> DNI
+
+
+# constraints
+# ad9361
+
+set_location_assignment PIN_G14   -to  rx_clk_in           ; ## G06   FMCA_HPC_LA00_CC_P
+set_location_assignment PIN_H14   -to  "rx_clk_in(n)"      ; ## G07   FMCA_HPC_LA00_CC_N
+set_location_assignment PIN_E12   -to  rx_frame_in         ; ## D08   FMCA_HPC_LA01_CC_P
+set_location_assignment PIN_E13   -to  "rx_frame_in(n)"    ; ## D09   FMCA_HPC_LA01_CC_N
+set_location_assignment PIN_C13   -to  rx_data_in[0]       ; ## H07   FMCA_HPC_LA02_P
+set_location_assignment PIN_D13   -to  "rx_data_in[0](n)"  ; ## H08   FMCA_HPC_LA02_N
+set_location_assignment PIN_C14   -to  rx_data_in[1]       ; ## G09   FMCA_HPC_LA03_P
+set_location_assignment PIN_D14   -to  "rx_data_in[1](n)"  ; ## G10  FMCA_HPC_LA03_N
+set_location_assignment PIN_H12   -to  rx_data_in[2]       ; ## H10  FMCA_HPC_LA04_P
+set_location_assignment PIN_H13   -to  "rx_data_in[2](n)"  ; ## H11  FMCA_HPC_LA04_N
+set_location_assignment PIN_F13   -to  rx_data_in[3]       ; ## D11  FMCA_HPC_LA05_P
+set_location_assignment PIN_F14   -to  "rx_data_in[3](n)"  ; ## D12  FMCA_HPC_LA05_N
+set_location_assignment PIN_A10   -to  rx_data_in[4]       ; ## C10  FMCA_HPC_LA06_P
+set_location_assignment PIN_B10   -to  "rx_data_in[4](n)"  ; ## C11  FMCA_HPC_LA06_N
+set_location_assignment PIN_A9    -to  rx_data_in[5]       ; ## H13  FMCA_HPC_LA07_P
+set_location_assignment PIN_B9    -to  "rx_data_in[5](n)"  ; ## H14  FMCA_HPC_LA07_N
+set_location_assignment PIN_B11   -to  tx_clk_out          ; ## G12  FMCA_HPC_LA08_P
+set_location_assignment PIN_B12   -to  "tx_clk_out(n)"     ; ## G13  FMCA_HPC_LA08_N
+set_location_assignment PIN_A12   -to  tx_frame_out        ; ## D14  FMCA_HPC_LA09_P
+set_location_assignment PIN_A13   -to  "tx_frame_out(n)"   ; ## D15  FMCA_HPC_LA09_N
+
+set_location_assignment PIN_C9    -to  tx_data_out[0]      ; ## H16  FMCA_HPC_LA11_P
+set_location_assignment PIN_D9    -to  "tx_data_out[0](n)" ; ## H17  FMCA_HPC_LA11_N
+set_location_assignment PIN_M12   -to  tx_data_out[1]      ; ## G15  FMCA_HPC_LA12_P
+set_location_assignment PIN_N13   -to  "tx_data_out[1](n)" ; ## G16  FMCA_HPC_LA12_N
+set_location_assignment PIN_J11   -to  tx_data_out[2]      ; ## D17  FMCA_HPC_LA13_P
+set_location_assignment PIN_K11   -to  "tx_data_out[2](n)" ; ## D18  FMCA_HPC_LA13_N
+set_location_assignment PIN_A7    -to  tx_data_out[3]      ; ## C14  FMCA_HPC_LA10_P
+set_location_assignment PIN_A8    -to  "tx_data_out[3](n)" ; ## C15  FMCA_HPC_LA10_N
+set_location_assignment PIN_J9    -to  tx_data_out[4]      ; ## C18  FMCA_HPC_LA14_P
+set_location_assignment PIN_J10   -to  "tx_data_out[4](n)" ; ## C19  FMCA_HPC_LA14_N
+set_location_assignment PIN_D4    -to  tx_data_out[5]      ; ## H19  FMCA_HPC_LA15_P
+set_location_assignment PIN_D5    -to  "tx_data_out[5](n)" ; ## H20  FMCA_HPC_LA15_N
+
+
+set_instance_assignment -name IO_STANDARD LVDS               -to rx_clk_in
+set_instance_assignment -name INPUT_TERMINATION DIFFERENTIAL -to rx_clk_in
+set_instance_assignment -name IO_STANDARD LVDS               -to rx_frame_in
+set_instance_assignment -name INPUT_TERMINATION DIFFERENTIAL -to rx_frame_in
+set_instance_assignment -name IO_STANDARD LVDS               -to rx_data_in[0]
+set_instance_assignment -name INPUT_TERMINATION DIFFERENTIAL -to rx_data_in[0]
+set_instance_assignment -name IO_STANDARD LVDS               -to rx_data_in[1]
+set_instance_assignment -name INPUT_TERMINATION DIFFERENTIAL -to rx_data_in[1]
+set_instance_assignment -name IO_STANDARD LVDS               -to rx_data_in[2]
+set_instance_assignment -name INPUT_TERMINATION DIFFERENTIAL -to rx_data_in[2]
+set_instance_assignment -name IO_STANDARD LVDS               -to rx_data_in[3]
+set_instance_assignment -name INPUT_TERMINATION DIFFERENTIAL -to rx_data_in[3]
+set_instance_assignment -name IO_STANDARD LVDS               -to rx_data_in[4]
+set_instance_assignment -name INPUT_TERMINATION DIFFERENTIAL -to rx_data_in[4]
+set_instance_assignment -name IO_STANDARD LVDS               -to rx_data_in[5]
+set_instance_assignment -name INPUT_TERMINATION DIFFERENTIAL -to rx_data_in[5]
+
+set_instance_assignment -name IO_STANDARD LVDS               -to tx_clk_out
+set_instance_assignment -name IO_STANDARD LVDS               -to tx_frame_out
+set_instance_assignment -name IO_STANDARD LVDS               -to tx_data_out[0]
+set_instance_assignment -name IO_STANDARD LVDS               -to tx_data_out[1]
+set_instance_assignment -name IO_STANDARD LVDS               -to tx_data_out[2]
+set_instance_assignment -name IO_STANDARD LVDS               -to tx_data_out[3]
+set_instance_assignment -name IO_STANDARD LVDS               -to tx_data_out[4]
+set_instance_assignment -name IO_STANDARD LVDS               -to tx_data_out[5]
+
+
+set_location_assignment PIN_C3   -to   gpio_status[0]                   ; ## G21  FMCA_HPC_LA20_P
+set_location_assignment PIN_C4   -to   gpio_status[1]                   ; ## G22  FMCA_HPC_LA20_N
+set_location_assignment PIN_C2   -to   gpio_status[2]                   ; ## H25  FMCA_HPC_LA21_P
+set_location_assignment PIN_D3   -to   gpio_status[3]                   ; ## H26  FMCA_HPC_LA21_N
+set_location_assignment PIN_F4   -to   gpio_status[4]                   ; ## G24  FMCA_HPC_LA22_P
+set_location_assignment PIN_G4   -to   gpio_status[5]                   ; ## G25  FMCA_HPC_LA22_N
+set_location_assignment PIN_C1   -to   gpio_status[6]                   ; ## D23  FMCA_HPC_LA23_P
+set_location_assignment PIN_D1   -to   gpio_status[7]                   ; ## D24  FMCA_HPC_LA23_N
+set_location_assignment PIN_E1   -to   gpio_ctl[0]                      ; ## H28  FMCA_HPC_LA24_P
+set_location_assignment PIN_E2   -to   gpio_ctl[1]                      ; ## H29  FMCA_HPC_LA24_N
+set_location_assignment PIN_E3   -to   gpio_ctl[2]                      ; ## G27  FMCA_HPC_LA25_P
+set_location_assignment PIN_F3   -to   gpio_ctl[3]                      ; ## G28  FMCA_HPC_LA25_N
+set_location_assignment PIN_G5   -to   gpio_en_agc                      ; ## H22  FMCA_HPC_LA19_P
+set_location_assignment PIN_G6   -to   gpio_sync                        ; ## H23  FMCA_HPC_LA19_N
+set_location_assignment PIN_L5   -to   gpio_resetb                      ; ## H31  FMCA_HPC_LA28_P
+set_location_assignment PIN_D6   -to   enable                           ; ## G18  FMCA_HPC_LA16_P
+set_location_assignment PIN_E6   -to   txnrx                            ; ## G19  FMCA_HPC_LA16_N
+
+set_instance_assignment -name IO_STANDARD "1.8 V" -to gpio_status[0]
+set_instance_assignment -name IO_STANDARD "1.8 V" -to gpio_status[1]
+set_instance_assignment -name IO_STANDARD "1.8 V" -to gpio_status[2]
+set_instance_assignment -name IO_STANDARD "1.8 V" -to gpio_status[3]
+set_instance_assignment -name IO_STANDARD "1.8 V" -to gpio_status[4]
+set_instance_assignment -name IO_STANDARD "1.8 V" -to gpio_status[5]
+set_instance_assignment -name IO_STANDARD "1.8 V" -to gpio_status[6]
+set_instance_assignment -name IO_STANDARD "1.8 V" -to gpio_status[7]
+set_instance_assignment -name IO_STANDARD "1.8 V" -to gpio_ctl[0]
+set_instance_assignment -name IO_STANDARD "1.8 V" -to gpio_ctl[1]
+set_instance_assignment -name IO_STANDARD "1.8 V" -to gpio_ctl[2]
+set_instance_assignment -name IO_STANDARD "1.8 V" -to gpio_ctl[3]
+set_instance_assignment -name IO_STANDARD "1.8 V" -to gpio_en_agc
+set_instance_assignment -name IO_STANDARD "1.8 V" -to gpio_sync
+set_instance_assignment -name IO_STANDARD "1.8 V" -to gpio_resetb
+set_instance_assignment -name IO_STANDARD "1.8 V" -to enable
+set_instance_assignment -name IO_STANDARD "1.8 V" -to txnrx
+
+set_location_assignment PIN_F2   -to    spi_csn                          ; ## D26  FMCA_HPC_LA26_P
+set_location_assignment PIN_G2   -to    spi_clk                          ; ## D27  FMCA_HPC_LA26_N
+set_location_assignment PIN_G1   -to    spi_mosi                         ; ## C26  FMCA_HPC_LA27_P
+set_location_assignment PIN_H2   -to    spi_miso                         ; ## C27  FMCA_HPC_LA27_N
+
+set_instance_assignment -name WEAK_PULL_UP_RESISTOR ON -to spi_csn
+set_instance_assignment -name IO_STANDARD "1.8 V" -to spi_csn
+set_instance_assignment -name IO_STANDARD "1.8 V" -to spi_clk
+set_instance_assignment -name IO_STANDARD "1.8 V" -to spi_mosi
+set_instance_assignment -name IO_STANDARD "1.8 V" -to spi_miso
+
+execute_flow -compile
+

--- a/projects/fmcomms2/a10soc/system_qsys.tcl
+++ b/projects/fmcomms2/a10soc/system_qsys.tcl
@@ -1,0 +1,4 @@
+source $ad_hdl_dir/projects/common/a10soc/a10soc_system_qsys.tcl
+source ../common/fmcomms2_qsys.tcl
+
+set_instance_parameter_value sys_spi {clockPolarity} {1}

--- a/projects/fmcomms2/a10soc/system_qsys.tcl
+++ b/projects/fmcomms2/a10soc/system_qsys.tcl
@@ -1,4 +1,13 @@
+source $ad_hdl_dir/projects/scripts/adi_pd_intel.tcl
 source $ad_hdl_dir/projects/common/a10soc/a10soc_system_qsys.tcl
 source ../common/fmcomms2_qsys.tcl
 
 set_instance_parameter_value sys_spi {clockPolarity} {1}
+
+#system ID
+set_instance_parameter_value axi_sysid_0 {ROM_ADDR_BITS} {9}
+set_instance_parameter_value rom_sys_0 {ROM_ADDR_BITS} {9}
+
+set_instance_parameter_value rom_sys_0 {PATH_TO_FILE} "[pwd]/mem_init_sys.txt"
+
+sysid_gen_sys_init_file;

--- a/projects/fmcomms2/a10soc/system_top.v
+++ b/projects/fmcomms2/a10soc/system_top.v
@@ -236,6 +236,7 @@ module system_top (
 
     .sys_hps_rstn_reset_n (sys_resetn),
     .sys_rstn_reset_n (sys_resetn_s),
+    .pr_rom_data_nc_rom_data('h0),
 
     .sys_spi_MISO (spi_miso),
     .sys_spi_MOSI (spi_mosi),

--- a/projects/fmcomms2/a10soc/system_top.v
+++ b/projects/fmcomms2/a10soc/system_top.v
@@ -1,0 +1,263 @@
+// ***************************************************************************
+// ***************************************************************************
+// Copyright 2014 - 2017 (c) Analog Devices, Inc. All rights reserved.
+//
+// In this HDL repository, there are many different and unique modules, consisting
+// of various HDL (Verilog or VHDL) components. The individual modules are
+// developed independently, and may be accompanied by separate and unique license
+// terms.
+//
+// The user should read each of these license terms, and understand the
+// freedoms and responsibilities that he or she has by using this source/core.
+//
+// This core is distributed in the hope that it will be useful, but WITHOUT ANY
+// WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+// A PARTICULAR PURPOSE.
+//
+// Redistribution and use of source or resulting binaries, with or without modification
+// of this file, are permitted under one of the following two license terms:
+//
+//   1. The GNU General Public License version 2 as published by the
+//      Free Software Foundation, which can be found in the top level directory
+//      of this repository (LICENSE_GPL2), and also online at:
+//      <https://www.gnu.org/licenses/old-licenses/gpl-2.0.html>
+//
+// OR
+//
+//   2. An ADI specific BSD license, which can be found in the top level directory
+//      of this repository (LICENSE_ADIBSD), and also on-line at:
+//      https://github.com/analogdevicesinc/hdl/blob/master/LICENSE_ADIBSD
+//      This will allow to generate bit files and not release the source code,
+//      as long as it attaches to an ADI device.
+//
+// ***************************************************************************
+// ***************************************************************************
+
+`timescale 1ns/100ps
+
+module system_top (
+
+  // clock and resets
+
+  input             sys_clk,
+  input             sys_resetn,
+
+  // hps-ddr4 (32)
+
+  input             hps_ddr_ref_clk,
+  output  [  0:0]   hps_ddr_clk_p,
+  output  [  0:0]   hps_ddr_clk_n,
+  output  [ 16:0]   hps_ddr_a,
+  output  [  1:0]   hps_ddr_ba,
+  output  [  0:0]   hps_ddr_bg,
+  output  [  0:0]   hps_ddr_cke,
+  output  [  0:0]   hps_ddr_cs_n,
+  output  [  0:0]   hps_ddr_odt,
+  output  [  0:0]   hps_ddr_reset_n,
+  output  [  0:0]   hps_ddr_act_n,
+  output  [  0:0]   hps_ddr_par,
+  input   [  0:0]   hps_ddr_alert_n,
+  inout   [  3:0]   hps_ddr_dqs_p,
+  inout   [  3:0]   hps_ddr_dqs_n,
+  inout   [ 31:0]   hps_ddr_dq,
+  inout   [  3:0]   hps_ddr_dbi_n,
+  input             hps_ddr_rzq,
+
+  // hps-ethernet
+
+  input   [  0:0]   hps_eth_rxclk,
+  input   [  0:0]   hps_eth_rxctl,
+  input   [  3:0]   hps_eth_rxd,
+  output  [  0:0]   hps_eth_txclk,
+  output  [  0:0]   hps_eth_txctl,
+  output  [  3:0]   hps_eth_txd,
+  output  [  0:0]   hps_eth_mdc,
+  inout   [  0:0]   hps_eth_mdio,
+
+  // hps-sdio
+
+  output  [  0:0]   hps_sdio_clk,
+  inout   [  0:0]   hps_sdio_cmd,
+  inout   [  7:0]   hps_sdio_d,
+
+  // hps-usb
+
+  input   [  0:0]   hps_usb_clk,
+  input   [  0:0]   hps_usb_dir,
+  input   [  0:0]   hps_usb_nxt,
+  output  [  0:0]   hps_usb_stp,
+  inout   [  7:0]   hps_usb_d,
+
+  // hps-uart
+
+  input   [  0:0]   hps_uart_rx,
+  output  [  0:0]   hps_uart_tx,
+
+  // hps-i2c (shared w fmc-a, fmc-b)
+
+  inout   [  0:0]   hps_i2c_sda,
+  inout   [  0:0]   hps_i2c_scl,
+
+  // hps-gpio (max-v-u16)
+
+  inout   [  3:0]   hps_gpio,
+
+  // gpio (max-v-u21)
+
+  input   [  7:0]   gpio_bd_i,
+  output  [  3:0]   gpio_bd_o,
+
+  // ad9361-interface
+
+  input             rx_clk_in,
+  input             rx_frame_in,
+  input   [  5:0]   rx_data_in,
+  output            tx_clk_out,
+  output            tx_frame_out,
+  output  [  5:0]   tx_data_out,
+  output            enable,
+  output            txnrx,
+
+  output            gpio_resetb,
+  output            gpio_sync,
+  output            gpio_en_agc,
+  output  [  3:0]   gpio_ctl,
+  input   [  7:0]   gpio_status,
+
+  output            spi_csn,
+  output            spi_clk,
+  output            spi_mosi,
+  input             spi_miso);
+
+  // internal signals
+
+  wire              sys_hps_resetn;
+  wire              sys_resetn_s;
+  wire    [ 63:0]   gpio_i;
+  wire    [ 63:0]   gpio_o;
+
+  // assignments
+
+  assign gpio_i[63:40] = gpio_o[63:40];
+
+  assign gpio_resetb    = gpio_o[46];
+  assign gpio_sync      = gpio_o[45];
+  assign gpio_en_agc    = gpio_o[44];
+  assign gpio_ctl       = gpio_o[43:40];
+  assign gpio_i[39:32]  = gpio_status;
+
+  // board stuff (max-v-u21)
+
+  assign gpio_i[31:12] = gpio_o[31:12];
+  assign gpio_i[11: 4] = gpio_bd_i;
+  assign gpio_i[ 3: 0] = gpio_o[ 3: 0];
+
+  assign gpio_bd_o = gpio_o[3:0];
+
+  // peripheral reset
+
+  assign sys_resetn_s = sys_resetn & sys_hps_resetn;
+
+  // instantiations
+
+  system_bd i_system_bd (
+    .sys_clk_clk (sys_clk),
+
+    .sys_gpio_bd_in_port (gpio_i[31:0]),
+    .sys_gpio_bd_out_port (gpio_o[31:0]),
+    .sys_gpio_in_export (gpio_i[63:32]),
+    .sys_gpio_out_export (gpio_o[63:32]),
+
+    .sys_hps_ddr_mem_ck (hps_ddr_clk_p),
+    .sys_hps_ddr_mem_ck_n (hps_ddr_clk_n),
+    .sys_hps_ddr_mem_a (hps_ddr_a),
+    .sys_hps_ddr_mem_act_n (hps_ddr_act_n),
+    .sys_hps_ddr_mem_ba (hps_ddr_ba),
+    .sys_hps_ddr_mem_bg (hps_ddr_bg),
+    .sys_hps_ddr_mem_cke (hps_ddr_cke),
+    .sys_hps_ddr_mem_cs_n (hps_ddr_cs_n),
+    .sys_hps_ddr_mem_odt (hps_ddr_odt),
+    .sys_hps_ddr_mem_reset_n (hps_ddr_reset_n),
+    .sys_hps_ddr_mem_par (hps_ddr_par),
+    .sys_hps_ddr_mem_alert_n (hps_ddr_alert_n),
+    .sys_hps_ddr_mem_dqs (hps_ddr_dqs_p),
+    .sys_hps_ddr_mem_dqs_n (hps_ddr_dqs_n),
+    .sys_hps_ddr_mem_dq (hps_ddr_dq),
+    .sys_hps_ddr_mem_dbi_n (hps_ddr_dbi_n),
+    .sys_hps_ddr_oct_oct_rzqin (hps_ddr_rzq),
+    .sys_hps_ddr_ref_clk_clk (hps_ddr_ref_clk),
+    .sys_hps_ddr_rstn_reset_n (sys_resetn),
+
+    .sys_hps_io_hps_io_phery_emac0_TX_CLK (hps_eth_txclk),
+    .sys_hps_io_hps_io_phery_emac0_TXD0 (hps_eth_txd[0]),
+    .sys_hps_io_hps_io_phery_emac0_TXD1 (hps_eth_txd[1]),
+    .sys_hps_io_hps_io_phery_emac0_TXD2 (hps_eth_txd[2]),
+    .sys_hps_io_hps_io_phery_emac0_TXD3 (hps_eth_txd[3]),
+    .sys_hps_io_hps_io_phery_emac0_RX_CTL (hps_eth_rxctl),
+    .sys_hps_io_hps_io_phery_emac0_TX_CTL (hps_eth_txctl),
+    .sys_hps_io_hps_io_phery_emac0_RX_CLK (hps_eth_rxclk),
+    .sys_hps_io_hps_io_phery_emac0_RXD0 (hps_eth_rxd[0]),
+    .sys_hps_io_hps_io_phery_emac0_RXD1 (hps_eth_rxd[1]),
+    .sys_hps_io_hps_io_phery_emac0_RXD2 (hps_eth_rxd[2]),
+    .sys_hps_io_hps_io_phery_emac0_RXD3 (hps_eth_rxd[3]),
+    .sys_hps_io_hps_io_phery_emac0_MDIO (hps_eth_mdio),
+    .sys_hps_io_hps_io_phery_emac0_MDC (hps_eth_mdc),
+    .sys_hps_io_hps_io_phery_sdmmc_CMD (hps_sdio_cmd),
+    .sys_hps_io_hps_io_phery_sdmmc_D0 (hps_sdio_d[0]),
+    .sys_hps_io_hps_io_phery_sdmmc_D1 (hps_sdio_d[1]),
+    .sys_hps_io_hps_io_phery_sdmmc_D2 (hps_sdio_d[2]),
+    .sys_hps_io_hps_io_phery_sdmmc_D3 (hps_sdio_d[3]),
+    .sys_hps_io_hps_io_phery_sdmmc_D4 (hps_sdio_d[4]),
+    .sys_hps_io_hps_io_phery_sdmmc_D5 (hps_sdio_d[5]),
+    .sys_hps_io_hps_io_phery_sdmmc_D6 (hps_sdio_d[6]),
+    .sys_hps_io_hps_io_phery_sdmmc_D7 (hps_sdio_d[7]),
+    .sys_hps_io_hps_io_phery_sdmmc_CCLK (hps_sdio_clk),
+    .sys_hps_io_hps_io_phery_usb0_DATA0 (hps_usb_d[0]),
+    .sys_hps_io_hps_io_phery_usb0_DATA1 (hps_usb_d[1]),
+    .sys_hps_io_hps_io_phery_usb0_DATA2 (hps_usb_d[2]),
+    .sys_hps_io_hps_io_phery_usb0_DATA3 (hps_usb_d[3]),
+    .sys_hps_io_hps_io_phery_usb0_DATA4 (hps_usb_d[4]),
+    .sys_hps_io_hps_io_phery_usb0_DATA5 (hps_usb_d[5]),
+    .sys_hps_io_hps_io_phery_usb0_DATA6 (hps_usb_d[6]),
+    .sys_hps_io_hps_io_phery_usb0_DATA7 (hps_usb_d[7]),
+    .sys_hps_io_hps_io_phery_usb0_CLK (hps_usb_clk),
+    .sys_hps_io_hps_io_phery_usb0_STP (hps_usb_stp),
+    .sys_hps_io_hps_io_phery_usb0_DIR (hps_usb_dir),
+    .sys_hps_io_hps_io_phery_usb0_NXT (hps_usb_nxt),
+    .sys_hps_io_hps_io_phery_uart1_RX (hps_uart_rx),
+    .sys_hps_io_hps_io_phery_uart1_TX (hps_uart_tx),
+    .sys_hps_io_hps_io_phery_i2c1_SDA (hps_i2c_sda),
+    .sys_hps_io_hps_io_phery_i2c1_SCL (hps_i2c_scl),
+    .sys_hps_io_hps_io_gpio_gpio1_io5 (hps_gpio[0]),
+    .sys_hps_io_hps_io_gpio_gpio1_io14 (hps_gpio[1]),
+    .sys_hps_io_hps_io_gpio_gpio1_io16 (hps_gpio[2]),
+    .sys_hps_io_hps_io_gpio_gpio1_io17 (hps_gpio[3]),
+    .sys_hps_out_rstn_reset_n (sys_hps_resetn),
+
+    .sys_hps_rstn_reset_n (sys_resetn),
+    .sys_rstn_reset_n (sys_resetn_s),
+
+    .sys_spi_MISO (spi_miso),
+    .sys_spi_MOSI (spi_mosi),
+    .sys_spi_SCLK (spi_clk),
+    .sys_spi_SS_n (spi_csn),
+
+    .axi_ad9361_device_if_enable (enable),
+    .axi_ad9361_device_if_rx_clk_in_p (rx_clk_in),
+    .axi_ad9361_device_if_rx_clk_in_n (1'b0),
+    .axi_ad9361_device_if_rx_data_in_p (rx_data_in),
+    .axi_ad9361_device_if_rx_data_in_n (6'd0),
+    .axi_ad9361_device_if_rx_frame_in_p (rx_frame_in),
+    .axi_ad9361_device_if_rx_frame_in_n (1'b0),
+    .axi_ad9361_device_if_tx_clk_out_p (tx_clk_out),
+    .axi_ad9361_device_if_tx_clk_out_n (),
+    .axi_ad9361_device_if_tx_data_out_p (tx_data_out),
+    .axi_ad9361_device_if_tx_data_out_n (),
+    .axi_ad9361_device_if_tx_frame_out_p (tx_frame_out),
+    .axi_ad9361_device_if_tx_frame_out_n (),
+    .axi_ad9361_device_if_txnrx (txnrx));
+
+endmodule
+
+// ***************************************************************************
+// ***************************************************************************


### PR DESCRIPTION
Bring back fmcomms2 support on arria10 SoC.
This project will be suported on Quartus 18.1 version.

Build tested.