### PR TITLE
ad9083: Removed FIFO and increased DMAC transfer length

### DIFF
--- a/projects/ad9083_evb/zcu102/system_bd.tcl
+++ b/projects/ad9083_evb/zcu102/system_bd.tcl
@@ -1,6 +1,5 @@
 
 source $ad_hdl_dir/projects/common/zcu102/zcu102_system_bd.tcl
-source $ad_hdl_dir/projects/common/xilinx/adcfifo_bd.tcl
 source ../common/ad9083_evb_bd.tcl
 source $ad_hdl_dir/projects/scripts/adi_pd.tcl
 


### PR DESCRIPTION
Removed intermediary FIFO as the bandwidth requirements are within the capabilities of the HPC port