### PR TITLE
[JESD] Support more options for TPL datapath width

### DIFF
--- a/library/jesd204/ad_ip_jesd204_tpl_adc/ad_ip_jesd204_tpl_adc_ip.tcl
+++ b/library/jesd204/ad_ip_jesd204_tpl_adc/ad_ip_jesd204_tpl_adc_ip.tcl
@@ -77,7 +77,7 @@ foreach {p v} {
   "DMA_BITS_PER_SAMPLE" "8 12 16" \
   "CONVERTER_RESOLUTION" "8 11 12 16" \
   "SAMPLES_PER_FRAME" "1 2 3 4 6 8 12 16" \
-  "OCTETS_PER_BEAT" "4 6 8 12" \
+  "OCTETS_PER_BEAT" "4 6 8 12 16 32 64" \
 } { \
   set_property -dict [list \
     "value_validation_type" "list" \

--- a/library/jesd204/ad_ip_jesd204_tpl_dac/ad_ip_jesd204_tpl_dac_ip.tcl
+++ b/library/jesd204/ad_ip_jesd204_tpl_dac/ad_ip_jesd204_tpl_dac_ip.tcl
@@ -100,7 +100,7 @@ foreach {p v} {
   "DMA_BITS_PER_SAMPLE" "8 12 16" \
   "CONVERTER_RESOLUTION" "8 11 12 16" \
   "SAMPLES_PER_FRAME" "1 2 3 4 6 8 12 16" \
-  "OCTETS_PER_BEAT" "4 6 8 12" \
+  "OCTETS_PER_BEAT" "4 6 8 12 16 32 64" \
 } { \
   set_property -dict [list \
     "value_validation_type" "list" \

--- a/library/jesd204/jesd204_rx/jesd204_rx.v
+++ b/library/jesd204/jesd204_rx/jesd204_rx.v
@@ -609,7 +609,7 @@ endgenerate
 assign status_synth_params0 = {NUM_LANES};
 assign status_synth_params1 = {
                  /*31:16 */  16'b0,
-                 /*15: 8 */  3'b0,TPL_DATA_PATH_WIDTH[4:0],
+                 /*15: 8 */  1'b0,TPL_DATA_PATH_WIDTH[6:0],
                  /* 7: 0 */  4'b0,DPW_LOG2[3:0]};
 assign status_synth_params2 = {
                  /*31:19 */  13'b0,

--- a/library/jesd204/jesd204_tx/jesd204_tx.v
+++ b/library/jesd204/jesd204_tx/jesd204_tx.v
@@ -539,7 +539,7 @@ pipeline_stage #(
 assign status_synth_params0 = {NUM_LANES};
 assign status_synth_params1 = {
                  /*31:16 */  16'b0,
-                 /*15: 8 */  3'b0,TPL_DATA_PATH_WIDTH[4:0],
+                 /*15: 8 */  1'b0,TPL_DATA_PATH_WIDTH[6:0],
                  /* 7: 0 */  4'b0,DPW_LOG2[3:0]};
 assign status_synth_params2 = {
                  /*31:19 */  13'b0,


### PR DESCRIPTION
Until now the supported max datapath width was 12 octets but this is not enough for wider frame sizes the AD9083 has.

Tested with AD9083  L=1,M=32,F=64

this PR goes together with https://github.com/analogdevicesinc/testbenches/pull/14
