### PR TITLE
JESD204C timing fixes

### DIFF
--- a/library/jesd204/ad_ip_jesd204_tpl_adc/ad_ip_jesd204_tpl_adc.v
+++ b/library/jesd204/ad_ip_jesd204_tpl_adc/ad_ip_jesd204_tpl_adc.v
@@ -36,6 +36,7 @@ module ad_ip_jesd204_tpl_adc #(
   parameter BITS_PER_SAMPLE = 16,
   parameter DMA_BITS_PER_SAMPLE = 16,
   parameter OCTETS_PER_BEAT = 4,
+  parameter EN_FRAME_ALIGN = 1,
   parameter TWOS_COMPLEMENT = 1
 ) (
   // jesd interface
@@ -177,6 +178,7 @@ module ad_ip_jesd204_tpl_adc #(
     .BITS_PER_SAMPLE (BITS_PER_SAMPLE),
     .CONVERTER_RESOLUTION (CONVERTER_RESOLUTION),
     .SAMPLES_PER_FRAME (SAMPLES_PER_FRAME),
+    .EN_FRAME_ALIGN (EN_FRAME_ALIGN),
     .OCTETS_PER_BEAT (OCTETS_PER_BEAT),
     .LINK_DATA_WIDTH (LINK_DATA_WIDTH),
     .DMA_DATA_WIDTH (DMA_DATA_WIDTH),

--- a/library/jesd204/ad_ip_jesd204_tpl_adc/ad_ip_jesd204_tpl_adc_core.v
+++ b/library/jesd204/ad_ip_jesd204_tpl_adc/ad_ip_jesd204_tpl_adc_core.v
@@ -31,6 +31,7 @@ module ad_ip_jesd204_tpl_adc_core #(
   parameter BITS_PER_SAMPLE = 16,
   parameter DMA_BITS_PER_SAMPLE = 16,
   parameter OCTETS_PER_BEAT = 4,
+  parameter EN_FRAME_ALIGN = 0,
   parameter DATA_PATH_WIDTH = 1,
   parameter LINK_DATA_WIDTH = NUM_LANES * OCTETS_PER_BEAT * 8,
   parameter DMA_DATA_WIDTH = DATA_PATH_WIDTH * DMA_BITS_PER_SAMPLE * NUM_CHANNELS,
@@ -94,6 +95,7 @@ module ad_ip_jesd204_tpl_adc_core #(
     .CONVERTER_RESOLUTION  (CONVERTER_RESOLUTION),
     .SAMPLES_PER_FRAME (SAMPLES_PER_FRAME),
     .OCTETS_PER_BEAT (OCTETS_PER_BEAT),
+    .EN_FRAME_ALIGN (EN_FRAME_ALIGN),
     .LINK_DATA_WIDTH (LINK_DATA_WIDTH),
     .ADC_DATA_WIDTH (ADC_DATA_WIDTH)
   ) i_deframer (

--- a/library/jesd204/ad_ip_jesd204_tpl_adc/ad_ip_jesd204_tpl_adc_deframer.v
+++ b/library/jesd204/ad_ip_jesd204_tpl_adc/ad_ip_jesd204_tpl_adc_deframer.v
@@ -30,6 +30,7 @@ module ad_ip_jesd204_tpl_adc_deframer #(
   parameter CONVERTER_RESOLUTION = 14,
   parameter SAMPLES_PER_FRAME = 1,
   parameter OCTETS_PER_BEAT = 8,
+  parameter EN_FRAME_ALIGN = 0,
   parameter LINK_DATA_WIDTH = OCTETS_PER_BEAT * 8 * NUM_LANES,
   parameter ADC_DATA_WIDTH = LINK_DATA_WIDTH * CONVERTER_RESOLUTION / BITS_PER_SAMPLE
 ) (
@@ -102,6 +103,7 @@ module ad_ip_jesd204_tpl_adc_deframer #(
 
   generate
   genvar n;
+  if (EN_FRAME_ALIGN) begin
   for (n = 0; n < NUM_LANES; n = n + 1) begin: g_xcvr_if
     localparam DW = OCTETS_PER_BEAT * 8;
     ad_xcvr_rx_if #(
@@ -113,6 +115,9 @@ module ad_ip_jesd204_tpl_adc_deframer #(
       .rx_sof (),
       .rx_data (link_data_s[n*DW+:DW])
     );
+  end
+  end else begin
+    assign link_data_s = link_data;
   end
   endgenerate
 

--- a/library/jesd204/ad_ip_jesd204_tpl_dac/ad_ip_jesd204_tpl_dac.v
+++ b/library/jesd204/ad_ip_jesd204_tpl_dac/ad_ip_jesd204_tpl_dac.v
@@ -35,6 +35,7 @@ module ad_ip_jesd204_tpl_dac #(
   parameter CONVERTER_RESOLUTION = 16, // JESD_N
   parameter BITS_PER_SAMPLE = 16,      // JESD_NP
   parameter DMA_BITS_PER_SAMPLE = 16,
+  parameter PADDING_TO_MSB_LSB_N = 0,
   parameter OCTETS_PER_BEAT = 4,
   parameter DDS_TYPE = 1,
   parameter DDS_CORDIC_DW = 16,
@@ -135,6 +136,7 @@ module ad_ip_jesd204_tpl_dac #(
     .DEV_PACKAGE (DEV_PACKAGE),
     .NUM_CHANNELS (NUM_CHANNELS),
     .DATA_PATH_WIDTH (DATA_PATH_WIDTH),
+    .PADDING_TO_MSB_LSB_N (PADDING_TO_MSB_LSB_N),
     .NUM_PROFILES(1)
   ) i_regmap (
     .s_axi_aclk (s_axi_aclk),
@@ -248,11 +250,15 @@ module ad_ip_jesd204_tpl_dac #(
 
   );
 
-  // Drop DMA padding bits from the MSB
+  // Drop DMA padding bits from the LSB or MSB based on configuration
   integer i;
   always @(*) begin
     for (i=0;i<NUM_CHANNELS*DATA_PATH_WIDTH;i=i+1) begin
-      dac_ddata_cr[i*BITS_PER_SAMPLE +: BITS_PER_SAMPLE] = dac_ddata[i*DMA_BITS_PER_SAMPLE +: BITS_PER_SAMPLE];
+      if (PADDING_TO_MSB_LSB_N==1) begin
+        dac_ddata_cr[i*BITS_PER_SAMPLE +: BITS_PER_SAMPLE] = dac_ddata[i*DMA_BITS_PER_SAMPLE +: BITS_PER_SAMPLE];
+      end else begin
+        dac_ddata_cr[i*BITS_PER_SAMPLE +: BITS_PER_SAMPLE] = dac_ddata[((i+1)*DMA_BITS_PER_SAMPLE)-1 -: BITS_PER_SAMPLE];
+      end
     end
   end
 

--- a/library/jesd204/ad_ip_jesd204_tpl_dac/ad_ip_jesd204_tpl_dac_regmap.v
+++ b/library/jesd204/ad_ip_jesd204_tpl_dac/ad_ip_jesd204_tpl_dac_regmap.v
@@ -34,6 +34,7 @@ module ad_ip_jesd204_tpl_dac_regmap #(
   parameter DEV_PACKAGE = 0,
   parameter NUM_CHANNELS = 2,
   parameter DATA_PATH_WIDTH = 16,
+  parameter PADDING_TO_MSB_LSB_N = 0,
   parameter NUM_PROFILES = 1    // Number of supported JESD profiles
 ) (
   input s_axi_aclk,
@@ -188,7 +189,8 @@ module ad_ip_jesd204_tpl_dac_regmap #(
 
   // dac common processor interface
   //
-  localparam CONFIG = (XBAR_ENABLE << 10) |
+  localparam CONFIG = (PADDING_TO_MSB_LSB_N << 11) |
+                      (XBAR_ENABLE << 10) |
                       (DATAPATH_DISABLE << 6) |
                       (IQCORRECTION_DISABLE << 0);
 

--- a/library/jesd204/ad_ip_jesd204_tpl_dac/ad_ip_jesd204_tpl_dac_regmap.v
+++ b/library/jesd204/ad_ip_jesd204_tpl_dac/ad_ip_jesd204_tpl_dac_regmap.v
@@ -188,8 +188,8 @@ module ad_ip_jesd204_tpl_dac_regmap #(
 
   // dac common processor interface
   //
-  localparam CONFIG = (XBAR_ENABLE << 10) ||
-                      (DATAPATH_DISABLE << 6) ||
+  localparam CONFIG = (XBAR_ENABLE << 10) |
+                      (DATAPATH_DISABLE << 6) |
                       (IQCORRECTION_DISABLE << 0);
 
   up_dac_common #(

--- a/library/jesd204/jesd204_rx/jesd204_rx.v
+++ b/library/jesd204/jesd204_rx/jesd204_rx.v
@@ -48,6 +48,7 @@ module jesd204_rx #(
   parameter NUM_LANES = 1,
   parameter NUM_LINKS = 1,
   parameter NUM_INPUT_PIPELINE = 1,
+  parameter NUM_OUTPUT_PIPELINE = 1,
   parameter LINK_MODE = 1, // 2 - 64B/66B;  1 - 8B/10B
   /* Only 4 is supported at the moment for 8b/10b and 8 for 64b */
   parameter DATA_PATH_WIDTH = LINK_MODE == 2 ? 8 : 4,
@@ -262,7 +263,7 @@ pipeline_stage #(
 
 pipeline_stage #(
   .WIDTH(ODW+2),
-  .REGISTERED(1)
+  .REGISTERED(NUM_OUTPUT_PIPELINE)
 ) i_output_pipeline_stage (
   .clk(device_clk),
   .in({

--- a/library/jesd204/jesd204_rx/jesd204_rx_constr.ttcl
+++ b/library/jesd204/jesd204_rx/jesd204_rx_constr.ttcl
@@ -61,6 +61,10 @@ set_property IOB <=: $sysref_iob :> \
 
 <: if {$async_clk} { :>
 
+set_property ASYNC_REG TRUE \
+  [get_cells {i_lmfc/cdc_sync_stage1_reg}] \
+  [get_cells {i_lmfc/cdc_sync_stage1_reg}]
+
 set link_clk [get_clocks -of_objects [get_ports -quiet {clk}]]
 set device_clk [get_clocks -of_objects [get_ports -quiet {device_clk}]]
 
@@ -70,15 +74,39 @@ set_false_path \
   -to [get_cells -quiet -hier *cdc_sync_stage1_reg* \
     -filter {NAME =~ *i_all_buffer_ready_cdc* && IS_SEQUENTIAL}]
 
+set_property ASYNC_REG TRUE \
+      [get_cells -quiet -hier *cdc_sync_stage1_reg* \
+    -filter {NAME =~ *i_all_buffer_ready_cdc* && IS_SEQUENTIAL}]
+
+set_property ASYNC_REG TRUE \
+      [get_cells -quiet -hier *cdc_sync_stage2_reg* \
+    -filter {NAME =~ *i_all_buffer_ready_cdc* && IS_SEQUENTIAL}]
+
 # sync event i_sync_lmfc
 set_false_path -quiet \
   -from $device_clk \
   -to [get_cells -quiet -hier *cdc_sync_stage1_reg* \
     -filter {NAME =~ *i_sync_lmfc/i_sync_out* && IS_SEQUENTIAL}]
 
+set_property ASYNC_REG TRUE \
+   [get_cells -quiet -hier *cdc_sync_stage1_reg* \
+    -filter {NAME =~ *i_sync_lmfc/i_sync_out* && IS_SEQUENTIAL}]
+
+set_property ASYNC_REG TRUE \
+   [get_cells -quiet -hier *cdc_sync_stage2_reg* \
+    -filter {NAME =~ *i_sync_lmfc/i_sync_out* && IS_SEQUENTIAL}]
+
 set_false_path -quiet \
   -from $link_clk \
   -to [get_cells -quiet -hier *cdc_sync_stage1_reg* \
+    -filter {NAME =~ *i_sync_lmfc/i_sync_in* && IS_SEQUENTIAL}]
+
+set_property ASYNC_REG TRUE \
+   [get_cells -quiet -hier *cdc_sync_stage1_reg* \
+    -filter {NAME =~ *i_sync_lmfc/i_sync_in* && IS_SEQUENTIAL}]
+
+set_property ASYNC_REG TRUE \
+   [get_cells -quiet -hier *cdc_sync_stage2_reg* \
     -filter {NAME =~ *i_sync_lmfc/i_sync_in* && IS_SEQUENTIAL}]
 
 # elastic buffer distributed RAM
@@ -92,6 +120,14 @@ set_false_path -quiet \
 set_false_path \
   -from $device_clk \
   -to [get_cells -quiet -hier *cdc_sync_stage1_reg* \
+    -filter {NAME =~ *i_buffer_release_cdc* && IS_SEQUENTIAL}]
+
+set_property ASYNC_REG TRUE \
+   [get_cells -quiet -hier *cdc_sync_stage1_reg* \
+    -filter {NAME =~ *i_buffer_release_cdc* && IS_SEQUENTIAL}]
+
+set_property ASYNC_REG TRUE \
+   [get_cells -quiet -hier *cdc_sync_stage2_reg* \
     -filter {NAME =~ *i_buffer_release_cdc* && IS_SEQUENTIAL}]
 <: } :>
 

--- a/library/jesd204/jesd204_rx/jesd204_rx_lane_64b.v
+++ b/library/jesd204/jesd204_rx/jesd204_rx_lane_64b.v
@@ -131,7 +131,7 @@ jesd204_rx_header i_rx_header (
 
 jesd204_crc12 i_crc12 (
   .clk(clk),
-  .reset(reset),
+  .reset(1'b0),
   .init(eomb),
   .data_in(phy_data),
   .crc12(crc12_calculated)
@@ -187,7 +187,7 @@ jesd204_scrambler_64b #(
   .DESCRAMBLE(1)
 ) i_descrambler (
   .clk(clk),
-  .reset(reset),
+  .reset(1'b0),
   .enable(~cfg_disable_scrambler),
   .data_in(phy_data),
   .data_out(data_descrambled_s)

--- a/library/jesd204/jesd204_tx/jesd204_tx_lane_64b.v
+++ b/library/jesd204/jesd204_tx/jesd204_tx_lane_64b.v
@@ -89,7 +89,7 @@ jesd204_scrambler_64b #(
   .DESCRAMBLE(0)
 ) i_scrambler (
   .clk(clk),
-  .reset(reset),
+  .reset(1'b0),
   .enable(~cfg_disable_scrambler),
   .data_in(tx_data_msb_s),
   .data_out(scrambled_data_r)


### PR DESCRIPTION
This series of fixes tries to address timing closure issues seen on larger designs like QuadMxFE on N' 12 and lane rate of 24.75Gbps setups where also the datapath increases.
- make non essential features opt-in to reduce resource usage
- reduce fanout of asynchronous reset signals
- add pipeline registers
- add ASYNC_REG to double synchronizers
- adjust padding for N'=12 in the DAC TPL to match fmcomms2 like sample arrangement

Tested with QuadMxFE + VCU118