### PR TITLE
Fix placement errors for ADRV9001 Zed

### DIFF
--- a/library/axi_adrv9001/adrv9001_rx.v
+++ b/library/axi_adrv9001/adrv9001_rx.v
@@ -41,6 +41,7 @@ module adrv9001_rx #(
   parameter NUM_LANES = 3,
   parameter DRP_WIDTH = 5,
   parameter IODELAY_CTRL = 0,
+  parameter USE_BUFG = 0,
   parameter IO_DELAY_GROUP = "dev_if_delay_group"
 ) (
   // device interface
@@ -200,13 +201,15 @@ module adrv9001_rx #(
       .CE (1'b1),
       .I (clk_in_s),
       .O (adc_clk_div_s));
-    /*
-    BUFG I_bufg (
-      .I (adc_clk_div_s),
-      .O (adc_clk_div)
-    );
-    */
-    assign adc_clk_div = adc_clk_div_s;
+
+    if (USE_BUFG == 1) begin
+      BUFG I_bufg (
+        .I (adc_clk_div_s),
+        .O (adc_clk_div)
+      );
+    end else begin
+      assign adc_clk_div = adc_clk_div_s;
+    end
 
     xpm_cdc_async_rst
     # (

--- a/library/axi_adrv9001/adrv9001_tx.v
+++ b/library/axi_adrv9001/adrv9001_tx.v
@@ -39,6 +39,7 @@ module adrv9001_tx #(
   parameter CMOS_LVDS_N = 0,
   parameter NUM_LANES = 4,
   parameter FPGA_TECHNOLOGY = 0,
+  parameter USE_BUFG = 0,
   parameter USE_RX_CLK_FOR_TX = 0
 ) (
   input                   ref_clk,
@@ -188,13 +189,15 @@ module adrv9001_tx #(
         .CE (1'b1),
         .I (tx_dclk_in_s),
         .O (dac_clk_div_s));
-/*
-      BUFG I_bufg (
-        .I (dac_clk_div_s),
-        .O (dac_clk_div)
-      );
-*/
-      assign dac_clk_div = dac_clk_div_s;
+
+      if (USE_BUFG == 1) begin
+        BUFG I_bufg (
+         .I (dac_clk_div_s),
+         .O (dac_clk_div)
+        );
+      end else begin
+        assign dac_clk_div = dac_clk_div_s;
+      end
 
       xpm_cdc_async_rst
       # (

--- a/library/axi_adrv9001/axi_adrv9001.v
+++ b/library/axi_adrv9001/axi_adrv9001.v
@@ -42,6 +42,8 @@ module axi_adrv9001 #(
   parameter DDS_DISABLE = 0,
   parameter INDEPENDENT_1R1T_SUPPORT = 1,
   parameter COMMON_2R2T_SUPPORT = 1,
+  parameter RX_USE_BUFG = 0,
+  parameter TX_USE_BUFG = 0,
   parameter IO_DELAY_GROUP = "dev_if_delay_group",
   parameter FPGA_TECHNOLOGY = 0,
   parameter FPGA_FAMILY = 0,
@@ -269,6 +271,8 @@ module axi_adrv9001 #(
     .FPGA_TECHNOLOGY (FPGA_TECHNOLOGY),
     .NUM_LANES (NUM_LANES),
     .DRP_WIDTH (DRP_WIDTH),
+    .RX_USE_BUFG (RX_USE_BUFG),
+    .TX_USE_BUFG (TX_USE_BUFG),
     .IO_DELAY_GROUP (IO_DELAY_GROUP),
    .USE_RX_CLK_FOR_TX (USE_RX_CLK_FOR_TX)
   ) i_if(

--- a/library/axi_adrv9001/axi_adrv9001_if.v
+++ b/library/axi_adrv9001/axi_adrv9001_if.v
@@ -40,6 +40,8 @@ module axi_adrv9001_if #(
   parameter FPGA_TECHNOLOGY = 0,
   parameter NUM_LANES = 3,
   parameter DRP_WIDTH = 5,
+  parameter RX_USE_BUFG = 0,
+  parameter TX_USE_BUFG = 0,
   parameter IO_DELAY_GROUP = "dev_if_delay_group",
   parameter USE_RX_CLK_FOR_TX = 0
 ) (
@@ -205,6 +207,7 @@ module axi_adrv9001_if #(
       .NUM_LANES (NUM_LANES),
       .DRP_WIDTH (DRP_WIDTH),
       .IODELAY_CTRL (1),
+      .USE_BUFG (RX_USE_BUFG),
       .IO_DELAY_GROUP ({IO_DELAY_GROUP,"_rx"})
     ) i_rx_1_phy (
     .rx_dclk_in_n_NC (rx1_dclk_in_n_NC),
@@ -270,6 +273,7 @@ module axi_adrv9001_if #(
       .NUM_LANES (NUM_LANES),
       .DRP_WIDTH (DRP_WIDTH),
       .IODELAY_CTRL (0),
+      .USE_BUFG (RX_USE_BUFG),
       .IO_DELAY_GROUP ({IO_DELAY_GROUP,"_rx"})
     ) i_rx_2_phy (
     .rx_dclk_in_n_NC (rx2_dclk_in_n_NC),
@@ -331,6 +335,7 @@ module axi_adrv9001_if #(
    .CMOS_LVDS_N (CMOS_LVDS_N),
    .NUM_LANES (TX_NUM_LANES),
    .FPGA_TECHNOLOGY (FPGA_TECHNOLOGY),
+   .USE_BUFG (TX_USE_BUFG),
    .USE_RX_CLK_FOR_TX (USE_RX_CLK_FOR_TX)
   ) i_tx_1_phy (
 
@@ -398,6 +403,7 @@ module axi_adrv9001_if #(
    .CMOS_LVDS_N (CMOS_LVDS_N),
    .NUM_LANES (TX_NUM_LANES),
    .FPGA_TECHNOLOGY (FPGA_TECHNOLOGY),
+   .USE_BUFG (TX_USE_BUFG),
    .USE_RX_CLK_FOR_TX (USE_RX_CLK_FOR_TX)
   ) i_tx_2_phy (
 

--- a/projects/adrv9001/zed/system_bd.tcl
+++ b/projects/adrv9001/zed/system_bd.tcl
@@ -3,6 +3,9 @@ source $ad_hdl_dir/projects/common/zed/zed_system_bd.tcl
 source ../common/adrv9001_bd.tcl
 source $ad_hdl_dir/projects/scripts/adi_pd.tcl
 
+ad_ip_parameter axi_adrv9001 CONFIG.RX_USE_BUFG 1
+ad_ip_parameter axi_adrv9001 CONFIG.TX_USE_BUFG 1
+
 #system ID
 ad_ip_parameter axi_sysid_0 CONFIG.ROM_ADDR_BITS 9
 ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "[pwd]/mem_init_sys.txt"


### PR DESCRIPTION
Occasionally with zed, the implementation failed at the placement stage where the tool could not fit the logic cells inside a single clock region, constraint required by the usage of regional clock buffers. 

This commit allows the usage of the global clock buffers which help the tool in such cases and allow a larger application logic to be implemented in fabric. 