### PR TITLE
data_offload: Second attempt at resolving issues with oversized TX transactions

### DIFF
--- a/library/data_offload/data_offload_fsm.v
+++ b/library/data_offload/data_offload_fsm.v
@@ -259,12 +259,12 @@ module data_offload_fsm #(
   end
 
   always @(posedge wr_clk) begin
-    wr_ready_d <= wr_ready;
+    wr_ready_d <= wr_ready && !(wr_valid_in && wr_last);
   end
 
   // flush out the DMA if the transfer is bigger than the storage size
   assign wr_ready = ((wr_fsm_state == WR_WRITE_TO_MEM) ||
-                     ((wr_fsm_state == WR_WAIT_TO_END) && wr_valid_in && wr_ready_d && wr_full)) ? 1'b1 : 1'b0;
+                     (TX_OR_RXN_PATH && ((wr_fsm_state == WR_WAIT_TO_END) && wr_ready_d))) ? 1'b1 : 1'b0;
 
   // write control
   assign wr_valid_out = (wr_fsm_state == WR_WRITE_TO_MEM) & wr_valid_in;


### PR DESCRIPTION
The previous commit did indeed resolve the issue i was trying to address, but broke a bunch of other stuff as reported in #778. This PR reverts the previous changes and introduces an alternative approach that should address the original issue, while also allowing the input valid to go low temporarily for TX transactions which haven't finished yet (Imagine a DMA being unable to keep up).