### PR TITLE
cn0540: Add axi_clkgen to Makefile

### DIFF
--- a/projects/cn0540/coraz7s/Makefile
+++ b/projects/cn0540/coraz7s/Makefile
@@ -12,6 +12,7 @@ M_DEPS += ../../common/coraz7s/coraz7s_system_bd.tcl
 M_DEPS += ../../../library/xilinx/common/ad_iobuf.v
 
 LIB_DEPS += axi_dmac
+LIB_DEPS += axi_clkgen
 LIB_DEPS += axi_sysid
 LIB_DEPS += spi_engine/axi_spi_engine
 LIB_DEPS += spi_engine/spi_engine_execution


### PR DESCRIPTION
fix missing dependency causing project to fail