### PR TITLE
adi_project_xilinx.tcl, adi_ip_xilinx.tcl: update version to 2021.1

### DIFF
--- a/library/scripts/adi_ip_xilinx.tcl
+++ b/library/scripts/adi_ip_xilinx.tcl
@@ -4,7 +4,7 @@ source $ad_hdl_dir/library/scripts/adi_xilinx_device_info_enc.tcl
 # check tool version
 
 if {![info exists REQUIRED_VIVADO_VERSION]} {
-  set REQUIRED_VIVADO_VERSION "2020.2"
+  set REQUIRED_VIVADO_VERSION "2021.1"
 }
 
 if {[info exists ::env(ADI_IGNORE_VERSION_CHECK)]} {

--- a/projects/scripts/adi_project_xilinx.tcl
+++ b/projects/scripts/adi_project_xilinx.tcl
@@ -1,7 +1,7 @@
 
 ## Define the supported tool version
 if {![info exists REQUIRED_VIVADO_VERSION]} {
-  set REQUIRED_VIVADO_VERSION "2020.2"
+  set REQUIRED_VIVADO_VERSION "2021.1"
 }
 
 ## Define the ADI_IGNORE_VERSION_CHECK environment variable to skip version check


### PR DESCRIPTION
Update vivado version from 2020.2 to 2021.1 in projects and library scripts.