### PR TITLE
sysid: Make sure gitbranch_string is always declared

### DIFF
--- a/projects/scripts/adi_pd.tcl
+++ b/projects/scripts/adi_pd.tcl
@@ -119,6 +119,8 @@ proc sysid_gen_sys_init_file {{custom_string {}}} {
     } else {
       set gitbranch_string [lindex $gitbranch_string [expr [lsearch -exact $gitbranch_string "*"] + 1]];
 	}
+  } else {
+    set gitbranch_string "";
   }
 
   set git_clean_hex [hexstr_flip [stringtohex $git_clean_string 4]];


### PR DESCRIPTION
Parsing of not existed "gitbranch_string" fails the build process. (Win, no git)