### PR TITLE
zcu102: ad_fmclidar1_ebz, fmcomms5, fmcomms8 & adrv2crr_fmc: adrv9009zu11eg

### DIFF
--- a/projects/ad_fmclidar1_ebz/zcu102/system_top.v
+++ b/projects/ad_fmclidar1_ebz/zcu102/system_top.v
@@ -119,6 +119,7 @@ module system_top (
   wire            rx_sync;
   wire            rx_sysref;
   wire            rx_device_clk;
+  wire            rx_device_clk_ds;
   wire            laser_driver;
 
   // instantiations
@@ -140,9 +141,13 @@ module system_top (
     .O (rx_sync1_p),
     .OB (rx_sync1_n));
 
-  IBUFGDS i_rx_device_clk (
+  IBUFDS i_rx_device_clk_ds (
     .I (rx_device_clk_p),
     .IB (rx_device_clk_n),
+    .O (rx_device_clk_ds));
+  
+  BUFG  i_rx_device_clk (
+    .I (rx_device_clk_ds),
     .O (rx_device_clk));
 
   IBUFDS i_rx_sysref (

--- a/projects/adrv9009zu11eg/adrv2crr_fmc/system_top.v
+++ b/projects/adrv9009zu11eg/adrv2crr_fmc/system_top.v
@@ -228,11 +228,13 @@ module system_top (
 
   wire            ref_clk_a;
   wire            core_clk_a;
+  wire            core_clk_a_ds;
   wire            rx_sync_rx;
   wire            tx_sync_a;
   wire            sysref_a;
   wire            ref_clk_b;
   wire            core_clk_b;
+  wire            core_clk_b_ds;
   wire            rx_sync_obs;
   wire            rx_os_sync_b;
   wire            tx_sync_b;
@@ -408,15 +410,23 @@ module system_top (
     .IB (sysref_b_n),
     .O (sysref_b));
 
-  IBUFGDS i_rx_clk_ibufg_1 (
+  IBUFDS i_rx_clk_ibuf_1 (
     .I (core_clk_a_p),
     .IB (core_clk_a_n),
-    .O (core_clk_a));
-
-  IBUFGDS i_rx_clk_ibufg_2 (
+    .O (core_clk_a_ds));
+ 
+  BUFG i_clk_bufg_1 (
+     .I (core_clk_a_ds),
+     .O (core_clk_a));
+   
+  IBUFDS i_rx_clk_ibuf_2 (
     .I (core_clk_b_p),
     .IB (core_clk_b_n),
-    .O (core_clk_b));
+    .O (core_clk_b_ds));
+
+  BUFG i_clk_bufg_2 (
+     .I (core_clk_b_ds),
+     .O (core_clk_b));
 
   IBUFDS i_ibufds_tx_sync_1 (
     .I (tx_sync_a_p),

--- a/projects/adrv9009zu11eg/adrv2crr_xmicrowave/system_top.v
+++ b/projects/adrv9009zu11eg/adrv2crr_xmicrowave/system_top.v
@@ -291,11 +291,13 @@ module system_top (
 
   wire            ref_clk_a;
   wire            core_clk_a;
+  wire            core_clk_a_ds;
   wire            rx_sync_rx;
   wire            tx_sync_a;
   wire            sysref_a;
   wire            ref_clk_b;
   wire            core_clk_b;
+  wire            core_clk_b_ds;
   wire            rx_sync_obs;
   wire            rx_os_sync_b;
   wire            tx_sync_b;
@@ -510,15 +512,23 @@ module system_top (
     .IB (sysref_b_n),
     .O (sysref_b));
 
-  IBUFGDS i_rx_clk_ibufg_1 (
+  IBUFDS i_rx_clk_ibuf_1 (
     .I (core_clk_a_p),
     .IB (core_clk_a_n),
-    .O (core_clk_a));
+    .O (core_clk_a_ds));
 
-  IBUFGDS i_rx_clk_ibufg_2 (
+  BUFG i_rx_clk_ibufg_1 (
+     .I (core_clk_a_ds),
+     .O (core_clk_a));
+
+  IBUFDS i_rx_clk_ibuf_2 (
     .I (core_clk_b_p),
     .IB (core_clk_b_n),
-    .O (core_clk_b));
+    .O (core_clk_b_ds));
+
+  BUFG i_rx_clk_ibufg_2 (
+     .I (core_clk_b_ds),
+     .O (core_clk_b));
 
   IBUFDS i_ibufds_tx_sync_1 (
     .I (tx_sync_a_p),

--- a/projects/fmcomms5/zcu102/system_top.v
+++ b/projects/fmcomms5/zcu102/system_top.v
@@ -107,6 +107,7 @@ module system_top (
 
   wire            sys_100m_resetn;
   wire            ref_clk_s;
+  wire            ref_clk_s_ds;
   wire            ref_clk;
   wire    [ 94:0] gpio_i;
   wire    [ 94:0] gpio_o;
@@ -134,9 +135,13 @@ module system_top (
 
   // instantiations
 
-  IBUFGDS i_ref_clk_ibuf (
+  IBUFDS i_ref_clk_ibuf_ds (
     .I (ref_clk_p),
     .IB (ref_clk_n),
+    .O (ref_clk_s_ds));
+
+  BUFG i_ref_clk_ibuf (
+    .I (ref_clk_s_ds),
     .O (ref_clk_s));
 
   BUFR #(.BUFR_DIVIDE("BYPASS")) i_ref_clk_rbuf (

--- a/projects/fmcomms8/zcu102/system_top.v
+++ b/projects/fmcomms8/zcu102/system_top.v
@@ -145,11 +145,13 @@ module system_top (
 
   wire            ref_clk_c;
   wire            core_clk_c;
+  wire            core_clk_c_ds;
   wire            rx_sync_rx;
   wire            tx_sync_c;
   wire            sysref_c;
   wire            ref_clk_d;
   wire            core_clk_d;
+  wire            core_clk_d_ds; 
   wire            rx_sync_obs;
   wire            rx_os_sync_d;
   wire            tx_sync_d;
@@ -257,14 +259,22 @@ module system_top (
     .IB (sysref_d_n),
     .O (sysref_d));
 
-  IBUFGDS i_rx_clk_ibufg_1 (
+  IBUFDS i_rx_clk_ibuf_1 (
     .I (core_clk_c_p),
     .IB (core_clk_c_n),
+    .O (core_clk_c_ds));
+
+  BUFG i_rx_clk_ibufg_1 (
+    .I (core_clk_c_ds),
     .O (core_clk_c));
 
-  IBUFGDS i_rx_clk_ibufg_2 (
+  IBUFDS i_rx_clk_ibuf_2 (
     .I (core_clk_d_p),
     .IB (core_clk_d_n),
+    .O (core_clk_d_ds));
+
+  BUFG i_rx_clk_ibufg_2(
+    .I (core_clk_d_ds),
     .O (core_clk_d));
 
   IBUFDS i_ibufds_tx_sync_1 (


### PR DESCRIPTION
The IBUFGDS primitive is deprecated in UltraScale devices.