### PR TITLE
SPI Engine: Add echoed SCLK support

### DIFF
--- a/library/spi_engine/scripts/spi_engine.tcl
+++ b/library/spi_engine/scripts/spi_engine.tcl
@@ -1,10 +1,13 @@
-proc spi_engine_create {{name "hier_spi_engine"} {data_width 32} {async_spi_clk 1} {num_cs 1} {num_sdi 1} {sdi_delay 2}} {
+proc spi_engine_create {{name "spi_engine"} {data_width 32} {async_spi_clk 1} {num_cs 1} {num_sdi 1} {sdi_delay 0} {echo_sclk 0}} {
 
   create_bd_cell -type hier $name
   current_bd_instance /$name
 
   if {$async_spi_clk == 1} {
     create_bd_pin -dir I -type clk spi_clk
+  }
+  if {$echo_sclk == 1} {
+    create_bd_pin -dir I -type clk echo_sclk
   }
   create_bd_pin -dir I -type clk clk
   create_bd_pin -dir I -type rst resetn
@@ -19,6 +22,7 @@ proc spi_engine_create {{name "hier_spi_engine"} {data_width 32} {async_spi_clk 
   ad_ip_parameter execution CONFIG.NUM_OF_SDI $num_sdi
   ad_ip_parameter execution CONFIG.SDO_DEFAULT 1
   ad_ip_parameter execution CONFIG.SDI_DELAY $sdi_delay
+  ad_ip_parameter execution CONFIG.ECHO_SCLK $echo_sclk
 
   ad_ip_instance axi_spi_engine axi_regmap
   ad_ip_parameter axi_regmap CONFIG.DATA_WIDTH $data_width
@@ -58,6 +62,10 @@ proc spi_engine_create {{name "hier_spi_engine"} {data_width 32} {async_spi_clk 
     ad_connect clk execution/clk
     ad_connect clk axi_regmap/spi_clk
     ad_connect clk interconnect/clk
+  }
+
+  if {$echo_sclk == 1} {
+    ad_connect echo_sclk execution/echo_sclk
   }
 
   ad_connect axi_regmap/spi_resetn offload/spi_resetn

--- a/library/spi_engine/spi_engine_execution/Makefile
+++ b/library/spi_engine/spi_engine_execution/Makefile
@@ -8,6 +8,7 @@ LIBRARY_NAME := spi_engine_execution
 GENERIC_DEPS += spi_engine_execution.v
 
 XILINX_DEPS += spi_engine_execution_ip.tcl
+XILINX_DEPS += spi_engine_execution_constr.ttcl
 
 XILINX_DEPS += ../../spi_engine/interfaces/spi_engine_ctrl.xml
 XILINX_DEPS += ../../spi_engine/interfaces/spi_engine_ctrl_rtl.xml

--- a/library/spi_engine/spi_engine_execution/spi_engine_execution_constr.ttcl
+++ b/library/spi_engine/spi_engine_execution/spi_engine_execution_constr.ttcl
@@ -1,0 +1,30 @@
+<: set ComponentName [getComponentNameString] :>
+<: setOutputDirectory "./" :>
+<: setFileName [ttcl_add $ComponentName "_constr"] :>
+<: setFileExtension ".xdc" :>
+<: setFileProcessingOrder late :>
+<: set echo_sclk [getBooleanValue "ECHO_SCLK"] :>
+
+# Relax the timing between the SDI shift register and DMA. The shift register
+# runs at negative edge of echoSCLK and the DMA runs at spi_clk. Registers
+# will have valid data at worst case (fastest rate) in every 8 echoSCLK cycle.
+
+set_multicycle_path -setup -from [get_pins -hier -filter {name=~*data_sdi_shift_reg[*]/C}] 8
+set_multicycle_path -hold -from [get_pins -hier -filter {name=~*data_sdi_shift_reg[*]/C}] 7
+
+# word_length is updated before transfer, never changes during transfer, therefor
+# it's safe to define a false path between word_length and sdi_counter
+set_false_path -from [get_cells -hierarchical -filter {NAME=~*word_length_reg[*]}] -to [get_cells -hierarchical -filter {NAME=~*sdi_counter_reg[*]}]
+
+<: if { $echo_sclk } { :>
+
+## SDI counter runs on echo_SCLK but sdi_data_valid is generated with spi_clk which
+#  is synchronous to SCLK. The last_sdi_bit should be transferred into spi_clk domain.
+set_property ASYNC_REG true [get_cells -hier {*last_sdi_bit_m_reg[0]}]
+set_property ASYNC_REG true [get_cells -hier {*last_sdi_bit_m_reg[1]}]
+set_false_path -to [get_cells -hier -filter {name =~ *last_sdi_bit_m_reg[0]* && IS_SEQUENTIAL}]
+
+# SDI shift registers are reset asynchronously after a negative edge of CSN - define the reset line as a false path
+set_false_path -to [get_pins -hierarchical -filter {NAME=~*g_echo_sclk_miso_latch.*.data_sdi_shift_reg[*]/CLR}]
+
+<: } :>

--- a/library/spi_engine/spi_engine_execution/spi_engine_execution_ip.tcl
+++ b/library/spi_engine/spi_engine_execution/spi_engine_execution_ip.tcl
@@ -107,6 +107,21 @@ set_property -dict [list \
  ] \
  [ipx::get_hdl_parameters SDI_DELAY -of_objects $cc]
 
+## ECHO SCLK
+set_property -dict [list \
+  "value_format" "bool" \
+  "value" "false" \
+ ] \
+ [ipx::get_user_parameters ECHO_SCLK -of_objects $cc]
+set_property -dict [list \
+  "value_format" "bool" \
+  "value" "false" \
+ ] \
+ [ipx::get_hdl_parameters ECHO_SCLK -of_objects $cc]
+
+## echo_sclk should be active only when ECHO_SCLK is set
+adi_set_ports_dependency echo_sclk ECHO_SCLK 0
+
 ## Customize IP Layout
 
 ## Remove the automatically generated GUI page
@@ -175,6 +190,15 @@ set_property -dict [list \
   "display_name" "MOSI default level" \
   "tooltip" "\[SDO_DEFAULT\] Define the default voltage level on MOSI"
 ] [ipgui::get_guiparamspec -name "SDO_DEFAULT" -component $cc]
+
+set custom_clocking_group [ipgui::add_group -name "Custom clocking options" -component $cc \
+    -parent $page0 -display_name "Custom clocking options" ]
+
+ipgui::add_param -name "ECHO_SCLK" -component $cc -parent $custom_clocking_group
+set_property -dict [list \
+  "display_name" "Echoed SCLK" \
+  "tooltip" "\[ECHO_SCLK\] Activate echo SCLK option (hardware support required)"
+] [ipgui::get_guiparamspec -name "ECHO_SCLK" -component $cc]
 
 ## Create and save the XGUI file
 ipx::create_xgui_files $cc

--- a/library/spi_engine/spi_engine_execution/spi_engine_execution_ip.tcl
+++ b/library/spi_engine/spi_engine_execution/spi_engine_execution_ip.tcl
@@ -4,10 +4,12 @@ source $ad_hdl_dir/library/scripts/adi_ip_xilinx.tcl
 
 adi_ip_create spi_engine_execution
 adi_ip_files spi_engine_execution [list \
+	"spi_engine_execution_constr.ttcl" \
 	"spi_engine_execution.v" \
 ]
 
 adi_ip_properties_lite spi_engine_execution
+adi_ip_ttcl spi_engine_execution "spi_engine_execution_constr.ttcl"
 # Remove all inferred interfaces
 ipx::remove_all_bus_interface [ipx::current_core]
 

--- a/projects/ad40xx_fmc/common/ad40xx_bd.tcl
+++ b/projects/ad40xx_fmc/common/ad40xx_bd.tcl
@@ -93,7 +93,7 @@ ad_ip_parameter axi_ad40xx_dma CONFIG.DMA_TYPE_SRC 1
 ad_ip_parameter axi_ad40xx_dma CONFIG.DMA_TYPE_DEST 0
 ad_ip_parameter axi_ad40xx_dma CONFIG.CYCLIC 0
 ad_ip_parameter axi_ad40xx_dma CONFIG.SYNC_TRANSFER_START 0
-ad_ip_parameter axi_ad40xx_dma CONFIG.AXI_SLICE_SRC 0
+ad_ip_parameter axi_ad40xx_dma CONFIG.AXI_SLICE_SRC 1
 ad_ip_parameter axi_ad40xx_dma CONFIG.AXI_SLICE_DEST 1
 ad_ip_parameter axi_ad40xx_dma CONFIG.DMA_2D_TRANSFER 0
 

--- a/projects/ad40xx_fmc/zed/system_constr_ad40xx.xdc
+++ b/projects/ad40xx_fmc/zed/system_constr_ad40xx.xdc
@@ -10,8 +10,12 @@ set_property -dict {PACKAGE_PIN P22 IOSTANDARD LVCMOS25} [get_ports ad40xx_amp_p
 
 ## There is a multi-cycle path between the axi_spi_engine's SDO_FIFO and the
 # execution's shift register, because we load new data into the shift register
-# in every DATA_WIDTH's x 2 cycle. (worst case scenario)
-# Set a multi-cycle delay of 2 spi_clk cycle, slightly over constraining the path.
-set_multicycle_path 2 -setup -from [get_cells -hierarchical -filter {NAME=~*/i_sdo_fifo/fifo.async_clocks.i_mem/m_ram_reg}] -to [get_pins -hierarchical -filter {NAME=~*/data_sdo_shift_reg[*]/D}]
-set_multicycle_path 1 -hold  -from [get_cells -hierarchical -filter {NAME=~*/i_sdo_fifo/fifo.async_clocks.i_mem/m_ram_reg}] -to [get_pins -hierarchical -filter {NAME=~*/data_sdo_shift_reg[*]/D}]
+# in every DATA_WIDTH's x 8 cycle. (worst case scenario)
+# Set a multi-cycle delay of 8 spi_clk cycle, slightly over constraining the path.
+
+set_multicycle_path -setup 8 -to [get_cells -hierarchical -filter {NAME=~*/data_sdo_shift_reg[*]}] -from [get_clocks clk_fpga_2]
+set_multicycle_path -hold  7 -to [get_cells -hierarchical -filter {NAME=~*/data_sdo_shift_reg[*]}] -from [get_clocks clk_fpga_2]
+
+set_multicycle_path -setup 8 -to [get_cells -hierarchical -filter {NAME=~*/execution/inst/left_aligned_reg*}] -from [get_clocks clk_fpga_2]
+set_multicycle_path -hold  7 -to [get_cells -hierarchical -filter {NAME=~*/execution/inst/left_aligned_reg*}] -from [get_clocks clk_fpga_2]
 

--- a/projects/ad40xx_fmc/zed/system_constr_adaq400x.xdc
+++ b/projects/ad40xx_fmc/zed/system_constr_adaq400x.xdc
@@ -8,8 +8,12 @@ set_property -dict {PACKAGE_PIN Y11  IOSTANDARD LVCMOS33} [get_ports adaq400x_sp
 
 ## There is a multi-cycle path between the axi_spi_engine's SDO_FIFO and the
 # execution's shift register, because we load new data into the shift register
-# in every DATA_WIDTH's x 2 cycle. (worst case scenario)
-# Set a multi-cycle delay of 2 spi_clk cycle, slightly over constraining the path.
-set_multicycle_path 2 -setup -from [get_cells -hierarchical -filter {NAME=~*/i_sdo_fifo/i_mem/m_ram_reg}] -to [get_pins -hierarchical -filter {NAME=~*/data_sdo_shift_reg[*]/D}]
-set_multicycle_path 1 -hold -from [get_cells -hierarchical -filter {NAME=~*/i_sdo_fifo/i_mem/m_ram_reg}] -to [get_pins -hierarchical -filter {NAME=~*/data_sdo_shift_reg[*]/D}]
+# in every DATA_WIDTH's x 8 cycle. (worst case scenario)
+# Set a multi-cycle delay of 8 spi_clk cycle, slightly over constraining the path.
+
+set_multicycle_path -setup 8 -to [get_cells -hierarchical -filter {NAME=~*/data_sdo_shift_reg[*]}] -from [get_clocks clk_fpga_2]
+set_multicycle_path -hold  7 -to [get_cells -hierarchical -filter {NAME=~*/data_sdo_shift_reg[*]}] -from [get_clocks clk_fpga_2]
+
+set_multicycle_path -setup 8 -to [get_cells -hierarchical -filter {NAME=~*/execution/inst/left_aligned_reg*}] -from [get_clocks clk_fpga_2]
+set_multicycle_path -hold  7 -to [get_cells -hierarchical -filter {NAME=~*/execution/inst/left_aligned_reg*}] -from [get_clocks clk_fpga_2]
 


### PR DESCRIPTION
There are boards, which takes the SCLK and echos back to
the FPGA through a level shifter - doing this removes the effect of
round-trip timing delays from the level shifter. This is commonly done
whenever isolators are used since they are very slow.

By setting the ECHO_SCLK parameter to 1, the IP will use the incoming
echoed SCLK clock to latch the SDI line(s).

The designer responsibility to time the SDI shift registers in a way
that respects the design requirements.