### PR TITLE
jesd204_rx/jesd204_lane_latency_monitor.v: Fix for datapath width of 4

### DIFF
--- a/library/jesd204/jesd204_rx/jesd204_lane_latency_monitor.v
+++ b/library/jesd204/jesd204_rx/jesd204_lane_latency_monitor.v
@@ -88,7 +88,7 @@ for (i = 0; i < NUM_LANES; i = i + 1) begin: gen_lane
     end
   end
 
-  assign lane_latency[i*14+13:i*14] = {lane_latency_mem[i],lane_frame_align[(i*DPW_LOG2)+DPW_LOG2-1:i*DPW_LOG2]};
+  assign lane_latency[i*14+13:i*14] = {lane_latency_mem[i],lane_frame_align[(i*3)+DPW_LOG2-1:i*3]};
   assign lane_latency_ready[i] = lane_captured[i];
 end
 endgenerate


### PR DESCRIPTION
Current implementation is correct only for datapath width of 8.
The buswidth of latency measurement inside a beat has a fixed width (3 bits)
for each lane that must be taken in account when computing the total latency.

Tested in simulation.