### PR TITLE
Revert "data_offload: Fix timing violation"

### DIFF
--- a/library/data_offload/data_offload.v
+++ b/library/data_offload/data_offload.v
@@ -184,6 +184,7 @@ module data_offload #(
   wire                                        m_axis_reset_int_s;
 
   wire  [33:0]                                src_transfer_length_s;
+  wire                                        src_wr_last_int_s;
   wire  [33:0]                                src_wr_last_beat_s;
 
   wire                                        int_not_full;
@@ -193,7 +194,6 @@ module data_offload #(
 
   // internal registers
 
-  reg        src_wr_last_int_s;
   reg [33:0] src_data_counter = 0;
   reg        dst_mem_valid_d = 1'b0;
 
@@ -407,18 +407,9 @@ always @(posedge s_axis_aclk) begin
     end
   end
 end
-
 // transfer length is in bytes, but counter monitors the source data beats
 assign src_wr_last_beat_s = (src_transfer_length_s == 'h0) ? MEM_SIZE[33:SRC_BEAT_BYTE]-1 : src_transfer_length_s[33:SRC_BEAT_BYTE]-1;
-
-always @ (posedge src_clk) begin
-    if (src_data_counter == (src_wr_last_beat_s - 'h1)) begin
-        src_wr_last_int_s <= 1'b1;
-    end
-    else begin
-        src_wr_last_int_s <= 1'b0;
-    end
-end
+assign src_wr_last_int_s = (src_data_counter == src_wr_last_beat_s) ?  1'b1 : 1'b0;
 
 endmodule
 


### PR DESCRIPTION
This reverts commit 1fe0d5f8e00b119a5a389213cf05e9db4646c86a.

This addresses https://github.com/analogdevicesinc/hdl/issues/755


We will revert this commit until a better solution is found for the timing closure problem. If needed, the timing closure can be addressed with higher effort Implementation strategies. 

