### PR TITLE
Update Quartus Prime version from 19.3.0 to 20.1.0

### DIFF
--- a/library/axi_ad9122/axi_ad9122_hw.tcl
+++ b/library/axi_ad9122/axi_ad9122_hw.tcl
@@ -1,5 +1,5 @@
 
-package require qsys
+package require qsys 14.0
 package require quartus::device
 
 source ../scripts/adi_env.tcl

--- a/library/axi_ad9144/axi_ad9144_hw.tcl
+++ b/library/axi_ad9144/axi_ad9144_hw.tcl
@@ -1,6 +1,6 @@
 
 
-package require qsys
+package require qsys 14.0
 package require quartus::device
 source ../scripts/adi_env.tcl
 source ../scripts/adi_ip_intel.tcl

--- a/library/axi_ad9152/axi_ad9152_hw.tcl
+++ b/library/axi_ad9152/axi_ad9152_hw.tcl
@@ -1,6 +1,6 @@
 
 
-package require qsys
+package require qsys 14.0
 package require quartus::device
 
 source ../scripts/adi_env.tcl

--- a/library/axi_ad9250/axi_ad9250_hw.tcl
+++ b/library/axi_ad9250/axi_ad9250_hw.tcl
@@ -1,6 +1,6 @@
 
 
-package require qsys
+package require qsys 14.0
 package require quartus::device
 
 source ../scripts/adi_env.tcl

--- a/library/axi_ad9361/axi_ad9361_hw.tcl
+++ b/library/axi_ad9361/axi_ad9361_hw.tcl
@@ -1,5 +1,5 @@
 
-package require qsys
+package require qsys 14.0
 package require quartus::device
 
 source ../scripts/adi_env.tcl

--- a/library/axi_ad9371/axi_ad9371_hw.tcl
+++ b/library/axi_ad9371/axi_ad9371_hw.tcl
@@ -1,6 +1,6 @@
 
 
-package require qsys
+package require qsys 14.0
 package require quartus::device
 
 source ../scripts/adi_env.tcl

--- a/library/axi_ad9671/axi_ad9671_hw.tcl
+++ b/library/axi_ad9671/axi_ad9671_hw.tcl
@@ -1,6 +1,6 @@
 
 
-package require qsys
+package require qsys 14.0
 package require quartus::device
 
 source ../scripts/adi_env.tcl

--- a/library/axi_ad9680/axi_ad9680_hw.tcl
+++ b/library/axi_ad9680/axi_ad9680_hw.tcl
@@ -1,6 +1,6 @@
 
 
-package require qsys
+package require qsys 14.0
 package require quartus::device
 
 source ../scripts/adi_env.tcl

--- a/library/axi_ad9684/axi_ad9684_hw.tcl
+++ b/library/axi_ad9684/axi_ad9684_hw.tcl
@@ -1,5 +1,5 @@
 
-package require qsys
+package require qsys 14.0
 package require quartus::device
 
 source ../scripts/adi_env.tcl

--- a/library/axi_adrv9001/axi_adrv9001_hw.tcl
+++ b/library/axi_adrv9001/axi_adrv9001_hw.tcl
@@ -1,4 +1,4 @@
-package require qsys
+package require qsys 14.0
 package require quartus::device
 
 source ../scripts/adi_env.tcl

--- a/library/axi_adrv9009/axi_adrv9009_hw.tcl
+++ b/library/axi_adrv9009/axi_adrv9009_hw.tcl
@@ -1,6 +1,6 @@
 
 
-package require qsys
+package require qsys 14.0
 package require quartus::device
 
 source ../scripts/adi_env.tcl

--- a/library/axi_dmac/axi_dmac_hw.tcl
+++ b/library/axi_dmac/axi_dmac_hw.tcl
@@ -1,6 +1,6 @@
 
 
-package require qsys
+package require qsys 14.0
 source ../scripts/adi_env.tcl
 source ../scripts/adi_ip_intel.tcl
 

--- a/library/axi_hdmi_tx/axi_hdmi_tx_hw.tcl
+++ b/library/axi_hdmi_tx/axi_hdmi_tx_hw.tcl
@@ -1,6 +1,6 @@
 
 
-package require qsys
+package require qsys 14.0
 package require quartus::device
 
 source ../scripts/adi_env.tcl

--- a/library/axi_laser_driver/axi_laser_driver_hw.tcl
+++ b/library/axi_laser_driver/axi_laser_driver_hw.tcl
@@ -1,5 +1,5 @@
 
-package require qsys
+package require qsys 14.0
 source ../scripts/adi_env.tcl
 source ../scripts/adi_ip_intel.tcl
 

--- a/library/axi_sysid/axi_sysid_hw.tcl
+++ b/library/axi_sysid/axi_sysid_hw.tcl
@@ -1,5 +1,5 @@
 
-package require qsys
+package require qsys 14.0
 source ../scripts/adi_env.tcl
 source ../scripts/adi_ip_intel.tcl
 

--- a/library/intel/adi_jesd204/adi_jesd204_glue_hw.tcl
+++ b/library/intel/adi_jesd204/adi_jesd204_glue_hw.tcl
@@ -42,7 +42,7 @@
 # is copyright © 2016-2017, Analog Devices, Inc.”
 #
 
-package require qsys
+package require qsys 14.0
 source ../../scripts/adi_env.tcl
 source ../../scripts/adi_ip_intel.tcl
 

--- a/library/intel/avl_adxcfg/avl_adxcfg_hw.tcl
+++ b/library/intel/avl_adxcfg/avl_adxcfg_hw.tcl
@@ -1,5 +1,5 @@
 
-package require qsys
+package require qsys 14.0
 
 set_module_property NAME avl_adxcfg
 set_module_property DESCRIPTION "Avalon ADXCFG Core"

--- a/library/intel/avl_adxcvr/avl_adxcvr_hw.tcl
+++ b/library/intel/avl_adxcvr/avl_adxcvr_hw.tcl
@@ -1,5 +1,5 @@
 
-package require qsys
+package require qsys 14.0
 source ../../scripts/adi_env.tcl
 source ../../scripts/adi_ip_intel.tcl
 

--- a/library/intel/avl_adxcvr_octet_swap/avl_adxcvr_octet_swap_hw.tcl
+++ b/library/intel/avl_adxcvr_octet_swap/avl_adxcvr_octet_swap_hw.tcl
@@ -1,5 +1,5 @@
 
-package require qsys
+package require qsys 14.0
 
 source ../../scripts/adi_env.tcl
 source $ad_hdl_dir/library/scripts/adi_ip_intel.tcl

--- a/library/intel/avl_adxphy/avl_adxphy_hw.tcl
+++ b/library/intel/avl_adxphy/avl_adxphy_hw.tcl
@@ -1,5 +1,5 @@
 
-package require qsys
+package require qsys 14.0
 
 source ../../scripts/adi_env.tcl
 source $ad_hdl_dir/library/scripts/adi_ip_intel.tcl

--- a/library/intel/avl_dacfifo/avl_dacfifo_hw.tcl
+++ b/library/intel/avl_dacfifo/avl_dacfifo_hw.tcl
@@ -1,5 +1,5 @@
 
-package require qsys
+package require qsys 14.0
 source ../../scripts/adi_env.tcl
 source ../../scripts/adi_ip_intel.tcl
 

--- a/library/intel/axi_adxcvr/axi_adxcvr_hw.tcl
+++ b/library/intel/axi_adxcvr/axi_adxcvr_hw.tcl
@@ -1,5 +1,5 @@
 
-package require qsys
+package require qsys 14.0
 package require quartus::device
 
 source ../../scripts/adi_env.tcl

--- a/library/intel/common/intel_mem_asym/intel_mem_asym_hw.tcl
+++ b/library/intel/common/intel_mem_asym/intel_mem_asym_hw.tcl
@@ -1,5 +1,5 @@
 
-package require qsys
+package require qsys 14.0
 
 source ../../../scripts/adi_env.tcl
 source $ad_hdl_dir/library/scripts/adi_ip_intel.tcl
@@ -29,7 +29,7 @@ proc p_intel_mem_asym {} {
     set m_size [expr ((2**$m_addr_width_b)*$m_data_width_b)]
   }
 
-  add_instance intel_mem ram_2port 1.0
+  add_instance intel_mem ram_2port
   set_instance_parameter_value intel_mem {GUI_MODE} 0
   set_instance_parameter_value intel_mem {GUI_MEM_IN_BITS} 1
   set_instance_parameter_value intel_mem {GUI_MEMSIZE_BITS} $m_size

--- a/library/intel/common/intel_serdes/intel_serdes_hw.tcl
+++ b/library/intel/common/intel_serdes/intel_serdes_hw.tcl
@@ -1,5 +1,5 @@
 
-package require qsys
+package require qsys 14.0
 
 source ../../../scripts/adi_env.tcl
 source $ad_hdl_dir/library/scripts/adi_ip_intel.tcl

--- a/library/intel/jesd204_phy/jesd204_phy_glue_hw.tcl
+++ b/library/intel/jesd204_phy/jesd204_phy_glue_hw.tcl
@@ -42,7 +42,7 @@
 # is copyright © 2016-2017, Analog Devices, Inc.”
 #
 
-package require qsys
+package require qsys 14.0
 source ../../scripts/adi_env.tcl
 source ../../scripts/adi_ip_intel.tcl
 

--- a/library/intel/jesd204_phy/jesd204_phy_hw.tcl
+++ b/library/intel/jesd204_phy/jesd204_phy_hw.tcl
@@ -42,12 +42,10 @@
 # is copyright © 2016-2017, Analog Devices, Inc.”
 #
 
-package require qsys
+package require qsys 14.0
 
 source ../../scripts/adi_env.tcl
 source $ad_hdl_dir/library/scripts/adi_ip_intel.tcl
-
-set version 19.2
 
 #
 # Instantiates the Arria 10 native PHY and configures it for JESD204 operation.
@@ -76,8 +74,6 @@ ad_ip_parameter BONDING_CLOCKS_EN BOOLEAN false false
 
 proc jesd204_phy_composition_callback {} {
 
-  global version
-
   set device [get_parameter_value "DEVICE"]
   set soft_pcs [get_parameter_value "SOFT_PCS"]
   set tx [get_parameter_value "TX_OR_RX_N"]
@@ -99,7 +95,7 @@ proc jesd204_phy_composition_callback {} {
     set device_type 0
   }
 
-  add_instance link_clock clock_source 19.3
+  add_instance link_clock clock_source
   set_instance_parameter_value link_clock {clockFrequency} [expr $link_clk_frequency*1000000]
   add_interface link_clk clock sink
   set_interface_property link_clk EXPORT_OF link_clock.clk_in
@@ -108,14 +104,14 @@ proc jesd204_phy_composition_callback {} {
 
   ## Arria10
   if {$device_type == 1} {
-    add_instance native_phy altera_xcvr_native_a10 19.1
+    add_instance native_phy altera_xcvr_native_a10
     set_instance_parameter_value native_phy {enh_txfifo_mode} "Phase compensation"
     set_instance_parameter_value native_phy {enh_rxfifo_mode} "Phase compensation"
     set_instance_property native_phy SUPPRESS_ALL_WARNINGS true
     set_instance_property native_phy SUPPRESS_ALL_INFO_MESSAGES true
   ## Stratix 10
   } elseif {$device_type == 2} {
-    add_instance native_phy altera_xcvr_native_s10_htile $version
+    add_instance native_phy altera_xcvr_native_s10_htile
     set_instance_parameter_value native_phy {tx_fifo_mode} "Phase compensation"
     set_instance_parameter_value native_phy {rx_fifo_mode} "Phase compensation"
   ## Unsupported device
@@ -178,7 +174,7 @@ proc jesd204_phy_composition_callback {} {
   set_instance_parameter_value native_phy {set_csr_soft_logic_enable} 1
   set_instance_parameter_value native_phy {set_prbs_soft_logic_enable} 0
 
-  add_instance phy_glue jesd204_phy_glue 1.0
+  add_instance phy_glue jesd204_phy_glue
   set_instance_parameter_value phy_glue DEVICE $device
   set_instance_parameter_value phy_glue TX_OR_RX_N $tx
   set_instance_parameter_value phy_glue SOFT_PCS $soft_pcs
@@ -279,7 +275,7 @@ proc jesd204_phy_composition_callback {} {
 
     if {$tx} {
       if {$soft_pcs} {
-        add_instance soft_pcs_${i} jesd204_soft_pcs_tx 1.0
+        add_instance soft_pcs_${i} jesd204_soft_pcs_tx
         set_instance_parameter_value soft_pcs_${i} INVERT_OUTPUTS \
           [expr ($lane_invert >> $i) & 1]
         add_connection link_clock.clk soft_pcs_${i}.clock
@@ -292,7 +288,7 @@ proc jesd204_phy_composition_callback {} {
       }
     } else {
       if {$soft_pcs} {
-        add_instance soft_pcs_${i} jesd204_soft_pcs_rx 1.0
+        add_instance soft_pcs_${i} jesd204_soft_pcs_rx
         set_instance_parameter_value soft_pcs_${i} REGISTER_INPUTS $register_inputs
         set_instance_parameter_value soft_pcs_${i} INVERT_INPUTS \
           [expr ($lane_invert >> $i) & 1]

--- a/library/jesd204/ad_ip_jesd204_tpl_adc/ad_ip_jesd204_tpl_adc_hw.tcl
+++ b/library/jesd204/ad_ip_jesd204_tpl_adc/ad_ip_jesd204_tpl_adc_hw.tcl
@@ -21,7 +21,7 @@
 # ***************************************************************************
 # ***************************************************************************
 
-package require qsys
+package require qsys 14.0
 source ../../scripts/adi_env.tcl
 source ../../scripts/adi_ip_intel.tcl
 

--- a/library/jesd204/ad_ip_jesd204_tpl_dac/ad_ip_jesd204_tpl_dac_hw.tcl
+++ b/library/jesd204/ad_ip_jesd204_tpl_dac/ad_ip_jesd204_tpl_dac_hw.tcl
@@ -21,7 +21,7 @@
 # ***************************************************************************
 # ***************************************************************************
 
-package require qsys
+package require qsys 14.0
 source ../../scripts/adi_env.tcl
 source ../../scripts/adi_ip_intel.tcl
 

--- a/library/jesd204/axi_jesd204_rx/axi_jesd204_rx_hw.tcl
+++ b/library/jesd204/axi_jesd204_rx/axi_jesd204_rx_hw.tcl
@@ -42,7 +42,7 @@
 # is copyright © 2016-2017, Analog Devices, Inc.”
 #
 
-package require qsys
+package require qsys 14.0
 
 source ../../scripts/adi_env.tcl
 source $ad_hdl_dir/library/scripts/adi_ip_intel.tcl

--- a/library/jesd204/axi_jesd204_tx/axi_jesd204_tx_hw.tcl
+++ b/library/jesd204/axi_jesd204_tx/axi_jesd204_tx_hw.tcl
@@ -42,7 +42,7 @@
 # is copyright © 2016-2017, Analog Devices, Inc.”
 #
 
-package require qsys
+package require qsys 14.0
 
 source ../../scripts/adi_env.tcl
 source $ad_hdl_dir/library/scripts/adi_ip_intel.tcl

--- a/library/jesd204/jesd204_rx/jesd204_rx_hw.tcl
+++ b/library/jesd204/jesd204_rx/jesd204_rx_hw.tcl
@@ -42,7 +42,7 @@
 # is copyright © 2016-2017, Analog Devices, Inc.”
 #
 
-package require qsys
+package require qsys 14.0
 
 source ../../scripts/adi_env.tcl
 source $ad_hdl_dir/library/scripts/adi_ip_intel.tcl

--- a/library/jesd204/jesd204_soft_pcs_rx/jesd204_soft_pcs_rx_hw.tcl
+++ b/library/jesd204/jesd204_soft_pcs_rx/jesd204_soft_pcs_rx_hw.tcl
@@ -42,7 +42,7 @@
 # is copyright © 2016-2017, Analog Devices, Inc.”
 #
 
-package require qsys
+package require qsys 14.0
 
 source ../../scripts/adi_env.tcl
 source $ad_hdl_dir/library/scripts/adi_ip_intel.tcl

--- a/library/jesd204/jesd204_soft_pcs_tx/jesd204_soft_pcs_tx_hw.tcl
+++ b/library/jesd204/jesd204_soft_pcs_tx/jesd204_soft_pcs_tx_hw.tcl
@@ -42,7 +42,7 @@
 # is copyright © 2016-2017, Analog Devices, Inc.”
 #
 
-package require qsys
+package require qsys 14.0
 
 source ../../scripts/adi_env.tcl
 source $ad_hdl_dir/library/scripts/adi_ip_intel.tcl

--- a/library/jesd204/jesd204_tx/jesd204_tx_hw.tcl
+++ b/library/jesd204/jesd204_tx/jesd204_tx_hw.tcl
@@ -42,7 +42,7 @@
 # is copyright © 2016-2017, Analog Devices, Inc.”
 #
 
-package require qsys
+package require qsys 14.0
 
 source ../../scripts/adi_env.tcl
 source $ad_hdl_dir/library/scripts/adi_ip_intel.tcl

--- a/library/spi_engine/axi_spi_engine/axi_spi_engine_hw.tcl
+++ b/library/spi_engine/axi_spi_engine/axi_spi_engine_hw.tcl
@@ -1,5 +1,5 @@
 
-package require qsys
+package require qsys 14.0
 source ../../scripts/adi_env.tcl
 source ../../scripts/adi_ip_intel.tcl
 

--- a/library/spi_engine/spi_engine_execution/spi_engine_execution_hw.tcl
+++ b/library/spi_engine/spi_engine_execution/spi_engine_execution_hw.tcl
@@ -1,5 +1,5 @@
 
-package require qsys
+package require qsys 14.0
 source ../../scripts/adi_env.tcl
 source ../../scripts/adi_ip_intel.tcl
 

--- a/library/spi_engine/spi_engine_interconnect/spi_engine_interconnect_hw.tcl
+++ b/library/spi_engine/spi_engine_interconnect/spi_engine_interconnect_hw.tcl
@@ -1,5 +1,5 @@
 
-package require qsys
+package require qsys 14.0
 source ../../scripts/adi_env.tcl
 source ../../scripts/adi_ip_intel.tcl
 

--- a/library/spi_engine/spi_engine_offload/spi_engine_offload_hw.tcl
+++ b/library/spi_engine/spi_engine_offload/spi_engine_offload_hw.tcl
@@ -1,5 +1,5 @@
 
-package require qsys
+package require qsys 14.0
 source ../../scripts/adi_env.tcl
 source ../../scripts/adi_ip_intel.tcl
 

--- a/library/sysid_rom/sysid_rom_hw.tcl
+++ b/library/sysid_rom/sysid_rom_hw.tcl
@@ -1,5 +1,5 @@
 
-package require qsys
+package require qsys 14.0
 source ../scripts/adi_env.tcl
 source ../scripts/adi_ip_intel.tcl
 

--- a/library/util_adcfifo/util_adcfifo_hw.tcl
+++ b/library/util_adcfifo/util_adcfifo_hw.tcl
@@ -1,5 +1,5 @@
 
-package require qsys
+package require qsys 14.0
 source ../scripts/adi_env.tcl
 source ../scripts/adi_ip_intel.tcl
 

--- a/library/util_bsplit/util_bsplit_hw.tcl
+++ b/library/util_bsplit/util_bsplit_hw.tcl
@@ -1,6 +1,6 @@
 
 
-package require qsys
+package require qsys 14.0
 source ../scripts/adi_env.tcl
 source ../scripts/adi_ip_intel.tcl
 

--- a/library/util_dacfifo/util_dacfifo_hw.tcl
+++ b/library/util_dacfifo/util_dacfifo_hw.tcl
@@ -1,5 +1,5 @@
 
-package require qsys
+package require qsys 14.0
 source ../scripts/adi_env.tcl
 source ../scripts/adi_ip_intel.tcl
 

--- a/library/util_pack/util_cpack2/util_cpack2_hw.tcl
+++ b/library/util_pack/util_cpack2/util_cpack2_hw.tcl
@@ -21,7 +21,7 @@
 # ***************************************************************************
 # ***************************************************************************
 
-package require qsys
+package require qsys 14.0
 source ../../scripts/adi_env.tcl
 source ../../scripts/adi_ip_intel.tcl
 

--- a/library/util_pack/util_upack2/util_upack2_hw.tcl
+++ b/library/util_pack/util_upack2/util_upack2_hw.tcl
@@ -21,7 +21,7 @@
 # ***************************************************************************
 # ***************************************************************************
 
-package require qsys
+package require qsys 14.0
 source ../../scripts/adi_env.tcl
 source ../../scripts/adi_ip_intel.tcl
 

--- a/library/util_rfifo/util_rfifo_hw.tcl
+++ b/library/util_rfifo/util_rfifo_hw.tcl
@@ -1,6 +1,6 @@
 
 
-package require qsys
+package require qsys 14.0
 source ../scripts/adi_env.tcl
 source ../scripts/adi_ip_intel.tcl
 

--- a/library/util_wfifo/util_wfifo_hw.tcl
+++ b/library/util_wfifo/util_wfifo_hw.tcl
@@ -1,6 +1,6 @@
 
 
-package require qsys
+package require qsys 14.0
 source ../scripts/adi_env.tcl
 source ../scripts/adi_ip_intel.tcl
 

--- a/projects/ad9081_fmca_ebz/common/ad9081_fmca_ebz_qsys.tcl
+++ b/projects/ad9081_fmca_ebz/common/ad9081_fmca_ebz_qsys.tcl
@@ -63,10 +63,10 @@ set dac_fifo_address_width [expr int(ceil(log(($dac_fifo_samples_per_converter*$
 
 # JESD204B clock bridges
 
-add_instance tx_device_clk altera_clock_bridge 19.1
+add_instance tx_device_clk altera_clock_bridge
 set_instance_parameter_value tx_device_clk {EXPLICIT_CLOCK_RATE} {250000000}
 
-add_instance rx_device_clk altera_clock_bridge 19.1
+add_instance rx_device_clk altera_clock_bridge
 set_instance_parameter_value rx_device_clk {EXPLICIT_CLOCK_RATE} {250000000}
 
 #

--- a/projects/common/intel/dacfifo_qsys.tcl
+++ b/projects/common/intel/dacfifo_qsys.tcl
@@ -5,7 +5,7 @@ proc ad_dacfifo_create {dac_fifo_name dac_data_width dac_dma_data_width dac_fifo
     return -code error [format "ERROR: util_dacfifo dac/dma widths must be the same!"]
   }
 
-  add_instance $dac_fifo_name util_dacfifo 1.0
+  add_instance $dac_fifo_name util_dacfifo
   set_instance_parameter_value $dac_fifo_name {ADDRESS_WIDTH} $dac_fifo_address_width
   set_instance_parameter_value $dac_fifo_name {DATA_WIDTH} $dac_data_width
 

--- a/projects/scripts/adi_project_intel.tcl
+++ b/projects/scripts/adi_project_intel.tcl
@@ -2,7 +2,7 @@
 ## Initialize global variable
 set family "none"
 set device "none"
-set version "19.3.0"
+set version "20.1.0"
 
 ## Define the ADI_IGNORE_VERSION_CHECK environment variable to skip version check
 if {[info exists ::env(ADI_IGNORE_VERSION_CHECK)]} {


### PR DESCRIPTION
adi_project_intel.tcl: Change quartus version to 20.1.0.
library: Set qsys version so that IP instances won't require a specific version.