### PR TITLE
ADRV9001 fixes for 2019_R2

### DIFF
--- a/library/axi_ad9361/axi_ad9361_constr.xdc
+++ b/library/axi_ad9361/axi_ad9361_constr.xdc
@@ -6,5 +6,5 @@ set_property ASYNC_REG TRUE \
 
 set_false_path -from [get_cells -hier -filter {name =~ *up_enable_int_reg   && IS_SEQUENTIAL}] -to [get_cells -hier -filter {name =~ *enable_up_m1_reg  && IS_SEQUENTIAL}]
 set_false_path -from [get_cells -hier -filter {name =~ *up_txnrx_int_reg    && IS_SEQUENTIAL}] -to [get_cells -hier -filter {name =~ *txnrx_up_m1_reg   && IS_SEQUENTIAL}]
-set_false_path -to [get_cells -hier -filter {name =~ *tdd_sync_d1_reg   && IS_SEQUENTIAL}]
+set_false_path -quiet -to [get_cells -quiet -hier -filter {name =~ *tdd_sync_d1_reg   && IS_SEQUENTIAL}]
 

--- a/library/axi_adrv9001/axi_adrv9001_constr.sdc
+++ b/library/axi_adrv9001/axi_adrv9001_constr.sdc
@@ -1,6 +1,13 @@
+set script_dir [file dirname [info script]]
+
+source "$script_dir/util_cdc_constr.tcl"
 
 set_false_path -from [get_registers *i_dev_if|up_enable_int*] -to [get_registers *i_dev_if|enable_up_m1*]
 set_false_path -from [get_registers *i_dev_if|up_txnrx_int*]  -to [get_registers *i_dev_if|txnrx_up_m1*]
 set_false_path -from [get_registers *up_xfer_cntrl:i_xfer_tdd_control|d_xfer_toggle*]   -to [get_registers *up_xfer_cntrl:i_xfer_tdd_control|up_xfer_state_m1*]
 set_false_path -from [get_registers *up_xfer_cntrl:i_xfer_tdd_control|up_xfer_toggle*]  -to [get_registers *up_xfer_cntrl:i_xfer_tdd_control|d_xfer_toggle_m1*]
 set_false_path -from [get_registers *up_xfer_cntrl:i_xfer_tdd_control|up_xfer_data*]    -to [get_registers *up_xfer_cntrl:i_xfer_tdd_control|d_data_cntrl*]
+
+util_cdc_sync_bits_constr {*|sync_bits:i_rx1_ctrl_sync}
+util_cdc_sync_bits_constr {*|sync_bits:i_tx1_ctrl_sync}
+

--- a/library/axi_adrv9001/axi_adrv9001_constr.xdc
+++ b/library/axi_adrv9001/axi_adrv9001_constr.xdc
@@ -3,3 +3,13 @@ set_false_path -quiet -from [get_cells -quiet -hier *out_toggle_d1_reg* -filter 
 
 set_false_path -through  [get_pins -hier *i_idelay/CNTVALUEOUT]
 set_false_path -through  [get_pins -hier *i_idelay/CNTVALUEIN]
+
+# sync bits i_rx1_ctrl_sync
+set_false_path \
+  -to [get_cells -quiet -hier *cdc_sync_stage1_reg* \
+    -filter {NAME =~ *i_rx1_ctrl_sync* && IS_SEQUENTIAL}]
+
+# sync bits i_tx1_ctrl_sync
+set_false_path \
+  -to [get_cells -quiet -hier *cdc_sync_stage1_reg* \
+    -filter {NAME =~ *i_tx1_ctrl_sync* && IS_SEQUENTIAL}]

--- a/library/axi_adrv9001/axi_adrv9001_core.v
+++ b/library/axi_adrv9001/axi_adrv9001_core.v
@@ -206,13 +206,31 @@ module axi_ad9001_core #(
   // rx1_r1_mode should be 0 only when rx1_clk and rx2_clk have the same frequency
   // tx1_r1_mode should be 0 only when tx1_clk and tx2_clk have the same frequency
 
-  assign rx2_rst = rx1_r1_mode ? rx2_rst_loc : rx1_rst;
-  assign rx2_single_lane = rx1_r1_mode ? rx2_single_lane_loc : rx1_single_lane;
-  assign rx2_sdr_ddr_n = rx1_r1_mode ? rx2_sdr_ddr_n_loc : rx1_sdr_ddr_n;
+  sync_bits #(
+    .NUM_OF_BITS (3),
+    .ASYNC_CLK (1))
+  i_rx1_ctrl_sync (
+    .in_bits ({rx1_sdr_ddr_n,rx1_single_lane,rx1_rst}),
+    .out_clk (rx2_clk),
+    .out_resetn (1'b1),
+    .out_bits ({rx1_sdr_ddr_n_s,rx1_single_lane_s,rx1_rst_s}));
 
-  assign tx2_rst = tx1_r1_mode ? tx2_rst_loc : tx1_rst;
-  assign tx2_single_lane = tx1_r1_mode ? tx2_single_lane_loc : tx1_single_lane;
-  assign tx2_sdr_ddr_n = tx1_r1_mode ? tx2_sdr_ddr_n_loc : tx1_sdr_ddr_n;
+  sync_bits #(
+    .NUM_OF_BITS (3),
+    .ASYNC_CLK (1))
+  i_tx1_ctrl_sync (
+    .in_bits ({tx1_sdr_ddr_n,tx1_single_lane,tx1_rst}),
+    .out_clk (tx2_clk),
+    .out_resetn (1'b1),
+    .out_bits ({tx1_sdr_ddr_n_s,tx1_single_lane_s,tx1_rst_s}));
+
+  assign rx2_rst = rx1_r1_mode ? rx2_rst_loc : rx1_rst_s;
+  assign rx2_single_lane = rx1_r1_mode ? rx2_single_lane_loc : rx1_single_lane_s;
+  assign rx2_sdr_ddr_n = rx1_r1_mode ? rx2_sdr_ddr_n_loc : rx1_sdr_ddr_n_s;
+
+  assign tx2_rst = tx1_r1_mode ? tx2_rst_loc : tx1_rst_s;
+  assign tx2_single_lane = tx1_r1_mode ? tx2_single_lane_loc : tx1_single_lane_s;
+  assign tx2_sdr_ddr_n = tx1_r1_mode ? tx2_sdr_ddr_n_loc : tx1_sdr_ddr_n_s;
 
   assign tx1_data_valid = tx1_data_valid_A_d;
   assign tx1_data_i = tx1_data_i_A_d;
@@ -565,7 +583,7 @@ module axi_ad9001_core #(
     .BASE_ADDRESS (6'h13)
   ) i_tdd_2 (
     .clk (rx2_clk),
-    .rst (rx2_rst),
+    .rst (rx2_rst_loc),
     .tdd_rx_vco_en (),
     .tdd_tx_vco_en (),
     .tdd_rx_rf_en (tdd_rx2_rf_en_loc),

--- a/library/axi_adrv9001/axi_adrv9001_hw.tcl
+++ b/library/axi_adrv9001/axi_adrv9001_hw.tcl
@@ -35,6 +35,8 @@ ad_ip_files axi_adrv9001 [list\
   "$ad_hdl_dir/library/intel/common/up_xfer_status_constr.sdc" \
   "$ad_hdl_dir/library/intel/common/up_clock_mon_constr.sdc" \
   "$ad_hdl_dir/library/intel/common/up_rst_constr.sdc" \
+  "$ad_hdl_dir/library/util_cdc/sync_bits.v" \
+  "$ad_hdl_dir/library/util_cdc/util_cdc_constr.tcl" \
   "intel/adrv9001_rx.v" \
   "intel/adrv9001_tx.v" \
   "adrv9001_pack.v" \

--- a/library/axi_adrv9001/axi_adrv9001_hw.tcl
+++ b/library/axi_adrv9001/axi_adrv9001_hw.tcl
@@ -182,19 +182,19 @@ proc axi_adrv9001_elab {} {
   set m_fpga_technology [get_parameter_value "FPGA_TECHNOLOGY"]
   set m_cmos_lvds_n [get_parameter_value "CMOS_LVDS_N"]
 
-  add_hdl_instance adrv9001_gpio_in altera_gpio
+  add_hdl_instance adrv9001_gpio_in altera_gpio 19.3
   set_instance_parameter_value adrv9001_gpio_in {DEVICE_FAMILY} {Arria 10}
   set_instance_parameter_value adrv9001_gpio_in {PIN_TYPE_GUI} {Input}
   set_instance_parameter_value adrv9001_gpio_in {SIZE} {1}
   set_instance_parameter_value adrv9001_gpio_in {gui_io_reg_mode} {DDIO}
 
-  add_hdl_instance adrv9001_gpio_out altera_gpio
+  add_hdl_instance adrv9001_gpio_out altera_gpio 19.3
   set_instance_parameter_value adrv9001_gpio_out {DEVICE_FAMILY} {Arria 10}
   set_instance_parameter_value adrv9001_gpio_out {PIN_TYPE_GUI} {Output}
   set_instance_parameter_value adrv9001_gpio_out {SIZE} {1}
   set_instance_parameter_value adrv9001_gpio_out {gui_io_reg_mode} {DDIO}
 
-  add_hdl_instance periphery_clk_buf altclkctrl
+  add_hdl_instance periphery_clk_buf altclkctrl 19.1
   set_instance_parameter_value periphery_clk_buf {DEVICE_FAMILY} {Arria 10}
   set_instance_parameter_value periphery_clk_buf {CLOCK_TYPE} {Periphery Clock}
 

--- a/projects/adrv9001/zcu102/cmos_constr.xdc
+++ b/projects/adrv9001/zcu102/cmos_constr.xdc
@@ -47,8 +47,10 @@ create_clock -name rx2_dclk_out   -period  12.5 [get_ports rx2_dclk_in_p]
 create_clock -name tx1_dclk_out   -period  12.5 [get_ports tx1_dclk_in_p]
 create_clock -name tx2_dclk_out   -period  12.5 [get_ports tx2_dclk_in_p]
 
-set_clock_latency -source -early 2 [get_clocks rx1_dclk_out]
-set_clock_latency -source -early 2 [get_clocks rx2_dclk_out]
+set_clock_latency -source -early -0.25 [get_clocks rx1_dclk_out]
+set_clock_latency -source -early -0.25 [get_clocks rx2_dclk_out]
 
-set_clock_latency -source -late 5 [get_clocks rx1_dclk_out]
-set_clock_latency -source -late 5 [get_clocks rx2_dclk_out]
+set_clock_latency -source -late 0.25 [get_clocks rx1_dclk_out]
+set_clock_latency -source -late 0.25 [get_clocks rx2_dclk_out]
+
+


### PR DESCRIPTION
Below commits are addressing timing failures or critical warnings related to constraints. 

Tested on 
ZCU102 + ADRV9001 CMOS
ZCU102 + ADRV9001 LVDS
ZED + ADRV9001 CMOS

