### PR TITLE
util_axis_fifo: Add dont_touch synthesis attribute for 'zero deep' CDC

### DIFF
--- a/library/util_axis_fifo/util_axis_fifo.v
+++ b/library/util_axis_fifo/util_axis_fifo.v
@@ -61,9 +61,9 @@ generate if (ADDRESS_WIDTH == 0) begin : zerodeep /* it's not a real FIFO, just 
 
   if (ASYNC_CLK) begin
 
-      reg [DATA_WIDTH-1:0] cdc_sync_fifo_ram;
-      reg s_axis_waddr = 1'b0;
-      reg m_axis_raddr = 1'b0;
+      (* dont_touch = "yes" *) reg [DATA_WIDTH-1:0] cdc_sync_fifo_ram;
+      (* dont_touch = "yes" *) reg s_axis_waddr = 1'b0;
+      (* dont_touch = "yes" *) reg m_axis_raddr = 1'b0;
 
       wire m_axis_waddr;
       wire s_axis_raddr;


### PR DESCRIPTION
Vivado synthesis is optimizing out the 'zerodeep' block, resulting untreated
clock domain crossing. Set dont_touch attribute for the registers.