### PR TITLE
adrv9001/zc706: Initial commit

### DIFF
--- a/projects/adrv9001/zc706/Makefile
+++ b/projects/adrv9001/zc706/Makefile
@@ -1,0 +1,25 @@
+####################################################################################
+## Copyright 2018(c) Analog Devices, Inc.
+## Auto-generated, do not modify!
+####################################################################################
+
+PROJECT_NAME := adrv9001_zc706
+
+M_DEPS += cmos_constr.xdc
+M_DEPS += ../common/adrv9001_bd.tcl
+M_DEPS += ../../scripts/adi_pd.tcl
+M_DEPS += ../../common/zc706/zc706_system_constr.xdc
+M_DEPS += ../../common/zc706/zc706_system_bd.tcl
+M_DEPS += ../../../library/common/ad_iobuf.v
+
+LIB_DEPS += axi_adrv9001
+LIB_DEPS += axi_clkgen
+LIB_DEPS += axi_dmac
+LIB_DEPS += axi_hdmi_tx
+LIB_DEPS += axi_spdif_tx
+LIB_DEPS += axi_sysid
+LIB_DEPS += sysid_rom
+LIB_DEPS += util_pack/util_cpack2
+LIB_DEPS += util_pack/util_upack2
+
+include ../../scripts/project-xilinx.mk

--- a/projects/adrv9001/zc706/cmos_constr.xdc
+++ b/projects/adrv9001/zc706/cmos_constr.xdc
@@ -1,0 +1,47 @@
+set_property  -dict {PACKAGE_PIN AF13	 IOSTANDARD LVCMOS18}  [get_ports rx1_dclk_in_n]    ;## G07 FMC_HPC0_LA00_CC_N
+set_property  -dict {PACKAGE_PIN AE13	 IOSTANDARD LVCMOS18}  [get_ports rx1_dclk_in_p]    ;## G06 FMC_HPC0_LA00_CC_P
+set_property  -dict {PACKAGE_PIN AH12	 IOSTANDARD LVCMOS18}  [get_ports rx1_idata_in_n]   ;## G10 FMC_HPC0_LA03_N
+set_property  -dict {PACKAGE_PIN AG12	 IOSTANDARD LVCMOS18}  [get_ports rx1_idata_in_p]   ;## G09 FMC_HPC0_LA03_P
+set_property  -dict {PACKAGE_PIN AK15	 IOSTANDARD LVCMOS18}  [get_ports rx1_qdata_in_n]   ;## H11 FMC_HPC0_LA04_N
+set_property  -dict {PACKAGE_PIN AJ15	 IOSTANDARD LVCMOS18}  [get_ports rx1_qdata_in_p]   ;## H10 FMC_HPC0_LA04_P
+set_property  -dict {PACKAGE_PIN AF12	 IOSTANDARD LVCMOS18}  [get_ports rx1_strobe_in_n]  ;## H08 FMC_HPC0_LA02_N
+set_property  -dict {PACKAGE_PIN AE12	 IOSTANDARD LVCMOS18}  [get_ports rx1_strobe_in_p]  ;## H07 FMC_HPC0_LA02_P
+
+set_property  -dict {PACKAGE_PIN AC27	 IOSTANDARD LVCMOS18}  [get_ports rx2_dclk_in_n]    ;## D21 FMC_HPC0_LA17_CC_N
+set_property  -dict {PACKAGE_PIN AB27	 IOSTANDARD LVCMOS18}  [get_ports rx2_dclk_in_p]    ;## D20 FMC_HPC0_LA17_CC_P
+set_property  -dict {PACKAGE_PIN AG27	 IOSTANDARD LVCMOS18}  [get_ports rx2_idata_in_n]   ;## G22 FMC_HPC0_LA20_N
+set_property  -dict {PACKAGE_PIN AG26	 IOSTANDARD LVCMOS18}  [get_ports rx2_idata_in_p]   ;## G21 FMC_HPC0_LA20_P
+set_property  -dict {PACKAGE_PIN AH27	 IOSTANDARD LVCMOS18}  [get_ports rx2_qdata_in_n]   ;## H23 FMC_HPC0_LA19_N
+set_property  -dict {PACKAGE_PIN AH26	 IOSTANDARD LVCMOS18}  [get_ports rx2_qdata_in_p]   ;## H22 FMC_HPC0_LA19_P
+set_property  -dict {PACKAGE_PIN AH29	 IOSTANDARD LVCMOS18}  [get_ports rx2_strobe_in_n]  ;## H26 FMC_HPC0_LA21_N
+set_property  -dict {PACKAGE_PIN AH28	 IOSTANDARD LVCMOS18}  [get_ports rx2_strobe_in_p]  ;## H25 FMC_HPC0_LA21_P
+
+set_property  -dict {PACKAGE_PIN AA14	 IOSTANDARD LVCMOS18}  [get_ports tx1_dclk_out_n]   ;## H14 FMC_HPC0_LA07_N
+set_property  -dict {PACKAGE_PIN AA15  IOSTANDARD LVCMOS18}  [get_ports tx1_dclk_out_p]   ;## H13 FMC_HPC0_LA07_P
+set_property  -dict {PACKAGE_PIN AG15	 IOSTANDARD LVCMOS18}  [get_ports tx1_dclk_in_n]    ;## D09 FMC_HPC0_LA01_CC_N
+set_property  -dict {PACKAGE_PIN AF15	 IOSTANDARD LVCMOS18}  [get_ports tx1_dclk_in_p]    ;## D08 FMC_HPC0_LA01_CC_P
+set_property  -dict {PACKAGE_PIN AD13	 IOSTANDARD LVCMOS18}  [get_ports tx1_idata_out_n]  ;## G13 FMC_HPC0_LA08_N
+set_property  -dict {PACKAGE_PIN AD14	 IOSTANDARD LVCMOS18}  [get_ports tx1_idata_out_p]  ;## G12 FMC_HPC0_LA08_P
+set_property  -dict {PACKAGE_PIN AE15	 IOSTANDARD LVCMOS18}  [get_ports tx1_qdata_out_n]  ;## D12 FMC_HPC0_LA05_N
+set_property  -dict {PACKAGE_PIN AE16	 IOSTANDARD LVCMOS18}  [get_ports tx1_qdata_out_p]  ;## D11 FMC_HPC0_LA05_P
+set_property  -dict {PACKAGE_PIN AC12	 IOSTANDARD LVCMOS18}  [get_ports tx1_strobe_out_n] ;## C11 FMC_HPC0_LA06_N
+set_property  -dict {PACKAGE_PIN AB12	 IOSTANDARD LVCMOS18}  [get_ports tx1_strobe_out_p] ;## C10 FMC_HPC0_LA06_P
+
+set_property  -dict {PACKAGE_PIN AK28	 IOSTANDARD LVCMOS18}  [get_ports tx2_dclk_out_n]   ;## G25 FMC_HPC0_LA22_N
+set_property  -dict {PACKAGE_PIN AK27	 IOSTANDARD LVCMOS18}  [get_ports tx2_dclk_out_p]   ;## G24 FMC_HPC0_LA22_P
+set_property  -dict {PACKAGE_PIN AF27	 IOSTANDARD LVCMOS18}  [get_ports tx2_dclk_in_n]    ;## C23 FMC_HPC0_LA18_CC_N
+set_property  -dict {PACKAGE_PIN AE27	 IOSTANDARD LVCMOS18}  [get_ports tx2_dclk_in_p]    ;## C22 FMC_HPC0_LA18_CC_P
+set_property  -dict {PACKAGE_PIN AK26	 IOSTANDARD LVCMOS18}  [get_ports tx2_idata_out_n]  ;## D24 FMC_HPC0_LA23_N
+set_property  -dict {PACKAGE_PIN AJ26	 IOSTANDARD LVCMOS18}  [get_ports tx2_idata_out_p]  ;## D23 FMC_HPC0_LA23_P
+set_property  -dict {PACKAGE_PIN AG29	 IOSTANDARD LVCMOS18}  [get_ports tx2_qdata_out_n]  ;## G28 FMC_HPC0_LA25_N
+set_property  -dict {PACKAGE_PIN AF29	 IOSTANDARD LVCMOS18}  [get_ports tx2_qdata_out_p]  ;## G27 FMC_HPC0_LA25_P
+set_property  -dict {PACKAGE_PIN AG30	 IOSTANDARD LVCMOS18}  [get_ports tx2_strobe_out_n] ;## H29 FMC_HPC0_LA24_N
+set_property  -dict {PACKAGE_PIN AF30	 IOSTANDARD LVCMOS18}  [get_ports tx2_strobe_out_p] ;## H28 FMC_HPC0_LA24_P
+
+# clocks
+
+create_clock -name rx1_dclk_out   -period  12.5 [get_ports rx1_dclk_in_p]
+create_clock -name rx2_dclk_out   -period  12.5 [get_ports rx2_dclk_in_p]
+create_clock -name tx1_dclk_out   -period  12.5 [get_ports tx1_dclk_in_p]
+create_clock -name tx2_dclk_out   -period  12.5 [get_ports tx2_dclk_in_p]
+

--- a/projects/adrv9001/zc706/system_bd.tcl
+++ b/projects/adrv9001/zc706/system_bd.tcl
@@ -1,0 +1,12 @@
+
+source $ad_hdl_dir/projects/common/zc706/zc706_system_bd.tcl
+source ../common/adrv9001_bd.tcl
+source $ad_hdl_dir/projects/scripts/adi_pd.tcl
+
+#system ID
+ad_ip_parameter axi_sysid_0 CONFIG.ROM_ADDR_BITS 9
+ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "[pwd]/mem_init_sys.txt"
+ad_ip_parameter rom_sys_0 CONFIG.ROM_ADDR_BITS 9
+set sys_cstring "CMOS_LVDS_N=${ad_project_params(CMOS_LVDS_N)}"
+sysid_gen_sys_init_file $sys_cstring
+

--- a/projects/adrv9001/zc706/system_constr.xdc
+++ b/projects/adrv9001/zc706/system_constr.xdc
@@ -1,0 +1,98 @@
+#
+#                     !!! WARNING !!!
+#
+#  This project must run on a board where VADJ is programmed to 1.8 V
+#
+#                     !!! WARNING !!!
+#
+
+set_property  -dict {PACKAGE_PIN AG17	 IOSTANDARD LVCMOS18}  [get_ports dev_clk_out]
+
+set_property  -dict {PACKAGE_PIN AE18	 IOSTANDARD LVCMOS18}  [get_ports dgpio_0]
+set_property  -dict {PACKAGE_PIN AE17	 IOSTANDARD LVCMOS18}  [get_ports dgpio_1]
+set_property  -dict {PACKAGE_PIN AB14	 IOSTANDARD LVCMOS18}  [get_ports dgpio_2]
+set_property  -dict {PACKAGE_PIN AK16	 IOSTANDARD LVCMOS18}  [get_ports dgpio_3]
+set_property  -dict {PACKAGE_PIN AH13	 IOSTANDARD LVCMOS18}  [get_ports dgpio_4]
+set_property  -dict {PACKAGE_PIN AC13	 IOSTANDARD LVCMOS18}  [get_ports dgpio_5]
+set_property  -dict {PACKAGE_PIN AJ28	 IOSTANDARD LVCMOS18}  [get_ports dgpio_6]
+set_property  -dict {PACKAGE_PIN AJ30	 IOSTANDARD LVCMOS18}  [get_ports dgpio_7]
+set_property  -dict {PACKAGE_PIN AD25	 IOSTANDARD LVCMOS18}  [get_ports dgpio_8]
+set_property  -dict {PACKAGE_PIN AE26	 IOSTANDARD LVCMOS18}  [get_ports dgpio_9]
+set_property  -dict {PACKAGE_PIN AJ16	 IOSTANDARD LVCMOS18}  [get_ports dgpio_10]
+set_property  -dict {PACKAGE_PIN AJ29	 IOSTANDARD LVCMOS18}  [get_ports dgpio_11]
+
+set_property  -dict {PACKAGE_PIN AB29	 IOSTANDARD LVCMOS18}  [get_ports gp_int]
+set_property  -dict {PACKAGE_PIN AH17	 IOSTANDARD LVCMOS18}  [get_ports mode]
+set_property  -dict {PACKAGE_PIN AH16	 IOSTANDARD LVCMOS18}  [get_ports reset_trx]
+
+set_property  -dict {PACKAGE_PIN AC14	 IOSTANDARD LVCMOS18}  [get_ports rx1_enable]
+set_property  -dict {PACKAGE_PIN AK30	 IOSTANDARD LVCMOS18}  [get_ports rx2_enable]
+
+set_property  -dict {PACKAGE_PIN AG16	 IOSTANDARD LVCMOS18}  [get_ports sm_fan_tach]
+
+set_property  -dict {PACKAGE_PIN AD16	 IOSTANDARD LVCMOS18}  [get_ports spi_clk]
+set_property  -dict {PACKAGE_PIN AF25	 IOSTANDARD LVCMOS18}  [get_ports spi_dio]
+set_property  -dict {PACKAGE_PIN AD15	 IOSTANDARD LVCMOS18}  [get_ports spi_do]
+set_property  -dict {PACKAGE_PIN AB15	 IOSTANDARD LVCMOS18}  [get_ports spi_en]
+
+set_property  -dict {PACKAGE_PIN AH14	 IOSTANDARD LVCMOS18}  [get_ports tx1_enable]
+set_property  -dict {PACKAGE_PIN AE25	 IOSTANDARD LVCMOS18}  [get_ports tx2_enable]
+
+set_property  -dict {PACKAGE_PIN AC29	 IOSTANDARD LVCMOS18}  [get_ports vadj_err]
+set_property  -dict {PACKAGE_PIN AD29	 IOSTANDARD LVCMOS18}  [get_ports platform_status]
+
+set_property  -dict {PACKAGE_PIN AJ21  IOSTANDARD LVCMOS18}  [get_ports  tdd_sync]      ;#PMOD1_0 J58.1
+
+# set IOSTANDARD according to VADJ 1.8V
+
+# hdmi
+
+set_property  -dict {IOSTANDARD LVCMOS18} [get_ports hdmi_out_clk]
+set_property  -dict {IOSTANDARD LVCMOS18} [get_ports hdmi_vsync]
+set_property  -dict {IOSTANDARD LVCMOS18} [get_ports hdmi_hsync]
+set_property  -dict {IOSTANDARD LVCMOS18} [get_ports hdmi_data_e]
+set_property  -dict {IOSTANDARD LVCMOS18} [get_ports hdmi_data[0]]
+set_property  -dict {IOSTANDARD LVCMOS18} [get_ports hdmi_data[1]]
+set_property  -dict {IOSTANDARD LVCMOS18} [get_ports hdmi_data[2]]
+set_property  -dict {IOSTANDARD LVCMOS18} [get_ports hdmi_data[3]]
+set_property  -dict {IOSTANDARD LVCMOS18} [get_ports hdmi_data[4]]
+set_property  -dict {IOSTANDARD LVCMOS18} [get_ports hdmi_data[5]]
+set_property  -dict {IOSTANDARD LVCMOS18} [get_ports hdmi_data[6]]
+set_property  -dict {IOSTANDARD LVCMOS18} [get_ports hdmi_data[7]]
+set_property  -dict {IOSTANDARD LVCMOS18} [get_ports hdmi_data[8]]
+set_property  -dict {IOSTANDARD LVCMOS18} [get_ports hdmi_data[9]]
+set_property  -dict {IOSTANDARD LVCMOS18} [get_ports hdmi_data[10]]
+set_property  -dict {IOSTANDARD LVCMOS18} [get_ports hdmi_data[11]]
+set_property  -dict {IOSTANDARD LVCMOS18} [get_ports hdmi_data[12]]
+set_property  -dict {IOSTANDARD LVCMOS18} [get_ports hdmi_data[13]]
+set_property  -dict {IOSTANDARD LVCMOS18} [get_ports hdmi_data[14]]
+set_property  -dict {IOSTANDARD LVCMOS18} [get_ports hdmi_data[15]]
+set_property  -dict {IOSTANDARD LVCMOS18} [get_ports hdmi_data[16]]
+set_property  -dict {IOSTANDARD LVCMOS18} [get_ports hdmi_data[17]]
+set_property  -dict {IOSTANDARD LVCMOS18} [get_ports hdmi_data[18]]
+set_property  -dict {IOSTANDARD LVCMOS18} [get_ports hdmi_data[19]]
+set_property  -dict {IOSTANDARD LVCMOS18} [get_ports hdmi_data[20]]
+set_property  -dict {IOSTANDARD LVCMOS18} [get_ports hdmi_data[21]]
+set_property  -dict {IOSTANDARD LVCMOS18} [get_ports hdmi_data[22]]
+set_property  -dict {IOSTANDARD LVCMOS18} [get_ports hdmi_data[23]]
+
+# spdif
+
+set_property  -dict {IOSTANDARD LVCMOS18} [get_ports spdif]
+
+# iic
+
+set_property  -dict {IOSTANDARD LVCMOS18} [get_ports iic_scl]
+set_property  -dict {IOSTANDARD LVCMOS18} [get_ports iic_sda]
+
+# gpio (switches, leds and such)
+
+set_property  -dict {IOSTANDARD LVCMOS18} [get_ports gpio_bd[0]]
+set_property  -dict {IOSTANDARD LVCMOS18} [get_ports gpio_bd[1]]
+set_property  -dict {IOSTANDARD LVCMOS18} [get_ports gpio_bd[2]]
+set_property  -dict {IOSTANDARD LVCMOS18} [get_ports gpio_bd[3]]
+set_property  -dict {IOSTANDARD LVCMOS18} [get_ports gpio_bd[4]]
+set_property  -dict {IOSTANDARD LVCMOS18} [get_ports gpio_bd[6]]
+
+set_property  -dict {IOSTANDARD LVCMOS18} [get_ports gpio_bd[7]]
+set_property  -dict {IOSTANDARD LVCMOS18} [get_ports gpio_bd[9]]

--- a/projects/adrv9001/zc706/system_project.tcl
+++ b/projects/adrv9001/zc706/system_project.tcl
@@ -1,0 +1,20 @@
+
+source ../../scripts/adi_env.tcl
+source $ad_hdl_dir/projects/scripts/adi_project_xilinx.tcl
+source $ad_hdl_dir/projects/scripts/adi_board.tcl
+
+adi_project adrv9001_zc706 0 [list \
+  CMOS_LVDS_N 1 \
+]
+
+adi_project_files adrv9001_zc706 [list \
+  "system_top.v" \
+  "system_constr.xdc"\
+  "cmos_constr.xdc" \
+  "$ad_hdl_dir/library/common/ad_iobuf.v" \
+  "$ad_hdl_dir/projects/common/zc706/zc706_system_constr.xdc"]
+
+set_property PROCESSING_ORDER LATE [get_files system_constr.xdc]
+
+adi_project_run adrv9001_zc706
+

--- a/projects/adrv9001/zc706/system_top.v
+++ b/projects/adrv9001/zc706/system_top.v
@@ -1,0 +1,346 @@
+// ***************************************************************************
+// ***************************************************************************
+// Copyright 2014 - 2020 (c) Analog Devices, Inc. All rights reserved.
+//
+// In this HDL repository, there are many different and unique modules, consisting
+// of various HDL (Verilog or VHDL) components. The individual modules are
+// developed independently, and may be accompanied by separate and unique license
+// terms.
+//
+// The user should read each of these license terms, and understand the
+// freedoms and responsibilities that he or she has by using this source/core.
+//
+// This core is distributed in the hope that it will be useful, but WITHOUT ANY
+// WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+// A PARTICULAR PURPOSE.
+//
+// Redistribution and use of source or resulting binaries, with or without modification
+// of this file, are permitted under one of the following two license terms:
+//
+//   1. The GNU General Public License version 2 as published by the
+//      Free Software Foundation, which can be found in the top level directory
+//      of this repository (LICENSE_GPL2), and also online at:
+//      <https://www.gnu.org/licenses/old-licenses/gpl-2.0.html>
+//
+// OR
+//
+//   2. An ADI specific BSD license, which can be found in the top level directory
+//      of this repository (LICENSE_ADIBSD), and also on-line at:
+//      https://github.com/analogdevicesinc/hdl/blob/master/LICENSE_ADIBSD
+//      This will allow to generate bit files and not release the source code,
+//      as long as it attaches to an ADI device.
+//
+// ***************************************************************************
+// ***************************************************************************
+
+`timescale 1ns/100ps
+
+module system_top (
+
+  inout       [14:0]      ddr_addr,
+  inout       [ 2:0]      ddr_ba,
+  inout                   ddr_cas_n,
+  inout                   ddr_ck_n,
+  inout                   ddr_ck_p,
+  inout                   ddr_cke,
+  inout                   ddr_cs_n,
+  inout       [ 3:0]      ddr_dm,
+  inout       [31:0]      ddr_dq,
+  inout       [ 3:0]      ddr_dqs_n,
+  inout       [ 3:0]      ddr_dqs_p,
+  inout                   ddr_odt,
+  inout                   ddr_ras_n,
+  inout                   ddr_reset_n,
+  inout                   ddr_we_n,
+
+  inout                   fixed_io_ddr_vrn,
+  inout                   fixed_io_ddr_vrp,
+  inout       [53:0]      fixed_io_mio,
+  inout                   fixed_io_ps_clk,
+  inout                   fixed_io_ps_porb,
+  inout                   fixed_io_ps_srstb,
+
+  inout       [14:0]      gpio_bd,
+
+  output                  hdmi_out_clk,
+  output                  hdmi_vsync,
+  output                  hdmi_hsync,
+  output                  hdmi_data_e,
+  output      [23:0]      hdmi_data,
+
+  output                  spdif,
+
+  inout                   iic_scl,
+  inout                   iic_sda,
+
+  output                  spi_clk,
+  output                  spi_dio,
+  input                   spi_do,
+  output                  spi_en,
+
+  // Device clock passed through 9002
+  input                   dev_clk_out,
+
+  inout                   dgpio_0,
+  inout                   dgpio_1,
+  inout                   dgpio_2,
+  inout                   dgpio_3,
+  inout                   dgpio_4,
+  inout                   dgpio_5,
+  inout                   dgpio_6,
+  inout                   dgpio_7,
+  inout                   dgpio_8,
+  inout                   dgpio_9,
+  inout                   dgpio_10,
+  inout                   dgpio_11,
+
+  inout                   gp_int,
+  inout                   mode,
+  inout                   reset_trx,
+
+  input                   rx1_dclk_in_n,
+  input                   rx1_dclk_in_p,
+  output                  rx1_enable,
+  input                   rx1_idata_in_n,
+  input                   rx1_idata_in_p,
+  input                   rx1_qdata_in_n,
+  input                   rx1_qdata_in_p,
+  input                   rx1_strobe_in_n,
+  input                   rx1_strobe_in_p,
+
+  input                   rx2_dclk_in_n,
+  input                   rx2_dclk_in_p,
+  output                  rx2_enable,
+  input                   rx2_idata_in_n,
+  input                   rx2_idata_in_p,
+  input                   rx2_qdata_in_n,
+  input                   rx2_qdata_in_p,
+  input                   rx2_strobe_in_n,
+  input                   rx2_strobe_in_p,
+
+  output                  tx1_dclk_out_n,
+  output                  tx1_dclk_out_p,
+  input                   tx1_dclk_in_n,
+  input                   tx1_dclk_in_p,
+  output                  tx1_enable,
+  output                  tx1_idata_out_n,
+  output                  tx1_idata_out_p,
+  output                  tx1_qdata_out_n,
+  output                  tx1_qdata_out_p,
+  output                  tx1_strobe_out_n,
+  output                  tx1_strobe_out_p,
+
+  output                  tx2_dclk_out_n,
+  output                  tx2_dclk_out_p,
+  input                   tx2_dclk_in_n,
+  input                   tx2_dclk_in_p,
+  output                  tx2_enable,
+  output                  tx2_idata_out_n,
+  output                  tx2_idata_out_p,
+  output                  tx2_qdata_out_n,
+  output                  tx2_qdata_out_p,
+  output                  tx2_strobe_out_n,
+  output                  tx2_strobe_out_p,
+
+  inout                   sm_fan_tach,
+  input                   vadj_err,
+  output                  platform_status,
+
+  inout                   tdd_sync
+);
+
+  // internal registers
+  // internal signals
+  wire   [94:0] gpio_i;
+  wire   [94:0] gpio_o;
+  wire   [94:0] gpio_t;
+  wire   [ 2:0] spi_csn;
+  wire          gpio_rx1_enable_in;
+  wire          gpio_rx2_enable_in;
+  wire          gpio_tx1_enable_in;
+  wire          gpio_tx2_enable_in;
+  wire          rx1_enable_s;
+  wire          rx2_enable_s;
+  wire          tx1_enable_s;
+  wire          tx2_enable_s;
+  wire          tdd_sync_loc;
+  wire          tdd_sync_i;
+  wire          tdd_sync_cntr;
+  wire          mssi_sync;
+
+  // instantiations
+
+  // multi-ssi synchronization
+  //
+  assign mssi_sync = gpio_o[54];
+
+  assign platform_status = vadj_err;
+
+  ad_iobuf #(.DATA_WIDTH(16)) i_iobuf (
+    .dio_t (vadj_err ? {16{1'b1}} : gpio_t[47:32]),
+    .dio_i ({gpio_o[47:32]}),
+    .dio_o ({gpio_i[47:32]}),
+    .dio_p ({sm_fan_tach,  // 47
+             reset_trx,    // 46
+             mode,         // 45
+             gp_int,       // 44
+             dgpio_11,     // 43
+             dgpio_10,     // 42
+             dgpio_9,      // 41
+             dgpio_8,      // 40
+             dgpio_7,      // 39
+             dgpio_6,      // 38
+             dgpio_5,      // 37
+             dgpio_4,      // 36
+             dgpio_3,      // 35
+             dgpio_2,      // 34
+             dgpio_1,      // 33
+             dgpio_0 }));  // 32
+
+  assign gpio_rx1_enable_in = gpio_o[48];
+  assign gpio_rx2_enable_in = gpio_o[49];
+  assign gpio_tx1_enable_in = gpio_o[50];
+  assign gpio_tx2_enable_in = gpio_o[51];
+
+  ad_iobuf #(.DATA_WIDTH(15)) i_iobuf_bd (
+    .dio_t (gpio_t[14:0]),
+    .dio_i (gpio_o[14:0]),
+    .dio_o (gpio_i[14:0]),
+    .dio_p (gpio_bd));
+
+  assign gpio_i[54:48] = gpio_o[54:48];
+  assign gpio_i[55] = vadj_err;
+  assign gpio_i[63:56] = gpio_o[63:56];
+
+  assign tdd_sync_loc = gpio_o[56];
+
+  // tdd_sync_loc - local sync signal from a GPIO or other source
+  // tdd_sync - external sync 
+  assign tdd_sync_i = tdd_sync_cntr ? tdd_sync_loc : tdd_sync;
+  assign tdd_sync = tdd_sync_cntr ? tdd_sync_loc : 1'bz;
+
+  system_wrapper i_system_wrapper (
+    .ddr_addr (ddr_addr),
+    .ddr_ba (ddr_ba),
+    .ddr_cas_n (ddr_cas_n),
+    .ddr_ck_n (ddr_ck_n),
+    .ddr_ck_p (ddr_ck_p),
+    .ddr_cke (ddr_cke),
+    .ddr_cs_n (ddr_cs_n),
+    .ddr_dm (ddr_dm),
+    .ddr_dq (ddr_dq),
+    .ddr_dqs_n (ddr_dqs_n),
+    .ddr_dqs_p (ddr_dqs_p),
+    .ddr_odt (ddr_odt),
+    .ddr_ras_n (ddr_ras_n),
+    .ddr_reset_n (ddr_reset_n),
+    .ddr_we_n (ddr_we_n),
+    .fixed_io_ddr_vrn (fixed_io_ddr_vrn),
+    .fixed_io_ddr_vrp (fixed_io_ddr_vrp),
+    .fixed_io_mio (fixed_io_mio),
+    .fixed_io_ps_clk (fixed_io_ps_clk),
+    .fixed_io_ps_porb (fixed_io_ps_porb),
+    .fixed_io_ps_srstb (fixed_io_ps_srstb),
+    .gpio_i (gpio_i),
+    .gpio_o (gpio_o),
+    .gpio_t (gpio_t),
+    .hdmi_data (hdmi_data),
+    .hdmi_data_e (hdmi_data_e),
+    .hdmi_hsync (hdmi_hsync),
+    .hdmi_out_clk (hdmi_out_clk),
+    .hdmi_vsync (hdmi_vsync),
+    .iic_main_scl_io (iic_scl),
+    .iic_main_sda_io (iic_sda),
+    .spdif (spdif),
+    .spi0_clk_i (1'b0),
+    .spi0_clk_o (spi_clk_s),
+    .spi0_csn_0_o (spi_en_s),
+    .spi0_csn_1_o (),
+    .spi0_csn_2_o (),
+    .spi0_csn_i (1'b1),
+    .spi0_sdi_i (spi_do),
+    .spi0_sdo_i (1'b0),
+    .spi0_sdo_o (spi_dio_s),
+    .spi1_clk_i (1'b0),
+    .spi1_clk_o (),
+    .spi1_csn_0_o (),
+    .spi1_csn_1_o (),
+    .spi1_csn_2_o (),
+    .spi1_csn_i (1'b1),
+    .spi1_sdi_i (1'b0),
+    .spi1_sdo_i (1'b0),
+    .spi1_sdo_o (),
+
+    //FMC connections
+    .mssi_sync (mssi_sync),
+
+    .tx_output_enable (~vadj_err),
+
+    .rx1_dclk_in_n (rx1_dclk_in_n),
+    .rx1_dclk_in_p (rx1_dclk_in_p),
+    .rx1_idata_in_n (rx1_idata_in_n),
+    .rx1_idata_in_p (rx1_idata_in_p),
+    .rx1_qdata_in_n (rx1_qdata_in_n),
+    .rx1_qdata_in_p (rx1_qdata_in_p),
+    .rx1_strobe_in_n (rx1_strobe_in_n),
+    .rx1_strobe_in_p (rx1_strobe_in_p),
+
+    .rx2_dclk_in_n (rx2_dclk_in_n),
+    .rx2_dclk_in_p (rx2_dclk_in_p),
+    .rx2_idata_in_n (rx2_idata_in_n),
+    .rx2_idata_in_p (rx2_idata_in_p),
+    .rx2_qdata_in_n (rx2_qdata_in_n),
+    .rx2_qdata_in_p (rx2_qdata_in_p),
+    .rx2_strobe_in_n (rx2_strobe_in_n),
+    .rx2_strobe_in_p (rx2_strobe_in_p),
+
+    .tx1_dclk_out_n (tx1_dclk_out_n),
+    .tx1_dclk_out_p (tx1_dclk_out_p),
+    .tx1_dclk_in_n (tx1_dclk_in_n),
+    .tx1_dclk_in_p (tx1_dclk_in_p),
+    .tx1_idata_out_n (tx1_idata_out_n),
+    .tx1_idata_out_p (tx1_idata_out_p),
+    .tx1_qdata_out_n (tx1_qdata_out_n),
+    .tx1_qdata_out_p (tx1_qdata_out_p),
+    .tx1_strobe_out_n (tx1_strobe_out_n),
+    .tx1_strobe_out_p (tx1_strobe_out_p),
+
+    .tx2_dclk_out_n (tx2_dclk_out_n),
+    .tx2_dclk_out_p (tx2_dclk_out_p),
+    .tx2_dclk_in_n (tx2_dclk_in_n),
+    .tx2_dclk_in_p (tx2_dclk_in_p),
+    .tx2_idata_out_n (tx2_idata_out_n),
+    .tx2_idata_out_p (tx2_idata_out_p),
+    .tx2_qdata_out_n (tx2_qdata_out_n),
+    .tx2_qdata_out_p (tx2_qdata_out_p),
+    .tx2_strobe_out_n (tx2_strobe_out_n),
+    .tx2_strobe_out_p (tx2_strobe_out_p),
+
+    .rx1_enable (rx1_enable_s),
+    .rx2_enable (rx2_enable_s),
+    .tx1_enable (tx1_enable_s),
+    .tx2_enable (tx2_enable_s),
+
+    .gpio_rx1_enable_in (gpio_rx1_enable_in),
+    .gpio_rx2_enable_in (gpio_rx2_enable_in),
+    .gpio_tx1_enable_in (gpio_tx1_enable_in),
+    .gpio_tx2_enable_in (gpio_tx2_enable_in),
+
+    .tdd_sync (tdd_sync_i),
+    .tdd_sync_cntr (tdd_sync_cntr)
+
+  );
+
+ assign spi_clk = vadj_err ? 1'bz : spi_clk_s;
+ assign spi_en  = vadj_err ? 1'bz : spi_en_s;
+ assign spi_dio = vadj_err ? 1'bz : spi_dio_s;
+
+ assign rx1_enable = vadj_err ? 1'bz : rx1_enable_s;
+ assign rx2_enable = vadj_err ? 1'bz : rx2_enable_s;
+ assign tx1_enable = vadj_err ? 1'bz : tx1_enable_s;
+ assign tx2_enable = vadj_err ? 1'bz : tx2_enable_s;
+
+endmodule
+
+// ***************************************************************************
+// ***************************************************************************


### PR DESCRIPTION
The project supports CMOS interface only.

VADJ on the ZC706 must be programmed to 1.8V

Tested on ZC706 and Navassa B0