### PR TITLE
adrv9001: fixes for reset metastability on xilinx ioserdes

### DIFF
--- a/library/axi_adrv9001/adrv9001_rx.v
+++ b/library/axi_adrv9001/adrv9001_rx.v
@@ -200,12 +200,26 @@ module adrv9001_rx #(
       .CE (1'b1),
       .I (clk_in_s),
       .O (adc_clk_div_s));
-
+    /*
     BUFG I_bufg (
       .I (adc_clk_div_s),
       .O (adc_clk_div)
     );
-    assign ssi_rst = mssi_sync;
+    */
+    assign adc_clk_div = adc_clk_div_s;
+
+    xpm_cdc_async_rst
+    # (
+       .DEST_SYNC_FF    (10), // DECIMAL; range: 2-10
+       .INIT_SYNC_FF    ( 0), // DECIMAL; 0=disable simulation init values, 1=enable simulation init values
+       .RST_ACTIVE_HIGH ( 1)  // DECIMAL; 0=active low reset, 1=active high reset
+      )
+    rst_syncro
+    (
+     .src_arst (mssi_sync  ),
+     .dest_clk (adc_clk_div),
+     .dest_arst(ssi_rst    )
+    );
 
   end else begin
     wire adc_clk_in;

--- a/library/axi_adrv9001/adrv9001_tx.v
+++ b/library/axi_adrv9001/adrv9001_tx.v
@@ -188,13 +188,26 @@ module adrv9001_tx #(
         .CE (1'b1),
         .I (tx_dclk_in_s),
         .O (dac_clk_div_s));
-
+/*
       BUFG I_bufg (
         .I (dac_clk_div_s),
         .O (dac_clk_div)
       );
+*/
+      assign dac_clk_div = dac_clk_div_s;
 
-      assign ssi_rst = mssi_sync;
+      xpm_cdc_async_rst
+      # (
+         .DEST_SYNC_FF    (10), // DECIMAL; range: 2-10
+         .INIT_SYNC_FF    ( 0), // DECIMAL; 0=disable simulation init values, 1=enable simulation init values
+         .RST_ACTIVE_HIGH ( 1)  // DECIMAL; 0=active low reset, 1=active high reset
+        )
+      rst_syncro
+      (
+       .src_arst (mssi_sync  ),
+       .dest_clk (dac_clk_div),
+       .dest_arst(ssi_rst    )
+      );
 
     end else begin
 

--- a/library/xilinx/common/ad_serdes_in.v
+++ b/library/xilinx/common/ad_serdes_in.v
@@ -137,6 +137,15 @@ module ad_serdes_in #(
     end
   endgenerate
 
+  reg [6:0] serdes_rst_seq;
+  wire      serdes_rst     = serdes_rst_seq [6];
+
+  always @ (posedge div_clk)
+  begin
+      if   (rst) serdes_rst_seq [6:0] <= 7'b0001110;
+      else       serdes_rst_seq [6:0] <= {serdes_rst_seq [5:0], 1'b0};
+  end
+
   generate if (FPGA_TECHNOLOGY == SEVEN_SERIES) begin
     for (l_inst = 0; l_inst <= (DATA_WIDTH-1); l_inst = l_inst + 1) begin: g_data
 
@@ -208,7 +217,7 @@ module ad_serdes_in #(
         .DDLY (data_in_idelay_s[l_inst]),
         .OFB (1'b0),
         .OCLKB (1'b0),
-        .RST (rst),
+        .RST (serdes_rst),
         .SHIFTIN1 (1'b0),
         .SHIFTIN2 (1'b0));
       end /* g_data */
@@ -303,7 +312,7 @@ module ad_serdes_in #(
        .D (data_in_idelay_s[l_inst]), // 1-bit input: Serial Data Input
        .FIFO_RD_CLK (div_clk),        // 1-bit input: FIFO read clock
        .FIFO_RD_EN (1'b1),            // 1-bit input: Enables reading the FIFO when asserted
-       .RST (rst)                     // 1-bit input: Asynchronous Reset
+       .RST (serdes_rst)             // 1-bit input: Asynchronous Reset
     );
    end
   end

--- a/library/xilinx/common/ad_serdes_out.v
+++ b/library/xilinx/common/ad_serdes_out.v
@@ -89,6 +89,15 @@ module ad_serdes_out #(
   assign buffer_disable = ~data_oe;
   // instantiations
 
+  reg [6:0] serdes_rst_seq;
+  wire      serdes_rst     = serdes_rst_seq [6];
+
+  always @ (posedge div_clk)
+  begin
+      if   (rst) serdes_rst_seq [6:0] <= 7'b0001110;
+      else       serdes_rst_seq [6:0] <= {serdes_rst_seq [5:0], 1'b0};
+  end
+
   genvar l_inst;
   generate
   for (l_inst = 0; l_inst <= (DATA_WIDTH-1); l_inst = l_inst + 1) begin: g_data
@@ -127,7 +136,7 @@ module ad_serdes_out #(
         .TBYTEIN (1'b0),
         .TBYTEOUT (),
         .TCE (1'b1),
-        .RST (rst & data_oe));
+        .RST (serdes_rst));
     end
 
     if (FPGA_TECHNOLOGY == ULTRASCALE || FPGA_TECHNOLOGY == ULTRASCALE_PLUS) begin
@@ -148,7 +157,7 @@ module ad_serdes_out #(
         .CLKDIV (div_clk),
         .OQ (data_out_s[l_inst]),
         .T_OUT (data_t[l_inst]),
-        .RST (rst & data_oe));
+        .RST (serdes_rst));
     end
 
     if (CMOS_LVDS_N == 0) begin


### PR DESCRIPTION
## The issue

After a reset with mssi_sync from the top level (mssi_sync is an input to axi_adrv9001.v), the data bus may be randomly left in a bad or corrupted state in a xilinx FPGA. This problem will occur more than 10% of the time. It is present in the provided evaluation images on xilinx series eval boards and on a custom FPGA design.

## The fix

The stream corruption is due to related IOserdes (being part of the same 16-bit serial stream like Q data on tx channel 0) being asynchronously reset, leaving them in a random phase relative to one another. The solution in this pull request is to synchronously de-assert the reset in the data clock domain.

## Testing

The applied fix was run thousands of times in an automated fashion using pattern loopback test after a mssi_sync to confirm working bus state.

## Up-streaming the fix

This took a lot of effort to track down and we are interested in upstreaming this bug fix so we can use the official adi/hdl repo without modifications. Additional details are provided below, please let me know if I need to change anything or clarify something. Thanks!

## Details

### 1) DRC warning with BUFG and use of divclk to IOserdes

In library/axi_adrv9001/adrv9001_rx.v, the signal adc_clk_div_s is passed through a BUFG to produce the signal adc_clk_div.  The ISERDES instance in this same module uses adc_clk_in_fast and adc_clk_div for its clk and div_clk inputs, respectively.  Feeding div_clk from a BUFG, however, generates a DRC warning that the clocking configuration may result in data errors.  The correct approach is to drive clk and div_clk from a BUFIO/BUFR pair (no intervening BUFG per xilinx spec).  Another possible with would be to feed div_clk from the BUFG input instead of the BUFG output.  The exact same issue exists in library/axi_adrv9001/adrv9001_tx.v

### 2) delayed synchronous reset pulse for IOserdes

In library/axi_adrv9001/adrv9001_rx.v, the mssi_sync input is delivered directly to the ssi_rst output.  The mssi_sync input also resets the BUFR that produces adc_clk_div_s.  The result is that the adc_clk_div output stops toggling during the assertion of mssi_sync/ssi_rst.  This, in turn, causes problems for any logic that requires synchronous resets (like the ISERDES and OSERDES primitives).  Our solution is to utilize something like the xpm_cdc_async_rst macro to delay the deassertion of reset until several clock edges have occurred.  The exact same issue exists in library/axi_adrv9001/adrv9001_tx.v

### 3) fulfill minimum required reset pulse time for IOserdes

Modules AD_SERDES_IN and AD_SERDES_OUT should reset their internal ISERDES and OSERDES primitives with signals that are asserted and deasserted synchronous to the div_clk input.  In our fix, I simply generated a signal that is low for three cycles, high for three cycles, and low thereafter following the deassertion of reset.  Note that the SERDES reset signals must be asserted for a minimum of two clock cycles per xilinx spec.