### PR TITLE
Fix critical warnings on adv7513@de10nano

### DIFF
--- a/projects/adv7513/de10nano/system_constr.sdc
+++ b/projects/adv7513/de10nano/system_constr.sdc
@@ -1,5 +1,6 @@
 
 create_clock -period "20.000 ns"  -name sys_clk_50mhz      [get_ports {sys_clk}]
+create_clock -period "16.666 ns"  -name usb_clk_60mhz      [get_ports {usb1_clk}]
 
 derive_pll_clocks
 derive_clock_uncertainty

--- a/projects/adv7513/de10nano/system_top.v
+++ b/projects/adv7513/de10nano/system_top.v
@@ -99,8 +99,8 @@ module system_top (
 
   // board gpio
 
-  output  [  3:0]   gpio_bd_o,
-  input   [  7:0]   gpio_bd_i,
+  output  [  7:0]   gpio_bd_o,
+  input   [  5:0]   gpio_bd_i,
 
   output            hdmi_out_clk,
   output            hdmi_vsync,
@@ -132,12 +132,10 @@ module system_top (
   // instantiations
 
   assign gpio_i[63:32] = gpio_o[63:32];
-
-  assign gpio_i[11:4] = gpio_bd_i[7:0];
-  assign gpio_bd_o[3:0] = gpio_o[3:0];
-
   assign gpio_i[31:12] = gpio_o[31:12];
+  assign gpio_i[11:4] = gpio_bd_i[5:0];
 
+  assign gpio_bd_o[7:0] = gpio_o[7:0];
   assign ltc2308_cs = gpio_o[41];
 
   ALT_IOBUF scl_iobuf (

--- a/projects/common/de10nano/de10nano_system_assign.tcl
+++ b/projects/common/de10nano/de10nano_system_assign.tcl
@@ -47,6 +47,19 @@ set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to gpio_bd_i[5]
 
 set_location_assignment PIN_A22 -to uart0_rx
 set_location_assignment PIN_B21 -to uart0_tx
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to uart0_rx
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to uart0_tx
+
+# hps spi master
+
+set_location_assignment PIN_C16 -to spim1_ss0
+set_location_assignment PIN_C19 -to spim1_clk
+set_location_assignment PIN_B16 -to spim1_mosi
+set_location_assignment PIN_B19 -to spim1_miso
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to spim1_ss0
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to spim1_clk
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to spim1_mosi
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to spim1_miso
 
 # SPI interface for ltc2308
 


### PR DESCRIPTION
Fix missing IO assignment definitions and delete unused IO ports.