### PR TITLE
tb: jesd204: update and automate frame_align_tb

### DIFF
--- a/library/jesd204/tb/frame_align_tb
+++ b/library/jesd204/tb/frame_align_tb
@@ -13,6 +13,11 @@ SOURCE+=" ../jesd204_tx_static_config/jesd204_tx_static_config.v"
 SOURCE+=" ../jesd204_tx_static_config/jesd204_ilas_cfg_static.v"
 SOURCE+=" ../../util_cdc/sync_bits.v"
 SOURCE+=" ../../util_cdc/sync_event.v"
+SOURCE+=" ../../common/ad_mem.v"
+SOURCE+=" ../../common/ad_mem_asym.v" 
+SOURCE+=" ../../util_axis_fifo/util_axis_fifo_address_generator.v"
+SOURCE+=" ../../util_axis_fifo/util_axis_fifo.v" 
+
 
 cd `dirname $0`
 source ../../common/tb/run_tb.sh

--- a/library/jesd204/tb/jesd204_frame_align_replace_tb.v
+++ b/library/jesd204/tb/jesd204_frame_align_replace_tb.v
@@ -66,10 +66,6 @@ wire [DATA_PATH_WIDTH*8-1:0]  data_out;
 wire [DATA_PATH_WIDTH-1:0]    charisk_out;
 reg [31:00] ii;
 
-initial begin
-  #10000;
-  $finish;
-end
 
 initial begin
   forever begin


### PR DESCRIPTION
Fix jesd204 frame_aligh_tb by adding a fifo to solve rx and tx delay.
It saves the data from tx and compares it with the recieved ones from
rx.