### PR TITLE
de10nano: Add hps_conv_usb_n signal to stabilize UART lines

### DIFF
--- a/projects/adv7513/de10nano/system_top.v
+++ b/projects/adv7513/de10nano/system_top.v
@@ -96,6 +96,7 @@ module system_top (
 
   input             uart0_rx,
   output            uart0_tx,
+  inout             hps_conv_usb_n,
 
   // board gpio
 
@@ -206,6 +207,7 @@ module system_top (
     .sys_hps_hps_io_hps_io_spim1_inst_MOSI (spim1_mosi),
     .sys_hps_hps_io_hps_io_spim1_inst_MISO (spim1_miso),
     .sys_hps_hps_io_hps_io_spim1_inst_SS0 (spim1_ss0),
+    .sys_hps_hps_io_hps_io_gpio_inst_GPIO09 (hps_conv_usb_n),
     .sys_gpio_bd_in_port (gpio_i[31:0]),
     .sys_gpio_bd_out_port (gpio_o[31:0]),
     .sys_gpio_in_export (gpio_i[63:32]),

--- a/projects/cn0540/de10nano/system_top.v
+++ b/projects/cn0540/de10nano/system_top.v
@@ -96,6 +96,7 @@ module system_top (
 
   input             uart0_rx,
   output            uart0_tx,
+  inout             hps_conv_usb_n,
 
   // board gpio
 
@@ -257,6 +258,7 @@ module system_top (
     .sys_hps_hps_io_hps_io_spim1_inst_MOSI (spim1_mosi),
     .sys_hps_hps_io_hps_io_spim1_inst_MISO (spim1_miso),
     .sys_hps_hps_io_hps_io_spim1_inst_SS0 (spim1_ss0),
+    .sys_hps_hps_io_hps_io_gpio_inst_GPIO09 (hps_conv_usb_n),
     .sys_hps_i2c1_sda (i2c1_sda),
     .sys_hps_i2c1_out_data (i2c1_sda_oe),
     .sys_hps_i2c1_clk_clk (i2c1_scl_oe),

--- a/projects/common/de10nano/de10nano_system_assign.tcl
+++ b/projects/common/de10nano/de10nano_system_assign.tcl
@@ -47,8 +47,11 @@ set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to gpio_bd_i[5]
 
 set_location_assignment PIN_A22 -to uart0_rx
 set_location_assignment PIN_B21 -to uart0_tx
+set_instance_assignment -name CURRENT_STRENGTH_NEW 4MA -to uart0_rx
+set_instance_assignment -name CURRENT_STRENGTH_NEW 4MA -to uart0_tx
 set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to uart0_rx
 set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to uart0_tx
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to hps_conv_usb_n
 
 # hps spi master
 

--- a/projects/common/de10nano/de10nano_system_qsys.tcl
+++ b/projects/common/de10nano/de10nano_system_qsys.tcl
@@ -39,6 +39,8 @@ set_instance_parameter_value sys_hps {I2C0_PinMuxing} {FPGA}
 set_instance_parameter_value sys_hps {I2C0_Mode} {Full}
 set_instance_parameter_value sys_hps {I2C1_PinMuxing} {FPGA}
 set_instance_parameter_value sys_hps {I2C1_Mode} {Full}
+set_instance_parameter_value sys_hps {GPIO_Enable} {No No No No No No No No No Yes No No No No No No No No No No No No No No No No No No No No No No No No No No No No No No No No No No No No No No No No No No No No No No No No No No No No No No No No No No No No No No No No No No No No No No No No No No No No No No No No No No No No No No No No No No}
+set_instance_parameter_value sys_hps {LOANIO_Enable} {No No No No No No No No No No No No No No No No No No No No No No No No No No No No No No No No No No No No No No No No No No No No No No No No No No No No No No No No No No No No No No No No No No No No No No No No No No No No No No No No No No No No No No No No No No No No No No No No No No No No}
 set_instance_parameter_value sys_hps {desired_cfg_clk_mhz} {80.0}
 set_instance_parameter_value sys_hps {S2FCLK_USER0CLK_Enable} {1}
 set_instance_parameter_value sys_hps {S2FCLK_USER1CLK_Enable} {1}


### PR DESCRIPTION
Fix UART instability while there is no cable connected to
the J4 USB UART port