### PR TITLE
M2k advanced trigger updates

### DIFF
--- a/library/axi_dac_interpolate/axi_dac_interpolate.v
+++ b/library/axi_dac_interpolate/axi_dac_interpolate.v
@@ -147,7 +147,7 @@ module axi_dac_interpolate #(
 
   wire              trigger_active;
   wire              trigger;
-  wire              ext_trigger;
+  wire    [ 1:0]    ext_trigger;
 
   wire              underflow_a;
   wire              underflow_b;
@@ -175,15 +175,15 @@ module axi_dac_interpolate #(
   assign en_trigger_la    = trigger_config[19];
 
   assign trigger_active = |trigger_config[19:16];
-  assign trigger = (ext_trigger & en_trigger_pins) |
+  assign trigger = (|(ext_trigger & en_trigger_pins)) |
                    (trigger_adc_m2 & en_trigger_adc) |
                    (trigger_la_m2 & en_trigger_la);
 
-  assign ext_trigger = |(any_edge_trigger |
-                        rise_edge_trigger |
-                        fall_edge_trigger |
-                        high_level_trigger |
-                        low_level_trigger);
+  assign ext_trigger = any_edge_trigger |
+                       rise_edge_trigger |
+                       fall_edge_trigger |
+                       high_level_trigger |
+                       low_level_trigger;
 
   // sync
   always @(posedge dac_clk) begin

--- a/library/axi_dac_interpolate/axi_dac_interpolate.v
+++ b/library/axi_dac_interpolate/axi_dac_interpolate.v
@@ -51,6 +51,8 @@ module axi_dac_interpolate #(
   input                 dma_valid_b,
   output                dma_ready_a,
   output                dma_ready_b,
+  input                 last_a,
+  input                 last_b,
 
   input                 dac_enable_a,
   input                 dac_enable_b,
@@ -154,6 +156,7 @@ module axi_dac_interpolate #(
 
   wire    [ 1:0]    lsample_hold_config;
   wire              sync_stop_channels;
+  wire              rearme_after_buffer;
 
   // signal name changes
 
@@ -168,6 +171,7 @@ module axi_dac_interpolate #(
   assign rise_edge  = trigger_config[7:6];
   assign fall_edge  = trigger_config[9:8];
 
+  assign rearme_after_buffer = trigger_config[13];
   assign en_start_trigger = trigger_config[14];
   assign en_stop_trigger  = trigger_config[15];
   assign en_trigger_pins  = trigger_config[17:16];
@@ -226,6 +230,7 @@ module axi_dac_interpolate #(
     .dac_int_data (dac_int_data_a),
     .dma_ready (dma_ready_a),
     .underflow (underflow_a),
+    .last_sample(last_a),
 
     .filter_mask (filter_mask_a),
     .interpolation_ratio (interpolation_ratio_a),
@@ -235,6 +240,7 @@ module axi_dac_interpolate #(
     .trigger_active (trigger_active),
     .en_start_trigger (en_start_trigger),
     .en_stop_trigger (en_stop_trigger),
+    .rearme_after_buffer (rearme_after_buffer),
     .dma_valid (dma_valid_a),
     .dma_valid_adjacent (dma_valid_b),
     .dac_correction_enable(dac_correction_enable_a),
@@ -252,6 +258,7 @@ module axi_dac_interpolate #(
     .dac_valid_out (dac_valid_out_b),
     .sync_stop_channels (sync_stop_channels),
     .underflow (underflow_b),
+    .last_sample(last_b),
 
     .dac_enable (dac_enable_b),
     .dac_int_data (dac_int_data_b),
@@ -265,6 +272,7 @@ module axi_dac_interpolate #(
     .trigger_active (trigger_active),
     .en_start_trigger (en_start_trigger),
     .en_stop_trigger (en_stop_trigger),
+    .rearme_after_buffer (rearme_after_buffer),
     .dma_valid (dma_valid_b),
     .dma_valid_adjacent (dma_valid_a),
     .dac_correction_enable(dac_correction_enable_b),

--- a/library/axi_dac_interpolate/axi_dac_interpolate_filter.v
+++ b/library/axi_dac_interpolate/axi_dac_interpolate_filter.v
@@ -134,7 +134,8 @@ module axi_dac_interpolate_filter #(
                              dma_valid & dma_valid_adjacent & !dma_transfer_suspend :
                              dma_valid & !dma_transfer_suspend;
 
-  assign dma_valid_ch = dma_valid_ch_sync;
+  assign dma_valid_ch = dma_valid_ch_sync & transmit_ready;
+
   always @(posedge dac_clk) begin
     if (dac_rst == 1'b1) begin
       dma_valid_m <= 'd0;

--- a/library/axi_dac_interpolate/axi_dac_interpolate_filter.v
+++ b/library/axi_dac_interpolate/axi_dac_interpolate_filter.v
@@ -52,6 +52,7 @@ module axi_dac_interpolate_filter #(
   output                dac_valid_out,
   input                 sync_stop_channels,
   output                underflow,
+  input                 last_sample,
 
   input       [ 2:0]    filter_mask,
   input       [31:0]    interpolation_ratio,
@@ -63,6 +64,7 @@ module axi_dac_interpolate_filter #(
   input                 trigger_active,
   input                 en_start_trigger,
   input                 en_stop_trigger,
+  input                 rearme_after_buffer,
   input                 dma_valid,
   input                 dma_valid_adjacent
 );
@@ -173,6 +175,8 @@ module axi_dac_interpolate_filter #(
     end
   end
 
+  assign rearme_trigger = last_sample & rearme_after_buffer;
+
   always @(posedge dac_clk) begin
     if (dma_transfer_suspend == 1'b1 || rearme_trigger == 1'b1) begin
       transfer <= 1'b0;
@@ -180,8 +184,6 @@ module axi_dac_interpolate_filter #(
       transfer <= trigger ? 1'b0 : transfer;
     end else begin
       transfer <= trigger ? 1'b1 : transfer | !(trigger_active & en_start_trigger);
-    end else begin
-      transfer <= 1'b0;
     end
 
     if (start_sync_channels == 1'b0) begin

--- a/library/axi_dac_interpolate/axi_dac_interpolate_filter.v
+++ b/library/axi_dac_interpolate/axi_dac_interpolate_filter.v
@@ -103,7 +103,7 @@ module axi_dac_interpolate_filter #(
     .SCALE_ONLY(1))
   i_ad_iqcor (
     .clk (dac_clk),
-    .valid (dac_valid),
+    .valid (dma_valid & dac_valid),
     .data_in (dac_data),
     .data_iq (16'h0),
     .valid_out (dac_valid_corrected),

--- a/library/axi_dac_interpolate/axi_dac_interpolate_reg.v
+++ b/library/axi_dac_interpolate/axi_dac_interpolate_reg.v
@@ -77,7 +77,7 @@ module axi_dac_interpolate_reg(
   reg     [1:0]   up_config = 2'h0;
   reg     [15:0]  up_correction_coefficient_a = 16'h0;
   reg     [15:0]  up_correction_coefficient_b = 16'h0;
-  reg     [19:0]  up_trigger_config = 20'h0;
+  reg     [19:0]  up_trigger_config = 20'h4000;
   reg     [ 1:0]  up_lsample_hold_config = 2'h0;
 
   wire    [ 1:0]  flags;
@@ -97,7 +97,7 @@ module axi_dac_interpolate_reg(
       up_config <= 'd0;
       up_correction_coefficient_a <= 'd0;
       up_correction_coefficient_b <= 'd0;
-      up_trigger_config <= 'd0;
+      up_trigger_config <= 20'h4000;
       up_lsample_hold_config <= 'h0;
     end else begin
       up_wack <= up_wreq;

--- a/library/axi_logic_analyzer/axi_logic_analyzer.v
+++ b/library/axi_logic_analyzer/axi_logic_analyzer.v
@@ -171,7 +171,7 @@ module axi_logic_analyzer (
   wire    [ 1:0]    pg_en_trigger_pins;
   wire              pg_en_trigger_adc;
   wire              pg_en_trigger_la;
-
+  wire    [ 1:0]    ext_trigger;
   wire    [ 1:0]    pg_low_level;
   wire    [ 1:0]    pg_high_level;
   wire    [ 1:0]    pg_any_edge;
@@ -349,15 +349,15 @@ module axi_logic_analyzer (
   assign pg_en_trigger_la   = pg_trigger_config[19];
 
   assign trigger_active = |pg_trigger_config[19:16];
-  assign trigger = (ext_trigger & pg_en_trigger_pins) |
+  assign trigger = (|(ext_trigger) & pg_en_trigger_pins) |
                    (trigger_adc_m2 & pg_en_trigger_adc) |
                    (trigger_out_s & pg_en_trigger_la);
 
-  assign ext_trigger = |(any_edge_trigger |
-                        rise_edge_trigger |
-                        fall_edge_trigger |
-                        high_level_trigger |
-                        low_level_trigger);
+  assign ext_trigger = any_edge_trigger |
+                       rise_edge_trigger |
+                       fall_edge_trigger |
+                       high_level_trigger |
+                       low_level_trigger;
 
   // sync
   always @(posedge clk) begin

--- a/library/scripts/adi_ip_xilinx.tcl
+++ b/library/scripts/adi_ip_xilinx.tcl
@@ -4,7 +4,7 @@ source $ad_hdl_dir/library/scripts/adi_xilinx_device_info_enc.tcl
 # check tool version
 
 if {![info exists REQUIRED_VIVADO_VERSION]} {
-  set REQUIRED_VIVADO_VERSION "2020.1"
+  set REQUIRED_VIVADO_VERSION "2019.1"
 }
 
 if {[info exists ::env(ADI_IGNORE_VERSION_CHECK)]} {

--- a/projects/m2k/common/m2k_bd.tcl
+++ b/projects/m2k/common/m2k_bd.tcl
@@ -249,10 +249,12 @@ ad_connect ad9963_dac_dmac_b/m_axis_aclk axi_ad9963/dac_clk
 ad_connect axi_dac_interpolate/dac_data_a     ad9963_dac_dmac_a/m_axis_data
 ad_connect axi_dac_interpolate/dma_ready_a    ad9963_dac_dmac_a/m_axis_ready
 ad_connect axi_dac_interpolate/dac_enable_a   axi_ad9963/dac_enable_i
+ad_connect axi_dac_interpolate/last_a         ad9963_dac_dmac_a/m_axis_last
 ad_connect ad9963_dac_dmac_a/m_axis_valid     axi_dac_interpolate/dma_valid_a
 ad_connect axi_dac_interpolate/dac_data_b     ad9963_dac_dmac_b/m_axis_data
 ad_connect axi_dac_interpolate/dma_ready_b    ad9963_dac_dmac_b/m_axis_ready
 ad_connect axi_dac_interpolate/dac_enable_b   axi_ad9963/dac_enable_q
+ad_connect axi_dac_interpolate/last_b         ad9963_dac_dmac_b/m_axis_last
 ad_connect ad9963_dac_dmac_b/m_axis_valid     axi_dac_interpolate/dma_valid_b
 
 ad_connect axi_dac_interpolate/trigger_i   trigger_i

--- a/projects/scripts/adi_project_xilinx.tcl
+++ b/projects/scripts/adi_project_xilinx.tcl
@@ -1,7 +1,7 @@
 
 ## Define the supported tool version
 if {![info exists REQUIRED_VIVADO_VERSION]} {
-  set REQUIRED_VIVADO_VERSION "2020.1"
+  set REQUIRED_VIVADO_VERSION "2019.1"
 }
 
 ## Define the ADI_IGNORE_VERSION_CHECK environment variable to skip version check
@@ -409,10 +409,10 @@ proc adi_project_run {project_name} {
   set timing_string $[report_timing_summary -return_string]
   if { [string match "*VIOLATED*" $timing_string] == 1 ||
        [string match "*Timing constraints are not met*" $timing_string] == 1} {
-    write_hw_platform -fixed -force  -include_bit -file $project_name.sdk/system_top_bad_timing.xsa
+    file copy -force $project_name.runs/impl_1/system_top.sysdef $project_name.sdk/system_top_bad_timing.hdf
     return -code error [format "ERROR: Timing Constraints NOT met!"]
   } else {
-    write_hw_platform -fixed -force  -include_bit -file $project_name.sdk/system_top.xsa
+    file copy -force $project_name.runs/impl_1/system_top.sysdef $project_name.sdk/system_top.hdf
   }
 }
 


### PR DESCRIPTION
- fix TO as input trigger on both DAC and Pattern Generator
- set the default value as start only, for the DAC transfer start/pause trigger behavior 
- support wait for trigger on non cyclic buffers(waiting for test results)
- integrate the last sample hold logic with the trigger pause.

Tested on m2k.