### PR TITLE
jesd204: Fix pn mon

### DIFF
--- a/library/axi_ad6676/axi_ad6676.v
+++ b/library/axi_ad6676/axi_ad6676.v
@@ -102,7 +102,7 @@ module axi_ad6676 #(
     .CONVERTER_RESOLUTION (16),
     .BITS_PER_SAMPLE (16),
     .OCTETS_PER_BEAT (4),
-    .TWOS_COMPLEMENT (0)
+    .TWOS_COMPLEMENT (1)
   ) i_adc_jesd204 (
     .link_clk (rx_clk),
 

--- a/library/jesd204/ad_ip_jesd204_tpl_adc/ad_ip_jesd204_tpl_adc_pnmon.v
+++ b/library/jesd204/ad_ip_jesd204_tpl_adc/ad_ip_jesd204_tpl_adc_pnmon.v
@@ -83,7 +83,7 @@ module ad_ip_jesd204_tpl_adc_pnmon #(
     localparam dst_lsb = (DATA_PATH_WIDTH - i - 1) * CONVERTER_RESOLUTION;
     localparam dst_msb = dst_lsb + CONVERTER_RESOLUTION - 1;
 
-    assign pn_data_in_s[dst_msb] = tc ^ data[src_msb];
+    assign pn_data_in_s[dst_msb] = (~tc) ^ data[src_msb];
     assign pn_data_in_s[dst_msb-1:dst_lsb] = data[src_msb-1:src_lsb];
   end
   endgenerate


### PR DESCRIPTION
Most of JESD projects have the PN checker not working. From Dan's experiment and my testing on AD9081 looks the MSB of the PN checker is inverted wrongly when the data format is two's complement. It should be the other way around.
The TWOS_COMPLEMENT parameter should reflect the data format of the part even if the parameter is currently used only in the pn monitor.  So changing the TWOS_COMPLEMENT to 0 in order to have the PN passed can cause confusion.

Tested on AD9081