### PR TITLE
xilinx/axi_adxcvr: Increase version to 17.02.a to show PRBS capability

### DIFF
--- a/library/xilinx/axi_adxcvr/axi_adxcvr_up.v
+++ b/library/xilinx/axi_adxcvr/axi_adxcvr_up.v
@@ -290,7 +290,7 @@ module axi_adxcvr_up #(
       if ((up_wreq == 1'b1) && (up_waddr == 10'h060)) begin
         up_prbssel <= up_wdata[3:0];
         up_prbscntreset <= up_wdata[8];
-        up_prbsforceerr <= up_wdata[15];
+        up_prbsforceerr <= up_wdata[16];
       end
     end
   end

--- a/library/xilinx/axi_adxcvr/axi_adxcvr_up.v
+++ b/library/xilinx/axi_adxcvr/axi_adxcvr_up.v
@@ -130,7 +130,7 @@ module axi_adxcvr_up #(
 
   // parameters
 
-  localparam  [31:0]  VERSION = 32'h00110161;
+  localparam  [31:0]  VERSION = 32'h00110261;
 
   // internal registers
 


### PR DESCRIPTION
Forgot to increase version when I added PRBS support. Software needs it so it can discover the capability.