### PR TITLE
ad9081_fmca_ebz: Fix critical warnings

### DIFF
--- a/projects/ad9081_fmca_ebz/common/versal_transceiver.tcl
+++ b/projects/ad9081_fmca_ebz/common/versal_transceiver.tcl
@@ -19,7 +19,6 @@ create_bd_pin -dir O ${ip_name}/txusrclk_out -type clk
 create_bd_pin -dir I ${ip_name}/GT_REFCLK -type clk
 
 create_bd_pin -dir I ${ip_name}/apb3clk -type clk
-create_bd_pin -dir I ${ip_name}/gtreset_in
 create_bd_pin -dir I ${ip_name}/reset_rx_pll_and_datapath_in
 create_bd_pin -dir I ${ip_name}/reset_tx_pll_and_datapath_in
 

--- a/projects/ad9081_fmca_ebz/vcu128/timing_constr.xdc
+++ b/projects/ad9081_fmca_ebz/vcu128/timing_constr.xdc
@@ -27,12 +27,10 @@ set tx_device_clk [expr $tx_link_clk*$tx_ll_width/$tx_tpl_width]
 set rx_device_clk_period [expr 1000/$rx_device_clk]
 set tx_device_clk_period [expr 1000/$tx_device_clk]
 
-# refclk and refclk_replica are connect to the same source on the PCB
 # Set reference clock to same frequency as the link clock, 
 # this will ease the XCVR out clocks propagation calculation.
 # TODO: this restricts RX_LANE_RATE=TX_LANE_RATE
 create_clock -name refclk         -period  $rx_link_clk_period [get_ports fpga_refclk_in_p]
-create_clock -name refclk_replica -period  $rx_link_clk_period [get_ports fpga_refclk_in_replica_p]
 
 # device clock
 create_clock -name rx_device_clk     -period  $rx_device_clk_period [get_ports clkin8_p]


### PR DESCRIPTION
Fix the critical warnings introduced by: https://github.com/analogdevicesinc/hdl/pull/808 and https://github.com/analogdevicesinc/hdl/pull/797