### PR TITLE
ad_mem_asym: Add option to control cascade layout

### DIFF
--- a/library/common/ad_mem_asym.v
+++ b/library/common/ad_mem_asym.v
@@ -43,7 +43,8 @@ module ad_mem_asym #(
   parameter   A_ADDRESS_WIDTH =  8,
   parameter   A_DATA_WIDTH = 256,
   parameter   B_ADDRESS_WIDTH =   10,
-  parameter   B_DATA_WIDTH =  64) (
+  parameter   B_DATA_WIDTH =  64,
+  parameter   CASCADE_HEIGHT = -1) (
 
   input                             clka,
   input                             wea,
@@ -82,7 +83,7 @@ module ad_mem_asym #(
 
   // internal registers
 
-  (* ram_style = "block" *)
+  (* ram_style = "block", cascade_height = CASCADE_HEIGHT *)
   reg      [MEM_DATA_WIDTH-1:0]    m_ram[0:MEM_SIZE-1];
 
   //---------------------------------------------------------------------------

--- a/projects/common/xilinx/data_offload_bd.tcl
+++ b/projects/common/xilinx/data_offload_bd.tcl
@@ -62,6 +62,7 @@ proc ad_data_offload_create {instance_name datapath_type mem_type mem_size sourc
         CONFIG.A_ADDRESS_WIDTH $source_awidth \
         CONFIG.B_DATA_WIDTH $destination_dwidth \
         CONFIG.B_ADDRESS_WIDTH $destination_awidth \
+        CONFIG.CASCADE_HEIGHT 1 \
       ] [get_bd_cells storage_unit]
 
       ad_connect storage_unit/clka i_data_offload/s_axis_aclk


### PR DESCRIPTION
With larger block rams the option to control cascade height might come in handy when the Xilinx tools fail to identify a group of block rams as timing critical. In that case the cascade hight may be overridden to 1.

For more information on this attribute, see page 45 of the [Vivado Design Suite
User Guide - Synthesis](https://www.xilinx.com/support/documentation/sw_manuals/xilinx2020_2/ug901-vivado-synthesis.pdf)