### PR TITLE
dac_fmc_ebz_bd.tcl: Updated bd for multiple tx_ref_clk

### DIFF
--- a/projects/dac_fmc_ebz/zc706/system_constr.xdc
+++ b/projects/dac_fmc_ebz/zc706/system_constr.xdc
@@ -36,22 +36,22 @@
 set_property  -dict {PACKAGE_PIN  AD10} [get_ports tx_ref_clk_p]                                      ; ## D04  FMC_HPC_GBTCLK0_M2C_P           MGTREFCLK0P_109_AD10
 set_property  -dict {PACKAGE_PIN  AD9 } [get_ports tx_ref_clk_n]                                      ; ## D05  FMC_HPC_GBTCLK0_M2C_N           MGTREFCLK0N_109_AD9
 
-set_property  -quiet -dict {PACKAGE_PIN  AK10} [get_ports tx_data_p[7]]                               ; ## C02  FMC_HPC_DP0_C2M_P               MGTXTXP0_109_AK10
-set_property  -quiet -dict {PACKAGE_PIN  AK9 } [get_ports tx_data_n[7]]                               ; ## C03  FMC_HPC_DP0_C2M_N               MGTXTXN0_109_AK9
-set_property  -quiet -dict {PACKAGE_PIN  AK6 } [get_ports tx_data_p[6]]                               ; ## A22  FMC_HPC_DP1_C2M_P               MGTXTXP1_109_AK6
-set_property  -quiet -dict {PACKAGE_PIN  AK5 } [get_ports tx_data_n[6]]                               ; ## A23  FMC_HPC_DP1_C2M_N               MGTXTXN1_109_AK5
-set_property  -quiet -dict {PACKAGE_PIN  AJ4 } [get_ports tx_data_p[5]]                               ; ## A26  FMC_HPC_DP2_C2M_P               MGTXTXP2_109_AJ4
-set_property  -quiet -dict {PACKAGE_PIN  AJ3 } [get_ports tx_data_n[5]]                               ; ## A27  FMC_HPC_DP2_C2M_N               MGTXTXN2_109_AJ3
-set_property  -quiet -dict {PACKAGE_PIN  AK2 } [get_ports tx_data_p[4]]                               ; ## A30  FMC_HPC_DP3_C2M_P               MGTXTXP3_109_AK2
-set_property  -quiet -dict {PACKAGE_PIN  AK1 } [get_ports tx_data_n[4]]                               ; ## A31  FMC_HPC_DP3_C2M_N               MGTXTXN3_109_AK1
-set_property  -quiet -dict {PACKAGE_PIN  AH2 } [get_ports tx_data_p[2]]                               ; ## A34  FMC_HPC_DP4_C2M_P               MGTXTXP0_110_AH2
-set_property  -quiet -dict {PACKAGE_PIN  AH1 } [get_ports tx_data_n[2]]                               ; ## A35  FMC_HPC_DP4_C2M_N               MGTXTXN0_110_AH1
-set_property  -quiet -dict {PACKAGE_PIN  AF2 } [get_ports tx_data_p[0]]                               ; ## A38  FMC_HPC_DP5_C2M_P               MGTXTXP1_110_AF2
-set_property  -quiet -dict {PACKAGE_PIN  AF1 } [get_ports tx_data_n[0]]                               ; ## A39  FMC_HPC_DP5_C2M_N               MGTXTXN1_110_AF1
-set_property  -quiet -dict {PACKAGE_PIN  AE4 } [get_ports tx_data_p[1]]                               ; ## B36  FMC_HPC_DP6_C2M_P               MGTXTXP2_110_AE4
-set_property  -quiet -dict {PACKAGE_PIN  AE3 } [get_ports tx_data_n[1]]                               ; ## B37  FMC_HPC_DP6_C2M_N               MGTXTXN2_110_AE3
-set_property  -quiet -dict {PACKAGE_PIN  AD2 } [get_ports tx_data_p[3]]                               ; ## B32  FMC_HPC_DP7_C2M_P               MGTXTXP3_110_AD2
-set_property  -quiet -dict {PACKAGE_PIN  AD1 } [get_ports tx_data_n[3]]                               ; ## B33  FMC_HPC_DP7_C2M_N               MGTXTXN3_110_AD1
+set_property  -dict {PACKAGE_PIN  AK10} [get_ports tx_data_p[7]]                                      ; ## C02  FMC_HPC_DP0_C2M_P               MGTXTXP0_109_AK10
+set_property  -dict {PACKAGE_PIN  AK9 } [get_ports tx_data_n[7]]                                      ; ## C03  FMC_HPC_DP0_C2M_N               MGTXTXN0_109_AK9
+set_property  -dict {PACKAGE_PIN  AK6 } [get_ports tx_data_p[6]]                                      ; ## A22  FMC_HPC_DP1_C2M_P               MGTXTXP1_109_AK6
+set_property  -dict {PACKAGE_PIN  AK5 } [get_ports tx_data_n[6]]                                      ; ## A23  FMC_HPC_DP1_C2M_N               MGTXTXN1_109_AK5
+set_property  -dict {PACKAGE_PIN  AJ4 } [get_ports tx_data_p[5]]                                      ; ## A26  FMC_HPC_DP2_C2M_P               MGTXTXP2_109_AJ4
+set_property  -dict {PACKAGE_PIN  AJ3 } [get_ports tx_data_n[5]]                                      ; ## A27  FMC_HPC_DP2_C2M_N               MGTXTXN2_109_AJ3
+set_property  -dict {PACKAGE_PIN  AK2 } [get_ports tx_data_p[4]]                                      ; ## A30  FMC_HPC_DP3_C2M_P               MGTXTXP3_109_AK2
+set_property  -dict {PACKAGE_PIN  AK1 } [get_ports tx_data_n[4]]                                      ; ## A31  FMC_HPC_DP3_C2M_N               MGTXTXN3_109_AK1
+set_property  -dict {PACKAGE_PIN  AH2 } [get_ports tx_data_p[2]]                                      ; ## A34  FMC_HPC_DP4_C2M_P               MGTXTXP0_110_AH2
+set_property  -dict {PACKAGE_PIN  AH1 } [get_ports tx_data_n[2]]                                      ; ## A35  FMC_HPC_DP4_C2M_N               MGTXTXN0_110_AH1
+set_property  -dict {PACKAGE_PIN  AF2 } [get_ports tx_data_p[0]]                                      ; ## A38  FMC_HPC_DP5_C2M_P               MGTXTXP1_110_AF2
+set_property  -dict {PACKAGE_PIN  AF1 } [get_ports tx_data_n[0]]                                      ; ## A39  FMC_HPC_DP5_C2M_N               MGTXTXN1_110_AF1
+set_property  -dict {PACKAGE_PIN  AE4 } [get_ports tx_data_p[1]]                                      ; ## B36  FMC_HPC_DP6_C2M_P               MGTXTXP2_110_AE4
+set_property  -dict {PACKAGE_PIN  AE3 } [get_ports tx_data_n[1]]                                      ; ## B37  FMC_HPC_DP6_C2M_N               MGTXTXN2_110_AE3
+set_property  -dict {PACKAGE_PIN  AD2 } [get_ports tx_data_p[3]]                                      ; ## B32  FMC_HPC_DP7_C2M_P               MGTXTXP3_110_AD2
+set_property  -dict {PACKAGE_PIN  AD1 } [get_ports tx_data_n[3]]                                      ; ## B33  FMC_HPC_DP7_C2M_N               MGTXTXN3_110_AD1
 
 set_property  -dict {PACKAGE_PIN  AG21  IOSTANDARD LVDS_25 DIFF_TERM TRUE} [get_ports tx_sync_p[0]]   ; ## D07  FMC_HPC_LA01_P                  IO_L13P_T2_MRCC_11_AG21
 set_property  -dict {PACKAGE_PIN  AH21  IOSTANDARD LVDS_25 DIFF_TERM TRUE} [get_ports tx_sync_n[0]]   ; ## D08  FMC_HPC_LA01_N                  IO_L13N_T2_MRCC_11_AH21

--- a/projects/dac_fmc_ebz/zc706/system_top.v
+++ b/projects/dac_fmc_ebz/zc706/system_top.v
@@ -36,8 +36,6 @@
 `timescale 1ns/100ps
 
 module system_top #(
-    parameter JESD_L = 4,
-    parameter NUM_LINKS = 2,
     parameter DEVICE_CODE = 0
   ) (
 
@@ -83,8 +81,8 @@ module system_top #(
   input                   tx_sysref_n,
   input       [ 1:0]      tx_sync_p,
   input       [ 1:0]      tx_sync_n,
-  output      [JESD_L*NUM_LINKS-1:0] tx_data_p,
-  output      [JESD_L*NUM_LINKS-1:0] tx_data_n,
+  output      [ 7:0]      tx_data_p,
+  output      [ 7:0]      tx_data_n,
 
   inout       [ 4:0]      dac_ctrl,
 
@@ -116,8 +114,6 @@ module system_top #(
   wire            tx_ref_clk;
   wire            tx_sysref;
   wire    [ 1:0]  tx_sync;
-  wire    [ 7:0]  tx_data_p_loc;
-  wire    [ 7:0]  tx_data_n_loc;
   wire            tx_sysref_loc;
 
   // spi
@@ -268,29 +264,27 @@ module system_top #(
     .spi1_sdi_i (spi1_miso),
     .spi1_sdo_i (spi1_mosi),
     .spi1_sdo_o (spi1_mosi),
-    .tx_data_0_n (tx_data_n_loc[0]),
-    .tx_data_0_p (tx_data_p_loc[0]),
-    .tx_data_1_n (tx_data_n_loc[1]),
-    .tx_data_1_p (tx_data_p_loc[1]),
-    .tx_data_2_n (tx_data_n_loc[2]),
-    .tx_data_2_p (tx_data_p_loc[2]),
-    .tx_data_3_n (tx_data_n_loc[3]),
-    .tx_data_3_p (tx_data_p_loc[3]),
-    .tx_data_4_n (tx_data_n_loc[4]),
-    .tx_data_4_p (tx_data_p_loc[4]),
-    .tx_data_5_n (tx_data_n_loc[5]),
-    .tx_data_5_p (tx_data_p_loc[5]),
-    .tx_data_6_n (tx_data_n_loc[6]),
-    .tx_data_6_p (tx_data_p_loc[6]),
-    .tx_data_7_n (tx_data_n_loc[7]),
-    .tx_data_7_p (tx_data_p_loc[7]),
-    .tx_ref_clk (tx_ref_clk),
+    .tx_data_0_n (tx_data_n[0]),
+    .tx_data_0_p (tx_data_p[0]),
+    .tx_data_1_n (tx_data_n[1]),
+    .tx_data_1_p (tx_data_p[1]),
+    .tx_data_2_n (tx_data_n[2]),
+    .tx_data_2_p (tx_data_p[2]),
+    .tx_data_3_n (tx_data_n[3]),
+    .tx_data_3_p (tx_data_p[3]),
+    .tx_data_4_n (tx_data_n[4]),
+    .tx_data_4_p (tx_data_p[4]),
+    .tx_data_5_n (tx_data_n[5]),
+    .tx_data_5_p (tx_data_p[5]),
+    .tx_data_6_n (tx_data_n[6]),
+    .tx_data_6_p (tx_data_p[6]),
+    .tx_data_7_n (tx_data_n[7]),
+    .tx_data_7_p (tx_data_p[7]),
+    .tx_ref_clk_0 (tx_ref_clk),
+    .tx_ref_clk_4 (tx_ref_clk),
     .tx_sync_0 (tx_sync[NUM_LINKS-1:0]),
     .tx_sysref_0 (tx_sysref_loc),
     .dac_fifo_bypass (dac_fifo_bypass));
-
-  assign tx_data_p[JESD_L*NUM_LINKS-1:0] = tx_data_p_loc[JESD_L*NUM_LINKS-1:0];
-  assign tx_data_n[JESD_L*NUM_LINKS-1:0] = tx_data_n_loc[JESD_L*NUM_LINKS-1:0];
 
   // AD9161/2/4-FMC-EBZ works only in single link,
   // The FMC connector instead of SYNC1 has SYSREF connected to it

--- a/projects/dac_fmc_ebz/zcu102/system_constr.xdc
+++ b/projects/dac_fmc_ebz/zcu102/system_constr.xdc
@@ -30,22 +30,22 @@ set_property  -dict {PACKAGE_PIN  W1  IOSTANDARD LVCMOS18} [get_ports dac_ctrl[4
 set_property  -dict {PACKAGE_PIN  G8} [get_ports tx_ref_clk_p]                                          ; ## D04  FMC_HPC0_GBTCLK0_M2C_C_P  MGTREFCLK0P_229_G8
 set_property  -dict {PACKAGE_PIN  G7} [get_ports tx_ref_clk_n]                                          ; ## D05  FMC_HPC0_GBTCLK0_M2C_C_N  MGTREFCLK0N_229_G7
 
-set_property  -quiet -dict {PACKAGE_PIN  G3} [get_ports tx_data_n[7]]                                   ; ## C03  FMC_HPC0_DP0_C2M_N        MGTHTXN2_229_G3
-set_property  -quiet -dict {PACKAGE_PIN  G4} [get_ports tx_data_p[7]]                                   ; ## C02  FMC_HPC0_DP0_C2M_P        MGTHTXP2_229_G4
-set_property  -quiet -dict {PACKAGE_PIN  H5} [get_ports tx_data_n[6]]                                   ; ## A23  FMC_HPC0_DP1_C2M_N        MGTHTXN1_229_H5
-set_property  -quiet -dict {PACKAGE_PIN  H6} [get_ports tx_data_p[6]]                                   ; ## A22  FMC_HPC0_DP1_C2M_P        MGTHTXP1_229_H6
-set_property  -quiet -dict {PACKAGE_PIN  F5} [get_ports tx_data_n[5]]                                   ; ## A27  FMC_HPC0_DP2_C2M_N        MGTHTXN3_229_F5
-set_property  -quiet -dict {PACKAGE_PIN  F6} [get_ports tx_data_p[5]]                                   ; ## A26  FMC_HPC0_DP2_C2M_P        MGTHTXP3_229_F6
-set_property  -quiet -dict {PACKAGE_PIN  K5} [get_ports tx_data_n[4]]                                   ; ## A31  FMC_HPC0_DP3_C2M_N        MGTHTXN0_229_K5
-set_property  -quiet -dict {PACKAGE_PIN  K6} [get_ports tx_data_p[4]]                                   ; ## A30  FMC_HPC0_DP3_C2M_P        MGTHTXP0_229_K6
-set_property  -quiet -dict {PACKAGE_PIN  M6} [get_ports tx_data_p[2]]                                   ; ## A34  FMC_HPC0_DP4_C2M_P        MGTHTXP3_228_M6
-set_property  -quiet -dict {PACKAGE_PIN  M5} [get_ports tx_data_n[2]]                                   ; ## A35  FMC_HPC0_DP4_C2M_N        MGTHTXN3_228_M5
-set_property  -quiet -dict {PACKAGE_PIN  P6} [get_ports tx_data_p[0]]                                   ; ## A38  FMC_HPC0_DP5_C2M_P        MGTHTXP1_228_P6
-set_property  -quiet -dict {PACKAGE_PIN  P5} [get_ports tx_data_n[0]]                                   ; ## A39  FMC_HPC0_DP5_C2M_N        MGTHTXN1_228_P5
-set_property  -quiet -dict {PACKAGE_PIN  R4} [get_ports tx_data_p[1]]                                   ; ## B36  FMC_HPC0_DP6_C2M_P        MGTHTXP0_228_R4
-set_property  -quiet -dict {PACKAGE_PIN  R3} [get_ports tx_data_n[1]]                                   ; ## B37  FMC_HPC0_DP6_C2M_N        MGTHTXN0_228_R3
-set_property  -quiet -dict {PACKAGE_PIN  N4} [get_ports tx_data_p[3]]                                   ; ## B32  FMC_HPC0_DP7_C2M_P        MGTHTXP2_228_N4
-set_property  -quiet -dict {PACKAGE_PIN  N3} [get_ports tx_data_n[3]]                                   ; ## B33  FMC_HPC0_DP7_C2M_N        MGTHTXN2_228_N3
+set_property  -dict {PACKAGE_PIN  G3} [get_ports tx_data_n[7]]                                          ; ## C03  FMC_HPC0_DP0_C2M_N        MGTHTXN2_229_G3
+set_property  -dict {PACKAGE_PIN  G4} [get_ports tx_data_p[7]]                                          ; ## C02  FMC_HPC0_DP0_C2M_P        MGTHTXP2_229_G4
+set_property  -dict {PACKAGE_PIN  H5} [get_ports tx_data_n[6]]                                          ; ## A23  FMC_HPC0_DP1_C2M_N        MGTHTXN1_229_H5
+set_property  -dict {PACKAGE_PIN  H6} [get_ports tx_data_p[6]]                                          ; ## A22  FMC_HPC0_DP1_C2M_P        MGTHTXP1_229_H6
+set_property  -dict {PACKAGE_PIN  F5} [get_ports tx_data_n[5]]                                          ; ## A27  FMC_HPC0_DP2_C2M_N        MGTHTXN3_229_F5
+set_property  -dict {PACKAGE_PIN  F6} [get_ports tx_data_p[5]]                                          ; ## A26  FMC_HPC0_DP2_C2M_P        MGTHTXP3_229_F6
+set_property  -dict {PACKAGE_PIN  K5} [get_ports tx_data_n[4]]                                          ; ## A31  FMC_HPC0_DP3_C2M_N        MGTHTXN0_229_K5
+set_property  -dict {PACKAGE_PIN  K6} [get_ports tx_data_p[4]]                                          ; ## A30  FMC_HPC0_DP3_C2M_P        MGTHTXP0_229_K6
+set_property  -dict {PACKAGE_PIN  M6} [get_ports tx_data_p[2]]                                          ; ## A34  FMC_HPC0_DP4_C2M_P        MGTHTXP3_228_M6
+set_property  -dict {PACKAGE_PIN  M5} [get_ports tx_data_n[2]]                                          ; ## A35  FMC_HPC0_DP4_C2M_N        MGTHTXN3_228_M5
+set_property  -dict {PACKAGE_PIN  P6} [get_ports tx_data_p[0]]                                          ; ## A38  FMC_HPC0_DP5_C2M_P        MGTHTXP1_228_P6
+set_property  -dict {PACKAGE_PIN  P5} [get_ports tx_data_n[0]]                                          ; ## A39  FMC_HPC0_DP5_C2M_N        MGTHTXN1_228_P5
+set_property  -dict {PACKAGE_PIN  R4} [get_ports tx_data_p[1]]                                          ; ## B36  FMC_HPC0_DP6_C2M_P        MGTHTXP0_228_R4
+set_property  -dict {PACKAGE_PIN  R3} [get_ports tx_data_n[1]]                                          ; ## B37  FMC_HPC0_DP6_C2M_N        MGTHTXN0_228_R3
+set_property  -dict {PACKAGE_PIN  N4} [get_ports tx_data_p[3]]                                          ; ## B32  FMC_HPC0_DP7_C2M_P        MGTHTXP2_228_N4
+set_property  -dict {PACKAGE_PIN  N3} [get_ports tx_data_n[3]]                                          ; ## B33  FMC_HPC0_DP7_C2M_N        MGTHTXN2_228_N3
 
 # PL PMOD 1 header
 set_property  -dict {PACKAGE_PIN  D20 IOSTANDARD LVCMOS33} [get_ports pmod_spi_clk]                     ; ## PMOD1_0                        IO_L8N_HDGC_AD4N_47_D20

--- a/projects/dac_fmc_ebz/zcu102/system_top.v
+++ b/projects/dac_fmc_ebz/zcu102/system_top.v
@@ -80,8 +80,6 @@ tx_sysref_p   SYSREF2_P       G06  FMC_HPC0_LA00_CC_P        Y4     IO_L13P_T2L_
 */
 
 module system_top #(
-    parameter JESD_L = 4,
-    parameter NUM_LINKS = 2,
     parameter DEVICE_CODE = 0
   ) (
 
@@ -94,8 +92,8 @@ module system_top #(
   input           tx_sysref_n,
   input   [ 1:0]  tx_sync_p,
   input   [ 1:0]  tx_sync_n,
-  output  [JESD_L*NUM_LINKS-1:0] tx_data_p,
-  output  [JESD_L*NUM_LINKS-1:0] tx_data_n,
+  output  [ 7:0]  tx_data_p,
+  output  [ 7:0]  tx_data_n,
 
   output          spi_csn_dac,
   output          spi_csn_clk,
@@ -124,8 +122,6 @@ module system_top #(
   wire            tx_ref_clk;
   wire            tx_sysref;
   wire    [ 1:0]  tx_sync;
-  wire    [ 7:0]  tx_data_p_loc;
-  wire    [ 7:0]  tx_data_n_loc;
   wire            tx_sysref_loc;
 
   // spi
@@ -229,28 +225,26 @@ module system_top #(
     .spi1_miso (pmod_spi_miso),
     .spi1_mosi (pmod_spi_mosi),
     .spi1_sclk (pmod_spi_clk),
-    .tx_data_0_n (tx_data_n_loc[0]),
-    .tx_data_0_p (tx_data_p_loc[0]),
-    .tx_data_1_n (tx_data_n_loc[1]),
-    .tx_data_1_p (tx_data_p_loc[1]),
-    .tx_data_2_n (tx_data_n_loc[2]),
-    .tx_data_2_p (tx_data_p_loc[2]),
-    .tx_data_3_n (tx_data_n_loc[3]),
-    .tx_data_3_p (tx_data_p_loc[3]),
-    .tx_data_4_n (tx_data_n_loc[4]),
-    .tx_data_4_p (tx_data_p_loc[4]),
-    .tx_data_5_n (tx_data_n_loc[5]),
-    .tx_data_5_p (tx_data_p_loc[5]),
-    .tx_data_6_n (tx_data_n_loc[6]),
-    .tx_data_6_p (tx_data_p_loc[6]),
-    .tx_data_7_n (tx_data_n_loc[7]),
-    .tx_data_7_p (tx_data_p_loc[7]),
-    .tx_ref_clk (tx_ref_clk),
+    .tx_data_0_n (tx_data_n[0]),
+    .tx_data_0_p (tx_data_p[0]),
+    .tx_data_1_n (tx_data_n[1]),
+    .tx_data_1_p (tx_data_p[1]),
+    .tx_data_2_n (tx_data_n[2]),
+    .tx_data_2_p (tx_data_p[2]),
+    .tx_data_3_n (tx_data_n[3]),
+    .tx_data_3_p (tx_data_p[3]),
+    .tx_data_4_n (tx_data_n[4]),
+    .tx_data_4_p (tx_data_p[4]),
+    .tx_data_5_n (tx_data_n[5]),
+    .tx_data_5_p (tx_data_p[5]),
+    .tx_data_6_n (tx_data_n[6]),
+    .tx_data_6_p (tx_data_p[6]),
+    .tx_data_7_n (tx_data_n[7]),
+    .tx_data_7_p (tx_data_p[7]),
+    .tx_ref_clk_0 (tx_ref_clk),
+    .tx_ref_clk_4 (tx_ref_clk),
     .tx_sync_0 (tx_sync[NUM_LINKS-1:0]),
     .tx_sysref_0 (tx_sysref));
-
-  assign tx_data_p[JESD_L*NUM_LINKS-1:0] = tx_data_p_loc[JESD_L*NUM_LINKS-1:0];
-  assign tx_data_n[JESD_L*NUM_LINKS-1:0] = tx_data_n_loc[JESD_L*NUM_LINKS-1:0];
 
   // AD9161/2/4-FMC-EBZ works only in single link,
   // The FMC connector instead of SYNC1 has SYSREF connected to it


### PR DESCRIPTION
This updated was made for the new VCU118 carrier support