### PR TITLE
Fix Intel fPLL configuration

### DIFF
--- a/library/intel/adi_jesd204/adi_jesd204_hw.tcl
+++ b/library/intel/adi_jesd204/adi_jesd204_hw.tcl
@@ -356,7 +356,7 @@ proc jesd204_compose {} {
     return
   }
 
-  add_instance sys_clock clock_source 19.2
+  add_instance sys_clock clock_source 19.3
   set_instance_parameter_value sys_clock {clockFrequency} [expr $sysclk_frequency*1000000]
   set_instance_parameter_value sys_clock {resetSynchronousEdges} {deassert}
   add_interface sys_clk clock sink

--- a/library/intel/jesd204_phy/jesd204_phy_hw.tcl
+++ b/library/intel/jesd204_phy/jesd204_phy_hw.tcl
@@ -101,7 +101,7 @@ proc jesd204_phy_composition_callback {} {
     set device_type 0
   }
 
-  add_instance link_clock clock_source $version
+  add_instance link_clock clock_source 19.3
   set_instance_parameter_value link_clock {clockFrequency} [expr $link_clk_frequency*1000000]
   add_interface link_clk clock sink
   set_interface_property link_clk EXPORT_OF link_clock.clk_in

--- a/projects/adrv9009/a10gx/system_constr.sdc
+++ b/projects/adrv9009/a10gx/system_constr.sdc
@@ -1,7 +1,7 @@
 
 create_clock -period "10.000 ns"  -name sys_clk_100mhz      [get_ports {sys_clk}]
-create_clock -period  "4.069 ns"  -name ref_clk0            [get_ports {ref_clk0}]
-create_clock -period  "4.069 ns"  -name ref_clk1            [get_ports {ref_clk1}]
+create_clock -period  "4.06504065 ns"  -name ref_clk0            [get_ports {ref_clk0}]
+create_clock -period  "4.06504065 ns"  -name ref_clk1            [get_ports {ref_clk1}]
 
 derive_pll_clocks
 derive_clock_uncertainty

--- a/projects/adrv9009/a10soc/system_constr.sdc
+++ b/projects/adrv9009/a10soc/system_constr.sdc
@@ -1,7 +1,7 @@
 
 create_clock -period "10.000 ns"  -name sys_clk_100mhz      [get_ports {sys_clk}]
-create_clock -period  "4.069 ns"  -name ref_clk0            [get_ports {ref_clk0}]
-create_clock -period  "4.069 ns"  -name ref_clk1            [get_ports {ref_clk1}]
+create_clock -period  "4.06504065 ns"  -name ref_clk0            [get_ports {ref_clk0}]
+create_clock -period  "4.06504065 ns"  -name ref_clk1            [get_ports {ref_clk1}]
 
 derive_pll_clocks
 derive_clock_uncertainty

--- a/projects/adrv9009/common/adrv9009_qsys.tcl
+++ b/projects/adrv9009/common/adrv9009_qsys.tcl
@@ -27,14 +27,18 @@ set dac_fifo_name avl_adrv9009_tx_fifo
 set dac_data_width 128
 set dac_dma_data_width 128
 
+# NOTE: The real lane rate is 2457.6 Gbps (Tx) and 4915.2 Gbps (RX/Rx_Obs),
+# with a real reference clock frequency of 122.88 MHz. A round up needed
+# because the fPLL's configuration interface does not support fractional numbers.
+
 # adrv9009_tx JESD204
 
 add_instance adrv9009_tx_jesd204 adi_jesd204
 set_instance_parameter_value adrv9009_tx_jesd204 {ID} {0}
 set_instance_parameter_value adrv9009_tx_jesd204 {TX_OR_RX_N} {1}
 set_instance_parameter_value adrv9009_tx_jesd204 {SOFT_PCS} {true}
-set_instance_parameter_value adrv9009_tx_jesd204 {LANE_RATE} {2457.6}
-set_instance_parameter_value adrv9009_tx_jesd204 {REFCLK_FREQUENCY} {122.88}
+set_instance_parameter_value adrv9009_tx_jesd204 {LANE_RATE} {2460}
+set_instance_parameter_value adrv9009_tx_jesd204 {REFCLK_FREQUENCY} {123}
 set_instance_parameter_value adrv9009_tx_jesd204 {NUM_OF_LANES} $TX_NUM_OF_LANES
 set_instance_parameter_value adrv9009_tx_jesd204 {LANE_MAP} {0 3 2 1}
 
@@ -55,8 +59,8 @@ add_instance adrv9009_rx_jesd204 adi_jesd204
 set_instance_parameter_value adrv9009_rx_jesd204 {ID} {1}
 set_instance_parameter_value adrv9009_rx_jesd204 {TX_OR_RX_N} {0}
 set_instance_parameter_value adrv9009_rx_jesd204 {SOFT_PCS} {true}
-set_instance_parameter_value adrv9009_rx_jesd204 {LANE_RATE} {4915.2}
-set_instance_parameter_value adrv9009_rx_jesd204 {REFCLK_FREQUENCY} {122.88}
+set_instance_parameter_value adrv9009_rx_jesd204 {LANE_RATE} {4920}
+set_instance_parameter_value adrv9009_rx_jesd204 {REFCLK_FREQUENCY} {123}
 set_instance_parameter_value adrv9009_rx_jesd204 {NUM_OF_LANES} $RX_NUM_OF_LANES
 set_instance_parameter_value adrv9009_rx_jesd204 {INPUT_PIPELINE_STAGES} {1}
 
@@ -77,8 +81,8 @@ add_instance adrv9009_rx_os_jesd204 adi_jesd204
 set_instance_parameter_value adrv9009_rx_os_jesd204 {ID} {1}
 set_instance_parameter_value adrv9009_rx_os_jesd204 {TX_OR_RX_N} {0}
 set_instance_parameter_value adrv9009_rx_os_jesd204 {SOFT_PCS} {true}
-set_instance_parameter_value adrv9009_rx_os_jesd204 {LANE_RATE} {4915.2}
-set_instance_parameter_value adrv9009_rx_os_jesd204 {REFCLK_FREQUENCY} {122.88}
+set_instance_parameter_value adrv9009_rx_os_jesd204 {LANE_RATE} {4920}
+set_instance_parameter_value adrv9009_rx_os_jesd204 {REFCLK_FREQUENCY} {123}
 set_instance_parameter_value adrv9009_rx_os_jesd204 {NUM_OF_LANES} $RX_OS_NUM_OF_LANES
 set_instance_parameter_value adrv9009_rx_os_jesd204 {INPUT_PIPELINE_STAGES} {1}
 

--- a/projects/adrv9371x/a10gx/system_constr.sdc
+++ b/projects/adrv9371x/a10gx/system_constr.sdc
@@ -1,7 +1,7 @@
 
 create_clock -period "10.000 ns"  -name sys_clk_100mhz      [get_ports {sys_clk}]
-create_clock -period  "8.138 ns"  -name ref_clk0            [get_ports {ref_clk0}]
-create_clock -period  "8.138 ns"  -name ref_clk1            [get_ports {ref_clk1}]
+create_clock -period  "8.1300813 ns"  -name ref_clk0            [get_ports {ref_clk0}]
+create_clock -period  "8.1300813 ns"  -name ref_clk1            [get_ports {ref_clk1}]
 
 derive_pll_clocks
 derive_clock_uncertainty

--- a/projects/adrv9371x/a10soc/system_constr.sdc
+++ b/projects/adrv9371x/a10soc/system_constr.sdc
@@ -1,7 +1,7 @@
 
 create_clock -period "10.000 ns"  -name sys_clk_100mhz      [get_ports {sys_clk}]
-create_clock -period  "8.138 ns"  -name ref_clk0            [get_ports {ref_clk0}]
-create_clock -period  "8.138 ns"  -name ref_clk1            [get_ports {ref_clk1}]
+create_clock -period  "8.1300813 ns"  -name ref_clk0            [get_ports {ref_clk0}]
+create_clock -period  "8.1300813 ns"  -name ref_clk1            [get_ports {ref_clk1}]
 
 derive_pll_clocks
 derive_clock_uncertainty

--- a/projects/adrv9371x/common/adrv9371x_qsys.tcl
+++ b/projects/adrv9371x/common/adrv9371x_qsys.tcl
@@ -2,13 +2,17 @@ set dac_fifo_name avl_ad9371_tx_fifo
 set dac_data_width 128
 set dac_dma_data_width 128
 
+# NOTE: The real lane rate is 4915.2 Gbps (Tx/RX/Rx_Obs), with a real reference
+# clock frequency of 122.88 MHz. A round up needed because the fPLL's
+# configuration interface does not support fractional numbers.
+
 # ad9371_tx JESD204
 
 add_instance ad9371_tx_jesd204 adi_jesd204
 set_instance_parameter_value ad9371_tx_jesd204 {ID} {0}
 set_instance_parameter_value ad9371_tx_jesd204 {TX_OR_RX_N} {1}
-set_instance_parameter_value ad9371_tx_jesd204 {LANE_RATE} {4915.2}
-set_instance_parameter_value ad9371_tx_jesd204 {REFCLK_FREQUENCY} {122.88}
+set_instance_parameter_value ad9371_tx_jesd204 {LANE_RATE} {4920}
+set_instance_parameter_value ad9371_tx_jesd204 {REFCLK_FREQUENCY} {123}
 set_instance_parameter_value ad9371_tx_jesd204 {NUM_OF_LANES} {4}
 set_instance_parameter_value ad9371_tx_jesd204 {LANE_MAP} {3 0 1 2}
 set_instance_parameter_value ad9371_tx_jesd204 {SOFT_PCS} {false}
@@ -29,8 +33,8 @@ set_interface_property tx_sync EXPORT_OF ad9371_tx_jesd204.sync
 add_instance ad9371_rx_jesd204 adi_jesd204
 set_instance_parameter_value ad9371_rx_jesd204 {ID} {1}
 set_instance_parameter_value ad9371_rx_jesd204 {TX_OR_RX_N} {0}
-set_instance_parameter_value ad9371_rx_jesd204 {LANE_RATE} {4915.2}
-set_instance_parameter_value ad9371_rx_jesd204 {REFCLK_FREQUENCY} {122.88}
+set_instance_parameter_value ad9371_rx_jesd204 {LANE_RATE} {4920}
+set_instance_parameter_value ad9371_rx_jesd204 {REFCLK_FREQUENCY} {123}
 set_instance_parameter_value ad9371_rx_jesd204 {NUM_OF_LANES} {2}
 set_instance_parameter_value ad9371_rx_jesd204 {SOFT_PCS} {false}
 
@@ -50,8 +54,8 @@ set_interface_property rx_sync EXPORT_OF ad9371_rx_jesd204.sync
 add_instance ad9371_rx_os_jesd204 adi_jesd204
 set_instance_parameter_value ad9371_rx_os_jesd204 {ID} {1}
 set_instance_parameter_value ad9371_rx_os_jesd204 {TX_OR_RX_N} {0}
-set_instance_parameter_value ad9371_rx_os_jesd204 {LANE_RATE} {4915.2}
-set_instance_parameter_value ad9371_rx_os_jesd204 {REFCLK_FREQUENCY} {122.88}
+set_instance_parameter_value ad9371_rx_os_jesd204 {LANE_RATE} {4920}
+set_instance_parameter_value ad9371_rx_os_jesd204 {REFCLK_FREQUENCY} {123}
 set_instance_parameter_value ad9371_rx_os_jesd204 {SOFT_PCS} {false}
 set_instance_parameter_value ad9371_rx_os_jesd204 {NUM_OF_LANES} {2}
 

--- a/projects/fmcomms8/a10soc/system_constr.sdc
+++ b/projects/fmcomms8/a10soc/system_constr.sdc
@@ -1,9 +1,9 @@
 
 create_clock -period "10.000 ns"  -name sys_clk_100mhz      [get_ports {sys_clk}]
-create_clock -period  "4.069 ns"  -name ref_clk_c           [get_ports {ref_clk_c}]
-create_clock -period  "4.069 ns"  -name ref_clk_d           [get_ports {ref_clk_d}]
-create_clock -period  "4.069 ns"  -name core_clk_c          [get_ports {core_clk_c}]
-create_clock -period  "4.069 ns"  -name core_clk_d          [get_ports {core_clk_d}]
+create_clock -period  "4.06504065 ns"  -name ref_clk_c      [get_ports {ref_clk_c}]
+create_clock -period  "4.06504065 ns"  -name ref_clk_d      [get_ports {ref_clk_d}]
+create_clock -period  "4.06504065 ns"  -name core_clk_c     [get_ports {core_clk_c}]
+create_clock -period  "4.06504065 ns"  -name core_clk_d     [get_ports {core_clk_d}]
 create_clock -period  "100 ns"    -name spi_clk             [get_nets {i_system_bd|sys_spi|sys_spi|SCLK_reg}]
 
 derive_pll_clocks

--- a/projects/fmcomms8/common/fmcomms8_qsys.tcl
+++ b/projects/fmcomms8/common/fmcomms8_qsys.tcl
@@ -27,13 +27,17 @@ set dac_fifo_name avl_fmcomms8_tx_fifo
 set dac_data_width 256
 set dac_dma_data_width 256
 
+# NOTE: The real lane rate is 9830.4 Gbps (Tx/Rx/Rx_Obs), with a real reference
+# clock frequency of 245.76 MHz. A round up needed because the fPLL's configuration
+# interface does not support fractional numbers.
+
 # JESD204B/C clock bridges
 
  add_instance core_clk_c altera_clock_bridge
- set_instance_parameter_value core_clk_c {EXPLICIT_CLOCK_RATE} {245760000}
+ set_instance_parameter_value core_clk_c {EXPLICIT_CLOCK_RATE} {246000000}
 
  add_instance core_clk_d altera_clock_bridge
- set_instance_parameter_value core_clk_d {EXPLICIT_CLOCK_RATE} {245760000}
+ set_instance_parameter_value core_clk_d {EXPLICIT_CLOCK_RATE} {246000000}
 
 # fmcomms8_tx JESD204
 
@@ -41,8 +45,8 @@ add_instance fmcomms8_tx_jesd204 adi_jesd204
 set_instance_parameter_value fmcomms8_tx_jesd204 {ID} {0}
 set_instance_parameter_value fmcomms8_tx_jesd204 {TX_OR_RX_N} {1}
 set_instance_parameter_value fmcomms8_tx_jesd204 {SOFT_PCS} {true}
-set_instance_parameter_value fmcomms8_tx_jesd204 {LANE_RATE} {9830.4}
-set_instance_parameter_value fmcomms8_tx_jesd204 {REFCLK_FREQUENCY} {245.76}
+set_instance_parameter_value fmcomms8_tx_jesd204 {LANE_RATE} {9840}
+set_instance_parameter_value fmcomms8_tx_jesd204 {REFCLK_FREQUENCY} {246}
 set_instance_parameter_value fmcomms8_tx_jesd204 {NUM_OF_LANES} $TX_NUM_OF_LANES
 set_instance_parameter_value fmcomms8_tx_jesd204 {LANE_MAP} {1 0 2 3 4 5 6 7}
 set_instance_parameter_value fmcomms8_tx_jesd204 {EXT_DEVICE_CLK_EN} {1}
@@ -64,8 +68,8 @@ add_instance fmcomms8_rx_jesd204 adi_jesd204
 set_instance_parameter_value fmcomms8_rx_jesd204 {ID} {1}
 set_instance_parameter_value fmcomms8_rx_jesd204 {TX_OR_RX_N} {0}
 set_instance_parameter_value fmcomms8_rx_jesd204 {SOFT_PCS} {true}
-set_instance_parameter_value fmcomms8_rx_jesd204 {LANE_RATE} {9830.4}
-set_instance_parameter_value fmcomms8_rx_jesd204 {REFCLK_FREQUENCY} {245.76}
+set_instance_parameter_value fmcomms8_rx_jesd204 {LANE_RATE} {9840}
+set_instance_parameter_value fmcomms8_rx_jesd204 {REFCLK_FREQUENCY} {246}
 set_instance_parameter_value fmcomms8_rx_jesd204 {NUM_OF_LANES} $RX_NUM_OF_LANES
 set_instance_parameter_value fmcomms8_rx_jesd204 {EXT_DEVICE_CLK_EN} {1}
 
@@ -86,8 +90,8 @@ add_instance fmcomms8_rx_os_jesd204 adi_jesd204
 set_instance_parameter_value fmcomms8_rx_os_jesd204 {ID} {1}
 set_instance_parameter_value fmcomms8_rx_os_jesd204 {TX_OR_RX_N} {0}
 set_instance_parameter_value fmcomms8_rx_os_jesd204 {SOFT_PCS} {true}
-set_instance_parameter_value fmcomms8_rx_os_jesd204 {LANE_RATE} {9830.4}
-set_instance_parameter_value fmcomms8_rx_os_jesd204 {REFCLK_FREQUENCY} {245.76}
+set_instance_parameter_value fmcomms8_rx_os_jesd204 {LANE_RATE} {9840}
+set_instance_parameter_value fmcomms8_rx_os_jesd204 {REFCLK_FREQUENCY} {246}
 set_instance_parameter_value fmcomms8_rx_os_jesd204 {NUM_OF_LANES} $RX_OS_NUM_OF_LANES
 set_instance_parameter_value fmcomms8_rx_os_jesd204 {EXT_DEVICE_CLK_EN} {1}
 


### PR DESCRIPTION
When phase alignment is active, the PFD frequency value should be used as outclk1 actual frequency.

The configuration interface of the fPLL does not support fractional values. If the reference clock is fractional, the tool will
throw an error, that requirement above is not respected.

Round up the reference clock for the SERDES and the lane rate in order to overcome this issue, until it's not fixed by Intel.