### PR TITLE
library/scripts/adi_xilinx_device_info_enc.tcl: Add K26 support

### DIFF
--- a/library/scripts/adi_xilinx_device_info_enc.tcl
+++ b/library/scripts/adi_xilinx_device_info_enc.tcl
@@ -145,6 +145,7 @@ proc adi_device_spec {cellpath param} {
              ^xc7          {set series_name 7series}
              ^xczu         {set series_name ultrascale+}
              ^xc.u.p       {set series_name ultrascale+}
+             ^xck26        {set series_name ultrascale+}
              ^xc.u         {set series_name ultrascale }
              ^xcv[ecmph]   {set series_name versal}
              default {


### PR DESCRIPTION
This PR addresses the issue https://github.com/analogdevicesinc/hdl/issues/795