### PR TITLE
scripts/adi_project_xilinx: Set number of parallel OOC jobs through env variable

### DIFF
--- a/projects/scripts/adi_project_xilinx.tcl
+++ b/projects/scripts/adi_project_xilinx.tcl
@@ -17,6 +17,12 @@ if {[info exists ::env(ADI_USE_OOC_SYNTHESIS)]} {
   set ADI_USE_OOC_SYNTHESIS 1
 } elseif {![info exists ADI_USE_OOC_SYNTHESIS]} {
   set ADI_USE_OOC_SYNTHESIS 0
+
+}
+
+## Set number of parallel out of context jobs through environment variable
+if {![info exists ::env(ADI_MAX_OOC_JOBS)]} {
+  set ADI_MAX_OOC_JOBS 4
 }
 
 ## Set to enable incremental compilation
@@ -269,9 +275,10 @@ proc adi_project_run {project_name} {
 
   global ADI_POWER_OPTIMIZATION
   global ADI_USE_OOC_SYNTHESIS
+  global ADI_MAX_OOC_JOBS
 
   if {$ADI_USE_OOC_SYNTHESIS == 1} {
-    launch_runs -jobs 4 system_*_synth_1 synth_1
+    launch_runs -jobs $ADI_MAX_OOC_JOBS system_*_synth_1 synth_1
   } else {
     launch_runs synth_1
   }


### PR DESCRIPTION
For the OOC flow it would be useful to have the number of parallel jobs controllable.

Tested in compile-only with dual-mxfe and vcu118.