### PR TITLE
daq2: Parameterize JESD204 configuration values

### DIFF
--- a/projects/daq2/kc705/system_project.tcl
+++ b/projects/daq2/kc705/system_project.tcl
@@ -3,7 +3,28 @@ source ../../scripts/adi_env.tcl
 source $ad_hdl_dir/projects/scripts/adi_project_xilinx.tcl
 source $ad_hdl_dir/projects/scripts/adi_board.tcl
 
-adi_project daq2_kc705
+# get_env_param retrieves parameter value from the environment if exists,
+# other case use the default value
+#
+#   Use over-writable parameters from the environment.
+#
+#    e.g.
+#      make RX_JESD_L=4 RX_JESD_M=2 TX_JESD_L=4 TX_JESD_M=2 
+
+# Parameter description:
+#   [RX/TX]_JESD_M : Number of converters per link
+#   [RX/TX]_JESD_L : Number of lanes per link
+#   [RX/TX]_JESD_S : Number of samples per frame
+
+adi_project daq2_kc705 0 [list \
+  RX_JESD_M    [get_env_param RX_JESD_M    2 ] \
+  RX_JESD_L    [get_env_param RX_JESD_L    4 ] \
+  RX_JESD_S    [get_env_param RX_JESD_S    1 ] \
+  TX_JESD_M    [get_env_param TX_JESD_M    2 ] \
+  TX_JESD_L    [get_env_param TX_JESD_L    4 ] \
+  TX_JESD_S    [get_env_param TX_JESD_S    1 ] \
+]
+
 adi_project_files daq2_kc705 [list \
   "../common/daq2_spi.v" \
   "system_top.v" \
@@ -13,4 +34,6 @@ adi_project_files daq2_kc705 [list \
 
 adi_project_run daq2_kc705
 
+## To improve timing in the axi_ad9680_offload component
+set_property strategy Performance_Retiming [get_runs impl_1]
 

--- a/projects/daq2/kcu105/system_project.tcl
+++ b/projects/daq2/kcu105/system_project.tcl
@@ -3,7 +3,28 @@ source ../../scripts/adi_env.tcl
 source $ad_hdl_dir/projects/scripts/adi_project_xilinx.tcl
 source $ad_hdl_dir/projects/scripts/adi_board.tcl
 
-adi_project daq2_kcu105
+# get_env_param retrieves parameter value from the environment if exists,
+# other case use the default value
+#
+#   Use over-writable parameters from the environment.
+#
+#    e.g.
+#      make RX_JESD_L=4 RX_JESD_M=2 TX_JESD_L=4 TX_JESD_M=2 
+
+# Parameter description:
+#   [RX/TX]_JESD_M : Number of converters per link
+#   [RX/TX]_JESD_L : Number of lanes per link
+#   [RX/TX]_JESD_S : Number of samples per frame
+
+adi_project daq2_kcu105 0 [list \
+  RX_JESD_M    [get_env_param RX_JESD_M    2 ] \
+  RX_JESD_L    [get_env_param RX_JESD_L    4 ] \
+  RX_JESD_S    [get_env_param RX_JESD_S    1 ] \
+  TX_JESD_M    [get_env_param TX_JESD_M    2 ] \
+  TX_JESD_L    [get_env_param TX_JESD_L    4 ] \
+  TX_JESD_S    [get_env_param TX_JESD_S    1 ] \
+]
+
 adi_project_files daq2_kcu105 [list \
   "../common/daq2_spi.v" \
   "system_top.v" \
@@ -15,5 +36,4 @@ adi_project_files daq2_kcu105 [list \
 set_property strategy Performance_Retiming [get_runs impl_1]
 
 adi_project_run daq2_kcu105
-
 

--- a/projects/daq2/zc706/system_project.tcl
+++ b/projects/daq2/zc706/system_project.tcl
@@ -3,7 +3,28 @@ source ../../scripts/adi_env.tcl
 source $ad_hdl_dir/projects/scripts/adi_project_xilinx.tcl
 source $ad_hdl_dir/projects/scripts/adi_board.tcl
 
-adi_project daq2_zc706
+# get_env_param retrieves parameter value from the environment if exists,
+# other case use the default value
+#
+#   Use over-writable parameters from the environment.
+#
+#    e.g.
+#      make RX_JESD_L=4 RX_JESD_M=2 TX_JESD_L=4 TX_JESD_M=2 
+
+# Parameter description:
+#   [RX/TX]_JESD_M : Number of converters per link
+#   [RX/TX]_JESD_L : Number of lanes per link
+#   [RX/TX]_JESD_S : Number of samples per frame
+
+adi_project daq2_zc706 0 [list \
+  RX_JESD_M    [get_env_param RX_JESD_M    2 ] \
+  RX_JESD_L    [get_env_param RX_JESD_L    4 ] \
+  RX_JESD_S    [get_env_param RX_JESD_S    1 ] \
+  TX_JESD_M    [get_env_param TX_JESD_M    2 ] \
+  TX_JESD_L    [get_env_param TX_JESD_L    4 ] \
+  TX_JESD_S    [get_env_param TX_JESD_S    1 ] \
+]
+
 adi_project_files daq2_zc706 [list \
   "../common/daq2_spi.v" \
   "system_top.v" \
@@ -13,5 +34,8 @@ adi_project_files daq2_zc706 [list \
   "$ad_hdl_dir/projects/common/zc706/zc706_system_constr.xdc" ]
 
 adi_project_run daq2_zc706
+
+## To improve timing in the axi_ad9680_offload component
+set_property strategy Performance_Retiming [get_runs impl_1]
 
 

--- a/projects/daq2/zcu102/system_project.tcl
+++ b/projects/daq2/zcu102/system_project.tcl
@@ -3,7 +3,28 @@ source ../../scripts/adi_env.tcl
 source $ad_hdl_dir/projects/scripts/adi_project_xilinx.tcl
 source $ad_hdl_dir/projects/scripts/adi_board.tcl
 
-adi_project daq2_zcu102
+# get_env_param retrieves parameter value from the environment if exists,
+# other case use the default value
+#
+#   Use over-writable parameters from the environment.
+#
+#    e.g.
+#      make RX_JESD_L=4 RX_JESD_M=2 TX_JESD_L=4 TX_JESD_M=2 
+
+# Parameter description:
+#   [RX/TX]_JESD_M : Number of converters per link
+#   [RX/TX]_JESD_L : Number of lanes per link
+#   [RX/TX]_JESD_S : Number of samples per frame
+
+adi_project daq2_zcu102 0 [list \
+  RX_JESD_M    [get_env_param RX_JESD_M    2 ] \
+  RX_JESD_L    [get_env_param RX_JESD_L    4 ] \
+  RX_JESD_S    [get_env_param RX_JESD_S    1 ] \
+  TX_JESD_M    [get_env_param TX_JESD_M    2 ] \
+  TX_JESD_L    [get_env_param TX_JESD_L    4 ] \
+  TX_JESD_S    [get_env_param TX_JESD_S    1 ] \
+]
+
 adi_project_files daq2_zcu102 [list \
   "../common/daq2_spi.v" \
   "system_top.v" \
@@ -13,4 +34,5 @@ adi_project_files daq2_zcu102 [list \
 
 adi_project_run daq2_zcu102
 
-
+## To improve timing in the axi_ad9680_offload component
+set_property strategy Performance_Retiming [get_runs impl_1]


### PR DESCRIPTION
Added the capability to set the JESD204 configuration values from a single
point in the code and to modify these default settings from the command
line for the Xilinx FPGAs in the project.

Signed-off-by: Dan Hotoleanu <dan.hotoleanu@analog.com>