### PR TITLE
ad469x/zed: Add multicycle path constraint

### DIFF
--- a/projects/ad469x_fmc/zed/system_constr.xdc
+++ b/projects/ad469x_fmc/zed/system_constr.xdc
@@ -9,3 +9,14 @@ set_property -dict {PACKAGE_PIN M20 IOSTANDARD LVCMOS25} [get_ports ad469x_spi_c
 
 set_property -dict {PACKAGE_PIN M21 IOSTANDARD LVCMOS25} [get_ports ad469x_resetn]        ; ## H10  FMC_LPC_LA04_P
 set_property -dict {PACKAGE_PIN P18 IOSTANDARD LVCMOS25} [get_ports ad469x_busy_alt_gp0]  ; ## H08  FMC_LPC_LA02_N
+
+# rename auto-generated clock for SPIEngine to spi_clk - 160MHz
+# NOTE: clk_fpga_0 is the first PL fabric clock, also called $sys_cpu_clk
+create_generated_clock -name spi_clk -source [get_pins -filter name=~*CLKIN1 -of [get_cells -hier -filter name=~*spi_clkgen*i_mmcm]] -master_clock clk_fpga_0 [get_pins -filter name=~*CLKOUT0 -of [get_cells -hier -filter name=~*spi_clkgen*i_mmcm]]
+
+# relax the SDO path to help closing timing at high frequencies
+set_multicycle_path -setup 8 -to [get_cells -hierarchical -filter {NAME=~*/data_sdo_shift_reg[*]}] -from [get_clocks spi_clk]
+set_multicycle_path -hold  7 -to [get_cells -hierarchical -filter {NAME=~*/data_sdo_shift_reg[*]}] -from [get_clocks spi_clk]
+set_multicycle_path -setup 8 -to [get_cells -hierarchical -filter {NAME=~*/execution/inst/left_aligned_reg*}] -from [get_clocks spi_clk]
+set_multicycle_path -hold  7 -to [get_cells -hierarchical -filter {NAME=~*/execution/inst/left_aligned_reg*}] -from [get_clocks spi_clk]
+


### PR DESCRIPTION
The project is using a 160MHz spi clock (internal) which sometimes causes timing failures which should be fixed with this commit.