### PR TITLE
ad9081_fmca_ebz: Fix signal length parameter

### DIFF
--- a/projects/ad9081_fmca_ebz/zc706/system_top.v
+++ b/projects/ad9081_fmca_ebz/zc706/system_top.v
@@ -342,8 +342,8 @@ module system_top  #(
     .tx_sysref_0 (sysref)
   );
 
-  assign rx_data_p_loc[TX_JESD_L*TX_NUM_LINKS-1:0] = rx_data_p[TX_JESD_L*TX_NUM_LINKS-1:0];
-  assign rx_data_n_loc[TX_JESD_L*TX_NUM_LINKS-1:0] = rx_data_n[TX_JESD_L*TX_NUM_LINKS-1:0];
+  assign rx_data_p_loc[RX_JESD_L*RX_NUM_LINKS-1:0] = rx_data_p[RX_JESD_L*RX_NUM_LINKS-1:0];
+  assign rx_data_n_loc[RX_JESD_L*RX_NUM_LINKS-1:0] = rx_data_n[RX_JESD_L*RX_NUM_LINKS-1:0];
 
   assign tx_data_p[TX_JESD_L*TX_NUM_LINKS-1:0] = tx_data_p_loc[TX_JESD_L*TX_NUM_LINKS-1:0];
   assign tx_data_n[TX_JESD_L*TX_NUM_LINKS-1:0] = tx_data_n_loc[TX_JESD_L*TX_NUM_LINKS-1:0];


### PR DESCRIPTION
Corrected the length parameter for the rx_data input.

Signed-off-by: Dan Hotoleanu <dan.hotoleanu@analog.com>