### PR TITLE
daq2/zcu102: Fix the ad9144 data offload to use internal BRAM

### DIFF
--- a/projects/daq2/zcu102/system_bd.tcl
+++ b/projects/daq2/zcu102/system_bd.tcl
@@ -1,15 +1,17 @@
+## Offload attributes
+set adc_offload_type 0
+set adc_offload_size 256000
 
-## FIFO depth is 8Mb - 500k samples
-set adc_fifo_address_width 17
+set dac_offload_type 0
+set dac_offload_size 256000
 
-## FIFO depth is 8Mb - 500k samples
-set dac_fifo_address_width 16
+# dummy defines
+set plddr_offload_axi_data_width 0
+set plddr_offload_axi_addr_width 0
 
 ## NOTE: With this configuration the #36Kb BRAM utilization is at ~57%
 
 source $ad_hdl_dir/projects/common/zcu102/zcu102_system_bd.tcl
-source $ad_hdl_dir/projects/common/xilinx/adcfifo_bd.tcl
-source $ad_hdl_dir/projects/common/xilinx/dacfifo_bd.tcl
 source ../common/daq2_bd.tcl
 source $ad_hdl_dir/projects/scripts/adi_pd.tcl
 
@@ -18,8 +20,5 @@ ad_ip_parameter axi_sysid_0 CONFIG.ROM_ADDR_BITS 9
 ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "[pwd]/mem_init_sys.txt"
 ad_ip_parameter rom_sys_0 CONFIG.ROM_ADDR_BITS 9
 
-sysid_gen_sys_init_file
-
-ad_ip_parameter util_daq2_xcvr CONFIG.QPLL_FBDIV 20
-ad_ip_parameter util_daq2_xcvr CONFIG.QPLL_REFCLK_DIV 1
-
+set sys_cstring "ADC_OFFLOAD_TYPE=$adc_offload_type\nDAC_OFFLOAD_TYPE=$dac_offload_type"
+sysid_gen_sys_init_file $sys_cstring


### PR DESCRIPTION
This PR fixes the wrongly instantiated DDR MIG for the data_offload IP on zcu102 + daq2. It now inserts two ~256k BRAM instead (one for the ADC path and one for the DAC path).
Tested with Vivado 2020.2.