### PR TITLE
adrv9001:a10soc:system_qsys.tcl: set clock polarity to 0

### DIFF
--- a/projects/adrv9001/a10soc/system_qsys.tcl
+++ b/projects/adrv9001/a10soc/system_qsys.tcl
@@ -2,7 +2,7 @@ source $ad_hdl_dir/projects/scripts/adi_pd.tcl
 source $ad_hdl_dir/projects/common/a10soc/a10soc_system_qsys.tcl
 source ../common/adrv9001_qsys.tcl
 
-set_instance_parameter_value sys_spi {clockPolarity} {1}
+set_instance_parameter_value sys_spi {clockPolarity} {0}
 
 #system ID
 set_instance_parameter_value axi_sysid_0 {ROM_ADDR_BITS} {9}


### PR DESCRIPTION
For fixing "Failed to reset the device and set SPI Config"
error, both clockPolarity and clockPhase should be disabled
or both enabled. By default both are unset.

Signed-off-by: Stefan Raus <stefan.raus@analog.com>