### PR TITLE
util_axis_fifo: Add KEEP synthesis attribute for zerodeep CDC

### DIFF
--- a/library/util_axis_fifo/util_axis_fifo.v
+++ b/library/util_axis_fifo/util_axis_fifo.v
@@ -61,7 +61,7 @@ generate if (ADDRESS_WIDTH == 0) begin : zerodeep /* it's not a real FIFO, just 
 
   if (ASYNC_CLK) begin
 
-      reg [DATA_WIDTH-1:0] cdc_sync_fifo_ram;
+      (* KEEP = "yes" *) reg [DATA_WIDTH-1:0] cdc_sync_fifo_ram;
       reg s_axis_waddr = 1'b0;
       reg m_axis_raddr = 1'b0;
 


### PR DESCRIPTION
Vivado synthesis is optimizing out the "zerodeep" block, resulting untreated clock domain crossing. Set **KEEP** attribute for the registers.

Although I closed this a week ago (#623), the problem still persist in some projects. The proper fix would be to refactor the DMA, to not use the util_axis_fifo with zero address width. Until then **KEEP** is used to prevent unwanted optimization.