### PR TITLE
Minor fixes on axi_hdmi_tx and axi_i2s_adi

### DIFF
--- a/library/axi_hdmi_tx/axi_hdmi_tx.v
+++ b/library/axi_hdmi_tx/axi_hdmi_tx.v
@@ -107,6 +107,7 @@ module axi_hdmi_tx #(
   localparam  EMBEDDED_SYNC = (INTERFACE == "16_BIT_EMBEDDED_SYNC") ? 1 : 0;
   localparam  XILINX_7SERIES = 1;
   localparam  XILINX_ULTRASCALE = 2;
+  localparam  XILINX_ULTRASCALE_PLUS = 3;
   localparam  INTEL_5SERIES = 101;
 
   // reset and clocks
@@ -302,7 +303,7 @@ module axi_hdmi_tx #(
   // hdmi output clock
 
   generate
-  if (FPGA_TECHNOLOGY == XILINX_ULTRASCALE) begin
+  if (FPGA_TECHNOLOGY == XILINX_ULTRASCALE || FPGA_TECHNOLOGY == XILINX_ULTRASCALE_PLUS) begin
   ODDRE1 #(.SRVAL(1'b0)) i_clk_oddr (
     .SR (1'b0),
     .D1 (~OUT_CLK_POLARITY),

--- a/library/axi_i2s_adi/fifo_synchronizer.vhd
+++ b/library/axi_i2s_adi/fifo_synchronizer.vhd
@@ -63,7 +63,7 @@ architecture impl of fifo_synchronizer is
 	signal rd_addr : natural range 0 to DEPTH - 1;
 	signal wr_addr : natural range 0 to DEPTH - 1;
 
-	signal cdc_sync_stage0_tick : std_logic;
+	signal cdc_sync_stage0_tick : std_logic := '0';
 	signal cdc_sync_stage1_tick : std_logic;
 	signal cdc_sync_stage2_tick : std_logic;
 	signal cdc_sync_stage3_tick : std_logic;

--- a/library/axi_i2s_adi/i2s_controller.vhd
+++ b/library/axi_i2s_adi/i2s_controller.vhd
@@ -83,7 +83,7 @@ constant NUM_RX			: integer := C_HAS_RX * C_NUM_CH;
 
 signal enable			: Boolean;
 
-signal cdc_sync_stage0_tick	: std_logic;
+signal cdc_sync_stage0_tick	: std_logic := '0';
 signal cdc_sync_stage1_tick	: std_logic;
 signal cdc_sync_stage2_tick	: std_logic;
 signal cdc_sync_stage3_tick	: std_logic;


### PR DESCRIPTION
### axi_hdmi_tx
On Xilinx UltraScale+ the output DDR FF uses the same ODDRE1 primitive as on Xilinx UltraScale (non "plus"): add it to the Verilog file. Without this, on Xilinx UltraScale+, the resulting design lacks the clock output stage.

### axi_i2s_adi
Add initialization on the cdc_sync_stage0_tick signals, or the simulation will not work (as cdc_sync_stage0_tick always has 'U' as value).