### PR TITLE
Quad MxFE support for Rev C board

### DIFF
--- a/library/Makefile
+++ b/library/Makefile
@@ -116,6 +116,7 @@ clean:
 	$(MAKE) -C util_mfifo clean
 	$(MAKE) -C util_pack/util_cpack2 clean
 	$(MAKE) -C util_pack/util_upack2 clean
+	$(MAKE) -C util_pad clean
 	$(MAKE) -C util_pulse_gen clean
 	$(MAKE) -C util_rfifo clean
 	$(MAKE) -C util_sigma_delta_spi clean
@@ -239,6 +240,7 @@ lib:
 	$(MAKE) -C util_mfifo
 	$(MAKE) -C util_pack/util_cpack2
 	$(MAKE) -C util_pack/util_upack2
+	$(MAKE) -C util_pad
 	$(MAKE) -C util_pulse_gen
 	$(MAKE) -C util_rfifo
 	$(MAKE) -C util_sigma_delta_spi

--- a/library/axi_dmac/axi_dmac_ip.tcl
+++ b/library/axi_dmac/axi_dmac_ip.tcl
@@ -258,7 +258,7 @@ set_property -dict [list \
 foreach dir {"SRC" "DEST"} {
 	set_property -dict [list \
 		"value_validation_type" "list" \
-		"value_validation_list" "16 32 64 128 256 512 1024" \
+		"value_validation_list" "16 32 64 128 256 512 1024 2048" \
 	] \
 	[ipx::get_user_parameters DMA_DATA_WIDTH_${dir} -of_objects $cc]
 
@@ -308,6 +308,7 @@ foreach {dir group} [list "SRC" $src_group "DEST" $dest_group] {
 	ipgui::move_param -component $cc -order 2 $p -parent $group
 	set_property -dict [list \
 		"display_name" "Bus Width" \
+    "tooltip" "Bus Width: For Memory-Mapped interface the valid range is 32-1024 bits" \
 	] $p
 
 	set p [ipgui::get_guiparamspec -name "AXI_SLICE_${dir}" -component $cc]

--- a/library/jesd204/scripts/jesd204.tcl
+++ b/library/jesd204/scripts/jesd204.tcl
@@ -459,3 +459,24 @@ proc adi_tpl_jesd204_rx_create {ip_name num_of_lanes num_of_converters samples_p
 
   return -options $resultoptions $resulttext
 }
+
+# Calculate Link Layer interface width towards Transport Layer
+# TPL width must be set to an integer multiple of F
+proc adi_jesd204_calc_tpl_width {link_datapath_width jesd_l jesd_m jesd_s jesd_np} {
+
+  set jesd_f [expr ($jesd_m*$jesd_s*$jesd_np)/(8*$jesd_l)]
+
+  # For F=3,6,12 get first pow 2 multiple of F greater than link_datapath_width
+  if {$jesd_f % 3 == 0} {
+    set np12_datapath_width $jesd_f
+    while {$np12_datapath_width < $link_datapath_width} {
+        set np12_datapath_width [expr 2*$np12_datapath_width]
+    }
+    return $np12_datapath_width
+  } else {
+    return [expr max($jesd_f,$link_datapath_width)]
+  }
+
+}
+
+

--- a/library/util_pad/Makefile
+++ b/library/util_pad/Makefile
@@ -1,0 +1,13 @@
+####################################################################################
+## Copyright (c) 2018 - 2021 Analog Devices, Inc.
+### SPDX short identifier: BSD-1-Clause
+## Auto-generated, do not modify!
+####################################################################################
+
+LIBRARY_NAME := util_pad
+
+GENERIC_DEPS += util_pad.v
+
+XILINX_DEPS += util_pad_ip.tcl
+
+include ../scripts/library.mk

--- a/library/util_pad/util_pad.v
+++ b/library/util_pad/util_pad.v
@@ -1,0 +1,71 @@
+// ***************************************************************************
+// ***************************************************************************
+// Copyright 2018 (c) Analog Devices, Inc. All rights reserved.
+//
+// Each core or library found in this collection may have its own licensing terms.
+// The user should keep this in in mind while exploring these cores.
+//
+// Redistribution and use in source and binary forms,
+// with or without modification of this file, are permitted under the terms of either
+//  (at the option of the user):
+//
+//   1. The GNU General Public License version 2 as published by the
+//      Free Software Foundation, which can be found in the top level directory, or at:
+// https://www.gnu.org/licenses/old-licenses/gpl-2.0.en.html
+//
+// OR
+//
+//   2.  An ADI specific BSD license as noted in the top level directory, or on-line at:
+// https://github.com/analogdevicesinc/hdl/blob/dev/LICENSE
+//
+// ***************************************************************************
+// ***************************************************************************
+
+`timescale 1ns/100ps
+
+module util_pad #(
+  parameter NUM_OF_SAMPLES = 2,
+  parameter IN_BITS_PER_SAMPLE = 16,
+  parameter OUT_BITS_PER_SAMPLE = 16,
+  parameter PADDING_TO_MSB_LSB_N = 0,
+  parameter SIGN_EXTEND = 1
+) (
+  input [NUM_OF_SAMPLES*IN_BITS_PER_SAMPLE-1:0] data_in,
+  output reg [NUM_OF_SAMPLES*OUT_BITS_PER_SAMPLE-1:0] data_out
+);
+
+// Remove padding
+if (IN_BITS_PER_SAMPLE >= OUT_BITS_PER_SAMPLE) begin
+  integer i;
+  always @(*) begin
+    for (i=0;i<NUM_OF_SAMPLES;i=i+1) begin
+      if (PADDING_TO_MSB_LSB_N==1) begin
+        data_out[i*OUT_BITS_PER_SAMPLE +: OUT_BITS_PER_SAMPLE] =
+          data_in[i*IN_BITS_PER_SAMPLE +: OUT_BITS_PER_SAMPLE];
+      end else begin
+        data_out[i*OUT_BITS_PER_SAMPLE +: OUT_BITS_PER_SAMPLE] =
+          data_in[((i+1)*IN_BITS_PER_SAMPLE)-1 -: OUT_BITS_PER_SAMPLE];
+      end
+    end
+  end
+end
+
+// Add padding
+if (IN_BITS_PER_SAMPLE < OUT_BITS_PER_SAMPLE) begin
+  integer i;
+  always @(*) begin
+    for (i=0;i<NUM_OF_SAMPLES;i=i+1) begin
+      if (PADDING_TO_MSB_LSB_N==1) begin
+        data_out[i*OUT_BITS_PER_SAMPLE +: OUT_BITS_PER_SAMPLE] =
+          {{OUT_BITS_PER_SAMPLE-IN_BITS_PER_SAMPLE{data_in[(i+1)*IN_BITS_PER_SAMPLE-1]&SIGN_EXTEND[0]}},
+          data_in[i*IN_BITS_PER_SAMPLE +: OUT_BITS_PER_SAMPLE]};
+      end else begin
+        data_out[i*OUT_BITS_PER_SAMPLE +: OUT_BITS_PER_SAMPLE] =
+          {data_in[((i+1)*IN_BITS_PER_SAMPLE)-1 -: OUT_BITS_PER_SAMPLE],
+          {OUT_BITS_PER_SAMPLE-IN_BITS_PER_SAMPLE{1'b0}}};
+      end
+    end
+  end
+end
+
+endmodule

--- a/library/util_pad/util_pad_ip.tcl
+++ b/library/util_pad/util_pad_ip.tcl
@@ -1,0 +1,12 @@
+# ip
+
+source ../scripts/adi_env.tcl
+source $ad_hdl_dir/library/scripts/adi_ip_xilinx.tcl
+
+adi_ip_create util_pad
+adi_ip_files util_pad [list \
+  "util_pad.v" ]
+
+adi_ip_properties_lite util_pad
+
+ipx::save_core [ipx::current_core]

--- a/projects/ad_quadmxfe1_ebz/Makefile
+++ b/projects/ad_quadmxfe1_ebz/Makefile
@@ -1,0 +1,7 @@
+####################################################################################
+## Copyright (c) 2018 - 2021 Analog Devices, Inc.
+### SPDX short identifier: BSD-1-Clause
+## Auto-generated, do not modify!
+####################################################################################
+
+include ../scripts/project-toplevel.mk

--- a/projects/ad_quadmxfe1_ebz/common/ad_quadmxfe1_ebz_bd.tcl
+++ b/projects/ad_quadmxfe1_ebz/common/ad_quadmxfe1_ebz_bd.tcl
@@ -1,0 +1,705 @@
+
+source $ad_hdl_dir/library/jesd204/scripts/jesd204.tcl
+
+# Common parameter for TX and RX
+set JESD_MODE  $ad_project_params(JESD_MODE)
+
+if {$JESD_MODE == "8B10B"} {
+  set DATAPATH_WIDTH 4
+  set ENCODER_SEL 1
+  set ADI_PHY_SEL 1
+} else {
+  set DATAPATH_WIDTH 8
+  set ENCODER_SEL 2
+  set ADI_PHY_SEL 0
+}
+
+# These are max values specific to the board
+set MAX_RX_LANES_PER_LINK 4
+set MAX_TX_LANES_PER_LINK 4
+set MAX_RX_LINKS 4
+set MAX_TX_LINKS 4
+set MAX_RX_LANES [expr $MAX_RX_LANES_PER_LINK*$MAX_RX_LINKS]
+set MAX_TX_LANES [expr $MAX_TX_LANES_PER_LINK*$MAX_TX_LINKS]
+
+# RX parameters
+set RX_NUM_OF_LINKS $ad_project_params(RX_NUM_LINKS)
+
+# RX JESD parameter per link
+set RX_JESD_M     $ad_project_params(RX_JESD_M)
+set RX_JESD_L     $ad_project_params(RX_JESD_L)
+set RX_JESD_S     $ad_project_params(RX_JESD_S)
+set RX_JESD_NP    $ad_project_params(RX_JESD_NP)
+
+set RX_NUM_OF_LANES      [expr $RX_JESD_L * $RX_NUM_OF_LINKS]
+set RX_NUM_OF_CONVERTERS [expr $RX_JESD_M * $RX_NUM_OF_LINKS]
+set RX_SAMPLES_PER_FRAME $RX_JESD_S
+set RX_SAMPLE_WIDTH      $RX_JESD_NP
+
+set RX_DMA_SAMPLE_WIDTH $RX_JESD_NP
+if {$RX_DMA_SAMPLE_WIDTH == 12} {
+  set RX_DMA_SAMPLE_WIDTH 16
+}
+
+set RX_DATAPATH_WIDTH [adi_jesd204_calc_tpl_width $DATAPATH_WIDTH $RX_JESD_L $RX_JESD_M $RX_JESD_S $RX_JESD_NP]
+
+set RX_SAMPLES_PER_CHANNEL [expr $RX_NUM_OF_LANES * 8*$RX_DATAPATH_WIDTH / ($RX_NUM_OF_CONVERTERS * $RX_SAMPLE_WIDTH)]
+
+# TX parameters
+set TX_NUM_OF_LINKS $ad_project_params(TX_NUM_LINKS)
+
+# TX JESD parameter per link
+set TX_JESD_M     $ad_project_params(TX_JESD_M)
+set TX_JESD_L     $ad_project_params(TX_JESD_L)
+set TX_JESD_S     $ad_project_params(TX_JESD_S)
+set TX_JESD_NP    $ad_project_params(TX_JESD_NP)
+
+set TX_NUM_OF_LANES      [expr $TX_JESD_L * $TX_NUM_OF_LINKS]
+set TX_NUM_OF_CONVERTERS [expr $TX_JESD_M * $TX_NUM_OF_LINKS]
+set TX_SAMPLES_PER_FRAME $TX_JESD_S
+set TX_SAMPLE_WIDTH      $TX_JESD_NP
+
+set TX_DMA_SAMPLE_WIDTH $TX_JESD_NP
+if {$TX_DMA_SAMPLE_WIDTH == 12} {
+  set TX_DMA_SAMPLE_WIDTH 16
+}
+
+set TX_DATAPATH_WIDTH [adi_jesd204_calc_tpl_width $DATAPATH_WIDTH $TX_JESD_L $TX_JESD_M $TX_JESD_S $TX_JESD_NP]
+
+set TX_SAMPLES_PER_CHANNEL [expr $TX_NUM_OF_LANES * 8*$TX_DATAPATH_WIDTH / ($TX_NUM_OF_CONVERTERS * $TX_SAMPLE_WIDTH)]
+
+set adc_fifo_name mxfe_adc_fifo
+set adc_data_width [expr $RX_DMA_SAMPLE_WIDTH*$RX_NUM_OF_CONVERTERS*$RX_SAMPLES_PER_CHANNEL]
+set adc_dma_data_width $adc_data_width
+set adc_fifo_address_width [expr int(ceil(log(($adc_fifo_samples_per_converter*$RX_NUM_OF_CONVERTERS) / ($adc_data_width/$RX_DMA_SAMPLE_WIDTH))/log(2)))]
+
+set dac_fifo_name mxfe_dac_fifo
+set dac_data_width [expr $TX_SAMPLE_WIDTH*$TX_NUM_OF_CONVERTERS*$TX_SAMPLES_PER_CHANNEL]
+set dac_dma_data_width [expr $TX_DMA_SAMPLE_WIDTH*$TX_NUM_OF_CONVERTERS*$TX_SAMPLES_PER_CHANNEL]
+set dac_fifo_address_width [expr int(ceil(log(($dac_fifo_samples_per_converter*$TX_NUM_OF_CONVERTERS) / ($dac_data_width/$TX_SAMPLE_WIDTH))/log(2)))]
+
+create_bd_port -dir I rx_device_clk
+create_bd_port -dir I tx_device_clk
+
+create_bd_port -dir I ext_sync
+
+if {$ADI_PHY_SEL == 1} {
+# common xcvr
+ad_ip_instance util_adxcvr util_mxfe_xcvr [list \
+  CPLL_FBDIV_4_5 5 \
+  TX_NUM_OF_LANES $MAX_TX_LANES \
+  RX_NUM_OF_LANES $MAX_RX_LANES \
+  RX_OUT_DIV 1 \
+]
+
+ad_ip_instance axi_adxcvr axi_mxfe_rx_xcvr [list \
+  ID 0 \
+  NUM_OF_LANES $RX_NUM_OF_LANES\
+  TX_OR_RX_N 0 \
+  QPLL_ENABLE 0 \
+  LPM_OR_DFE_N 1 \
+  SYS_CLK_SEL 0x3 \
+]
+
+ad_ip_instance axi_adxcvr axi_mxfe_tx_xcvr [list \
+  ID 0 \
+  NUM_OF_LANES $TX_NUM_OF_LANES \
+  TX_OR_RX_N 1 \
+  QPLL_ENABLE 1 \
+  SYS_CLK_SEL 0x3 \
+]
+} else {
+for {set i 0} {$i < $MAX_RX_LANES} {incr i} {
+create_bd_port -dir I rx_data_${i}_n
+create_bd_port -dir I rx_data_${i}_p
+}
+
+for {set i 0} {$i < $MAX_TX_LANES} {incr i} {
+create_bd_port -dir O tx_data_${i}_n
+create_bd_port -dir O tx_data_${i}_p
+}
+
+create_bd_port -dir I rx_sysref_0
+create_bd_port -dir I tx_sysref_0
+
+# unused, keep for port map compatibility with JESD204B
+create_bd_port -from 0 -to [expr $MAX_RX_LINKS-1] -dir O  rx_sync_0
+create_bd_port -from 0 -to [expr $MAX_TX_LINKS-1] -dir I  tx_sync_0
+
+# reset generator
+ad_ip_instance proc_sys_reset rx_device_clk_rstgen
+ad_connect  rx_device_clk rx_device_clk_rstgen/slowest_sync_clk
+ad_connect  $sys_cpu_resetn rx_device_clk_rstgen/ext_reset_in
+
+ad_ip_instance proc_sys_reset tx_device_clk_rstgen
+ad_connect  tx_device_clk tx_device_clk_rstgen/slowest_sync_clk
+ad_connect  $sys_cpu_resetn tx_device_clk_rstgen/ext_reset_in
+
+# Common PHYs
+# Use two instances since they are located on different SLRS
+set rx_rate $ad_project_params(RX_RATE)
+set tx_rate $ad_project_params(TX_RATE)
+set ref_clk_rate $ad_project_params(REF_CLK_RATE)
+
+ad_ip_instance jesd204_phy jesd204_phy_121_122 [list \
+  C_LANES {8} \
+  GT_Line_Rate $tx_rate \
+  GT_REFCLK_FREQ $ref_clk_rate \
+  DRPCLK_FREQ {50} \
+  C_PLL_SELECTION $ad_project_params(TX_PLL_SEL) \
+  RX_GT_Line_Rate $rx_rate \
+  RX_GT_REFCLK_FREQ $ref_clk_rate \
+  RX_PLL_SELECTION $ad_project_params(RX_PLL_SEL) \
+  GT_Location {X0Y8} \
+  Tx_JesdVersion {1} \
+  Rx_JesdVersion {1} \
+  Tx_use_64b {1} \
+  Rx_use_64b {1} \
+  Min_Line_Rate [expr min($rx_rate,$tx_rate)] \
+  Max_Line_Rate [expr max($rx_rate,$tx_rate)] \
+  Axi_Lite {true} \
+]
+
+ad_ip_instance jesd204_phy jesd204_phy_125_126 [list \
+  C_LANES {8} \
+  GT_Line_Rate $tx_rate \
+  GT_REFCLK_FREQ $ref_clk_rate \
+  DRPCLK_FREQ {50} \
+  C_PLL_SELECTION $ad_project_params(TX_PLL_SEL) \
+  RX_GT_Line_Rate $rx_rate \
+  RX_GT_REFCLK_FREQ $ref_clk_rate \
+  RX_PLL_SELECTION $ad_project_params(RX_PLL_SEL) \
+  GT_Location {X0Y24} \
+  Tx_JesdVersion {1} \
+  Rx_JesdVersion {1} \
+  Tx_use_64b {1} \
+  Rx_use_64b {1} \
+  Min_Line_Rate [expr min($rx_rate,$tx_rate)] \
+  Max_Line_Rate [expr max($rx_rate,$tx_rate)] \
+  Axi_Lite {true} \
+]
+}
+
+# adc peripherals
+
+adi_axi_jesd204_rx_create axi_mxfe_rx_jesd $RX_NUM_OF_LANES $RX_NUM_OF_LINKS $ENCODER_SEL
+ad_ip_parameter axi_mxfe_rx_jesd/rx CONFIG.TPL_DATA_PATH_WIDTH $RX_DATAPATH_WIDTH
+
+ad_ip_parameter axi_mxfe_rx_jesd/rx CONFIG.SYSREF_IOB false
+ad_ip_parameter axi_mxfe_rx_jesd/rx CONFIG.NUM_INPUT_PIPELINE 2
+ad_ip_parameter axi_mxfe_rx_jesd/rx CONFIG.NUM_OUTPUT_PIPELINE 0
+
+adi_tpl_jesd204_rx_create rx_mxfe_tpl_core $RX_NUM_OF_LANES \
+                                           $RX_NUM_OF_CONVERTERS \
+                                           $RX_SAMPLES_PER_FRAME \
+                                           $RX_SAMPLE_WIDTH \
+                                           $RX_DATAPATH_WIDTH \
+                                           $RX_DMA_SAMPLE_WIDTH
+
+ad_ip_parameter rx_mxfe_tpl_core/adc_tpl_core CONFIG.EN_FRAME_ALIGN 0
+
+ad_ip_instance util_cpack2 util_mxfe_cpack [list \
+  NUM_OF_CHANNELS $RX_NUM_OF_CONVERTERS \
+  SAMPLES_PER_CHANNEL $RX_SAMPLES_PER_CHANNEL \
+  SAMPLE_DATA_WIDTH $RX_DMA_SAMPLE_WIDTH \
+]
+
+ad_adcfifo_create $adc_fifo_name $adc_data_width $adc_dma_data_width $adc_fifo_address_width
+
+ad_ip_instance axi_dmac axi_mxfe_rx_dma [list \
+  DMA_TYPE_SRC 1 \
+  DMA_TYPE_DEST 0 \
+  ID 0 \
+  AXI_SLICE_SRC 1 \
+  AXI_SLICE_DEST 1 \
+  SYNC_TRANSFER_START 0 \
+  DMA_LENGTH_WIDTH 24 \
+  DMA_2D_TRANSFER 0 \
+  MAX_BYTES_PER_BURST 4096 \
+  CYCLIC 0 \
+  DMA_DATA_WIDTH_SRC $adc_dma_data_width \
+  DMA_DATA_WIDTH_DEST 512 \
+]
+
+# dac peripherals
+
+adi_axi_jesd204_tx_create axi_mxfe_tx_jesd $TX_NUM_OF_LANES $TX_NUM_OF_LINKS $ENCODER_SEL
+ad_ip_parameter axi_mxfe_tx_jesd/tx CONFIG.TPL_DATA_PATH_WIDTH $TX_DATAPATH_WIDTH
+
+ad_ip_parameter axi_mxfe_tx_jesd/tx CONFIG.SYSREF_IOB false
+ad_ip_parameter axi_mxfe_tx_jesd/tx CONFIG.NUM_OUTPUT_PIPELINE 0
+
+adi_tpl_jesd204_tx_create tx_mxfe_tpl_core $TX_NUM_OF_LANES \
+                                           $TX_NUM_OF_CONVERTERS \
+                                           $TX_SAMPLES_PER_FRAME \
+                                           $TX_SAMPLE_WIDTH \
+                                           $TX_DATAPATH_WIDTH \
+                                           $TX_SAMPLE_WIDTH
+
+ad_ip_parameter tx_mxfe_tpl_core/dac_tpl_core CONFIG.IQCORRECTION_DISABLE 0
+ad_ip_parameter tx_mxfe_tpl_core/dac_tpl_core CONFIG.XBAR_ENABLE $ad_project_params(DAC_TPL_XBAR_ENABLE)
+ad_ip_parameter tx_mxfe_tpl_core/dac_tpl_core CONFIG.EXT_SYNC 1
+
+ad_ip_instance util_upack2 util_mxfe_upack [list \
+  NUM_OF_CHANNELS $TX_NUM_OF_CONVERTERS \
+  SAMPLES_PER_CHANNEL $TX_SAMPLES_PER_CHANNEL \
+  SAMPLE_DATA_WIDTH $TX_SAMPLE_WIDTH \
+]
+
+ad_dacfifo_create $dac_fifo_name $dac_data_width $dac_data_width $dac_fifo_address_width
+
+ad_ip_instance util_pad tx_util_pad [list \
+  NUM_OF_SAMPLES [expr $TX_NUM_OF_CONVERTERS*$TX_SAMPLES_PER_CHANNEL] \
+  IN_BITS_PER_SAMPLE $TX_DMA_SAMPLE_WIDTH \
+  OUT_BITS_PER_SAMPLE $TX_SAMPLE_WIDTH \
+  PADDING_TO_MSB_LSB_N 0 \
+]
+
+ad_ip_instance axi_dmac axi_mxfe_tx_dma [list \
+  DMA_TYPE_SRC 0 \
+  DMA_TYPE_DEST 1 \
+  ID 0 \
+  AXI_SLICE_SRC 1 \
+  AXI_SLICE_DEST 1 \
+  SYNC_TRANSFER_START 0 \
+  DMA_LENGTH_WIDTH 24 \
+  DMA_2D_TRANSFER 0 \
+  CYCLIC 1 \
+  DMA_DATA_WIDTH_SRC 512 \
+  DMA_DATA_WIDTH_DEST $dac_dma_data_width \
+  MAX_BYTES_PER_BURST 4096 \
+]
+
+# extra GPIO peripheral
+ad_ip_instance axi_gpio axi_gpio_2 [list \
+  C_INTERRUPT_PRESENT 1 \
+  C_IS_DUAL 1 \
+]
+
+create_bd_port -dir I -from 31 -to 0 gpio2_i
+create_bd_port -dir O -from 31 -to 0 gpio2_o
+create_bd_port -dir O -from 31 -to 0 gpio2_t
+create_bd_port -dir I -from 31 -to 0 gpio3_i
+create_bd_port -dir O -from 31 -to 0 gpio3_o
+create_bd_port -dir O -from 31 -to 0 gpio3_t
+
+# reference clocks & resets
+
+create_bd_port -dir I ref_clk_q0
+create_bd_port -dir I ref_clk_q1
+create_bd_port -dir I ref_clk_q2
+create_bd_port -dir I ref_clk_q3
+
+if {$ADI_PHY_SEL == 1} {
+
+ad_xcvrpll  ref_clk_q0 util_mxfe_xcvr/qpll_ref_clk_0
+ad_xcvrpll  ref_clk_q0 util_mxfe_xcvr/cpll_ref_clk_0
+ad_xcvrpll  ref_clk_q0 util_mxfe_xcvr/cpll_ref_clk_1
+ad_xcvrpll  ref_clk_q0 util_mxfe_xcvr/cpll_ref_clk_2
+ad_xcvrpll  ref_clk_q0 util_mxfe_xcvr/cpll_ref_clk_3
+ad_xcvrpll  ref_clk_q1 util_mxfe_xcvr/qpll_ref_clk_4
+ad_xcvrpll  ref_clk_q1 util_mxfe_xcvr/cpll_ref_clk_4
+ad_xcvrpll  ref_clk_q1 util_mxfe_xcvr/cpll_ref_clk_5
+ad_xcvrpll  ref_clk_q1 util_mxfe_xcvr/cpll_ref_clk_6
+ad_xcvrpll  ref_clk_q1 util_mxfe_xcvr/cpll_ref_clk_7
+ad_xcvrpll  ref_clk_q2 util_mxfe_xcvr/qpll_ref_clk_8
+ad_xcvrpll  ref_clk_q2 util_mxfe_xcvr/cpll_ref_clk_8
+ad_xcvrpll  ref_clk_q2 util_mxfe_xcvr/cpll_ref_clk_9
+ad_xcvrpll  ref_clk_q2 util_mxfe_xcvr/cpll_ref_clk_10
+ad_xcvrpll  ref_clk_q2 util_mxfe_xcvr/cpll_ref_clk_11
+ad_xcvrpll  ref_clk_q3 util_mxfe_xcvr/qpll_ref_clk_12
+ad_xcvrpll  ref_clk_q3 util_mxfe_xcvr/cpll_ref_clk_12
+ad_xcvrpll  ref_clk_q3 util_mxfe_xcvr/cpll_ref_clk_13
+ad_xcvrpll  ref_clk_q3 util_mxfe_xcvr/cpll_ref_clk_14
+ad_xcvrpll  ref_clk_q3 util_mxfe_xcvr/cpll_ref_clk_15
+
+ad_xcvrpll  axi_mxfe_rx_xcvr/up_pll_rst util_mxfe_xcvr/up_cpll_rst_*
+
+ad_xcvrpll  axi_mxfe_tx_xcvr/up_pll_rst util_mxfe_xcvr/up_qpll_rst_*
+
+ad_connect  $sys_cpu_resetn util_mxfe_xcvr/up_rstn
+ad_connect  $sys_cpu_clk util_mxfe_xcvr/up_clk
+
+# connections (adc)
+#  map the logical lane $n onto the physical lane  $lane_map[$n]
+#         n     0  1  2  3  4  5  6  7  8  9 10 11 12 13 14 15
+#  lane_map = {13 10 11  9  3 15 12 14  2  5  0  4  8  7  6  1}
+
+set max_lane_map {13 10 11  9  3 15 12 14  2  5  0  4  8  7  6  1}
+set lane_map {}
+
+for {set i 0}  {$i < $RX_NUM_OF_LINKS} {incr i} {
+  for {set j 0}  {$j < $RX_JESD_L} {incr j} {
+    set cur_lane [expr $i*$MAX_RX_LANES_PER_LINK+$j]
+    lappend lane_map [lindex $max_lane_map $cur_lane]
+  }
+}
+
+ad_xcvrcon  util_mxfe_xcvr axi_mxfe_rx_xcvr axi_mxfe_rx_jesd $lane_map {} rx_device_clk
+
+# connections (dac)
+#  map the logical lane $n onto the physical lane  $lane_map[$n]
+#         n     0  1  2  3  4  5  6  7  8  9 10 11 12 13 14 15
+#  lane_map = {13  8  9  7  3 15 12 14  6  5  2  4  0 10  1 11}
+#
+set max_lane_map {13 8 9 7 3 15 12 14 6 5 2 4 0 10 1 11}
+set lane_map {}
+
+for {set i 0}  {$i < $TX_NUM_OF_LINKS} {incr i} {
+  for {set j 0}  {$j < $TX_JESD_L} {incr j} {
+    set cur_lane [expr $i*$MAX_TX_LANES_PER_LINK+$j]
+    lappend lane_map [lindex $max_lane_map $cur_lane]
+  }
+}
+
+ad_xcvrcon  util_mxfe_xcvr axi_mxfe_tx_xcvr axi_mxfe_tx_jesd $lane_map {} tx_device_clk
+
+} else {
+
+ad_connect  ref_clk_q0 jesd204_phy_121_122/cpll_refclk
+ad_connect  ref_clk_q0 jesd204_phy_121_122/qpll0_refclk
+ad_connect  ref_clk_q0 jesd204_phy_121_122/qpll1_refclk
+ad_connect  ref_clk_q2 jesd204_phy_125_126/cpll_refclk
+ad_connect  ref_clk_q2 jesd204_phy_125_126/qpll0_refclk
+ad_connect  ref_clk_q2 jesd204_phy_125_126/qpll1_refclk
+
+# link clock domain
+
+ad_ip_instance util_ds_buf txoutclk_BUFG_GT
+ad_ip_parameter txoutclk_BUFG_GT CONFIG.C_BUF_TYPE {BUFG_GT}
+ad_connect txoutclk_BUFG_GT/BUFG_GT_CE VCC
+ad_connect txoutclk_BUFG_GT/BUFG_GT_CEMASK GND
+ad_connect txoutclk_BUFG_GT/BUFG_GT_CLR GND
+ad_connect txoutclk_BUFG_GT/BUFG_GT_CLRMASK GND
+ad_connect txoutclk_BUFG_GT/BUFG_GT_DIV GND
+ad_connect jesd204_phy_121_122/txoutclk txoutclk_BUFG_GT/BUFG_GT_I
+
+set tx_link_clock  txoutclk_BUFG_GT/BUFG_GT_O
+
+ad_ip_instance util_ds_buf rxoutclk_BUFG_GT
+ad_ip_parameter rxoutclk_BUFG_GT CONFIG.C_BUF_TYPE {BUFG_GT}
+ad_connect rxoutclk_BUFG_GT/BUFG_GT_CE VCC
+ad_connect rxoutclk_BUFG_GT/BUFG_GT_CEMASK GND
+ad_connect rxoutclk_BUFG_GT/BUFG_GT_CLR GND
+ad_connect rxoutclk_BUFG_GT/BUFG_GT_CLRMASK GND
+ad_connect rxoutclk_BUFG_GT/BUFG_GT_DIV GND
+ad_connect jesd204_phy_121_122/rxoutclk rxoutclk_BUFG_GT/BUFG_GT_I
+
+set rx_link_clock  rxoutclk_BUFG_GT/BUFG_GT_O
+
+ad_connect  $tx_link_clock jesd204_phy_121_122/tx_core_clk
+ad_connect  $tx_link_clock jesd204_phy_125_126/tx_core_clk
+ad_connect  $tx_link_clock axi_mxfe_tx_jesd/link_clk
+ad_connect  tx_device_clk axi_mxfe_tx_jesd/device_clk
+
+ad_connect  $rx_link_clock jesd204_phy_121_122/rx_core_clk
+ad_connect  $rx_link_clock jesd204_phy_125_126/rx_core_clk
+ad_connect  $rx_link_clock axi_mxfe_rx_jesd/link_clk
+ad_connect  rx_device_clk axi_mxfe_rx_jesd/device_clk
+}
+
+# device clock domain
+ad_connect  rx_device_clk rx_mxfe_tpl_core/link_clk
+ad_connect  rx_device_clk util_mxfe_cpack/clk
+ad_connect  rx_device_clk mxfe_adc_fifo/adc_clk
+
+ad_connect  tx_device_clk tx_mxfe_tpl_core/link_clk
+ad_connect  tx_device_clk util_mxfe_upack/clk
+ad_connect  tx_device_clk mxfe_dac_fifo/dac_clk
+
+# dma clock domain
+ad_connect  $sys_cpu_clk mxfe_adc_fifo/dma_clk
+ad_connect  $sys_dma_clk mxfe_dac_fifo/dma_clk
+ad_connect  $sys_cpu_clk axi_mxfe_rx_dma/s_axis_aclk
+ad_connect  $sys_dma_clk axi_mxfe_tx_dma/m_axis_aclk
+
+# connect resets
+ad_connect  rx_device_clk_rstgen/peripheral_reset mxfe_adc_fifo/adc_rst
+ad_connect  tx_device_clk_rstgen/peripheral_reset mxfe_dac_fifo/dac_rst
+ad_connect  tx_device_clk_rstgen/peripheral_reset util_mxfe_upack/reset
+ad_connect  $sys_cpu_resetn axi_mxfe_rx_dma/m_dest_axi_aresetn
+ad_connect  $sys_dma_resetn axi_mxfe_tx_dma/m_src_axi_aresetn
+ad_connect  $sys_dma_reset mxfe_dac_fifo/dma_rst
+
+if {$ADI_PHY_SEL == 0} {
+ad_connect  jesd204_phy_121_122/tx_sys_reset GND
+ad_connect  jesd204_phy_125_126/tx_sys_reset GND
+
+ad_connect  jesd204_phy_121_122/rx_sys_reset GND
+ad_connect  jesd204_phy_125_126/rx_sys_reset GND
+
+ad_connect  axi_mxfe_tx_jesd/tx_axi/device_reset jesd204_phy_121_122/tx_reset_gt
+ad_connect  axi_mxfe_rx_jesd/rx_axi/device_reset jesd204_phy_121_122/rx_reset_gt
+ad_connect  axi_mxfe_tx_jesd/tx_axi/device_reset jesd204_phy_125_126/tx_reset_gt
+ad_connect  axi_mxfe_rx_jesd/rx_axi/device_reset jesd204_phy_125_126/rx_reset_gt
+}
+
+#
+# connect adc dataflow
+#
+if {$ADI_PHY_SEL == 0} {
+# Rx Physical lanes to PHY
+ad_ip_instance xlconcat rx_concat_7_0_p [list NUM_PORTS {8}]
+ad_ip_instance xlconcat rx_concat_7_0_n [list NUM_PORTS {8}]
+
+ad_connect  rx_data_0_p rx_concat_7_0_p/In0
+ad_connect  rx_data_1_p rx_concat_7_0_p/In1
+ad_connect  rx_data_2_p rx_concat_7_0_p/In2
+ad_connect  rx_data_3_p rx_concat_7_0_p/In3
+ad_connect  rx_data_4_p rx_concat_7_0_p/In4
+ad_connect  rx_data_5_p rx_concat_7_0_p/In5
+ad_connect  rx_data_6_p rx_concat_7_0_p/In6
+ad_connect  rx_data_7_p rx_concat_7_0_p/In7
+
+ad_connect  rx_data_0_n rx_concat_7_0_n/In0
+ad_connect  rx_data_1_n rx_concat_7_0_n/In1
+ad_connect  rx_data_2_n rx_concat_7_0_n/In2
+ad_connect  rx_data_3_n rx_concat_7_0_n/In3
+ad_connect  rx_data_4_n rx_concat_7_0_n/In4
+ad_connect  rx_data_5_n rx_concat_7_0_n/In5
+ad_connect  rx_data_6_n rx_concat_7_0_n/In6
+ad_connect  rx_data_7_n rx_concat_7_0_n/In7
+
+ad_connect  jesd204_phy_121_122/rxp_in rx_concat_7_0_p/dout
+ad_connect  jesd204_phy_121_122/rxn_in rx_concat_7_0_n/dout
+
+ad_ip_instance xlconcat rx_concat_15_8_p [list NUM_PORTS {8}]
+ad_ip_instance xlconcat rx_concat_15_8_n [list NUM_PORTS {8}]
+
+ad_connect  rx_data_8_p rx_concat_15_8_p/In0
+ad_connect  rx_data_9_p rx_concat_15_8_p/In1
+ad_connect  rx_data_10_p rx_concat_15_8_p/In2
+ad_connect  rx_data_11_p rx_concat_15_8_p/In3
+ad_connect  rx_data_12_p rx_concat_15_8_p/In4
+ad_connect  rx_data_13_p rx_concat_15_8_p/In5
+ad_connect  rx_data_14_p rx_concat_15_8_p/In6
+ad_connect  rx_data_15_p rx_concat_15_8_p/In7
+
+ad_connect  rx_data_8_n rx_concat_15_8_n/In0
+ad_connect  rx_data_9_n rx_concat_15_8_n/In1
+ad_connect  rx_data_10_n rx_concat_15_8_n/In2
+ad_connect  rx_data_11_n rx_concat_15_8_n/In3
+ad_connect  rx_data_12_n rx_concat_15_8_n/In4
+ad_connect  rx_data_13_n rx_concat_15_8_n/In5
+ad_connect  rx_data_14_n rx_concat_15_8_n/In6
+ad_connect  rx_data_15_n rx_concat_15_8_n/In7
+
+ad_connect  jesd204_phy_125_126/rxp_in rx_concat_15_8_p/dout
+ad_connect  jesd204_phy_125_126/rxn_in rx_concat_15_8_n/dout
+
+# Connect PHY to Link Layer
+#  map the logical lane $n onto the physical lane  $lane_map[$n]
+#         n     0  1  2  3  4  5  6  7  8  9 10 11 12 13 14 15
+#  lane_map = {13 10 11  9  3 15 12 14  2  5  0  4  8  7  6  1}
+#
+# Logical lane to physical lane map for maximum of lanes per link
+#     logical lane                                physical lane
+set logic_lane(10) jesd204_phy_121_122/gt0_rx ; # 0
+set logic_lane(15) jesd204_phy_121_122/gt1_rx ; # 1
+set logic_lane(8)  jesd204_phy_121_122/gt2_rx ; # 2
+set logic_lane(4)  jesd204_phy_121_122/gt3_rx ; # 3
+set logic_lane(11) jesd204_phy_121_122/gt4_rx ; # 4
+set logic_lane(9)  jesd204_phy_121_122/gt5_rx ; # 5
+set logic_lane(14) jesd204_phy_121_122/gt6_rx ; # 6
+set logic_lane(13) jesd204_phy_121_122/gt7_rx ; # 7
+set logic_lane(12) jesd204_phy_125_126/gt0_rx ; # 8
+set logic_lane(3)  jesd204_phy_125_126/gt1_rx ; # 9
+set logic_lane(1)  jesd204_phy_125_126/gt2_rx ; # 10
+set logic_lane(2)  jesd204_phy_125_126/gt3_rx ; # 11
+set logic_lane(6)  jesd204_phy_125_126/gt4_rx ; # 12
+set logic_lane(0)  jesd204_phy_125_126/gt5_rx ; # 13
+set logic_lane(7)  jesd204_phy_125_126/gt6_rx ; # 14
+set logic_lane(5)  jesd204_phy_125_126/gt7_rx ; # 15
+set cur_lane 0
+for {set i 0}  {$i < $RX_NUM_OF_LINKS} {incr i} {
+  for {set j 0}  {$j < $RX_JESD_L} {incr j} {
+   ad_connect  axi_mxfe_rx_jesd/rx_phy$cur_lane $logic_lane([expr $i*$MAX_RX_LANES_PER_LINK+$j])
+   incr cur_lane
+  }
+}
+
+ad_connect  rx_sysref_0  axi_mxfe_rx_jesd/sysref
+
+}
+
+#
+# rx link layer to tpl
+#
+ad_connect  axi_mxfe_rx_jesd/rx_sof rx_mxfe_tpl_core/link_sof
+ad_connect  axi_mxfe_rx_jesd/rx_data_tdata rx_mxfe_tpl_core/link_data
+ad_connect  axi_mxfe_rx_jesd/rx_data_tvalid rx_mxfe_tpl_core/link_valid
+
+ad_connect ext_sync rx_mxfe_tpl_core/adc_tpl_core/adc_sync_in
+ad_connect rx_mxfe_tpl_core/adc_tpl_core/adc_rst util_mxfe_cpack/reset
+
+#
+# rx tpl to cpack
+#
+ad_connect rx_mxfe_tpl_core/adc_valid_0 util_mxfe_cpack/fifo_wr_en
+for {set i 0} {$i < $RX_NUM_OF_CONVERTERS} {incr i} {
+  ad_connect  rx_mxfe_tpl_core/adc_enable_$i util_mxfe_cpack/enable_$i
+  ad_connect  rx_mxfe_tpl_core/adc_data_$i util_mxfe_cpack/fifo_wr_data_$i
+}
+ad_connect rx_mxfe_tpl_core/adc_dovf util_mxfe_cpack/fifo_wr_overflow
+
+#
+# cpack to adc_fifo
+#
+ad_connect  util_mxfe_cpack/packed_fifo_wr_data mxfe_adc_fifo/adc_wdata
+ad_connect  util_mxfe_cpack/packed_fifo_wr_en mxfe_adc_fifo/adc_wr
+#
+# adc_fifo to dma
+#
+ad_connect  mxfe_adc_fifo/dma_wr axi_mxfe_rx_dma/s_axis_valid
+ad_connect  mxfe_adc_fifo/dma_wdata axi_mxfe_rx_dma/s_axis_data
+ad_connect  mxfe_adc_fifo/dma_wready axi_mxfe_rx_dma/s_axis_ready
+ad_connect  mxfe_adc_fifo/dma_xfer_req axi_mxfe_rx_dma/s_axis_xfer_req
+
+#
+#connect dac dataflow
+#
+if {$ADI_PHY_SEL == 0} {
+# Tx Physical lanes to PHY
+#
+for {set i 0} {$i < $MAX_TX_LANES} {incr i} {
+  ad_ip_instance xlslice txp_out_slice_$i [list \
+    DIN_TO [expr $i % 8] \
+    DIN_FROM [expr $i % 8] \
+    DIN_WIDTH {8} \
+    DOUT_WIDTH {1} \
+  ]
+  ad_ip_instance xlslice txn_out_slice_$i [list \
+    DIN_TO [expr $i % 8] \
+    DIN_FROM [expr $i % 8] \
+    DIN_WIDTH {8} \
+    DOUT_WIDTH {1} \
+  ]
+}
+
+for {set i 0} {$i < 8} {incr i} {
+  ad_connect  jesd204_phy_121_122/txn_out  txn_out_slice_$i/Din
+  ad_connect  jesd204_phy_121_122/txp_out  txp_out_slice_$i/Din
+  ad_connect  jesd204_phy_125_126/txn_out  txn_out_slice_[expr $i+8]/Din
+  ad_connect  jesd204_phy_125_126/txp_out  txp_out_slice_[expr $i+8]/Din
+}
+
+for {set i 0} {$i < $MAX_TX_LANES} {incr i} {
+  ad_connect  txn_out_slice_$i/Dout tx_data_${i}_n
+  ad_connect  txp_out_slice_$i/Dout tx_data_${i}_p
+}
+
+# Tx connect PHY to Link Layer
+#  map the logical lane $n onto the physical lane  $lane_map[$n]
+#         n     0  1  2  3  4  5  6  7  8  9 10 11 12 13 14 15
+#  lane_map = {13  8  9  7  3 15 12 14  6  5  2  4  0 10  1 11}
+#
+# logical lane to physical lane map for maximum of lanes per link
+#     logical lane                                physical lane
+set logic_lane(12) jesd204_phy_121_122/gt0_tx ; # 0
+set logic_lane(14) jesd204_phy_121_122/gt1_tx ; # 1
+set logic_lane(10) jesd204_phy_121_122/gt2_tx ; # 2
+set logic_lane(4)  jesd204_phy_121_122/gt3_tx ; # 3
+set logic_lane(11) jesd204_phy_121_122/gt4_tx ; # 4
+set logic_lane(9)  jesd204_phy_121_122/gt5_tx ; # 5
+set logic_lane(8)  jesd204_phy_121_122/gt6_tx ; # 6
+set logic_lane(3)  jesd204_phy_121_122/gt7_tx ; # 7
+set logic_lane(1)  jesd204_phy_125_126/gt0_tx ; # 8
+set logic_lane(2)  jesd204_phy_125_126/gt1_tx ; # 9
+set logic_lane(13) jesd204_phy_125_126/gt2_tx ; # 10
+set logic_lane(15) jesd204_phy_125_126/gt3_tx ; # 11
+set logic_lane(6)  jesd204_phy_125_126/gt4_tx ; # 12
+set logic_lane(0)  jesd204_phy_125_126/gt5_tx ; # 13
+set logic_lane(7)  jesd204_phy_125_126/gt6_tx ; # 14
+set logic_lane(5)  jesd204_phy_125_126/gt7_tx ; # 15
+set cur_lane 0
+for {set i 0}  {$i < $TX_NUM_OF_LINKS} {incr i} {
+  for {set j 0}  {$j < $TX_JESD_L} {incr j} {
+   ad_connect  axi_mxfe_tx_jesd/tx_phy$cur_lane $logic_lane([expr $i*$MAX_TX_LANES_PER_LINK+$j])
+   incr cur_lane
+  }
+}
+
+ad_connect  tx_sysref_0  axi_mxfe_tx_jesd/sysref
+
+}
+
+#
+# tpl to link layer
+#
+ad_connect  tx_mxfe_tpl_core/link axi_mxfe_tx_jesd/tx_data
+
+ad_connect  tx_mxfe_tpl_core/dac_valid_0 util_mxfe_upack/fifo_rd_en
+for {set i 0} {$i < $TX_NUM_OF_CONVERTERS} {incr i} {
+  ad_connect  util_mxfe_upack/fifo_rd_data_$i tx_mxfe_tpl_core/dac_data_$i
+  ad_connect  tx_mxfe_tpl_core/dac_enable_$i  util_mxfe_upack/enable_$i
+}
+
+ad_connect ext_sync tx_mxfe_tpl_core/dac_tpl_core/dac_sync_in
+
+#
+# dac fifo to upack
+#
+
+# TODO: Add streaming AXI interface for DAC FIFO
+ad_connect  util_mxfe_upack/s_axis_valid VCC
+ad_connect  util_mxfe_upack/s_axis_ready mxfe_dac_fifo/dac_valid
+ad_connect  util_mxfe_upack/s_axis_data mxfe_dac_fifo/dac_data
+
+#
+# dma to dac fifo
+#
+ad_connect  mxfe_dac_fifo/dma_valid axi_mxfe_tx_dma/m_axis_valid
+ad_connect  tx_util_pad/data_out mxfe_dac_fifo/dma_data
+ad_connect  axi_mxfe_tx_dma/m_axis_data tx_util_pad/data_in
+ad_connect  mxfe_dac_fifo/dma_ready axi_mxfe_tx_dma/m_axis_ready
+ad_connect  mxfe_dac_fifo/dma_xfer_req axi_mxfe_tx_dma/m_axis_xfer_req
+ad_connect  mxfe_dac_fifo/dma_xfer_last axi_mxfe_tx_dma/m_axis_last
+ad_connect  mxfe_dac_fifo/dac_dunf tx_mxfe_tpl_core/dac_dunf
+
+create_bd_port -dir I dac_fifo_bypass
+ad_connect  mxfe_dac_fifo/bypass dac_fifo_bypass
+
+# extra GPIOs
+ad_connect gpio2_i axi_gpio_2/gpio_io_i
+ad_connect gpio2_o axi_gpio_2/gpio_io_o
+ad_connect gpio2_t axi_gpio_2/gpio_io_t
+ad_connect gpio3_i axi_gpio_2/gpio2_io_i
+ad_connect gpio3_o axi_gpio_2/gpio2_io_o
+ad_connect gpio3_t axi_gpio_2/gpio2_io_t
+
+# interconnect (cpu)
+if {$ADI_PHY_SEL == 1} {
+ad_cpu_interconnect 0x44a60000 axi_mxfe_rx_xcvr
+ad_cpu_interconnect 0x44b60000 axi_mxfe_tx_xcvr
+} else {
+ad_cpu_interconnect 0x44a60000 jesd204_phy_121_122
+ad_cpu_interconnect 0x44b60000 jesd204_phy_125_126
+}
+ad_cpu_interconnect 0x44a10000 rx_mxfe_tpl_core
+ad_cpu_interconnect 0x44b10000 tx_mxfe_tpl_core
+ad_cpu_interconnect 0x44a90000 axi_mxfe_rx_jesd
+ad_cpu_interconnect 0x44b90000 axi_mxfe_tx_jesd
+ad_cpu_interconnect 0x7c420000 axi_mxfe_rx_dma
+ad_cpu_interconnect 0x7c430000 axi_mxfe_tx_dma
+ad_cpu_interconnect 0x7c440000 axi_gpio_2
+
+# interconnect (gt/adc)
+#
+if {$ADI_PHY_SEL == 1} {
+ad_mem_hp0_interconnect $sys_cpu_clk sys_ps7/S_AXI_HP0
+ad_mem_hp0_interconnect $sys_cpu_clk axi_mxfe_rx_xcvr/m_axi
+}
+
+ad_mem_hp1_interconnect $sys_cpu_clk sys_ps7/S_AXI_HP1
+ad_mem_hp0_interconnect $sys_cpu_clk axi_mxfe_rx_dma/m_dest_axi
+ad_mem_hp2_interconnect $sys_dma_clk sys_ps7/S_AXI_HP2
+ad_mem_hp0_interconnect $sys_dma_clk axi_mxfe_tx_dma/m_src_axi
+
+# interrupts
+
+ad_cpu_interrupt ps-13 mb-12 axi_mxfe_rx_dma/irq
+ad_cpu_interrupt ps-12 mb-13 axi_mxfe_tx_dma/irq
+ad_cpu_interrupt ps-11 mb-14 axi_mxfe_rx_jesd/irq
+ad_cpu_interrupt ps-10 mb-15 axi_mxfe_tx_jesd/irq
+ad_cpu_interrupt ps-14 mb-8  axi_gpio_2/ip2intc_irpt
+

--- a/projects/ad_quadmxfe1_ebz/common/quad_mxfe_gpio_mux.v
+++ b/projects/ad_quadmxfe1_ebz/common/quad_mxfe_gpio_mux.v
@@ -1,0 +1,154 @@
+// ***************************************************************************
+// ***************************************************************************
+// Copyright 2014 - 2021 (c) Analog Devices, Inc. All rights reserved.
+//
+// In this HDL repository, there are many different and unique modules, consisting
+// of various HDL (Verilog or VHDL) components. The individual modules are
+// developed independently, and may be accompanied by separate and unique license
+// terms.
+//
+// The user should read each of these license terms, and understand the
+// freedoms and responsibilities that he or she has by using this source/core.
+//
+// This core is distributed in the hope that it will be useful, but WITHOUT ANY
+// WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+// A PARTICULAR PURPOSE.
+//
+// Redistribution and use of source or resulting binaries, with or without modification
+// of this file, are permitted under one of the following two license terms:
+//
+//   1. The GNU General Public License version 2 as published by the
+//      Free Software Foundation, which can be found in the top level directory
+//      of this repository (LICENSE_GPL2), and also online at:
+//      <https://www.gnu.org/licenses/old-licenses/gpl-2.0.html>
+//
+// OR
+//
+//   2. An ADI specific BSD license, which can be found in the top level directory
+//      of this repository (LICENSE_ADIBSD), and also on-line at:
+//      https://github.com/analogdevicesinc/hdl/blob/master/LICENSE_ADIBSD
+//      This will allow to generate bit files and not release the source code,
+//      as long as it attaches to an ADI device.
+//
+// ***************************************************************************
+// ***************************************************************************
+
+`timescale 1ns/100ps
+
+module quad_mxfe_gpio_mux #() (
+
+  inout  [8:0] mxfe0_gpio,
+  inout  [8:0] mxfe1_gpio,
+  inout  [8:0] mxfe2_gpio,
+  inout  [8:0] mxfe3_gpio,
+
+  input  [127:64] gpio_t,
+  output [127:64] gpio_i,
+  input  [127:64] gpio_o
+
+);
+
+  wire gpio0_mode;
+  wire mxfe3_gpio0_in;
+  wire mxfe3_gpio1_in;
+  wire mxfe3_gpio2_in;
+  wire mxfe3_gpio3_in;
+  wire mxfe3_gpio4_in;
+  wire mxfe3_gpio5_in;
+  wire [5:0] gpio_t_69_64;
+  wire [5:0] gpio_o_69_64;
+  wire [5:0] gpio_t_80_75;
+  wire [5:0] gpio_o_80_75;
+  wire [5:0] gpio_t_91_86;
+  wire [5:0] gpio_o_91_86;
+  wire [5:0] gpio_t_102_97;
+
+  ad_iobuf #(.DATA_WIDTH(9)) i_iobuf_mxfe_0 (
+    .dio_t ({gpio_t[72:70],gpio_t_69_64}),
+    .dio_i ({gpio_o[72:70],gpio_o_69_64}),
+    .dio_o (gpio_i[72:64]),
+    .dio_p (mxfe0_gpio)); // 72-64
+
+  assign gpio_t_69_64[0] = gpio0_mode ? 1'b0 : gpio_t[64];
+  assign gpio_t_69_64[1] = gpio1_mode ? 1'b0 : gpio_t[65];
+  assign gpio_t_69_64[2] = gpio2_mode ? 1'b0 : gpio_t[66];
+  assign gpio_t_69_64[3] = gpio3_mode ? 1'b0 : gpio_t[67];
+  assign gpio_t_69_64[4] = gpio4_mode ? 1'b0 : gpio_t[68];
+  assign gpio_t_69_64[5] = gpio5_mode ? 1'b0 : gpio_t[69];
+  assign gpio_o_69_64[0] = gpio0_mode ? mxfe3_gpio0_in : gpio_o[64];
+  assign gpio_o_69_64[1] = gpio1_mode ? mxfe3_gpio1_in : gpio_o[65];
+  assign gpio_o_69_64[2] = gpio2_mode ? mxfe3_gpio2_in : gpio_o[66];
+  assign gpio_o_69_64[3] = gpio3_mode ? mxfe3_gpio3_in : gpio_o[67];
+  assign gpio_o_69_64[4] = gpio4_mode ? mxfe3_gpio4_in : gpio_o[68];
+  assign gpio_o_69_64[5] = gpio5_mode ? mxfe3_gpio5_in : gpio_o[69];
+
+  ad_iobuf #(.DATA_WIDTH(9)) i_iobuf_mxfe_1 (
+    .dio_t ({gpio_t[83:81],gpio_t_80_75}),
+    .dio_i ({gpio_o[83:81],gpio_o_80_75}),
+    .dio_o (gpio_i[83:75]),
+    .dio_p (mxfe1_gpio)); // 83-75
+
+  assign gpio_t_80_75[0] = gpio0_mode ? 1'b0 : gpio_t[75];
+  assign gpio_t_80_75[1] = gpio1_mode ? 1'b0 : gpio_t[76];
+  assign gpio_t_80_75[2] = gpio2_mode ? 1'b0 : gpio_t[77];
+  assign gpio_t_80_75[3] = gpio3_mode ? 1'b0 : gpio_t[78];
+  assign gpio_t_80_75[4] = gpio4_mode ? 1'b0 : gpio_t[79];
+  assign gpio_t_80_75[5] = gpio5_mode ? 1'b0 : gpio_t[80];
+  assign gpio_o_80_75[0] = gpio0_mode ? mxfe3_gpio0_in : gpio_o[75];
+  assign gpio_o_80_75[1] = gpio1_mode ? mxfe3_gpio1_in : gpio_o[76];
+  assign gpio_o_80_75[2] = gpio2_mode ? mxfe3_gpio2_in : gpio_o[77];
+  assign gpio_o_80_75[3] = gpio3_mode ? mxfe3_gpio3_in : gpio_o[78];
+  assign gpio_o_80_75[4] = gpio4_mode ? mxfe3_gpio4_in : gpio_o[79];
+  assign gpio_o_80_75[5] = gpio5_mode ? mxfe3_gpio5_in : gpio_o[80];
+
+  ad_iobuf #(.DATA_WIDTH(9)) i_iobuf_mxfe_2 (
+    .dio_t ({gpio_t[94:92],gpio_t_91_86}),
+    .dio_i ({gpio_o[94:92],gpio_o_91_86}),
+    .dio_o (gpio_i[94:86]),
+    .dio_p (mxfe2_gpio)); // 94-86
+
+  assign gpio_t_91_86[0] = gpio0_mode ? 1'b0 : gpio_t[86];
+  assign gpio_t_91_86[1] = gpio1_mode ? 1'b0 : gpio_t[87];
+  assign gpio_t_91_86[2] = gpio2_mode ? 1'b0 : gpio_t[88];
+  assign gpio_t_91_86[3] = gpio3_mode ? 1'b0 : gpio_t[89];
+  assign gpio_t_91_86[4] = gpio4_mode ? 1'b0 : gpio_t[90];
+  assign gpio_t_91_86[5] = gpio5_mode ? 1'b0 : gpio_t[91];
+  assign gpio_o_91_86[0] = gpio0_mode ? mxfe3_gpio0_in : gpio_o[86];
+  assign gpio_o_91_86[1] = gpio1_mode ? mxfe3_gpio1_in : gpio_o[87];
+  assign gpio_o_91_86[2] = gpio2_mode ? mxfe3_gpio2_in : gpio_o[88];
+  assign gpio_o_91_86[3] = gpio3_mode ? mxfe3_gpio3_in : gpio_o[89];
+  assign gpio_o_91_86[4] = gpio4_mode ? mxfe3_gpio4_in : gpio_o[90];
+  assign gpio_o_91_86[5] = gpio5_mode ? mxfe3_gpio5_in : gpio_o[91];
+
+  ad_iobuf #(.DATA_WIDTH(9)) i_iobuf_mxfe_3 (
+    .dio_t ({gpio_t[105:103],gpio_t_102_97}),
+    .dio_i (gpio_o[105:97]),
+    .dio_o (gpio_i[105:97]),
+    .dio_p (mxfe3_gpio)); // 105-97
+
+  assign gpio_t_102_97[0] = gpio0_mode ? 1'b1 : gpio_t[97];
+  assign gpio_t_102_97[1] = gpio1_mode ? 1'b1 : gpio_t[98];
+  assign gpio_t_102_97[2] = gpio2_mode ? 1'b1 : gpio_t[99];
+  assign gpio_t_102_97[3] = gpio3_mode ? 1'b1 : gpio_t[100];
+  assign gpio_t_102_97[4] = gpio4_mode ? 1'b1 : gpio_t[101];
+  assign gpio_t_102_97[5] = gpio5_mode ? 1'b1 : gpio_t[102];
+  assign mxfe3_gpio0_in = gpio_i[97];
+  assign mxfe3_gpio1_in = gpio_i[98];
+  assign mxfe3_gpio2_in = gpio_i[99];
+  assign mxfe3_gpio3_in = gpio_i[100];
+  assign mxfe3_gpio4_in = gpio_i[101];
+  assign mxfe3_gpio5_in = gpio_i[102];
+
+  // 0 - Software controlled GPIO
+  // 1 - LMFC based Master-Slave NCO Sync
+  assign gpio0_mode = gpio_o[108];
+  assign gpio1_mode = gpio_o[110];
+  assign gpio2_mode = gpio_o[112];
+  assign gpio3_mode = gpio_o[114];
+  assign gpio4_mode = gpio_o[116];
+  assign gpio5_mode = gpio_o[118];
+
+  //loopback unused gpios
+  assign gpio_i[127:108] = gpio_o[127:108];
+
+endmodule

--- a/projects/ad_quadmxfe1_ebz/vcu118/Makefile
+++ b/projects/ad_quadmxfe1_ebz/vcu118/Makefile
@@ -1,0 +1,38 @@
+####################################################################################
+## Copyright (c) 2018 - 2021 Analog Devices, Inc.
+### SPDX short identifier: BSD-1-Clause
+## Auto-generated, do not modify!
+####################################################################################
+
+PROJECT_NAME := ad_quadmxfe1_ebz_vcu118
+
+M_DEPS += timing_constr.xdc
+M_DEPS += ../common/quad_mxfe_gpio_mux.v
+M_DEPS += ../common/ad_quadmxfe1_ebz_bd.tcl
+M_DEPS += ../../scripts/adi_pd.tcl
+M_DEPS += ../../common/xilinx/dacfifo_bd.tcl
+M_DEPS += ../../common/xilinx/adcfifo_bd.tcl
+M_DEPS += ../../common/vcu118/vcu118_system_constr.xdc
+M_DEPS += ../../common/vcu118/vcu118_system_bd.tcl
+M_DEPS += ../../../library/jesd204/scripts/jesd204.tcl
+M_DEPS += ../../../library/common/ad_iobuf.v
+M_DEPS += ../../../library/common/ad_3w_spi.v
+
+LIB_DEPS += axi_dmac
+LIB_DEPS += axi_sysid
+LIB_DEPS += jesd204/ad_ip_jesd204_tpl_adc
+LIB_DEPS += jesd204/ad_ip_jesd204_tpl_dac
+LIB_DEPS += jesd204/axi_jesd204_rx
+LIB_DEPS += jesd204/axi_jesd204_tx
+LIB_DEPS += jesd204/jesd204_rx
+LIB_DEPS += jesd204/jesd204_tx
+LIB_DEPS += sysid_rom
+LIB_DEPS += util_adcfifo
+LIB_DEPS += util_dacfifo
+LIB_DEPS += util_pack/util_cpack2
+LIB_DEPS += util_pack/util_upack2
+LIB_DEPS += util_pad
+LIB_DEPS += xilinx/axi_adxcvr
+LIB_DEPS += xilinx/util_adxcvr
+
+include ../../scripts/project-xilinx.mk

--- a/projects/ad_quadmxfe1_ebz/vcu118/system_bd.tcl
+++ b/projects/ad_quadmxfe1_ebz/vcu118/system_bd.tcl
@@ -1,0 +1,118 @@
+
+## ADC FIFO depth in samples per converter
+set adc_fifo_samples_per_converter [expr $ad_project_params(RX_KS_PER_CHANNEL)*1024]
+## DAC FIFO depth in samples per converter
+set dac_fifo_samples_per_converter [expr $ad_project_params(TX_KS_PER_CHANNEL)*1024]
+
+source $ad_hdl_dir/projects/common/vcu118/vcu118_system_bd.tcl
+source $ad_hdl_dir/projects/common/xilinx/adcfifo_bd.tcl
+source $ad_hdl_dir/projects/common/xilinx/dacfifo_bd.tcl
+source ../common/ad_quadmxfe1_ebz_bd.tcl
+source $ad_hdl_dir/projects/scripts/adi_pd.tcl
+
+# Set SPI clock to 100/16 =  6.25 MHz
+ad_ip_parameter axi_spi CONFIG.C_SCK_RATIO 16
+
+#system ID
+ad_ip_parameter axi_sysid_0 CONFIG.ROM_ADDR_BITS 9
+ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "[pwd]/mem_init_sys.txt"
+ad_ip_parameter rom_sys_0 CONFIG.ROM_ADDR_BITS 9
+set sys_cstring "sys rom custom string placeholder"
+sysid_gen_sys_init_file $sys_cstring
+
+if {$ad_project_params(JESD_MODE) == "8B10B"} {
+  # Parameters for 10Gpbs lane rate
+  ad_ip_parameter util_mxfe_xcvr CONFIG.RX_CLK25_DIV 20
+  ad_ip_parameter util_mxfe_xcvr CONFIG.TX_CLK25_DIV 20
+  ad_ip_parameter util_mxfe_xcvr CONFIG.CPLL_CFG0 0x3fe
+  ad_ip_parameter util_mxfe_xcvr CONFIG.CPLL_CFG1 0x29
+  ad_ip_parameter util_mxfe_xcvr CONFIG.CPLL_CFG2 0x203
+  ad_ip_parameter util_mxfe_xcvr CONFIG.CPLL_FBDIV 2
+  ad_ip_parameter util_mxfe_xcvr CONFIG.A_TXDIFFCTRL 0xc
+  ad_ip_parameter util_mxfe_xcvr CONFIG.RXCDR_CFG0 0x3
+  ad_ip_parameter util_mxfe_xcvr CONFIG.RXCDR_CFG2_GEN2 0x265
+  ad_ip_parameter util_mxfe_xcvr CONFIG.RXCDR_CFG2_GEN4 0x164
+  ad_ip_parameter util_mxfe_xcvr CONFIG.RXCDR_CFG3 0x12
+  ad_ip_parameter util_mxfe_xcvr CONFIG.RXCDR_CFG3_GEN2 0x12
+  ad_ip_parameter util_mxfe_xcvr CONFIG.RXCDR_CFG3_GEN3 0x12
+  ad_ip_parameter util_mxfe_xcvr CONFIG.RXCDR_CFG3_GEN4 0x12
+  ad_ip_parameter util_mxfe_xcvr CONFIG.CH_HSPMUX 0x2020
+  ad_ip_parameter util_mxfe_xcvr CONFIG.PREIQ_FREQ_BST 0
+  ad_ip_parameter util_mxfe_xcvr CONFIG.RXPI_CFG0 0x1002
+  ad_ip_parameter util_mxfe_xcvr CONFIG.RXPI_CFG1 0x15
+  ad_ip_parameter util_mxfe_xcvr CONFIG.TXPI_CFG 0x54
+  ad_ip_parameter util_mxfe_xcvr CONFIG.TX_PI_BIASSET 0
+
+  ad_ip_parameter util_mxfe_xcvr CONFIG.QPLL_REFCLK_DIV 1
+  ad_ip_parameter util_mxfe_xcvr CONFIG.POR_CFG 0x0
+  ad_ip_parameter util_mxfe_xcvr CONFIG.QPLL_CFG0 0x331c
+  ad_ip_parameter util_mxfe_xcvr CONFIG.QPLL_CFG2 0xFC1
+  ad_ip_parameter util_mxfe_xcvr CONFIG.QPLL_CFG2_G3 0xFC1
+  ad_ip_parameter util_mxfe_xcvr CONFIG.QPLL_CFG4 0x1
+  ad_ip_parameter util_mxfe_xcvr CONFIG.QPLL_FBDIV 20
+  ad_ip_parameter util_mxfe_xcvr CONFIG.PPF0_CFG 0x400
+  ad_ip_parameter util_mxfe_xcvr CONFIG.QPLL_CP 0xFF
+  ad_ip_parameter util_mxfe_xcvr CONFIG.QPLL_CP_G3 0xF
+  ad_ip_parameter util_mxfe_xcvr CONFIG.QPLL_LPF 0x27F
+} else {
+  set_property -dict [list CONFIG.ADDN_UI_CLKOUT4_FREQ_HZ {50}] [get_bd_cells axi_ddr_cntrl]
+  ad_connect  /axi_ddr_cntrl/addn_ui_clkout4 jesd204_phy_121_122/drpclk
+  ad_connect  /axi_ddr_cntrl/addn_ui_clkout4 jesd204_phy_125_126/drpclk
+}
+
+# Second SPI controller
+create_bd_port -dir O -from 7 -to 0 spi_2_csn_o
+create_bd_port -dir I -from 7 -to 0 spi_2_csn_i
+create_bd_port -dir I spi_2_clk_i
+create_bd_port -dir O spi_2_clk_o
+create_bd_port -dir I spi_2_sdo_i
+create_bd_port -dir O spi_2_sdo_o
+create_bd_port -dir I spi_2_sdi_i
+
+ad_ip_instance axi_quad_spi axi_spi_2
+ad_ip_parameter axi_spi_2 CONFIG.C_USE_STARTUP 0
+ad_ip_parameter axi_spi_2 CONFIG.C_NUM_SS_BITS 8
+ad_ip_parameter axi_spi_2 CONFIG.C_SCK_RATIO 8
+
+ad_connect spi_2_csn_i axi_spi_2/ss_i
+ad_connect spi_2_csn_o axi_spi_2/ss_o
+ad_connect spi_2_clk_i axi_spi_2/sck_i
+ad_connect spi_2_clk_o axi_spi_2/sck_o
+ad_connect spi_2_sdo_i axi_spi_2/io0_i
+ad_connect spi_2_sdo_o axi_spi_2/io0_o
+ad_connect spi_2_sdi_i axi_spi_2/io1_i
+
+ad_connect sys_cpu_clk axi_spi_2/ext_spi_clk
+
+ad_cpu_interrupt ps-15 mb-7 axi_spi_2/ip2intc_irpt
+
+ad_cpu_interconnect 0x44A80000 axi_spi_2
+
+# Third SPI controller
+create_bd_port -dir O -from 7 -to 0 spi_3_csn_o
+create_bd_port -dir I -from 7 -to 0 spi_3_csn_i
+create_bd_port -dir I spi_3_clk_i
+create_bd_port -dir O spi_3_clk_o
+create_bd_port -dir I spi_3_sdo_i
+create_bd_port -dir O spi_3_sdo_o
+create_bd_port -dir I spi_3_sdi_i
+
+ad_ip_instance axi_quad_spi axi_spi_3
+ad_ip_parameter axi_spi_3 CONFIG.C_USE_STARTUP 0
+ad_ip_parameter axi_spi_3 CONFIG.C_NUM_SS_BITS 8
+ad_ip_parameter axi_spi_3 CONFIG.C_SCK_RATIO 16
+ad_ip_parameter axi_spi_3 CONFIG.Multiples16 16
+
+ad_connect spi_3_csn_i axi_spi_3/ss_i
+ad_connect spi_3_csn_o axi_spi_3/ss_o
+ad_connect spi_3_clk_i axi_spi_3/sck_i
+ad_connect spi_3_clk_o axi_spi_3/sck_o
+ad_connect spi_3_sdo_i axi_spi_3/io0_i
+ad_connect spi_3_sdo_o axi_spi_3/io0_o
+ad_connect spi_3_sdi_i axi_spi_3/io1_i
+
+ad_connect sys_cpu_clk axi_spi_3/ext_spi_clk
+
+ad_cpu_interrupt ps-15 mb-6 axi_spi_3/ip2intc_irpt
+
+ad_cpu_interconnect 0x44B80000 axi_spi_3

--- a/projects/ad_quadmxfe1_ebz/vcu118/system_constr.xdc
+++ b/projects/ad_quadmxfe1_ebz/vcu118/system_constr.xdc
@@ -1,0 +1,213 @@
+#
+## quad mxfe
+#
+set_property  -dict {PACKAGE_PIN V33   IOSTANDARD LVCMOS18                       } [get_ports adf4371_cs[0]            ]; ## LA27_P         C26  IO_L5P_T0U_N8_AD14P_45
+set_property  -dict {PACKAGE_PIN V34   IOSTANDARD LVCMOS18                       } [get_ports adf4371_cs[1]            ]; ## LA27_N         C27  IO_L5N_T0U_N9_AD14N_45
+set_property  -dict {PACKAGE_PIN V32   IOSTANDARD LVCMOS18                       } [get_ports adf4371_cs[2]            ]; ## LA26_P         D26  IO_L2P_T0L_N2_45
+set_property  -dict {PACKAGE_PIN U33   IOSTANDARD LVCMOS18                       } [get_ports adf4371_cs[3]            ]; ## LA26_N         D27  IO_L2N_T0L_N3_45
+set_property  -dict {PACKAGE_PIN R31   IOSTANDARD LVCMOS18                       } [get_ports adf4371_sclk             ]; ## LA18_P_CC      C22  IO_L10P_T1U_N6_QBC_AD4P_45
+set_property  -dict {PACKAGE_PIN P31   IOSTANDARD LVCMOS18                       } [get_ports adf4371_sdio             ]; ## LA18_N_CC      C23  IO_L10N_T1U_N7_QBC_AD4N_45
+set_property  -dict {PACKAGE_PIN W32   IOSTANDARD LVCMOS18                       } [get_ports adrf5020_ctrl            ]; ## LA23_N         D24  IO_L1N_T0L_N1_DBC_45
+set_property  -dict {PACKAGE_PIN P43                                             } [get_ports c2m_n[0]                 ]; ## DP5_C2M_N      A39  MGTYTXN1_126
+set_property  -dict {PACKAGE_PIN AC41                                            } [get_ports c2m_n[1]                 ]; ## DP12_C2M_N     Z29  MGTYTXN0_125
+set_property  -dict {PACKAGE_PIN AA41                                            } [get_ports c2m_n[2]                 ]; ## DP13_C2M_N     Y31  MGTYTXN1_125
+set_property  -dict {PACKAGE_PIN AE41                                            } [get_ports c2m_n[3]                 ]; ## DP11_C2M_N     Y27  MGTYTXN3_122
+set_property  -dict {PACKAGE_PIN AL41                                            } [get_ports c2m_n[4]                 ]; ## DP3_C2M_N      A31  MGTYTXN3_121
+set_property  -dict {PACKAGE_PIN K43                                             } [get_ports c2m_n[5]                 ]; ## DP7_C2M_N      B33  MGTYTXN3_126
+set_property  -dict {PACKAGE_PIN T43                                             } [get_ports c2m_n[6]                 ]; ## DP4_C2M_N      A35  MGTYTXN0_126
+set_property  -dict {PACKAGE_PIN M43                                             } [get_ports c2m_n[7]                 ]; ## DP6_C2M_N      B37  MGTYTXN2_126
+set_property  -dict {PACKAGE_PIN AG41                                            } [get_ports c2m_n[8]                 ]; ## DP10_C2M_N     Z25  MGTYTXN2_122
+set_property  -dict {PACKAGE_PIN AJ41                                            } [get_ports c2m_n[9]                 ]; ## DP9_C2M_N      B25  MGTYTXN1_122
+set_property  -dict {PACKAGE_PIN AM43                                            } [get_ports c2m_n[10]                ]; ## DP2_C2M_N      A27  MGTYTXN2_121
+set_property  -dict {PACKAGE_PIN AK43                                            } [get_ports c2m_n[11]                ]; ## DP8_C2M_N      B29  MGTYTXN0_122
+set_property  -dict {PACKAGE_PIN AT43                                            } [get_ports c2m_n[12]                ]; ## DP0_C2M_N      C03  MGTYTXN0_121
+set_property  -dict {PACKAGE_PIN W41                                             } [get_ports c2m_n[13]                ]; ## DP14_C2M_N     M19  MGTYTXN2_125
+set_property  -dict {PACKAGE_PIN AP43                                            } [get_ports c2m_n[14]                ]; ## DP1_C2M_N      A23  MGTYTXN1_121
+set_property  -dict {PACKAGE_PIN U41                                             } [get_ports c2m_n[15]                ]; ## DP15_C2M_N     M23  MGTYTXN3_125
+set_property  -dict {PACKAGE_PIN P42                                             } [get_ports c2m_p[0]                 ]; ## DP5_C2M_P      A38  MGTYTXP1_126
+set_property  -dict {PACKAGE_PIN AC40                                            } [get_ports c2m_p[1]                 ]; ## DP12_C2M_P     Z28  MGTYTXP0_125
+set_property  -dict {PACKAGE_PIN AA40                                            } [get_ports c2m_p[2]                 ]; ## DP13_C2M_P     Y30  MGTYTXP1_125
+set_property  -dict {PACKAGE_PIN AE40                                            } [get_ports c2m_p[3]                 ]; ## DP11_C2M_P     Y26  MGTYTXP3_122
+set_property  -dict {PACKAGE_PIN AL40                                            } [get_ports c2m_p[4]                 ]; ## DP3_C2M_P      A30  MGTYTXP3_121
+set_property  -dict {PACKAGE_PIN K42                                             } [get_ports c2m_p[5]                 ]; ## DP7_C2M_P      B32  MGTYTXP3_126
+set_property  -dict {PACKAGE_PIN T42                                             } [get_ports c2m_p[6]                 ]; ## DP4_C2M_P      A34  MGTYTXP0_126
+set_property  -dict {PACKAGE_PIN M42                                             } [get_ports c2m_p[7]                 ]; ## DP6_C2M_P      B36  MGTYTXP2_126
+set_property  -dict {PACKAGE_PIN AG40                                            } [get_ports c2m_p[8]                 ]; ## DP10_C2M_P     Z24  MGTYTXP2_122
+set_property  -dict {PACKAGE_PIN AJ40                                            } [get_ports c2m_p[9]                 ]; ## DP9_C2M_P      B24  MGTYTXP1_122
+set_property  -dict {PACKAGE_PIN AM42                                            } [get_ports c2m_p[10]                ]; ## DP2_C2M_P      A26  MGTYTXP2_121
+set_property  -dict {PACKAGE_PIN AK42                                            } [get_ports c2m_p[11]                ]; ## DP8_C2M_P      B28  MGTYTXP0_122
+set_property  -dict {PACKAGE_PIN AT42                                            } [get_ports c2m_p[12]                ]; ## DP0_C2M_P      C02  MGTYTXP0_121
+set_property  -dict {PACKAGE_PIN W40                                             } [get_ports c2m_p[13]                ]; ## DP14_C2M_P     M18  MGTYTXP2_125
+set_property  -dict {PACKAGE_PIN AP42                                            } [get_ports c2m_p[14]                ]; ## DP1_C2M_P      A22  MGTYTXP1_121
+set_property  -dict {PACKAGE_PIN U40                                             } [get_ports c2m_p[15]                ]; ## DP15_C2M_P     M22  MGTYTXP3_125
+set_property  -dict {PACKAGE_PIN AK39                                            } [get_ports fpga_clk_m2c_n[0]        ]; ## GBTCLK0_M2C_N  D05  MGTREFCLK0N_121
+set_property  -dict {PACKAGE_PIN V39                                             } [get_ports fpga_clk_m2c_0_replica_n ]; ## -              -    MGTREFCLK0N_126
+set_property  -dict {PACKAGE_PIN P34   IOSTANDARD LVDS     DIFF_TERM_ADV TERM_100} [get_ports fpga_clk_m2c_n[1]        ]; ## LA17_N_CC      D21  IO_L13N_T2L_N1_GC_QBC_45
+set_property  -dict {PACKAGE_PIN AM32  IOSTANDARD LVDS     DIFF_TERM_ADV TERM_100} [get_ports fpga_clk_m2c_n[2]        ]; ## CLK0_M2C_N     H05  IO_L13N_T2L_N1_GC_QBC_43
+set_property  -dict {PACKAGE_PIN AK38                                            } [get_ports fpga_clk_m2c_p[0]        ]; ## GBTCLK0_M2C_P  D04  MGTREFCLK0P_121
+set_property  -dict {PACKAGE_PIN V38                                             } [get_ports fpga_clk_m2c_0_replica_p ]; ## -              -    MGTREFCLK0P_126
+set_property  -dict {PACKAGE_PIN R34   IOSTANDARD LVDS     DIFF_TERM_ADV TERM_100} [get_ports fpga_clk_m2c_p[1]        ]; ## LA17_P_CC      D20  IO_L13P_T2L_N0_GC_QBC_45
+set_property  -dict {PACKAGE_PIN AL32  IOSTANDARD LVDS     DIFF_TERM_ADV TERM_100} [get_ports fpga_clk_m2c_p[2]        ]; ## CLK0_M2C_P     H04  IO_L13P_T2L_N0_GC_QBC_43
+set_property  -dict {PACKAGE_PIN AL36  IOSTANDARD LVDS                           } [get_ports fpga_sysref_c2m_n        ]; ## LA00_N_CC      G07  IO_L7N_T1L_N1_QBC_AD13N_43
+set_property  -dict {PACKAGE_PIN AL35  IOSTANDARD LVDS                           } [get_ports fpga_sysref_c2m_p        ]; ## LA00_P_CC      G06  IO_L7P_T1L_N0_QBC_AD13P_43
+set_property  -dict {PACKAGE_PIN P36   IOSTANDARD LVDS     DIFF_TERM_ADV TERM_100} [get_ports fpga_sysref_m2c_n        ]; ## CLK1_M2C_N     G03  IO_L14N_T2L_N3_GC_45
+set_property  -dict {PACKAGE_PIN P35   IOSTANDARD LVDS     DIFF_TERM_ADV TERM_100} [get_ports fpga_sysref_m2c_p        ]; ## CLK1_M2C_P     G02  IO_L14P_T2L_N2_GC_45
+set_property  -dict {PACKAGE_PIN AH31  IOSTANDARD LVCMOS18                       } [get_ports hmc425a_v[1]             ]; ## LA14_N         C19  IO_L23N_T3U_N9_43
+set_property  -dict {PACKAGE_PIN AG31  IOSTANDARD LVCMOS18                       } [get_ports hmc425a_v[2]             ]; ## LA14_P         C18  IO_L23P_T3U_N8_43
+set_property  -dict {PACKAGE_PIN AR35  IOSTANDARD LVCMOS18                       } [get_ports hmc425a_v[3]             ]; ## LA10_N         C15  IO_L3N_T0L_N5_AD15N_43
+set_property  -dict {PACKAGE_PIN AP35  IOSTANDARD LVCMOS18                       } [get_ports hmc425a_v[4]             ]; ## LA10_P         C14  IO_L3P_T0L_N4_AD15P_43
+set_property  -dict {PACKAGE_PIN Y32   IOSTANDARD LVCMOS18                       } [get_ports hmc7043_gpio             ]; ## LA23_P         D23  IO_L1P_T0L_N0_DBC_45
+set_property  -dict {PACKAGE_PIN AJ35  IOSTANDARD LVCMOS18                       } [get_ports hmc7043_reset            ]; ## LA13_P         D17  IO_L20P_T3L_N2_AD1P_43
+set_property  -dict {PACKAGE_PIN AT35  IOSTANDARD LVCMOS18                       } [get_ports hmc7043_sclk             ]; ## LA06_P         C10  IO_L2P_T0L_N2_43
+set_property  -dict {PACKAGE_PIN AT36  IOSTANDARD LVCMOS18                       } [get_ports hmc7043_sdata            ]; ## LA06_N         C11  IO_L2N_T0L_N3_43
+set_property  -dict {PACKAGE_PIN AJ36  IOSTANDARD LVCMOS18                       } [get_ports hmc7043_slen             ]; ## LA13_N         D18  IO_L20N_T3L_N3_AD1N_43
+set_property  -dict {PACKAGE_PIN U46                                             } [get_ports m2c_n[0]                 ]; ## DP5_M2C_N      A19  MGTYRXN1_126
+set_property  -dict {PACKAGE_PIN AA46                                            } [get_ports m2c_n[1]                 ]; ## DP14_M2C_N     Y19  MGTYRXN2_125
+set_property  -dict {PACKAGE_PIN Y44                                             } [get_ports m2c_n[2]                 ]; ## DP15_M2C_N     Y23  MGTYRXN3_125
+set_property  -dict {PACKAGE_PIN AB44                                            } [get_ports m2c_n[3]                 ]; ## DP13_M2C_N     Z17  MGTYRXN1_125
+set_property  -dict {PACKAGE_PIN AJ46                                            } [get_ports m2c_n[4]                 ]; ## DP3_M2C_N      A11  MGTYRXN3_121
+set_property  -dict {PACKAGE_PIN N46                                             } [get_ports m2c_n[5]                 ]; ## DP7_M2C_N      B13  MGTYRXN3_126
+set_property  -dict {PACKAGE_PIN W46                                             } [get_ports m2c_n[6]                 ]; ## DP4_M2C_N      A15  MGTYRXN0_126
+set_property  -dict {PACKAGE_PIN R46                                             } [get_ports m2c_n[7]                 ]; ## DP6_M2C_N      B17  MGTYRXN2_126
+set_property  -dict {PACKAGE_PIN AL46                                            } [get_ports m2c_n[8]                 ]; ## DP2_M2C_N      A07  MGTYRXN2_121
+set_property  -dict {PACKAGE_PIN AF44                                            } [get_ports m2c_n[9]                 ]; ## DP9_M2C_N      B05  MGTYRXN1_122
+set_property  -dict {PACKAGE_PIN AR46                                            } [get_ports m2c_n[10]                ]; ## DP0_M2C_N      C07  MGTYRXN0_121
+set_property  -dict {PACKAGE_PIN AG46                                            } [get_ports m2c_n[11]                ]; ## DP8_M2C_N      B09  MGTYRXN0_122
+set_property  -dict {PACKAGE_PIN AC46                                            } [get_ports m2c_n[12]                ]; ## DP12_M2C_N     Y15  MGTYRXN0_125
+set_property  -dict {PACKAGE_PIN AD44                                            } [get_ports m2c_n[13]                ]; ## DP11_M2C_N     Z13  MGTYRXN3_122
+set_property  -dict {PACKAGE_PIN AE46                                            } [get_ports m2c_n[14]                ]; ## DP10_M2C_N     Y11  MGTYRXN2_122
+set_property  -dict {PACKAGE_PIN AN46                                            } [get_ports m2c_n[15]                ]; ## DP1_M2C_N      A03  MGTYRXN1_121
+set_property  -dict {PACKAGE_PIN U45                                             } [get_ports m2c_p[0]                 ]; ## DP5_M2C_P      A18  MGTYRXP1_126
+set_property  -dict {PACKAGE_PIN AA45                                            } [get_ports m2c_p[1]                 ]; ## DP14_M2C_P     Y18  MGTYRXP2_125
+set_property  -dict {PACKAGE_PIN Y43                                             } [get_ports m2c_p[2]                 ]; ## DP15_M2C_P     Y22  MGTYRXP3_125
+set_property  -dict {PACKAGE_PIN AB43                                            } [get_ports m2c_p[3]                 ]; ## DP13_M2C_P     Z16  MGTYRXP1_125
+set_property  -dict {PACKAGE_PIN AJ45                                            } [get_ports m2c_p[4]                 ]; ## DP3_M2C_P      A10  MGTYRXP3_121
+set_property  -dict {PACKAGE_PIN N45                                             } [get_ports m2c_p[5]                 ]; ## DP7_M2C_P      B12  MGTYRXP3_126
+set_property  -dict {PACKAGE_PIN W45                                             } [get_ports m2c_p[6]                 ]; ## DP4_M2C_P      A14  MGTYRXP0_126
+set_property  -dict {PACKAGE_PIN R45                                             } [get_ports m2c_p[7]                 ]; ## DP6_M2C_P      B16  MGTYRXP2_126
+set_property  -dict {PACKAGE_PIN AL45                                            } [get_ports m2c_p[8]                 ]; ## DP2_M2C_P      A06  MGTYRXP2_121
+set_property  -dict {PACKAGE_PIN AF43                                            } [get_ports m2c_p[9]                 ]; ## DP9_M2C_P      B04  MGTYRXP1_122
+set_property  -dict {PACKAGE_PIN AR45                                            } [get_ports m2c_p[10]                ]; ## DP0_M2C_P      C06  MGTYRXP0_121
+set_property  -dict {PACKAGE_PIN AG45                                            } [get_ports m2c_p[11]                ]; ## DP8_M2C_P      B08  MGTYRXP0_122
+set_property  -dict {PACKAGE_PIN AC45                                            } [get_ports m2c_p[12]                ]; ## DP12_M2C_P     Y14  MGTYRXP0_125
+set_property  -dict {PACKAGE_PIN AD43                                            } [get_ports m2c_p[13]                ]; ## DP11_M2C_P     Z12  MGTYRXP3_122
+set_property  -dict {PACKAGE_PIN AE45                                            } [get_ports m2c_p[14]                ]; ## DP10_M2C_P     Y10  MGTYRXP2_122
+set_property  -dict {PACKAGE_PIN AN45                                            } [get_ports m2c_p[15]                ]; ## DP1_M2C_P      A02  MGTYRXP1_121
+set_property  -dict {PACKAGE_PIN Y13   IOSTANDARD LVCMOS18                       } [get_ports mxfe_cs[0]               ]; ## HA04_N         F08  IO_L1N_T0L_N1_DBC_70
+set_property  -dict {PACKAGE_PIN AT37  IOSTANDARD LVCMOS18                       } [get_ports mxfe_cs[1]               ]; ## LA04_N         H11  IO_L6N_T0U_N11_AD6N_43
+set_property  -dict {PACKAGE_PIN K13   IOSTANDARD LVCMOS18                       } [get_ports mxfe_cs[2]               ]; ## HA21_N         K20  IO_L23N_T3U_N9_70
+set_property  -dict {PACKAGE_PIN AR38  IOSTANDARD LVCMOS18                       } [get_ports mxfe_cs[3]               ]; ## LA05_N         D12  IO_L1N_T0L_N1_DBC_43
+set_property  -dict {PACKAGE_PIN N13   IOSTANDARD LVCMOS18                       } [get_ports mxfe_miso[0]             ]; ## HA00_N_CC      F05  IO_L13N_T2L_N1_GC_QBC_70
+set_property  -dict {PACKAGE_PIN AT40  IOSTANDARD LVCMOS18                       } [get_ports mxfe_miso[1]             ]; ## LA03_N         G10  IO_L4N_T0U_N7_DBC_AD7N_43
+set_property  -dict {PACKAGE_PIN P11   IOSTANDARD LVCMOS18                       } [get_ports mxfe_miso[2]             ]; ## HA17_N_CC      K17  IO_L16N_T2U_N7_QBC_AD3N_70
+set_property  -dict {PACKAGE_PIN AL31  IOSTANDARD LVCMOS18                       } [get_ports mxfe_miso[3]             ]; ## LA01_N_CC      D09  IO_L16N_T2U_N7_QBC_AD3N_43
+set_property  -dict {PACKAGE_PIN AA13  IOSTANDARD LVCMOS18                       } [get_ports mxfe_mosi[0]             ]; ## HA04_P         F07  IO_L1P_T0L_N0_DBC_70
+set_property  -dict {PACKAGE_PIN AR37  IOSTANDARD LVCMOS18                       } [get_ports mxfe_mosi[1]             ]; ## LA04_P         H10  IO_L6P_T0U_N10_AD6P_43
+set_property  -dict {PACKAGE_PIN K14   IOSTANDARD LVCMOS18                       } [get_ports mxfe_mosi[2]             ]; ## HA21_P         K19  IO_L23P_T3U_N8_70
+set_property  -dict {PACKAGE_PIN AP38  IOSTANDARD LVCMOS18                       } [get_ports mxfe_mosi[3]             ]; ## LA05_P         D11  IO_L1P_T0L_N0_DBC_43
+set_property  -dict {PACKAGE_PIN AK29  IOSTANDARD LVCMOS18                       } [get_ports mxfe_reset[0]            ]; ## LA08_P         G12  IO_L18P_T2U_N10_AD2P_43
+set_property  -dict {PACKAGE_PIN N33   IOSTANDARD LVCMOS18                       } [get_ports mxfe_reset[1]            ]; ## LA19_P         H22  IO_L22P_T3U_N6_DBC_AD0P_45
+set_property  -dict {PACKAGE_PIN W12   IOSTANDARD LVCMOS18                       } [get_ports mxfe_reset[2]            ]; ## HA03_P         J06  IO_L3P_T0L_N4_AD15P_70
+set_property  -dict {PACKAGE_PIN T16   IOSTANDARD LVCMOS18                       } [get_ports mxfe_reset[3]            ]; ## HA12_P         F13  IO_L9P_T1L_N4_AD12P_70
+set_property  -dict {PACKAGE_PIN L34   IOSTANDARD LVCMOS18                       } [get_ports mxfe_rx_en0[0]           ]; ## LA33_P         G36  IO_L19P_T3L_N0_DBC_AD9P_45
+set_property  -dict {PACKAGE_PIN AP36  IOSTANDARD LVCMOS18                       } [get_ports mxfe_rx_en0[1]           ]; ## LA07_P         H13  IO_L5P_T0U_N8_AD14P_43
+set_property  -dict {PACKAGE_PIN V16   IOSTANDARD LVCMOS18                       } [get_ports mxfe_rx_en0[2]           ]; ## HA10_P         K13  IO_L8P_T1L_N2_AD5P_70
+set_property  -dict {PACKAGE_PIN M15   IOSTANDARD LVCMOS18                       } [get_ports mxfe_rx_en0[3]           ]; ## HA20_P         E18  IO_L17P_T2U_N8_AD10P_70
+set_property  -dict {PACKAGE_PIN K34   IOSTANDARD LVCMOS18                       } [get_ports mxfe_rx_en1[0]           ]; ## LA33_N         G37  IO_L19N_T3L_N1_DBC_AD9N_45
+set_property  -dict {PACKAGE_PIN AP37  IOSTANDARD LVCMOS18                       } [get_ports mxfe_rx_en1[1]           ]; ## LA07_N         H14  IO_L5N_T0U_N9_AD14N_43
+set_property  -dict {PACKAGE_PIN U16   IOSTANDARD LVCMOS18                       } [get_ports mxfe_rx_en1[2]           ]; ## HA10_N         K14  IO_L8N_T1L_N3_AD5N_70
+set_property  -dict {PACKAGE_PIN L15   IOSTANDARD LVCMOS18                       } [get_ports mxfe_rx_en1[3]           ]; ## HA20_N         E19  IO_L17N_T2U_N9_AD10N_70
+set_property  -dict {PACKAGE_PIN N14   IOSTANDARD LVCMOS18                       } [get_ports mxfe_sclk[0]             ]; ## HA00_P_CC      F04  IO_L13P_T2L_N0_GC_QBC_70
+set_property  -dict {PACKAGE_PIN AT39  IOSTANDARD LVCMOS18                       } [get_ports mxfe_sclk[1]             ]; ## LA03_P         G09  IO_L4P_T0U_N6_DBC_AD7P_43
+set_property  -dict {PACKAGE_PIN R11   IOSTANDARD LVCMOS18                       } [get_ports mxfe_sclk[2]             ]; ## HA17_P_CC      K16  IO_L16P_T2U_N6_QBC_AD3P_70
+set_property  -dict {PACKAGE_PIN AL30  IOSTANDARD LVCMOS18                       } [get_ports mxfe_sclk[3]             ]; ## LA01_P_CC      D08  IO_L16P_T2U_N6_QBC_AD3P_43
+set_property  -dict {PACKAGE_PIN T36   IOSTANDARD LVDS                           } [get_ports mxfe_syncin_n[0]         ]; ## LA29_N         G31  IO_L4N_T0U_N7_DBC_AD7N_45
+set_property  -dict {PACKAGE_PIN AJ31  IOSTANDARD LVDS                           } [get_ports mxfe_syncin_n[1]         ]; ## LA11_N         H17  IO_L17N_T2U_N9_AD10N_43
+set_property  -dict {PACKAGE_PIN Y12   IOSTANDARD LVDS                           } [get_ports mxfe_syncin_n[2]         ]; ## HA02_N         K08  IO_L5N_T0U_N9_AD14N_70
+set_property  -dict {PACKAGE_PIN U12   IOSTANDARD LVDS                           } [get_ports mxfe_syncin_n[3]         ]; ## HA13_N         E13  IO_L4N_T0U_N7_DBC_AD7N_70
+set_property  -dict {PACKAGE_PIN W34   IOSTANDARD LVCMOS18                       } [get_ports mxfe_syncin_p[0]         ]; ## LA25_N         G28  IO_L3N_T0L_N5_AD15N_45
+set_property  -dict {PACKAGE_PIN U35   IOSTANDARD LVDS                           } [get_ports mxfe_syncin_p[1]         ]; ## LA29_P         G30  IO_L4P_T0U_N6_DBC_AD7P_45
+set_property  -dict {PACKAGE_PIN K33   IOSTANDARD LVCMOS18                       } [get_ports mxfe_syncin_p[2]         ]; ## LA32_N         H38  IO_L21N_T3L_N5_AD8N_45
+set_property  -dict {PACKAGE_PIN AJ30  IOSTANDARD LVDS                           } [get_ports mxfe_syncin_p[3]         ]; ## LA11_P         H16  IO_L17P_T2U_N8_AD10P_43
+set_property  -dict {PACKAGE_PIN J12   IOSTANDARD LVCMOS18                       } [get_ports mxfe_syncin_p[4]         ]; ## HA22_N         J22  IO_L24N_T3U_N11_70
+set_property  -dict {PACKAGE_PIN AA12  IOSTANDARD LVDS                           } [get_ports mxfe_syncin_p[5]         ]; ## HA02_P         K07  IO_L5P_T0U_N8_AD14P_70
+set_property  -dict {PACKAGE_PIN V14   IOSTANDARD LVCMOS18                       } [get_ports mxfe_syncin_p[6]         ]; ## HA09_N         E10  IO_L6N_T0U_N11_AD6N_70
+set_property  -dict {PACKAGE_PIN V13   IOSTANDARD LVDS                           } [get_ports mxfe_syncin_p[7]         ]; ## HA13_P         E12  IO_L4P_T0U_N6_DBC_AD7P_70
+set_property  -dict {PACKAGE_PIN N37   IOSTANDARD LVDS     DIFF_TERM_ADV TERM_100} [get_ports mxfe_syncout_n[0]        ]; ## LA31_N         G34  IO_L16N_T2U_N7_QBC_AD3N_45
+set_property  -dict {PACKAGE_PIN AG33  IOSTANDARD LVDS     DIFF_TERM_ADV TERM_100} [get_ports mxfe_syncout_n[1]        ]; ## LA15_N         H20  IO_L24N_T3U_N11_43
+set_property  -dict {PACKAGE_PIN T13   IOSTANDARD LVDS     DIFF_TERM_ADV TERM_100} [get_ports mxfe_syncout_n[2]        ]; ## HA06_N         K11  IO_L12N_T1U_N11_GC_70
+set_property  -dict {PACKAGE_PIN R13   IOSTANDARD LVDS     DIFF_TERM_ADV TERM_100} [get_ports mxfe_syncout_n[3]        ]; ## HA16_N         E16  IO_L11N_T1U_N9_GC_70
+set_property  -dict {PACKAGE_PIN Y34   IOSTANDARD LVCMOS18                       } [get_ports mxfe_syncout_p[0]        ]; ## LA25_P         G27  IO_L3P_T0L_N4_AD15P_45
+set_property  -dict {PACKAGE_PIN P37   IOSTANDARD LVDS     DIFF_TERM_ADV TERM_100} [get_ports mxfe_syncout_p[1]        ]; ## LA31_P         G33  IO_L16P_T2U_N6_QBC_AD3P_45
+set_property  -dict {PACKAGE_PIN L33   IOSTANDARD LVCMOS18                       } [get_ports mxfe_syncout_p[2]        ]; ## LA32_P         H37  IO_L21P_T3L_N4_AD8P_45
+set_property  -dict {PACKAGE_PIN AG32  IOSTANDARD LVDS     DIFF_TERM_ADV TERM_100} [get_ports mxfe_syncout_p[3]        ]; ## LA15_P         H19  IO_L24P_T3U_N10_43
+set_property  -dict {PACKAGE_PIN K12   IOSTANDARD LVCMOS18                       } [get_ports mxfe_syncout_p[4]        ]; ## HA22_P         J21  IO_L24P_T3U_N10_70
+set_property  -dict {PACKAGE_PIN U13   IOSTANDARD LVDS     DIFF_TERM_ADV TERM_100} [get_ports mxfe_syncout_p[5]        ]; ## HA06_P         K10  IO_L12P_T1U_N10_GC_70
+set_property  -dict {PACKAGE_PIN W14   IOSTANDARD LVCMOS18                       } [get_ports mxfe_syncout_p[6]        ]; ## HA09_P         E09  IO_L6P_T0U_N10_AD6P_70
+set_property  -dict {PACKAGE_PIN T14   IOSTANDARD LVDS     DIFF_TERM_ADV TERM_100} [get_ports mxfe_syncout_p[7]        ]; ## HA16_P         E15  IO_L11P_T1U_N8_GC_70
+set_property  -dict {PACKAGE_PIN U11   IOSTANDARD LVCMOS18                       } [get_ports mxfe_tx_en0[0]           ]; ## HA08_P         F10  IO_L10P_T1U_N6_QBC_AD4P_70
+set_property  -dict {PACKAGE_PIN AJ32  IOSTANDARD LVCMOS18                       } [get_ports mxfe_tx_en0[1]           ]; ## LA02_P         H07  IO_L14P_T2L_N2_GC_43
+set_property  -dict {PACKAGE_PIN K11   IOSTANDARD LVCMOS18                       } [get_ports mxfe_tx_en0[2]           ]; ## HA23_P         K22  IO_L21P_T3L_N4_AD8P_70
+set_property  -dict {PACKAGE_PIN AJ33  IOSTANDARD LVCMOS18                       } [get_ports mxfe_tx_en0[3]           ]; ## LA09_P         D14  IO_L19P_T3L_N0_DBC_AD9P_43
+set_property  -dict {PACKAGE_PIN T11   IOSTANDARD LVCMOS18                       } [get_ports mxfe_tx_en1[0]           ]; ## HA08_N         F11  IO_L10N_T1U_N7_QBC_AD4N_70
+set_property  -dict {PACKAGE_PIN AK32  IOSTANDARD LVCMOS18                       } [get_ports mxfe_tx_en1[1]           ]; ## LA02_N         H08  IO_L14N_T2L_N3_GC_43
+set_property  -dict {PACKAGE_PIN J11   IOSTANDARD LVCMOS18                       } [get_ports mxfe_tx_en1[2]           ]; ## HA23_N         K23  IO_L21N_T3L_N5_AD8N_70
+set_property  -dict {PACKAGE_PIN AK33  IOSTANDARD LVCMOS18                       } [get_ports mxfe_tx_en1[3]           ]; ## LA09_N         D15  IO_L19N_T3L_N1_DBC_AD9N_43
+set_property  -dict {PACKAGE_PIN AK30  IOSTANDARD LVCMOS18                       } [get_ports mxfe0_gpio[0]            ]; ## LA08_N         G13  IO_L18N_T2U_N11_AD2N_43
+set_property  -dict {PACKAGE_PIN AH33  IOSTANDARD LVCMOS18                       } [get_ports mxfe0_gpio[1]            ]; ## LA12_P         G15  IO_L21P_T3L_N4_AD8P_43
+set_property  -dict {PACKAGE_PIN AH34  IOSTANDARD LVCMOS18                       } [get_ports mxfe0_gpio[2]            ]; ## LA12_N         G16  IO_L21N_T3L_N5_AD8N_43
+set_property  -dict {PACKAGE_PIN AG34  IOSTANDARD LVCMOS18                       } [get_ports mxfe0_gpio[3]            ]; ## LA16_P         G18  IO_L22P_T3U_N6_DBC_AD0P_43
+set_property  -dict {PACKAGE_PIN AH35  IOSTANDARD LVCMOS18                       } [get_ports mxfe0_gpio[4]            ]; ## LA16_N         G19  IO_L22N_T3U_N7_DBC_AD0N_43
+set_property  -dict {PACKAGE_PIN N32   IOSTANDARD LVCMOS18                       } [get_ports mxfe0_gpio[5]            ]; ## LA20_P         G21  IO_L23P_T3U_N8_45
+set_property  -dict {PACKAGE_PIN M32   IOSTANDARD LVCMOS18                       } [get_ports mxfe0_gpio[6]            ]; ## LA20_N         G22  IO_L23N_T3U_N9_45
+set_property  -dict {PACKAGE_PIN N34   IOSTANDARD LVCMOS18                       } [get_ports mxfe0_gpio[7]            ]; ## LA22_P         G24  IO_L20P_T3L_N2_AD1P_45
+set_property  -dict {PACKAGE_PIN N35   IOSTANDARD LVCMOS18                       } [get_ports mxfe0_gpio[8]            ]; ## LA22_N         G25  IO_L20N_T3L_N3_AD1N_45
+set_property  -dict {PACKAGE_PIN M33   IOSTANDARD LVCMOS18                       } [get_ports mxfe1_gpio[0]            ]; ## LA19_N         H23  IO_L22N_T3U_N7_DBC_AD0N_45
+set_property  -dict {PACKAGE_PIN M35   IOSTANDARD LVCMOS18                       } [get_ports mxfe1_gpio[1]            ]; ## LA21_P         H25  IO_L24P_T3U_N10_45
+set_property  -dict {PACKAGE_PIN L35   IOSTANDARD LVCMOS18                       } [get_ports mxfe1_gpio[2]            ]; ## LA21_N         H26  IO_L24N_T3U_N11_45
+set_property  -dict {PACKAGE_PIN T34   IOSTANDARD LVCMOS18                       } [get_ports mxfe1_gpio[3]            ]; ## LA24_P         H28  IO_L6P_T0U_N10_AD6P_45
+set_property  -dict {PACKAGE_PIN T35   IOSTANDARD LVCMOS18                       } [get_ports mxfe1_gpio[4]            ]; ## LA24_N         H29  IO_L6N_T0U_N11_AD6N_45
+set_property  -dict {PACKAGE_PIN M36   IOSTANDARD LVCMOS18                       } [get_ports mxfe1_gpio[5]            ]; ## LA28_P         H31  IO_L17P_T2U_N8_AD10P_45
+set_property  -dict {PACKAGE_PIN L36   IOSTANDARD LVCMOS18                       } [get_ports mxfe1_gpio[6]            ]; ## LA28_N         H32  IO_L17N_T2U_N9_AD10N_45
+set_property  -dict {PACKAGE_PIN N38   IOSTANDARD LVCMOS18                       } [get_ports mxfe1_gpio[7]            ]; ## LA30_P         H34  IO_L18P_T2U_N10_AD2P_45
+set_property  -dict {PACKAGE_PIN M38   IOSTANDARD LVCMOS18                       } [get_ports mxfe1_gpio[8]            ]; ## LA30_N         H35  IO_L18N_T2U_N11_AD2N_45
+set_property  -dict {PACKAGE_PIN V12   IOSTANDARD LVCMOS18                       } [get_ports mxfe2_gpio[0]            ]; ## HA03_N         J07  IO_L3N_T0L_N5_AD15N_70
+set_property  -dict {PACKAGE_PIN AA14  IOSTANDARD LVCMOS18                       } [get_ports mxfe2_gpio[1]            ]; ## HA07_P         J09  IO_L2P_T0L_N2_70
+set_property  -dict {PACKAGE_PIN Y14   IOSTANDARD LVCMOS18                       } [get_ports mxfe2_gpio[2]            ]; ## HA07_N         J10  IO_L2N_T0L_N3_70
+set_property  -dict {PACKAGE_PIN R12   IOSTANDARD LVCMOS18                       } [get_ports mxfe2_gpio[3]            ]; ## HA11_P         J12  IO_L18P_T2U_N10_AD2P_70
+set_property  -dict {PACKAGE_PIN P12   IOSTANDARD LVCMOS18                       } [get_ports mxfe2_gpio[4]            ]; ## HA11_N         J13  IO_L18N_T2U_N11_AD2N_70
+set_property  -dict {PACKAGE_PIN M11   IOSTANDARD LVCMOS18                       } [get_ports mxfe2_gpio[5]            ]; ## HA14_P         J15  IO_L22P_T3U_N6_DBC_AD0P_70
+set_property  -dict {PACKAGE_PIN L11   IOSTANDARD LVCMOS18                       } [get_ports mxfe2_gpio[6]            ]; ## HA14_N         J16  IO_L22N_T3U_N7_DBC_AD0N_70
+set_property  -dict {PACKAGE_PIN P15   IOSTANDARD LVCMOS18                       } [get_ports mxfe2_gpio[7]            ]; ## HA18_P         J18  IO_L15P_T2L_N4_AD11P_70
+set_property  -dict {PACKAGE_PIN N15   IOSTANDARD LVCMOS18                       } [get_ports mxfe2_gpio[8]            ]; ## HA18_N         J19  IO_L15N_T2L_N5_AD11N_70
+set_property  -dict {PACKAGE_PIN T15   IOSTANDARD LVCMOS18                       } [get_ports mxfe3_gpio[0]            ]; ## HA12_N         F14  IO_L9N_T1L_N5_AD12N_70
+set_property  -dict {PACKAGE_PIN M13   IOSTANDARD LVCMOS18                       } [get_ports mxfe3_gpio[1]            ]; ## HA15_P         F16  IO_L19P_T3L_N0_DBC_AD9P_70
+set_property  -dict {PACKAGE_PIN M12   IOSTANDARD LVCMOS18                       } [get_ports mxfe3_gpio[2]            ]; ## HA15_N         F17  IO_L19N_T3L_N1_DBC_AD9N_70
+set_property  -dict {PACKAGE_PIN L14   IOSTANDARD LVCMOS18                       } [get_ports mxfe3_gpio[3]            ]; ## HA19_P         F19  IO_L20P_T3L_N2_AD1P_70
+set_property  -dict {PACKAGE_PIN L13   IOSTANDARD LVCMOS18                       } [get_ports mxfe3_gpio[4]            ]; ## HA19_N         F20  IO_L20N_T3L_N3_AD1N_70
+set_property  -dict {PACKAGE_PIN V15   IOSTANDARD LVCMOS18                       } [get_ports mxfe3_gpio[5]            ]; ## HA01_P_CC      E02  IO_L7P_T1L_N0_QBC_AD13P_70
+set_property  -dict {PACKAGE_PIN U15   IOSTANDARD LVCMOS18                       } [get_ports mxfe3_gpio[6]            ]; ## HA01_N_CC      E03  IO_L7N_T1L_N1_QBC_AD13N_70
+set_property  -dict {PACKAGE_PIN R14   IOSTANDARD LVCMOS18                       } [get_ports mxfe3_gpio[7]            ]; ## HA05_P         E06  IO_L14P_T2L_N2_GC_70
+set_property  -dict {PACKAGE_PIN P14   IOSTANDARD LVCMOS18                       } [get_ports mxfe3_gpio[8]            ]; ## HA05_N         E07  IO_L14N_T2L_N3_GC_70
+
+set_property  -dict {PACKAGE_PIN AK35  IOSTANDARD LVCMOS18 PULLTYPE PULLUP       } [get_ports vadj_1v8_pgood             ];   ## IO_T1U_N12_43_AK35 
+
+# PMOD1 calibration board connector
+set_property  -dict {PACKAGE_PIN N28   IOSTANDARD LVCMOS12                      } [get_ports pmod1_adc_sync_n           ]; ## PMOD1_0 J53.1
+set_property  -dict {PACKAGE_PIN M30   IOSTANDARD LVCMOS12                      } [get_ports pmod1_adc_sdi              ]; ## PMOD1_1 J53.3
+set_property  -dict {PACKAGE_PIN N30   IOSTANDARD LVCMOS12                      } [get_ports pmod1_adc_sdo              ]; ## PMOD1_2 J53.5
+set_property  -dict {PACKAGE_PIN P30   IOSTANDARD LVCMOS12                      } [get_ports pmod1_adc_sclk             ]; ## PMOD1_3 J53.7
+
+set_property  -dict {PACKAGE_PIN P29   IOSTANDARD LVCMOS12                      } [get_ports pmod1_5045_v2              ]; ## PMOD1_4 J53.2
+set_property  -dict {PACKAGE_PIN L31   IOSTANDARD LVCMOS12                      } [get_ports pmod1_5045_v1              ]; ## PMOD1_5 J53.4
+set_property  -dict {PACKAGE_PIN M31   IOSTANDARD LVCMOS12                      } [get_ports pmod1_ctrl_ind             ]; ## PMOD1_6 J53.6
+set_property  -dict {PACKAGE_PIN R29   IOSTANDARD LVCMOS12                      } [get_ports pmod1_ctrl_rx_combined     ]; ## PMOD1_7 J53.8
+
+create_pblock pblock_axi_mem_interconnect
+add_cells_to_pblock [get_pblocks pblock_axi_mem_interconnect] [get_cells -quiet [list i_system_wrapper/system_i/axi_mem_interconnect]]
+resize_pblock [get_pblocks pblock_axi_mem_interconnect] -add {CLOCKREGION_X0Y0:CLOCKREGION_X5Y4}
+
+create_pblock SLR1
+add_cells_to_pblock [get_pblocks SLR1] [get_cells -quiet [list i_system_wrapper/system_i/util_mxfe_upack]]
+resize_pblock SLR1 -add SLR1:SLR1
+

--- a/projects/ad_quadmxfe1_ebz/vcu118/system_project.tcl
+++ b/projects/ad_quadmxfe1_ebz/vcu118/system_project.tcl
@@ -1,0 +1,65 @@
+
+source ../../scripts/adi_env.tcl
+source $ad_hdl_dir/projects/scripts/adi_project_xilinx.tcl
+source $ad_hdl_dir/projects/scripts/adi_board.tcl
+
+# The get_env_param procedure retrieves parameter value from the environment if exists,
+# other case returns the default value specified in its second parameter field.
+#
+#   How to use over-writable parameters from the environment:
+#    
+#    e.g.
+#      make JESD_MODE=8B10B  RX_JESD_L=4 RX_JESD_M=8 TX_JESD_L=4 TX_JESD_M=8
+#      make JESD_MODE=64B66B RX_JESD_L=2 RX_JESD_M=8 TX_JESD_L=4 TX_JESD_M=16 
+#      make JESD_MODE=64B66B RX_RATE=24.75 TX_RATE=24.75 REF_CLK_RATE=250 RX_JESD_M=4 RX_JESD_L=4 RX_JESD_S=2 RX_JESD_NP=12 TX_JESD_M=4 TX_JESD_L=4 TX_JESD_S=2 TX_JESD_NP=12 RX_PLL_SEL=1 TX_PLL_SEL=1
+#
+#  RX_RATE,TX_RATE,REF_CLK_RATE used only in 64B66B mode
+#
+# Parameter description:
+#   JESD_MODE : used link layer encoder mode 
+#      64B66B - 64b66b link layer defined in JESD 204C, uses Xilinx IP as Physical layer
+#      8B10B  - 8b10b link layer defined in JESD 204B, uses ADI IP as Physical layer
+#    
+#    RX_RATE :  line rate of the Rx link ( MxFE to FPGA ) used in 64B66B mode 
+#    TX_RATE :  line rate of the Tx link ( FPGA to MxFE ) used in 64B66B mode 
+#    REF_CLK_RATE : frequency of reference clock in MHz used in 64B66B mode
+#    [RX/TX]_JESD_M : number of converters per link
+#    [RX/TX]_JESD_L : number of lanes per link
+#    [RX/TX]_JESD_NP : number of bits per sample, only 16 is supported
+#    [RX/TX]_NUM_LINKS : number of links, matches numer of MxFE devices
+
+adi_project ad_quadmxfe1_ebz_vcu118 0 [list \
+  JESD_MODE    [get_env_param JESD_MODE    64B66B ] \
+  RX_RATE      [get_env_param RX_RATE      16.5 ] \
+  TX_RATE      [get_env_param TX_RATE      16.5 ] \
+  RX_PLL_SEL   [get_env_param RX_PLL_SEL   2 ] \
+  TX_PLL_SEL   [get_env_param TX_PLL_SEL   2 ] \
+  REF_CLK_RATE [get_env_param REF_CLK_RATE 250 ] \
+  RX_JESD_M    [get_env_param RX_JESD_M    8 ] \
+  RX_JESD_L    [get_env_param RX_JESD_L    2 ] \
+  RX_JESD_S    [get_env_param RX_JESD_S    1 ] \
+  RX_JESD_NP   [get_env_param RX_JESD_NP   16 ] \
+  RX_NUM_LINKS [get_env_param RX_NUM_LINKS 4 ] \
+  TX_JESD_M    [get_env_param TX_JESD_M    16 ] \
+  TX_JESD_L    [get_env_param TX_JESD_L    4 ] \
+  TX_JESD_S    [get_env_param TX_JESD_S    1 ] \
+  TX_JESD_NP   [get_env_param TX_JESD_NP   16 ] \
+  TX_NUM_LINKS [get_env_param TX_NUM_LINKS 4 ] \
+  RX_KS_PER_CHANNEL [get_env_param RX_KS_PER_CHANNEL 32 ] \
+  TX_KS_PER_CHANNEL [get_env_param TX_KS_PER_CHANNEL 16 ] \
+  DAC_TPL_XBAR_ENABLE  [get_env_param DAC_TPL_XBAR_ENABLE 0 ] \
+]
+
+adi_project_files ad_quadmxfe1_ebz_vcu118 [list \
+  "system_top.v" \
+  "system_constr.xdc" \
+  "timing_constr.xdc" \
+  "../common/quad_mxfe_gpio_mux.v" \
+  "../../../library/common/ad_3w_spi.v" \
+  "$ad_hdl_dir/library/common/ad_iobuf.v" \
+  "$ad_hdl_dir/projects/common/vcu118/vcu118_system_constr.xdc" ]
+
+set_property strategy Performance_RefinePlacement [get_runs impl_1]
+
+adi_project_run ad_quadmxfe1_ebz_vcu118
+

--- a/projects/ad_quadmxfe1_ebz/vcu118/system_top.v
+++ b/projects/ad_quadmxfe1_ebz/vcu118/system_top.v
@@ -1,0 +1,506 @@
+// ***************************************************************************
+// ***************************************************************************
+// Copyright 2014 - 2021 (c) Analog Devices, Inc. All rights reserved.
+//
+// In this HDL repository, there are many different and unique modules, consisting
+// of various HDL (Verilog or VHDL) components. The individual modules are
+// developed independently, and may be accompanied by separate and unique license
+// terms.
+//
+// The user should read each of these license terms, and understand the
+// freedoms and responsibilities that he or she has by using this source/core.
+//
+// This core is distributed in the hope that it will be useful, but WITHOUT ANY
+// WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+// A PARTICULAR PURPOSE.
+//
+// Redistribution and use of source or resulting binaries, with or without modification
+// of this file, are permitted under one of the following two license terms:
+//
+//   1. The GNU General Public License version 2 as published by the
+//      Free Software Foundation, which can be found in the top level directory
+//      of this repository (LICENSE_GPL2), and also online at:
+//      <https://www.gnu.org/licenses/old-licenses/gpl-2.0.html>
+//
+// OR
+//
+//   2. An ADI specific BSD license, which can be found in the top level directory
+//      of this repository (LICENSE_ADIBSD), and also on-line at:
+//      https://github.com/analogdevicesinc/hdl/blob/master/LICENSE_ADIBSD
+//      This will allow to generate bit files and not release the source code,
+//      as long as it attaches to an ADI device.
+//
+// ***************************************************************************
+// ***************************************************************************
+
+`timescale 1ns/100ps
+
+module system_top (
+
+  input         sys_rst,
+  input         sys_clk_p,
+  input         sys_clk_n,
+
+  input         uart_sin,
+  output        uart_sout,
+
+  output        ddr4_act_n,
+  output [16:0] ddr4_addr,
+  output [ 1:0] ddr4_ba,
+  output [ 0:0] ddr4_bg,
+  output        ddr4_ck_p,
+  output        ddr4_ck_n,
+  output [ 0:0] ddr4_cke,
+  output [ 0:0] ddr4_cs_n,
+  inout  [ 7:0] ddr4_dm_n,
+  inout  [63:0] ddr4_dq,
+  inout  [ 7:0] ddr4_dqs_p,
+  inout  [ 7:0] ddr4_dqs_n,
+  output [ 0:0] ddr4_odt,
+  output        ddr4_reset_n,
+
+  output        mdio_mdc,
+  inout         mdio_mdio,
+  input         phy_clk_p,
+  input         phy_clk_n,
+  output        phy_rst_n,
+  input         phy_rx_p,
+  input         phy_rx_n,
+  output        phy_tx_p,
+  output        phy_tx_n,
+
+  inout  [16:0] gpio_bd,
+
+  output        iic_rstn,
+  inout         iic_scl,
+  inout         iic_sda,
+
+  input         vadj_1v8_pgood,
+
+  // FMCp IOs
+  //
+  output  [3:0] adf4371_cs,
+  output        adf4371_sclk,
+  inout         adf4371_sdio,
+
+  output        adrf5020_ctrl,
+
+  input   [2:0] fpga_clk_m2c_n,
+  input   [2:0] fpga_clk_m2c_p,
+  input         fpga_clk_m2c_0_replica_n,
+  input         fpga_clk_m2c_0_replica_p,
+  output        fpga_sysref_c2m_n,
+  output        fpga_sysref_c2m_p,
+  input         fpga_sysref_m2c_n,
+  input         fpga_sysref_m2c_p,
+
+  output [15:0] c2m_n,
+  output [15:0] c2m_p,
+  input  [15:0] m2c_n,
+  input  [15:0] m2c_p,
+  output  [3:0] mxfe_syncin_n,
+  output  [7:0] mxfe_syncin_p,
+  input   [3:0] mxfe_syncout_n,
+  input   [7:0] mxfe_syncout_p,
+
+  inout         hmc7043_gpio,
+  output        hmc7043_reset,
+  output        hmc7043_sclk,
+  inout         hmc7043_sdata,
+  output        hmc7043_slen,
+
+  output  [4:1] hmc425a_v,
+
+  output  [3:0] mxfe_sclk,
+  output  [3:0] mxfe_cs,
+  input   [3:0] mxfe_miso,
+  output  [3:0] mxfe_mosi,
+
+  output  [3:0] mxfe_reset,
+  output  [3:0] mxfe_rx_en0,
+  output  [3:0] mxfe_rx_en1,
+  output  [3:0] mxfe_tx_en0,
+  output  [3:0] mxfe_tx_en1,
+
+  inout  [8:0] mxfe0_gpio,
+  inout  [8:0] mxfe1_gpio,
+  inout  [8:0] mxfe2_gpio,
+  inout  [8:0] mxfe3_gpio,
+
+  // PMOD1 for calibration board 
+  output pmod1_adc_sync_n,
+  output pmod1_adc_sdi,
+  input  pmod1_adc_sdo,
+  output pmod1_adc_sclk,
+
+  output pmod1_5045_v2,
+  output pmod1_5045_v1,
+  output pmod1_ctrl_ind,
+  output pmod1_ctrl_rx_combined
+
+);
+
+  // internal signals
+
+  wire    [127:0]  gpio_i;
+  wire    [127:0]  gpio_o;
+  wire    [127:0]  gpio_t;
+
+  wire            spi_clk;
+  wire    [ 7:0]  spi_csn;
+  wire            spi_mosi;
+  wire            spi_miso;
+  wire            spi_4371_miso;
+  wire            spi_hmc_miso;
+
+  wire            spi_2_clk;
+  wire    [ 7:0]  spi_2_csn;
+  wire            spi_2_mosi;
+  wire            spi_2_miso;
+
+  wire            spi_3_clk;
+  wire    [ 7:0]  spi_3_csn;
+  wire            spi_3_mosi;
+  wire            spi_3_miso;
+
+  wire            ref_clk;
+  wire            sysref;
+  wire    [3:0]   link0_tx_syncin;
+  wire    [3:0]   link0_rx_syncout;
+  wire    [3:0]   link1_tx_syncin;
+  wire    [3:0]   link1_rx_syncout;
+
+  wire            fpga_clk_m2c_4;
+  wire            device_clk;
+
+  wire            ext_sync_at_sysref;
+
+  reg             ext_sync_ms = 1'b0;
+  reg             ext_sync_noms = 1'b0;
+  reg             ext_sync_noms_d1 = 1'b0;
+
+  assign iic_rstn = 1'b1;
+
+  // instantiations
+
+  // Link 1 SYNC differential lines
+  genvar i;
+  generate
+  for(i=0;i<=3;i=i+1) begin : g_buffers
+    IBUFDS i_ibufds_syncin (
+      .I (mxfe_syncout_p[2*i+1]),
+      .IB (mxfe_syncout_n[i]),
+      .O (link1_tx_syncin[i]));
+
+    OBUFDS i_obufds_syncout (
+      .I (link1_rx_syncout[i]),
+      .O (mxfe_syncin_p[2*i+1]),
+      .OB (mxfe_syncin_n[i]));
+  end
+  endgenerate
+
+  // Link 0 SYNC single ended lines 
+  assign mxfe_syncin_p[0] = link0_rx_syncout[0];
+  assign mxfe_syncin_p[2] = link0_rx_syncout[1];
+  assign mxfe_syncin_p[4] = link0_rx_syncout[2];
+  assign mxfe_syncin_p[6] = link0_rx_syncout[3];
+
+  assign link0_tx_syncin[0] = mxfe_syncout_p[0];
+  assign link0_tx_syncin[1] = mxfe_syncout_p[2];
+  assign link0_tx_syncin[2] = mxfe_syncout_p[4];
+  assign link0_tx_syncin[3] = mxfe_syncout_p[6];
+
+  IBUFDS_GTE4 i_ibufds_ref_clk (
+    .CEB (1'd0),
+    .I (fpga_clk_m2c_p[0]),
+    .IB (fpga_clk_m2c_n[0]),
+    .O (ref_clk),
+    .ODIV2 ());
+
+  IBUFDS_GTE4 i_ibufds_ref_clk_replica (
+    .CEB (1'd0),
+    .I (fpga_clk_m2c_0_replica_p),
+    .IB (fpga_clk_m2c_0_replica_n),
+    .O (ref_clk_replica),
+    .ODIV2 ());
+
+  IBUFDS i_ibufds_sysref (
+    .I (fpga_sysref_m2c_p),
+    .IB (fpga_sysref_m2c_n),
+    .O (sysref));
+
+  OBUFDS i_obufds_sysref (
+    .O (fpga_sysref_c2m_p),
+    .OB (fpga_sysref_c2m_n),
+    .I (sysref));
+
+  IBUFDS i_ibufds_rx_device_clk (
+    .I (fpga_clk_m2c_p[1]),
+    .IB (fpga_clk_m2c_n[1]),
+    .O (fpga_clk_m2c_1));
+
+  BUFG i_rx_device_clk (
+    .I (fpga_clk_m2c_1),
+    .O (rx_device_clk)
+  );
+
+  IBUFDS i_ibufds_tx_device_clk (
+    .I (fpga_clk_m2c_p[2]),
+    .IB (fpga_clk_m2c_n[2]),
+    .O (fpga_clk_m2c_2));
+
+  BUFG i_tx_device_clk (
+    .I (fpga_clk_m2c_2),
+    .O (tx_device_clk)
+  );
+
+  // spi
+
+  assign mxfe_cs = spi_csn[3:0];
+  assign mxfe_mosi = {4{spi_mosi}};
+  assign mxfe_sclk = {4{spi_clk}};
+
+  assign adf4371_cs = spi_2_csn[3:0];
+  assign adf4371_sclk = spi_2_clk;
+
+  assign hmc7043_slen = spi_2_csn[4];
+  assign hmc7043_sclk = spi_2_clk;
+
+  assign pmod1_adc_sync_n = spi_3_csn[0];
+  assign pmod1_adc_sdi = spi_3_mosi;
+  assign pmod1_adc_sclk = spi_3_clk;
+
+  assign spi_miso = ~spi_csn[0] ? mxfe_miso[0] :
+                    ~spi_csn[1] ? mxfe_miso[1] :
+                    ~spi_csn[2] ? mxfe_miso[2] :
+                    ~spi_csn[3] ? mxfe_miso[3] :
+                    1'b0;
+
+  assign spi_2_miso =  |(~spi_2_csn[3:0]) ? spi_4371_miso :
+                         ~spi_2_csn[4]    ? spi_hmc_miso :
+                          1'b0;
+
+  assign spi_3_miso =  ~pmod1_adc_sync_n ? pmod1_adc_sdo : 1'b0;
+
+   ad_3w_spi #(.NUM_OF_SLAVES(1)) i_spi_hmc (
+    .spi_csn (spi_2_csn[4]),
+    .spi_clk (spi_2_clk),
+    .spi_mosi (spi_2_mosi),
+    .spi_miso (spi_hmc_miso),
+    .spi_sdio (hmc7043_sdata),
+    .spi_dir ());
+
+   ad_3w_spi #(.NUM_OF_SLAVES(1)) i_spi_4371 (
+    .spi_csn (&spi_2_csn[3:0]),
+    .spi_clk (spi_2_clk),
+    .spi_mosi (spi_2_mosi),
+    .spi_miso (spi_4371_miso),
+    .spi_sdio (adf4371_sdio),
+    .spi_dir ());
+
+  // gpios
+
+  ad_iobuf #(.DATA_WIDTH(1)) i_iobuf (
+    .dio_t (gpio_t[32:32]),
+    .dio_i (gpio_o[32:32]),
+    .dio_o (gpio_i[32:32]),
+    .dio_p ({hmc7043_gpio       // 32
+             }));
+
+  assign hmc7043_reset = gpio_o[33];
+  assign adrf5020_ctrl = gpio_o[34];
+  assign hmc425a_v     = gpio_o[38:35];
+  assign mxfe_reset    = gpio_o[44:41];
+  assign mxfe_rx_en0   = gpio_o[48:45];
+  assign mxfe_rx_en1   = gpio_o[52:49];
+  assign mxfe_tx_en0   = gpio_o[56:53];
+  assign mxfe_tx_en1   = gpio_o[60:57];
+
+  assign dac_fifo_bypass  = gpio_o[61];
+
+  ad_iobuf #(.DATA_WIDTH(17)) i_iobuf_bd (
+    .dio_t (gpio_t[16:0]),
+    .dio_i (gpio_o[16:0]),
+    .dio_o (gpio_i[16:0]),
+    .dio_p (gpio_bd));
+
+  assign gpio_i[63:33] = gpio_o[63:33];
+  assign gpio_i[31:17] = gpio_o[31:17];
+
+  quad_mxfe_gpio_mux i_quad_mxfe_gpio_mux (
+    .mxfe0_gpio(mxfe0_gpio),
+    .mxfe1_gpio(mxfe1_gpio),
+    .mxfe2_gpio(mxfe2_gpio),
+    .mxfe3_gpio(mxfe3_gpio),
+
+    .gpio_t(gpio_t[127:64]),
+    .gpio_i(gpio_i[127:64]),
+    .gpio_o(gpio_o[127:64])
+  );
+
+  assign pmod1_5045_v2 = gpio_o[120];
+  assign pmod1_5045_v1 = gpio_o[121];
+  assign pmod1_ctrl_ind = gpio_o[122];
+  assign pmod1_ctrl_rx_combined = gpio_o[123];
+
+  system_wrapper i_system_wrapper (
+    .sys_rst (sys_rst),
+    .sys_clk_clk_n (sys_clk_n),
+    .sys_clk_clk_p (sys_clk_p),
+    .ddr4_act_n (ddr4_act_n),
+    .ddr4_adr (ddr4_addr),
+    .ddr4_ba (ddr4_ba),
+    .ddr4_bg (ddr4_bg),
+    .ddr4_ck_c (ddr4_ck_n),
+    .ddr4_ck_t (ddr4_ck_p),
+    .ddr4_cke (ddr4_cke),
+    .ddr4_cs_n (ddr4_cs_n),
+    .ddr4_dm_n (ddr4_dm_n),
+    .ddr4_dq (ddr4_dq),
+    .ddr4_dqs_c (ddr4_dqs_n),
+    .ddr4_dqs_t (ddr4_dqs_p),
+    .ddr4_odt (ddr4_odt),
+    .ddr4_reset_n (ddr4_reset_n),
+    .phy_sd (1'b1),
+    .phy_rst_n (phy_rst_n),
+    .sgmii_rxn (phy_rx_n),
+    .sgmii_rxp (phy_rx_p),
+    .sgmii_txn (phy_tx_n),
+    .sgmii_txp (phy_tx_p),
+    .mdio_mdc (mdio_mdc),
+    .mdio_mdio_io (mdio_mdio),
+    .sgmii_phyclk_clk_n (phy_clk_n),
+    .sgmii_phyclk_clk_p (phy_clk_p),
+    .iic_main_scl_io (iic_scl),
+    .iic_main_sda_io (iic_sda),
+    .uart_sin (uart_sin),
+    .uart_sout (uart_sout),
+    .spi_clk_i (spi_clk),
+    .spi_clk_o (spi_clk),
+    .spi_csn_i (spi_csn),
+    .spi_csn_o (spi_csn),
+    .spi_sdi_i (spi_miso),
+    .spi_sdo_i (spi_mosi),
+    .spi_sdo_o (spi_mosi),
+
+    .spi_2_clk_i (spi_2_clk),
+    .spi_2_clk_o (spi_2_clk),
+    .spi_2_csn_i (spi_2_csn),
+    .spi_2_csn_o (spi_2_csn),
+    .spi_2_sdi_i (spi_2_miso),
+    .spi_2_sdo_i (spi_2_mosi),
+    .spi_2_sdo_o (spi_2_mosi),
+
+    .spi_3_clk_i (spi_3_clk),
+    .spi_3_clk_o (spi_3_clk),
+    .spi_3_csn_i (spi_3_csn),
+    .spi_3_csn_o (spi_3_csn),
+    .spi_3_sdi_i (spi_3_miso),
+    .spi_3_sdo_i (spi_3_mosi),
+    .spi_3_sdo_o (spi_3_mosi),
+
+    .gpio0_i (gpio_i[31:0]),
+    .gpio0_o (gpio_o[31:0]),
+    .gpio0_t (gpio_t[31:0]),
+    .gpio1_i (gpio_i[63:32]),
+    .gpio1_o (gpio_o[63:32]),
+    .gpio1_t (gpio_t[63:32]),
+    // FMCp
+    // quad 121
+    .rx_data_0_n (m2c_n[10]), // {10 15 8 4 11 9 14 13 12 3 1 2 6 0 7 5}
+    .rx_data_0_p (m2c_p[10]),
+    .rx_data_1_n (m2c_n[15]),
+    .rx_data_1_p (m2c_p[15]),
+    .rx_data_2_n (m2c_n[8]),
+    .rx_data_2_p (m2c_p[8]),
+    .rx_data_3_n (m2c_n[4]),
+    .rx_data_3_p (m2c_p[4]),
+    // quad 122
+    .rx_data_4_n (m2c_n[11]),
+    .rx_data_4_p (m2c_p[11]),
+    .rx_data_5_n (m2c_n[9]),
+    .rx_data_5_p (m2c_p[9]),
+    .rx_data_6_n (m2c_n[14]),
+    .rx_data_6_p (m2c_p[14]),
+    .rx_data_7_n (m2c_n[13]),
+    .rx_data_7_p (m2c_p[13]),
+    // quad 125
+    .rx_data_8_n (m2c_n[12]),
+    .rx_data_8_p (m2c_p[12]),
+    .rx_data_9_n (m2c_n[3]),
+    .rx_data_9_p (m2c_p[3]),
+    .rx_data_10_n (m2c_n[1]),
+    .rx_data_10_p (m2c_p[1]),
+    .rx_data_11_n (m2c_n[2]),
+    .rx_data_11_p (m2c_p[2]),
+    // quad 126
+    .rx_data_12_n (m2c_n[6]),
+    .rx_data_12_p (m2c_p[6]),
+    .rx_data_13_n (m2c_n[0]),
+    .rx_data_13_p (m2c_p[0]),
+    .rx_data_14_n (m2c_n[7]),
+    .rx_data_14_p (m2c_p[7]),
+    .rx_data_15_n (m2c_n[5]),
+    .rx_data_15_p (m2c_p[5]),
+    // quad 121
+    .tx_data_0_n (c2m_n[12]), // {12 14 10 4 11 9 8 3 1 2 13 15 6 0 7 5}
+    .tx_data_0_p (c2m_p[12]),
+    .tx_data_1_n (c2m_n[14]),
+    .tx_data_1_p (c2m_p[14]),
+    .tx_data_2_n (c2m_n[10]),
+    .tx_data_2_p (c2m_p[10]),
+    .tx_data_3_n (c2m_n[4]),
+    .tx_data_3_p (c2m_p[4]),
+    // quad 122
+    .tx_data_4_n (c2m_n[11]),
+    .tx_data_4_p (c2m_p[11]),
+    .tx_data_5_n (c2m_n[9]),
+    .tx_data_5_p (c2m_p[9]),
+    .tx_data_6_n (c2m_n[8]),
+    .tx_data_6_p (c2m_p[8]),
+    .tx_data_7_n (c2m_n[3]),
+    .tx_data_7_p (c2m_p[3]),
+    // quad 125
+    .tx_data_8_n (c2m_n[1]),
+    .tx_data_8_p (c2m_p[1]),
+    .tx_data_9_n (c2m_n[2]),
+    .tx_data_9_p (c2m_p[2]),
+    .tx_data_10_n (c2m_n[13]),
+    .tx_data_10_p (c2m_p[13]),
+    .tx_data_11_n (c2m_n[15]),
+    .tx_data_11_p (c2m_p[15]),
+    // quad 126
+    .tx_data_12_n (c2m_n[6]),
+    .tx_data_12_p (c2m_p[6]),
+    .tx_data_13_n (c2m_n[0]),
+    .tx_data_13_p (c2m_p[0]),
+    .tx_data_14_n (c2m_n[7]),
+    .tx_data_14_p (c2m_p[7]),
+    .tx_data_15_n (c2m_n[5]),
+    .tx_data_15_p (c2m_p[5]),
+    .ref_clk_q0 (ref_clk),
+    .ref_clk_q1 (ref_clk),
+    .ref_clk_q2 (ref_clk_replica),
+    .ref_clk_q3 (ref_clk_replica),
+    .rx_device_clk (rx_device_clk),
+    .tx_device_clk (tx_device_clk),
+    .rx_sync_0 (link0_rx_syncout),
+    .tx_sync_0 (link0_tx_syncin),
+    .rx_sysref_0 (sysref),
+    .tx_sysref_0 (sysref),
+    .dac_fifo_bypass (dac_fifo_bypass),
+    .gpio2_i (gpio_i[95:64]),
+    .gpio2_o (gpio_o[95:64]),
+    .gpio2_t (gpio_t[95:64]),
+    .gpio3_i (gpio_i[127:96]),
+    .gpio3_o (gpio_o[127:96]),
+    .gpio3_t (gpio_t[127:96]),
+    .ext_sync (sysref)
+  );
+
+  assign link1_rx_syncout = 4'b1111;
+
+endmodule
+
+// ***************************************************************************
+// ***************************************************************************

--- a/projects/ad_quadmxfe1_ebz/vcu118/timing_constr.xdc
+++ b/projects/ad_quadmxfe1_ebz/vcu118/timing_constr.xdc
@@ -1,0 +1,27 @@
+# Primary clock definitions
+
+# These two reference clocks are connect to the same source on the PCB
+create_clock -name refclk         -period  4.00 [get_ports fpga_clk_m2c_p[0]]
+create_clock -name refclk_replica -period  4.00 [get_ports fpga_clk_m2c_0_replica_n]
+
+# rx device clock
+create_clock -name rx_device_clk     -period  4.00 [get_ports fpga_clk_m2c_p[1]]
+# tx device clock
+create_clock -name tx_device_clk     -period  4.00 [get_ports fpga_clk_m2c_p[2]]
+
+# SPI 2 clock
+create_generated_clock -name spi_2_clk  \
+  -source [get_pins i_system_wrapper/system_i/axi_spi_2/ext_spi_clk] \
+  -divide_by 2 [get_pins i_system_wrapper/system_i/axi_spi_2/sck_o]
+
+# Constraint SYSREFs
+# Assumption is that REFCLK and SYSREF have similar propagation delay,
+# and the SYSREF is a source synchronous Edge-Aligned signal to REFCLK
+set_input_delay -clock [get_clocks rx_device_clk] \
+  [get_property PERIOD [get_clocks rx_device_clk]] \
+  [get_ports {fpga_sysref_m2c_*}]
+set_input_delay -clock [get_clocks tx_device_clk] -add_delay\
+  [get_property PERIOD [get_clocks tx_device_clk]] \
+  [get_ports {fpga_sysref_m2c_*}]
+set_clock_groups -group rx_device_clk -group tx_device_clk -asynchronous
+


### PR DESCRIPTION
This version uses the Xilinx PHY for the 204C modes. Replacing the PHY with the util_adxcvr can be done later since this would break compatibility with excising device trees and would imply a significant amount of work in the Linux side. 

Tested in hardware