### PR TITLE
axi_dmac: fix non-blocking assignment in combinatorial block

### DIFF
--- a/library/axi_dmac/axi_dmac_burst_memory.v
+++ b/library/axi_dmac/axi_dmac_burst_memory.v
@@ -207,9 +207,9 @@ assign src_data_request_id = src_dest_id;
 
 always @(*) begin
   if (src_last_beat == 1'b1) begin
-    src_id_next <= inc_id(src_id);
+    src_id_next = inc_id(src_id);
   end else begin
-    src_id_next <= src_id;
+    src_id_next = src_id;
   end
 end
 


### PR DESCRIPTION
Non-blocking assignments in combinatorial blocks can cause simulation problems. In this particular case iverilog coughed up a hairball.