### PR TITLE
jesd204_rx_constr.ttcl: Remove ASYNC_REG from i_lmfc/cdc_sync_stage1_reg

### DIFF
--- a/library/jesd204/jesd204_rx/jesd204_rx_constr.ttcl
+++ b/library/jesd204/jesd204_rx/jesd204_rx_constr.ttcl
@@ -61,10 +61,6 @@ set_property IOB <=: $sysref_iob :> \
 
 <: if {$async_clk} { :>
 
-set_property ASYNC_REG TRUE \
-  [get_cells {i_lmfc/cdc_sync_stage1_reg}] \
-  [get_cells {i_lmfc/cdc_sync_stage1_reg}]
-
 set link_clk [get_clocks -of_objects [get_ports -quiet {clk}]]
 set device_clk [get_clocks -of_objects [get_ports -quiet {device_clk}]]
 


### PR DESCRIPTION
get_cell on i_lmfc/cdc_sync_stage1_reg doesn't return anything because design was updated.
This generates a CRITICAL WARNING and since the constraint it not necessary anymore, it can be deleted.