### PR TITLE
scripts/adi_xilinx_device_info_enc.tcl: Change regex for vcu128

### DIFF
--- a/library/scripts/adi_xilinx_device_info_enc.tcl
+++ b/library/scripts/adi_xilinx_device_info_enc.tcl
@@ -144,7 +144,7 @@ proc adi_device_spec {cellpath param} {
           switch  -regexp -- $part {
              ^xc7          {set series_name 7series}
              ^xczu         {set series_name ultrascale+}
-             ^xc.u.p       {set series_name ultrascale+}
+             ^xc.u..?p     {set series_name ultrascale+}
              ^xck26        {set series_name ultrascale+}
              ^xc.u         {set series_name ultrascale }
              ^xcv[ecmph]   {set series_name versal}


### PR DESCRIPTION
The regex does not work for vcu128. It sets it as Ultrascale instead of Ultrascale+.

The part can be found here: https://github.com/analogdevicesinc/hdl/blob/master/projects/scripts/adi_project_xilinx.tcl#L85

And the regex is here: https://github.com/analogdevicesinc/hdl/blob/master/library/scripts/adi_xilinx_device_info_enc.tcl#L147

I made a build for the project and checked the axi_mxfe_tx_xcvr IP and it has ultrascale set as fpga technology.


![UltrascaleIP](https://user-images.githubusercontent.com/84326610/149130852-30dff2de-8067-466e-b698-82283b3a8773.png)
