### PR TITLE
Vivado 2020.2 update

### DIFF
--- a/library/axi_clkgen/axi_clkgen.v
+++ b/library/axi_clkgen/axi_clkgen.v
@@ -63,7 +63,7 @@ module axi_clkgen #(
 
   // axi interface
 
-  input                   s_axi_aclk,
+(* keep = "true" *) input                   s_axi_aclk,
   input                   s_axi_aresetn,
   input                   s_axi_awvalid,
   input       [15:0]      s_axi_awaddr,

--- a/library/axi_dmac/axi_dmac.v
+++ b/library/axi_dmac/axi_dmac.v
@@ -35,7 +35,7 @@
 
 `timescale 1ns/100ps
 
-module axi_dmac #(
+(* keep_hierarchy = "yes" *) module axi_dmac #(
 
   parameter ID = 0,
   parameter DMA_DATA_WIDTH_SRC = 64,
@@ -65,7 +65,7 @@ module axi_dmac #(
   parameter ALLOW_ASYM_MEM = 0
 ) (
   // Slave AXI interface
-  input s_axi_aclk,
+  (* keep = "TRUE" *)input s_axi_aclk,
   input s_axi_aresetn,
 
   input         s_axi_awvalid,

--- a/library/axi_dmac/axi_dmac_regmap.v
+++ b/library/axi_dmac/axi_dmac_regmap.v
@@ -53,7 +53,7 @@ module axi_dmac_regmap #(
   parameter SYNC_TRANSFER_START = 0
 ) (
   // Slave AXI interface
-  input s_axi_aclk,
+(* keep = "true" *)  input s_axi_aclk,
   input s_axi_aresetn,
 
   input s_axi_awvalid,

--- a/library/axi_dmac/axi_dmac_transfer.v
+++ b/library/axi_dmac/axi_dmac_transfer.v
@@ -130,7 +130,7 @@ module axi_dmac_transfer #(
   input [1:0] m_axi_rresp,
 
   // Slave streaming AXI interface
-  input s_axis_aclk,
+  (* keep = "TRUE" *)input s_axis_aclk,
   output s_axis_ready,
   input s_axis_valid,
   input [DMA_DATA_WIDTH_SRC-1:0] s_axis_data,
@@ -139,7 +139,7 @@ module axi_dmac_transfer #(
   output s_axis_xfer_req,
 
   // Master streaming AXI interface
-  input m_axis_aclk,
+  (* keep = "TRUE" *)input m_axis_aclk,
   input m_axis_ready,
   output m_axis_valid,
   output [DMA_DATA_WIDTH_DEST-1:0] m_axis_data,

--- a/library/axi_dmac/dest_axi_stream.v
+++ b/library/axi_dmac/dest_axi_stream.v
@@ -41,7 +41,7 @@ module dmac_dest_axi_stream #(
   parameter S_AXIS_DATA_WIDTH = 64,
   parameter BEATS_PER_BURST_WIDTH = 4)(
 
-  input s_axis_aclk,
+  (* keep = "TRUE" *)input s_axis_aclk,
   input s_axis_aresetn,
 
   input enable,

--- a/library/axi_dmac/src_axi_stream.v
+++ b/library/axi_dmac/src_axi_stream.v
@@ -42,7 +42,7 @@ module dmac_src_axi_stream #(
   parameter LENGTH_WIDTH = 24,
   parameter BEATS_PER_BURST_WIDTH = 4)(
 
-  input s_axis_aclk,
+  (* keep = "TRUE" *)input s_axis_aclk,
   input s_axis_aresetn,
 
   input enable,

--- a/library/axi_hdmi_tx/axi_hdmi_tx.v
+++ b/library/axi_hdmi_tx/axi_hdmi_tx.v
@@ -80,7 +80,7 @@ module axi_hdmi_tx #(
 
   // axi interface
 
-  input                   s_axi_aclk,
+(* keep = "true" *)  input                   s_axi_aclk,
   input                   s_axi_aresetn,
   input                   s_axi_awvalid,
   input       [15:0]      s_axi_awaddr,

--- a/library/jesd204/ad_ip_jesd204_tpl_adc/ad_ip_jesd204_tpl_adc.v
+++ b/library/jesd204/ad_ip_jesd204_tpl_adc/ad_ip_jesd204_tpl_adc.v
@@ -61,7 +61,7 @@ module ad_ip_jesd204_tpl_adc #(
 
   // axi interface
 
-  input s_axi_aclk,
+  (* keep = "TRUE" *)input s_axi_aclk,
   input s_axi_aresetn,
 
   input s_axi_awvalid,

--- a/library/jesd204/ad_ip_jesd204_tpl_adc/ad_ip_jesd204_tpl_adc_regmap.v
+++ b/library/jesd204/ad_ip_jesd204_tpl_adc/ad_ip_jesd204_tpl_adc_regmap.v
@@ -34,7 +34,7 @@ module ad_ip_jesd204_tpl_adc_regmap #(
   parameter NUM_PROFILES = 1    // Number of supported JESD profiles
 ) (
   // axi interface
-  input s_axi_aclk,
+  (* keep = "TRUE" *)input s_axi_aclk,
   input s_axi_aresetn,
   input s_axi_awvalid,
   input [12:0] s_axi_awaddr,

--- a/library/jesd204/ad_ip_jesd204_tpl_dac/ad_ip_jesd204_tpl_dac.v
+++ b/library/jesd204/ad_ip_jesd204_tpl_dac/ad_ip_jesd204_tpl_dac.v
@@ -66,7 +66,7 @@ module ad_ip_jesd204_tpl_dac #(
 
   // axi interface
 
-  input s_axi_aclk,
+  (* keep = "TRUE" *)input s_axi_aclk,
   input s_axi_aresetn,
 
   input s_axi_awvalid,

--- a/library/jesd204/ad_ip_jesd204_tpl_dac/ad_ip_jesd204_tpl_dac_regmap.v
+++ b/library/jesd204/ad_ip_jesd204_tpl_dac/ad_ip_jesd204_tpl_dac_regmap.v
@@ -37,7 +37,7 @@ module ad_ip_jesd204_tpl_dac_regmap #(
   parameter PADDING_TO_MSB_LSB_N = 0,
   parameter NUM_PROFILES = 1    // Number of supported JESD profiles
 ) (
-  input s_axi_aclk,
+  (* keep = "TRUE" *) input s_axi_aclk,
   input s_axi_aresetn,
 
   input s_axi_awvalid,

--- a/library/jesd204/axi_jesd204_rx/axi_jesd204_rx.v
+++ b/library/jesd204/axi_jesd204_rx/axi_jesd204_rx.v
@@ -52,7 +52,7 @@ module axi_jesd204_rx #(
   parameter ENABLE_LINK_STATS = 0,
   parameter DATA_PATH_WIDTH = LINK_MODE == 2 ? 8 : 4
 ) (
-  input s_axi_aclk,
+  (* keep = "TRUE" *)input s_axi_aclk,
   input s_axi_aresetn,
 
   input s_axi_awvalid,

--- a/library/jesd204/axi_jesd204_tx/axi_jesd204_tx.v
+++ b/library/jesd204/axi_jesd204_tx/axi_jesd204_tx.v
@@ -52,7 +52,7 @@ module axi_jesd204_tx #(
   parameter ENABLE_LINK_STATS = 0,
   parameter DATA_PATH_WIDTH = LINK_MODE == 2 ? 8 : 4
 ) (
-  input s_axi_aclk,
+  (* keep = "TRUE" *) input s_axi_aclk,
   input s_axi_aresetn,
 
   input s_axi_awvalid,

--- a/library/scripts/adi_ip_xilinx.tcl
+++ b/library/scripts/adi_ip_xilinx.tcl
@@ -4,7 +4,7 @@ source $ad_hdl_dir/library/scripts/adi_xilinx_device_info_enc.tcl
 # check tool version
 
 if {![info exists REQUIRED_VIVADO_VERSION]} {
-  set REQUIRED_VIVADO_VERSION "2020.1"
+  set REQUIRED_VIVADO_VERSION "2020.2"
 }
 
 if {[info exists ::env(ADI_IGNORE_VERSION_CHECK)]} {

--- a/library/spi_engine/axi_spi_engine/axi_spi_engine.v
+++ b/library/spi_engine/axi_spi_engine/axi_spi_engine.v
@@ -52,7 +52,7 @@ module axi_spi_engine #(
 
   // Slave AXI interface
 
-  input         s_axi_aclk,
+(* keep="true" *)  input         s_axi_aclk,
   input         s_axi_aresetn,
   input         s_axi_awvalid,
   input  [15:0] s_axi_awaddr,

--- a/library/util_axis_fifo/util_axis_fifo.v
+++ b/library/util_axis_fifo/util_axis_fifo.v
@@ -45,7 +45,7 @@ module util_axis_fifo #(
   parameter TKEEP_EN = 0,
   parameter REMOVE_NULL_BEAT_EN = 0
 ) (
-  input m_axis_aclk,
+  (* keep = "TRUE" *)input m_axis_aclk,
   input m_axis_aresetn,
   input m_axis_ready,
   output m_axis_valid,
@@ -56,7 +56,7 @@ module util_axis_fifo #(
   output m_axis_empty,
   output m_axis_almost_empty,
 
-  input s_axis_aclk,
+  (* keep = "TRUE" *)input s_axis_aclk,
   input s_axis_aresetn,
   output s_axis_ready,
   input s_axis_valid,

--- a/library/util_axis_fifo/util_axis_fifo_address_generator.v
+++ b/library/util_axis_fifo/util_axis_fifo_address_generator.v
@@ -42,7 +42,7 @@ module util_axis_fifo_address_generator #(
 ) (
   // Read interface - Sink side
 
-  input m_axis_aclk,
+  (* keep = "TRUE" *)input m_axis_aclk,
   input m_axis_aresetn,
   input m_axis_ready,
   output m_axis_valid,
@@ -53,7 +53,7 @@ module util_axis_fifo_address_generator #(
 
   // Write interface - Source side
 
-  input s_axis_aclk,
+  (* keep = "TRUE" *)input s_axis_aclk,
   input s_axis_aresetn,
   output s_axis_ready,
   input s_axis_valid,

--- a/library/xilinx/axi_xcvrlb/axi_xcvrlb.v
+++ b/library/xilinx/axi_xcvrlb/axi_xcvrlb.v
@@ -39,10 +39,10 @@ module axi_xcvrlb #(
 
   // parameters
 
-  parameter   CPLL_FBDIV = 1,
-  parameter   CPLL_FBDIV_4_5 = 5,
+  parameter   integer CPLL_FBDIV = 1,
+  parameter   integer CPLL_FBDIV_4_5 = 5,
   parameter   NUM_OF_LANES = 1,
-  parameter   XCVR_TYPE = 2) (
+  parameter   integer XCVR_TYPE = 2) (
 
   // transceiver interface
 

--- a/library/xilinx/axi_xcvrlb/axi_xcvrlb_ip.tcl
+++ b/library/xilinx/axi_xcvrlb/axi_xcvrlb_ip.tcl
@@ -17,6 +17,10 @@ adi_ip_properties_lite axi_xcvrlb
 adi_init_bd_tcl
 adi_ip_bd axi_xcvrlb "bd/bd.tcl"
 
+adi_ip_add_core_dependencies { \
+	analog.com:user:util_cdc:1.0 \
+}
+
 ipx::remove_all_bus_interface [ipx::current_core]
 
 set_property driver_value 0 [ipx::get_ports -filter "direction==in" -of_objects [ipx::current_core]]

--- a/library/xilinx/util_adxcvr/util_adxcvr_constr.xdc
+++ b/library/xilinx/util_adxcvr/util_adxcvr_constr.xdc
@@ -1,8 +1,8 @@
 
-set_property ASYNC_REG TRUE [get_cells -hier -filter {name =~ *up_rx_rst_done*}]
-set_property ASYNC_REG TRUE [get_cells -hier -filter {name =~ *up_tx_rst_done*}]
-set_property ASYNC_REG TRUE [get_cells -hier -filter {name =~ *rx_rate*}]
-set_property ASYNC_REG TRUE [get_cells -hier -filter {name =~ *tx_rate*}]
+set_property ASYNC_REG TRUE -quiet [get_cells -hier -filter {name =~ *up_rx_rst_done*}]
+set_property ASYNC_REG TRUE -quiet [get_cells -hier -filter {name =~ *up_tx_rst_done*}]
+set_property ASYNC_REG TRUE -quiet [get_cells -hier -filter {name =~ *rx_rate*}]
+set_property ASYNC_REG TRUE -quiet [get_cells -hier -filter {name =~ *tx_rate*}]
 
 set_false_path -to [get_cells -hier -filter {name =~ *up_rx_rst_done_m1_reg && IS_SEQUENTIAL}]
 set_false_path -to [get_cells -hier -filter {name =~ *up_tx_rst_done_m1_reg && IS_SEQUENTIAL}]

--- a/projects/ad9082_fmca_ebz/vcu118/system_project.tcl
+++ b/projects/ad9082_fmca_ebz/vcu118/system_project.tcl
@@ -53,6 +53,11 @@ adi_project_files ad9082_fmca_ebz_vcu118 [list \
   "$ad_hdl_dir/library/common/ad_iobuf.v" \
   "$ad_hdl_dir/projects/common/vcu118/vcu118_system_constr.xdc" ]
 
+# Avoid critical warning in OOC mode from the clock definitions
+# since at that stage the submodules are not stiched together yet
+if {$ADI_USE_OOC_SYNTHESIS == 1} {
+  set_property used_in_synthesis false [get_files timing_constr.xdc]
+}
 
 adi_project_run ad9082_fmca_ebz_vcu118
 

--- a/projects/common/kcu105/kcu105_system_bd.tcl
+++ b/projects/common/kcu105/kcu105_system_bd.tcl
@@ -75,7 +75,7 @@ ad_ip_parameter sys_200m_rstgen CONFIG.C_EXT_RST_WIDTH 1
 
 ad_ip_instance ip:ddr4 axi_ddr_cntrl
 ad_ip_parameter axi_ddr_cntrl CONFIG.C0_CLOCK_BOARD_INTERFACE default_sysclk_300
-ad_ip_parameter axi_ddr_cntrl CONFIG.C0_DDR4_BOARD_INTERFACE ddr4_sdram
+ad_ip_parameter axi_ddr_cntrl CONFIG.C0_DDR4_BOARD_INTERFACE ddr4_sdram_DR
 ad_ip_parameter axi_ddr_cntrl CONFIG.RESET_BOARD_INTERFACE reset
 ad_ip_parameter axi_ddr_cntrl CONFIG.ADDN_UI_CLKOUT2_FREQ_HZ 200
 

--- a/projects/common/kcu105/kcu105_system_constr.xdc
+++ b/projects/common/kcu105/kcu105_system_constr.xdc
@@ -50,8 +50,6 @@ set_property -dict  {INTERNAL_VREF {0.84}}  [get_iobanks 44]
 set_property -dict  {INTERNAL_VREF {0.84}}  [get_iobanks 45]
 set_property -dict  {INTERNAL_VREF {0.84}}  [get_iobanks 46]
 
-create_clock -name phy_clk      -period  1.60 [get_ports phy_clk_p]
-
 #Setting the Configuration Bank Voltage Select
 set_property CFGBVS GND [current_design]
 set_property CONFIG_VOLTAGE 1.8 [current_design]

--- a/projects/common/vcu118/vcu118_system_bd.tcl
+++ b/projects/common/vcu118/vcu118_system_bd.tcl
@@ -78,7 +78,7 @@ ad_ip_parameter sys_500m_rstgen CONFIG.C_EXT_RST_WIDTH 1
 
 ad_ip_instance ip:ddr4 axi_ddr_cntrl
 ad_ip_parameter axi_ddr_cntrl CONFIG.C0_CLOCK_BOARD_INTERFACE default_250mhz_clk2
-ad_ip_parameter axi_ddr_cntrl CONFIG.C0_DDR4_BOARD_INTERFACE ddr4_sdram_c2
+ad_ip_parameter axi_ddr_cntrl CONFIG.C0_DDR4_BOARD_INTERFACE ddr4_sdram_c2_083
 ad_ip_parameter axi_ddr_cntrl CONFIG.RESET_BOARD_INTERFACE reset
 ad_ip_parameter axi_ddr_cntrl CONFIG.ADDN_UI_CLKOUT2_FREQ_HZ 250
 ad_ip_parameter axi_ddr_cntrl CONFIG.ADDN_UI_CLKOUT3_FREQ_HZ 500

--- a/projects/scripts/adi_project_xilinx.tcl
+++ b/projects/scripts/adi_project_xilinx.tcl
@@ -1,7 +1,7 @@
 
 ## Define the supported tool version
 if {![info exists REQUIRED_VIVADO_VERSION]} {
-  set REQUIRED_VIVADO_VERSION "2020.1"
+  set REQUIRED_VIVADO_VERSION "2020.2"
 }
 
 ## Define the ADI_IGNORE_VERSION_CHECK environment variable to skip version check

--- a/projects/scripts/adi_project_xilinx.tcl
+++ b/projects/scripts/adi_project_xilinx.tcl
@@ -13,12 +13,14 @@ if {[info exists ::env(ADI_IGNORE_VERSION_CHECK)]} {
 
 ## Define the ADI_USE_OOC_SYNTHESIS environment variable to enable out of context
 #  synthesis
-if {[info exists ::env(ADI_USE_OOC_SYNTHESIS)]} {
-  set ADI_USE_OOC_SYNTHESIS 1
-} elseif {![info exists ADI_USE_OOC_SYNTHESIS]} {
-  set ADI_USE_OOC_SYNTHESIS 0
+# if {[info exists ::env(ADI_USE_OOC_SYNTHESIS)]} {
+#   set ADI_USE_OOC_SYNTHESIS 1
+# } elseif {![info exists ADI_USE_OOC_SYNTHESIS]} {
+#   set ADI_USE_OOC_SYNTHESIS 0
+# }
 
-}
+## Set ADI_USE_OOC_SYNTHESIS to 1 for Vivado version 2020.2
+   set ADI_USE_OOC_SYNTHESIS 1
 
 ## Set number of parallel out of context jobs through environment variable
 if {![info exists ::env(ADI_MAX_OOC_JOBS)]} {


### PR DESCRIPTION
Update Vivado version to 2020.2
    
    Update vivado version to 2020.2:
     - update default vivado version from 2020.1 to 2020.2
     - add conditions to apply specific contraints only in Out Of Context mode.
     - update DDR controler parameters for vcu118 and kcu105 dev boards
     - set ADI_USE_OOC_SYTHESIS variable by default to 1.