### PR TITLE
ad_fmclidar1_ebz/a10soc: Fix a typo

### DIFF
--- a/projects/ad_fmclidar1_ebz/a10soc/system_top.v
+++ b/projects/ad_fmclidar1_ebz/a10soc/system_top.v
@@ -241,7 +241,7 @@ module system_top (
   wire i2c_0_sda_oe;
 
   ad_iobuf #(.DATA_WIDTH(2)) i_iobuf_i2c (
-    .dio_t ({i2c_0_scl_out,i2c_0_sda_oe}}),
+    .dio_t ({i2c_0_scl_out,i2c_0_sda_oe}),
     .dio_i (2'b0),
     .dio_o ({i2c_0_scl_in,i2c_0_sda_in}),
     .dio_p ({afe_dac_scl,afe_dac_sda}));


### PR DESCRIPTION
Fixing a typo in projects/ad_fmclidar1_ebz/a10soc/system_top.v.