### PR TITLE
axi_adrv9001/intel: Add dummy parameters to match Xilinx interface

### DIFF
--- a/library/axi_adrv9001/intel/adrv9001_rx.v
+++ b/library/axi_adrv9001/intel/adrv9001_rx.v
@@ -41,6 +41,7 @@ module adrv9001_rx #(
   parameter NUM_LANES = 3,
   parameter DRP_WIDTH = 5,
   parameter IODELAY_CTRL = 0,
+  parameter USE_BUFG = 0,
   parameter IO_DELAY_GROUP = "dev_if_delay_group"
 ) (
   // device interface

--- a/library/axi_adrv9001/intel/adrv9001_tx.v
+++ b/library/axi_adrv9001/intel/adrv9001_tx.v
@@ -39,6 +39,7 @@ module adrv9001_tx #(
   parameter CMOS_LVDS_N = 0,
   parameter NUM_LANES = 4,
   parameter FPGA_TECHNOLOGY = 0,
+  parameter USE_BUFG = 0,
   parameter USE_RX_CLK_FOR_TX = 0
 ) (
   input                   ref_clk,


### PR DESCRIPTION
This commit fixes failures introduces by https://github.com/analogdevicesinc/hdl/commit/fcb16daf5b16ad7c1838c4ff815f7eafab796071

