### PR TITLE
axi_adrv9001: Add support for symbol operation mode on Xilinx devices

### DIFF
--- a/library/axi_adrv9001/axi_adrv9001.v
+++ b/library/axi_adrv9001/axi_adrv9001.v
@@ -213,22 +213,30 @@ module axi_adrv9001 #(
   wire            rx1_data_valid;
   wire            rx1_single_lane;
   wire            rx1_sdr_ddr_n;
+  wire            rx1_symb_op;
+  wire            rx1_symb_8_16b;
   wire    [15:0]  rx2_data_i;
   wire    [15:0]  rx2_data_q;
   wire            rx2_data_valid;
   wire            rx2_single_lane;
   wire            rx2_sdr_ddr_n;
+  wire            rx2_symb_op;
+  wire            rx2_symb_8_16b;
 
   wire    [15:0]  tx1_data_i;
   wire    [15:0]  tx1_data_q;
   wire            tx1_data_valid;
   wire            tx1_single_lane;
   wire            tx1_sdr_ddr_n;
+  wire            tx1_symb_op;
+  wire            tx1_symb_8_16b;
   wire    [15:0]  tx2_data_i;
   wire    [15:0]  tx2_data_q;
   wire            tx2_data_valid;
   wire            tx2_single_lane;
   wire            tx2_sdr_ddr_n;
+  wire            tx2_symb_op;
+  wire            tx2_symb_8_16b;
 
   wire            adc_1_valid;
   wire            adc_2_valid;
@@ -345,6 +353,8 @@ module axi_adrv9001 #(
 
     .rx1_single_lane (rx1_single_lane),
     .rx1_sdr_ddr_n (rx1_sdr_ddr_n),
+    .rx1_symb_op (rx1_symb_op),
+    .rx1_symb_8_16b (rx1_symb_8_16b),
 
     .rx2_clk (adc_2_clk),
     .rx2_rst (adc_2_rst),
@@ -354,6 +364,8 @@ module axi_adrv9001 #(
 
     .rx2_single_lane (rx2_single_lane),
     .rx2_sdr_ddr_n (rx2_sdr_ddr_n),
+    .rx2_symb_op (rx2_symb_op),
+    .rx2_symb_8_16b (rx2_symb_8_16b),
 
     // DAC interface
     .dac_clk_ratio (dac_clk_ratio),
@@ -365,6 +377,8 @@ module axi_adrv9001 #(
 
     .tx1_single_lane (tx1_single_lane),
     .tx1_sdr_ddr_n (tx1_sdr_ddr_n),
+    .tx1_symb_op (tx1_symb_op),
+    .tx1_symb_8_16b (tx1_symb_8_16b),
 
     .tx2_clk (dac_2_clk),
     .tx2_rst (dac_2_rst),
@@ -373,7 +387,9 @@ module axi_adrv9001 #(
     .tx2_data_q (tx2_data_q),
 
     .tx2_single_lane (tx2_single_lane),
-    .tx2_sdr_ddr_n (tx2_sdr_ddr_n)
+    .tx2_sdr_ddr_n (tx2_sdr_ddr_n),
+    .tx2_symb_op (tx2_symb_op),
+    .tx2_symb_8_16b (tx2_symb_8_16b)
   );
 
   // common processor control
@@ -401,6 +417,8 @@ module axi_adrv9001 #(
 
     .rx1_single_lane (rx1_single_lane),
     .rx1_sdr_ddr_n (rx1_sdr_ddr_n),
+    .rx1_symb_op (rx1_symb_op),
+    .rx1_symb_8_16b (rx1_symb_8_16b),
 
     .rx2_clk (adc_2_clk),
     .rx2_rst (adc_2_rst),
@@ -410,6 +428,8 @@ module axi_adrv9001 #(
 
     .rx2_single_lane (rx2_single_lane),
     .rx2_sdr_ddr_n (rx2_sdr_ddr_n),
+    .rx2_symb_op (rx2_symb_op),
+    .rx2_symb_8_16b (rx2_symb_8_16b),
 
     .adc_clk_ratio (adc_clk_ratio),
 
@@ -422,6 +442,8 @@ module axi_adrv9001 #(
 
     .tx1_single_lane (tx1_single_lane),
     .tx1_sdr_ddr_n (tx1_sdr_ddr_n),
+    .tx1_symb_op (tx1_symb_op),
+    .tx1_symb_8_16b (tx1_symb_8_16b),
 
     .tx2_clk (dac_2_clk),
     .tx2_rst (dac_2_rst),
@@ -431,6 +453,8 @@ module axi_adrv9001 #(
 
     .tx2_single_lane (tx2_single_lane),
     .tx2_sdr_ddr_n (tx2_sdr_ddr_n),
+    .tx2_symb_op (tx2_symb_op),
+    .tx2_symb_8_16b (tx2_symb_8_16b),
 
     .dac_clk_ratio (dac_clk_ratio),
     //

--- a/library/axi_adrv9001/axi_adrv9001_core.v
+++ b/library/axi_adrv9001/axi_adrv9001_core.v
@@ -63,6 +63,8 @@ module axi_ad9001_core #(
 
   output                  rx1_single_lane,
   output                  rx1_sdr_ddr_n,
+  output                  rx1_symb_op,
+  output                  rx1_symb_8_16b,
 
   input                   rx2_clk,
   output                  rx2_rst,
@@ -72,6 +74,8 @@ module axi_ad9001_core #(
 
   output                  rx2_single_lane,
   output                  rx2_sdr_ddr_n,
+  output                  rx2_symb_op,
+  output                  rx2_symb_8_16b,
 
   // DAC interface
   input                   tx1_clk,
@@ -82,7 +86,9 @@ module axi_ad9001_core #(
 
   output                  tx1_single_lane,
   output                  tx1_sdr_ddr_n,
-
+  output                  tx1_symb_op,
+  output                  tx1_symb_8_16b,
+  
   input                   tx2_clk,
   output                  tx2_rst,
   output                  tx2_data_valid,
@@ -91,7 +97,9 @@ module axi_ad9001_core #(
 
   output                  tx2_single_lane,
   output                  tx2_sdr_ddr_n,
-
+  output                  tx2_symb_op,
+  output                  tx2_symb_8_16b,
+ 
   input       [ 31:0]     adc_clk_ratio,
   input       [ 31:0]     dac_clk_ratio,
 
@@ -191,11 +199,15 @@ module axi_ad9001_core #(
   wire           rx2_rst_loc;
   wire           rx2_single_lane_loc;
   wire           rx2_sdr_ddr_n_loc;
+  wire           rx2_symb_op_loc;
+  wire           rx2_symb_8_16b_loc;
   wire           up_tx1_r1_mode;
   wire           tx1_r1_mode;
   wire           tx2_rst_loc;
   wire           tx2_single_lane_loc;
   wire           tx2_sdr_ddr_n_loc;
+  wire           tx2_symb_op_loc;
+  wire           tx2_symb_8_16b_loc;
 
   reg            tx1_data_valid_A_d;
   reg    [15:0]  tx1_data_i_A_d;
@@ -212,31 +224,34 @@ module axi_ad9001_core #(
   // tx1_r1_mode should be 0 only when tx1_clk and tx2_clk have the same frequency
 
   sync_bits #(
-    .NUM_OF_BITS (4),
+    .NUM_OF_BITS (6),
     .ASYNC_CLK (1))
   i_rx1_ctrl_sync (
-    .in_bits ({up_rx1_r1_mode,rx1_sdr_ddr_n,rx1_single_lane,rx1_rst}),
+    .in_bits ({up_rx1_r1_mode,rx1_symb_op,rx1_symb_8_16b,rx1_sdr_ddr_n,rx1_single_lane,rx1_rst}),
     .out_clk (rx2_clk),
     .out_resetn (1'b1),
-    .out_bits ({rx1_r1_mode,rx1_sdr_ddr_n_s,rx1_single_lane_s,rx1_rst_s}));
+    .out_bits ({rx1_r1_mode,rx1_symb_op_s,rx1_symb_8_16b_s,rx1_sdr_ddr_n_s,rx1_single_lane_s,rx1_rst_s}));
 
   sync_bits #(
-    .NUM_OF_BITS (4),
+    .NUM_OF_BITS (6),
     .ASYNC_CLK (1))
   i_tx1_ctrl_sync (
-    .in_bits ({up_tx1_r1_mode,tx1_sdr_ddr_n,tx1_single_lane,tx1_rst}),
+    .in_bits ({up_tx1_r1_mode,tx1_symb_op,tx1_symb_8_16b,tx1_sdr_ddr_n,tx1_single_lane,tx1_rst}),
     .out_clk (tx2_clk),
     .out_resetn (1'b1),
-    .out_bits ({tx1_r1_mode,tx1_sdr_ddr_n_s,tx1_single_lane_s,tx1_rst_s}));
+    .out_bits ({tx1_r1_mode,tx1_symb_op_s,tx1_symb_8_16b_s,tx1_sdr_ddr_n_s,tx1_single_lane_s,tx1_rst_s}));
 
   assign rx2_rst = rx1_r1_mode ? rx2_rst_loc : rx1_rst_s;
   assign rx2_single_lane = rx1_r1_mode ? rx2_single_lane_loc : rx1_single_lane_s;
   assign rx2_sdr_ddr_n = rx1_r1_mode ? rx2_sdr_ddr_n_loc : rx1_sdr_ddr_n_s;
+  assign rx2_symb_op = rx1_r1_mode ? rx2_symb_op_loc : rx1_symb_op_s;
+  assign rx2_symb_8_16b = rx1_r1_mode ? rx2_symb_8_16b_loc : rx1_symb_8_16b_s;
 
   assign tx2_rst = tx1_r1_mode ? tx2_rst_loc : tx1_rst_s;
   assign tx2_single_lane = tx1_r1_mode ? tx2_single_lane_loc : tx1_single_lane_s;
   assign tx2_sdr_ddr_n = tx1_r1_mode ? tx2_sdr_ddr_n_loc : tx1_sdr_ddr_n_s;
-
+  assign tx2_symb_op = tx1_r1_mode ? tx2_symb_op_loc : tx1_symb_op_s;
+  assign tx2_symb_8_16b = tx1_r1_mode ? tx2_symb_8_16b_loc : tx1_symb_8_16b_s;
   assign tx1_data_valid = tx1_data_valid_A_d;
   assign tx1_data_i = tx1_data_i_A_d;
   assign tx1_data_q = tx1_data_q_A_d;
@@ -314,6 +329,8 @@ module axi_ad9001_core #(
 
     .adc_single_lane (rx1_single_lane),
     .adc_sdr_ddr_n (rx1_sdr_ddr_n),
+    .adc_symb_op (rx1_symb_op),
+    .adc_symb_8_16b (rx1_symb_8_16b),
     .up_adc_r1_mode (up_rx1_r1_mode),
 
     .adc_clk_ratio (adc_clk_ratio),
@@ -376,6 +393,8 @@ module axi_ad9001_core #(
 
     .adc_single_lane (rx2_single_lane_loc),
     .adc_sdr_ddr_n (rx2_sdr_ddr_n_loc),
+    .adc_symb_op (rx2_symb_op_loc),
+    .adc_symb_8_16b (rx2_symb_8_16b_loc),
 
     .adc_clk_ratio (adc_clk_ratio),
 
@@ -433,6 +452,8 @@ module axi_ad9001_core #(
     .dac_data_q_B (tx1_data_q_B),
     .dac_single_lane (tx1_single_lane),
     .dac_sdr_ddr_n (tx1_sdr_ddr_n),
+    .dac_symb_op (tx1_symb_op),
+    .dac_symb_8_16b (tx1_symb_8_16b),
     .up_dac_r1_mode (up_tx1_r1_mode),
     .tdd_tx_valid (tdd_tx1_valid),
     .dac_clk_ratio (dac_clk_ratio),
@@ -487,6 +508,8 @@ module axi_ad9001_core #(
     .dac_data_q_B (),
     .dac_single_lane (tx2_single_lane_loc),
     .dac_sdr_ddr_n (tx2_sdr_ddr_n_loc),
+    .dac_symb_op (tx2_symb_op_loc),
+    .dac_symb_8_16b (tx2_symb_8_16b_loc),
     .dac_sync_in (1'b0),
     .dac_sync_out (),
     .dac_valid (dac_2_valid),

--- a/library/axi_adrv9001/axi_adrv9001_if.v
+++ b/library/axi_adrv9001/axi_adrv9001_if.v
@@ -119,6 +119,8 @@ module axi_adrv9001_if #(
 
   input             rx1_single_lane,
   input             rx1_sdr_ddr_n,
+  input             rx1_symb_op,
+  input             rx1_symb_8_16b,
 
   output            rx2_clk,
   input             rx2_rst,
@@ -128,6 +130,8 @@ module axi_adrv9001_if #(
 
   input             rx2_single_lane,
   input             rx2_sdr_ddr_n,
+  input             rx2_symb_op,
+  input             rx2_symb_8_16b,
 
   output            tx1_clk,
   input             tx1_rst,
@@ -137,6 +141,8 @@ module axi_adrv9001_if #(
 
   input             tx1_single_lane,
   input             tx1_sdr_ddr_n,
+  input             tx1_symb_op,
+  input             tx1_symb_8_16b,
 
   output            tx2_clk,
   input             tx2_rst,
@@ -145,7 +151,9 @@ module axi_adrv9001_if #(
   input     [15:0]  tx2_data_q,
 
   input             tx2_single_lane,
-  input             tx2_sdr_ddr_n
+  input             tx2_sdr_ddr_n,
+  input             tx2_symb_op,
+  input             tx2_symb_8_16b
 );
 
   // Tx has an extra lane to drive the clock
@@ -251,7 +259,9 @@ module axi_adrv9001_if #(
     .rx_data_i (rx1_data_i),
     .rx_data_q (rx1_data_q),
     .rx_single_lane (rx1_single_lane),
-    .rx_sdr_ddr_n (rx1_sdr_ddr_n)
+    .rx_sdr_ddr_n (rx1_sdr_ddr_n),
+    .rx_symb_op (rx1_symb_op),
+    .rx_symb_8_16b (rx1_symb_8_16b)
   );
 
   adrv9001_rx
@@ -312,7 +322,9 @@ module axi_adrv9001_if #(
     .rx_data_i (rx2_data_i),
     .rx_data_q (rx2_data_q),
     .rx_single_lane (rx2_single_lane),
-    .rx_sdr_ddr_n (rx2_sdr_ddr_n)
+    .rx_sdr_ddr_n (rx2_sdr_ddr_n),
+    .rx_symb_op (rx2_symb_op),
+    .rx_symb_8_16b (rx2_symb_8_16b)
   );
 
   adrv9001_tx #(
@@ -377,7 +389,9 @@ module axi_adrv9001_if #(
     .tx_data_i (tx1_data_i),
     .tx_data_q (tx1_data_q),
     .tx_sdr_ddr_n (tx1_sdr_ddr_n),
-    .tx_single_lane (tx1_single_lane)
+    .tx_single_lane (tx1_single_lane),
+    .tx_symb_op (tx1_symb_op),
+    .tx_symb_8_16b (tx1_symb_8_16b)
   );
 
  adrv9001_tx #(
@@ -440,7 +454,9 @@ module axi_adrv9001_if #(
     .tx_data_i (tx2_data_i),
     .tx_data_q (tx2_data_q),
     .tx_sdr_ddr_n (tx2_sdr_ddr_n),
-    .tx_single_lane (tx2_single_lane)
+    .tx_single_lane (tx2_single_lane),
+    .tx_symb_op (tx2_symb_op),
+    .tx_symb_8_16b (tx2_symb_8_16b)
   );
 
 endmodule

--- a/library/axi_adrv9001/axi_adrv9001_rx.v
+++ b/library/axi_adrv9001/axi_adrv9001_rx.v
@@ -63,6 +63,8 @@ module axi_adrv9001_rx #(
 
   output                  adc_single_lane,
   output                  adc_sdr_ddr_n,
+  output                  adc_symb_op,
+  output                  adc_symb_8_16b,
   output                  up_adc_r1_mode,
 
   input       [ 31:0]     adc_clk_ratio,
@@ -110,6 +112,8 @@ if (ENABLED == 0) begin : core_disabled
   assign adc_rst = 1'b0;
   assign adc_single_lane = 1'b0;
   assign adc_sdr_ddr_n = 1'b0;
+  assign adc_symb_op = 1'b0;
+  assign adc_symb_8_16b = 1'b0;
   assign up_adc_r1_mode = 1'b0;
   assign adc_valid = 1'b0;
   assign adc_enable_i0 = 1'b0;
@@ -361,6 +365,8 @@ end else begin : core_enabled
     .adc_sync (),
     .adc_num_lanes (adc_num_lanes),
     .adc_sdr_ddr_n (adc_sdr_ddr_n),
+    .adc_symb_op (adc_symb_op),
+    .adc_symb_8_16b (adc_symb_8_16b),
     .up_pps_rcounter(32'h0),
     .up_pps_status(1'b0),
     .up_pps_irq_mask(),

--- a/library/axi_adrv9001/axi_adrv9001_rx_channel.v
+++ b/library/axi_adrv9001/axi_adrv9001_rx_channel.v
@@ -246,6 +246,8 @@ module axi_adrv9001_rx_channel #(
                         adc_pnseq_sel == 4'd5 ? pn15_data :
                         adc_pnseq_sel == 4'd10 ? {4{full_ramp_counter[3:0]}} :
                         adc_pnseq_sel == 4'd11 ? full_ramp_counter : 'h0;
+  assign valid_seq_sel = adc_pnseq_sel == 4'd4 || adc_pnseq_sel == 4'd5 || 
+                         adc_pnseq_sel == 4'd10 || adc_pnseq_sel == 4'd11;
 
   ad_pnmon #(
     .DATA_WIDTH (DATA_WIDTH),
@@ -283,8 +285,8 @@ module axi_adrv9001_rx_channel #(
     .adc_iqcor_coeff_2 (adc_iqcor_coeff_2_s),
     .adc_pnseq_sel (adc_pnseq_sel),
     .adc_data_sel (adc_data_sel_s),
-    .adc_pn_err (adc_pn_err_s),
-    .adc_pn_oos (adc_pn_oos_s),
+    .adc_pn_err (adc_pn_err_s & valid_seq_sel),
+    .adc_pn_oos (adc_pn_oos_s & valid_seq_sel),
     .adc_or (1'd0),
     .up_adc_pn_err (up_adc_pn_err),
     .up_adc_pn_oos (up_adc_pn_oos),

--- a/library/axi_adrv9001/axi_adrv9001_tx.v
+++ b/library/axi_adrv9001/axi_adrv9001_tx.v
@@ -67,6 +67,8 @@ module axi_adrv9001_tx #(
 
   output                  dac_single_lane,
   output                  dac_sdr_ddr_n,
+  output                  dac_symb_op,
+  output                  dac_symb_8_16b,
   output                  up_dac_r1_mode,
 
   input                   tdd_tx_valid,
@@ -116,6 +118,8 @@ if (ENABLED == 0) begin : core_disabled
   assign dac_data_q_B = 16'b0;
   assign dac_single_lane = 1'b0;
   assign dac_sdr_ddr_n = 1'b0;
+  assign dac_symb_op = 1'b0;
+  assign dac_symb_8_16b = 1'b0;
   assign up_dac_r1_mode = 1'b0;
   assign dac_sync_out = 1'b0;
   assign dac_valid = 1'b0;
@@ -370,6 +374,8 @@ end else begin : core_enabled
     .dac_rst (dac_rst),
     .dac_num_lanes (dac_num_lanes),
     .dac_sdr_ddr_n (dac_sdr_ddr_n),
+    .dac_symb_op (dac_symb_op),
+    .dac_symb_8_16b (dac_symb_8_16b),
     .dac_sync (dac_sync_out),
     .dac_frame (),
     .dac_clksel (),

--- a/library/common/up_adc_common.v
+++ b/library/common/up_adc_common.v
@@ -71,6 +71,8 @@ module up_adc_common #(
   output              adc_sync,
   output       [4:0]  adc_num_lanes,
   output              adc_sdr_ddr_n,
+  output              adc_symb_op,
+  output              adc_symb_8_16b,
   input       [31:0]  up_pps_rcounter,
   input               up_pps_status,
   output  reg         up_pps_irq_mask,
@@ -131,6 +133,8 @@ module up_adc_common #(
   reg                 up_adc_sref_sync = 'd0;
   reg         [4:0]   up_adc_num_lanes = 'd0;
   reg                 up_adc_sdr_ddr_n = 'd0;
+  reg                 up_adc_symb_op = 'd0;
+  reg                 up_adc_symb_8_16b = 'd0;
   reg                 up_adc_ddr_edgesel = 'd0;
   reg                 up_adc_pin_mode = 'd0;
   reg                 up_status_ovf = 'd0;
@@ -181,6 +185,8 @@ module up_adc_common #(
       up_adc_sref_sync <= 'd0;
       up_adc_num_lanes <= 'd0;
       up_adc_sdr_ddr_n <= 'd0;
+      up_adc_symb_op <= 'd0;
+      up_adc_symb_8_16b <= 'd0;
       up_adc_r1_mode <= 'd0;
       up_adc_ddr_edgesel <= 'd0;
       up_adc_pin_mode <= 'd0;
@@ -210,6 +216,8 @@ module up_adc_common #(
       end
       if ((up_wreq_s == 1'b1) && (up_waddr[6:0] == 7'h11)) begin
         up_adc_sdr_ddr_n <= up_wdata[16];
+	  up_adc_symb_op <= up_wdata[15];
+	  up_adc_symb_8_16b <= up_wdata[14];
         up_adc_num_lanes <= up_wdata[12:8];
         up_adc_sref_sync <= up_wdata[4];
         up_adc_r1_mode <= up_wdata[2];
@@ -391,7 +399,8 @@ module up_adc_common #(
           7'h07: up_rdata_int <= {FPGA_TECHNOLOGY,FPGA_FAMILY,SPEED_GRADE,DEV_PACKAGE}; // [8,8,8,8]
           7'h10: up_rdata_int <= {29'd0, up_adc_clk_enb, up_mmcm_resetn, up_resetn};
           7'h11: up_rdata_int <= {15'd0, up_adc_sdr_ddr_n,
-                                  3'd0, up_adc_num_lanes,
+		                    up_adc_symb_op, up_adc_symb_8_16b,
+                                  1'd0, up_adc_num_lanes,
                                   3'd0, up_adc_sref_sync,
                                   up_adc_sync, up_adc_r1_mode, up_adc_ddr_edgesel, up_adc_pin_mode};
           7'h15: up_rdata_int <= up_adc_clk_count_s;
@@ -426,10 +435,12 @@ module up_adc_common #(
 
   // adc control & status
 
-  up_xfer_cntrl #(.DATA_WIDTH(44)) i_xfer_cntrl (
+  up_xfer_cntrl #(.DATA_WIDTH(46)) i_xfer_cntrl (
     .up_rstn (up_rstn),
     .up_clk (up_clk),
     .up_data_cntrl ({ up_adc_sdr_ddr_n,
+                      up_adc_symb_op,
+		        up_adc_symb_8_16b,
                       up_adc_num_lanes,
                       up_adc_sref_sync,
                       up_adc_sync,
@@ -442,6 +453,8 @@ module up_adc_common #(
     .d_rst (adc_rst_s),
     .d_clk (adc_clk),
     .d_data_cntrl ({  adc_sdr_ddr_n,
+                      adc_symb_op,
+		        adc_symb_8_16b,
                       adc_num_lanes,
                       adc_sref_sync,
                       adc_sync,

--- a/library/common/up_dac_common.v
+++ b/library/common/up_dac_common.v
@@ -61,6 +61,8 @@ module up_dac_common #(
   output              dac_rst,
   output      [4:0]   dac_num_lanes,
   output              dac_sdr_ddr_n,
+  output              dac_symb_op,
+  output              dac_symb_8_16b,
   output              dac_sync,
   output              dac_frame,
   output              dac_clksel,
@@ -126,6 +128,8 @@ module up_dac_common #(
   reg             up_dac_sync = 'd0;
   reg      [4:0]  up_dac_num_lanes = 'd0;
   reg             up_dac_sdr_ddr_n = 'd0;
+  reg             up_dac_symb_op = 'd0;
+  reg             up_dac_symb_8_16b = 'd0;
   reg             up_dac_par_type = 'd0;
   reg             up_dac_par_enb = 'd0;
   reg             up_dac_datafmt = 'd0;
@@ -188,6 +192,8 @@ module up_dac_common #(
       up_dac_sync <= 'd0;
       up_dac_num_lanes <= 'd0;
       up_dac_sdr_ddr_n <= 'd0;
+      up_dac_symb_op <= 'd0;
+      up_dac_symb_8_16b <= 'd0;
       up_dac_par_type <= 'd0;
       up_dac_par_enb <= 'd0;
       up_dac_r1_mode <= 'd0;
@@ -220,7 +226,9 @@ module up_dac_common #(
         up_dac_sync <= up_wdata[0];
       end
       if ((up_wreq_s == 1'b1) && (up_waddr[6:0] == 7'h12)) begin
-        up_dac_sdr_ddr_n <= up_wdata[16];
+	  up_dac_sdr_ddr_n <= up_wdata[16];
+	  up_dac_symb_op <= up_wdata[15];
+	  up_dac_symb_8_16b <= up_wdata[14];
         up_dac_num_lanes <= up_wdata[12:8];
         up_dac_par_type <= up_wdata[7];
         up_dac_par_enb <= up_wdata[6];
@@ -397,7 +405,8 @@ module up_dac_common #(
           7'h10: up_rdata_int <= {29'd0, up_dac_clk_enb, up_mmcm_resetn, up_resetn};
           7'h11: up_rdata_int <= {31'd0, up_dac_sync};
           7'h12: up_rdata_int <= {15'd0, up_dac_sdr_ddr_n,
-                                  3'd0, up_dac_num_lanes,
+		                    up_dac_symb_op, up_dac_symb_8_16b,
+		                    1'd0, up_dac_num_lanes,
                                   up_dac_par_type, up_dac_par_enb, up_dac_r1_mode, up_dac_datafmt,
                                   4'd0};
           7'h13: up_rdata_int <= {16'd0, up_dac_datarate};
@@ -433,10 +442,12 @@ module up_dac_common #(
 
   // dac control & status
 
-  up_xfer_cntrl #(.DATA_WIDTH(30)) i_xfer_cntrl (
+  up_xfer_cntrl #(.DATA_WIDTH(32)) i_xfer_cntrl (
     .up_rstn (up_rstn),
     .up_clk (up_clk),
     .up_data_cntrl ({ up_dac_sdr_ddr_n,
+    		        up_dac_symb_op,
+		        up_dac_symb_8_16b,
                       up_dac_num_lanes,
                       up_dac_sync,
                       up_dac_clksel,
@@ -451,6 +462,8 @@ module up_dac_common #(
     .d_rst (dac_rst_s),
     .d_clk (dac_clk),
     .d_data_cntrl ({  dac_sdr_ddr_n,
+                      dac_symb_op,
+		        dac_symb_8_16b,
                       dac_num_lanes,
                       dac_sync_s,
                       dac_clksel,


### PR DESCRIPTION
Add CMOS support for the interface for the following symbol modes on Xilinx devices:
| A |  B | C | D | E | F | G | H |  
| --- | --- | --- | --- | --- | --- | --- | --- |
| CSSI__1-lane | 1 |  16/8 | 80-SDR/160-DDR | 80 | - | SDR/DDR | SDR/DDR->4/2(C=16),2/1(C=8) |

Columns description:
A - SSI Modes
B - Data Lanes Per Channel
C - Serialization factor Per data lane
D - Max data lane rate(MHz)
E - Max Clock rate (MHz)
F - Max Sample Rate for I/Q (MHz)
G - Data Type
H - DDS Rate

CSSI - CMOS Source Synchronous Interface      