### PR TITLE
Dev axi pwm gen

### DIFF
--- a/library/axi_pulse_gen/axi_pulse_gen.v
+++ b/library/axi_pulse_gen/axi_pulse_gen.v
@@ -129,6 +129,7 @@ module axi_pulse_gen #(
     .pulse_width (pulse_width_s),
     .pulse_period (pulse_period_s),
     .load_config (load_config_s),
+    .sync (1'b0),
     .pulse (pulse));
 
   up_axi #(

--- a/library/axi_pwm_gen/Makefile
+++ b/library/axi_pwm_gen/Makefile
@@ -1,0 +1,20 @@
+####################################################################################
+## Copyright 2018(c) Analog Devices, Inc.
+## Auto-generated, do not modify!
+####################################################################################
+
+LIBRARY_NAME := axi_pwm_gen
+
+GENERIC_DEPS += ../common/ad_rst.v
+GENERIC_DEPS += ../common/up_axi.v
+GENERIC_DEPS += axi_pwm_gen.v
+GENERIC_DEPS += axi_pwm_gen_1.v
+GENERIC_DEPS += axi_pwm_gen_regmap.v
+
+XILINX_DEPS += ../xilinx/common/ad_rst_constr.xdc
+XILINX_DEPS += axi_pwm_gen_constr.ttcl
+XILINX_DEPS += axi_pwm_gen_ip.tcl
+
+XILINX_LIB_DEPS += util_cdc
+
+include ../scripts/library.mk

--- a/library/axi_pwm_gen/axi_pwm_gen.v
+++ b/library/axi_pwm_gen/axi_pwm_gen.v
@@ -1,0 +1,337 @@
+// ***************************************************************************
+// ***************************************************************************
+// Copyright 2014 - 2019 (c) Analog Devices, Inc. All rights reserved.
+//
+// In this HDL repository, there are many different and unique modules, consisting
+// of various HDL (Verilog or VHDL) components. The individual modules are
+// developed independently, and may be accompanied by separate and unique license
+// terms.
+//
+// The user should read each of these license terms, and understand the
+// freedoms and responsibilities that he or she has by using this source/core.
+//
+// This core is distributed in the hope that it will be useful, but WITHOUT ANY
+// WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+// A PARTICULAR PURPOSE.
+//
+// Redistribution and use of source or resulting binaries, with or without modification
+// of this file, are permitted under one of the following two license terms:
+//
+//   1. The GNU General Public License version 2 as published by the
+//      Free Software Foundation, which can be found in the top level directory
+//      of this repository (LICENSE_GPL2), and also online at:
+//      <https://www.gnu.org/licenses/old-licenses/gpl-2.0.html>
+//
+// OR
+//
+//   2. An ADI specific BSD license, which can be found in the top level directory
+//      of this repository (LICENSE_ADIBSD), and also on-line at:
+//      https://github.com/analogdevicesinc/hdl/blob/master/LICENSE_ADIBSD
+//      This will allow to generate bit files and not release the source code,
+//      as long as it attaches to an ADI device.
+//
+// ***************************************************************************
+// ***************************************************************************
+`timescale 1ns/100ps
+
+module axi_pwm_gen #(
+
+  parameter  ID = 0,
+  parameter  ASYNC_CLK_EN = 1,
+  parameter  N_PWMS = 1,
+  parameter  PWM_0_EXT_SYNC = 0,
+  parameter  EXT_ASYNC_SYNC = 0,
+  parameter  PULSE_0_WIDTH = 7,
+  parameter  PULSE_1_WIDTH = 7,
+  parameter  PULSE_2_WIDTH = 7,
+  parameter  PULSE_3_WIDTH = 7,
+  parameter  PULSE_0_PERIOD = 10,
+  parameter  PULSE_1_PERIOD = 10,
+  parameter  PULSE_2_PERIOD = 10,
+  parameter  PULSE_3_PERIOD = 10,
+  parameter  PULSE_1_OFFSET = 0,
+  parameter  PULSE_2_OFFSET = 0,
+  parameter  PULSE_3_OFFSET = 0)(
+
+  // axi interface
+
+  input                   s_axi_aclk,
+  input                   s_axi_aresetn,
+  input                   s_axi_awvalid,
+  input       [15:0]      s_axi_awaddr,
+  input       [ 2:0]      s_axi_awprot,
+  output                  s_axi_awready,
+  input                   s_axi_wvalid,
+  input       [31:0]      s_axi_wdata,
+  input       [ 3:0]      s_axi_wstrb,
+  output                  s_axi_wready,
+  output                  s_axi_bvalid,
+  output      [ 1:0]      s_axi_bresp,
+  input                   s_axi_bready,
+  input                   s_axi_arvalid,
+  input       [15:0]      s_axi_araddr,
+  input       [ 2:0]      s_axi_arprot,
+  output                  s_axi_arready,
+  output                  s_axi_rvalid,
+  output      [ 1:0]      s_axi_rresp,
+  output      [31:0]      s_axi_rdata,
+  input                   s_axi_rready,
+  input                   ext_clk,
+  input                   ext_sync,
+
+  output                  pwm_0,
+  output                  pwm_1,
+  output                  pwm_2,
+  output                  pwm_3);
+
+  // local parameters
+
+  localparam [31:0] CORE_VERSION = {16'h0001,     /* MAJOR */
+                                     8'h00,       /* MINOR */
+                                     8'h00};      /* PATCH */
+  localparam [31:0] CORE_MAGIC = 32'h601a3471;    // PLSG
+
+  // internal registers
+
+  reg             sync_0;
+  reg             sync_1;
+  reg             sync_2;
+  reg             sync_3;
+  reg             sync_active_0;
+  reg             sync_active_1;
+  reg             sync_active_2;
+  reg             sync_active_3;
+
+  // internal signals
+
+  wire            clk;
+  wire            up_clk;
+  wire            up_rstn;
+  wire            up_rreq_s;
+  wire            up_wack_s;
+  wire            up_rack_s;
+  wire   [ 13:0]  up_raddr_s;
+  wire   [ 31:0]  up_rdata_s;
+  wire            up_wreq_s;
+  wire   [ 13:0]  up_waddr_s;
+  wire   [ 31:0]  up_wdata_s;
+  wire   [127:0]  pwm_width_s;
+  wire   [127:0]  pwm_period_s;
+  wire   [127:0]  pwm_offset_s;
+  wire   [ 31:0]  pwm_counter[0:N_PWMS-1];
+  wire            load_config_s;
+  wire            pwm_gen_resetn;
+  wire            ext_sync_s;
+
+  assign up_clk = s_axi_aclk;
+  assign up_rstn = s_axi_aresetn;
+
+  axi_pwm_gen_regmap #(
+    .ID (ID),
+    .ASYNC_CLK_EN (ASYNC_CLK_EN),
+    .CORE_MAGIC (CORE_MAGIC),
+    .CORE_VERSION (CORE_VERSION),
+    .N_PWMS (N_PWMS),
+    .PULSE_0_WIDTH (PULSE_0_WIDTH),
+    .PULSE_1_WIDTH (PULSE_1_WIDTH),
+    .PULSE_2_WIDTH (PULSE_2_WIDTH),
+    .PULSE_3_WIDTH (PULSE_3_WIDTH),
+    .PULSE_0_PERIOD (PULSE_0_PERIOD),
+    .PULSE_1_PERIOD (PULSE_1_PERIOD),
+    .PULSE_2_PERIOD (PULSE_2_PERIOD),
+    .PULSE_3_PERIOD (PULSE_3_PERIOD),
+    .PULSE_1_OFFSET (PULSE_1_OFFSET),
+    .PULSE_2_OFFSET (PULSE_2_OFFSET),
+    .PULSE_3_OFFSET (PULSE_3_OFFSET))
+  i_regmap (
+    .ext_clk (ext_clk),
+    .clk_out (clk),
+    .pwm_gen_resetn (pwm_gen_resetn),
+    .pwm_width (pwm_width_s),
+    .pwm_period (pwm_period_s),
+    .pwm_offset (pwm_offset_s),
+    .load_config (load_config_s),
+    .up_rstn (up_rstn),
+    .up_clk (up_clk),
+    .up_wreq (up_wreq_s),
+    .up_waddr (up_waddr_s),
+    .up_wdata (up_wdata_s),
+    .up_wack (up_wack_s),
+    .up_rreq (up_rreq_s),
+    .up_raddr (up_raddr_s),
+    .up_rdata (up_rdata_s),
+    .up_rack (up_rack_s));
+
+  axi_pwm_gen_1  #(
+    .PULSE_WIDTH (PULSE_0_WIDTH),
+    .PULSE_PERIOD (PULSE_0_PERIOD))
+  i0_axi_pwm_gen_1(
+    .clk (clk),
+    .rstn (pwm_gen_resetn),
+    .pulse_width (pwm_width_s[31:0]),
+    .pulse_period (pwm_period_s[31:0]),
+    .load_config (load_config_s),
+    .sync (sync_0),
+    .pulse (pwm_0),
+    .pulse_counter (pwm_counter[0]));
+
+  always @(posedge clk) begin
+    if (pwm_gen_resetn == 1'b0) begin
+      sync_active_0 <= 1'b1;
+      sync_0 <= 1'b1;
+    end else begin
+      sync_active_0 <= PWM_0_EXT_SYNC;
+      if (sync_active_0) begin
+        sync_0 <= ext_sync_s;
+      end else begin
+        sync_0 <= 1'b0;
+      end
+    end
+  end
+
+  generate
+
+    reg ext_sync_m0 = 1'b1;
+    reg ext_sync_m1 = 1'b1;
+
+    if (EXT_ASYNC_SYNC) begin
+      always @(posedge clk) begin
+        if (pwm_gen_resetn == 1'b0) begin
+          ext_sync_m0 <=  1'b1;
+          ext_sync_m1 <=  1'b1;
+        end else begin
+          ext_sync_m0 <= ext_sync;
+          ext_sync_m1 <= ext_sync_m0;
+        end
+      end
+      assign ext_sync_s = ext_sync_m1;
+    end else begin
+      assign ext_sync_s = ext_sync;
+    end
+
+    if (N_PWMS >= 2) begin
+      axi_pwm_gen_1  #(
+        .PULSE_WIDTH (PULSE_1_WIDTH),
+        .PULSE_PERIOD (PULSE_1_PERIOD))
+      i1_axi_pwm_gen_1(
+        .clk (clk),
+        .rstn (pwm_gen_resetn),
+        .pulse_width (pwm_width_s[63:32]),
+        .pulse_period (pwm_period_s[63:32]),
+        .load_config (load_config_s),
+        .sync (sync_1),
+        .pulse (pwm_1),
+        .pulse_counter (pwm_counter[1]));
+
+      always @(posedge clk) begin
+        if (pwm_gen_resetn == 1'b0) begin
+          sync_active_1 <= 1'b1;
+          sync_1 <= 1'b1;
+        end else begin
+          sync_active_1 <= |pwm_offset_s[63:32];
+          if (sync_active_1) begin
+            sync_1 <= (pwm_counter[0] == pwm_offset_s[63:32]) ? 1'b0 : 1'b1;
+          end else begin
+            sync_1 <= 1'b0;
+          end
+        end
+      end
+    end else begin
+      assign pwm_1 = 1'b0;
+    end
+
+    if (N_PWMS >= 3) begin
+      axi_pwm_gen_1  #(
+        .PULSE_WIDTH (PULSE_2_WIDTH),
+        .PULSE_PERIOD (PULSE_2_PERIOD))
+      i2_axi_pwm_gen_1(
+        .clk (clk),
+        .rstn (pwm_gen_resetn),
+        .pulse_width (pwm_width_s[95:64]),
+        .pulse_period (pwm_period_s[95:64]),
+        .load_config (load_config_s),
+        .sync (sync_2),
+        .pulse (pwm_2),
+        .pulse_counter (pwm_counter[2]));
+
+      always @(posedge clk) begin
+        if (pwm_gen_resetn == 1'b0) begin
+          sync_active_2 <= 1'b1;
+          sync_2 <= 1'b1;
+        end else begin
+          sync_active_2 <= |pwm_offset_s[95:64];
+          if (sync_active_2) begin
+            sync_2 <= (pwm_counter[0] == pwm_offset_s[95:64]) ? 1'b0 : 1'b1;
+          end else begin
+            sync_2 <= 1'b0;
+          end
+        end
+      end
+    end else begin
+      assign pwm_2 = 1'b0;
+    end
+
+    if (N_PWMS >= 4) begin
+      axi_pwm_gen_1  #(
+        .PULSE_WIDTH (PULSE_3_WIDTH),
+        .PULSE_PERIOD (PULSE_3_PERIOD))
+      i3_axi_pwm_gen_1(
+        .clk (clk),
+        .rstn (pwm_gen_resetn),
+        .pulse_width (pwm_width_s[127:96]),
+        .pulse_period (pwm_period_s[127:96]),
+        .load_config (load_config_s),
+        .sync (sync_3),
+        .pulse (pwm_3),
+        .pulse_counter (pwm_counter[3]));
+
+      always @(posedge clk) begin
+        if (pwm_gen_resetn == 1'b0) begin
+          sync_active_3 <= 1'b1;
+          sync_3 <= 1'b1;
+        end else begin
+          sync_active_3 <= |pwm_offset_s[127:96];
+          if (sync_active_3) begin
+            sync_3 <= (pwm_counter[0] == pwm_offset_s[127:96]) ? 1'b0 : 1'b1;
+          end else begin
+            sync_3 <= 1'b0;
+          end
+        end
+      end
+    end else begin
+      assign pwm_3 = 1'b0;
+    end
+  endgenerate
+
+  up_axi #(
+    .AXI_ADDRESS_WIDTH(16))
+  i_up_axi (
+    .up_rstn (up_rstn),
+    .up_clk (up_clk),
+    .up_axi_awvalid (s_axi_awvalid),
+    .up_axi_awaddr (s_axi_awaddr),
+    .up_axi_awready (s_axi_awready),
+    .up_axi_wvalid (s_axi_wvalid),
+    .up_axi_wdata (s_axi_wdata),
+    .up_axi_wstrb (s_axi_wstrb),
+    .up_axi_wready (s_axi_wready),
+    .up_axi_bvalid (s_axi_bvalid),
+    .up_axi_bresp (s_axi_bresp),
+    .up_axi_bready (s_axi_bready),
+    .up_axi_arvalid (s_axi_arvalid),
+    .up_axi_araddr (s_axi_araddr),
+    .up_axi_arready (s_axi_arready),
+    .up_axi_rvalid (s_axi_rvalid),
+    .up_axi_rresp (s_axi_rresp),
+    .up_axi_rdata (s_axi_rdata),
+    .up_axi_rready (s_axi_rready),
+    .up_wreq (up_wreq_s),
+    .up_waddr (up_waddr_s),
+    .up_wdata (up_wdata_s),
+    .up_wack (up_wack_s),
+    .up_rreq (up_rreq_s),
+    .up_raddr (up_raddr_s),
+    .up_rdata (up_rdata_s),
+    .up_rack (up_rack_s));
+
+endmodule

--- a/library/axi_pwm_gen/axi_pwm_gen_1.v
+++ b/library/axi_pwm_gen/axi_pwm_gen_1.v
@@ -1,0 +1,140 @@
+// ***************************************************************************
+// ***************************************************************************
+// Copyright (c) Analog Devices, Inc. All rights reserved.
+//
+// In this HDL repository, there are many different and unique modules, consisting
+// of various HDL (Verilog or VHDL) components. The individual modules are
+// developed independently, and may be accompanied by separate and unique license
+// terms.
+//
+// The user should read each of these license terms, and understand the
+// freedoms and responsibilities that he or she has by using this source/core.
+//
+// This core is distributed in the hope that it will be useful, but WITHOUT ANY
+// WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+// A PARTICULAR PURPOSE.
+//
+// Redistribution and use of source or resulting binaries, with or without modification
+// of this file, are permitted under one of the following two license terms:
+//
+//   1. The GNU General Public License version 2 as published by the
+//      Free Software Foundation, which can be found in the top level directory
+//      of this repository (LICENSE_GPL2), and also online at:
+//      <https://www.gnu.org/licenses/old-licenses/gpl-2.0.html>
+//
+// OR
+//
+//   2. An ADI specific BSD license, which can be found in the top level directory
+//      of this repository (LICENSE_ADIBSD), and also on-line at:
+//      https://github.com/analogdevicesinc/hdl/blob/master/LICENSE_ADIBSD
+//      This will allow to generate bit files and not release the source code,
+//      as long as it attaches to an ADI device.
+//
+// ***************************************************************************
+// ***************************************************************************
+`timescale 1ns/1ps
+
+module axi_pwm_gen_1 #(
+
+  // the width and period are defined in number of clock cycles
+  parameter   PULSE_WIDTH = 7,
+  parameter   PULSE_PERIOD = 100000000) (
+
+  input               clk,
+  input               rstn,
+
+  input       [31:0]  pulse_width,
+  input       [31:0]  pulse_period,
+  input               load_config,
+  input               sync,
+
+  output  reg         pulse,
+  output      [31:0]  pulse_counter
+);
+
+  // internal registers
+
+  reg     [31:0]               pulse_period_cnt = 32'h0;
+  reg     [31:0]               pulse_period_read = 32'b0;
+  reg     [31:0]               pulse_width_read = 32'b0;
+  reg     [31:0]               pulse_period_d = 32'b0;
+  reg     [31:0]               pulse_width_d = 32'b0;
+  reg                          phase_align_armed = 1'b1;
+
+  // internal wires
+
+  wire                         phase_align;
+  wire                         end_of_period;
+  wire                         end_of_pulse;
+  wire                         pulse_enable;
+
+  // enable pwm
+
+  assign pulse_enable = (pulse_period_d != 32'd0) ? 1'b1 : 1'b0;
+
+  // flop the desired period
+
+  always @(posedge clk) begin
+    if (rstn == 1'b0) begin
+      pulse_period_d <= PULSE_PERIOD;
+      pulse_width_d <= PULSE_WIDTH;
+      pulse_period_read <= PULSE_PERIOD;
+      pulse_width_read <= PULSE_WIDTH;
+    end else begin
+      // load the input period/width values
+      if (load_config) begin
+        pulse_period_read <= pulse_period;
+        pulse_width_read <= pulse_width;
+      end
+      // update the current period/width at the end of the period
+      if (end_of_period | ~pulse_enable) begin
+        pulse_period_d <= pulse_period_read;
+        pulse_width_d <= pulse_width_read;
+      end
+    end
+  end
+
+  // phase align to the first sync pulse until another load_config
+
+  always @(posedge clk) begin
+    if (rstn == 1'b0) begin
+      phase_align_armed <= 1'b1;
+    end else begin
+      if (load_config == 1'b1) begin
+        phase_align_armed <= sync;
+      end else begin
+        phase_align_armed <= phase_align_armed & sync;
+      end
+    end
+  end
+
+  assign phase_align = phase_align_armed & sync;
+
+  // a free running counter
+
+  always @(posedge clk) begin
+    if (rstn == 1'b0 || phase_align == 1'b1 || end_of_period == 1'b1) begin
+      pulse_period_cnt <= 32'd1;
+    end else begin
+      if (pulse_enable == 1'b1) begin
+        pulse_period_cnt <= pulse_period_cnt + 1'b1;
+      end
+    end
+  end
+
+  assign end_of_period = (pulse_period_cnt == pulse_period_d) ? 1'b1 : 1'b0;
+  assign end_of_pulse = (pulse_period_cnt == pulse_width_d) ? 1'b1 : 1'b0;
+
+  // generate pulse with a specified width
+
+  always @ (posedge clk) begin
+    if ((rstn == 1'b0) || (phase_align == 1'b1) || (end_of_pulse == 1'b1)) begin
+      pulse <= 1'b0;
+    end else if (end_of_period == 1'b1 && pulse_enable == 1'b1) begin
+      pulse <= 1'b1;
+    end
+  end
+
+  assign pulse_counter = pulse_period_cnt;
+
+endmodule

--- a/library/axi_pwm_gen/axi_pwm_gen_constr.sdc
+++ b/library/axi_pwm_gen/axi_pwm_gen_constr.sdc
@@ -1,0 +1,4 @@
+
+set_false_path -to [get_registers *axi_pwm_gen_regmap*cdc_sync_stage1*]
+set_false_path -to [get_registers *axi_pwm_gen_regmap*sync_data*out_data*]
+

--- a/library/axi_pwm_gen/axi_pwm_gen_constr.ttcl
+++ b/library/axi_pwm_gen/axi_pwm_gen_constr.ttcl
@@ -1,0 +1,52 @@
+<: set ComponentName [getComponentNameString] :>
+<: setOutputDirectory "./" :>
+<: setFileName [ttcl_add $ComponentName "_constr"] :>
+<: setFileExtension ".xdc" :>
+<: setFileProcessingOrder late :>
+<: set async_clock [getBooleanValue "ASYNC_CLK_EN"] :>
+
+## False path definitions for ASYNC mode
+<: if { $async_clock } { :>
+
+set_property ASYNC_REG TRUE \
+  [get_cells -hier {*cdc_sync_stage1_reg*}] \
+  [get_cells -hier {*cdc_sync_stage2_reg*}]
+
+  set_false_path -from [get_cells -hierarchical * -filter {NAME=~*i_pwm_period_sync/cdc_hold_reg*}] \
+                 -to   [get_cells -hierarchical * -filter {NAME=~*i_pwm_period_sync/out_data_reg*}] \
+
+  set_false_path -from [get_cells -hierarchical * -filter {NAME=~*i_pwm_width_sync/cdc_hold_reg*}] \
+                 -to   [get_cells -hierarchical * -filter {NAME=~*i_pwm_width_sync/out_data_reg*}] \
+
+  set_false_path -from [get_cells -hierarchical * -filter {NAME=~*i_pwm_offset_sync/cdc_hold_reg*}] \
+                 -to   [get_cells -hierarchical * -filter {NAME=~*i_pwm_offset_sync/out_data_reg*}] \
+
+  set_false_path \
+    -from [get_pins -hierarchical * -filter {NAME=~*i_pwm_period_sync/out_toggle_d1_reg/C}] \
+    -to [get_pins -hierarchical * -filter {NAME=~*i_pwm_period_sync/i_sync_in/cdc_sync_stage1_reg[0]/D}]
+  set_false_path \
+    -from [get_pins -hierarchical * -filter {NAME=~*i_pwm_period_sync/in_toggle_d1_reg/C}] \
+    -to [get_pins -hierarchical * -filter {NAME=~*i_pwm_period_sync/i_sync_out/cdc_sync_stage1_reg[0]/D}]
+
+  set_false_path \
+    -from [get_pins -hierarchical * -filter {NAME=~*i_pwm_width_sync/out_toggle_d1_reg/C}] \
+    -to [get_pins -hierarchical * -filter {NAME=~*i_pwm_width_sync/i_sync_in/cdc_sync_stage1_reg[0]/D}]
+  set_false_path \
+    -from [get_pins -hierarchical * -filter {NAME=~*i_pwm_width_sync/in_toggle_d1_reg/C}] \
+    -to [get_pins -hierarchical * -filter {NAME=~*i_pwm_width_sync/i_sync_out/cdc_sync_stage1_reg[0]/D}]
+
+  set_false_path \
+    -from [get_pins -hierarchical * -filter {NAME=~*i_pwm_offset_sync/out_toggle_d1_reg/C}] \
+    -to [get_pins -hierarchical * -filter {NAME=~*i_pwm_offset_sync/i_sync_in/cdc_sync_stage1_reg[0]/D}]
+  set_false_path \
+    -from [get_pins -hierarchical * -filter {NAME=~*i_pwm_offset_sync/in_toggle_d1_reg/C}] \
+    -to [get_pins -hierarchical * -filter {NAME=~*i_pwm_offset_sync/i_sync_out/cdc_sync_stage1_reg[0]/D}]
+
+  set_false_path \
+    -from [get_pins -hierarchical * -filter {NAME=~*i_load_config_sync/out_toggle_d1_reg/C}] \
+    -to [get_pins -hierarchical * -filter {NAME=~*i_load_config_sync/i_sync_in/cdc_sync_stage1_reg[0]/D}]
+  set_false_path \
+    -from [get_pins -hierarchical * -filter {NAME=~*i_load_config_sync/in_toggle_d1_reg/C}] \
+    -to [get_pins -hierarchical * -filter {NAME=~*i_load_config_sync/i_sync_out/cdc_sync_stage1_reg[0]/D}]
+
+<: } :>

--- a/library/axi_pwm_gen/axi_pwm_gen_ip.tcl
+++ b/library/axi_pwm_gen/axi_pwm_gen_ip.tcl
@@ -1,0 +1,145 @@
+# ip
+
+source ../scripts/adi_env.tcl
+source $ad_hdl_dir/library/scripts/adi_ip_xilinx.tcl
+
+adi_ip_create axi_pwm_gen
+adi_ip_files axi_pwm_gen [list \
+  "$ad_hdl_dir/library/common/ad_rst.v" \
+  "$ad_hdl_dir/library/common/up_axi.v" \
+  "$ad_hdl_dir/library/xilinx/common/ad_rst_constr.xdc" \
+  "axi_pwm_gen_constr.ttcl" \
+  "axi_pwm_gen_regmap.v" \
+  "axi_pwm_gen_1.v" \
+  "axi_pwm_gen.v"]
+
+adi_ip_properties axi_pwm_gen
+adi_ip_ttcl axi_pwm_gen "axi_pwm_gen_constr.ttcl"
+
+adi_ip_add_core_dependencies { \
+	analog.com:user:util_cdc:1.0 \
+}
+
+set cc [ipx::current_core]
+
+set_property display_name "ADI AXI PWM Generator" $cc
+set_property description  "ADI AXI PWM Generator" $cc
+
+## define ext_clk port as a clock interface
+adi_add_bus ext_clk slave \
+  "xilinx.com:signal:clock_rtl:1.0" \
+  "xilinx.com:signal:clock:1.0" \
+  [list {"ext_clk" "CLK"} ]
+
+adi_set_ports_dependency "ext_clk" \
+  "(spirit:decode(id('MODELPARAM_VALUE.ASYNC_CLK_EN')) = 1)" 0
+
+## Parameter validation
+
+set_property -dict [list \
+  "value_format" "bool" \
+  "value" "true" \
+ ] \
+[ipx::get_user_parameters ASYNC_CLK_EN -of_objects $cc]
+
+set_property -dict [list \
+  "value_format" "bool" \
+  "value" "true" \
+ ] \
+[ipx::get_hdl_parameters ASYNC_CLK_EN -of_objects $cc]
+
+## Customize XGUI layout
+
+## Remove the automatically generated GUI page
+ipgui::remove_page -component $cc [ipgui::get_pagespec -name "Page 0" -component $cc]
+ipx::save_core $cc
+
+## Create a new GUI page
+
+ipgui::add_page -name {AXI PWM Generator} -component $cc -display_name {AXI PWM Generator}
+set page0 [ipgui::get_pagespec -name "AXI PWM Generator" -component $cc]
+
+ipgui::add_param -name "ASYNC_CLK_EN" -component $cc -parent $page0
+set_property -dict [list \
+  "display_name" "ASYNC_CLK_EN" \
+  "tooltip" "External clock for the counter" \
+  "widget" "checkBox" \
+] [ipgui::get_guiparamspec -name "ASYNC_CLK_EN" -component $cc]
+
+ipgui::add_param -name "EXT_ASYNC_SYNC" -component $cc -parent $page0
+set_property -dict [list \
+  "display_name" "External sync signal for pwm_0 is asynchronous" \
+  "tooltip" "NOTE: If active the ext_sync will be delayed 2 clock cycles." \
+  "widget" "checkBox" \
+] [ipgui::get_guiparamspec -name "EXT_ASYNC_SYNC" -component $cc]
+
+ipgui::add_param -name "N_PWMS" -component $cc -parent $page0
+set_property -dict [list \
+  "display_name" "Number of pwms" \
+] [ipgui::get_guiparamspec -name "N_PWMS" -component $cc]
+
+# Maximum 4 pwms
+for {set i 1} {$i < 4} {incr i} {
+  ipgui::add_param -name "PULSE_${i}_WIDTH" -component $cc -parent $page0
+  set_property -dict [list \
+    "display_name" "PULSE $i width" \
+    "tooltip" "PULSE width of the generated signal. The unit interval is the system or external clock period." \
+  ] [ipgui::get_guiparamspec -name "PULSE_${i}_WIDTH" -component $cc]
+
+  set_property -dict [list \
+    "value_validation_type" "range_long" \
+    "value_validation_range_minimum" "0" \
+    "value_validation_range_maximum" "2147483647" \
+   ] \
+  [ipx::get_user_parameters PULSE_${i}_WIDTH -of_objects $cc]
+
+  ipgui::add_param -name "PULSE_${i}_PERIOD" -component $cc -parent $page0
+  set_property -dict [list \
+    "display_name" "PULSE ${i} period" \
+    "tooltip" "Period of the generated signal. The unit interval is the system or external clock period." \
+  ] [ipgui::get_guiparamspec -name "PULSE_${i}_PERIOD" -component $cc]
+
+  set_property -dict [list \
+    "value_validation_type" "range_long" \
+    "value_validation_range_minimum" "0" \
+    "value_validation_range_maximum" "2147483647" \
+   ] \
+  [ipx::get_user_parameters PULSE_${i}_PERIOD -of_objects $cc]
+
+  if { $i == 1 } {
+    ipgui::add_param -name "PWM_0_EXT_SYNC" -component $cc -parent $page0
+    set_property -dict [list \
+      "display_name" "Main pwm(1) sync" \
+      "tooltip" "NOTE: If active the whole pwm gen module will be waiting for the ext_sync to be set high." \
+      "widget" "checkBox" \
+    ] [ipgui::get_guiparamspec -name "PWM_0_EXT_SYNC" -component $cc]
+  } else {
+    ipgui::add_param -name "PULSE_${i}_OFFSET" -component $cc -parent $page0
+    set_property -dict [list \
+      "display_name" "PULSE ${i} offset" \
+      "tooltip" "Offset of the generated signal referenced to PULSE 1. The unit interval is the system or external clock period." \
+    ] [ipgui::get_guiparamspec -name "PULSE_${i}_OFFSET" -component $cc]
+
+    set_property -dict [list \
+      "value_validation_type" "range_long" \
+      "value_validation_range_minimum" "0" \
+      "value_validation_range_maximum" "2147483647" \
+     ] \
+    [ipx::get_user_parameters PULSE_${i}_OFFSET -of_objects $cc]
+  }
+}
+
+for {set i 1} {$i < 4} {incr i} {
+	adi_set_ports_dependency "pwm_$i" \
+		"(spirit:decode(id('MODELPARAM_VALUE.N_PWMS')) > $i)"
+}
+
+adi_set_ports_dependency "ext_sync" \
+	"(spirit:decode(id('MODELPARAM_VALUE.PWM_0_EXT_SYNC')) == 1)"
+
+set_property driver_value 0 [ipx::get_ports -filter "direction==in" -of_objects $cc]
+
+## Save the modifications
+
+ipx::create_xgui_files $cc
+ipx::save_core $cc

--- a/library/axi_pwm_gen/axi_pwm_gen_regmap.v
+++ b/library/axi_pwm_gen/axi_pwm_gen_regmap.v
@@ -1,0 +1,272 @@
+// ***************************************************************************
+// ***************************************************************************
+// Copyright 2014 - 2019 (c) Analog Devices, Inc. All rights reserved.
+//
+// In this HDL repository, there are many different and unique modules, consisting
+// of various HDL (Verilog or VHDL) components. The individual modules are
+// developed independently, and may be accompanied by separate and unique license
+// terms.
+//
+// The user should read each of these license terms, and understand the
+// freedoms and responsibilities that he or she has by using this source/core.
+//
+// This core is distributed in the hope that it will be useful, but WITHOUT ANY
+// WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+// A PARTICULAR PURPOSE.
+//
+// Redistribution and use of source or resulting binaries, with or without modification
+// of this file, are permitted under one of the following two license terms:
+//
+//   1. The GNU General Public License version 2 as published by the
+//      Free Software Foundation, which can be found in the top level directory
+//      of this repository (LICENSE_GPL2), and also online at:
+//      <https://www.gnu.org/licenses/old-licenses/gpl-2.0.html>
+//
+// OR
+//
+//   2. An ADI specific BSD license, which can be found in the top level directory
+//      of this repository (LICENSE_ADIBSD), and also on-line at:
+//      https://github.com/analogdevicesinc/hdl/blob/master/LICENSE_ADIBSD
+//      This will allow to generate bit files and not release the source code,
+//      as long as it attaches to an ADI device.
+//
+// ***************************************************************************
+// ***************************************************************************
+`timescale 1ns/100ps
+
+module axi_pwm_gen_regmap #(
+
+  parameter  ID = 0,
+  parameter  CORE_MAGIC = 0,
+  parameter  CORE_VERSION = 0,
+  parameter  ASYNC_CLK_EN = 1,
+  parameter  N_PWMS = 3,
+  parameter  PULSE_0_WIDTH = 7,
+  parameter  PULSE_1_WIDTH = 7,
+  parameter  PULSE_2_WIDTH = 7,
+  parameter  PULSE_3_WIDTH = 7,
+  parameter  PULSE_0_PERIOD = 10,
+  parameter  PULSE_1_PERIOD = 10,
+  parameter  PULSE_2_PERIOD = 10,
+  parameter  PULSE_3_PERIOD = 10,
+  parameter  PULSE_0_EXT_SYNC = 0,
+  parameter  PULSE_1_OFFSET = 0,
+  parameter  PULSE_2_OFFSET = 0,
+  parameter  PULSE_3_OFFSET = 0)(
+
+  // external clock
+
+  input                   ext_clk,
+
+  // control and status signals
+
+  output                  clk_out,
+  output                  pwm_gen_resetn,
+  output     [127:0]      pwm_width,
+  output     [127:0]      pwm_period,
+  output     [127:0]      pwm_offset,
+  output                  load_config,
+
+  // processor interface
+
+  input                   up_rstn,
+  input                   up_clk,
+  input                   up_wreq,
+  input       [13:0]      up_waddr,
+  input       [31:0]      up_wdata,
+  output reg              up_wack,
+  input                   up_rreq,
+  input       [13:0]      up_raddr,
+  output reg  [31:0]      up_rdata,
+  output reg              up_rack
+);
+
+  // internal registers
+
+  reg     [31:0]  up_scratch = 'd0;
+  reg     [31:0]  up_pwm_width_0 = PULSE_0_WIDTH;
+  reg     [31:0]  up_pwm_width_1 = PULSE_1_WIDTH;
+  reg     [31:0]  up_pwm_width_2 = PULSE_2_WIDTH;
+  reg     [31:0]  up_pwm_width_3 = PULSE_3_WIDTH;
+  reg     [31:0]  up_pwm_period_0 = PULSE_0_PERIOD;
+  reg     [31:0]  up_pwm_period_1 = PULSE_1_PERIOD;
+  reg     [31:0]  up_pwm_period_2 = PULSE_2_PERIOD;
+  reg     [31:0]  up_pwm_period_3 = PULSE_3_PERIOD;
+  reg     [31:0]  up_pwm_offset_0 = 32'd0;
+  reg     [31:0]  up_pwm_offset_1 = PULSE_1_OFFSET;
+  reg     [31:0]  up_pwm_offset_2 = PULSE_2_OFFSET;
+  reg     [31:0]  up_pwm_offset_3 = PULSE_3_OFFSET;
+  reg             up_load_config = 1'b0;
+  reg             up_reset;
+
+  always @(posedge up_clk) begin
+    if (up_rstn == 0) begin
+      up_wack <= 'd0;
+      up_scratch <= 'd0;
+      up_pwm_width_0 <= PULSE_0_WIDTH;
+      up_pwm_width_1 <= PULSE_1_WIDTH;
+      up_pwm_width_2 <= PULSE_2_WIDTH;
+      up_pwm_width_3 <= PULSE_3_WIDTH;
+      up_pwm_period_0 <= PULSE_0_PERIOD;
+      up_pwm_period_1 <= PULSE_1_PERIOD;
+      up_pwm_period_2 <= PULSE_2_PERIOD;
+      up_pwm_period_3 <= PULSE_3_PERIOD;
+      up_pwm_offset_0 <= 32'd0;
+      up_pwm_offset_1 <= PULSE_1_OFFSET;
+      up_pwm_offset_2 <= PULSE_2_OFFSET;
+      up_pwm_offset_3 <= PULSE_3_OFFSET;
+      up_load_config <= 1'b0;
+      up_reset <= 1'b1;
+    end else begin
+      up_wack <= up_wreq;
+      if ((up_wreq == 1'b1) && (up_waddr == 14'h2)) begin
+        up_scratch <= up_wdata;
+      end
+      if ((up_wreq == 1'b1) && (up_waddr == 14'h4)) begin
+        up_reset <= up_wdata[0];
+        up_load_config <= up_wdata[1];
+      end else begin
+        up_load_config <= 1'b0;
+      end
+      if ((up_wreq == 1'b1) && (up_waddr == 14'h10)) begin
+        up_pwm_period_0 <= up_wdata;
+      end
+      if ((up_wreq == 1'b1) && (up_waddr == 14'h11)) begin
+        up_pwm_width_0 <= up_wdata;
+      end
+      if ((up_wreq == 1'b1) && (up_waddr == 14'h12)) begin
+        up_pwm_offset_0 <= up_wdata;
+      end
+      if ((up_wreq == 1'b1) && (up_waddr == 14'h13)) begin
+        up_pwm_period_1 <= up_wdata;
+      end
+      if ((up_wreq == 1'b1) && (up_waddr == 14'h14)) begin
+        up_pwm_width_1 <= up_wdata;
+      end
+      if ((up_wreq == 1'b1) && (up_waddr == 14'h15)) begin
+        up_pwm_offset_1 <= up_wdata;
+      end
+      if ((up_wreq == 1'b1) && (up_waddr == 14'h16)) begin
+        up_pwm_period_2 <= up_wdata;
+      end
+      if ((up_wreq == 1'b1) && (up_waddr == 14'h17)) begin
+        up_pwm_width_2 <= up_wdata;
+      end
+      if ((up_wreq == 1'b1) && (up_waddr == 14'h18)) begin
+        up_pwm_offset_2 <= up_wdata;
+      end
+      if ((up_wreq == 1'b1) && (up_waddr == 14'h19)) begin
+        up_pwm_period_3 <= up_wdata;
+      end
+      if ((up_wreq == 1'b1) && (up_waddr == 14'h1a)) begin
+        up_pwm_width_3 <= up_wdata;
+      end
+      if ((up_wreq == 1'b1) && (up_waddr == 14'h1b)) begin
+        up_pwm_offset_3 <= up_wdata;
+      end
+    end
+  end
+
+  always @(posedge up_clk) begin
+    if (up_rstn == 0) begin
+      up_rack <= 'd0;
+      up_rdata <= 'd0;
+    end else begin
+      up_rack <= up_rreq;
+      if (up_rreq == 1'b1) begin
+        case (up_raddr)
+          14'h0: up_rdata <= CORE_VERSION;
+          14'h1: up_rdata <= ID;
+          14'h2: up_rdata <= up_scratch;
+          14'h3: up_rdata <= CORE_MAGIC;
+          14'h4: up_rdata <= up_reset;
+          14'h5: up_rdata <= N_PWMS;
+          14'h10: up_rdata <= up_pwm_period_0;
+          14'h11: up_rdata <= up_pwm_width_0;
+          14'h12: up_rdata <= up_pwm_offset_0;
+          14'h13: up_rdata <= up_pwm_period_1;
+          14'h14: up_rdata <= up_pwm_width_1;
+          14'h15: up_rdata <= up_pwm_offset_1;
+          14'h16: up_rdata <= up_pwm_period_2;
+          14'h17: up_rdata <= up_pwm_width_2;
+          14'h18: up_rdata <= up_pwm_offset_2;
+          14'h19: up_rdata <= up_pwm_period_3;
+          14'h1a: up_rdata <= up_pwm_width_3;
+          14'h1b: up_rdata <= up_pwm_offset_3;
+          default: up_rdata <= 0;
+        endcase
+      end else begin
+        up_rdata <= 32'd0;
+      end
+    end
+  end
+
+  generate
+  if (ASYNC_CLK_EN) begin : counter_external_clock
+
+    assign clk_out = ext_clk;
+
+    ad_rst i_d_rst_reg (
+      .rst_async (up_reset),
+      .clk (clk_out),
+      .rstn (pwm_gen_resetn),
+      .rst ());
+
+    sync_data #(
+      .NUM_OF_BITS (128),
+      .ASYNC_CLK (1))
+    i_pwm_period_sync (
+      .in_clk (up_clk),
+      .in_data ({up_pwm_period_3,
+                 up_pwm_period_2,
+                 up_pwm_period_1,
+                 up_pwm_period_0}),
+      .out_clk (clk_out),
+      .out_data (pwm_period));
+
+    sync_data #(
+      .NUM_OF_BITS (128),
+      .ASYNC_CLK (1))
+    i_pwm_width_sync (
+      .in_clk (up_clk),
+      .in_data ({up_pwm_width_3,
+                 up_pwm_width_2,
+                 up_pwm_width_1,
+                 up_pwm_width_0}),
+      .out_clk (clk_out),
+      .out_data (pwm_width));
+
+    sync_data #(
+      .NUM_OF_BITS (128),
+      .ASYNC_CLK (1))
+    i_pwm_offset_sync (
+      .in_clk (up_clk),
+      .in_data ({up_pwm_offset_3,
+                 up_pwm_offset_2,
+                 up_pwm_offset_1,
+                 32'd0}),
+      .out_clk (clk_out),
+      .out_data (pwm_offset));
+
+    sync_event #(
+      .NUM_OF_EVENTS (1),
+      .ASYNC_CLK (1))
+    i_load_config_sync (
+      .in_clk (up_clk),
+      .in_event (up_load_config),
+      .out_clk (clk_out),
+      .out_event (load_config));
+
+  end else begin : counter_sys_clock        // counter is running on system clk
+
+    assign clk_out = up_clk;
+    assign pwm_gen_resetn = ~up_reset;
+    assign pwm_period = {up_pwm_period_3, up_pwm_period_2, up_pwm_period_1, up_pwm_period_0};
+    assign pwm_width = {up_pwm_width_3, up_pwm_width_2, up_pwm_width_1, up_pwm_width_0};
+    assign pwm_offset = {up_pwm_offset_3, up_pwm_offset_2, up_pwm_offset_1, 32'd0};
+    assign load_config = up_load_config;
+
+  end
+  endgenerate
+
+endmodule


### PR DESCRIPTION
Added axi_pwm_gen which is an improved version of axi_pulse_gen with a different register map structure(compatible with Linux PWM framework).
This option was also chosen to keep the backwards compatibility with other projects for a short period.

Tested on a testbench and cora.