### PR TITLE
Add single-shot feature to util_dacfifo

### DIFF
--- a/library/util_dacfifo/util_dacfifo.v
+++ b/library/util_dacfifo/util_dacfifo.v
@@ -38,7 +38,8 @@
 module util_dacfifo #(
 
   parameter       ADDRESS_WIDTH = 6,
-  parameter       DATA_WIDTH = 128) (
+  parameter       DATA_WIDTH = 128,
+  parameter       ENABLE_SINGLE_SHOT_CONTROL = 1'b0) (
 
   // DMA interface
 
@@ -59,7 +60,8 @@ module util_dacfifo #(
   output  reg             dac_dunf,
   output  reg             dac_xfer_out,
 
-  input                   bypass);
+  input                   bypass,
+  input                   single_shot_output);
 
 
   localparam  FIFO_THRESHOLD_HI = {(ADDRESS_WIDTH){1'b1}} - 4;
@@ -93,6 +95,9 @@ module util_dacfifo #(
   reg                                 dac_xfer_out_fifo_d = 1'b0;
   reg                                 dac_bypass = 1'b0;
   reg                                 dac_bypass_m1 = 1'b0;
+  reg                                 dac_done = 1'b0;
+  reg                                 dac_single_shot_output = 1'b0;
+  reg                                 dac_single_shot_output_m1 = 1'b0;
 
   // internal wires
 
@@ -253,12 +258,20 @@ module util_dacfifo #(
   always @(posedge dac_clk) begin
     if (dac_rst_int_s == 1'b1) begin
       dac_raddr <= 'b0;
+
+      if (ENABLE_SINGLE_SHOT_CONTROL) begin
+        dac_done <= 'b0;
+      end
     end else begin
       if (dac_mem_ren_s == 1'b1) begin
         if (dac_lastaddr == 'b0 || dac_raddr != dac_lastaddr) begin
           dac_raddr <= dac_raddr + 1'b1;
         end else begin
           dac_raddr <= 'b0;
+
+          if (ENABLE_SINGLE_SHOT_CONTROL) begin
+            dac_done <= 1'b1;
+          end
         end
       end
     end
@@ -324,12 +337,35 @@ module util_dacfifo #(
     dma_ready <= (dma_bypass == 1'b1) ? dma_ready_bypass_s : 1'b1;
   end
 
+  // Align single_shot_output to dac clock domain
   always @(posedge dac_clk) begin
-    if (dac_valid) begin
-      dac_data <= (dac_bypass == 1'b1) ? dac_data_bypass_s : dac_data_fifo_s;
+    if (ENABLE_SINGLE_SHOT_CONTROL) begin
+      dac_single_shot_output_m1 <= single_shot_output;
+      dac_single_shot_output <= dac_single_shot_output_m1;
     end
-    // this signal along with the dac_valid validate the data coming out from the buffer
-    dac_xfer_out <= (dac_bypass == 1'b1) ? dac_xfer_req : dac_xfer_out_fifo_d;
+  end
+
+  always @(posedge dac_clk) begin
+    if (dac_bypass) begin
+
+      dac_xfer_out <= dac_xfer_req;
+
+      if (dac_valid) begin
+        dac_data <= dac_data_bypass_s;
+      end
+
+    end else if (!dac_xfer_out || dac_valid) begin
+
+      if (ENABLE_SINGLE_SHOT_CONTROL) begin
+        dac_xfer_out <= (~dac_rst_int_s) & (dac_xfer_out_fifo_d & ((~dac_single_shot_output) | (~dac_done)));
+        dac_data <= ((!dac_rst_int_s) & ((!dac_single_shot_output) || (!dac_done))) ? dac_data_fifo_s : 'b0;
+      end else begin
+        dac_xfer_out <= dac_xfer_out_fifo_d;
+        dac_data <= dac_data_fifo_s;
+      end
+
+    end
+
   end
 
 endmodule

--- a/library/util_dacfifo/util_dacfifo_constr.sdc
+++ b/library/util_dacfifo/util_dacfifo_constr.sdc
@@ -1,5 +1,6 @@
 
 set_false_path -to [get_registers *dac_bypass_m1*]
+set_false_path -to [get_registers *dac_single_shot_output_m1*]
 set_false_path -to [get_registers *dma_bypass_m1*]
 
 set_false_path -from [get_registers *dac_raddr_g*] -to [get_registers *dma_raddr_m1*]

--- a/library/util_dacfifo/util_dacfifo_constr.xdc
+++ b/library/util_dacfifo/util_dacfifo_constr.xdc
@@ -4,6 +4,7 @@ set_property ASYNC_REG TRUE [get_cells -hierarchical -filter {name =~ *dac_waddr
   [get_cells -hierarchical -filter {name =~ *dac_xfer_out_*}] \
   [get_cells -hierarchical -filter {name =~ *dma_bypass*}] \
   [get_cells -hierarchical -filter {name =~ *dac_bypass*}] \
+  [get_cells -hierarchical -filter {name =~ *dac_single_shot_output*}] \
   [get_cells -hierarchical -filter {name =~ *dac_xfer_req_m*}]
 
 set_false_path -from [get_cells -hierarchical -filter {name =~ *dma_waddr_g* && IS_SEQUENTIAL}] \
@@ -13,6 +14,7 @@ set_false_path -from [get_cells -hierarchical -filter {name =~ *dma_lastaddr_g* 
 set_false_path -from [get_cells -hierarchical -filter {name =~ *dma_xfer_out_fifo* && IS_SEQUENTIAL}] \
                -to [get_cells -hierarchical -filter {name =~ *dac_xfer_out_fifo_m1* && IS_SEQUENTIAL}]
 set_false_path -to [get_cells -hierarchical -filter {name =~ *dac_bypass_m1* && IS_SEQUENTIAL}]
+set_false_path -to [get_cells -hierarchical -filter {name =~ *dac_single_shot_output_m1* && IS_SEQUENTIAL}]
 set_false_path -to [get_cells -hierarchical -filter {name =~ *dma_bypass_m1* && IS_SEQUENTIAL}]
 
 # util_dacfifo_bypass CDC false-paths

--- a/library/util_dacfifo/util_dacfifo_hw.tcl
+++ b/library/util_dacfifo/util_dacfifo_hw.tcl
@@ -18,6 +18,7 @@ ad_ip_files util_dacfifo [list\
 ad_ip_parameter DEVICE_FAMILY STRING {Arria 10}
 ad_ip_parameter ADDRESS_WIDTH INTEGER 6
 ad_ip_parameter DATA_WIDTH INTEGER 128
+ad_ip_parameter ENABLE_SINGLE_SHOT_CONTROL INTEGER 0
 
 # interfaces
 
@@ -41,4 +42,5 @@ ad_interface signal dac_xfer_out output 1 xfer_req
 ad_interface signal dac_dunf output 1 unf
 
 ad_interface signal bypass input 1 bypass
+ad_interface signal single_shot_output input 1 single_shot_output
 

--- a/projects/ad9081_fmca_ebz/common/ad9081_fmca_ebz_bd.tcl
+++ b/projects/ad9081_fmca_ebz/common/ad9081_fmca_ebz_bd.tcl
@@ -540,6 +540,9 @@ ad_connect  mxfe_dac_fifo/dac_dunf tx_mxfe_tpl_core/dac_dunf
 create_bd_port -dir I dac_fifo_bypass
 ad_connect  mxfe_dac_fifo/bypass dac_fifo_bypass
 
+create_bd_port -dir I dac_fifo_single_shot_output
+ad_connect  mxfe_dac_fifo/single_shot_output dac_fifo_single_shot_output
+
 # interconnect (cpu)
 if {$ADI_PHY_SEL == 1} {
 ad_cpu_interconnect 0x44a60000 axi_mxfe_rx_xcvr

--- a/projects/ad9081_fmca_ebz/zcu102/system_bd.tcl
+++ b/projects/ad9081_fmca_ebz/zcu102/system_bd.tcl
@@ -19,6 +19,8 @@ ad_ip_parameter axi_sysid_0 CONFIG.ROM_ADDR_BITS 9
 ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "[pwd]/mem_init_sys.txt"
 ad_ip_parameter rom_sys_0 CONFIG.ROM_ADDR_BITS 9
 
+ad_ip_parameter mxfe_dac_fifo CONFIG.ENABLE_SINGLE_SHOT_CONTROL "1"
+
 sysid_gen_sys_init_file
 
 # Parameters for 15.5Gpbs lane rate

--- a/projects/ad9081_fmca_ebz/zcu102/system_top.v
+++ b/projects/ad9081_fmca_ebz/zcu102/system_top.v
@@ -111,6 +111,9 @@ module system_top  #(
   wire            tx_device_clk;
   wire            rx_device_clk;
 
+  wire            dac_fifo_bypass;
+  wire            dac_fifo_single_shot_output;
+
   assign iic_rstn = 1'b1;
 
   // instantiations
@@ -204,6 +207,7 @@ module system_top  #(
   assign txen[0]          = gpio_o[58];
   assign txen[1]          = gpio_o[59];
   assign dac_fifo_bypass  = gpio_o[60];
+  assign dac_fifo_single_shot_output = gpio_o[61];
 
   /* Board GPIOS. Buttons, LEDs, etc... */
   assign gpio_i[20: 8] = gpio_bd_i;
@@ -267,7 +271,8 @@ module system_top  #(
     .tx_sync_0 (tx_syncin),
     .rx_sysref_0 (sysref),
     .tx_sysref_0 (sysref),
-    .dac_fifo_bypass (dac_fifo_bypass)
+    .dac_fifo_bypass (dac_fifo_bypass),
+    .dac_fifo_single_shot_output (dac_fifo_single_shot_output)
   );
 
   assign rx_data_p_loc[TX_JESD_L*TX_NUM_LINKS-1:0] = rx_data_p[TX_JESD_L*TX_NUM_LINKS-1:0];


### PR DESCRIPTION
This commit adds a single-shot mode to the dacfifo that is _disabled_ by default, unless you set `ENABLE_SINGLE_SHOT_CONTROL` to "1". The controlling GPIO will default to low, and thus even for configurations where single-shot is available, the FIFO will default to running cyclically.

The second commit in this PR enables this feature in the m8-l4 configuration of the AD9081 eval board.

The accompanying driver: https://github.com/analogdevicesinc/linux/pull/1502
