### PR TITLE
data_offload: Fix oversized inputs in TX mode

### DIFF
--- a/library/data_offload/data_offload_fsm.v
+++ b/library/data_offload/data_offload_fsm.v
@@ -55,7 +55,7 @@ module data_offload_fsm #(
   output  reg                         wr_resetn_out,
   input                               wr_valid_in,
   output                              wr_valid_out,
-  output                              wr_ready,
+  output  reg                         wr_ready,
   output  reg [WR_ADDRESS_WIDTH-1:0]  wr_addr,
   input                               wr_last,
   input       [WR_DATA_WIDTH/8-1:0]   wr_tkeep,
@@ -260,11 +260,10 @@ module data_offload_fsm #(
 
   always @(posedge wr_clk) begin
     wr_ready_d <= wr_ready;
+    // flush out the DMA if the transfer is bigger than the storage size
+    wr_ready <= ((wr_fsm_state == WR_WRITE_TO_MEM) ||
+                ((wr_fsm_state == WR_WAIT_TO_END) && wr_ready_d && !(wr_valid_in && wr_last))) ? 1'b1 : 1'b0;
   end
-
-  // flush out the DMA if the transfer is bigger than the storage size
-  assign wr_ready = ((wr_fsm_state == WR_WRITE_TO_MEM) ||
-                     ((wr_fsm_state == WR_WAIT_TO_END) && wr_valid_in && wr_ready_d && wr_full)) ? 1'b1 : 1'b0;
 
   // write control
   assign wr_valid_out = (wr_fsm_state == WR_WRITE_TO_MEM) & wr_valid_in;


### PR DESCRIPTION
This commit fixes an issue in situations where we provide an oversized
transaction to the data offload in TX mode. Previously, the data offload
would stop accepting new data (wr_ready <= 0) after filling up the
internal storage, and get stuck waiting for the input transaction to
end, thus locking up the device.

This commit addresses that issue by allowing the data offload to consume
the full input transaction, even if the tail of the buffer will be
truncated in the output.

Note, i am opening this as a **draft** to request feedback, but i haven't finished testing yet!