### PR TITLE
ad9081_fmca_ebz_qsys.tcl: Add RX_LANE_RATE and TX_LANE_RATE parameters

### DIFF
--- a/projects/ad9081_fmca_ebz/a10soc/system_project.tcl
+++ b/projects/ad9081_fmca_ebz/a10soc/system_project.tcl
@@ -8,12 +8,15 @@ source ../../scripts/adi_project_intel.tcl
 #   Use over-writable parameters from the environment.
 #
 #    e.g.
-#      make RX_JESD_L=4 RX_JESD_M=8 RX_JESD_S=1 RX_JESD_NP=16 TX_JESD_L=4 TX_JESD_M=8 TX_JESD_S=1 TX_JESD_NP=16 SAMPLE_RATE=250
-#      make RX_JESD_L=8 RX_JESD_M=4 RX_JESD_S=1 RX_JESD_NP=16 TX_JESD_L=8 TX_JESD_M=4 TX_JESD_S=1 TX_JESD_NP=16 SAMPLE_RATE=250
-#      make RX_JESD_L=2 RX_JESD_M=8 RX_JESD_S=1 RX_JESD_NP=12 TX_JESD_L=2 TX_JESD_M=8 TX_JESD_S=1 TX_JESD_NP=12 SAMPLE_RATE=166.66666667
+#      make RX_RATE=10 TX_RATE=10 RX_JESD_L=4 RX_JESD_M=8 RX_JESD_S=1 RX_JESD_NP=16 TX_JESD_L=4 TX_JESD_M=8 TX_JESD_S=1 TX_JESD_NP=16
+#      make RX_RATE=2.5 TX_RATE=2.5 RX_JESD_L=8 RX_JESD_M=4 RX_JESD_S=1 RX_JESD_NP=16 TX_JESD_L=8 TX_JESD_M=4 TX_JESD_S=1 TX_JESD_NP=16
+#      make RX_RATE=10 TX_RATE=10 RX_JESD_L=2 RX_JESD_M=8 RX_JESD_S=1 RX_JESD_NP=12 TX_JESD_L=2 TX_JESD_M=8 TX_JESD_S=1 TX_JESD_NP=12
+#
+# Lane Rate = I/Q Sample Rate x M x N' x (10 \ 8) \ L
 
 adi_project ad9081_fmca_ebz_a10soc [list \
-  SAMPLE_RATE        [get_env_param SAMPLE_RATE  250] \
+  RX_LANE_RATE       [get_env_param RX_RATE      10 ] \
+  TX_LANE_RATE       [get_env_param TX_RATE      10 ] \
   RX_JESD_M          [get_env_param RX_JESD_M    8 ] \
   RX_JESD_L          [get_env_param RX_JESD_L    4 ] \
   RX_JESD_S          [get_env_param RX_JESD_S    1 ] \

--- a/projects/ad9081_fmca_ebz/a10soc/system_top.v
+++ b/projects/ad9081_fmca_ebz/a10soc/system_top.v
@@ -37,7 +37,8 @@
 
 module system_top #(
   // Dummy parameters to workaround critical warning
-  parameter SAMPLE_RATE        = 250,
+  parameter RX_LANE_RATE       = 10,
+  parameter TX_LANE_RATE       = 10,
   parameter RX_JESD_M          = 8,
   parameter RX_JESD_L          = 4,
   parameter RX_JESD_S          = 1,

--- a/projects/ad9081_fmca_ebz/common/ad9081_fmca_ebz_qsys.tcl
+++ b/projects/ad9081_fmca_ebz/common/ad9081_fmca_ebz_qsys.tcl
@@ -1,6 +1,3 @@
-# Common parameter for TX and RX
-set SAMPLE_RATE $ad_project_params(SAMPLE_RATE)
-
 # RX parameters
 set RX_NUM_OF_LINKS $ad_project_params(RX_NUM_LINKS)
 
@@ -47,9 +44,9 @@ set TX_DMA_SAMPLE_WIDTH  16
 set TX_SAMPLES_PER_CHANNEL [expr $TX_NUM_OF_LANES * 8*$TX_TPL_DATA_PATH_WIDTH / \
                                 ($TX_NUM_OF_CONVERTERS * $TX_SAMPLE_WIDTH)]
 
-#Lane Rate = I/Q Sample Rate x M x N' x (10 \ 8) \ L
-set TX_LANE_RATE [expr ($SAMPLE_RATE*$TX_NUM_OF_CONVERTERS*$TX_SAMPLE_WIDTH*10)/(8*$TX_NUM_OF_LANES)]
-set RX_LANE_RATE [expr ($SAMPLE_RATE*$RX_NUM_OF_CONVERTERS*$RX_SAMPLE_WIDTH*10)/(8*$RX_NUM_OF_LANES)]
+# Lane Rate = I/Q Sample Rate x M x N' x (10 \ 8) \ L
+set TX_LANE_RATE [expr $ad_project_params(RX_LANE_RATE)*1000]
+set RX_LANE_RATE [expr $ad_project_params(TX_LANE_RATE)*1000]
 
 set adc_fifo_name mxfe_adc_fifo
 set adc_data_width [expr 8*$RX_TPL_DATA_PATH_WIDTH*$RX_NUM_OF_LANES*$RX_DMA_SAMPLE_WIDTH/$RX_SAMPLE_WIDTH]


### PR DESCRIPTION
For ad9081/a10soc project, the RX_LANE_RATE and TX_LANE_RATE were computed
from SAMPLE_RATE. Remove SAMPLE_RATE and add RX_LANE_RATE and TX_LANE_RATE
as parameters. Update also computation examples from comments.

Signed-off-by: stefan.raus <stefan.raus@analog.com>