### PR TITLE
Revert "intel: Update projects to use ad_iobuf instead of ALT_IOBUF"

### DIFF
--- a/projects/ad_fmclidar1_ebz/a10soc/Makefile
+++ b/projects/ad_fmclidar1_ebz/a10soc/Makefile
@@ -12,7 +12,6 @@ M_DEPS += ../../scripts/adi_pd_intel.tcl
 M_DEPS += ../../common/a10soc/a10soc_system_qsys.tcl
 M_DEPS += ../../common/a10soc/a10soc_system_assign.tcl
 M_DEPS += ../../../library/util_cdc/sync_bits.v
-M_DEPS += ../../../library/common/ad_iobuf.v
 
 LIB_DEPS += axi_dmac
 LIB_DEPS += axi_laser_driver

--- a/projects/ad_fmclidar1_ebz/a10soc/system_project.tcl
+++ b/projects/ad_fmclidar1_ebz/a10soc/system_project.tcl
@@ -11,7 +11,6 @@ source $ad_hdl_dir/projects/common/a10soc/a10soc_system_assign.tcl
 set_global_assignment -name VERILOG_FILE ../common/util_tia_chsel.v
 set_global_assignment -name VERILOG_FILE ../common/util_axis_syncgen.v
 set_global_assignment -name VERILOG_FILE ../../../library/util_cdc/sync_bits.v
-set_global_assignment -name VERILOG_FILE ../../../library/common/ad_iobuf.v
 
 #
 # Note: This project requires a hardware rework to function correctly.

--- a/projects/ad_fmclidar1_ebz/a10soc/system_top.v
+++ b/projects/ad_fmclidar1_ebz/a10soc/system_top.v
@@ -240,11 +240,8 @@ module system_top (
   wire i2c_0_sda_in;
   wire i2c_0_sda_oe;
 
-  ad_iobuf #(.DATA_WIDTH(2)) i_iobuf_i2c (
-    .dio_t ({i2c_0_scl_out,i2c_0_sda_oe}),
-    .dio_i (2'b0),
-    .dio_o ({i2c_0_scl_in,i2c_0_sda_in}),
-    .dio_p ({afe_dac_scl,afe_dac_sda}));
+  ALT_IOBUF scl_iobuf (.i(1'b0), .oe(i2c_0_scl_out), .o(i2c_0_scl_in), .io(afe_dac_scl));
+  ALT_IOBUF sda_iobuf (.i(1'b0), .oe(i2c_0_sda_oe), .o(i2c_0_sda_in), .io(afe_dac_sda));
 
   // Block design instance
 

--- a/projects/adv7513/de10nano/Makefile
+++ b/projects/adv7513/de10nano/Makefile
@@ -7,7 +7,6 @@ PROJECT_NAME := adv7513_de10nano
 
 M_DEPS += ../../common/de10nano/de10nano_system_qsys.tcl
 M_DEPS += ../../common/de10nano/de10nano_system_assign.tcl
-M_DEPS += ../../../library/common/ad_iobuf.v
 
 LIB_DEPS += axi_dmac
 LIB_DEPS += axi_hdmi_tx

--- a/projects/adv7513/de10nano/system_project.tcl
+++ b/projects/adv7513/de10nano/system_project.tcl
@@ -6,7 +6,4 @@ adi_project adv7513_de10nano
 
 source $ad_hdl_dir/projects/common/de10nano/de10nano_system_assign.tcl
 
-# files
-set_global_assignment -name VERILOG_FILE ../../../library/common/ad_iobuf.v
-
 execute_flow -compile

--- a/projects/adv7513/de10nano/system_top.v
+++ b/projects/adv7513/de10nano/system_top.v
@@ -138,11 +138,17 @@ module system_top (
   assign gpio_bd_o[7:0] = gpio_o[7:0];
   assign ltc2308_cs = gpio_o[41];
 
-  ad_iobuf #(.DATA_WIDTH(2)) i_iobuf_hdmi_i2c (
-    .dio_t ({i2c0_out_clk,i2c0_out_data}),
-    .dio_i (2'b0),
-    .dio_o ({i2c0_scl_in_clk,i2c0_sda}),
-    .dio_p ({hdmi_i2c_scl,hdmi_i2c_sda}));
+  ALT_IOBUF scl_iobuf (
+    .i(1'b0),
+    .oe(i2c0_out_clk),
+    .o(i2c0_scl_in_clk),
+    .io(hdmi_i2c_scl));
+
+  ALT_IOBUF sda_iobuf (
+    .i(1'b0),
+    .oe(i2c0_out_data),
+    .o(i2c0_sda),
+    .io(hdmi_i2c_sda));
 
   system_bd i_system_bd (
     .sys_clk_clk (sys_clk),

--- a/projects/arradio/c5soc/Makefile
+++ b/projects/arradio/c5soc/Makefile
@@ -9,7 +9,6 @@ M_DEPS += ../common/arradio_qsys.tcl
 M_DEPS += ../../scripts/adi_pd_intel.tcl
 M_DEPS += ../../common/c5soc/c5soc_system_qsys.tcl
 M_DEPS += ../../common/c5soc/c5soc_system_assign.tcl
-M_DEPS += ../../../library/common/ad_iobuf.v
 
 LIB_DEPS += axi_ad9361
 LIB_DEPS += axi_dmac

--- a/projects/arradio/c5soc/system_project.tcl
+++ b/projects/arradio/c5soc/system_project.tcl
@@ -6,9 +6,6 @@ adi_project arradio_c5soc
 
 source $ad_hdl_dir/projects/common/c5soc/c5soc_system_assign.tcl
 
-# files
-set_global_assignment -name VERILOG_FILE ../../../library/common/ad_iobuf.v
-
 # ad9361 interface
 
 set_location_assignment PIN_H15 -to rx_clk_in               ; ##  HSMC_CLKIN_p2   P201.156

--- a/projects/arradio/c5soc/system_top.v
+++ b/projects/arradio/c5soc/system_top.v
@@ -187,11 +187,8 @@ module system_top (
   assign ga0 = 1'b0;
   assign ga1 = 1'b0;
 
-  ad_iobuf #(.DATA_WIDTH(2)) i_iobuf_i2c (
-    .dio_t ({i2c0_out_clk,i2c0_out_data}),
-    .dio_i (2'b0),
-    .dio_o ({i2c0_scl_in_clk,i2c0_sda}),
-    .dio_p ({scl,sda}));
+  ALT_IOBUF scl_iobuf (.i(1'b0), .oe(i2c0_out_clk), .o(i2c0_scl_in_clk), .io(scl));
+  ALT_IOBUF sda_iobuf (.i(1'b0), .oe(i2c0_out_data), .o(i2c0_sda), .io(sda));
 
   // instantiations
 

--- a/projects/cn0506_mii/a10soc/Makefile
+++ b/projects/cn0506_mii/a10soc/Makefile
@@ -9,7 +9,6 @@ M_DEPS += ../common/cn0506_qsys.tcl
 M_DEPS += ../../scripts/adi_pd_intel.tcl
 M_DEPS += ../../common/a10soc/a10soc_system_qsys.tcl
 M_DEPS += ../../common/a10soc/a10soc_system_assign.tcl
-M_DEPS += ../../../library/common/ad_iobuf.v
 
 LIB_DEPS += axi_sysid
 LIB_DEPS += sysid_rom

--- a/projects/cn0506_mii/a10soc/system_project.tcl
+++ b/projects/cn0506_mii/a10soc/system_project.tcl
@@ -6,9 +6,6 @@ adi_project cn0506_mii_a10soc
 
 source $ad_hdl_dir/projects/common/a10soc/a10soc_system_assign.tcl
 
-# files
-set_global_assignment -name VERILOG_FILE ../../../library/common/ad_iobuf.v
-
 # Note: This projects requires a hardware rework to function correctly.
 # The rework connects FMC header pins directly to the FPGA so that they can be
 # accessed by the fabric.

--- a/projects/cn0506_mii/a10soc/system_top.v
+++ b/projects/cn0506_mii/a10soc/system_top.v
@@ -210,11 +210,8 @@ module system_top (
   assign gpio_i[11: 4] = gpio_bd_i;
   assign gpio_bd_o = gpio_o[3:0];
 
-  ad_iobuf #(.DATA_WIDTH(2)) i_iobuf_mdio (
-    .dio_t ({hps_emac_mdo_o_e_b,hps_emac_mdo_o_e_a}),
-    .dio_i ({hps_emac_mdo_o_b,hps_emac_mdo_o_a}),
-    .dio_o ({hps_emac_mdi_i_b,hps_emac_mdi_i_a}),
-    .dio_p ({mdio_fmc_b,mdio_fmc_a}));
+  ALT_IOBUF md_iobuf_a (.i(hps_emac_mdo_o_a), .oe(hps_emac_mdo_o_e_a), .o(hps_emac_mdi_i_a), .io(mdio_fmc_a));
+  ALT_IOBUF md_iobuf_b (.i(hps_emac_mdo_o_b), .oe(hps_emac_mdo_o_e_b), .o(hps_emac_mdi_i_b), .io(mdio_fmc_b));
 
   // peripheral reset
 

--- a/projects/cn0506_rgmii/a10soc/Makefile
+++ b/projects/cn0506_rgmii/a10soc/Makefile
@@ -9,7 +9,6 @@ M_DEPS += ../common/cn0506_qsys.tcl
 M_DEPS += ../../scripts/adi_pd_intel.tcl
 M_DEPS += ../../common/a10soc/a10soc_system_qsys.tcl
 M_DEPS += ../../common/a10soc/a10soc_system_assign.tcl
-M_DEPS += ../../../library/common/ad_iobuf.v
 
 LIB_DEPS += axi_sysid
 LIB_DEPS += sysid_rom

--- a/projects/cn0506_rgmii/a10soc/system_project.tcl
+++ b/projects/cn0506_rgmii/a10soc/system_project.tcl
@@ -6,9 +6,6 @@ adi_project cn0506_rgmii_a10soc
 
 source $ad_hdl_dir/projects/common/a10soc/a10soc_system_assign.tcl
 
-# files
-set_global_assignment -name VERILOG_FILE ../../../library/common/ad_iobuf.v
-
 set_location_assignment PIN_G14    -to  rgmii_rxc_a               ; ## G06 FMCA_HPC_LA00_CC_P
 set_location_assignment PIN_B9     -to  rgmii_rx_ctl_a            ; ## H14 FMCA_HPC_LA07_N
 set_location_assignment PIN_C13    -to  rgmii_rxd_a[0]            ; ## H07 FMCA_HPC_LA02_P

--- a/projects/cn0506_rgmii/a10soc/system_top.v
+++ b/projects/cn0506_rgmii/a10soc/system_top.v
@@ -233,11 +233,8 @@ module system_top (
   assign gpio_i[11: 4] = gpio_bd_i;
   assign gpio_bd_o = gpio_o[3:0];
 
-  ad_iobuf #(.DATA_WIDTH(2)) i_iobuf_mdio (
-    .dio_t ({hps_emac_mdo_o_e_b,hps_emac_mdo_o_e_a}),
-    .dio_i ({hps_emac_mdo_o_b,hps_emac_mdo_o_a}),
-    .dio_o ({hps_emac_mdi_i_b,hps_emac_mdi_i_a}),
-    .dio_p ({mdio_fmc_b,mdio_fmc_a}));
+  ALT_IOBUF md_iobuf_a (.i(hps_emac_mdo_o_a), .oe(hps_emac_mdo_o_e_a), .o(hps_emac_mdi_i_a), .io(mdio_fmc_a));
+  ALT_IOBUF md_iobuf_b (.i(hps_emac_mdo_o_b), .oe(hps_emac_mdo_o_e_b), .o(hps_emac_mdi_i_b), .io(mdio_fmc_b));
 
   // peripheral reset
 

--- a/projects/cn0540/de10nano/Makefile
+++ b/projects/cn0540/de10nano/Makefile
@@ -8,7 +8,6 @@ PROJECT_NAME := cn0540_de10nano
 M_DEPS += ../common/cn0540_qsys.tcl
 M_DEPS += ../../common/de10nano/de10nano_system_qsys.tcl
 M_DEPS += ../../common/de10nano/de10nano_system_assign.tcl
-M_DEPS += ../../../library/common/ad_iobuf.v
 
 LIB_DEPS += axi_dmac
 LIB_DEPS += axi_hdmi_tx

--- a/projects/cn0540/de10nano/system_project.tcl
+++ b/projects/cn0540/de10nano/system_project.tcl
@@ -13,7 +13,6 @@ source $ad_hdl_dir/projects/common/de10nano/de10nano_system_assign.tcl
 set_global_assignment -name MESSAGE_DISABLE 15003
 
 # files
-set_global_assignment -name VERILOG_FILE ../../../library/common/ad_iobuf.v
 
 # SPI interface for ad7768-1
 

--- a/projects/cn0540/de10nano/system_top.v
+++ b/projects/cn0540/de10nano/system_top.v
@@ -183,17 +183,29 @@ module system_top (
 
   // IO Buffers for I2C
 
-  ad_iobuf #(.DATA_WIDTH(2)) i_iobuf_i2c (
-    .dio_t ({i2c1_scl_oe,i2c1_sda_oe}),
-    .dio_i (2'b0),
-    .dio_o ({i2c1_scl,i2c1_sda}),
-    .dio_p ({i2c_scl,i2c_sda}));
+  ALT_IOBUF scl_iobuf (
+    .i(1'b0),
+    .oe(i2c1_scl_oe),
+    .o(i2c1_scl),
+    .io(i2c_scl));
 
-  ad_iobuf #(.DATA_WIDTH(2)) i_iobuf_hdmi_i2c (
-    .dio_t ({i2c0_out_clk,i2c0_out_data}),
-    .dio_i (2'b0),
-    .dio_o ({i2c0_scl_in_clk,i2c0_sda}),
-    .dio_p ({hdmi_i2c_scl,hdmi_i2c_sda}));
+  ALT_IOBUF sda_iobuf (
+    .i(1'b0),
+    .oe(i2c1_sda_oe),
+    .o(i2c1_sda),
+    .io(i2c_sda));
+
+  ALT_IOBUF scl_video_iobuf (
+    .i(1'b0),
+    .oe(i2c0_out_clk),
+    .o(i2c0_scl_in_clk),
+    .io(hdmi_i2c_scl));
+
+  ALT_IOBUF sda_video_iobuf (
+    .i(1'b0),
+    .oe(i2c0_out_data),
+    .o(i2c0_sda),
+    .io(hdmi_i2c_sda));
 
   system_bd i_system_bd (
     .sys_clk_clk (sys_clk),


### PR DESCRIPTION
This reverts commit a3a610728c0bee96950ebd95d2e908ea6a7f3d49.
The ad_iobuf module works for Xilinx but not for Intel, where the IOBUF is not correctly inferred from the HDL description.

Build tested on arria 10. Tested in hardware only on cyclone 5.