### PR TITLE
axi_spi_engine: Fix make/script after util_axis_fifo refactoring

### DIFF
--- a/library/spi_engine/axi_spi_engine/Makefile
+++ b/library/spi_engine/axi_spi_engine/Makefile
@@ -25,10 +25,8 @@ XILINX_LIB_DEPS += util_cdc
 
 INTEL_DEPS += ../../common/ad_mem.v
 INTEL_DEPS += ../../intel/common/up_rst_constr.sdc
-INTEL_DEPS += ../../util_axis_fifo/address_gray.v
-INTEL_DEPS += ../../util_axis_fifo/address_gray_pipelined.v
-INTEL_DEPS += ../../util_axis_fifo/address_sync.v
 INTEL_DEPS += ../../util_axis_fifo/util_axis_fifo.v
+INTEL_DEPS += ../../util_axis_fifo/util_axis_fifo_address_generator.v
 INTEL_DEPS += ../../util_cdc/sync_bits.v
 INTEL_DEPS += ../../util_cdc/sync_gray.v
 INTEL_DEPS += axi_spi_engine_constr.sdc

--- a/library/spi_engine/axi_spi_engine/axi_spi_engine.v
+++ b/library/spi_engine/axi_spi_engine/axi_spi_engine.v
@@ -415,7 +415,6 @@ module axi_spi_engine #(
     .s_axis_data(cmd_fifo_in_data),
     .s_axis_room(cmd_fifo_room),
     .s_axis_full(),
-    .s_axis_room(),
     .m_axis_aclk(spi_clk),
     .m_axis_aresetn(spi_resetn),
     .m_axis_ready(cmd_ready),
@@ -442,13 +441,14 @@ module axi_spi_engine #(
     .s_axis_valid(sdo_fifo_in_valid),
     .s_axis_data(sdo_fifo_in_data),
     .s_axis_room(sdo_fifo_room),
-    .s_axis_empty(),
+    .s_axis_full(),
     .m_axis_aclk(spi_clk),
     .m_axis_aresetn(spi_resetn),
     .m_axis_ready(sdo_data_ready),
     .m_axis_valid(sdo_data_valid),
     .m_axis_data(sdo_data),
-    .m_axis_level()
+    .m_axis_level(),
+    .m_axis_empty()
   );
 
   assign sdi_fifo_out_ready = up_rreq_s == 1'b1 && up_raddr_s == 8'h3a;
@@ -467,13 +467,14 @@ module axi_spi_engine #(
     .s_axis_valid(sdi_data_valid),
     .s_axis_data(sdi_data),
     .s_axis_room(),
-    .s_axis_empty(),
+    .s_axis_full(),
     .m_axis_aclk(clk),
     .m_axis_aresetn(up_sw_resetn),
     .m_axis_ready(sdi_fifo_out_ready),
     .m_axis_valid(sdi_fifo_out_valid),
     .m_axis_data(sdi_fifo_out_data),
-    .m_axis_level(sdi_fifo_level)
+    .m_axis_level(sdi_fifo_level),
+    .m_axis_empty()
   );
 
   generate if (ASYNC_SPI_CLK) begin
@@ -491,13 +492,14 @@ module axi_spi_engine #(
       .s_axis_valid(sync_valid),
       .s_axis_data(sync_data),
       .s_axis_room(),
-      .s_axis_empty(),
+      .s_axis_full(),
       .m_axis_aclk(clk),
       .m_axis_aresetn(up_sw_resetn),
       .m_axis_ready(1'b1),
       .m_axis_valid(sync_fifo_valid),
       .m_axis_data(sync_fifo_data),
-      .m_axis_level()
+      .m_axis_level(),
+      .m_axis_empty()
     );
 
     // synchronization FIFO for the offload command interface
@@ -516,13 +518,14 @@ module axi_spi_engine #(
       .s_axis_valid(up_offload0_cmd_wr_en_s),
       .s_axis_data(up_offload0_cmd_wr_data_s),
       .s_axis_room(),
-      .s_axis_empty(),
+      .s_axis_full(),
       .m_axis_aclk(spi_clk),
       .m_axis_aresetn(spi_resetn),
       .m_axis_ready(1'b1),
       .m_axis_valid(offload0_cmd_wr_en),
       .m_axis_data(offload0_cmd_wr_data),
-      .m_axis_level()
+      .m_axis_level(),
+      .m_axis_empty()
     );
 
     assign up_offload0_cmd_wr_en_s = up_wreq_s == 1'b1 && up_waddr_s == 8'h44;
@@ -544,13 +547,14 @@ module axi_spi_engine #(
       .s_axis_valid(up_offload0_sdo_wr_en_s),
       .s_axis_data(up_offload0_sdo_wr_data_s),
       .s_axis_room(),
-      .s_axis_empty(),
+      .s_axis_full(),
       .m_axis_aclk(spi_clk),
       .m_axis_aresetn(spi_resetn),
       .m_axis_ready(1'b1),
       .m_axis_valid(offload0_sdo_wr_en),
       .m_axis_data(offload0_sdo_wr_data),
-      .m_axis_level()
+      .m_axis_level(),
+      .m_axis_empty()
     );
 
     assign up_offload0_sdo_wr_en_s = up_wreq_s == 1'b1 && up_waddr_s == 8'h45;
@@ -569,13 +573,14 @@ module axi_spi_engine #(
       .s_axis_valid(offload_sync_valid),
       .s_axis_data(offload_sync_data),
       .s_axis_room(),
-      .s_axis_empty(),
+      .s_axis_full(),
       .m_axis_aclk(clk),
       .m_axis_aresetn(up_sw_resetn),
       .m_axis_ready(1'b1),
       .m_axis_valid(offload_sync_fifo_valid),
       .m_axis_data(offload_sync_fifo_data),
-      .m_axis_level()
+      .m_axis_level(),
+      .m_axis_empty()
     );
 
   end else begin /* ASYNC_SPI_CLK == 0 */

--- a/library/spi_engine/axi_spi_engine/axi_spi_engine_hw.tcl
+++ b/library/spi_engine/axi_spi_engine/axi_spi_engine_hw.tcl
@@ -6,9 +6,7 @@ source ../../scripts/adi_ip_intel.tcl
 ad_ip_create axi_spi_engine {AXI SPI Engine} p_elaboration
 ad_ip_files axi_spi_engine [list\
   $ad_hdl_dir/library/util_axis_fifo/util_axis_fifo.v \
-  $ad_hdl_dir/library/util_axis_fifo/address_sync.v \
-  $ad_hdl_dir/library/util_axis_fifo/address_gray_pipelined.v \
-  $ad_hdl_dir/library/util_axis_fifo/address_gray.v \
+  $ad_hdl_dir/library/util_axis_fifo/util_axis_fifo_address_generator.v \
   $ad_hdl_dir/library/util_cdc/sync_bits.v \
   $ad_hdl_dir/library/util_cdc/sync_gray.v \
   $ad_hdl_dir/library/common/ad_mem.v \

--- a/projects/ad40xx_fmc/zed/system_constr_ad40xx.xdc
+++ b/projects/ad40xx_fmc/zed/system_constr_ad40xx.xdc
@@ -12,6 +12,6 @@ set_property -dict {PACKAGE_PIN P22 IOSTANDARD LVCMOS25} [get_ports ad40xx_amp_p
 # execution's shift register, because we load new data into the shift register
 # in every DATA_WIDTH's x 2 cycle. (worst case scenario)
 # Set a multi-cycle delay of 2 spi_clk cycle, slightly over constraining the path.
-set_multicycle_path 2 -setup -from [get_cells -hierarchical -filter {NAME=~*/i_sdo_fifo/i_mem/m_ram_reg}] -to [get_pins -hierarchical -filter {NAME=~*/data_sdo_shift_reg[*]/D}]
-set_multicycle_path 1 -hold  -from [get_cells -hierarchical -filter {NAME=~*/i_sdo_fifo/i_mem/m_ram_reg}] -to [get_pins -hierarchical -filter {NAME=~*/data_sdo_shift_reg[*]/D}]
+set_multicycle_path 2 -setup -from [get_cells -hierarchical -filter {NAME=~*/i_sdo_fifo/fifo.async_clocks.i_mem/m_ram_reg}] -to [get_pins -hierarchical -filter {NAME=~*/data_sdo_shift_reg[*]/D}]
+set_multicycle_path 1 -hold  -from [get_cells -hierarchical -filter {NAME=~*/i_sdo_fifo/fifo.async_clocks.i_mem/m_ram_reg}] -to [get_pins -hierarchical -filter {NAME=~*/data_sdo_shift_reg[*]/D}]
 


### PR DESCRIPTION
Missed to update the Makefile/hw script for axi_spi_engine after util_axis_fifo refactoring. This patch will fix the broken build for all SPI Engine projects.