### PR TITLE
Quick fix of standalone projects

### DIFF
--- a/projects/adrv9009zu11eg/adrv2crr_fmc/system_project.tcl
+++ b/projects/adrv9009zu11eg/adrv2crr_fmc/system_project.tcl
@@ -3,10 +3,7 @@ source ../../scripts/adi_env.tcl
 source $ad_hdl_dir/projects/scripts/adi_project_xilinx.tcl
 source $ad_hdl_dir/projects/scripts/adi_board.tcl
 
-set p_device "xczu11eg-ffvf1517-2-i"
-set sys_zynq 2
-
-adi_project adrv9009zu11eg 0 [list \
+adi_project_create adrv9009zu11eg 0 [list \
   JESD_RX_M 8 \
   JESD_RX_L 4 \
   JESD_RX_S 1 \
@@ -16,7 +13,8 @@ adi_project adrv9009zu11eg 0 [list \
   JESD_OBS_M 4 \
   JESD_OBS_L 4 \
   JESD_OBS_S 1 \
-]
+] "xczu11eg-ffvf1517-2-i"
+
 adi_project_files adrv9009zu11eg [list \
   "system_top.v" \
   "../common/adrv9009zu11eg_spi.v" \

--- a/projects/adrv9009zu11eg/adrv2crr_fmcomms8/system_project.tcl
+++ b/projects/adrv9009zu11eg/adrv2crr_fmcomms8/system_project.tcl
@@ -3,10 +3,7 @@ source ../../scripts/adi_env.tcl
 source $ad_hdl_dir/projects/scripts/adi_project_xilinx.tcl
 source $ad_hdl_dir/projects/scripts/adi_board.tcl
 
-set p_device "xczu11eg-ffvf1517-2-i"
-set sys_zynq 2
-
-adi_project fmcomms8_adrv9009zu11eg 0 [list \
+adi_project_create fmcomms8_adrv9009zu11eg 0 [list \
   JESD_RX_M 16 \
   JESD_RX_L 8 \
   JESD_RX_S 1 \
@@ -16,7 +13,8 @@ adi_project fmcomms8_adrv9009zu11eg 0 [list \
   JESD_OBS_M 8 \
   JESD_OBS_L 8 \
   JESD_OBS_S 1 \
-]
+] "xczu11eg-ffvf1517-2-i"
+
 
 adi_project_files  fmcomms8_adrv9009zu11eg [list \
   "system_top.v" \

--- a/projects/adrv9361z7035/ccbob_cmos/system_project.tcl
+++ b/projects/adrv9361z7035/ccbob_cmos/system_project.tcl
@@ -3,8 +3,7 @@ source ../../scripts/adi_env.tcl
 source $ad_hdl_dir/projects/scripts/adi_project_xilinx.tcl
 source $ad_hdl_dir/projects/scripts/adi_board.tcl
 
-set p_device "xc7z035ifbg676-2L"
-adi_project adrv9361z7035_ccbob_cmos
+adi_project_create adrv9361z7035_ccbob_cmos 0 {} "xc7z035ifbg676-2L"
 adi_project_files adrv9361z7035_ccbob_cmos [list \
   "$ad_hdl_dir/library/common/ad_iobuf.v" \
   "../common/adrv9361z7035_constr.xdc" \

--- a/projects/adrv9361z7035/ccbob_lvds/system_project.tcl
+++ b/projects/adrv9361z7035/ccbob_lvds/system_project.tcl
@@ -3,8 +3,7 @@ source ../../scripts/adi_env.tcl
 source $ad_hdl_dir/projects/scripts/adi_project_xilinx.tcl
 source $ad_hdl_dir/projects/scripts/adi_board.tcl
 
-set p_device "xc7z035ifbg676-2L"
-adi_project adrv9361z7035_ccbob_lvds
+adi_project_create adrv9361z7035_ccbob_lvds 0 {} "xc7z035ifbg676-2L"
 adi_project_files adrv9361z7035_ccbob_lvds [list \
   "$ad_hdl_dir/library/common/ad_iobuf.v" \
   "../common/adrv9361z7035_constr.xdc" \

--- a/projects/adrv9361z7035/ccfmc_lvds/system_project.tcl
+++ b/projects/adrv9361z7035/ccfmc_lvds/system_project.tcl
@@ -3,8 +3,7 @@ source ../../scripts/adi_env.tcl
 source $ad_hdl_dir/projects/scripts/adi_project_xilinx.tcl
 source $ad_hdl_dir/projects/scripts/adi_board.tcl
 
-set p_device "xc7z035ifbg676-2L"
-adi_project adrv9361z7035_ccfmc_lvds
+adi_project_create adrv9361z7035_ccfmc_lvds 0 {} "xc7z035ifbg676-2L"
 adi_project_files adrv9361z7035_ccfmc_lvds [list \
   "$ad_hdl_dir/library/common/ad_iobuf.v" \
   "$ad_hdl_dir/library/common/ad_adl5904_rst.v" \

--- a/projects/adrv9361z7035/ccpackrf_lvds/system_project.tcl
+++ b/projects/adrv9361z7035/ccpackrf_lvds/system_project.tcl
@@ -3,8 +3,7 @@ source ../../scripts/adi_env.tcl
 source $ad_hdl_dir/projects/scripts/adi_project_xilinx.tcl
 source $ad_hdl_dir/projects/scripts/adi_board.tcl
 
-set p_device "xc7z035ifbg676-2L"
-adi_project adrv9361z7035_ccpackrf_lvds
+adi_project_create adrv9361z7035_ccpackrf_lvds 0 {} "xc7z035ifbg676-2L"
 adi_project_files adrv9361z7035_ccpackrf_lvds [list \
   "$ad_hdl_dir/library/common/ad_iobuf.v" \
   "$ad_hdl_dir/library/common/ad_adl5904_rst.v" \

--- a/projects/adrv9364z7020/ccbob_cmos/system_project.tcl
+++ b/projects/adrv9364z7020/ccbob_cmos/system_project.tcl
@@ -3,8 +3,7 @@ source ../../scripts/adi_env.tcl
 source $ad_hdl_dir/projects/scripts/adi_project_xilinx.tcl
 source $ad_hdl_dir/projects/scripts/adi_board.tcl
 
-set p_device "xc7z020clg400-1"
-adi_project adrv9364z7020_ccbob_cmos
+adi_project_create adrv9364z7020_ccbob_cmos 0 {} "xc7z020clg400-1"
 adi_project_files adrv9364z7020_ccbob_cmos [list \
   "$ad_hdl_dir/library/common/ad_iobuf.v" \
   "../common/adrv9364z7020_constr.xdc" \

--- a/projects/adrv9364z7020/ccbob_lvds/system_project.tcl
+++ b/projects/adrv9364z7020/ccbob_lvds/system_project.tcl
@@ -3,8 +3,7 @@ source ../../scripts/adi_env.tcl
 source $ad_hdl_dir/projects/scripts/adi_project_xilinx.tcl
 source $ad_hdl_dir/projects/scripts/adi_board.tcl
 
-set p_device "xc7z020clg400-1"
-adi_project adrv9364z7020_ccbob_lvds
+adi_project_create adrv9364z7020_ccbob_lvds 0 {} "xc7z020clg400-1"
 adi_project_files adrv9364z7020_ccbob_lvds [list \
   "$ad_hdl_dir/library/common/ad_iobuf.v" \
   "../common/adrv9364z7020_constr.xdc" \

--- a/projects/adrv9364z7020/ccpackrf_lvds/system_project.tcl
+++ b/projects/adrv9364z7020/ccpackrf_lvds/system_project.tcl
@@ -3,8 +3,7 @@ source ../../scripts/adi_env.tcl
 source $ad_hdl_dir/projects/scripts/adi_project_xilinx.tcl
 source $ad_hdl_dir/projects/scripts/adi_board.tcl
 
-set p_device "xc7z020clg400-1"
-adi_project adrv9364z7020_ccpackrf_lvds
+adi_project_create adrv9364z7020_ccpackrf_lvds 0 {} "xc7z020clg400-1"
 adi_project_files adrv9364z7020_ccpackrf_lvds [list \
   "$ad_hdl_dir/library/common/ad_iobuf.v" \
   "$ad_hdl_dir/library/common/ad_adl5904_rst.v" \

--- a/projects/m2k/standalone/system_project.tcl
+++ b/projects/m2k/standalone/system_project.tcl
@@ -3,8 +3,7 @@ source ../../scripts/adi_env.tcl
 source $ad_hdl_dir/projects/scripts/adi_project_xilinx.tcl
 source $ad_hdl_dir/projects/scripts/adi_board.tcl
 
-set p_device "xc7z010clg225-1"
-adi_project m2k
+adi_project_create m2k 0 {} "xc7z010clg225-1"
 
 adi_project_files m2k [list \
   "../common/m2k_spi.v" \

--- a/projects/pluto/system_project.tcl
+++ b/projects/pluto/system_project.tcl
@@ -3,8 +3,7 @@ source ../scripts/adi_env.tcl
 source $ad_hdl_dir/projects/scripts/adi_project_xilinx.tcl
 source $ad_hdl_dir/projects/scripts/adi_board.tcl
 
-set p_device "xc7z010clg225-1"
-adi_project pluto
+adi_project_create pluto 0 {} "xc7z010clg225-1"
 
 adi_project_files pluto [list \
   "system_top.v" \

--- a/projects/scripts/adi_project_xilinx.tcl
+++ b/projects/scripts/adi_project_xilinx.tcl
@@ -47,6 +47,9 @@ set p_prcfg_status ""
 #
 proc adi_project {project_name {mode 0} {parameter_list {}} } {
 
+  set device ""
+  set board ""
+
   # Determine the device based on the board name
   if [regexp "_ac701$" $project_name] {
     set device "xc7a200tfbg676-2"
@@ -123,12 +126,15 @@ proc adi_project_create {project_name mode parameter_list device {board "not-app
   global ADI_USE_OOC_SYNTHESIS
   global ADI_USE_INCR_COMP
 
-  set p_device $device
+  ## update the value of $p_device only if it was not already updated elsewhere
+  if {$p_device eq "none"} {
+    set p_device $device
+  } 
   set p_board $board
 
-  if [regexp "^xc7z" $device] {
+  if [regexp "^xc7z" $p_device] {
     set sys_zynq 1
-  } elseif [regexp "^xczu" $device]  {
+  } elseif [regexp "^xczu" $p_device]  {
     set sys_zynq 2
   } else {
     set sys_zynq 0

--- a/projects/sidekiqz2/system_project.tcl
+++ b/projects/sidekiqz2/system_project.tcl
@@ -3,8 +3,7 @@ source ../scripts/adi_env.tcl
 source $ad_hdl_dir/projects/scripts/adi_project_xilinx.tcl
 source $ad_hdl_dir/projects/scripts/adi_board.tcl
 
-set p_device "xc7z010clg225-1"
-adi_project sidekiqz2
+adi_project_create sidekiqz2 0 {} "xc7z010clg225-1"
 
 adi_project_files sidekiqz2 [list \
   "system_top.v" \

--- a/projects/usrpe31x/system_project.tcl
+++ b/projects/usrpe31x/system_project.tcl
@@ -3,8 +3,7 @@ source ../scripts/adi_env.tcl
 source $ad_hdl_dir/projects/scripts/adi_project_xilinx.tcl
 source $ad_hdl_dir/projects/scripts/adi_board.tcl
 
-set p_device "xc7z020clg484-1"
-adi_project usrpe31x
+adi_project_create usrpe31x 0 {} "xc7z020clg484-1"
 
 adi_project_files usrpe31x [list \
   "system_top.v" \


### PR DESCRIPTION
After the #602 all standalone projects fails. In this patch all the standalone projects are using the **adi_project_create** process directly in their system_project.tcl file, instead the **adi_project**. 