### PR TITLE
Fix width of device_cfg_octets_per_multiframe

### DIFF
--- a/library/jesd204/axi_jesd204_tx/axi_jesd204_tx.v
+++ b/library/jesd204/axi_jesd204_tx/axi_jesd204_tx.v
@@ -95,7 +95,7 @@ module axi_jesd204_tx #(
   output core_cfg_disable_char_replacement,
   output core_cfg_disable_scrambler,
 
-  output [7:0] device_cfg_octets_per_multiframe,
+  output [9:0] device_cfg_octets_per_multiframe,
   output [7:0] device_cfg_octets_per_frame,
   output [7:0] device_cfg_beats_per_multiframe,
   output [7:0] device_cfg_lmfc_offset,


### PR DESCRIPTION
The width of the parameter `device_cfg_octets_per_multiframe` doesn't match the width in the submodules and corresponding slave interface of the jesd204_tx module, resulting in a warning generated during validation in Vivado. 

This patch increases the width of this parameter in axi_jesd204_tx.

Vivado warning:

    WARNING: [BD 41-2384] Width mismatch when connecting pin: '/axi_adrv9009_tx_jesd/tx/device_cfg_octets_per_multiframe'(10) to pin: '/axi_adrv9009_tx_jesd/tx_axi/device_cfg_octets_per_multiframe'(8) - Only lower order bits will be connected.