### PR TITLE
fmcomms8: zcu102: Fix lane swapping

### DIFF
--- a/projects/adrv9009zu11eg/common/adrv9009zu11eg_bd.tcl
+++ b/projects/adrv9009zu11eg/common/adrv9009zu11eg_bd.tcl
@@ -349,7 +349,11 @@ ad_xcvrpll  axi_adrv9009_som_obs_xcvr/up_pll_rst util_adrv9009_som_xcvr/up_cpll_
 ad_connect  sys_cpu_resetn util_adrv9009_som_xcvr/up_rstn
 ad_connect  sys_cpu_clk util_adrv9009_som_xcvr/up_clk
 
+if {$TX_NUM_OF_LANES == 16} {
+ad_xcvrcon  util_adrv9009_som_xcvr axi_adrv9009_som_tx_xcvr axi_adrv9009_som_tx_jesd {0 1 2 3 4 5 6 7 9 8 10 11 12 13 14 15 16} core_clk_a
+} else {
 ad_xcvrcon  util_adrv9009_som_xcvr axi_adrv9009_som_tx_xcvr axi_adrv9009_som_tx_jesd {} core_clk_a
+}
 
 if {$RX_NUM_OF_LANES == 8} {
 ad_xcvrcon  util_adrv9009_som_xcvr axi_adrv9009_som_rx_xcvr axi_adrv9009_som_rx_jesd {0 1 4 5 8 9 12 13} core_clk_b

--- a/projects/fmcomms8/common/fmcomms8_bd.tcl
+++ b/projects/fmcomms8/common/fmcomms8_bd.tcl
@@ -162,7 +162,7 @@ ad_xcvrpll  axi_adrv9009_fmc_obs_xcvr/up_pll_rst util_adrv9009_fmc_xcvr/up_cpll_
 ad_connect  sys_cpu_resetn util_adrv9009_fmc_xcvr/up_rstn
 ad_connect  sys_cpu_clk util_adrv9009_fmc_xcvr/up_clk
 
-ad_xcvrcon  util_adrv9009_fmc_xcvr axi_adrv9009_fmc_tx_xcvr axi_adrv9009_fmc_tx_jesd {} core_clk_c
+ad_xcvrcon  util_adrv9009_fmc_xcvr axi_adrv9009_fmc_tx_xcvr axi_adrv9009_fmc_tx_jesd {1 0 2 3 4 5 6 7} core_clk_c
 ad_xcvrcon  util_adrv9009_fmc_xcvr axi_adrv9009_fmc_rx_xcvr axi_adrv9009_fmc_rx_jesd {0 1 4 5} core_clk_d
 ad_xcvrcon  util_adrv9009_fmc_xcvr axi_adrv9009_fmc_obs_xcvr axi_adrv9009_fmc_obs_jesd {2 3 6 7} core_clk_c
 


### PR DESCRIPTION
The TX lanes 0 and 1 are swapped in hardware, resulting I/Q sample swap for TX RF channel 0. This fixes the swap. Tested on the ZCU102