### PR TITLE
Versal support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -92,3 +92,8 @@ _vmake
 *.qdb
 *.qpg
 *.qtl
+*.xpe
+*.gen*
+*.xsa
+*.pdi
+

--- a/library/jesd204/jesd204_rx/jesd204_rx_ip.tcl
+++ b/library/jesd204/jesd204_rx/jesd204_rx_ip.tcl
@@ -100,6 +100,10 @@ adi_add_multi_bus 16 "rx_phy" "slave" \
   ] \
   "(spirit:decode(id('MODELPARAM_VALUE.NUM_LANES')) > {i})"
 
+set_property driver_value 0 [ipx::get_ports phy_charisk -of_objects [ipx::current_core]]
+set_property driver_value 0 [ipx::get_ports phy_disperr -of_objects [ipx::current_core]]
+set_property driver_value 0 [ipx::get_ports phy_notintable -of_objects [ipx::current_core]]
+
 adi_add_bus "rx_cfg" "slave" \
   "analog.com:interface:jesd204_rx_cfg_rtl:1.0" \
   "analog.com:interface:jesd204_rx_cfg:1.0" \

--- a/library/jesd204/jesd204_tx/jesd204_tx.v
+++ b/library/jesd204/jesd204_tx/jesd204_tx.v
@@ -141,7 +141,7 @@ wire [HW-1:0] phy_header_r;
 
 wire eof_gen_reset;
 wire tx_ready_64b_next;
-reg tx_ready_64b;
+reg tx_ready_64b = 1'b0;
 wire frame_mark_reset;
 wire [DATA_PATH_WIDTH-1:0] tx_sof_fm;
 wire [DATA_PATH_WIDTH-1:0] tx_eof_fm;

--- a/library/jesd204/jesd204_versal_gt_adapter_rx/Makefile
+++ b/library/jesd204/jesd204_versal_gt_adapter_rx/Makefile
@@ -1,0 +1,14 @@
+####################################################################################
+## Copyright (c) 2018 - 2021 Analog Devices, Inc.
+### SPDX short identifier: BSD-1-Clause
+## Auto-generated, do not modify!
+####################################################################################
+
+LIBRARY_NAME := jesd204_versal_gt_adapter_rx
+
+GENERIC_DEPS += jesd204_versal_gt_adapter_rx.v
+
+XILINX_DEPS += ../jesd204_common/sync_header_align.v
+XILINX_DEPS += jesd204_versal_gt_adapter_rx_ip.tcl
+
+include ../../scripts/library.mk

--- a/library/jesd204/jesd204_versal_gt_adapter_rx/jesd204_versal_gt_adapter_rx.v
+++ b/library/jesd204/jesd204_versal_gt_adapter_rx/jesd204_versal_gt_adapter_rx.v
@@ -1,0 +1,98 @@
+//
+// The ADI JESD204 Core is released under the following license, which is
+// different than all other HDL cores in this repository.
+//
+// Please read this, and understand the freedoms and responsibilities you have
+// by using this source code/core.
+//
+// The JESD204 HDL, is copyright © 2016-2017 Analog Devices Inc.
+//
+// This core is free software, you can use run, copy, study, change, ask
+// questions about and improve this core. Distribution of source, or resulting
+// binaries (including those inside an FPGA or ASIC) require you to release the
+// source of the entire project (excluding the system libraries provide by the
+// tools/compiler/FPGA vendor). These are the terms of the GNU General Public
+// License version 2 as published by the Free Software Foundation.
+//
+// This core  is distributed in the hope that it will be useful, but WITHOUT ANY
+// WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+// A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License version 2
+// along with this source code, and binary.  If not, see
+// <http://www.gnu.org/licenses/>.
+//
+// Commercial licenses (with commercial support) of this JESD204 core are also
+// available under terms different than the General Public License. (e.g. they
+// do not require you to accompany any image (FPGA or ASIC) using the JESD204
+// core with any corresponding source code.) For these alternate terms you must
+// purchase a license from Analog Devices Technology Licensing Office. Users
+// interested in such a license should contact jesd204-licensing@analog.com for
+// more information. This commercial license is sub-licensable (if you purchase
+// chips from Analog Devices, incorporate them into your PCB level product, and
+// purchase a JESD204 license, end users of your product will also have a
+// license to use this core in a commercial setting without releasing their
+// source code).
+//
+// In addition, we kindly ask you to acknowledge ADI in any program, application
+// or publication in which you use this JESD204 HDL core. (You are not required
+// to do so; it is up to your common sense to decide whether you want to comply
+// with this request or not.) For general publications, we suggest referencing :
+// “The design and implementation of the JESD204 HDL Core used in this project
+// is copyright © 2016-2017, Analog Devices, Inc.”
+//
+
+`timescale 1ns/100ps
+
+module  jesd204_versal_gt_adapter_rx (
+  input  [127 : 0] rxdata,
+  input    [5 : 0] rxheader,
+  output           rxgearboxslip,
+  input    [1 : 0] rxheadervalid,
+
+  // Interface to Link layer core
+  output  [63:0]  rx_data,
+  output   [1:0]  rx_header,
+  output          rx_block_sync,
+
+  input           usr_clk
+
+);
+
+  // Sync header alignment
+  wire rx_bitslip_req_s;
+  reg [4:0] rx_bitslip_done_cnt = 'h0;
+  always @(posedge usr_clk) begin
+    if (rx_bitslip_done_cnt[4]) begin
+      rx_bitslip_done_cnt <= 'b0;
+    end else if (rx_bitslip_req_s & ~rx_bitslip_done_cnt[4]) begin
+      rx_bitslip_done_cnt <= rx_bitslip_done_cnt + 1;
+    end
+  end
+
+  reg rx_bitslip_req_s_d = 1'b0;
+  always @(posedge usr_clk) begin
+     rx_bitslip_req_s_d <= rx_bitslip_req_s;
+  end
+  assign rxgearboxslip = rx_bitslip_req_s & ~rx_bitslip_req_s_d;
+
+  wire [63:0] rxdata_flip;
+  genvar i;
+  for (i = 0; i < 64; i=i+1) begin
+    assign rxdata_flip[63-i] = rxdata[i];
+  end
+
+  // Sync header alignment
+  sync_header_align i_sync_header_align (
+    .clk(usr_clk),
+    .reset(~rxheadervalid[0]),
+    // Flip header bits and data
+    .i_data({rxheader[0],rxheader[1],rxdata_flip[63:0]}),
+    .i_slip(rx_bitslip_req_s),
+    .i_slip_done(rx_bitslip_done_cnt[4]),
+    .o_data(rx_data),
+    .o_header(rx_header),
+    .o_block_sync(rx_block_sync)
+  );
+
+endmodule

--- a/library/jesd204/jesd204_versal_gt_adapter_rx/jesd204_versal_gt_adapter_rx_ip.tcl
+++ b/library/jesd204/jesd204_versal_gt_adapter_rx/jesd204_versal_gt_adapter_rx_ip.tcl
@@ -1,0 +1,68 @@
+#
+# The ADI JESD204 Core is released under the following license, which is
+# different than all other HDL cores in this repository.
+#
+# Please read this, and understand the freedoms and responsibilities you have
+# by using this source code/core.
+#
+# The JESD204 HDL, is copyright © 2016-2017 Analog Devices Inc.
+#
+# This core is free software, you can use run, copy, study, change, ask
+# questions about and improve this core. Distribution of source, or resulting
+# binaries (including those inside an FPGA or ASIC) require you to release the
+# source of the entire project (excluding the system libraries provide by the
+# tools/compiler/FPGA vendor). These are the terms of the GNU General Public
+# License version 2 as published by the Free Software Foundation.
+#
+# This core  is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+# A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License version 2
+# along with this source code, and binary.  If not, see
+# <http://www.gnu.org/licenses/>.
+#
+# Commercial licenses (with commercial support) of this JESD204 core are also
+# available under terms different than the General Public License. (e.g. they
+# do not require you to accompany any image (FPGA or ASIC) using the JESD204
+# core with any corresponding source code.) For these alternate terms you must
+# purchase a license from Analog Devices Technology Licensing Office. Users
+# interested in such a license should contact jesd204-licensing@analog.com for
+# more information. This commercial license is sub-licensable (if you purchase
+# chips from Analog Devices, incorporate them into your PCB level product, and
+# purchase a JESD204 license, end users of your product will also have a
+# license to use this core in a commercial setting without releasing their
+# source code).
+#
+# In addition, we kindly ask you to acknowledge ADI in any program, application
+# or publication in which you use this JESD204 HDL core. (You are not required
+# to do so; it is up to your common sense to decide whether you want to comply
+# with this request or not.) For general publications, we suggest referencing :
+# “The design and implementation of the JESD204 HDL Core used in this project
+# is copyright © 2016-2017, Analog Devices, Inc.”
+#
+
+source ../../scripts/adi_env.tcl
+source $ad_hdl_dir/library/scripts/adi_ip_xilinx.tcl
+
+adi_ip_create jesd204_versal_gt_adapter_rx
+adi_ip_files jesd204_versal_gt_adapter_rx [list \
+  jesd204_versal_gt_adapter_rx.v \
+  ../jesd204_common/sync_header_align.v \
+  ]
+
+adi_ip_properties_lite jesd204_versal_gt_adapter_rx
+
+set_property display_name "ADI JESD204 Versal Transceiver Rx Lane Adapter" [ipx::current_core]
+set_property description "ADI JESD204 Versal Transceiver Rx Lane Adapter" [ipx::current_core]
+
+adi_add_bus "RX" "master" \
+  "xilinx.com:display_jesd204:jesd204_rx_bus_rtl:1.0" \
+  "xilinx.com:display_jesd204:jesd204_rx_bus:1.0" \
+  { \
+   { "rx_data" "rxdata" } \
+   { "rx_header" "rxheader" } \
+   { "rx_block_sync" "rxblock_sync" } \
+  }
+
+ipx::save_core [ipx::current_core]

--- a/library/jesd204/jesd204_versal_gt_adapter_tx/Makefile
+++ b/library/jesd204/jesd204_versal_gt_adapter_tx/Makefile
@@ -1,0 +1,13 @@
+####################################################################################
+## Copyright (c) 2018 - 2021 Analog Devices, Inc.
+### SPDX short identifier: BSD-1-Clause
+## Auto-generated, do not modify!
+####################################################################################
+
+LIBRARY_NAME := jesd204_versal_gt_adapter_tx
+
+GENERIC_DEPS += jesd204_versal_gt_adapter_tx.v
+
+XILINX_DEPS += jesd204_versal_gt_adapter_tx_ip.tcl
+
+include ../../scripts/library.mk

--- a/library/jesd204/jesd204_versal_gt_adapter_tx/jesd204_versal_gt_adapter_tx.v
+++ b/library/jesd204/jesd204_versal_gt_adapter_tx/jesd204_versal_gt_adapter_tx.v
@@ -1,0 +1,68 @@
+//
+// The ADI JESD204 Core is released under the following license, which is
+// different than all other HDL cores in this repository.
+//
+// Please read this, and understand the freedoms and responsibilities you have
+// by using this source code/core.
+//
+// The JESD204 HDL, is copyright © 2016-2017 Analog Devices Inc.
+//
+// This core is free software, you can use run, copy, study, change, ask
+// questions about and improve this core. Distribution of source, or resulting
+// binaries (including those inside an FPGA or ASIC) require you to release the
+// source of the entire project (excluding the system libraries provide by the
+// tools/compiler/FPGA vendor). These are the terms of the GNU General Public
+// License version 2 as published by the Free Software Foundation.
+//
+// This core  is distributed in the hope that it will be useful, but WITHOUT ANY
+// WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+// A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License version 2
+// along with this source code, and binary.  If not, see
+// <http://www.gnu.org/licenses/>.
+//
+// Commercial licenses (with commercial support) of this JESD204 core are also
+// available under terms different than the General Public License. (e.g. they
+// do not require you to accompany any image (FPGA or ASIC) using the JESD204
+// core with any corresponding source code.) For these alternate terms you must
+// purchase a license from Analog Devices Technology Licensing Office. Users
+// interested in such a license should contact jesd204-licensing@analog.com for
+// more information. This commercial license is sub-licensable (if you purchase
+// chips from Analog Devices, incorporate them into your PCB level product, and
+// purchase a JESD204 license, end users of your product will also have a
+// license to use this core in a commercial setting without releasing their
+// source code).
+//
+// In addition, we kindly ask you to acknowledge ADI in any program, application
+// or publication in which you use this JESD204 HDL core. (You are not required
+// to do so; it is up to your common sense to decide whether you want to comply
+// with this request or not.) For general publications, we suggest referencing :
+// “The design and implementation of the JESD204 HDL Core used in this project
+// is copyright © 2016-2017, Analog Devices, Inc.”
+//
+
+`timescale 1ns/100ps
+
+module  jesd204_versal_gt_adapter_tx (
+  output  [127 : 0] txdata,
+  output    [5 : 0] txheader,
+
+  // Interface to Link layer core
+  input      [63:0] tx_data,
+  input       [1:0] tx_header,
+
+  input             usr_clk
+);
+
+  wire [63:0] tx_data_flip;
+  genvar i;
+  for (i = 0; i < 64; i=i+1) begin
+    assign tx_data_flip[63-i] = tx_data[i];
+  end
+
+  assign txdata = {64'b0,tx_data_flip};
+  // Flip header bits and data
+  assign txheader = {4'b0,tx_header[0],tx_header[1]};
+
+endmodule

--- a/library/jesd204/jesd204_versal_gt_adapter_tx/jesd204_versal_gt_adapter_tx_ip.tcl
+++ b/library/jesd204/jesd204_versal_gt_adapter_tx/jesd204_versal_gt_adapter_tx_ip.tcl
@@ -1,0 +1,66 @@
+#
+# The ADI JESD204 Core is released under the following license, which is
+# different than all other HDL cores in this repository.
+#
+# Please read this, and understand the freedoms and responsibilities you have
+# by using this source code/core.
+#
+# The JESD204 HDL, is copyright © 2016-2017 Analog Devices Inc.
+#
+# This core is free software, you can use run, copy, study, change, ask
+# questions about and improve this core. Distribution of source, or resulting
+# binaries (including those inside an FPGA or ASIC) require you to release the
+# source of the entire project (excluding the system libraries provide by the
+# tools/compiler/FPGA vendor). These are the terms of the GNU General Public
+# License version 2 as published by the Free Software Foundation.
+#
+# This core  is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+# A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License version 2
+# along with this source code, and binary.  If not, see
+# <http://www.gnu.org/licenses/>.
+#
+# Commercial licenses (with commercial support) of this JESD204 core are also
+# available under terms different than the General Public License. (e.g. they
+# do not require you to accompany any image (FPGA or ASIC) using the JESD204
+# core with any corresponding source code.) For these alternate terms you must
+# purchase a license from Analog Devices Technology Licensing Office. Users
+# interested in such a license should contact jesd204-licensing@analog.com for
+# more information. This commercial license is sub-licensable (if you purchase
+# chips from Analog Devices, incorporate them into your PCB level product, and
+# purchase a JESD204 license, end users of your product will also have a
+# license to use this core in a commercial setting without releasing their
+# source code).
+#
+# In addition, we kindly ask you to acknowledge ADI in any program, application
+# or publication in which you use this JESD204 HDL core. (You are not required
+# to do so; it is up to your common sense to decide whether you want to comply
+# with this request or not.) For general publications, we suggest referencing :
+# “The design and implementation of the JESD204 HDL Core used in this project
+# is copyright © 2016-2017, Analog Devices, Inc.”
+#
+
+source ../../scripts/adi_env.tcl
+source $ad_hdl_dir/library/scripts/adi_ip_xilinx.tcl
+
+adi_ip_create jesd204_versal_gt_adapter_tx
+adi_ip_files jesd204_versal_gt_adapter_tx [list \
+  jesd204_versal_gt_adapter_tx.v
+  ]
+
+adi_ip_properties_lite jesd204_versal_gt_adapter_tx
+
+set_property display_name "ADI JESD204 Versal Transceiver Tx Lane Adapter" [ipx::current_core]
+set_property description "ADI JESD204 Versal Transceiver Tx Lane Adapter" [ipx::current_core]
+
+adi_add_bus "TX" "slave" \
+  "xilinx.com:display_jesd204:jesd204_tx_bus_rtl:1.0" \
+  "xilinx.com:display_jesd204:jesd204_tx_bus:1.0" \
+  { \
+   { "tx_data" "txdata" } \
+   { "tx_header" "txheader" } \
+  }
+
+ipx::save_core [ipx::current_core]

--- a/library/scripts/adi_ip_xilinx.tcl
+++ b/library/scripts/adi_ip_xilinx.tcl
@@ -329,17 +329,7 @@ proc adi_ip_properties_lite {ip_name} {
   set_property vendor_display_name {Analog Devices} [ipx::current_core]
   set_property company_url {http://www.analog.com} [ipx::current_core]
 
-  set i_families ""
-  foreach i_part [get_parts] {
-    lappend i_families [get_property FAMILY $i_part]
-  }
-  set i_families [lsort -unique $i_families]
-  set s_families [get_property supported_families [ipx::current_core]]
-  foreach i_family $i_families {
-    set s_families "$s_families $i_family Production"
-    set s_families "$s_families $i_family Beta"
-  }
-  set_property supported_families $s_families [ipx::current_core]
+  set_property AUTO_FAMILY_SUPPORT_LEVEL level_2 [ipx::current_core]
 
   ipx::save_core [ipx::current_core]
 

--- a/library/scripts/adi_xilinx_device_info_enc.tcl
+++ b/library/scripts/adi_xilinx_device_info_enc.tcl
@@ -61,14 +61,18 @@ set fpga_technology_list { \
         { Unknown     0 } \
         { 7series     1 } \
         { ultrascale  2 } \
-        { ultrascale+ 3 }}
+        { ultrascale+ 3 } \
+        { versal      4 }}
 
 set fpga_family_list { \
-        { Unknown 0 } \
-        { artix   1 } \
-        { kintex  2 } \
-        { virtex  3 } \
-        { zynq    4 }}
+        { Unknown      0 } \
+        { artix        1 } \
+        { kintex       2 } \
+        { virtex       3 } \
+        { zynq         4 } \
+        { versalprime  5 } \
+        { versalaicore 6 } \
+      }
 
 set speed_grade_list { \
         { Unknown 0  } \
@@ -80,6 +84,7 @@ set speed_grade_list { \
         { -2      20 } \
         { -2L     21 } \
         { -2LV    22 } \
+        { -2MP    23 } \
         { -3      30 }}
 
 set dev_package_list { \
@@ -102,7 +107,8 @@ set dev_package_list { \
         { ba      16 } \
         { fa      17 } \
         { fs      18 } \
-        { fi      19 }}
+        { fi      19 } \
+        { vs      20 }}
 
 
 set xcvr_type_list { \
@@ -136,10 +142,11 @@ proc adi_device_spec {cellpath param} {
   switch -regexp -- $param {
       FPGA_TECHNOLOGY {
           switch  -regexp -- $part {
-             ^xc7    {set series_name 7series}
-             ^xczu   {set series_name ultrascale+}
-             ^xc.u.p {set series_name ultrascale+}
-             ^xc.u   {set series_name ultrascale }
+             ^xc7          {set series_name 7series}
+             ^xczu         {set series_name ultrascale+}
+             ^xc.u.p       {set series_name ultrascale+}
+             ^xc.u         {set series_name ultrascale }
+             ^xcv[ecmph]   {set series_name versal}
              default {
                  puts "Undefined fpga technology for \"$part\"!"
                  exit -1

--- a/projects/ad9081_fmca_ebz/common/ad9081_fmca_ebz_bd.tcl
+++ b/projects/ad9081_fmca_ebz/common/ad9081_fmca_ebz_bd.tcl
@@ -439,7 +439,7 @@ if {$ADI_PHY_SEL == 1} {
 ad_mem_hp0_interconnect $sys_cpu_clk axi_mxfe_rx_xcvr/m_axi
 }
 ad_mem_hp1_interconnect $sys_cpu_clk sys_ps7/S_AXI_HP1
-ad_mem_hp1_interconnect $sys_cpu_clk axi_mxfe_rx_dma/m_dest_axi
+ad_mem_hp1_interconnect $sys_dma_clk axi_mxfe_rx_dma/m_dest_axi
 ad_mem_hp2_interconnect $sys_dma_clk sys_ps7/S_AXI_HP2
 ad_mem_hp2_interconnect $sys_dma_clk axi_mxfe_tx_dma/m_src_axi
 

--- a/projects/ad9081_fmca_ebz/common/ad9081_fmca_ebz_bd.tcl
+++ b/projects/ad9081_fmca_ebz/common/ad9081_fmca_ebz_bd.tcl
@@ -137,6 +137,8 @@ if {$ADI_PHY_SEL == 1} {
 
   create_bd_cell -type container -reference jesd_phy jesd204_phy
 
+  create_bd_port -dir I gt_reset
+
 }
 
 if {$ADI_PHY_SEL == 1} {
@@ -322,7 +324,7 @@ if {$ADI_PHY_SEL == 1} {
   ad_connect GND jesd204_phy/reset_rx_pll_and_datapath_in
   ad_connect GND jesd204_phy/reset_tx_pll_and_datapath_in
 
-  ad_connect GND jesd204_phy/gt_reset_gt_bridge_ip_0
+  ad_connect gt_reset jesd204_phy/gt_reset_gt_bridge_ip_0
 
   ad_connect axi_mxfe_rx_jesd/rx_axi/device_reset jesd204_phy/reset_rx_datapath_in
   ad_connect axi_mxfe_tx_jesd/tx_axi/device_reset jesd204_phy/reset_tx_datapath_in

--- a/projects/ad9081_fmca_ebz/common/versal_transceiver.tcl
+++ b/projects/ad9081_fmca_ebz/common/versal_transceiver.tcl
@@ -1,0 +1,174 @@
+
+set top_design [current_bd_design]
+
+create_bd_design "jesd_phy"
+
+create_bd_cell -type ip -vlnv xilinx.com:ip:gt_bridge_ip:1.1 gt_bridge_ip_0
+
+set_property -dict [list \
+  CONFIG.BYPASS_MODE {true} \
+  CONFIG.IP_PRESET {GTY-JESD204_64B66B} \
+  CONFIG.IP_LR0_SETTINGS { \
+     PRESET GTY-JESD204_64B66B \
+     INTERNAL_PRESET JESD204_64B66B \
+     GT_TYPE GTY \
+     GT_DIRECTION DUPLEX \
+     TX_LINE_RATE 24.75 \
+     TX_PLL_TYPE LCPLL \
+     TX_REFCLK_FREQUENCY 375 \
+     TX_ACTUAL_REFCLK_FREQUENCY 375.000000000000 \
+     TX_FRACN_ENABLED true \
+     TX_FRACN_NUMERATOR 0 \
+     TX_REFCLK_SOURCE R0 \
+     TX_DATA_ENCODING 64B66B_ASYNC \
+     TX_USER_DATA_WIDTH 64 \
+     TX_INT_DATA_WIDTH 64 \
+     TX_BUFFER_MODE 1 \
+     TX_BUFFER_BYPASS_MODE Fast_Sync \
+     TX_PIPM_ENABLE false \
+     TX_OUTCLK_SOURCE TXPROGDIVCLK \
+     TXPROGDIV_FREQ_ENABLE true \
+     TXPROGDIV_FREQ_SOURCE LCPLL \
+     TXPROGDIV_FREQ_VAL 375.000 \
+     TX_DIFF_SWING_EMPH_MODE CUSTOM \
+     TX_64B66B_SCRAMBLER false \
+     TX_64B66B_ENCODER false \
+     TX_64B66B_CRC false \
+     TX_RATE_GROUP A \
+     RX_LINE_RATE 24.75 \
+     RX_PLL_TYPE LCPLL \
+     RX_REFCLK_FREQUENCY 375 \
+     RX_ACTUAL_REFCLK_FREQUENCY 375.000000000000 \
+     RX_FRACN_ENABLED true \
+     RX_FRACN_NUMERATOR 0 \
+     RX_REFCLK_SOURCE R0 \
+     RX_DATA_DECODING 64B66B_ASYNC \
+     RX_USER_DATA_WIDTH 64 \
+     RX_INT_DATA_WIDTH 64 \
+     RX_BUFFER_MODE 1 \
+     RX_OUTCLK_SOURCE RXPROGDIVCLK \
+     RXPROGDIV_FREQ_ENABLE true \
+     RXPROGDIV_FREQ_SOURCE LCPLL \
+     RXPROGDIV_FREQ_VAL 375.000 \
+     INS_LOSS_NYQ 12 \
+     RX_EQ_MODE LPM \
+     RX_COUPLING AC \
+     RX_TERMINATION PROGRAMMABLE \
+     RX_RATE_GROUP A \
+     RX_TERMINATION_PROG_VALUE 800 \
+     RX_PPM_OFFSET 0 \
+     RX_64B66B_DESCRAMBLER false \
+     RX_64B66B_DECODER false \
+     RX_64B66B_CRC false \
+     OOB_ENABLE false \
+     RX_COMMA_ALIGN_WORD 1 \
+     RX_COMMA_SHOW_REALIGN_ENABLE true \
+     PCIE_ENABLE false \
+     RX_COMMA_P_ENABLE false \
+     RX_COMMA_M_ENABLE false \
+     RX_COMMA_DOUBLE_ENABLE false \
+     RX_COMMA_P_VAL 0101111100 \
+     RX_COMMA_M_VAL 1010000011 \
+     RX_COMMA_MASK 0000000000 \
+     RX_SLIDE_MODE OFF \
+     RX_SSC_PPM 0 \
+     RX_CB_NUM_SEQ 0 \
+     RX_CB_LEN_SEQ 1 \
+     RX_CB_MAX_SKEW 1 \
+     RX_CB_MAX_LEVEL 1 \
+     RX_CB_MASK_0_0 false \
+     RX_CB_VAL_0_0 00000000 \
+     RX_CB_K_0_0 false \
+     RX_CB_DISP_0_0 false \
+     RX_CB_MASK_0_1 false \
+     RX_CB_VAL_0_1 00000000 \
+     RX_CB_K_0_1 false \
+     RX_CB_DISP_0_1 false \
+     RX_CB_MASK_0_2 false \
+     RX_CB_VAL_0_2 00000000 \
+     RX_CB_K_0_2 false \
+     RX_CB_DISP_0_2 false \
+     RX_CB_MASK_0_3 false \
+     RX_CB_VAL_0_3 00000000 \
+     RX_CB_K_0_3 false \
+     RX_CB_DISP_0_3 false \
+     RX_CB_MASK_1_0 false \
+     RX_CB_VAL_1_0 00000000 \
+     RX_CB_K_1_0 false \
+     RX_CB_DISP_1_0 false \
+     RX_CB_MASK_1_1 false \
+     RX_CB_VAL_1_1 00000000 \
+     RX_CB_K_1_1 false \
+     RX_CB_DISP_1_1 false \
+     RX_CB_MASK_1_2 false \
+     RX_CB_VAL_1_2 00000000 \
+     RX_CB_K_1_2 false \
+     RX_CB_DISP_1_2 false \
+     RX_CB_MASK_1_3 false \
+     RX_CB_VAL_1_3 00000000 \
+     RX_CB_K_1_3 false \
+     RX_CB_DISP_1_3 false \
+     RX_CC_NUM_SEQ 0 \
+     RX_CC_LEN_SEQ 1 \
+     RX_CC_PERIODICITY 5000 \
+     RX_CC_KEEP_IDLE DISABLE \
+     RX_CC_PRECEDENCE ENABLE \
+     RX_CC_REPEAT_WAIT 0 \
+     RX_CC_VAL 00000000000000000000000000000000000000000000000000000000000000000000000000000000 \
+     RX_CC_MASK_0_0 false \
+     RX_CC_VAL_0_0 00000000 \
+     RX_CC_K_0_0 false \
+     RX_CC_DISP_0_0 false \
+     RX_CC_MASK_0_1 false \
+     RX_CC_VAL_0_1 00000000 \
+     RX_CC_K_0_1 false \
+     RX_CC_DISP_0_1 false \
+     RX_CC_MASK_0_2 false \
+     RX_CC_VAL_0_2 00000000 \
+     RX_CC_K_0_2 false \
+     RX_CC_DISP_0_2 false \
+     RX_CC_MASK_0_3 false \
+     RX_CC_VAL_0_3 00000000 \
+     RX_CC_K_0_3 false \
+     RX_CC_DISP_0_3 false \
+     RX_CC_MASK_1_0 false \
+     RX_CC_VAL_1_0 00000000 \
+     RX_CC_K_1_0 false \
+     RX_CC_DISP_1_0 false \
+     RX_CC_MASK_1_1 false \
+     RX_CC_VAL_1_1 00000000 \
+     RX_CC_K_1_1 false \
+     RX_CC_DISP_1_1 false \
+     RX_CC_MASK_1_2 false \
+     RX_CC_VAL_1_2 00000000 \
+     RX_CC_K_1_2 false \
+     RX_CC_DISP_1_2 false \
+     RX_CC_MASK_1_3 false \
+     RX_CC_VAL_1_3 00000000 \
+     RX_CC_K_1_3 false \
+     RX_CC_DISP_1_3 false \
+     PCIE_USERCLK2_FREQ 250 \
+     PCIE_USERCLK_FREQ 250 \
+     RX_JTOL_FC 10 \
+     RX_JTOL_LF_SLOPE -20 \
+     RX_BUFFER_BYPASS_MODE Fast_Sync \
+     RX_BUFFER_BYPASS_MODE_LANE MULTI \
+     RX_BUFFER_RESET_ON_CB_CHANGE ENABLE \
+     RX_BUFFER_RESET_ON_COMMAALIGN DISABLE \
+     RX_BUFFER_RESET_ON_RATE_CHANGE ENABLE \
+     TX_BUFFER_RESET_ON_RATE_CHANGE ENABLE \
+     RESET_SEQUENCE_INTERVAL 0 \
+     RX_COMMA_PRESET NONE \
+     RX_COMMA_VALID_ONLY 0 \
+     } \
+] [get_bd_cells gt_bridge_ip_0]
+
+apply_bd_automation -rule xilinx.com:bd_rule:gt_ips -config { DataPath_Interface_Connection {Auto} Lane0_selection {NULL} Lane10_selection {NULL} Lane11_selection {NULL} Lane12_selection {NULL} Lane13_selection {NULL} Lane14_selection {NULL} Lane15_selection {NULL} Lane16_selection {NULL} Lane17_selection {NULL} Lane18_selection {NULL} Lane19_selection {NULL} Lane1_selection {NULL} Lane2_selection {NULL} Lane3_selection {NULL} Lane4_selection {NULL} Lane5_selection {NULL} Lane6_selection {NULL} Lane7_selection {NULL} Lane8_selection {NULL} Lane9_selection {NULL} Quad0_selection {NULL} Quad10_selection {NULL} Quad11_selection {NULL} Quad12_selection {NULL} Quad13_selection {NULL} Quad14_selection {NULL} Quad15_selection {NULL} Quad16_selection {NULL} Quad17_selection {NULL} Quad18_selection {NULL} Quad19_selection {NULL} Quad1_selection {NULL} Quad2_selection {NULL} Quad3_selection {NULL} Quad4_selection {NULL} Quad5_selection {NULL} Quad6_selection {NULL} Quad7_selection {NULL} Quad8_selection {NULL} Quad9_selection {NULL}}  [get_bd_cells gt_bridge_ip_0]
+
+validate_bd_design
+
+save_bd_design
+close_bd_design [current_bd_design]
+
+current_bd_design [get_bd_designs $top_design]
+

--- a/projects/ad9081_fmca_ebz/vck190/Makefile
+++ b/projects/ad9081_fmca_ebz/vck190/Makefile
@@ -1,0 +1,46 @@
+####################################################################################
+## Copyright (c) 2018 - 2021 Analog Devices, Inc.
+### SPDX short identifier: BSD-1-Clause
+## Auto-generated, do not modify!
+####################################################################################
+
+PROJECT_NAME := ad9081_fmca_ebz_vck190
+
+M_DEPS += timing_constr.xdc
+M_DEPS += ../../../library/common/ad_edge_detect.v
+M_DEPS += ../../scripts/adi_pd.tcl
+M_DEPS += ../../common/xilinx/data_offload_bd.tcl
+M_DEPS += ../../common/xilinx/dacfifo_bd.tcl
+M_DEPS += ../../common/xilinx/adcfifo_bd.tcl
+M_DEPS += ../../common/vmk180/vmk180_system_bd.tcl
+M_DEPS += ../../common/vck190/vck190_system_constr.xdc
+M_DEPS += ../../common/vck190/vck190_system_bd.tcl
+M_DEPS += ../../ad9081_fmca_ebz/common/versal_transceiver.tcl
+M_DEPS += ../../ad9081_fmca_ebz/common/ad9081_fmca_ebz_bd.tcl
+M_DEPS += ../../../library/jesd204/scripts/jesd204.tcl
+M_DEPS += ../../../library/common/ad_iobuf.v
+M_DEPS += ../../../library/common/ad_3w_spi.v
+
+LIB_DEPS += axi_dmac
+LIB_DEPS += axi_sysid
+LIB_DEPS += axi_tdd
+LIB_DEPS += data_offload
+LIB_DEPS += jesd204/ad_ip_jesd204_tpl_adc
+LIB_DEPS += jesd204/ad_ip_jesd204_tpl_dac
+LIB_DEPS += jesd204/axi_jesd204_rx
+LIB_DEPS += jesd204/axi_jesd204_tx
+LIB_DEPS += jesd204/jesd204_rx
+LIB_DEPS += jesd204/jesd204_tx
+LIB_DEPS += jesd204/jesd204_versal_gt_adapter_rx
+LIB_DEPS += jesd204/jesd204_versal_gt_adapter_tx
+LIB_DEPS += sysid_rom
+LIB_DEPS += util_adcfifo
+LIB_DEPS += util_dacfifo
+LIB_DEPS += util_fifo2axi_bridge
+LIB_DEPS += util_pack/util_cpack2
+LIB_DEPS += util_pack/util_upack2
+LIB_DEPS += util_tdd_sync
+LIB_DEPS += xilinx/axi_adxcvr
+LIB_DEPS += xilinx/util_adxcvr
+
+include ../../scripts/project-xilinx.mk

--- a/projects/ad9081_fmca_ebz/vck190/system_bd.tcl
+++ b/projects/ad9081_fmca_ebz/vck190/system_bd.tcl
@@ -1,0 +1,23 @@
+
+## ADC FIFO depth in samples per converter
+set adc_fifo_samples_per_converter [expr $ad_project_params(RX_KS_PER_CHANNEL)*1024]
+## DAC FIFO depth in samples per converter
+set dac_fifo_samples_per_converter [expr $ad_project_params(TX_KS_PER_CHANNEL)*1024]
+
+source $ad_hdl_dir/projects/common/vck190/vck190_system_bd.tcl
+source $ad_hdl_dir/projects/common/xilinx/adcfifo_bd.tcl
+source $ad_hdl_dir/projects/common/xilinx/dacfifo_bd.tcl
+
+# use versal transceiver wizard
+set ADI_PHY_SEL 0
+
+source $ad_hdl_dir/projects/ad9081_fmca_ebz/common/ad9081_fmca_ebz_bd.tcl
+source $ad_hdl_dir/projects/scripts/adi_pd.tcl
+
+#system ID
+ad_ip_parameter axi_sysid_0 CONFIG.ROM_ADDR_BITS 9
+ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "[pwd]/mem_init_sys.txt"
+ad_ip_parameter rom_sys_0 CONFIG.ROM_ADDR_BITS 9
+
+sysid_gen_sys_init_file
+

--- a/projects/ad9081_fmca_ebz/vck190/system_constr.xdc
+++ b/projects/ad9081_fmca_ebz/vck190/system_constr.xdc
@@ -1,0 +1,88 @@
+#
+## mxfe
+#
+
+set_property         -dict {PACKAGE_PIN BB16  IOSTANDARD LVCMOS15                                     } [get_ports agc0[0]          ]    ; ## FMC0_LA17_CC_P      IO_L13P_T2L_N0_GC_QBC_67   
+set_property         -dict {PACKAGE_PIN BC16  IOSTANDARD LVCMOS15                                     } [get_ports agc0[1]          ]    ; ## FMC0_LA17_CC_N      IO_L13N_T2L_N1_GC_QBC_67
+set_property         -dict {PACKAGE_PIN BE17  IOSTANDARD LVCMOS15                                     } [get_ports agc1[0]          ]    ; ## FMC0_LA18_CC_P      IO_L16P_T2U_N6_QBC_AD3P_67
+set_property         -dict {PACKAGE_PIN BD17  IOSTANDARD LVCMOS15                                     } [get_ports agc1[1]          ]    ; ## FMC0_LA18_CC_N      IO_L16N_T2U_N7_QBC_AD3N_67
+set_property         -dict {PACKAGE_PIN BE16  IOSTANDARD LVCMOS15                                     } [get_ports agc2[0]          ]    ; ## FMC0_LA20_P         IO_L22P_T3U_N6_DBC_AD0P_67
+set_property         -dict {PACKAGE_PIN BF17  IOSTANDARD LVCMOS15                                     } [get_ports agc2[1]          ]    ; ## FMC0_LA20_N         IO_L22N_T3U_N7_DBC_AD0N_67
+set_property         -dict {PACKAGE_PIN BE19  IOSTANDARD LVCMOS15                                     } [get_ports agc3[0]          ]    ; ## FMC0_LA21_P         IO_L21P_T3L_N4_AD8P_67
+set_property         -dict {PACKAGE_PIN BD19  IOSTANDARD LVCMOS15                                     } [get_ports agc3[1]          ]    ; ## FMC0_LA21_N         IO_L21N_T3L_N5_AD8N_67
+set_property         -dict {PACKAGE_PIN BD24  IOSTANDARD LVDS15   DIFF_TERM_ADV TERM_100              } [get_ports clkin10_n        ]    ; ## FMC0_CLK2_IO_N      IO_L13N_T2L_N1_GC_QBC_66 
+set_property         -dict {PACKAGE_PIN BD23  IOSTANDARD LVDS15   DIFF_TERM_ADV TERM_100              } [get_ports clkin10_p        ]    ; ## FMC0_CLK2_IO_P      IO_L13P_T2L_N0_GC_QBC_66 
+set_property         -dict {PACKAGE_PIN AP18  IOSTANDARD LVDS15   DIFF_TERM_ADV TERM_100              } [get_ports clkin6_n         ]    ; ## FMC0_CLK1_M2C_N     IO_L12N_T1U_N11_GC_67
+set_property         -dict {PACKAGE_PIN AP19  IOSTANDARD LVDS15   DIFF_TERM_ADV TERM_100              } [get_ports clkin6_p         ]    ; ## FMC0_CLK1_M2C_P     IO_L12P_T1U_N10_GC_67
+set_property         -dict {PACKAGE_PIN M14                                                           } [get_ports fpga_refclk_in_n ]    ; ## FMC0_GBTCLK0_M2C_N  MGTREFCLK0N_229
+set_property         -dict {PACKAGE_PIN M15                                                           } [get_ports fpga_refclk_in_p ]    ; ## FMC0_GBTCLK0_M2C_P  MGTREFCLK0P_229
+set_property  -quiet -dict {PACKAGE_PIN Y1                                                            } [get_ports rx_data_n[2]     ]    ; ## FMC0_DP2_M2C_N      MGTHRXN3_229    FPGA_SERDIN_0_N
+set_property  -quiet -dict {PACKAGE_PIN Y2                                                            } [get_ports rx_data_p[2]     ]    ; ## FMC0_DP2_M2C_P      MGTHRXP3_229    FPGA_SERDIN_0_P
+set_property  -quiet -dict {PACKAGE_PIN AB1                                                           } [get_ports rx_data_n[0]     ]    ; ## FMC0_DP0_M2C_N      MGTHRXN2_229    FPGA_SERDIN_1_N
+set_property  -quiet -dict {PACKAGE_PIN AB2                                                           } [get_ports rx_data_p[0]     ]    ; ## FMC0_DP0_M2C_P      MGTHRXP2_229    FPGA_SERDIN_1_P
+set_property  -quiet -dict {PACKAGE_PIN R3                                                            } [get_ports rx_data_n[7]     ]    ; ## FMC0_DP7_M2C_N      MGTHRXN2_228    FPGA_SERDIN_2_N
+set_property  -quiet -dict {PACKAGE_PIN R4                                                            } [get_ports rx_data_p[7]     ]    ; ## FMC0_DP7_M2C_P      MGTHRXP2_228    FPGA_SERDIN_2_P
+set_property  -quiet -dict {PACKAGE_PIN T1                                                            } [get_ports rx_data_n[6]     ]    ; ## FMC0_DP6_M2C_N      MGTHRXN0_228    FPGA_SERDIN_3_N
+set_property  -quiet -dict {PACKAGE_PIN T2                                                            } [get_ports rx_data_p[6]     ]    ; ## FMC0_DP6_M2C_P      MGTHRXP0_228    FPGA_SERDIN_3_P
+set_property  -quiet -dict {PACKAGE_PIN U3                                                            } [get_ports rx_data_n[5]     ]    ; ## FMC0_DP5_M2C_N      MGTHRXN1_228    FPGA_SERDIN_4_N
+set_property  -quiet -dict {PACKAGE_PIN U4                                                            } [get_ports rx_data_p[5]     ]    ; ## FMC0_DP5_M2C_P      MGTHRXP1_228    FPGA_SERDIN_4_P
+set_property  -quiet -dict {PACKAGE_PIN V1                                                            } [get_ports rx_data_n[4]     ]    ; ## FMC0_DP4_M2C_N      MGTHRXN3_228    FPGA_SERDIN_5_N
+set_property  -quiet -dict {PACKAGE_PIN V2                                                            } [get_ports rx_data_p[4]     ]    ; ## FMC0_DP4_M2C_P      MGTHRXP3_228    FPGA_SERDIN_5_P
+set_property  -quiet -dict {PACKAGE_PIN W3                                                            } [get_ports rx_data_n[3]     ]    ; ## FMC0_DP3_M2C_N      MGTHRXN0_229    FPGA_SERDIN_6_N
+set_property  -quiet -dict {PACKAGE_PIN W4                                                            } [get_ports rx_data_p[3]     ]    ; ## FMC0_DP3_M2C_P      MGTHRXP0_229    FPGA_SERDIN_6_P
+set_property  -quiet -dict {PACKAGE_PIN AA3                                                           } [get_ports rx_data_n[1]     ]    ; ## FMC0_DP1_M2C_N      MGTHRXN1_229    FPGA_SERDIN_7_N
+set_property  -quiet -dict {PACKAGE_PIN AA4                                                           } [get_ports rx_data_p[1]     ]    ; ## FMC0_DP1_M2C_P      MGTHRXP1_229    FPGA_SERDIN_7_P
+set_property  -quiet -dict {PACKAGE_PIN AB6                                                           } [get_ports tx_data_n[0]     ]    ; ## FMC0_DP0_C2M_N      MGTHTXN2_229    FPGA_SERDOUT_0_N
+set_property  -quiet -dict {PACKAGE_PIN AB7                                                           } [get_ports tx_data_p[0]     ]    ; ## FMC0_DP0_C2M_P      MGTHTXP2_229    FPGA_SERDOUT_0_P
+set_property  -quiet -dict {PACKAGE_PIN Y6                                                            } [get_ports tx_data_n[2]     ]    ; ## FMC0_DP2_C2M_N      MGTHTXN3_229    FPGA_SERDOUT_1_N
+set_property  -quiet -dict {PACKAGE_PIN Y7                                                            } [get_ports tx_data_p[2]     ]    ; ## FMC0_DP2_C2M_P      MGTHTXP3_229    FPGA_SERDOUT_1_P
+set_property  -quiet -dict {PACKAGE_PIN R8                                                            } [get_ports tx_data_n[7]     ]    ; ## FMC0_DP7_C2M_N      MGTHTXN2_228    FPGA_SERDOUT_2_N
+set_property  -quiet -dict {PACKAGE_PIN R9                                                            } [get_ports tx_data_p[7]     ]    ; ## FMC0_DP7_C2M_P      MGTHTXP2_228    FPGA_SERDOUT_2_P
+set_property  -quiet -dict {PACKAGE_PIN T6                                                            } [get_ports tx_data_n[6]     ]    ; ## FMC0_DP6_C2M_N      MGTHTXN0_228    FPGA_SERDOUT_3_N
+set_property  -quiet -dict {PACKAGE_PIN T7                                                            } [get_ports tx_data_p[6]     ]    ; ## FMC0_DP6_C2M_P      MGTHTXP0_228    FPGA_SERDOUT_3_P
+set_property  -quiet -dict {PACKAGE_PIN AA8                                                           } [get_ports tx_data_n[1]     ]    ; ## FMC0_DP1_C2M_N      MGTHTXN1_229    FPGA_SERDOUT_4_N
+set_property  -quiet -dict {PACKAGE_PIN AA9                                                           } [get_ports tx_data_p[1]     ]    ; ## FMC0_DP1_C2M_P      MGTHTXP1_229    FPGA_SERDOUT_4_P
+set_property  -quiet -dict {PACKAGE_PIN U8                                                            } [get_ports tx_data_n[5]     ]    ; ## FMC0_DP5_C2M_N      MGTHTXN1_228    FPGA_SERDOUT_5_N
+set_property  -quiet -dict {PACKAGE_PIN U9                                                            } [get_ports tx_data_p[5]     ]    ; ## FMC0_DP5_C2M_P      MGTHTXP1_228    FPGA_SERDOUT_5_P
+set_property  -quiet -dict {PACKAGE_PIN V6                                                            } [get_ports tx_data_n[4]     ]    ; ## FMC0_DP4_C2M_N      MGTHTXN3_228    FPGA_SERDOUT_6_N
+set_property  -quiet -dict {PACKAGE_PIN V7                                                            } [get_ports tx_data_p[4]     ]    ; ## FMC0_DP4_C2M_P      MGTHTXP3_228    FPGA_SERDOUT_6_P
+set_property  -quiet -dict {PACKAGE_PIN W8                                                            } [get_ports tx_data_n[3]     ]    ; ## FMC0_DP3_C2M_N      MGTHTXN0_229    FPGA_SERDOUT_7_N
+set_property  -quiet -dict {PACKAGE_PIN W9                                                            } [get_ports tx_data_p[3]     ]    ; ## FMC0_DP3_C2M_P      MGTHTXP0_229    FPGA_SERDOUT_7_P
+set_property  -quiet -dict {PACKAGE_PIN AY25  IOSTANDARD LVDS15   DIFF_TERM_ADV TERM_100              } [get_ports fpga_syncin_n[0] ]    ; ## FMC0_LA02_N         IO_L23N_T3U_N9_66
+set_property  -quiet -dict {PACKAGE_PIN AW24  IOSTANDARD LVDS15   DIFF_TERM_ADV TERM_100              } [get_ports fpga_syncin_p[0] ]    ; ## FMC0_LA02_P         IO_L23P_T3U_N8_66
+set_property  -quiet -dict {PACKAGE_PIN AW21  IOSTANDARD LVDS15   DIFF_TERM_ADV TERM_100              } [get_ports fpga_syncin_n[1] ]    ; ## FMC0_LA03_N         IO_L22N_T3U_N7_DBC_AD0N_66
+set_property  -quiet -dict {PACKAGE_PIN AV22  IOSTANDARD LVDS15   DIFF_TERM_ADV TERM_100              } [get_ports fpga_syncin_p[1] ]    ; ## FMC0_LA03_P         IO_L22P_T3U_N6_DBC_AD0P_66
+set_property  -quiet -dict {PACKAGE_PIN BD22  IOSTANDARD LVDS15                                       } [get_ports fpga_syncout_n[0]]    ; ## FMC0_LA01_CC_N      IO_L16N_T2U_N7_QBC_AD3N_66
+set_property  -quiet -dict {PACKAGE_PIN BC23  IOSTANDARD LVDS15                                       } [get_ports fpga_syncout_p[0]]    ; ## FMC0_LA01_CC_P      IO_L16P_T2U_N6_QBC_AD3P_66
+set_property  -quiet -dict {PACKAGE_PIN BD20  IOSTANDARD LVDS15                                       } [get_ports fpga_syncout_n[1]]    ; ## FMC0_LA06_N         IO_L19N_T3L_N1_DBC_AD9N_66
+set_property  -quiet -dict {PACKAGE_PIN BC20  IOSTANDARD LVDS15                                       } [get_ports fpga_syncout_p[1]]    ; ## FMC0_LA06_P         IO_L19P_T3L_N0_DBC_AD9P_66
+set_property         -dict {PACKAGE_PIN AY22  IOSTANDARD LVCMOS15                                     } [get_ports gpio[0]          ]    ; ## FMC0_LA15_P         IO_L6P_T0U_N10_AD6P_66
+set_property         -dict {PACKAGE_PIN AY23  IOSTANDARD LVCMOS15                                     } [get_ports gpio[1]          ]    ; ## FMC0_LA15_N         IO_L6N_T0U_N11_AD6N_66
+set_property         -dict {PACKAGE_PIN BA17  IOSTANDARD LVCMOS15                                     } [get_ports gpio[2]          ]    ; ## FMC0_LA19_P         IO_L23P_T3U_N8_67
+set_property         -dict {PACKAGE_PIN BA16  IOSTANDARD LVCMOS15                                     } [get_ports gpio[3]          ]    ; ## FMC0_LA19_N         IO_L23N_T3U_N9_67
+set_property         -dict {PACKAGE_PIN BE21  IOSTANDARD LVCMOS15                                     } [get_ports gpio[4]          ]    ; ## FMC0_LA13_P         IO_L8P_T1L_N2_AD5P_66
+set_property         -dict {PACKAGE_PIN BE20  IOSTANDARD LVCMOS15                                     } [get_ports gpio[5]          ]    ; ## FMC0_LA13_N         IO_L8N_T1L_N3_AD5N_66
+set_property         -dict {PACKAGE_PIN AU24  IOSTANDARD LVCMOS15                                     } [get_ports gpio[6]          ]    ; ## FMC0_LA14_P         IO_L7P_T1L_N0_QBC_AD13P_66
+set_property         -dict {PACKAGE_PIN AU23  IOSTANDARD LVCMOS15                                     } [get_ports gpio[7]          ]    ; ## FMC0_LA14_N         IO_L7N_T1L_N1_QBC_AD13N_66
+set_property         -dict {PACKAGE_PIN BF21  IOSTANDARD LVCMOS15                                     } [get_ports gpio[8]          ]    ; ## FMC0_LA16_P         IO_L5P_T0U_N8_AD14P_66
+set_property         -dict {PACKAGE_PIN BG20  IOSTANDARD LVCMOS15                                     } [get_ports gpio[9]          ]    ; ## FMC0_LA16_N         IO_L5N_T0U_N9_AD14N_66
+set_property         -dict {PACKAGE_PIN BG18  IOSTANDARD LVCMOS15                                     } [get_ports gpio[10]         ]    ; ## FMC0_LA22_N         IO_L20N_T3L_N3_AD1N_67
+set_property         -dict {PACKAGE_PIN BE22  IOSTANDARD LVCMOS15                                     } [get_ports hmc_gpio1        ]    ; ## FMC0_LA11_N         IO_L10N_T1U_N7_QBC_AD4N_66
+set_property         -dict {PACKAGE_PIN BD25  IOSTANDARD LVCMOS15                                     } [get_ports hmc_sync         ]    ; ## FMC0_LA07_N         IO_L18N_T2U_N11_AD2N_66
+set_property         -dict {PACKAGE_PIN BC22  IOSTANDARD LVCMOS15                                     } [get_ports irqb[0]          ]    ; ## FMC0_LA08_P         IO_L17P_T2U_N8_AD10P_66
+set_property         -dict {PACKAGE_PIN BC21  IOSTANDARD LVCMOS15                                     } [get_ports irqb[1]          ]    ; ## FMC0_LA08_N         IO_L17N_T2U_N9_AD10N_66
+set_property         -dict {PACKAGE_PIN BC25  IOSTANDARD LVCMOS15                                     } [get_ports rstb             ]    ; ## FMC0_LA07_P         IO_L18P_T2U_N10_AD2P_66
+set_property         -dict {PACKAGE_PIN BG25  IOSTANDARD LVCMOS15                                     } [get_ports rxen[0]          ]    ; ## FMC0_LA10_P         IO_L15P_T2L_N4_AD11P_66
+set_property         -dict {PACKAGE_PIN BG24  IOSTANDARD LVCMOS15                                     } [get_ports rxen[1]          ]    ; ## FMC0_LA10_N         IO_L15N_T2L_N5_AD11N_66
+set_property         -dict {PACKAGE_PIN BF24  IOSTANDARD LVCMOS15                                     } [get_ports spi0_csb         ]    ; ## FMC0_LA05_P         IO_L20P_T3L_N2_AD1P_66
+set_property         -dict {PACKAGE_PIN BG23  IOSTANDARD LVCMOS15                                     } [get_ports spi0_miso        ]    ; ## FMC0_LA05_N         IO_L20N_T3L_N3_AD1N_66
+set_property         -dict {PACKAGE_PIN AU21  IOSTANDARD LVCMOS15                                     } [get_ports spi0_mosi        ]    ; ## FMC0_LA04_P         IO_L21P_T3L_N4_AD8P_66
+set_property         -dict {PACKAGE_PIN AV21  IOSTANDARD LVCMOS15                                     } [get_ports spi0_sclk        ]    ; ## FMC0_LA04_N         IO_L21N_T3L_N5_AD8N_66
+set_property         -dict {PACKAGE_PIN BG21  IOSTANDARD LVCMOS15                                     } [get_ports spi1_csb         ]    ; ## FMC0_LA12_P         IO_L9P_T1L_N4_AD12P_66
+set_property         -dict {PACKAGE_PIN BF23  IOSTANDARD LVCMOS15                                     } [get_ports spi1_sclk        ]    ; ## FMC0_LA11_P         IO_L10P_T1U_N6_QBC_AD4P_66
+set_property         -dict {PACKAGE_PIN BF22  IOSTANDARD LVCMOS15                                     } [get_ports spi1_sdio        ]    ; ## FMC0_LA12_N         IO_L9N_T1L_N5_AD12N_66
+set_property         -dict {PACKAGE_PIN AW23  IOSTANDARD LVDS15   DIFF_TERM_ADV TERM_100              } [get_ports sysref2_n        ]    ; ## FMC0_CLK0_M2C_N     IO_L12N_T1U_N11_GC_66
+set_property         -dict {PACKAGE_PIN AV23  IOSTANDARD LVDS15   DIFF_TERM_ADV TERM_100              } [get_ports sysref2_p        ]    ; ## FMC0_CLK0_M2C_P     IO_L12P_T1U_N10_GC_66
+set_property         -dict {PACKAGE_PIN BE25  IOSTANDARD LVCMOS15                                     } [get_ports txen[0]          ]    ; ## FMC0_LA09_P         IO_L24P_T3U_N10_66
+set_property         -dict {PACKAGE_PIN BE24  IOSTANDARD LVCMOS15                                     } [get_ports txen[1]          ]    ; ## FMC0_LA09_N         IO_L24N_T3U_N11_66
+

--- a/projects/ad9081_fmca_ebz/vck190/system_project.tcl
+++ b/projects/ad9081_fmca_ebz/vck190/system_project.tcl
@@ -1,0 +1,61 @@
+
+source ../../scripts/adi_env.tcl
+source $ad_hdl_dir/projects/scripts/adi_project_xilinx.tcl
+source $ad_hdl_dir/projects/scripts/adi_board.tcl
+
+# get_env_param retrieves parameter value from the environment if exists,
+# other case use the default value
+#
+#   Use over-writable parameters from the environment.
+#
+#    e.g.
+#      make RX_JESD_L=4 RX_JESD_M=8 RX_JESD_S=1 TX_JESD_L=4 TX_JESD_M=8 TX_JESD_S=1
+#      make RX_JESD_L=8 RX_JESD_M=4 RX_JESD_S=1 TX_JESD_L=8 TX_JESD_M=4 TX_JESD_S=1
+
+#
+# Parameter description:
+#   JESD_MODE : Used link layer encoder mode
+#      64B66B - 64b66b link layer defined in JESD 204C, uses Xilinx IP as Physical layer
+#      8B10B  - 8b10b link layer defined in JESD 204B, uses ADI IP as Physical layer
+#
+#   RX_RATE :  Line rate of the Rx link ( MxFE to FPGA )
+#   TX_RATE :  Line rate of the Tx link ( FPGA to MxFE )
+#   [RX/TX]_JESD_M : Number of converters per link
+#   [RX/TX]_JESD_L : Number of lanes per link
+#   [RX/TX]_JESD_NP : Number of bits per sample, only 16 is supported
+#   [RX/TX]_NUM_LINKS : Number of links, matches numer of MxFE devices
+#
+#
+
+#      make JESD_MODE=64B66B RX_RATE=24.75 TX_RATE=24.75 RX_JESD_M=4 RX_JESD_L=4 RX_JESD_S=2 RX_JESD_NP=12 TX_JESD_M=4 TX_JESD_L=4 TX_JESD_S=2 TX_JESD_NP=12
+
+adi_project ad9081_fmca_ebz_vck190 0 [list \
+  JESD_MODE    [get_env_param JESD_MODE    64B66B ]\
+  RX_LANE_RATE [get_env_param RX_RATE      24.75 ] \
+  TX_LANE_RATE [get_env_param TX_RATE      24.75 ] \
+  RX_JESD_M    [get_env_param RX_JESD_M    4 ] \
+  RX_JESD_L    [get_env_param RX_JESD_L    4 ] \
+  RX_JESD_S    [get_env_param RX_JESD_S    2 ] \
+  RX_JESD_NP   [get_env_param RX_JESD_NP   12] \
+  RX_NUM_LINKS [get_env_param RX_NUM_LINKS 1 ] \
+  TX_JESD_M    [get_env_param TX_JESD_M    4 ] \
+  TX_JESD_L    [get_env_param TX_JESD_L    4 ] \
+  TX_JESD_S    [get_env_param TX_JESD_S    2 ] \
+  TX_JESD_NP   [get_env_param TX_JESD_NP   12] \
+  TX_NUM_LINKS [get_env_param TX_NUM_LINKS 1 ] \
+  RX_KS_PER_CHANNEL [get_env_param RX_KS_PER_CHANNEL 64 ] \
+  TX_KS_PER_CHANNEL [get_env_param TX_KS_PER_CHANNEL 64 ] \
+]
+
+adi_project_files ad9081_fmca_ebz_vck190 [list \
+  "system_top.v" \
+  "system_constr.xdc"\
+  "timing_constr.xdc"\
+  "../../../library/common/ad_3w_spi.v"\
+  "$ad_hdl_dir/library/common/ad_iobuf.v" \
+  "$ad_hdl_dir/projects/common/vck190/vck190_system_constr.xdc" ]
+
+set_property strategy Performance_Explore [get_runs impl_1]
+
+adi_project_run ad9081_fmca_ebz_vck190
+

--- a/projects/ad9081_fmca_ebz/vck190/system_top.v
+++ b/projects/ad9081_fmca_ebz/vck190/system_top.v
@@ -219,6 +219,15 @@ module system_top  #(
   assign gpio_i[94:54] = gpio_o[94:54];
   assign gpio_i[31:10] = gpio_o[31:10];
 
+  reg ext_pll_lock,ext_pll_lock_d;
+
+  always @(posedge tx_device_clk) begin
+    ext_pll_lock <= gpio_i[43];
+    ext_pll_lock_d <= ext_pll_lock;
+  end
+
+  assign gt_reset = ext_pll_lock & ~ext_pll_lock_d;
+
   system_wrapper i_system_wrapper (
     .gpio0_i (gpio_i[31:0]),
     .gpio0_o (gpio_o[31:0]),
@@ -268,7 +277,8 @@ module system_top  #(
     .rx_sync_0 (rx_syncout),
     .tx_sync_0 (tx_syncin),
     .rx_sysref_0 (sysref),
-    .tx_sysref_0 (sysref)
+    .tx_sysref_0 (sysref),
+    .gt_reset (gt_reset)
   );
 
   assign rx_data_p_loc[RX_JESD_L*RX_NUM_LINKS-1:0] = rx_data_p[RX_JESD_L*RX_NUM_LINKS-1:0];

--- a/projects/ad9081_fmca_ebz/vck190/system_top.v
+++ b/projects/ad9081_fmca_ebz/vck190/system_top.v
@@ -1,0 +1,283 @@
+// ***************************************************************************
+// ***************************************************************************
+// Copyright 2014 - 2017 (c) Analog Devices, Inc. All rights reserved.
+//
+// In this HDL repository, there are many different and unique modules, consisting
+// of various HDL (Verilog or VHDL) components. The individual modules are
+// developed independently, and may be accompanied by separate and unique license
+// terms.
+//
+// The user should read each of these license terms, and understand the
+// freedoms and responsibilities that he or she has by using this source/core.
+//
+// This core is distributed in the hope that it will be useful, but WITHOUT ANY
+// WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+// A PARTICULAR PURPOSE.
+//
+// Redistribution and use of source or resulting binaries, with or without modification
+// of this file, are permitted under one of the following two license terms:
+//
+//   1. The GNU General Public License version 2 as published by the
+//      Free Software Foundation, which can be found in the top level directory
+//      of this repository (LICENSE_GPL2), and also online at:
+//      <https://www.gnu.org/licenses/old-licenses/gpl-2.0.html>
+//
+// OR
+//
+//   2. An ADI specific BSD license, which can be found in the top level directory
+//      of this repository (LICENSE_ADIBSD), and also on-line at:
+//      https://github.com/analogdevicesinc/hdl/blob/master/LICENSE_ADIBSD
+//      This will allow to generate bit files and not release the source code,
+//      as long as it attaches to an ADI device.
+//
+// ***************************************************************************
+// ***************************************************************************
+
+`timescale 1ns/100ps
+
+module system_top  #(
+    parameter TX_JESD_L = 4,
+    parameter TX_NUM_LINKS = 1,
+    parameter RX_JESD_L = 4,
+    parameter RX_NUM_LINKS = 1
+  ) (
+  input         sys_clk_n,
+  input         sys_clk_p,
+  output        ddr4_act_n,
+  output [16:0] ddr4_adr,
+  output  [1:0] ddr4_ba,
+  output  [1:0] ddr4_bg,
+  output        ddr4_ck_c,
+  output        ddr4_ck_t,
+  output        ddr4_cke,
+  output        ddr4_cs_n,
+  inout   [7:0] ddr4_dm_n,
+  inout  [63:0] ddr4_dq,
+  inout   [7:0] ddr4_dqs_c,
+  inout   [7:0] ddr4_dqs_t,
+  output        ddr4_odt,
+  output        ddr4_reset_n,
+  // GPIOs
+  output  [3:0] gpio_led,
+  input   [3:0] gpio_dip_sw,
+  input   [1:0] gpio_pb,
+
+  // FMC HPC IOs
+  input  [1:0]  agc0,
+  input  [1:0]  agc1,
+  input  [1:0]  agc2,
+  input  [1:0]  agc3,
+  input         clkin6_n,
+  input         clkin6_p,
+  input         clkin10_n,
+  input         clkin10_p,
+  input         fpga_refclk_in_n,
+  input         fpga_refclk_in_p,
+  input  [RX_JESD_L*RX_NUM_LINKS-1:0]  rx_data_n,
+  input  [RX_JESD_L*RX_NUM_LINKS-1:0]  rx_data_p,
+  output [TX_JESD_L*TX_NUM_LINKS-1:0]  tx_data_n,
+  output [TX_JESD_L*TX_NUM_LINKS-1:0]  tx_data_p,
+  input  [TX_NUM_LINKS-1:0]  fpga_syncin_n,
+  input  [TX_NUM_LINKS-1:0]  fpga_syncin_p,
+  output [RX_NUM_LINKS-1:0]  fpga_syncout_n,
+  output [RX_NUM_LINKS-1:0]  fpga_syncout_p,
+  inout  [10:0] gpio,
+  inout         hmc_gpio1,
+  output        hmc_sync,
+  input  [1:0]  irqb,
+  output        rstb,
+  output [1:0]  rxen,
+  output        spi0_csb,
+  input         spi0_miso,
+  output        spi0_mosi,
+  output        spi0_sclk,
+  output        spi1_csb,
+  output        spi1_sclk,
+  inout         spi1_sdio,
+  input         sysref2_n,
+  input         sysref2_p,
+  output [1:0]  txen
+
+);
+
+  // internal signals
+
+  wire    [95:0]  gpio_i;
+  wire    [95:0]  gpio_o;
+  wire    [95:0]  gpio_t;
+
+  wire    [ 2:0]  spi0_csn;
+
+  wire    [ 2:0]  spi1_csn;
+  wire            spi1_mosi;
+  wire            spi1_miso;
+
+  wire            sysref;
+  wire    [TX_NUM_LINKS-1:0]   tx_syncin;
+  wire    [RX_NUM_LINKS-1:0]   rx_syncout;
+
+  wire    [7:0]   rx_data_p_loc;
+  wire    [7:0]   rx_data_n_loc;
+  wire    [7:0]   tx_data_p_loc;
+  wire    [7:0]   tx_data_n_loc;
+
+  wire            clkin6;
+  wire            clkin10;
+  wire            tx_device_clk;
+  wire            rx_device_clk;
+
+  // instantiations
+
+  IBUFDS i_ibufds_sysref (
+    .I (sysref2_p),
+    .IB (sysref2_n),
+    .O (sysref));
+
+  IBUFDS i_ibufds_tx_device_clk (
+    .I (clkin6_p),
+    .IB (clkin6_n),
+    .O (clkin6));
+
+  IBUFDS i_ibufds_rx_device_clk (
+    .I (clkin10_p),
+    .IB (clkin10_n),
+    .O (clkin10));
+
+  genvar i;
+  generate
+  for(i=0;i<TX_NUM_LINKS;i=i+1) begin : g_tx_buffers
+    IBUFDS i_ibufds_syncin (
+      .I (fpga_syncin_p[i]),
+      .IB (fpga_syncin_n[i]),
+      .O (tx_syncin[i]));
+  end
+
+  for(i=0;i<RX_NUM_LINKS;i=i+1) begin : g_rx_buffers
+    OBUFDS i_obufds_syncout (
+      .I (rx_syncout[i]),
+      .O (fpga_syncout_p[i]),
+      .OB (fpga_syncout_n[i]));
+  end
+  endgenerate
+
+  BUFG i_tx_device_clk (
+    .I (clkin6),
+    .O (tx_device_clk)
+  );
+
+  BUFG i_rx_device_clk (
+    .I (clkin10),
+    .O (rx_device_clk)
+  );
+  // spi
+
+  assign spi0_csb   = spi0_csn[0];
+  assign spi1_csb   = spi1_csn[0];
+
+  ad_3w_spi #(.NUM_OF_SLAVES(1)) i_spi (
+    .spi_csn (spi1_csn[0]),
+    .spi_clk (spi1_sclk),
+    .spi_mosi (spi1_mosi),
+    .spi_miso (spi1_miso),
+    .spi_sdio (spi1_sdio),
+    .spi_dir ());
+
+  // gpios
+
+  ad_iobuf #(.DATA_WIDTH(12)) i_iobuf (
+    .dio_t (gpio_t[43:32]),
+    .dio_i (gpio_o[43:32]),
+    .dio_o (gpio_i[43:32]),
+    .dio_p ({hmc_gpio1,       // 43
+             gpio[10:0]}));   // 42-32
+
+  assign gpio_i[44] = agc0[0];
+  assign gpio_i[45] = agc0[1];
+  assign gpio_i[46] = agc1[0];
+  assign gpio_i[47] = agc1[1];
+  assign gpio_i[48] = agc2[0];
+  assign gpio_i[49] = agc2[1];
+  assign gpio_i[50] = agc3[0];
+  assign gpio_i[51] = agc3[1];
+  assign gpio_i[52] = irqb[0];
+  assign gpio_i[53] = irqb[1];
+
+  assign hmc_sync   = gpio_o[54];
+  assign rstb       = gpio_o[55];
+  assign rxen[0]    = gpio_o[56];
+  assign rxen[1]    = gpio_o[57];
+  assign txen[0]    = gpio_o[58];
+  assign txen[1]    = gpio_o[59];
+
+  /* Board GPIOS. Buttons, LEDs, etc... */
+  assign gpio_led = gpio_o[3:0];
+  assign gpio_i[3:0] = gpio_o[3:0];
+  assign gpio_i[7: 4] = gpio_dip_sw;
+  assign gpio_i[9: 8] = gpio_pb;
+
+  // Unused GPIOs
+  assign gpio_i[94:54] = gpio_o[94:54];
+  assign gpio_i[31:10] = gpio_o[31:10];
+
+  system_wrapper i_system_wrapper (
+    .gpio0_i (gpio_i[31:0]),
+    .gpio0_o (gpio_o[31:0]),
+    .gpio0_t (gpio_t[31:0]),
+    .gpio1_i (gpio_i[63:32]),
+    .gpio1_o (gpio_o[63:32]),
+    .gpio1_t (gpio_t[63:32]),
+    .gpio2_i (gpio_i[95:64]),
+    .gpio2_o (gpio_o[95:64]),
+    .gpio2_t (gpio_t[95:64]),
+    .ddr4_dimm1_sma_clk_clk_n (sys_clk_n),
+    .ddr4_dimm1_sma_clk_clk_p (sys_clk_p),
+    .ddr4_dimm1_act_n (ddr4_act_n),
+    .ddr4_dimm1_adr (ddr4_adr),
+    .ddr4_dimm1_ba (ddr4_ba),
+    .ddr4_dimm1_bg (ddr4_bg),
+    .ddr4_dimm1_ck_c (ddr4_ck_c),
+    .ddr4_dimm1_ck_t (ddr4_ck_t),
+    .ddr4_dimm1_cke (ddr4_cke),
+    .ddr4_dimm1_cs_n (ddr4_cs_n),
+    .ddr4_dimm1_dm_n (ddr4_dm_n),
+    .ddr4_dimm1_dq (ddr4_dq),
+    .ddr4_dimm1_dqs_c (ddr4_dqs_c),
+    .ddr4_dimm1_dqs_t (ddr4_dqs_t),
+    .ddr4_dimm1_odt (ddr4_odt),
+    .ddr4_dimm1_reset_n (ddr4_reset_n),
+    .spi0_csn (spi0_csn),
+    .spi0_miso (spi0_miso),
+    .spi0_mosi (spi0_mosi),
+    .spi0_sclk (spi0_sclk),
+    .spi1_csn (spi1_csn),
+    .spi1_miso (spi1_miso),
+    .spi1_mosi (spi1_mosi),
+    .spi1_sclk (spi1_sclk),
+    // FMC HPC
+    // TODO: Max 4 lanes
+    .GT_Serial_0_gtx_p (tx_data_p_loc[3:0]),
+    .GT_Serial_0_gtx_n (tx_data_n_loc[3:0]),
+    .GT_Serial_0_grx_p (rx_data_p_loc[3:0]),
+    .GT_Serial_0_grx_n (rx_data_n_loc[3:0]),
+
+    .gt_bridge_ip_0_diff_gt_ref_clock_0_clk_p(fpga_refclk_in_p),
+    .gt_bridge_ip_0_diff_gt_ref_clock_0_clk_n(fpga_refclk_in_n),
+
+    .rx_device_clk (rx_device_clk),
+    .tx_device_clk (tx_device_clk),
+    .rx_sync_0 (rx_syncout),
+    .tx_sync_0 (tx_syncin),
+    .rx_sysref_0 (sysref),
+    .tx_sysref_0 (sysref)
+  );
+
+  assign rx_data_p_loc[RX_JESD_L*RX_NUM_LINKS-1:0] = rx_data_p[RX_JESD_L*RX_NUM_LINKS-1:0];
+  assign rx_data_n_loc[RX_JESD_L*RX_NUM_LINKS-1:0] = rx_data_n[RX_JESD_L*RX_NUM_LINKS-1:0];
+
+  assign tx_data_p[TX_JESD_L*TX_NUM_LINKS-1:0] = tx_data_p_loc[TX_JESD_L*TX_NUM_LINKS-1:0];
+  assign tx_data_n[TX_JESD_L*TX_NUM_LINKS-1:0] = tx_data_n_loc[TX_JESD_L*TX_NUM_LINKS-1:0];
+
+endmodule
+
+// ***************************************************************************
+// ***************************************************************************

--- a/projects/ad9081_fmca_ebz/vck190/timing_constr.xdc
+++ b/projects/ad9081_fmca_ebz/vck190/timing_constr.xdc
@@ -1,0 +1,14 @@
+# Primary clock definitions
+create_clock -name refclk         -period  2.66 [get_ports fpga_refclk_in_p]
+
+# device clock
+create_clock -name tx_device_clk     -period  4 [get_ports clkin6_p]
+create_clock -name rx_device_clk     -period  4 [get_ports clkin10_p]
+
+# Constraint SYSREFs
+# Assumption is that REFCLK and SYSREF have similar propagation delay,
+# and the SYSREF is a source synchronous Edge-Aligned signal to REFCLK
+set_input_delay -clock [get_clocks tx_device_clk] \
+  [get_property PERIOD [get_clocks tx_device_clk]] \
+  [get_ports {sysref2_*}]
+

--- a/projects/common/vck190/vck190_system_bd.tcl
+++ b/projects/common/vck190/vck190_system_bd.tcl
@@ -1,0 +1,1 @@
+source $ad_hdl_dir/projects/common/vmk180/vmk180_system_bd.tcl

--- a/projects/common/vck190/vck190_system_constr.xdc
+++ b/projects/common/vck190/vck190_system_constr.xdc
@@ -1,0 +1,25 @@
+
+create_clock -period 5.000 -name sys_clk_p [get_ports sys_clk_p]
+
+
+set_property	PACKAGE_PIN	AF43 	[get_ports sys_clk_n]
+set_property	PACKAGE_PIN	AE42	[get_ports sys_clk_p]
+
+# Define SPI clock
+create_clock -name spi0_clk      -period 40   [get_pins -hier */EMIOSPI0SCLKO]
+create_clock -name spi1_clk      -period 40   [get_pins -hier */EMIOSPI1SCLKO]
+
+# GPIOs
+# (switches, leds and such)
+set_property -dict {PACKAGE_PIN H34 IOSTANDARD LVCMOS18} [get_ports gpio_led[0]] ; # DS6
+set_property -dict {PACKAGE_PIN J33 IOSTANDARD LVCMOS18} [get_ports gpio_led[1]] ; # DS5
+set_property -dict {PACKAGE_PIN K36 IOSTANDARD LVCMOS18} [get_ports gpio_led[2]] ; # DS4
+set_property -dict {PACKAGE_PIN L35 IOSTANDARD LVCMOS18} [get_ports gpio_led[3]] ; # DS3
+
+set_property -dict {PACKAGE_PIN J35 IOSTANDARD LVCMOS18} [get_ports gpio_dip_sw[0]] ; # SW6.1
+set_property -dict {PACKAGE_PIN J34 IOSTANDARD LVCMOS18} [get_ports gpio_dip_sw[1]] ; # SW6.2
+set_property -dict {PACKAGE_PIN H37 IOSTANDARD LVCMOS18} [get_ports gpio_dip_sw[2]] ; # SW6.3
+set_property -dict {PACKAGE_PIN H36 IOSTANDARD LVCMOS18} [get_ports gpio_dip_sw[3]] ; # SW6.4
+
+set_property -dict {PACKAGE_PIN G37 IOSTANDARD LVCMOS18} [get_ports gpio_pb[0]] ; # SW4
+set_property -dict {PACKAGE_PIN G36 IOSTANDARD LVCMOS18} [get_ports gpio_pb[1]] ; # SW5

--- a/projects/common/vmk180/vmk180_system_bd.tcl
+++ b/projects/common/vmk180/vmk180_system_bd.tcl
@@ -1,0 +1,195 @@
+
+# create board design
+# default ports
+
+create_bd_port -dir O -from 2 -to 0 spi0_csn
+create_bd_port -dir O spi0_sclk
+create_bd_port -dir O spi0_mosi
+create_bd_port -dir I spi0_miso
+
+create_bd_port -dir O -from 2 -to 0 spi1_csn
+create_bd_port -dir O spi1_sclk
+create_bd_port -dir O spi1_mosi
+create_bd_port -dir I spi1_miso
+
+create_bd_port -dir I -from 31 -to 0 gpio0_i
+create_bd_port -dir O -from 31 -to 0 gpio0_o
+create_bd_port -dir O -from 31 -to 0 gpio0_t
+create_bd_port -dir I -from 31 -to 0 gpio1_i
+create_bd_port -dir O -from 31 -to 0 gpio1_o
+create_bd_port -dir O -from 31 -to 0 gpio1_t
+create_bd_port -dir I -from 31 -to 0 gpio2_i
+create_bd_port -dir O -from 31 -to 0 gpio2_o
+create_bd_port -dir O -from 31 -to 0 gpio2_t
+
+# instance: versal_cips and NoC
+ad_ip_instance versal_cips sys_cips
+
+apply_bd_automation -rule xilinx.com:bd_rule:cips -config { \
+  board_preset {Yes} \
+  boot_config {Custom} \
+  configure_noc {Add new AXI NoC} \
+  debug_config {JTAG} \
+  design_flow {Full System} \
+  mc_type {DDR} \
+  num_mc {1} \
+  pl_clocks {2} \
+  pl_resets {1} \
+}  [get_bd_cells sys_cips]
+
+set_property -dict [list \
+  CONFIG.PS_PMC_CONFIG { \
+    CLOCK_MODE Custom \
+    DDR_MEMORY_MODE {Connectivity to DDR via NOC} \
+    DEBUG_MODE JTAG \
+    DESIGN_MODE 1 \
+    IO_CONFIG_MODE Custom \
+    PCIE_APERTURES_DUAL_ENABLE 0 \
+    PCIE_APERTURES_SINGLE_ENABLE 0 \
+    PMC_CRP_PL0_REF_CTRL_FREQMHZ 100 \
+    PMC_GPIO0_MIO_PERIPHERAL {{ENABLE 1} {IO {PMC_MIO 0 .. 25}}} \
+    PMC_GPIO1_MIO_PERIPHERAL {{ENABLE 1} {IO {PMC_MIO 26 .. 51}}} \
+    PMC_I2CPMC_PERIPHERAL {{ENABLE 1} {IO {PMC_MIO 46 .. 47}}} \
+    PMC_MIO37 {{AUX_IO 0} {DIRECTION out} {DRIVE_STRENGTH 8mA} {OUTPUT_DATA high} {PULL pullup} {SCHMITT 0} {SLEW slow} {USAGE GPIO}} \
+    PMC_OSPI_PERIPHERAL {{ENABLE 0} {IO {PMC_MIO 0 .. 11}} {MODE Single}} \
+    PMC_QSPI_COHERENCY 0 \
+    PMC_QSPI_FBCLK {{ENABLE 1} {IO {PMC_MIO 6}}} \
+    PMC_QSPI_PERIPHERAL_DATA_MODE x4 \
+    PMC_QSPI_PERIPHERAL_ENABLE 1 \
+    PMC_QSPI_PERIPHERAL_MODE {Dual Parallel} \
+    PMC_REF_CLK_FREQMHZ 33.3333 \
+    PMC_SD1 {{CD_ENABLE 1} {CD_IO {PMC_MIO 28}} {POW_ENABLE 1} {POW_IO {PMC_MIO 51}} {RESET_ENABLE 0} {RESET_IO {PMC_MIO 1}} {WP_ENABLE 0} {WP_IO {PMC_MIO 1}}} \
+    PMC_SD1_COHERENCY 0 \
+    PMC_SD1_DATA_TRANSFER_MODE 8Bit \
+    PMC_SD1_PERIPHERAL {{ENABLE 1} {IO {PMC_MIO 26 .. 36}}} \
+    PMC_SD1_SLOT_TYPE {SD 3.0} \
+    PMC_USE_PMC_NOC_AXI0 1 \
+    PS_BOARD_INTERFACE ps_pmc_fixed_io \
+    PS_CAN1_PERIPHERAL {{ENABLE 1} {IO {PMC_MIO 40 .. 41}}} \
+    PS_ENET0_MDIO {{ENABLE 1} {IO {PS_MIO 24 .. 25}}} \
+    PS_ENET0_PERIPHERAL {{ENABLE 1} {IO {PS_MIO 0 .. 11}}} \
+    PS_ENET1_PERIPHERAL {{ENABLE 1} {IO {PS_MIO 12 .. 23}}} \
+    PS_GEN_IPI0_ENABLE 1 \
+    PS_GEN_IPI0_MASTER A72 \
+    PS_GEN_IPI1_ENABLE 1 \
+    PS_GEN_IPI2_ENABLE 1 \
+    PS_GEN_IPI3_ENABLE 1 \
+    PS_GEN_IPI4_ENABLE 1 \
+    PS_GEN_IPI5_ENABLE 1 \
+    PS_GEN_IPI6_ENABLE 1 \
+    PS_GPIO_EMIO_PERIPHERAL_ENABLE 1 \
+    PS_HSDP_EGRESS_TRAFFIC JTAG \
+    PS_HSDP_INGRESS_TRAFFIC JTAG \
+    PS_HSDP_MODE None \
+    PS_I2C1_PERIPHERAL {{ENABLE 1} {IO {PMC_MIO 44 .. 45}}} \
+    PS_MIO19 {{AUX_IO 0} {DIRECTION in} {DRIVE_STRENGTH 8mA} {OUTPUT_DATA default} {PULL disable} {SCHMITT 0} {SLEW slow} {USAGE Reserved}} \
+    PS_MIO21 {{AUX_IO 0} {DIRECTION in} {DRIVE_STRENGTH 8mA} {OUTPUT_DATA default} {PULL disable} {SCHMITT 0} {SLEW slow} {USAGE Reserved}} \
+    PS_MIO7 {{AUX_IO 0} {DIRECTION in} {DRIVE_STRENGTH 8mA} {OUTPUT_DATA default} {PULL disable} {SCHMITT 0} {SLEW slow} {USAGE Reserved}} \
+    PS_MIO9 {{AUX_IO 0} {DIRECTION in} {DRIVE_STRENGTH 8mA} {OUTPUT_DATA default} {PULL disable} {SCHMITT 0} {SLEW slow} {USAGE Reserved}} \
+    PS_NUM_FABRIC_RESETS 1 \
+    PS_PCIE1_PERIPHERAL_ENABLE 0 \
+    PS_PCIE2_PERIPHERAL_ENABLE 0 \
+    PS_PCIE_RESET {{ENABLE 1} {IO {PMC_MIO 38 .. 39}}} \
+    PS_PL_CONNECTIVITY_MODE Custom \
+    PS_SPI0 {{GRP_SS0_ENABLE 1} {GRP_SS0_IO EMIO} {GRP_SS1_ENABLE 1} {GRP_SS1_IO EMIO} {GRP_SS2_ENABLE 1} {GRP_SS2_IO EMIO} {PERIPHERAL_ENABLE 1} {PERIPHERAL_IO EMIO}} \
+    PS_SPI1 {{GRP_SS0_ENABLE 1} {GRP_SS0_IO EMIO} {GRP_SS1_ENABLE 1} {GRP_SS1_IO EMIO} {GRP_SS2_ENABLE 1} {GRP_SS2_IO EMIO} {PERIPHERAL_ENABLE 1} {PERIPHERAL_IO EMIO}} \
+    PS_UART0_PERIPHERAL {{ENABLE 1} {IO {PMC_MIO 42 .. 43}}} \
+    PS_USB3_PERIPHERAL {{ENABLE 1} {IO {PMC_MIO 13 .. 25}}} \
+    PS_USE_FPD_CCI_NOC 1 \
+    PS_USE_FPD_CCI_NOC0 1 \
+    PS_USE_M_AXI_FPD 1 \
+    PS_USE_NOC_LPD_AXI0 1 \
+    PS_USE_PMCPL_CLK0 1 \
+    PS_USE_PMCPL_CLK1 1  SMON_ALARMS Set_Alarms_On  SMON_ENABLE_TEMP_AVERAGING 0  SMON_TEMP_AVERAGING_SAMPLES 8 \
+    PS_IRQ_USAGE {{CH0 1} {CH1 1} {CH10 1} {CH11 1} {CH12 1} {CH13 1} {CH14 1} {CH15 1} {CH2 1} {CH3 1} {CH4 1} {CH5 1} {CH6 1} {CH7 1} {CH8 1} {CH9 1}} \
+  } \
+  CONFIG.PS_PMC_CONFIG_APPLIED {1} \
+  CONFIG.CLOCK_MODE {Custom} \
+  CONFIG.IO_CONFIG_MODE {Custom} \
+  CONFIG.PS_PL_CONNECTIVITY_MODE {Custom} \
+] [get_bd_cells sys_cips]
+
+ad_ip_instance proc_sys_reset sys_rstgen
+ad_ip_parameter sys_rstgen CONFIG.C_EXT_RST_WIDTH 1
+ad_ip_instance proc_sys_reset sys_350m_rstgen
+ad_ip_parameter sys_350m_rstgen CONFIG.C_EXT_RST_WIDTH 1
+
+# system reset/clock definitions
+
+ad_connect  sys_cpu_clk sys_cips/pl0_ref_clk
+ad_connect  sys_350m_clk sys_cips/pl1_ref_clk
+
+ad_connect  sys_cips/pl0_resetn sys_rstgen/ext_reset_in
+ad_connect  sys_cpu_clk sys_rstgen/slowest_sync_clk
+ad_connect  sys_cips/pl0_resetn sys_350m_rstgen/ext_reset_in
+ad_connect  sys_350m_clk sys_350m_rstgen/slowest_sync_clk
+
+ad_connect  sys_cpu_reset sys_rstgen/peripheral_reset
+ad_connect  sys_cpu_resetn sys_rstgen/peripheral_aresetn
+ad_connect  sys_350m_reset sys_350m_rstgen/peripheral_reset
+ad_connect  sys_350m_resetn sys_350m_rstgen/peripheral_aresetn
+
+# gpio
+ad_connect gpio0_i sys_cips/lpd_gpio_i
+ad_connect gpio0_o sys_cips/lpd_gpio_o
+ad_connect gpio0_t sys_cips/lpd_gpio_t
+
+# gpio extension witn 64 IOs
+ad_ip_instance axi_gpio axi_gpio
+ad_ip_parameter axi_gpio CONFIG.C_IS_DUAL 1
+ad_ip_parameter axi_gpio CONFIG.C_GPIO_WIDTH 32
+ad_ip_parameter axi_gpio CONFIG.C_GPIO2_WIDTH 32
+ad_ip_parameter axi_gpio CONFIG.C_INTERRUPT_PRESENT 1
+
+ad_connect gpio1_i axi_gpio/gpio_io_i
+ad_connect gpio1_o axi_gpio/gpio_io_o
+ad_connect gpio1_t axi_gpio/gpio_io_t
+ad_connect gpio2_i axi_gpio/gpio2_io_i
+ad_connect gpio2_o axi_gpio/gpio2_io_o
+ad_connect gpio2_t axi_gpio/gpio2_io_t
+
+ad_cpu_interconnect 0x44000000 axi_gpio
+
+ad_cpu_interrupt ps-0 mb-xx axi_gpio/ip2intc_irpt
+
+## generic system clocks&resets pointers
+
+set sys_cpu_clk           [get_bd_nets sys_cpu_clk]
+set sys_dma_clk           [get_bd_nets sys_350m_clk]
+
+set sys_cpu_reset         [get_bd_nets sys_cpu_reset]
+set sys_cpu_resetn        [get_bd_nets sys_cpu_resetn]
+set sys_dma_reset         [get_bd_nets sys_350m_reset]
+set sys_dma_resetn        [get_bd_nets sys_350m_resetn]
+
+# spi
+
+ad_connect  sys_cips/spi0_sck_o spi0_sclk
+ad_connect  sys_cips/spi0_sck_i GND
+ad_connect  sys_cips/spi0_io0_o spi0_mosi
+ad_connect  sys_cips/spi0_io0_i spi0_miso
+ad_connect  sys_cips/spi0_io1_i GND
+ad_connect  sys_cips/spi0_ss_o spi0_csn
+ad_connect  sys_cips/spi0_ss_i VCC
+
+ad_connect  sys_cips/spi1_sck_o spi1_sclk
+ad_connect  sys_cips/spi1_sck_i GND
+ad_connect  sys_cips/spi1_io0_o spi1_mosi
+ad_connect  sys_cips/spi1_io0_i spi1_miso
+ad_connect  sys_cips/spi1_io1_i GND
+ad_connect  sys_cips/spi1_ss_o spi1_csn
+ad_connect  sys_cips/spi1_ss_i VCC
+
+# system id
+
+ad_ip_instance axi_sysid axi_sysid_0
+ad_ip_instance sysid_rom rom_sys_0
+
+ad_connect  axi_sysid_0/rom_addr   	    rom_sys_0/rom_addr
+ad_connect  axi_sysid_0/sys_rom_data   	rom_sys_0/rom_data
+ad_connect  sys_cpu_clk                 rom_sys_0/clk
+
+ad_cpu_interconnect 0x45000000 axi_sysid_0
+
+# interrupts
+

--- a/projects/common/vmk180/vmk180_system_constr.xdc
+++ b/projects/common/vmk180/vmk180_system_constr.xdc
@@ -1,0 +1,24 @@
+
+create_clock -period 5.000 -name sys_clk_p [get_ports sys_clk_p]
+
+set_property	PACKAGE_PIN	AF43 	[get_ports sys_clk_n]
+set_property	PACKAGE_PIN	AE42	[get_ports sys_clk_p]
+
+# Define SPI clock
+create_clock -name spi0_clk      -period 40   [get_pins -hier */EMIOSPI0SCLKO]
+create_clock -name spi1_clk      -period 40   [get_pins -hier */EMIOSPI1SCLKO]
+
+# GPIOs
+# (switches, leds and such)
+set_property -dict {PACKAGE_PIN H34 IOSTANDARD LVCMOS18} [get_ports gpio_led[0]] ; # DS6
+set_property -dict {PACKAGE_PIN J33 IOSTANDARD LVCMOS18} [get_ports gpio_led[1]] ; # DS5
+set_property -dict {PACKAGE_PIN K36 IOSTANDARD LVCMOS18} [get_ports gpio_led[2]] ; # DS4
+set_property -dict {PACKAGE_PIN L35 IOSTANDARD LVCMOS18} [get_ports gpio_led[3]] ; # DS3
+
+set_property -dict {PACKAGE_PIN J35 IOSTANDARD LVCMOS18} [get_ports gpio_dip_sw[0]] ; # SW6.1
+set_property -dict {PACKAGE_PIN J34 IOSTANDARD LVCMOS18} [get_ports gpio_dip_sw[1]] ; # SW6.2
+set_property -dict {PACKAGE_PIN H37 IOSTANDARD LVCMOS18} [get_ports gpio_dip_sw[2]] ; # SW6.3
+set_property -dict {PACKAGE_PIN H36 IOSTANDARD LVCMOS18} [get_ports gpio_dip_sw[3]] ; # SW6.4
+
+set_property -dict {PACKAGE_PIN G37 IOSTANDARD LVCMOS18} [get_ports gpio_pb[0]] ; # SW4
+set_property -dict {PACKAGE_PIN G36 IOSTANDARD LVCMOS18} [get_ports gpio_pb[1]] ; # SW5

--- a/projects/common/vmk180_es1/vmk180_es1_system_bd.tcl
+++ b/projects/common/vmk180_es1/vmk180_es1_system_bd.tcl
@@ -1,0 +1,2 @@
+source $ad_hdl_dir/projects/common/vmk180/vmk180_system_bd.tcl
+

--- a/projects/common/vmk180_es1/vmk180_es1_system_constr.xdc
+++ b/projects/common/vmk180_es1/vmk180_es1_system_constr.xdc
@@ -1,0 +1,24 @@
+
+create_clock -period 5.000 -name sys_clk_p [get_ports sys_clk_p]
+
+set_property	PACKAGE_PIN	AF43 	[get_ports sys_clk_n]
+set_property	PACKAGE_PIN	AE42	[get_ports sys_clk_p]
+
+# Define SPI clock
+create_clock -name spi0_clk      -period 40   [get_pins -hier */EMIOSPI0SCLKO]
+create_clock -name spi1_clk      -period 40   [get_pins -hier */EMIOSPI1SCLKO]
+
+# GPIOs
+# (switches, leds and such)
+set_property -dict {PACKAGE_PIN H34 IOSTANDARD LVCMOS18} [get_ports gpio_led[0]] ; # DS6
+set_property -dict {PACKAGE_PIN J33 IOSTANDARD LVCMOS18} [get_ports gpio_led[1]] ; # DS5
+set_property -dict {PACKAGE_PIN K36 IOSTANDARD LVCMOS18} [get_ports gpio_led[2]] ; # DS4
+set_property -dict {PACKAGE_PIN L35 IOSTANDARD LVCMOS18} [get_ports gpio_led[3]] ; # DS3
+
+set_property -dict {PACKAGE_PIN J35 IOSTANDARD LVCMOS18} [get_ports gpio_dip_sw[0]] ; # SW6.1
+set_property -dict {PACKAGE_PIN J34 IOSTANDARD LVCMOS18} [get_ports gpio_dip_sw[1]] ; # SW6.2
+set_property -dict {PACKAGE_PIN H37 IOSTANDARD LVCMOS18} [get_ports gpio_dip_sw[2]] ; # SW6.3
+set_property -dict {PACKAGE_PIN H36 IOSTANDARD LVCMOS18} [get_ports gpio_dip_sw[3]] ; # SW6.4
+
+set_property -dict {PACKAGE_PIN G37 IOSTANDARD LVCMOS18} [get_ports gpio_pb[0]] ; # SW4
+set_property -dict {PACKAGE_PIN G36 IOSTANDARD LVCMOS18} [get_ports gpio_pb[1]] ; # SW5

--- a/projects/scripts/adi_board.tcl
+++ b/projects/scripts/adi_board.tcl
@@ -493,10 +493,12 @@ proc ad_mem_hp0_interconnect {p_clk p_name} {
 
   global sys_zynq
 
-  if {($sys_zynq <= 0) && ($p_name eq "sys_ps7/S_AXI_HP0")} {return}
+  if {($sys_zynq != 1 && $sys_zynq != 2) && ($p_name eq "sys_ps7/S_AXI_HP0")} {return}
   if {$sys_zynq == -1} {ad_mem_hpx_interconnect "SIM" $p_clk $p_name}
   if {$sys_zynq == 0} {ad_mem_hpx_interconnect "MEM" $p_clk $p_name}
-  if {$sys_zynq >= 1} {ad_mem_hpx_interconnect "HP0" $p_clk $p_name}
+  if {$sys_zynq == 1} {ad_mem_hpx_interconnect "HP0" $p_clk $p_name}
+  if {$sys_zynq == 2} {ad_mem_hpx_interconnect "HP0" $p_clk $p_name}
+  if {$sys_zynq == 3} {ad_mem_hpx_interconnect "NOC" $p_clk $p_name}
 }
 
 ## Create an memory mapped interface connection to a MIG or PS7/8 IP, using a
@@ -509,10 +511,12 @@ proc ad_mem_hp1_interconnect {p_clk p_name} {
 
   global sys_zynq
 
-  if {($sys_zynq <= 0) && ($p_name eq "sys_ps7/S_AXI_HP1")} {return}
+  if {($sys_zynq != 1 && $sys_zynq != 2) && ($p_name eq "sys_ps7/S_AXI_HP1")} {return}
   if {$sys_zynq == -1} {ad_mem_hpx_interconnect "SIM" $p_clk $p_name}
   if {$sys_zynq == 0} {ad_mem_hpx_interconnect "MEM" $p_clk $p_name}
-  if {$sys_zynq >= 1} {ad_mem_hpx_interconnect "HP1" $p_clk $p_name}
+  if {$sys_zynq == 1} {ad_mem_hpx_interconnect "HP1" $p_clk $p_name}
+  if {$sys_zynq == 2} {ad_mem_hpx_interconnect "HP1" $p_clk $p_name}
+  if {$sys_zynq == 3} {ad_mem_hpx_interconnect "NOC" $p_clk $p_name}
 }
 
 ## Create an memory mapped interface connection to a MIG or PS7/8 IP, using a
@@ -525,10 +529,12 @@ proc ad_mem_hp2_interconnect {p_clk p_name} {
 
   global sys_zynq
 
-  if {($sys_zynq <= 0) && ($p_name eq "sys_ps7/S_AXI_HP2")} {return}
+  if {($sys_zynq != 1 && $sys_zynq != 2) && ($p_name eq "sys_ps7/S_AXI_HP2")} {return}
   if {$sys_zynq == -1} {ad_mem_hpx_interconnect "SIM" $p_clk $p_name}
   if {$sys_zynq == 0} {ad_mem_hpx_interconnect "MEM" $p_clk $p_name}
-  if {$sys_zynq >= 1} {ad_mem_hpx_interconnect "HP2" $p_clk $p_name}
+  if {$sys_zynq == 1} {ad_mem_hpx_interconnect "HP2" $p_clk $p_name}
+  if {$sys_zynq == 2} {ad_mem_hpx_interconnect "HP2" $p_clk $p_name}
+  if {$sys_zynq == 3} {ad_mem_hpx_interconnect "NOC" $p_clk $p_name}
 }
 
 ## Create an memory mapped interface connection to a MIG or PS7/8 IP, using a
@@ -541,10 +547,12 @@ proc ad_mem_hp3_interconnect {p_clk p_name} {
 
   global sys_zynq
 
-  if {($sys_zynq <= 0) && ($p_name eq "sys_ps7/S_AXI_HP3")} {return}
+  if {($sys_zynq != 1 && $sys_zynq != 2) && ($p_name eq "sys_ps7/S_AXI_HP3")} {return}
   if {$sys_zynq == -1} {ad_mem_hpx_interconnect "SIM" $p_clk $p_name}
   if {$sys_zynq == 0} {ad_mem_hpx_interconnect "MEM" $p_clk $p_name}
-  if {$sys_zynq >= 1} {ad_mem_hpx_interconnect "HP3" $p_clk $p_name}
+  if {$sys_zynq == 1} {ad_mem_hpx_interconnect "HP3" $p_clk $p_name}
+  if {$sys_zynq == 2} {ad_mem_hpx_interconnect "HP3" $p_clk $p_name}
+  if {$sys_zynq == 3} {ad_mem_hpx_interconnect "NOC" $p_clk $p_name}
 }
 
 ## Create an memory mapped interface connection to a MIG or PS7/8 IP, proc is
@@ -676,6 +684,13 @@ proc ad_mem_hpx_interconnect {p_sel p_clk p_name} {
     set m_addr_seg [get_bd_addr_segs sys_ps8/SAXIGP5/HP3_DDR_*]
   }
 
+  if {$p_sel eq "NOC"} {
+    set m_interconnect_index [get_property CONFIG.NUM_SI [get_bd_cells axi_noc_0]]
+    set m_interconnect_cell [get_bd_cells axi_noc_0]
+    set m_addr_seg [get_bd_addr_segs  axi_noc_0/S[format "%02s" [expr $m_interconnect_index +1]]_AXI/C0_DDR_LOW0]
+    set sys_mem_clk_index [expr [get_property CONFIG.NUM_CLKS [get_bd_cells axi_noc_0]]-1]
+  }
+
   set i_str "S$m_interconnect_index"
   if {$m_interconnect_index < 10} {
     set i_str "S0$m_interconnect_index"
@@ -710,14 +725,28 @@ proc ad_mem_hpx_interconnect {p_sel p_clk p_name} {
   } else {
 
     set_property CONFIG.NUM_SI $m_interconnect_index $m_interconnect_cell
-    if {[lsearch [get_bd_nets -of_object [get_bd_pins $m_interconnect_cell/ACLK*]] [get_bd_nets $p_clk]] == -1 } {
+    set clk_index [lsearch [get_bd_nets -of_object [get_bd_pins $m_interconnect_cell/ACLK*]] [get_bd_nets $p_clk]]
+    if { $clk_index == -1 } {
         incr sys_mem_clk_index
         set_property CONFIG.NUM_CLKS [expr $sys_mem_clk_index +1] $m_interconnect_cell
         ad_connect $p_clk $m_interconnect_cell/ACLK$sys_mem_clk_index
+        set asocc_clk_pin  $m_interconnect_cell/ACLK$sys_mem_clk_index
+    } else {
+      set asocc_clk_pin [lindex [get_bd_pins $m_interconnect_cell/ACLK*] $clk_index]
     }
     ad_connect $m_interconnect_cell/${i_str}_AXI $p_name_int
     if {$p_intf_clock ne ""} {
       ad_connect $p_clk $p_intf_clock
+    }
+
+    if {$p_sel eq "NOC"} {
+      set_property -dict [list CONFIG.CONNECTIONS {MC_0 { read_bw {1720} write_bw {1720} read_avg_burst {4} write_avg_burst {4}} }] [get_bd_intf_pins /axi_noc_0/${i_str}_AXI]
+      # Add the new bus as associated to the clock pin, append new if other exists
+      set clk_asoc_port [get_property CONFIG.ASSOCIATED_BUSIF [get_bd_pins $asocc_clk_pin]]
+      if {$clk_asoc_port != {}} {
+       set clk_asoc_port ${clk_asoc_port}:
+      }
+      set_property -dict [list CONFIG.ASSOCIATED_BUSIF ${clk_asoc_port}${i_str}_AXI] [get_bd_pins $asocc_clk_pin]
     }
 
     set mem_mapped ""
@@ -768,6 +797,10 @@ proc ad_cpu_interconnect {p_address p_name} {
     ]
     ad_connect sys_cpu_clk axi_cpu_interconnect/aclk
     ad_connect sys_cpu_resetn axi_cpu_interconnect/aresetn
+    if {$sys_zynq == 3} {
+      ad_connect sys_cpu_clk sys_cips/m_axi_fpd_aclk
+      ad_connect axi_cpu_interconnect/S00_AXI sys_cips/M_AXI_FPD
+    }
     if {$sys_zynq == 2} {
       ad_connect sys_cpu_clk sys_ps8/maxihpm0_lpd_aclk
       ad_connect axi_cpu_interconnect/S00_AXI sys_ps8/M_AXI_HPM0_LPD
@@ -784,6 +817,9 @@ proc ad_cpu_interconnect {p_address p_name} {
     }
   }
 
+  if {$sys_zynq == 3} {
+    set sys_addr_cntrl_space [get_bd_addr_spaces /sys_cips/M_AXI_FPD]
+  }
   if {$sys_zynq == 2} {
     set sys_addr_cntrl_space [get_bd_addr_spaces sys_ps8/Data]
   }
@@ -897,6 +933,18 @@ proc ad_cpu_interconnect {p_address p_name} {
       if {$p_seg_range < 0x1000} {
         set p_seg_range 0x1000
       }
+      if {$sys_zynq == 3} {
+        if {($p_address >= 0x44000000) && ($p_address <= 0x4fffffff)} {
+          # place axi peripherics in A400_0000-AFFF_FFFF range
+          set p_address [expr ($p_address + 0x60000000)]
+        } elseif {($p_address >= 0x70000000) && ($p_address <= 0x7fffffff)} {
+          # place axi peripherics in B000_0000-BFFF_FFFF range
+          set p_address [expr ($p_address + 0x40000000)]
+        } else {
+          error "ERROR: ad_cpu_interconnect : Cannot map ($p_address) to aperture, \
+                Addess out of range 0x4400_0000 - 0X4FFF_FFFF; 0x7000_0000 - 0X7FFF_FFFF !"
+        }
+      }
       if {$sys_zynq == 2} {
         if {($p_address >= 0x40000000) && ($p_address <= 0x4fffffff)} {
           set p_address [expr ($p_address + 0x40000000)]
@@ -930,6 +978,13 @@ proc ad_cpu_interrupt {p_ps_index p_mb_index p_name} {
 
   set p_index [regsub -all {[^0-9]} $p_index_int ""]
   set m_index [expr ($p_index - 8)]
+
+  if {$sys_zynq == 3} {
+   if {$p_index < 0 || $p_index > 15} {
+      error "ERROR: ad_cpu_interrupt : Interrupt index ($p_index) out of range 0-15 "
+    }
+    ad_connect $p_name sys_cips/pl_ps_irq$p_index
+  }
 
   if {($sys_zynq == 2) && ($p_index <= 7)} {
     set p_net [get_bd_nets -of_objects [get_bd_pins sys_concat_intc_0/In$p_index]]

--- a/projects/scripts/adi_board.tcl
+++ b/projects/scripts/adi_board.tcl
@@ -368,7 +368,7 @@ proc ad_xcvrcon {u_xcvr a_xcvr a_jesd {lane_map {}} {link_clk {}} {device_clk {}
 
   set use_2x_clk 0
   if {$link_clk == {}} {
-    # For 204C modes on GTH a 2x clock is required to drive the PCS 
+    # For 204C modes on GTH a 2x clock is required to drive the PCS
     # In such case set the xcvr out clock to be the double of the lane rate/66(40)
     # and use the secondary div2 clock output for the link clock
     if {$link_mode == 2 && ($xcvr_type == 5 || $xcvr_type == 8)} {
@@ -762,35 +762,24 @@ proc ad_cpu_interconnect {p_address p_name} {
   }
 
   if {$sys_cpu_interconnect_index == 0} {
-    ad_ip_instance axi_interconnect axi_cpu_interconnect
+    ad_ip_instance smartconnect axi_cpu_interconnect [ list \
+      NUM_MI 1 \
+      NUM_SI 1 \
+    ]
+    ad_connect sys_cpu_clk axi_cpu_interconnect/aclk
+    ad_connect sys_cpu_resetn axi_cpu_interconnect/aresetn
     if {$sys_zynq == 2} {
       ad_connect sys_cpu_clk sys_ps8/maxihpm0_lpd_aclk
-      ad_connect sys_cpu_clk axi_cpu_interconnect/ACLK
-      ad_connect sys_cpu_clk axi_cpu_interconnect/S00_ACLK
-      ad_connect sys_cpu_resetn axi_cpu_interconnect/ARESETN
-      ad_connect sys_cpu_resetn axi_cpu_interconnect/S00_ARESETN
       ad_connect axi_cpu_interconnect/S00_AXI sys_ps8/M_AXI_HPM0_LPD
     }
     if {$sys_zynq == 1} {
       ad_connect sys_cpu_clk sys_ps7/M_AXI_GP0_ACLK
-      ad_connect sys_cpu_clk axi_cpu_interconnect/ACLK
-      ad_connect sys_cpu_clk axi_cpu_interconnect/S00_ACLK
-      ad_connect sys_cpu_resetn axi_cpu_interconnect/ARESETN
-      ad_connect sys_cpu_resetn axi_cpu_interconnect/S00_ARESETN
       ad_connect axi_cpu_interconnect/S00_AXI sys_ps7/M_AXI_GP0
     }
     if {$sys_zynq == 0} {
-      ad_connect sys_cpu_clk axi_cpu_interconnect/ACLK
-      ad_connect sys_cpu_clk axi_cpu_interconnect/S00_ACLK
-      ad_connect sys_cpu_resetn axi_cpu_interconnect/ARESETN
-      ad_connect sys_cpu_resetn axi_cpu_interconnect/S00_ARESETN
       ad_connect axi_cpu_interconnect/S00_AXI sys_mb/M_AXI_DP
     }
     if {$sys_zynq == -1} {
-      ad_connect sys_cpu_clk axi_cpu_interconnect/ACLK
-      ad_connect sys_cpu_clk axi_cpu_interconnect/S00_ACLK
-      ad_connect sys_cpu_resetn axi_cpu_interconnect/ARESETN
-      ad_connect sys_cpu_resetn axi_cpu_interconnect/S00_ARESETN
       ad_connect axi_cpu_interconnect/S00_AXI mng_axi_vip/M_AXI
     }
   }
@@ -892,11 +881,9 @@ proc ad_cpu_interconnect {p_address p_name} {
 
   set_property CONFIG.NUM_MI $sys_cpu_interconnect_index [get_bd_cells axi_cpu_interconnect]
 
-  ad_connect sys_cpu_clk axi_cpu_interconnect/${i_str}_ACLK
   if {$p_intf_clock ne ""} {
     ad_connect sys_cpu_clk ${p_intf_clock}
   }
-  ad_connect sys_cpu_resetn axi_cpu_interconnect/${i_str}_ARESETN
   if {$p_intf_reset ne ""} {
     ad_connect sys_cpu_resetn ${p_intf_reset}
   }

--- a/projects/scripts/adi_project_xilinx.tcl
+++ b/projects/scripts/adi_project_xilinx.tcl
@@ -110,7 +110,15 @@ proc adi_project {project_name {mode 0} {parameter_list {}} } {
     set device "xczu9eg-ffvb1156-2-e"
     set board [lindex [lsearch -all -inline [get_board_parts] *zcu102*] end]
   }
-
+  if [regexp "_vmk180_es1$" $project_name] {
+    enable_beta_device xcvm*
+    set device "xcvm1802-vsva2197-2MP-e-S-es1"
+    set board [lindex [lsearch -all -inline [get_board_parts] *vmk180_es*] end]
+  }
+  if [regexp "_vmk180$" $project_name] {
+    set device "xcvm1802-vsva2197-2MP-e-S"
+    set board [lindex [lsearch -all -inline [get_board_parts] *vmk180*] end]
+  }
   adi_project_create $project_name $mode $parameter_list $device $board
 }
 
@@ -147,6 +155,8 @@ proc adi_project_create {project_name mode parameter_list device {board "not-app
     set sys_zynq 1
   } elseif [regexp "^xczu" $p_device]  {
     set sys_zynq 2
+  } elseif [regexp "^xcv\[ecmph\]" $p_device]  {
+    set sys_zynq 3
   } else {
     set sys_zynq 0
   }

--- a/projects/scripts/adi_project_xilinx.tcl
+++ b/projects/scripts/adi_project_xilinx.tcl
@@ -112,6 +112,9 @@ proc adi_project {project_name {mode 0} {parameter_list {}} } {
   }
   if [regexp "_vmk180_es1$" $project_name] {
     enable_beta_device xcvm*
+    xhub::refresh_catalog [xhub::get_xstores xilinx_board_store]
+    xhub::install [xhub::get_xitems xilinx.com:xilinx_board_store:vmk180_es:*] -quiet
+    set_param board.repoPaths [get_property LOCAL_ROOT_DIR [xhub::get_xstores xilinx_board_store]]
     set device "xcvm1802-vsva2197-2MP-e-S-es1"
     set board [lindex [lsearch -all -inline [get_board_parts] *vmk180_es*] end]
   }
@@ -309,6 +312,8 @@ proc adi_project_run {project_name} {
   set_property STEPS.POWER_OPT_DESIGN.IS_ENABLED true [get_runs impl_1]
   set_property STEPS.POST_PLACE_POWER_OPT_DESIGN.IS_ENABLED true [get_runs impl_1]
   }
+
+  set_param board.repoPaths [get_property LOCAL_ROOT_DIR [xhub::get_xstores xilinx_board_store]]
 
   launch_runs impl_1 -to_step write_bitstream
   wait_on_run impl_1

--- a/projects/scripts/adi_project_xilinx.tcl
+++ b/projects/scripts/adi_project_xilinx.tcl
@@ -122,6 +122,10 @@ proc adi_project {project_name {mode 0} {parameter_list {}} } {
     set device "xcvm1802-vsva2197-2MP-e-S"
     set board [lindex [lsearch -all -inline [get_board_parts] *vmk180*] end]
   }
+  if [regexp "_vck190$" $project_name] {
+    set device "xcvc1902-vsva2197-2MP-e-S"
+    set board [lindex [lsearch -all -inline [get_board_parts] *vck190*] end]
+  }
   adi_project_create $project_name $mode $parameter_list $device $board
 }
 

--- a/projects/scripts/project-xilinx.mk
+++ b/projects/scripts/project-xilinx.mk
@@ -29,6 +29,8 @@ CLEAN_TARGET += mem_init_sys.txt
 CLEAN_TARGET += *.csv
 CLEAN_TARGET += *.hbs
 CLEAN_TARGET += *.gen
+CLEAN_TARGET += *.xpe
+CLEAN_TARGET += *.xsa
 
 # Common dependencies that all projects have
 M_DEPS += system_project.tcl
@@ -42,7 +44,7 @@ M_DEPS += $(HDL_PROJECT_PATH)scripts/adi_board.tcl
 M_DEPS += $(foreach dep,$(LIB_DEPS),$(HDL_LIBRARY_PATH)$(dep)/component.xml)
 
 .PHONY: all lib clean clean-all
-all: lib $(PROJECT_NAME).sdk/system_top.hdf
+all: lib $(PROJECT_NAME).sdk/system_top.xsa
 
 clean:
 	-rm -f reference.dcp
@@ -57,7 +59,7 @@ clean-all: clean
 
 MODE ?= "default"
 
-$(PROJECT_NAME).sdk/system_top.hdf: $(M_DEPS)
+$(PROJECT_NAME).sdk/system_top.xsa: $(M_DEPS)
 	@if [ $(MODE) = incr ]; then \
 		if [ -f */impl_1/system_top_routed.dcp ]; then \
 			echo Found previous run result at `ls */impl_1/system_top_routed.dcp`; \


### PR DESCRIPTION
This series of changes contains:
- Versal support 
   -  Changed cpu interconnect to SmartConnect
   - NOC support
- Base design for VMK180, VMK180_ES1, VCK190
- AD9081 project for VCK190


Tested on VCK190 + AD9081