### PR TITLE
axi_pulse_gen: Fix typo introduced in c235e5e58

### DIFF
--- a/library/axi_pulse_gen/axi_pulse_gen.v
+++ b/library/axi_pulse_gen/axi_pulse_gen.v
@@ -129,7 +129,6 @@ module axi_pulse_gen #(
     .pulse_width (pulse_width_s),
     .pulse_period (pulse_period_s),
     .load_config (load_config_s),
-    .sync (1'b0),
     .pulse (pulse));
 
   up_axi #(


### PR DESCRIPTION
Fix axi_pulse_gen typo added in commit https://github.com/analogdevicesinc/hdl/commit/c235e5e583756fccd86223548e27405dd04b25aa
