### PR TITLE
Axi gpreg update

### DIFF
--- a/library/axi_gpreg/axi_gpreg.v
+++ b/library/axi_gpreg/axi_gpreg.v
@@ -49,9 +49,7 @@ module axi_gpreg #(
   parameter   integer BUF_ENABLE_4 = 1,
   parameter   integer BUF_ENABLE_5 = 1,
   parameter   integer BUF_ENABLE_6 = 1,
-  parameter   integer BUF_ENABLE_7 = 1)
-
- (
+  parameter   integer BUF_ENABLE_7 = 1) (
 
   // io
 
@@ -301,13 +299,13 @@ module axi_gpreg #(
   // gpio
 
   if (NUM_OF_IO < 8) begin
-  for (n = NUM_OF_IO; n < 8; n = n + 1) begin: g_unused_io
-  assign up_gp_ioenb_s[n] = 32'd0;
-  assign up_gp_out_s[n] = 32'd0;
-  assign up_wack_s[n] = 1'd0;
-  assign up_rdata_s[n] = 32'd0;
-  assign up_rack_s[n] = 1'd0;
-  end
+    for (n = NUM_OF_IO; n < 8; n = n + 1) begin: g_unused_io
+      assign up_gp_ioenb_s[n] = 32'd0;
+      assign up_gp_out_s[n] = 32'd0;
+      assign up_wack_s[n] = 1'd0;
+      assign up_rdata_s[n] = 32'd0;
+      assign up_rack_s[n] = 1'd0;
+    end
   end
 
   for (n = 0; n < NUM_OF_IO; n = n + 1) begin: g_io
@@ -334,11 +332,11 @@ module axi_gpreg #(
   // clock monitors
 
   if (NUM_OF_CLK_MONS < 8) begin
-  for (n = NUM_OF_CLK_MONS; n < 8; n = n + 1) begin: g_unused_clock_mon
-  assign up_wack_s[(8+n)] = 1'd0;
-  assign up_rdata_s[(8+n)] = 32'd0;
-  assign up_rack_s[(8+n)] = 1'd0;
-  end
+    for (n = NUM_OF_CLK_MONS; n < 8; n = n + 1) begin: g_unused_clock_mon
+      assign up_wack_s[(8+n)] = 1'd0;
+      assign up_rdata_s[(8+n)] = 32'd0;
+      assign up_rack_s[(8+n)] = 1'd0;
+    end
   end
 
   for (n = 0; n < NUM_OF_CLK_MONS; n = n + 1) begin: g_clock_mon

--- a/library/axi_gpreg/axi_gpreg.v
+++ b/library/axi_gpreg/axi_gpreg.v
@@ -94,6 +94,8 @@ module axi_gpreg #(
   // core clock
 
   input             clk,
+  output            reset_out,
+
   // axi interface
 
   input             s_axi_aclk,
@@ -143,6 +145,7 @@ module axi_gpreg #(
   reg     [ 31:0]   up_rdata_d = 'd0;
   reg               up_wack = 'd0;
   reg     [ 31:0]   up_scratch = 'd0;
+  reg               up_reset_core = 'd0;
   reg               up_rack = 'd0;
   reg     [ 31:0]   up_rdata = 'd0;
 
@@ -236,10 +239,14 @@ module axi_gpreg #(
     if (up_rstn == 0) begin
       up_wack <= 'd0;
       up_scratch <= 'd0;
+      up_reset_core <= 'd0;
     end else begin
       up_wack <= up_wreq_s;
       if ((up_wreq_s == 1'b1) && (up_waddr[7:0] == 8'h02)) begin
         up_scratch <= up_wdata;
+      end
+      if ((up_wreq_s == 1'b1) && (up_waddr[7:0] == 8'h03)) begin
+        up_reset_core <= up_wdata[0];
       end
     end
   end
@@ -257,6 +264,7 @@ module axi_gpreg #(
           8'h00: up_rdata <= PCORE_VERSION;
           8'h01: up_rdata <= ID;
           8'h02: up_rdata <= up_scratch;
+          8'h03: up_rdata <= up_reset_core;
           default: up_rdata <= 0;
         endcase
       end else begin

--- a/library/axi_gpreg/axi_gpreg_clock_mon.v
+++ b/library/axi_gpreg/axi_gpreg_clock_mon.v
@@ -129,11 +129,11 @@ module axi_gpreg_clock_mon #(
 
   generate
   if (BUF_ENABLE == 1) begin
-  BUFG i_bufg (
-    .I (d_clk),
-    .O (d_clk_g));
+    BUFG i_bufg (
+      .I (d_clk),
+      .O (d_clk_g));
   end else begin
-  assign d_clk_g = d_clk;
+    assign d_clk_g = d_clk;
   end
   endgenerate
 

--- a/library/axi_gpreg/axi_gpreg_io.v
+++ b/library/axi_gpreg/axi_gpreg_io.v
@@ -37,13 +37,14 @@
 
 module axi_gpreg_io #(
 
-  parameter   ID = 0) (
+  parameter   ID = 0,
+  parameter   ASINC_DEST_CLK = 1) (
 
-  // gpio
+  input                   clk,
 
-  output  reg [31:0]      up_gp_ioenb,
-  output  reg [31:0]      up_gp_out,
-  input       [31:0]      up_gp_in,
+  output      [31:0]      gp_ioenb,
+  output      [31:0]      gp_out,
+  input       [31:0]      gp_in,
 
   // bus interface
 
@@ -61,10 +62,14 @@ module axi_gpreg_io #(
 
   // internal registers
 
+  reg   [31:0]    up_gp_ioenb = 'd0;
+  reg   [31:0]    up_gp_out = 'd0;
+
   // internal signals
 
   wire            up_wreq_s;
   wire            up_rreq_s;
+  wire  [31:0]    up_gp_in;
 
   // decode block select
 
@@ -109,6 +114,24 @@ module axi_gpreg_io #(
       end
     end
   end
+
+  sync_data #(
+    .NUM_OF_BITS (64),
+    .ASYNC_CLK (ASINC_DEST_CLK))
+  i_control_sync (
+    .in_clk (up_clk),
+    .in_data ({up_gp_ioenb,up_gp_out}),
+    .out_clk (clk),
+    .out_data ({gp_ioenb,gp_out}));
+
+  sync_data #(
+    .NUM_OF_BITS (32),
+    .ASYNC_CLK (ASINC_DEST_CLK))
+  i_status_sync (
+    .in_clk (clk),
+    .in_data (gp_in),
+    .out_clk (up_clk),
+    .out_data (up_gp_in));
 
 endmodule
 

--- a/library/axi_gpreg/axi_gpreg_ip.tcl
+++ b/library/axi_gpreg/axi_gpreg_ip.tcl
@@ -19,39 +19,6 @@ adi_ip_properties axi_gpreg
 adi_ip_add_core_dependencies { \
 	analog.com:user:util_cdc:1.0 \
 }
-set_property enablement_dependency {spirit:decode(id('MODELPARAM_VALUE.NUM_OF_IO')) > 0} \
-  [ipx::get_ports up_gp_*_0 -of_objects [ipx::current_core]]
-set_property enablement_dependency {spirit:decode(id('MODELPARAM_VALUE.NUM_OF_IO')) > 1} \
-  [ipx::get_ports up_gp_*_1 -of_objects [ipx::current_core]]
-set_property enablement_dependency {spirit:decode(id('MODELPARAM_VALUE.NUM_OF_IO')) > 2} \
-  [ipx::get_ports up_gp_*_2 -of_objects [ipx::current_core]]
-set_property enablement_dependency {spirit:decode(id('MODELPARAM_VALUE.NUM_OF_IO')) > 3} \
-  [ipx::get_ports up_gp_*_3 -of_objects [ipx::current_core]]
-set_property enablement_dependency {spirit:decode(id('MODELPARAM_VALUE.NUM_OF_IO')) > 4} \
-  [ipx::get_ports up_gp_*_4 -of_objects [ipx::current_core]]
-set_property enablement_dependency {spirit:decode(id('MODELPARAM_VALUE.NUM_OF_IO')) > 5} \
-  [ipx::get_ports up_gp_*_5 -of_objects [ipx::current_core]]
-set_property enablement_dependency {spirit:decode(id('MODELPARAM_VALUE.NUM_OF_IO')) > 6} \
-  [ipx::get_ports up_gp_*_6 -of_objects [ipx::current_core]]
-set_property enablement_dependency {spirit:decode(id('MODELPARAM_VALUE.NUM_OF_IO')) > 7} \
-  [ipx::get_ports up_gp_*_7 -of_objects [ipx::current_core]]
-
-set_property enablement_dependency {spirit:decode(id('MODELPARAM_VALUE.NUM_OF_CLK_MONS')) > 0} \
-  [ipx::get_ports d_clk_0 -of_objects [ipx::current_core]]
-set_property enablement_dependency {spirit:decode(id('MODELPARAM_VALUE.NUM_OF_CLK_MONS')) > 1} \
-  [ipx::get_ports d_clk_1 -of_objects [ipx::current_core]]
-set_property enablement_dependency {spirit:decode(id('MODELPARAM_VALUE.NUM_OF_CLK_MONS')) > 2} \
-  [ipx::get_ports d_clk_2 -of_objects [ipx::current_core]]
-set_property enablement_dependency {spirit:decode(id('MODELPARAM_VALUE.NUM_OF_CLK_MONS')) > 3} \
-  [ipx::get_ports d_clk_3 -of_objects [ipx::current_core]]
-set_property enablement_dependency {spirit:decode(id('MODELPARAM_VALUE.NUM_OF_CLK_MONS')) > 4} \
-  [ipx::get_ports d_clk_4 -of_objects [ipx::current_core]]
-set_property enablement_dependency {spirit:decode(id('MODELPARAM_VALUE.NUM_OF_CLK_MONS')) > 5} \
-  [ipx::get_ports d_clk_5 -of_objects [ipx::current_core]]
-set_property enablement_dependency {spirit:decode(id('MODELPARAM_VALUE.NUM_OF_CLK_MONS')) > 6} \
-  [ipx::get_ports d_clk_6 -of_objects [ipx::current_core]]
-set_property enablement_dependency {spirit:decode(id('MODELPARAM_VALUE.NUM_OF_CLK_MONS')) > 7} \
-  [ipx::get_ports d_clk_7 -of_objects [ipx::current_core]]
 
 # Standalone(axi_interface) - or part of a subcore(read/write interaface)
 set_property widget {checkBox} [ipgui::get_guiparamspec -name "STAND_ALONE" -component [ipx::current_core] ]
@@ -66,6 +33,29 @@ set_property value true [ipx::get_user_parameters DESTINATION_CLK -of_objects [i
 set_property value true [ipx::get_hdl_parameters DESTINATION_CLK -of_objects [ipx::current_core]]
 set_property value_format bool [ipx::get_user_parameters DESTINATION_CLK -of_objects [ipx::current_core]]
 set_property value_format bool [ipx::get_hdl_parameters DESTINATION_CLK -of_objects [ipx::current_core]]
+
+# Number of IOs
+set_property value_format long [ipx::get_user_parameters NUM_OF_IO -of_objects [ipx::current_core]]
+set_property value_format long [ipx::get_hdl_parameters NUM_OF_IO -of_objects [ipx::current_core]]
+set_property -dict [list \
+	"value_validation_type" "range_long" \
+	"value_validation_range_minimum" "0" \
+	"value_validation_range_maximum" "8" \
+	] \
+	[ipx::get_user_parameters NUM_OF_IO -of_objects [ipx::current_core]]
+
+# Number of clock monitors
+set_property value_format long [ipx::get_user_parameters NUM_OF_CLK_MONS -of_objects [ipx::current_core]]
+set_property value_format long [ipx::get_hdl_parameters NUM_OF_CLK_MONS -of_objects [ipx::current_core]]
+set_property -dict [list \
+	"value_validation_type" "range_long" \
+	"value_validation_range_minimum" "0" \
+	"value_validation_range_maximum" "8" \
+	] \
+	[ipx::get_user_parameters NUM_OF_CLK_MONS -of_objects [ipx::current_core]]
+
+# Enable ports
+
 set_property enablement_dependency {spirit:decode(id('MODELPARAM_VALUE.STAND_ALONE')) = 0} \
   [ipx::get_ports up_*_ext -of_objects [ipx::current_core]]
 
@@ -75,6 +65,20 @@ adi_set_bus_dependency "s_axi" "s_axi" \
 #set_property enablement_dependency {spirit:decode(id('MODELPARAM_VALUE.STAND_ALONE')) = 1} \
   [ipx::get_ports s_axi* -of_objects [ipx::current_core]]
 
+for {set i 0} {$i < 8} {incr i} {
+	adi_set_ports_dependency "up_gp_*_$i" \
+		"(spirit:decode(id('MODELPARAM_VALUE.NUM_OF_IO')) > $i)"
+}
+
+for {set i 0} {$i < 8} {incr i} {
+	adi_set_ports_dependency "d_clk_$i" \
+		"(spirit:decode(id('MODELPARAM_VALUE.NUM_OF_CLK_MONS')) > $i)"
+}
+
+set_property enablement_dependency {spirit:decode(id('MODELPARAM_VALUE.DESTINATION_CLK')) = 1} \
+  [ipx::get_ports clk -of_objects [ipx::current_core]]
+
+# Drive to GND the unused input ports
 set_property driver_value 0 [ipx::get_ports -filter "direction==in" -of_objects [ipx::current_core]]
 
 ipx::save_core [ipx::current_core]

--- a/library/axi_gpreg/axi_gpreg_ip.tcl
+++ b/library/axi_gpreg/axi_gpreg_ip.tcl
@@ -16,6 +16,9 @@ adi_ip_files axi_gpreg [list \
 
 adi_ip_properties axi_gpreg
 
+adi_ip_add_core_dependencies { \
+	analog.com:user:util_cdc:1.0 \
+}
 set_property enablement_dependency {spirit:decode(id('MODELPARAM_VALUE.NUM_OF_IO')) > 0} \
   [ipx::get_ports up_gp_*_0 -of_objects [ipx::current_core]]
 set_property enablement_dependency {spirit:decode(id('MODELPARAM_VALUE.NUM_OF_IO')) > 1} \
@@ -50,6 +53,13 @@ set_property enablement_dependency {spirit:decode(id('MODELPARAM_VALUE.NUM_OF_CL
 set_property enablement_dependency {spirit:decode(id('MODELPARAM_VALUE.NUM_OF_CLK_MONS')) > 7} \
   [ipx::get_ports d_clk_7 -of_objects [ipx::current_core]]
 
+
+# Destination clock
+set_property widget {checkBox} [ipgui::get_guiparamspec -name "DESTINATION_CLK" -component [ipx::current_core] ]
+set_property value true [ipx::get_user_parameters DESTINATION_CLK -of_objects [ipx::current_core]]
+set_property value true [ipx::get_hdl_parameters DESTINATION_CLK -of_objects [ipx::current_core]]
+set_property value_format bool [ipx::get_user_parameters DESTINATION_CLK -of_objects [ipx::current_core]]
+set_property value_format bool [ipx::get_hdl_parameters DESTINATION_CLK -of_objects [ipx::current_core]]
 set_property driver_value 0 [ipx::get_ports -filter "direction==in" -of_objects [ipx::current_core]]
 
 ipx::save_core [ipx::current_core]

--- a/library/axi_gpreg/axi_gpreg_ip.tcl
+++ b/library/axi_gpreg/axi_gpreg_ip.tcl
@@ -53,6 +53,12 @@ set_property enablement_dependency {spirit:decode(id('MODELPARAM_VALUE.NUM_OF_CL
 set_property enablement_dependency {spirit:decode(id('MODELPARAM_VALUE.NUM_OF_CLK_MONS')) > 7} \
   [ipx::get_ports d_clk_7 -of_objects [ipx::current_core]]
 
+# Standalone(axi_interface) - or part of a subcore(read/write interaface)
+set_property widget {checkBox} [ipgui::get_guiparamspec -name "STAND_ALONE" -component [ipx::current_core] ]
+set_property value true [ipx::get_user_parameters STAND_ALONE -of_objects [ipx::current_core]]
+set_property value true [ipx::get_hdl_parameters STAND_ALONE -of_objects [ipx::current_core]]
+set_property value_format bool [ipx::get_user_parameters STAND_ALONE -of_objects [ipx::current_core]]
+set_property value_format bool [ipx::get_hdl_parameters STAND_ALONE -of_objects [ipx::current_core]]
 
 # Destination clock
 set_property widget {checkBox} [ipgui::get_guiparamspec -name "DESTINATION_CLK" -component [ipx::current_core] ]
@@ -60,6 +66,15 @@ set_property value true [ipx::get_user_parameters DESTINATION_CLK -of_objects [i
 set_property value true [ipx::get_hdl_parameters DESTINATION_CLK -of_objects [ipx::current_core]]
 set_property value_format bool [ipx::get_user_parameters DESTINATION_CLK -of_objects [ipx::current_core]]
 set_property value_format bool [ipx::get_hdl_parameters DESTINATION_CLK -of_objects [ipx::current_core]]
+set_property enablement_dependency {spirit:decode(id('MODELPARAM_VALUE.STAND_ALONE')) = 0} \
+  [ipx::get_ports up_*_ext -of_objects [ipx::current_core]]
+
+adi_set_bus_dependency "s_axi" "s_axi" \
+	"(spirit:decode(id('MODELPARAM_VALUE.STAND_ALONE')) = 1)"
+
+#set_property enablement_dependency {spirit:decode(id('MODELPARAM_VALUE.STAND_ALONE')) = 1} \
+  [ipx::get_ports s_axi* -of_objects [ipx::current_core]]
+
 set_property driver_value 0 [ipx::get_ports -filter "direction==in" -of_objects [ipx::current_core]]
 
 ipx::save_core [ipx::current_core]


### PR DESCRIPTION
Update axi_gpreg IP

Add support for:
- destination clock domain(CDC between uP clock)
- integration in other axi controlled IPs(non standalone)
- add user reset

Documentation at https://wiki.analog.com/resources/fpga/docs/axi_gpreg