### PR TITLE
daq3: Parameterize JESD204 configuration values

### DIFF
--- a/projects/daq3/kcu105/system_project.tcl
+++ b/projects/daq3/kcu105/system_project.tcl
@@ -3,7 +3,28 @@ source ../../scripts/adi_env.tcl
 source $ad_hdl_dir/projects/scripts/adi_project_xilinx.tcl
 source $ad_hdl_dir/projects/scripts/adi_board.tcl
 
-adi_project daq3_kcu105
+# get_env_param retrieves parameter value from the environment if exists,
+# other case use the default value
+#
+#   Use over-writable parameters from the environment.
+#
+#    e.g.
+#      make RX_JESD_L=4 RX_JESD_M=2 TX_JESD_L=4 TX_JESD_M=2 
+
+# Parameter description:
+#   [RX/TX]_JESD_M : Number of converters per link
+#   [RX/TX]_JESD_L : Number of lanes per link
+#   [RX/TX]_JESD_S : Number of samples per frame
+
+adi_project daq3_kcu105 0 [list \
+  RX_JESD_M    [get_env_param RX_JESD_M    2 ] \
+  RX_JESD_L    [get_env_param RX_JESD_L    4 ] \
+  RX_JESD_S    [get_env_param RX_JESD_S    1 ] \
+  TX_JESD_M    [get_env_param TX_JESD_M    2 ] \
+  TX_JESD_L    [get_env_param TX_JESD_L    4 ] \
+  TX_JESD_S    [get_env_param TX_JESD_S    1 ] \
+]
+
 adi_project_files daq3_kcu105 [list \
   "../common/daq3_spi.v" \
   "system_top.v" \

--- a/projects/daq3/vcu118/system_project.tcl
+++ b/projects/daq3/vcu118/system_project.tcl
@@ -3,7 +3,28 @@ source ../../scripts/adi_env.tcl
 source $ad_hdl_dir/projects/scripts/adi_project_xilinx.tcl
 source $ad_hdl_dir/projects/scripts/adi_board.tcl
 
-adi_project daq3_vcu118
+# get_env_param retrieves parameter value from the environment if exists,
+# other case use the default value
+#
+#   Use over-writable parameters from the environment.
+#
+#    e.g.
+#      make RX_JESD_L=4 RX_JESD_M=2 TX_JESD_L=4 TX_JESD_M=2 
+
+# Parameter description:
+#   [RX/TX]_JESD_M : Number of converters per link
+#   [RX/TX]_JESD_L : Number of lanes per link
+#   [RX/TX]_JESD_S : Number of samples per frame
+
+adi_project daq3_vcu118 0 [list \
+  RX_JESD_M    [get_env_param RX_JESD_M    2 ] \
+  RX_JESD_L    [get_env_param RX_JESD_L    4 ] \
+  RX_JESD_S    [get_env_param RX_JESD_S    1 ] \
+  TX_JESD_M    [get_env_param TX_JESD_M    2 ] \
+  TX_JESD_L    [get_env_param TX_JESD_L    4 ] \
+  TX_JESD_S    [get_env_param TX_JESD_S    1 ] \
+]
+
 adi_project_files daq3_vcu118 [list \
   "../common/daq3_spi.v" \
   "system_top.v" \

--- a/projects/daq3/zc706/system_project.tcl
+++ b/projects/daq3/zc706/system_project.tcl
@@ -1,11 +1,30 @@
 
-
-
 source ../../scripts/adi_env.tcl
 source $ad_hdl_dir/projects/scripts/adi_project_xilinx.tcl
 source $ad_hdl_dir/projects/scripts/adi_board.tcl
 
-adi_project daq3_zc706
+# get_env_param retrieves parameter value from the environment if exists,
+# other case use the default value
+#
+#   Use over-writable parameters from the environment.
+#
+#    e.g.
+#      make RX_JESD_L=4 RX_JESD_M=2 TX_JESD_L=4 TX_JESD_M=2
+
+# Parameter description:
+#   [RX/TX]_JESD_M : Number of converters per link
+#   [RX/TX]_JESD_L : Number of lanes per link
+#   [RX/TX]_JESD_S : Number of samples per frame
+
+adi_project daq3_zc706 0 [list \
+  RX_JESD_M    [get_env_param RX_JESD_M    2 ] \
+  RX_JESD_L    [get_env_param RX_JESD_L    4 ] \
+  RX_JESD_S    [get_env_param RX_JESD_S    1 ] \
+  TX_JESD_M    [get_env_param TX_JESD_M    2 ] \
+  TX_JESD_L    [get_env_param TX_JESD_L    4 ] \
+  TX_JESD_S    [get_env_param TX_JESD_S    1 ] \
+]
+
 adi_project_files daq3_zc706 [list \
   "../common/daq3_spi.v" \
   "system_top.v" \

--- a/projects/daq3/zcu102/system_project.tcl
+++ b/projects/daq3/zcu102/system_project.tcl
@@ -3,7 +3,28 @@ source ../../scripts/adi_env.tcl
 source $ad_hdl_dir/projects/scripts/adi_project_xilinx.tcl
 source $ad_hdl_dir/projects/scripts/adi_board.tcl
 
-adi_project daq3_zcu102
+# get_env_param retrieves parameter value from the environment if exists,
+# other case use the default value
+#
+#   Use over-writable parameters from the environment.
+#
+#    e.g.
+#      make RX_JESD_L=4 RX_JESD_M=2 TX_JESD_L=4 TX_JESD_M=2 
+
+# Parameter description:
+#   [RX/TX]_JESD_M : Number of converters per link
+#   [RX/TX]_JESD_L : Number of lanes per link
+#   [RX/TX]_JESD_S : Number of samples per frame
+
+adi_project daq3_zcu102 0 [list \
+  RX_JESD_M    [get_env_param RX_JESD_M    2 ] \
+  RX_JESD_L    [get_env_param RX_JESD_L    4 ] \
+  RX_JESD_S    [get_env_param RX_JESD_S    1 ] \
+  TX_JESD_M    [get_env_param TX_JESD_M    2 ] \
+  TX_JESD_L    [get_env_param TX_JESD_L    4 ] \
+  TX_JESD_S    [get_env_param TX_JESD_S    1 ] \
+]
+
 adi_project_files daq3_zcu102 [list \
   "../common/daq3_spi.v" \
   "system_top.v" \


### PR DESCRIPTION
Added the capability to set the JESD204 configuration values from a single
point in the code and to modify these default settings from the command
line for the Xilinx FPGAs in the project.

Signed-off-by: Dan Hotoleanu <dan.hotoleanu@analog.com>