### PR TITLE
axi_tdd: Add false paths to tdd sync input

### DIFF
--- a/library/axi_tdd/Makefile
+++ b/library/axi_tdd/Makefile
@@ -16,7 +16,7 @@ GENERIC_DEPS += axi_tdd.v
 
 XILINX_DEPS += ../xilinx/common/up_xfer_cntrl_constr.xdc
 XILINX_DEPS += ../xilinx/common/up_xfer_status_constr.xdc
-XILINX_DEPS += axi_tdd_constr.xdc
+XILINX_DEPS += axi_tdd_constr.ttcl
 XILINX_DEPS += axi_tdd_ip.tcl
 
 include ../scripts/library.mk

--- a/library/axi_tdd/axi_tdd.v
+++ b/library/axi_tdd/axi_tdd.v
@@ -35,7 +35,13 @@
 
 `timescale 1ns/1ps
 
-module axi_tdd (
+module axi_tdd #(
+  // Boolean. Whether a false path constraint should be introduced for the tdd_sync
+  // trigger input. This allows asynchronous (or external) sources to be used.
+  // Note: This parameter isn't used inside of the core, but just for the
+  // configuration of the constraints file.
+  parameter ASYNC_TDD_SYNC = 1
+) (
 
   // clock
 

--- a/library/axi_tdd/axi_tdd_constr.ttcl
+++ b/library/axi_tdd/axi_tdd_constr.ttcl
@@ -1,0 +1,16 @@
+<: set ComponentName [getComponentNameString] :>
+<: setOutputDirectory "./" :>
+<: setFileName [ttcl_add $ComponentName "_constr"] :>
+<: setFileExtension ".xdc" :>
+<: setFileProcessingOrder late :>
+<: set async_tdd_sync [getBooleanValue "ASYNC_TDD_SYNC"] :>
+
+## For RX in case of BRAMs
+<: if { $async_tdd_sync == 1 } { :>
+
+# TDD sync false paths
+set_property ASYNC_REG TRUE [get_cells -hier -filter {name =~ *tdd_sync_d && IS_SEQUENTIAL}]
+set_false_path -quiet -to [get_cells -quiet -hier -filter {name =~ *tdd_sync_d1_reg && IS_SEQUENTIAL}]
+
+<: } :>
+

--- a/library/axi_tdd/axi_tdd_constr.xdc
+++ b/library/axi_tdd/axi_tdd_constr.xdc
@@ -1,3 +1,0 @@
-# TDD sync false paths
-set_property ASYNC_REG TRUE [get_cells -hier -filter {name =~ *tdd_sync_d && IS_SEQUENTIAL}]
-set_false_path -quiet -to [get_cells -quiet -hier -filter {name =~ *tdd_sync_d1_reg && IS_SEQUENTIAL}]

--- a/library/axi_tdd/axi_tdd_constr.xdc
+++ b/library/axi_tdd/axi_tdd_constr.xdc
@@ -1,0 +1,3 @@
+# TDD sync false paths
+set_property ASYNC_REG TRUE [get_cells -hier -filter {name =~ *tdd_sync_d && IS_SEQUENTIAL}]
+set_false_path -quiet -to [get_cells -quiet -hier -filter {name =~ *tdd_sync_d1_reg && IS_SEQUENTIAL}]

--- a/library/axi_tdd/axi_tdd_ip.tcl
+++ b/library/axi_tdd/axi_tdd_ip.tcl
@@ -13,10 +13,10 @@ adi_ip_files axi_tdd [list \
   "$ad_hdl_dir/library/common/up_axi.v" \
   "$ad_hdl_dir/library/xilinx/common/up_xfer_status_constr.xdc" \
   "$ad_hdl_dir/library/xilinx/common/up_xfer_cntrl_constr.xdc" \
-  "axi_tdd_constr.xdc" \
   "axi_tdd.v" ]
 
 adi_ip_properties axi_tdd
+adi_ip_ttcl axi_tdd "axi_tdd_constr.ttcl"
 set_property display_name "ADI AXI TDD Controller" [ipx::current_core]
 set_property description "ADI AXI TDD Controller" [ipx::current_core]
 set_property company_url {https://wiki.analog.com/resources/fpga/docs/axi_tdd} [ipx::current_core]
@@ -37,6 +37,25 @@ add_reset s_axi_aresetn ACTIVE_LOW
 
 ipx::add_bus_parameter ASSOCIATED_BUSIF [ipx::get_bus_interfaces s_axi_aclk -of_objects [ipx::current_core]]
 set_property value s_axi [ipx::get_bus_parameters ASSOCIATED_BUSIF -of_objects [ipx::get_bus_interfaces s_axi_aclk -of_objects [ipx::current_core]]]
+
+set cc [ipx::current_core]
+## Remove the automatically generated GUI page
+ipgui::remove_page -component $cc [ipgui::get_pagespec -name "Page 0" -component $cc]
+ipx::save_core [ipx::current_core]
+
+## Create a new GUI page
+ipgui::add_page -name {ADI AXI TDD Controller} -component [ipx::current_core] -display_name {ADI AXI TDD Controller}
+set page0 [ipgui::get_pagespec -name "ADI AXI TDD Controller" -component $cc]
+
+## General Configurations
+set general_group [ipgui::add_group -name "General Configuration" -component $cc \
+    -parent $page0 -display_name "General Configuration" ]
+
+set param [ipgui::add_param -name {ASYNC_TDD_SYNC} -component $cc -parent $page0]
+set_property -dict [list \
+	display_name {Insert false path for tdd_sync} \
+	widget {checkBox} \
+] $param
 
 ipx::create_xgui_files [ipx::current_core]
 

--- a/projects/ad9081_fmca_ebz/common/ad9081_fmca_ebz_bd.tcl
+++ b/projects/ad9081_fmca_ebz/common/ad9081_fmca_ebz_bd.tcl
@@ -502,7 +502,7 @@ if {$TDD_SUPPORT} {
   ad_connect tdd_sync_0/sync_mode GND
   ad_ip_parameter tdd_sync_0 CONFIG.TDD_SYNC_PERIOD 250000000; # More or less 1 PPS ;)
 
-  ad_ip_instance axi_tdd axi_tdd_0
+  ad_ip_instance axi_tdd axi_tdd_0 [list ASYNC_TDD_SYNC 0]
   ad_connect tx_device_clk axi_tdd_0/clk
   ad_connect tx_device_clk_rstgen/peripheral_reset axi_tdd_0/rst
   ad_connect $sys_cpu_clk axi_tdd_0/s_axi_aclk


### PR DESCRIPTION
This allows the external synchronization input to be driven from
asynchronous sources like a 1 PPS signal or just signals from different
clock domains in general.