### PR TITLE
Vivado 2020.1 upgrade

### DIFF
--- a/library/scripts/adi_ip_xilinx.tcl
+++ b/library/scripts/adi_ip_xilinx.tcl
@@ -4,7 +4,7 @@ source $ad_hdl_dir/library/scripts/adi_xilinx_device_info_enc.tcl
 # check tool version
 
 if {![info exists REQUIRED_VIVADO_VERSION]} {
-  set REQUIRED_VIVADO_VERSION "2019.1"
+  set REQUIRED_VIVADO_VERSION "2020.1"
 }
 
 if {[info exists ::env(ADI_IGNORE_VERSION_CHECK)]} {

--- a/library/scripts/adi_ip_xilinx.tcl
+++ b/library/scripts/adi_ip_xilinx.tcl
@@ -283,7 +283,10 @@ proc adi_ip_create {ip_name} {
   create_project $ip_name . -force
 
   ## Load custom message severity definitions
-  source $ad_hdl_dir/projects/scripts/adi_xilinx_msg.tcl
+
+  if {![info exists ::env(ADI_DISABLE_MESSAGE_SUPPRESION)]} {
+    source $ad_hdl_dir/projects/scripts/adi_xilinx_msg.tcl
+  }
 
   set lib_dirs $ad_hdl_dir/library
   if {$ad_hdl_dir ne $ad_ghdl_dir} {

--- a/projects/common/vc707/vc707_system_bd.tcl
+++ b/projects/common/vc707/vc707_system_bd.tcl
@@ -9,7 +9,7 @@ create_bd_port -dir O -type rst phy_rstn
 create_bd_port -dir I phy_sd
 create_bd_intf_port -mode Slave -vlnv xilinx.com:interface:diff_clock_rtl:1.0 mgt_clk
 create_bd_intf_port -mode Master -vlnv xilinx.com:interface:sgmii_rtl:1.0 sgmii
-create_bd_intf_port -mode Master -vlnv xilinx.com:interface:mdio_io:1.0 mdio
+create_bd_intf_port -mode Master -vlnv xilinx.com:interface:mdio_rtl:1.0 mdio
 
 create_bd_intf_port -mode Master -vlnv xilinx.com:interface:gpio_rtl:1.0 gpio_lcd
 

--- a/projects/scripts/adi_project_xilinx.tcl
+++ b/projects/scripts/adi_project_xilinx.tcl
@@ -1,7 +1,7 @@
 
 ## Define the supported tool version
 if {![info exists REQUIRED_VIVADO_VERSION]} {
-  set REQUIRED_VIVADO_VERSION "2019.1"
+  set REQUIRED_VIVADO_VERSION "2020.1"
 }
 
 ## Define the ADI_IGNORE_VERSION_CHECK environment variable to skip version check
@@ -384,10 +384,10 @@ proc adi_project_run {project_name} {
   set timing_string $[report_timing_summary -return_string]
   if { [string match "*VIOLATED*" $timing_string] == 1 ||
        [string match "*Timing constraints are not met*" $timing_string] == 1} {
-    file copy -force $project_name.runs/impl_1/system_top.sysdef $project_name.sdk/system_top_bad_timing.hdf
+    write_hw_platform -fixed -force  -include_bit -file $project_name.sdk/system_top_bad_timing.xsa
     return -code error [format "ERROR: Timing Constraints NOT met!"]
   } else {
-    file copy -force $project_name.runs/impl_1/system_top.sysdef $project_name.sdk/system_top.hdf
+    write_hw_platform -fixed -force  -include_bit -file $project_name.sdk/system_top.xsa
   }
 }
 

--- a/projects/scripts/adi_project_xilinx.tcl
+++ b/projects/scripts/adi_project_xilinx.tcl
@@ -168,7 +168,10 @@ proc adi_project {project_name {mode 0} {parameter_list {}} } {
   update_ip_catalog
 
   ## Load custom message severity definitions
-  source $ad_hdl_dir/projects/scripts/adi_xilinx_msg.tcl
+
+  if {![info exists ::env(ADI_DISABLE_MESSAGE_SUPPRESION)]} {
+    source $ad_hdl_dir/projects/scripts/adi_xilinx_msg.tcl
+  }
 
   ## In Vivado there is a limit for the number of warnings and errors which are
   ## displayed by the tool for a particular error or warning; the default value

--- a/projects/scripts/adi_xilinx_msg.tcl
+++ b/projects/scripts/adi_xilinx_msg.tcl
@@ -96,6 +96,13 @@ set_msg_config -id {IP_Flow 19-459} -new_severity INFO
 ## reach to the order of thousends. Downgrade to INFO.
 set_msg_config -id {Synth 8-3331} -new_severity INFO
 
+## [Synth 8-2490] overwriting previous definition of module xxxx
+## Vivado version 2020.1 changed the way it adds modules as source files and
+## the above critical error is generated after synthesis. Also discussed in
+## AR# 58282: https://www.xilinx.com/support/answers/58282.html.
+## Downgrade to WARNING.
+set_msg_config -id {Synth 8-2490} -new_severity WARNING
+
 ################################################################################
 ## Implementation related messages
 ## IDs : [Place 30-xxxx]

--- a/projects/scripts/project-xilinx.mk
+++ b/projects/scripts/project-xilinx.mk
@@ -26,6 +26,7 @@ CLEAN_TARGET += *.ip_user_files
 CLEAN_TARGET += *.str
 CLEAN_TARGET += mem_init_sys.txt
 CLEAN_TARGET += *.csv
+CLEAN_TARGET += *.hbs
 
 # Common dependencies that all projects have
 M_DEPS += system_project.tcl


### PR DESCRIPTION
projects affected by missing (discontinued) ip in xilinx catalog: 
cn0506_rmii.zed
cn0506_rmii.zcu102
cn0506_rmii.zc706