### PR TITLE
adrv9009zu11eg & common/zcu102 : Fix zynqmp ref clock definition

### DIFF
--- a/projects/adrv9009zu11eg/common/adrv9009zu11eg_bd.tcl
+++ b/projects/adrv9009zu11eg/common/adrv9009zu11eg_bd.tcl
@@ -26,6 +26,7 @@ create_bd_port -dir I dac_fifo_bypass
 
 ad_ip_instance zynq_ultra_ps_e sys_ps8
 
+ad_ip_parameter sys_ps8 CONFIG.PSU__PSS_REF_CLK__FREQMHZ 33.333333333
 ad_ip_parameter sys_ps8 CONFIG.PSU__USE__M_AXI_GP0 0
 ad_ip_parameter sys_ps8 CONFIG.PSU__USE__M_AXI_GP1 0
 ad_ip_parameter sys_ps8 CONFIG.PSU__USE__M_AXI_GP2 1

--- a/projects/common/zcu102/zcu102_system_bd.tcl
+++ b/projects/common/zcu102/zcu102_system_bd.tcl
@@ -22,6 +22,7 @@ ad_ip_instance zynq_ultra_ps_e sys_ps8
 apply_bd_automation -rule xilinx.com:bd_rule:zynq_ultra_ps_e \
   -config {apply_board_preset 1}  [get_bd_cells sys_ps8]
 
+ad_ip_parameter sys_ps8 CONFIG.PSU__PSS_REF_CLK__FREQMHZ 33.333333333
 ad_ip_parameter sys_ps8 CONFIG.PSU__USE__M_AXI_GP0 0
 ad_ip_parameter sys_ps8 CONFIG.PSU__USE__M_AXI_GP1 0
 ad_ip_parameter sys_ps8 CONFIG.PSU__USE__M_AXI_GP2 1


### PR DESCRIPTION
The derived clocks of the zynqmp core are not calculated correctly due
rounding issues, instead of 100MHz the value of 99999001 is received
causing warnings during system validation.

This can be fixed/worked around with the proper reference clock
definition.

The issue is present in Vivado 2020.1 and 2020.2
I have not tested newer versions.