### PR TITLE
Hdl 2019 r2 navassa backport

### DIFF
--- a/library/axi_adrv9001/axi_adrv9001_core.v
+++ b/library/axi_adrv9001/axi_adrv9001_core.v
@@ -183,10 +183,12 @@ module axi_ad9001_core #(
   wire           tx2_data_valid_A;
   wire   [15:0]  tx2_data_i_A;
   wire   [15:0]  tx2_data_q_A;
+  wire           up_rx1_r1_mode;
   wire           rx1_r1_mode;
   wire           rx2_rst_loc;
   wire           rx2_single_lane_loc;
   wire           rx2_sdr_ddr_n_loc;
+  wire           up_tx1_r1_mode;
   wire           tx1_r1_mode;
   wire           tx2_rst_loc;
   wire           tx2_single_lane_loc;
@@ -207,22 +209,22 @@ module axi_ad9001_core #(
   // tx1_r1_mode should be 0 only when tx1_clk and tx2_clk have the same frequency
 
   sync_bits #(
-    .NUM_OF_BITS (3),
+    .NUM_OF_BITS (4),
     .ASYNC_CLK (1))
   i_rx1_ctrl_sync (
-    .in_bits ({rx1_sdr_ddr_n,rx1_single_lane,rx1_rst}),
+    .in_bits ({up_rx1_r1_mode,rx1_sdr_ddr_n,rx1_single_lane,rx1_rst}),
     .out_clk (rx2_clk),
     .out_resetn (1'b1),
-    .out_bits ({rx1_sdr_ddr_n_s,rx1_single_lane_s,rx1_rst_s}));
+    .out_bits ({rx1_r1_mode,rx1_sdr_ddr_n_s,rx1_single_lane_s,rx1_rst_s}));
 
   sync_bits #(
-    .NUM_OF_BITS (3),
+    .NUM_OF_BITS (4),
     .ASYNC_CLK (1))
   i_tx1_ctrl_sync (
-    .in_bits ({tx1_sdr_ddr_n,tx1_single_lane,tx1_rst}),
+    .in_bits ({up_tx1_r1_mode,tx1_sdr_ddr_n,tx1_single_lane,tx1_rst}),
     .out_clk (tx2_clk),
     .out_resetn (1'b1),
-    .out_bits ({tx1_sdr_ddr_n_s,tx1_single_lane_s,tx1_rst_s}));
+    .out_bits ({tx1_r1_mode,tx1_sdr_ddr_n_s,tx1_single_lane_s,tx1_rst_s}));
 
   assign rx2_rst = rx1_r1_mode ? rx2_rst_loc : rx1_rst_s;
   assign rx2_single_lane = rx1_r1_mode ? rx2_single_lane_loc : rx1_single_lane_s;
@@ -309,7 +311,7 @@ module axi_ad9001_core #(
 
     .adc_single_lane (rx1_single_lane),
     .adc_sdr_ddr_n (rx1_sdr_ddr_n),
-    .adc_r1_mode (rx1_r1_mode),
+    .up_adc_r1_mode (up_rx1_r1_mode),
 
     .dac_data_valid_A (tx1_data_valid_A),
     .dac_data_i_A (tx1_data_i_A),
@@ -424,7 +426,7 @@ module axi_ad9001_core #(
     .dac_data_q_B (tx1_data_q_B),
     .dac_single_lane (tx1_single_lane),
     .dac_sdr_ddr_n (tx1_sdr_ddr_n),
-    .dac_r1_mode (tx1_r1_mode),
+    .up_dac_r1_mode (up_tx1_r1_mode),
     .tdd_tx_valid (tdd_tx1_valid),
     .dac_sync_in (1'b0),
     .dac_sync_out (),

--- a/library/axi_adrv9001/axi_adrv9001_rx.v
+++ b/library/axi_adrv9001/axi_adrv9001_rx.v
@@ -63,7 +63,7 @@ module axi_adrv9001_rx #(
 
   output                  adc_single_lane,
   output                  adc_sdr_ddr_n,
-  output                  adc_r1_mode,
+  output                  up_adc_r1_mode,
 
   // dac loopback interface
   input                   dac_data_valid_A,
@@ -108,7 +108,7 @@ if (ENABLED == 0) begin : core_disabled
   assign adc_rst = 1'b0;
   assign adc_single_lane = 1'b0;
   assign adc_sdr_ddr_n = 1'b0;
-  assign adc_r1_mode = 1'b0;
+  assign up_adc_r1_mode = 1'b0;
   assign adc_valid = 1'b0;
   assign adc_enable_i0 = 1'b0;
   assign adc_data_i0 = 16'b0;
@@ -154,7 +154,6 @@ end else begin : core_enabled
   wire    [  4:0]   up_wack_s;
   wire    [  4:0]   up_rack_s;
   wire    [ 31:0]   up_rdata_s[0:4];
-  wire              up_adc_r1_mode;
   wire              adc_valid_out_i0;
   wire              adc_valid_out_i1;
 
@@ -348,7 +347,7 @@ end else begin : core_enabled
     .mmcm_rst (),
     .adc_clk (adc_clk),
     .adc_rst (adc_rst),
-    .adc_r1_mode (adc_r1_mode),
+    .adc_r1_mode (),
     .adc_ddr_edgesel (),
     .adc_pin_mode (),
     .adc_status (1'b1),

--- a/library/axi_adrv9001/axi_adrv9001_tx.v
+++ b/library/axi_adrv9001/axi_adrv9001_tx.v
@@ -67,7 +67,7 @@ module axi_adrv9001_tx #(
 
   output                  dac_single_lane,
   output                  dac_sdr_ddr_n,
-  output                  dac_r1_mode,
+  output                  up_dac_r1_mode,
 
   input                   tdd_tx_valid,
 
@@ -114,7 +114,7 @@ if (ENABLED == 0) begin : core_disabled
   assign dac_data_q_B = 16'b0;
   assign dac_single_lane = 1'b0;
   assign dac_sdr_ddr_n = 1'b0;
-  assign dac_r1_mode = 1'b0;
+  assign up_dac_r1_mode = 1'b0;
   assign dac_sync_out = 1'b0;
   assign dac_valid = 1'b0;
   assign dac_enable_i0 = 1'b0;
@@ -373,7 +373,8 @@ end else begin : core_enabled
     .dac_clksel (),
     .dac_par_type (),
     .dac_par_enb (),
-    .dac_r1_mode (dac_r1_mode),
+    .dac_r1_mode (),
+    .up_dac_r1_mode (up_dac_r1_mode),
     .dac_datafmt (dac_dds_format_s),
     .dac_datarate (dac_datarate_s),
     .dac_status (1'b1),

--- a/library/common/up_dac_common.v
+++ b/library/common/up_dac_common.v
@@ -77,6 +77,7 @@ module up_dac_common #(
   input       [31:0]  up_pps_rcounter,
   input               up_pps_status,
   output  reg         up_pps_irq_mask,
+  output  reg         up_dac_r1_mode = 'd0,
 
   // drp interface
 
@@ -127,7 +128,6 @@ module up_dac_common #(
   reg             up_dac_sdr_ddr_n = 'd0;
   reg             up_dac_par_type = 'd0;
   reg             up_dac_par_enb = 'd0;
-  reg             up_dac_r1_mode = 'd0;
   reg             up_dac_datafmt = 'd0;
   reg     [15:0]  up_dac_datarate = 'd0;
   reg             up_dac_frame = 'd0;

--- a/projects/adrv9001/zcu102/cmos_constr.xdc
+++ b/projects/adrv9001/zcu102/cmos_constr.xdc
@@ -53,4 +53,18 @@ set_clock_latency -source -early -0.25 [get_clocks rx2_dclk_out]
 set_clock_latency -source -late 0.25 [get_clocks rx1_dclk_out]
 set_clock_latency -source -late 0.25 [get_clocks rx2_dclk_out]
 
+create_pblock SSI_REGION
+add_cells_to_pblock [get_pblocks SSI_REGION] [get_cells -quiet [list \
+    i_system_wrapper/system_i/axi_adrv9001/inst/i_if/i_rx_1_phy/i_clk_buf_fast \
+    i_system_wrapper/system_i/axi_adrv9001/inst/i_if/i_rx_1_phy/i_div_clk_buf \
+    i_system_wrapper/system_i/axi_adrv9001/inst/i_if/i_rx_2_phy/i_clk_buf_fast \
+    i_system_wrapper/system_i/axi_adrv9001/inst/i_if/i_rx_2_phy/i_div_clk_buf \
+    i_system_wrapper/system_i/axi_adrv9001/inst/i_if/i_tx_1_phy/i_dac_clk_in_gbuf \
+    i_system_wrapper/system_i/axi_adrv9001/inst/i_if/i_tx_1_phy/i_dac_div_clk_rbuf \
+    i_system_wrapper/system_i/axi_adrv9001/inst/i_if/i_tx_2_phy/i_dac_clk_in_gbuf \
+    i_system_wrapper/system_i/axi_adrv9001/inst/i_if/i_tx_2_phy/i_dac_div_clk_rbuf \
+    ]]
+resize_pblock SSI_REGION -add CLOCKREGION_X3Y2:CLOCKREGION_X3Y3
 
+set_property CLOCK_DEDICATED_ROUTE FALSE [get_nets i_system_wrapper/system_i/axi_adrv9001/inst/i_if/i_tx_1_phy/i_dac_clk_in_ibuf/O]
+set_property CLOCK_DEDICATED_ROUTE FALSE [get_nets i_system_wrapper/system_i/axi_adrv9001/inst/i_if/i_tx_2_phy/i_dac_clk_in_ibuf/O]

--- a/projects/adrv9001/zcu102/system_bd.tcl
+++ b/projects/adrv9001/zcu102/system_bd.tcl
@@ -2,7 +2,7 @@
 source $ad_hdl_dir/projects/common/zcu102/zcu102_system_bd.tcl
 source ../common/adrv9001_bd.tcl
 
-ad_ip_parameter axi_adrv9001 CONFIG.USE_RX_CLK_FOR_TX 1
+ad_ip_parameter axi_adrv9001 CONFIG.USE_RX_CLK_FOR_TX [expr $ad_project_params(CMOS_LVDS_N) == 0]
 
 #system ID
 ad_ip_parameter axi_sysid_0 CONFIG.ROM_ADDR_BITS 9


### PR DESCRIPTION
These changes will allow 
- independent Tx channels from Rx channels on zcu102 CMOS mode