### PR TITLE
fmcjesdadc1: Update block design

### DIFF
--- a/projects/fmcjesdadc1/common/fmcjesdadc1_bd.tcl
+++ b/projects/fmcjesdadc1/common/fmcjesdadc1_bd.tcl
@@ -1,4 +1,12 @@
 
+# RX parameters for each converter
+set RX_NUM_OF_LANES 4      ; # L
+set RX_NUM_OF_CONVERTERS 4 ; # M
+set RX_SAMPLES_PER_FRAME 1 ; # S
+set RX_SAMPLE_WIDTH 16     ; # N/NP
+
+set RX_SAMPLES_PER_CHANNEL 2 ; # L * 32 / (M * N)
+
 source $ad_hdl_dir/library/jesd204/scripts/jesd204.tcl
 
 # adc peripherals
@@ -13,52 +21,33 @@ ad_ip_parameter axi_ad9250_xcvr CONFIG.SYS_CLK_SEL 0x0
 
 adi_axi_jesd204_rx_create axi_ad9250_jesd 4
 
-ad_ip_instance util_bsplit data_bsplit
-ad_ip_parameter data_bsplit CONFIG.CHANNEL_DATA_WIDTH 64
-ad_ip_parameter data_bsplit CONFIG.NUM_OF_CHANNELS 2
+adi_tpl_jesd204_rx_create axi_ad9250_core $RX_NUM_OF_LANES \
+                                            $RX_NUM_OF_CONVERTERS \
+                                            $RX_SAMPLES_PER_FRAME \
+                                            $RX_SAMPLE_WIDTH
+ad_ip_parameter axi_ad9250_core CONFIG.CONVERTER_RESOLUTION 14
+ad_ip_parameter axi_ad9250_core CONFIG.BITS_PER_SAMPLE 16
+ad_ip_parameter axi_ad9250_core CONFIG.DMA_BITS_PER_SAMPLE 16
 
-ad_ip_instance axi_ad9250 axi_ad9250_0_core
-ad_ip_instance axi_ad9250 axi_ad9250_1_core
+ad_ip_instance util_cpack2 axi_ad9250_cpack [list \
+  NUM_OF_CHANNELS $RX_NUM_OF_CONVERTERS \
+  SAMPLES_PER_CHANNEL $RX_SAMPLES_PER_CHANNEL \
+  SAMPLE_DATA_WIDTH $RX_SAMPLE_WIDTH \
+]
 
-ad_ip_instance util_cpack2 axi_ad9250_0_cpack { \
-  NUM_OF_CHANNELS 2 \
-  SAMPLES_PER_CHANNEL 2 \
-  SAMPLE_DATA_WIDTH 16 \
-}
-
-ad_ip_instance util_cpack2 axi_ad9250_1_cpack { \
-  NUM_OF_CHANNELS 2 \
-  SAMPLES_PER_CHANNEL 2 \
-  SAMPLE_DATA_WIDTH 16 \
-}
-
-ad_ip_instance axi_dmac axi_ad9250_0_dma
-ad_ip_parameter axi_ad9250_0_dma CONFIG.DMA_TYPE_SRC 2
-ad_ip_parameter axi_ad9250_0_dma CONFIG.DMA_TYPE_DEST 0
-ad_ip_parameter axi_ad9250_0_dma CONFIG.ID 0
-ad_ip_parameter axi_ad9250_0_dma CONFIG.AXI_SLICE_SRC 0
-ad_ip_parameter axi_ad9250_0_dma CONFIG.AXI_SLICE_DEST 0
-ad_ip_parameter axi_ad9250_0_dma CONFIG.SYNC_TRANSFER_START 1
-ad_ip_parameter axi_ad9250_0_dma CONFIG.DMA_LENGTH_WIDTH 24
-ad_ip_parameter axi_ad9250_0_dma CONFIG.DMA_2D_TRANSFER 0
-ad_ip_parameter axi_ad9250_0_dma CONFIG.CYCLIC 0
-ad_ip_parameter axi_ad9250_0_dma CONFIG.DMA_DATA_WIDTH_SRC 64
-ad_ip_parameter axi_ad9250_0_dma CONFIG.DMA_DATA_WIDTH_DEST 64
-ad_ip_parameter axi_ad9250_0_dma CONFIG.FIFO_SIZE 8
-
-ad_ip_instance axi_dmac axi_ad9250_1_dma
-ad_ip_parameter axi_ad9250_1_dma CONFIG.DMA_TYPE_SRC 2
-ad_ip_parameter axi_ad9250_1_dma CONFIG.DMA_TYPE_DEST 0
-ad_ip_parameter axi_ad9250_1_dma CONFIG.ID 0
-ad_ip_parameter axi_ad9250_1_dma CONFIG.AXI_SLICE_SRC 0
-ad_ip_parameter axi_ad9250_1_dma CONFIG.AXI_SLICE_DEST 0
-ad_ip_parameter axi_ad9250_1_dma CONFIG.SYNC_TRANSFER_START 1
-ad_ip_parameter axi_ad9250_1_dma CONFIG.DMA_LENGTH_WIDTH 24
-ad_ip_parameter axi_ad9250_1_dma CONFIG.DMA_2D_TRANSFER 0
-ad_ip_parameter axi_ad9250_1_dma CONFIG.CYCLIC 0
-ad_ip_parameter axi_ad9250_1_dma CONFIG.DMA_DATA_WIDTH_SRC 64
-ad_ip_parameter axi_ad9250_1_dma CONFIG.DMA_DATA_WIDTH_DEST 64
-ad_ip_parameter axi_ad9250_0_dma CONFIG.FIFO_SIZE 8
+ad_ip_instance axi_dmac axi_ad9250_dma
+ad_ip_parameter axi_ad9250_dma CONFIG.DMA_TYPE_SRC 2
+ad_ip_parameter axi_ad9250_dma CONFIG.DMA_TYPE_DEST 0
+ad_ip_parameter axi_ad9250_dma CONFIG.ID 0
+ad_ip_parameter axi_ad9250_dma CONFIG.AXI_SLICE_SRC 0
+ad_ip_parameter axi_ad9250_dma CONFIG.AXI_SLICE_DEST 0
+ad_ip_parameter axi_ad9250_dma CONFIG.SYNC_TRANSFER_START 1
+ad_ip_parameter axi_ad9250_dma CONFIG.DMA_LENGTH_WIDTH 24
+ad_ip_parameter axi_ad9250_dma CONFIG.DMA_2D_TRANSFER 0
+ad_ip_parameter axi_ad9250_dma CONFIG.CYCLIC 0
+ad_ip_parameter axi_ad9250_dma CONFIG.DMA_DATA_WIDTH_SRC 128
+ad_ip_parameter axi_ad9250_dma CONFIG.DMA_DATA_WIDTH_DEST 128
+ad_ip_parameter axi_ad9250_dma CONFIG.FIFO_SIZE 8
 
 # transceiver core
 
@@ -92,36 +81,38 @@ create_bd_port -dir O rx_core_clk
 
 ad_xcvrcon  util_fmcjesdadc1_xcvr axi_ad9250_xcvr axi_ad9250_jesd
 ad_connect  util_fmcjesdadc1_xcvr/rx_out_clk_0 rx_core_clk
+ 
+ad_connect axi_ad9250_core/adc_valid_0 axi_ad9250_cpack/fifo_wr_en   
+    
+ad_connect axi_ad9250_core/adc_enable_0 axi_ad9250_cpack/enable_0
+ad_connect axi_ad9250_core/adc_enable_1 axi_ad9250_cpack/enable_1
+ad_connect axi_ad9250_core/adc_enable_2 axi_ad9250_cpack/enable_2
+ad_connect axi_ad9250_core/adc_enable_3 axi_ad9250_cpack/enable_3    
 
-ad_connect  axi_ad9250_jesd/rx_data_tdata data_bsplit/data
+ad_connect  util_fmcjesdadc1_xcvr/rx_out_clk_0 axi_ad9250_core/link_clk
+ad_connect  axi_ad9250_jesd/rx_sof axi_ad9250_core/link_sof
+ad_connect  axi_ad9250_core/link_data axi_ad9250_jesd/rx_data_tdata
 
-for {set i 0} {$i < 2} {incr i} {
-  ad_connect  util_fmcjesdadc1_xcvr/rx_out_clk_0 axi_ad9250_${i}_core/rx_clk
-  ad_connect  axi_ad9250_jesd/rx_sof axi_ad9250_${i}_core/rx_sof
-  ad_connect  axi_ad9250_${i}_core/rx_data data_bsplit/split_data_${i}
+ad_connect  util_fmcjesdadc1_xcvr/rx_out_clk_0 axi_ad9250_cpack/clk
+ad_connect  axi_ad9250_jesd_rstgen/peripheral_reset axi_ad9250_cpack/reset
 
-  ad_connect  util_fmcjesdadc1_xcvr/rx_out_clk_0 axi_ad9250_${i}_cpack/clk
-  ad_connect  axi_ad9250_jesd_rstgen/peripheral_reset axi_ad9250_${i}_cpack/reset
+ad_connect  axi_ad9250_core/adc_dovf axi_ad9250_cpack/fifo_wr_overflow
+ad_connect  axi_ad9250_core/adc_data_0 axi_ad9250_cpack/fifo_wr_data_0
+ad_connect  axi_ad9250_core/adc_data_1 axi_ad9250_cpack/fifo_wr_data_1
+ad_connect  axi_ad9250_core/adc_data_2 axi_ad9250_cpack/fifo_wr_data_2
+ad_connect  axi_ad9250_core/adc_data_3 axi_ad9250_cpack/fifo_wr_data_3
 
-  ad_connect  axi_ad9250_${i}_core/adc_dovf axi_ad9250_${i}_cpack/fifo_wr_overflow
-  ad_connect  axi_ad9250_${i}_core/adc_valid_a axi_ad9250_${i}_cpack/fifo_wr_en
-  ad_connect  axi_ad9250_${i}_core/adc_enable_a axi_ad9250_${i}_cpack/enable_0
-  ad_connect  axi_ad9250_${i}_core/adc_data_a axi_ad9250_${i}_cpack/fifo_wr_data_0
-  ad_connect  axi_ad9250_${i}_core/adc_enable_b axi_ad9250_${i}_cpack/enable_1
-  ad_connect  axi_ad9250_${i}_core/adc_data_b axi_ad9250_${i}_cpack/fifo_wr_data_1
+ad_connect  axi_ad9250_core/link_clk axi_ad9250_dma/fifo_wr_clk
+ad_connect  axi_ad9250_dma/fifo_wr axi_ad9250_cpack/packed_fifo_wr
 
-  ad_connect  axi_ad9250_${i}_core/adc_clk axi_ad9250_${i}_dma/fifo_wr_clk
-  ad_connect  axi_ad9250_${i}_dma/fifo_wr axi_ad9250_${i}_cpack/packed_fifo_wr
-}
+ad_connect  axi_ad9250_core/link_valid axi_ad9250_jesd/rx_data_tvalid  
 
 # interconnect (cpu)
 
 ad_cpu_interconnect 0x44A60000 axi_ad9250_xcvr
-ad_cpu_interconnect 0x44A10000 axi_ad9250_0_core
-ad_cpu_interconnect 0x44A20000 axi_ad9250_1_core
+ad_cpu_interconnect 0x44A10000 axi_ad9250_core
 ad_cpu_interconnect 0x44AA0000 axi_ad9250_jesd
-ad_cpu_interconnect 0x7c420000 axi_ad9250_0_dma
-ad_cpu_interconnect 0x7c430000 axi_ad9250_1_dma
+ad_cpu_interconnect 0x7c420000 axi_ad9250_dma
 
 # xcvr uses hp3, and 100MHz clock for both DRP and AXI4
 
@@ -131,15 +122,12 @@ ad_mem_hp3_interconnect $sys_cpu_clk axi_ad9250_xcvr/m_axi
 # interconnect (adc)
 
 ad_mem_hp2_interconnect $sys_dma_clk sys_ps7/S_AXI_HP2
-ad_mem_hp2_interconnect $sys_dma_clk axi_ad9250_0_dma/m_dest_axi
-ad_mem_hp2_interconnect $sys_dma_clk axi_ad9250_1_dma/m_dest_axi
+ad_mem_hp2_interconnect $sys_dma_clk axi_ad9250_dma/m_dest_axi
 
-ad_connect  $sys_dma_resetn axi_ad9250_0_dma/m_dest_axi_aresetn
-ad_connect  $sys_dma_resetn axi_ad9250_1_dma/m_dest_axi_aresetn
+ad_connect  $sys_dma_resetn axi_ad9250_dma/m_dest_axi_aresetn
 
 #interrupts
 
 ad_cpu_interrupt ps-11 mb-14 axi_ad9250_jesd/irq
-ad_cpu_interrupt ps-12 mb-12 axi_ad9250_1_dma/irq
-ad_cpu_interrupt ps-13 mb-13 axi_ad9250_0_dma/irq
+ad_cpu_interrupt ps-13 mb-13 axi_ad9250_dma/irq
 

--- a/projects/fmcjesdadc1/kc705/Makefile
+++ b/projects/fmcjesdadc1/kc705/Makefile
@@ -15,13 +15,12 @@ M_DEPS += ../../../library/jesd204/scripts/jesd204.tcl
 M_DEPS += ../../../library/common/ad_sysref_gen.v
 M_DEPS += ../../../library/common/ad_iobuf.v
 
-LIB_DEPS += axi_ad9250
 LIB_DEPS += axi_dmac
 LIB_DEPS += axi_sysid
+LIB_DEPS += jesd204/ad_ip_jesd204_tpl_adc
 LIB_DEPS += jesd204/axi_jesd204_rx
 LIB_DEPS += jesd204/jesd204_rx
 LIB_DEPS += sysid_rom
-LIB_DEPS += util_bsplit
 LIB_DEPS += util_pack/util_cpack2
 LIB_DEPS += xilinx/axi_adxcvr
 LIB_DEPS += xilinx/util_adxcvr

--- a/projects/fmcjesdadc1/kc705/system_bd.tcl
+++ b/projects/fmcjesdadc1/kc705/system_bd.tcl
@@ -10,8 +10,6 @@ ad_ip_parameter rom_sys_0 CONFIG.ROM_ADDR_BITS 9
 
 sysid_gen_sys_init_file
 
-ad_ip_parameter axi_ad9250_0_dma CONFIG.DMA_DATA_WIDTH_DEST 512
-ad_ip_parameter axi_ad9250_0_dma CONFIG.FIFO_SIZE 32
-ad_ip_parameter axi_ad9250_1_dma CONFIG.DMA_DATA_WIDTH_DEST 512
-ad_ip_parameter axi_ad9250_1_dma CONFIG.FIFO_SIZE 32
+ad_ip_parameter axi_ad9250_dma CONFIG.DMA_DATA_WIDTH_DEST 512
+ad_ip_parameter axi_ad9250_dma CONFIG.FIFO_SIZE 32
 

--- a/projects/fmcjesdadc1/vc707/Makefile
+++ b/projects/fmcjesdadc1/vc707/Makefile
@@ -15,13 +15,12 @@ M_DEPS += ../../../library/jesd204/scripts/jesd204.tcl
 M_DEPS += ../../../library/common/ad_sysref_gen.v
 M_DEPS += ../../../library/common/ad_iobuf.v
 
-LIB_DEPS += axi_ad9250
 LIB_DEPS += axi_dmac
 LIB_DEPS += axi_sysid
+LIB_DEPS += jesd204/ad_ip_jesd204_tpl_adc
 LIB_DEPS += jesd204/axi_jesd204_rx
 LIB_DEPS += jesd204/jesd204_rx
 LIB_DEPS += sysid_rom
-LIB_DEPS += util_bsplit
 LIB_DEPS += util_pack/util_cpack2
 LIB_DEPS += xilinx/axi_adxcvr
 LIB_DEPS += xilinx/util_adxcvr

--- a/projects/fmcjesdadc1/vc707/system_bd.tcl
+++ b/projects/fmcjesdadc1/vc707/system_bd.tcl
@@ -10,7 +10,5 @@ ad_ip_parameter rom_sys_0 CONFIG.ROM_ADDR_BITS 9
 
 sysid_gen_sys_init_file
 
-ad_ip_parameter axi_ad9250_0_dma CONFIG.DMA_DATA_WIDTH_DEST 256
-ad_ip_parameter axi_ad9250_0_dma CONFIG.FIFO_SIZE 32
-ad_ip_parameter axi_ad9250_1_dma CONFIG.DMA_DATA_WIDTH_DEST 256
-ad_ip_parameter axi_ad9250_1_dma CONFIG.FIFO_SIZE 32
+ad_ip_parameter axi_ad9250_dma CONFIG.DMA_DATA_WIDTH_DEST 256
+ad_ip_parameter axi_ad9250_dma CONFIG.FIFO_SIZE 32

--- a/projects/fmcjesdadc1/zc706/Makefile
+++ b/projects/fmcjesdadc1/zc706/Makefile
@@ -14,16 +14,15 @@ M_DEPS += ../../../library/jesd204/scripts/jesd204.tcl
 M_DEPS += ../../../library/common/ad_sysref_gen.v
 M_DEPS += ../../../library/common/ad_iobuf.v
 
-LIB_DEPS += axi_ad9250
 LIB_DEPS += axi_clkgen
 LIB_DEPS += axi_dmac
 LIB_DEPS += axi_hdmi_tx
 LIB_DEPS += axi_spdif_tx
 LIB_DEPS += axi_sysid
+LIB_DEPS += jesd204/ad_ip_jesd204_tpl_adc
 LIB_DEPS += jesd204/axi_jesd204_rx
 LIB_DEPS += jesd204/jesd204_rx
 LIB_DEPS += sysid_rom
-LIB_DEPS += util_bsplit
 LIB_DEPS += util_pack/util_cpack2
 LIB_DEPS += xilinx/axi_adxcvr
 LIB_DEPS += xilinx/util_adxcvr


### PR DESCRIPTION
Modified the project such that there is only one data path for the ADC
data: deleted one of the JESD tpl instances, one of the cpack instances and
one of the dma instances.

This pull request was opened after closing the https://github.com/analogdevicesinc/hdl/pull/701 pull request. It introduces the same modification as the closed pull request but the branch it is linked to is up-to-date with the master branch. It also contains all the modifications suggested by the users who commented on the previous pull  request.

Signed-off-by: Dan Hotoleanu <dan.hotoleanu@analog.com>