### PR TITLE
axi_ad9361: Fix typo in tdd interface

### DIFF
--- a/library/axi_ad9361/axi_ad9361_tdd.v
+++ b/library/axi_ad9361/axi_ad9361_tdd.v
@@ -143,7 +143,7 @@ module axi_ad9361_tdd (
   end
 
   always @(posedge clk) begin
-    if((tdd_enable_s == 1) && (tdd_gated_tx_dmapath_s == 1)) begin
+    if((tdd_enable_s == 1) && (tdd_gated_rx_dmapath_s == 1)) begin
       tdd_rx_valid <= tdd_rx_dp_en_s;
     end else begin
       tdd_rx_valid <= 1'b1;


### PR DESCRIPTION
As alluded to in the subject, this commit simply fixes what appears to be a copy-paste bug.