### PR TITLE
Update Vivado version to 2020.2

### DIFF
--- a/library/scripts/adi_ip_xilinx.tcl
+++ b/library/scripts/adi_ip_xilinx.tcl
@@ -4,7 +4,7 @@ source $ad_hdl_dir/library/scripts/adi_xilinx_device_info_enc.tcl
 # check tool version
 
 if {![info exists REQUIRED_VIVADO_VERSION]} {
-  set REQUIRED_VIVADO_VERSION "2020.1"
+  set REQUIRED_VIVADO_VERSION "2020.2"
 }
 
 if {[info exists ::env(ADI_IGNORE_VERSION_CHECK)]} {

--- a/library/xilinx/axi_xcvrlb/axi_xcvrlb.v
+++ b/library/xilinx/axi_xcvrlb/axi_xcvrlb.v
@@ -39,10 +39,10 @@ module axi_xcvrlb #(
 
   // parameters
 
-  parameter   CPLL_FBDIV = 1,
-  parameter   CPLL_FBDIV_4_5 = 5,
+  parameter   integer CPLL_FBDIV = 1,
+  parameter   integer CPLL_FBDIV_4_5 = 5,
   parameter   NUM_OF_LANES = 1,
-  parameter   XCVR_TYPE = 2) (
+  parameter   integer XCVR_TYPE = 2) (
 
   // transceiver interface
 

--- a/library/xilinx/axi_xcvrlb/axi_xcvrlb_ip.tcl
+++ b/library/xilinx/axi_xcvrlb/axi_xcvrlb_ip.tcl
@@ -17,6 +17,10 @@ adi_ip_properties_lite axi_xcvrlb
 adi_init_bd_tcl
 adi_ip_bd axi_xcvrlb "bd/bd.tcl"
 
+adi_ip_add_core_dependencies { \
+	analog.com:user:util_cdc:1.0 \
+}
+
 ipx::remove_all_bus_interface [ipx::current_core]
 
 set_property driver_value 0 [ipx::get_ports -filter "direction==in" -of_objects [ipx::current_core]]

--- a/library/xilinx/util_adxcvr/util_adxcvr_constr.xdc
+++ b/library/xilinx/util_adxcvr/util_adxcvr_constr.xdc
@@ -1,8 +1,8 @@
 
-set_property ASYNC_REG TRUE [get_cells -hier -filter {name =~ *up_rx_rst_done*}]
-set_property ASYNC_REG TRUE [get_cells -hier -filter {name =~ *up_tx_rst_done*}]
-set_property ASYNC_REG TRUE [get_cells -hier -filter {name =~ *rx_rate*}]
-set_property ASYNC_REG TRUE [get_cells -hier -filter {name =~ *tx_rate*}]
+set_property ASYNC_REG TRUE -quiet [get_cells -hier -filter {name =~ *up_rx_rst_done*}]
+set_property ASYNC_REG TRUE -quiet [get_cells -hier -filter {name =~ *up_tx_rst_done*}]
+set_property ASYNC_REG TRUE -quiet [get_cells -hier -filter {name =~ *rx_rate*}]
+set_property ASYNC_REG TRUE -quiet [get_cells -hier -filter {name =~ *tx_rate*}]
 
 set_false_path -to [get_cells -hier -filter {name =~ *up_rx_rst_done_m1_reg && IS_SEQUENTIAL}]
 set_false_path -to [get_cells -hier -filter {name =~ *up_tx_rst_done_m1_reg && IS_SEQUENTIAL}]

--- a/projects/ad9082_fmca_ebz/vcu118/system_project.tcl
+++ b/projects/ad9082_fmca_ebz/vcu118/system_project.tcl
@@ -53,6 +53,11 @@ adi_project_files ad9082_fmca_ebz_vcu118 [list \
   "$ad_hdl_dir/library/common/ad_iobuf.v" \
   "$ad_hdl_dir/projects/common/vcu118/vcu118_system_constr.xdc" ]
 
+# Avoid critical warning in OOC mode from the clock definitions
+# since at that stage the submodules are not stiched together yet
+if {$ADI_USE_OOC_SYNTHESIS == 1} {
+  set_property used_in_synthesis false [get_files timing_constr.xdc]
+}
 
 adi_project_run ad9082_fmca_ebz_vcu118
 

--- a/projects/common/kcu105/kcu105_system_bd.tcl
+++ b/projects/common/kcu105/kcu105_system_bd.tcl
@@ -75,7 +75,7 @@ ad_ip_parameter sys_200m_rstgen CONFIG.C_EXT_RST_WIDTH 1
 
 ad_ip_instance ip:ddr4 axi_ddr_cntrl
 ad_ip_parameter axi_ddr_cntrl CONFIG.C0_CLOCK_BOARD_INTERFACE default_sysclk_300
-ad_ip_parameter axi_ddr_cntrl CONFIG.C0_DDR4_BOARD_INTERFACE ddr4_sdram
+ad_ip_parameter axi_ddr_cntrl CONFIG.C0_DDR4_BOARD_INTERFACE ddr4_sdram_DR
 ad_ip_parameter axi_ddr_cntrl CONFIG.RESET_BOARD_INTERFACE reset
 ad_ip_parameter axi_ddr_cntrl CONFIG.ADDN_UI_CLKOUT2_FREQ_HZ 200
 

--- a/projects/common/kcu105/kcu105_system_constr.xdc
+++ b/projects/common/kcu105/kcu105_system_constr.xdc
@@ -50,8 +50,6 @@ set_property -dict  {INTERNAL_VREF {0.84}}  [get_iobanks 44]
 set_property -dict  {INTERNAL_VREF {0.84}}  [get_iobanks 45]
 set_property -dict  {INTERNAL_VREF {0.84}}  [get_iobanks 46]
 
-create_clock -name phy_clk      -period  1.60 [get_ports phy_clk_p]
-
 #Setting the Configuration Bank Voltage Select
 set_property CFGBVS GND [current_design]
 set_property CONFIG_VOLTAGE 1.8 [current_design]

--- a/projects/common/vcu118/vcu118_system_bd.tcl
+++ b/projects/common/vcu118/vcu118_system_bd.tcl
@@ -78,7 +78,7 @@ ad_ip_parameter sys_500m_rstgen CONFIG.C_EXT_RST_WIDTH 1
 
 ad_ip_instance ip:ddr4 axi_ddr_cntrl
 ad_ip_parameter axi_ddr_cntrl CONFIG.C0_CLOCK_BOARD_INTERFACE default_250mhz_clk2
-ad_ip_parameter axi_ddr_cntrl CONFIG.C0_DDR4_BOARD_INTERFACE ddr4_sdram_c2
+ad_ip_parameter axi_ddr_cntrl CONFIG.C0_DDR4_BOARD_INTERFACE ddr4_sdram_c2_083
 ad_ip_parameter axi_ddr_cntrl CONFIG.RESET_BOARD_INTERFACE reset
 ad_ip_parameter axi_ddr_cntrl CONFIG.ADDN_UI_CLKOUT2_FREQ_HZ 250
 ad_ip_parameter axi_ddr_cntrl CONFIG.ADDN_UI_CLKOUT3_FREQ_HZ 500

--- a/projects/scripts/adi_project_xilinx.tcl
+++ b/projects/scripts/adi_project_xilinx.tcl
@@ -14,10 +14,13 @@ if {[info exists ::env(ADI_IGNORE_VERSION_CHECK)]} {
 ## Define the ADI_USE_OOC_SYNTHESIS environment variable to enable out of context
 #  synthesis
 if {[info exists ::env(ADI_USE_OOC_SYNTHESIS)]} {
-  set ADI_USE_OOC_SYNTHESIS 1
+  if {[string equal $::env(ADI_USE_OOC_SYNTHESIS) n]} {
+     set ADI_USE_OOC_SYNTHESIS 0
+  } else {
+     set ADI_USE_OOC_SYNTHESIS 1
+  }
 } elseif {![info exists ADI_USE_OOC_SYNTHESIS]} {
-  set ADI_USE_OOC_SYNTHESIS 0
-
+   set ADI_USE_OOC_SYNTHESIS 1
 }
 
 ## Set number of parallel out of context jobs through environment variable

--- a/projects/scripts/adi_project_xilinx.tcl
+++ b/projects/scripts/adi_project_xilinx.tcl
@@ -1,7 +1,7 @@
 
 ## Define the supported tool version
 if {![info exists REQUIRED_VIVADO_VERSION]} {
-  set REQUIRED_VIVADO_VERSION "2020.1"
+  set REQUIRED_VIVADO_VERSION "2020.2"
 }
 
 ## Define the ADI_IGNORE_VERSION_CHECK environment variable to skip version check


### PR DESCRIPTION
Update vivado version to 2020.2:
     - update default vivado version from 2020.1 to 2020.2
     - add conditions to apply specific contraints only in Out Of Context mode.
     - update DDR controler parameters for vcu118 and kcu105 dev boards
     - set default value of ADI_USE_OOC_SYNTHESIS variable to 1