### PR TITLE
ad7768evb: Remove buffers, add parallel data path

### DIFF
--- a/projects/ad7768evb/common/ad7768_if.v
+++ b/projects/ad7768evb/common/ad7768_if.v
@@ -47,7 +47,24 @@ module ad7768_if (
 
   output                  adc_clk,
   output  reg             adc_valid,
+  output  reg             adc_valid_0,
+  output  reg             adc_valid_1,
+  output  reg             adc_valid_2,
+  output  reg             adc_valid_3,
+  output  reg             adc_valid_4,
+  output  reg             adc_valid_5,
+  output  reg             adc_valid_6,
+  output  reg             adc_valid_7,
+  output  reg             adc_valid_pp,
   output  reg [ 31:0]     adc_data,
+  output  reg [ 31:0]     adc_data_0,
+  output  reg [ 31:0]     adc_data_1,
+  output  reg [ 31:0]     adc_data_2,
+  output  reg [ 31:0]     adc_data_3,
+  output  reg [ 31:0]     adc_data_4,
+  output  reg [ 31:0]     adc_data_5,
+  output  reg [ 31:0]     adc_data_6,
+  output  reg [ 31:0]     adc_data_7,
   output                  adc_sync,
 
   // control interface
@@ -197,6 +214,9 @@ module ad7768_if (
   assign up_status[ 7: 4] = {1'd0, adc_status_1};
   assign up_status[ 3: 0] = {1'd0, adc_status_0};
 
+  assign adc_ready_in_s = ready_in;
+  assign adc_clk = clk_in;
+
   always @(posedge adc_clk) begin
     if (adc_valid == 1'b1) begin
       adc_status_8 <= adc_status_8 | adc_status[1:0];
@@ -255,7 +275,41 @@ module ad7768_if (
   always @(posedge adc_clk) begin
     adc_valid <= adc_valid_int & adc_enable_int;
     adc_data <= {{8{adc_data_int[23]}}, adc_data_int[23:0]};
+    if (adc_ch_valid_0 == 1'b1) begin
+      adc_data_0 <= adc_ch_data_0;
+    end
+    if (adc_ch_valid_1 == 1'b1) begin
+      adc_data_1 <= adc_ch_data_1;
+    end
+    if (adc_ch_valid_2 == 1'b1) begin
+      adc_data_2 <= adc_ch_data_2;
+    end
+    if (adc_ch_valid_3 == 1'b1) begin
+      adc_data_3 <= adc_ch_data_3;
+    end
+    if (adc_ch_valid_4 == 1'b1) begin
+      adc_data_4 <= adc_ch_data_4;
+    end
+    if (adc_ch_valid_5 == 1'b1) begin
+      adc_data_5 <= adc_ch_data_5;
+    end
+    if (adc_ch_valid_6 == 1'b1) begin
+      adc_data_6 <= adc_ch_data_6;
+    end
+    if (adc_ch_valid_7 == 1'b1) begin
+      adc_data_7 <= adc_ch_data_7;
+    end
     adc_seq <= adc_seq_int;
+    adc_valid_0 <= adc_ch_valid_7;
+    adc_valid_1 <= adc_ch_valid_7;
+    adc_valid_2 <= adc_ch_valid_7;
+    adc_valid_3 <= adc_ch_valid_7;
+    adc_valid_4 <= adc_ch_valid_7;
+    adc_valid_5 <= adc_ch_valid_7;
+    adc_valid_6 <= adc_ch_valid_7;
+    adc_valid_7 <= adc_ch_valid_7;
+    adc_valid_pp <= adc_valid_0 | adc_valid_1 | adc_valid_2 | adc_valid_3 |
+	            adc_valid_4 | adc_valid_5 | adc_valid_6 | adc_valid_7;
     if ((adc_crc_enable == 1'b1) && (adc_crc_scnt_int == 4'd0)) begin
       adc_status[4] <= adc_crc_mismatch_8[7] & adc_enable_int;
       adc_status[3] <= 1'b0;
@@ -268,7 +322,7 @@ module ad7768_if (
       adc_status[2] <= adc_data_int[27] & adc_enable_int;
       adc_status[1] <= adc_data_int[31] & adc_enable_int;
       adc_status[0] <= adc_seq_foos;
-    end 
+    end
   end
 
   // crc- not much useful at the interface, since it is post-framing
@@ -441,6 +495,7 @@ module ad7768_if (
     end
   end
 
+
   // data (common)
 
   assign adc_cnt_enable_1_s = (adc_cnt_p <= 9'h01f) ? 1'b1 : 1'b0;
@@ -482,9 +537,7 @@ module ad7768_if (
     adc_data_d2[n] <= adc_data_d1[n];
   end
 
-  IBUF i_ibuf_data (
-    .I (data_in[n]),
-    .O (adc_data_in_s[n]));
+  assign adc_data_in_s[n] = data_in[n];
 
   end
   endgenerate
@@ -496,20 +549,6 @@ module ad7768_if (
     adc_ready <= adc_sshot ~^ adc_ready_d1;
     adc_ready_d <= adc_ready;
   end
-
-  IBUF i_ibuf_ready (
-    .I (ready_in),
-    .O (adc_ready_in_s));
-
-  // clock (use bufg delay ~4ns on 29ns)
-
-  BUFG i_bufg_clk (
-    .I (adc_clk_in_s),
-    .O (adc_clk));
-
-  IBUFG i_ibufg_clk (
-    .I (clk_in),
-    .O (adc_clk_in_s));
 
   // control signals
 

--- a/projects/ad7768evb/common/ad7768evb_bd.tcl
+++ b/projects/ad7768evb/common/ad7768evb_bd.tcl
@@ -3,8 +3,17 @@
 
 create_bd_port -dir I adc_clk
 create_bd_port -dir I adc_valid
+create_bd_port -dir I adc_valid_pp
 create_bd_port -dir I adc_sync
 create_bd_port -dir I -from 31 -to 0 adc_data
+create_bd_port -dir I -from 31 -to 0 adc_data_0
+create_bd_port -dir I -from 31 -to 0 adc_data_1
+create_bd_port -dir I -from 31 -to 0 adc_data_2
+create_bd_port -dir I -from 31 -to 0 adc_data_3
+create_bd_port -dir I -from 31 -to 0 adc_data_4
+create_bd_port -dir I -from 31 -to 0 adc_data_5
+create_bd_port -dir I -from 31 -to 0 adc_data_6
+create_bd_port -dir I -from 31 -to 0 adc_data_7
 create_bd_port -dir I -from 31 -to 0 adc_gpio_0_i
 create_bd_port -dir O -from 31 -to 0 adc_gpio_0_o
 create_bd_port -dir O -from 31 -to 0 adc_gpio_0_t
@@ -24,6 +33,16 @@ ad_ip_parameter ad7768_dma CONFIG.AXI_SLICE_DEST 0
 ad_ip_parameter ad7768_dma CONFIG.DMA_2D_TRANSFER 0
 ad_ip_parameter ad7768_dma CONFIG.DMA_DATA_WIDTH_SRC 32
 
+ad_ip_instance axi_dmac ad7768_dma_2
+ad_ip_parameter ad7768_dma_2 CONFIG.DMA_TYPE_SRC 2
+ad_ip_parameter ad7768_dma_2 CONFIG.DMA_TYPE_DEST 0
+ad_ip_parameter ad7768_dma_2 CONFIG.CYCLIC 0
+ad_ip_parameter ad7768_dma_2 CONFIG.SYNC_TRANSFER_START 1
+ad_ip_parameter ad7768_dma_2 CONFIG.AXI_SLICE_SRC 0
+ad_ip_parameter ad7768_dma_2 CONFIG.AXI_SLICE_DEST 0
+ad_ip_parameter ad7768_dma_2 CONFIG.DMA_2D_TRANSFER 0
+ad_ip_parameter ad7768_dma_2 CONFIG.DMA_DATA_WIDTH_SRC 256
+
 # ps7-hp1
 
 ad_ip_parameter sys_ps7 CONFIG.PCW_USE_S_AXI_HP1 1
@@ -36,12 +55,45 @@ ad_ip_parameter ad7768_gpio CONFIG.C_GPIO_WIDTH 32
 ad_ip_parameter ad7768_gpio CONFIG.C_GPIO2_WIDTH 32
 ad_ip_parameter ad7768_gpio CONFIG.C_INTERRUPT_PRESENT 1
 
+# adc-path channel pack
+
+ad_ip_instance util_cpack2 util_ad7768_adc_pack
+ad_ip_parameter util_ad7768_adc_pack CONFIG.NUM_OF_CHANNELS 8
+ad_ip_parameter util_ad7768_adc_pack CONFIG.SAMPLE_DATA_WIDTH 32
+
+ad_connect adc_clk util_ad7768_adc_pack/clk
+ad_connect sys_rstgen/peripheral_reset util_ad7768_adc_pack/reset
+ad_connect adc_valid_pp util_ad7768_adc_pack/fifo_wr_en
+
+for {set i 0} {$i < 8} {incr i} {
+  ad_connect adc_data_$i util_ad7768_adc_pack/fifo_wr_data_$i
+}
+
+# axi_generic_adc
+
+ad_ip_instance axi_generic_adc axi_ad7768_adc
+ad_ip_parameter axi_ad7768_adc CONFIG.NUM_OF_CHANNELS 8
+
+for {set i 0} {$i < 8} {incr i} {
+  ad_ip_instance xlslice xlslice_$i
+  set_property -dict [list CONFIG.DIN_FROM $i CONFIG.DIN_WIDTH {8} CONFIG.DOUT_WIDTH {1} CONFIG.DIN_TO $i] [get_bd_cells xlslice_$i]
+  ad_connect axi_ad7768_adc/adc_enable xlslice_$i/Din
+  ad_connect xlslice_$i/Dout util_ad7768_adc_pack/enable_$i
+}
+
 # interconnects
 
+ad_connect  sys_cpu_resetn ad7768_dma/m_dest_axi_aresetn
+ad_connect  sys_cpu_resetn ad7768_dma_2/m_dest_axi_aresetn
 ad_connect  adc_clk ad7768_dma/fifo_wr_clk
 ad_connect  adc_valid ad7768_dma/fifo_wr_en
 ad_connect  adc_sync ad7768_dma/fifo_wr_sync
 ad_connect  adc_data ad7768_dma/fifo_wr_din
+ad_connect  adc_clk ad7768_dma_2/fifo_wr_clk
+ad_connect  util_ad7768_adc_pack/packed_fifo_wr ad7768_dma_2/fifo_wr
+ad_connect  util_ad7768_adc_pack/fifo_wr_overflow axi_ad7768_adc/adc_dovf
+ad_connect  adc_clk axi_ad7768_adc/adc_clk
+ad_connect  sys_ps7/FCLK_CLK0 axi_ad7768_adc/s_axi_aclk
 ad_connect  adc_gpio_0_i ad7768_gpio/gpio_io_i
 ad_connect  adc_gpio_0_o ad7768_gpio/gpio_io_o
 ad_connect  adc_gpio_0_t ad7768_gpio/gpio_io_t
@@ -53,12 +105,16 @@ ad_connect  adc_gpio_1_t ad7768_gpio/gpio2_io_t
 
 ad_cpu_interrupt ps-13 mb-13  ad7768_dma/irq
 ad_cpu_interrupt ps-12 mb-12  ad7768_gpio/ip2intc_irpt
+ad_cpu_interrupt ps-10 mb-10  ad7768_dma_2/irq
 
 # cpu / memory interconnects
 
 ad_cpu_interconnect 0x7C400000 ad7768_dma
 ad_cpu_interconnect 0x7C420000 ad7768_gpio
+ad_cpu_interconnect 0x7C480000 ad7768_dma_2
+ad_cpu_interconnect 0x43c00000 axi_ad7768_adc
 
 ad_mem_hp1_interconnect sys_cpu_clk sys_ps7/S_AXI_HP1
 ad_mem_hp1_interconnect sys_cpu_clk ad7768_dma/m_dest_axi
+ad_mem_hp1_interconnect sys_cpu_clk ad7768_dma_2/m_dest_axi
 

--- a/projects/ad7768evb/zed/Makefile
+++ b/projects/ad7768evb/zed/Makefile
@@ -19,5 +19,7 @@ LIB_DEPS += axi_spdif_tx
 LIB_DEPS += axi_sysid
 LIB_DEPS += sysid_rom
 LIB_DEPS += util_i2c_mixer
+LIB_DEPS += axi_generic_adc
+LIB_DEPS += util_pack/util_cpack2
 
 include ../../scripts/project-xilinx.mk

--- a/projects/ad7768evb/zed/system_top.v
+++ b/projects/ad7768evb/zed/system_top.v
@@ -107,8 +107,17 @@ module system_top (
 
   wire            adc_clk;
   wire            adc_valid;
+  wire            adc_valid_pp;
   wire            adc_sync;
   wire    [31:0]  adc_data;
+  wire    [31:0]  adc_data_0;
+  wire    [31:0]  adc_data_1;
+  wire    [31:0]  adc_data_2;
+  wire    [31:0]  adc_data_3;
+  wire    [31:0]  adc_data_4;
+  wire    [31:0]  adc_data_5;
+  wire    [31:0]  adc_data_6;
+  wire    [31:0]  adc_data_7;
   wire            up_sshot;
   wire    [ 1:0]  up_format;
   wire            up_crc_enable;
@@ -179,8 +188,17 @@ module system_top (
     .data_in (data_in),
     .adc_clk (adc_clk),
     .adc_valid (adc_valid),
+    .adc_valid_pp (adc_valid_pp),
     .adc_sync (adc_sync),
     .adc_data (adc_data),
+    .adc_data_0 (adc_data_0),
+    .adc_data_1 (adc_data_1),
+    .adc_data_2 (adc_data_2),
+    .adc_data_3 (adc_data_3),
+    .adc_data_4 (adc_data_4),
+    .adc_data_5 (adc_data_5),
+    .adc_data_6 (adc_data_6),
+    .adc_data_7 (adc_data_7),
     .up_sshot (up_sshot),
     .up_format (up_format),
     .up_crc_enable (up_crc_enable),
@@ -191,6 +209,14 @@ module system_top (
   system_wrapper i_system_wrapper (
     .adc_clk (adc_clk),
     .adc_data (adc_data),
+    .adc_data_0 (adc_data_0),
+    .adc_data_1 (adc_data_1),
+    .adc_data_2 (adc_data_2),
+    .adc_data_3 (adc_data_3),
+    .adc_data_4 (adc_data_4),
+    .adc_data_5 (adc_data_5),
+    .adc_data_6 (adc_data_6),
+    .adc_data_7 (adc_data_7),
     .adc_gpio_0_i (adc_gpio_i[31:0]),
     .adc_gpio_0_o (adc_gpio_o[31:0]),
     .adc_gpio_0_t (adc_gpio_t[31:0]),
@@ -198,6 +224,7 @@ module system_top (
     .adc_gpio_1_o (adc_gpio_o[63:32]),
     .adc_gpio_1_t (adc_gpio_t[63:32]),
     .adc_valid (adc_valid),
+    .adc_valid_pp (adc_valid_pp),
     .adc_sync (adc_sync),
     .ddr_addr (ddr_addr),
     .ddr_ba (ddr_ba),


### PR DESCRIPTION
A parallel data path has been added to the initial design to enable only the desired channels of the ADC. 