### PR TITLE
data_offload: Add sync to cyclic mode

### DIFF
--- a/library/data_offload/data_offload_fsm.v
+++ b/library/data_offload/data_offload_fsm.v
@@ -328,8 +328,14 @@ module data_offload_fsm #(
 
         // read until empty or next init_req
         RD_READ_FROM_MEM : begin
-          if ((rd_empty_s && (rd_init_req_s || (rd_oneshot && rd_last)) && rd_ready)) begin
-            rd_fsm_state <= RD_IDLE;
+          if (rd_empty_s && rd_ready) begin
+            if (rd_init_req_s || (rd_oneshot && rd_last)) begin
+              rd_fsm_state <= RD_IDLE;
+            end else if (TX_OR_RXN_PATH && sync_config && (!rd_oneshot)) begin
+              rd_fsm_state <= RD_SYNC;
+            end else begin
+              rd_fsm_state <= RD_READ_FROM_MEM;
+            end
           end else begin
             rd_fsm_state <= RD_READ_FROM_MEM;
           end


### PR DESCRIPTION
This commit slightly changes the behavior of cyclic mode when a synchronization mode is enabled, to always wait before each iteration for another sync impulse. This allows the user to repeatedly replay a waveform at precise, and externally controlled timing, without having to refill the buffer each time. This does not change the behavior when synchronization is disabled or oneshot is enabled.