### PR TITLE
axi_adxcvr_ip.tcl util_adxcvr_ip.tcl: fixed asynchronous resets critical warnings in XCVR

### DIFF
--- a/library/xilinx/axi_adxcvr/axi_adxcvr_ip.tcl
+++ b/library/xilinx/axi_adxcvr/axi_adxcvr_ip.tcl
@@ -97,6 +97,8 @@ set_property VALUE ACTIVE_HIGH [ipx::get_bus_parameters POLARITY -of [ipx::get_b
 ipx::infer_bus_interface s_axi_aclk xilinx.com:signal:clock_rtl:1.0 [ipx::current_core]
 ipx::infer_bus_interface s_axi_aresetn xilinx.com:signal:reset_rtl:1.0 [ipx::current_core]
 
+ipx::associate_bus_interfaces -clock s_axi_aclk -reset up_pll_rst -remove [ipx::current_core]
+
 set_property value s_axi:m_axi [ipx::get_bus_parameters ASSOCIATED_BUSIF \
   -of_objects [ipx::get_bus_interfaces s_axi_aclk -of_objects [ipx::current_core]]]
 

--- a/library/xilinx/util_adxcvr/util_adxcvr_ip.tcl
+++ b/library/xilinx/util_adxcvr/util_adxcvr_ip.tcl
@@ -227,6 +227,14 @@ ipx::infer_bus_interface up_qpll_rst_4 xilinx.com:signal:reset_rtl:1.0 [ipx::cur
 ipx::infer_bus_interface up_qpll_rst_8 xilinx.com:signal:reset_rtl:1.0 [ipx::current_core]
 ipx::infer_bus_interface up_qpll_rst_12 xilinx.com:signal:reset_rtl:1.0 [ipx::current_core]
 
+for {set n 0} {$n < 16} {incr n} {
+
+  if {($n%4) == 0} {
+	ipx::associate_bus_interfaces -clock cpll_ref_clk_${n} -reset up_qpll_rst_${n} -remove [ipx::current_core]
+  }
+  ipx::associate_bus_interfaces -clock cpll_ref_clk_${n} -reset up_cpll_rst_${n} -remove [ipx::current_core]
+}
+
 set_property driver_value 0 [ipx::get_ports -filter "direction==in" -of_objects [ipx::current_core]]
 
 for {set n 0} {$n < 16} {incr n} {


### PR DESCRIPTION
Defining up_qpll_rst and up_cpll_rst resets pins from util_adxcvr as asynchronous resets by removing clock associations.
Applying the same logic for up_pll_rst pin from axi_adxcvr ip.

Tested with jesd loopback test bench.