### PR TITLE
adi_make: Update bin build flow for 2020.1 tools

### DIFF
--- a/projects/scripts/adi_make.tcl
+++ b/projects/scripts/adi_make.tcl
@@ -245,7 +245,7 @@ namespace eval adi_make {
 
     set arm_tr_sw_elf "bl31.elf"
     set boot_bin_folder "boot_bin"
-    if {[catch {set hdf_file "[glob "./*.sdk/system_top.hdf"]"} fid]} {
+    if {[catch {set xsa_file "[glob "./*.sdk/system_top.xsa"]"} fid]} {
       puts stderr "ERROR: $fid\n\rNOTE: you must have built hdl project\n\
       \rSee: https://wiki.analog.com/resources/fpga/docs/build\n"
       return
@@ -258,7 +258,7 @@ namespace eval adi_make {
 
     puts "root_hdl_folder $root_hdl_folder"
     puts "uboot_elf $uboot_elf"
-    puts "hdf_file $hdf_file"
+    puts "xsa_file $xsa_file"
 
     # determine if Xilinx SDK tools are set in the enviroment
     package require platform
@@ -281,7 +281,7 @@ namespace eval adi_make {
     }
 
     set xsct_script "exec xsct $root_hdl_folder/projects/scripts/adi_make_boot_bin.tcl"
-    set build_args "$hdf_file $uboot_elf $boot_bin_folder $arm_tr_sw_elf"
+    set build_args "$xsa_file $uboot_elf $boot_bin_folder $arm_tr_sw_elf"
     puts "Please wait, this may take a few minutes."
     eval $xsct_script $build_args
   }

--- a/projects/scripts/adi_make_boot_bin.tcl
+++ b/projects/scripts/adi_make_boot_bin.tcl
@@ -39,7 +39,7 @@
 #
 # This script was designed to work within the Xilinx tool command line interface
 # Script arguments:
-# 1 - hdf file location (default: ./system_top.hdf)
+# 1 - xsa file location (default: ./system_top.xsa)
 # 2 - u-boot.elf file location/name (default: ./u-boot.elf)
 # 3 - build location (default: pwd: $PWD)"
 # 4 - bl31.elf(mp soc projects only) file location
@@ -48,37 +48,44 @@
 #
 # Examples:
 # - adi_make_boot_bin.tcl
-# - adi_make_boot_bin.tcl $hdf_path/system_top.hdf $uboot_path/u-boot.elf
-# - adi_make_boot_bin.tcl $hdf_path/system_top.hdf $uboot_path/u-boot.elf $workspace
-# - adi_make_boot_bin.tcl $hdf_path/system_top.hdf $uboot_path/u-boot.elf $workspace $arm_trf_repo/bl31.elf
+# - adi_make_boot_bin.tcl $xsa_path/system_top.xsa $uboot_path/u-boot.elf
+# - adi_make_boot_bin.tcl $xsa_path/system_top.xsa $uboot_path/u-boot.elf $workspace
+# - adi_make_boot_bin.tcl $xsa_path/system_top.xsa $uboot_path/u-boot.elf $workspace $arm_trf_repo/bl31.elf
 
 set PWD [pwd]
 
-# getting parsed arguments
+# init variables
 set app_type ""
-set hdf_file ""
+set xsa_file ""
 set uboot_file ""
 
-set hdf_file [lindex $argv 0]
+# getting parsed arguments
+set xsa_file [lindex $argv 0 ] ; # or .xsa(xilinx shell archive)
 set uboot_file [lindex $argv 1]
 set build_dir [lindex $argv 2]
 set arm_tr_frm_file [lindex $argv 3]
 
-# hdf file exists
-if { $hdf_file == "" } {
-  set hdf_file system_top.hdf
+# xsa file exists
+if { $xsa_file == "" } {
+  set xsa_file system_top.xsa
+  if { ![file exists $xsa_file] } {
+    set xsa_file system_top.xsa
+  }
 }
-if { ![file exists $hdf_file] } {
-  puts "ERROR: hdf file is not defined or located in $PWD"
+if { ![file exists $xsa_file] } {
+  puts "ERROR: xsa file location is not set nor located in $PWD"
   return
 }
 
 # uboot file exists
 if { $uboot_file == "" } {
-  set uboot_file u-boot.elf
+    if {[catch {set uboot_file "[glob "./u-boot*.elf"]" } fid]} {
+      puts stderr "ERROR: $fid\n\rNOTE: you must have a the u-boot.elf in [pwd]\n\
+      \rSee: https://wiki.analog.com/resources/fpga/docs/build\n"
+   }
 }
 if { ![file exists $uboot_file] } {
-  puts "ERROR: uboot file is not defined or located in $PWD"
+  puts "ERROR: uboot file location is not set, nor located in $PWD"
   return
 }
 
@@ -87,12 +94,15 @@ if { $build_dir == "" } {
   set build_dir "boot_bin"
 }
 
+if { [file exists $build_dir] } {
+  file delete -force $build_dir
+}
 catch { file mkdir $build_dir } err
 if { ![file exists $build_dir] } {
   puts "ERROR: Failed to create \"$build_dir\" dir"
   return
 }
-file copy -force $hdf_file $build_dir/system_top.hdf
+file copy -force $xsa_file $build_dir/system_top.xsa
 file copy -force $uboot_file $build_dir
 
 # Zynq MP arm trusted firwmware
@@ -108,11 +118,11 @@ if { $app_type == "Zynq MP FSBL" } {
 # get cpu(app_type)
 set cpu_name ""
 set app_type ""
-hsi open_hw_design $build_dir/system_top.hdf
+hsi open_hw_design $build_dir/system_top.xsa
 set cpu_name [lindex [hsi get_cells -filter {IP_TYPE==PROCESSOR}] 0]
 
 if { $cpu_name == ""} {
-  puts "ERROR: cpu name could not be determine from hdf file"
+  puts "ERROR: cpu name could not be determine from .xsa file"
   return
 } else {
   if { [regexp psu_cortexa53.. $cpu_name] } {
@@ -123,10 +133,23 @@ if { $cpu_name == ""} {
     puts "ERROR: boot_bin (first stage boot loader + ...) is design for arm processors"
     return
   } else {
-    puts "ERROR: unknown processor \"$cpu_name\" detected in $build_dir/system_top.hdf"
+    puts "ERROR: unknown processor \"$cpu_name\" detected in $build_dir/system_top.xsa"
     return
   }
 }
+
+# Zynq MP arm trusted firwmware
+if { $app_type == "Zynq MP FSBL" } {
+  if { $arm_tr_frm_file == "" } {
+    set arm_tr_frm_file bl31.elf
+  }
+  if { ![file exists $arm_tr_frm_file] } {
+    puts "ERROR: arm trusted firmware (bl31.el) file is not defined or located in $PWD"
+  } else {
+    file copy -force $arm_tr_frm_file $build_dir
+  }
+}
+
 puts "Using CPU $cpu_name"
 
 # create zynq.bif for target app
@@ -135,11 +158,10 @@ set l_sq_bracket "\["
 set r_sq_bracket "\]"
 if { $app_type == "Zynq FSBL" } {
 
-  file delete -force $build_dir/zynq.bif
   set zynq_bif [open "$build_dir/zynq.bif" a+]
   puts  $zynq_bif "the_ROM_image:"
   puts  $zynq_bif "{"
-  puts  $zynq_bif "${l_sq_bracket}bootloader${r_sq_bracket} ./fsbl_prj/fsbl/Debug/fsbl.elf"
+  puts  $zynq_bif "${l_sq_bracket}bootloader${r_sq_bracket} ./fsbl.elf"
   puts  $zynq_bif "./system_top.bit"
   puts  $zynq_bif "$uboot_file"
   puts  $zynq_bif "}"
@@ -147,25 +169,16 @@ if { $app_type == "Zynq FSBL" } {
 
 } elseif { $app_type == "Zynq MP FSBL" } {
 
-  file delete -force $build_dir/zynqmp.bif
   set zynqmp_bif [open "$build_dir/zynqmp.bif" a+]
   puts  $zynqmp_bif "the_ROM_image:"
   puts  $zynqmp_bif "{"
-  puts  $zynqmp_bif "${l_sq_bracket}fsbl_config${r_sq_bracket} a53_x64"
-  puts  $zynqmp_bif "${l_sq_bracket}bootloader${r_sq_bracket} ./fsbl_prj/fsbl/Debug/fsbl.elf"
-  puts  $zynqmp_bif "${l_sq_bracket}pmufw_image${r_sq_bracket} ./pmufw/executable.elf"
+  puts  $zynqmp_bif "${l_sq_bracket}pmufw_image${r_sq_bracket} ./pmufw.elf"
+  puts  $zynqmp_bif "${l_sq_bracket}bootloader,destination_cpu=a53-0${r_sq_bracket} ./fsbl.elf"
   puts  $zynqmp_bif "${l_sq_bracket}destination_device=pl${r_sq_bracket} ./system_top.bit"
   puts  $zynqmp_bif "${l_sq_bracket}destination_cpu=a53-0,exception_level=el-3,trustzone${r_sq_bracket} $arm_tr_frm_file"
   puts  $zynqmp_bif "${l_sq_bracket}destination_cpu=a53-0,exception_level=el-2${r_sq_bracket} $uboot_file"
   puts  $zynqmp_bif "}"
   close $zynqmp_bif
-
-  file delete -force $build_dir/create_pmufw_project.tcl
-  set pmufw_proj [open "$build_dir/create_pmufw_project.tcl" a+]
-  puts  $pmufw_proj "set hwdsgn ${l_sq_bracket}open_hw_design ./system_top.hdf${r_sq_bracket}"
-  puts  $pmufw_proj "generate_app -hw \$hwdsgn -os standalone -proc psu_pmu_0 -app zynqmp_pmufw -compile -sw pmufw -dir pmufw"
-  puts  $pmufw_proj "quit"
-  close $pmufw_proj
 
 } else {
   puts "ERROR: unknown \"$app_type\" when creating zynqx.bif "
@@ -173,25 +186,25 @@ if { $app_type == "Zynq FSBL" } {
 }
 
 # create fsbl_build.tcl script
-file delete -force $build_dir/fsbl_build.tcl
 set fsbl_build [open "$build_dir/fsbl_build.tcl" a+]
-puts  $fsbl_build "hsi open_hw_design system_top.hdf"
-puts  $fsbl_build "setws ./fsbl_prj"
-puts  $fsbl_build "createhw -name hw -hwspec system_top.hdf"
-puts  $fsbl_build "createapp -name fsbl -app \"$app_type\" -proc $cpu_name -bsp bsp -hwproject hw -os standalone -lang C"
-puts  $fsbl_build "projects -build -type all\n"
+puts  $fsbl_build "hsi open_hw_design system_top.xsa"
+puts  $fsbl_build "platform create -name hw0 -hw system_top.xsa -os standalone -out ./output -proc $cpu_name"
+puts  $fsbl_build "platform generate"
 close $fsbl_build
 
 cd $build_dir
-file delete -force fsbl_prj
-file delete -force pmufw
 
-exec xsdk -batch -source fsbl_build.tcl -wait
+if {[catch { [exec xsct fsbl_build.tcl] } msg]} {
+  puts "$msg"
+}
+puts "end of FSBL build"
+
+file copy -force output/hw0/export/hw0/sw/hw0/boot/fsbl.elf .
 
 if { $app_type == "Zynq FSBL" } {
     exec bootgen -image zynq.bif -w -o i BOOT.BIN
 } elseif { $app_type == "Zynq MP FSBL" } {
-    exec hsi -source create_pmufw_project.tcl
+    file copy -force output/hw0/export/hw0/sw/hw0/boot/pmufw.elf .
     exec bootgen -image zynqmp.bif -arch zynqmp -o BOOT.BIN -w
 }
 


### PR DESCRIPTION
The 2020.1 Xilinx tools have a different tcl procedures to build the boot.bin file.
This commit updates the adi_make tcl flow for the new tools. The new process is not backwards compatible with tools older than 2020 version.