### PR TITLE
scripts: Add *.gen to clean list

### DIFF
--- a/projects/scripts/project-xilinx.mk
+++ b/projects/scripts/project-xilinx.mk
@@ -27,6 +27,7 @@ CLEAN_TARGET += *.str
 CLEAN_TARGET += mem_init_sys.txt
 CLEAN_TARGET += *.csv
 CLEAN_TARGET += *.hbs
+CLEAN_TARGET += *.gen
 
 # Common dependencies that all projects have
 M_DEPS += system_project.tcl


### PR DESCRIPTION
After cleaning a project build a *.gen folder remains in the project folder which should be cleaned when running "make clean"