### PR TITLE
dac_fmc_ebz_vcu118: Initial commit

### DIFF
--- a/projects/dac_fmc_ebz/vcu118/Makefile
+++ b/projects/dac_fmc_ebz/vcu118/Makefile
@@ -1,0 +1,29 @@
+####################################################################################
+## Copyright (c) 2018 - 2021 Analog Devices, Inc.
+### SPDX short identifier: BSD-1-Clause
+## Auto-generated, do not modify!
+####################################################################################
+
+PROJECT_NAME := dac_fmc_ebz_vcu118
+
+M_DEPS += ../common/dac_fmc_ebz_bd.tcl
+M_DEPS += ../common/config.tcl
+M_DEPS += ../../scripts/adi_pd.tcl
+M_DEPS += ../../common/vcu118/vcu118_system_constr.xdc
+M_DEPS += ../../common/vcu118/vcu118_system_bd.tcl
+M_DEPS += ../../common/xilinx/dacfifo_bd.tcl
+M_DEPS += ../../../library/jesd204/scripts/jesd204.tcl
+M_DEPS += ../../../library/common/ad_iobuf.v
+
+LIB_DEPS += axi_dmac
+LIB_DEPS += axi_sysid
+LIB_DEPS += jesd204/ad_ip_jesd204_tpl_dac
+LIB_DEPS += jesd204/axi_jesd204_tx
+LIB_DEPS += jesd204/jesd204_tx
+LIB_DEPS += sysid_rom
+LIB_DEPS += util_dacfifo
+LIB_DEPS += util_pack/util_upack2
+LIB_DEPS += xilinx/axi_adxcvr
+LIB_DEPS += xilinx/util_adxcvr
+
+include ../../scripts/project-xilinx.mk

--- a/projects/dac_fmc_ebz/vcu118/README.md
+++ b/projects/dac_fmc_ebz/vcu118/README.md
@@ -1,0 +1,7 @@
+# AD-DAC-FMC-EBZ reference HDL design for VCU118
+
+|||
+| ------ | ------ |
+| Wiki  | https://wiki.analog.com/resources/eval/user-guides/ad-dac-fmc-ebz |
+| FMC Location | FMCP HSPC Slot |
+| Configuration file | ../common/config.tcl |

--- a/projects/dac_fmc_ebz/vcu118/system_bd.tcl
+++ b/projects/dac_fmc_ebz/vcu118/system_bd.tcl
@@ -1,0 +1,18 @@
+
+set dac_fifo_address_width 14
+
+source $ad_hdl_dir/projects/common/vcu118/vcu118_system_bd.tcl
+source $ad_hdl_dir/projects/common/xilinx/dacfifo_bd.tcl
+source ../common/dac_fmc_ebz_bd.tcl
+source $ad_hdl_dir/projects/scripts/adi_pd.tcl
+
+#system ID
+ad_ip_parameter axi_sysid_0 CONFIG.ROM_ADDR_BITS 9
+ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "[pwd]/mem_init_sys.txt"
+ad_ip_parameter rom_sys_0 CONFIG.ROM_ADDR_BITS 9
+set ADI_DAC_DEVICE $::env(ADI_DAC_DEVICE)
+set ADI_DAC_MODE $::env(ADI_DAC_MODE)
+set sys_cstring "$ADI_DAC_DEVICE - $ADI_DAC_MODE"
+sysid_gen_sys_init_file $sys_cstring
+
+ad_ip_parameter dac_jesd204_link/tx CONFIG.SYSREF_IOB false

--- a/projects/dac_fmc_ebz/vcu118/system_constr.xdc
+++ b/projects/dac_fmc_ebz/vcu118/system_constr.xdc
@@ -1,0 +1,74 @@
+
+# DAC FMC signals
+
+set_property  -dict {PACKAGE_PIN  AL30 IOSTANDARD LVDS DIFF_TERM_ADV TERM_100} [get_ports tx_sync_p[0]]  ; ## D08  FMCP_HSPC_LA01_CC_P       IO_L16P_T2U_N6_QBC_AD3P_43
+set_property  -dict {PACKAGE_PIN  AL31 IOSTANDARD LVDS DIFF_TERM_ADV TERM_100} [get_ports tx_sync_n[0]]  ; ## D09  FMCP_HSPC_LA01_CC_N       IO_L16N_T2U_N7_QBC_AD3N_43
+set_property  -dict {PACKAGE_PIN  AJ32 IOSTANDARD LVDS DIFF_TERM_ADV TERM_100} [get_ports tx_sync_p[1]]  ; ## H07  FMCP_HSPC_LA02_P          IO_L14P_T2L_N2_GC_43
+set_property  -dict {PACKAGE_PIN  AK32 IOSTANDARD LVDS DIFF_TERM_ADV TERM_100} [get_ports tx_sync_n[1]]  ; ## H08  FMCP_HSPC_LA02_N          IO_L14N_T2L_N3_GC_43
+set_property  -dict {PACKAGE_PIN  AL35 IOSTANDARD LVDS DIFF_TERM_ADV TERM_100} [get_ports tx_sysref_p]   ; ## G06  FMCP_HSPC_LA00_CC_P       IO_L7P_T1L_N0_QBC_AD13P_43
+set_property  -dict {PACKAGE_PIN  AL36 IOSTANDARD LVDS DIFF_TERM_ADV TERM_100} [get_ports tx_sysref_n]   ; ## G07  FMCP_HSPC_LA00_CC_N       IO_L7N_T1L_N1_QBC_AD13N_43
+
+set_property  -dict {PACKAGE_PIN  AT37 IOSTANDARD LVCMOS18} [get_ports spi_csn_dac]                      ; ## H11  FMCP_HSPC_LA04_N          IO_L6N_T0U_N11_AD6N_43
+set_property  -dict {PACKAGE_PIN  AP38 IOSTANDARD LVCMOS18} [get_ports spi_csn_clk]                      ; ## D11  FMCP_HSPC_LA05_P          IO_L1P_T0L_N0_DBC_43 
+set_property  -dict {PACKAGE_PIN  AR37 IOSTANDARD LVCMOS18} [get_ports spi_miso]                         ; ## H10  FMCP_HSPC_LA04_P          IO_L6P_T0U_N10_AD6P_43 
+set_property  -dict {PACKAGE_PIN  AT40 IOSTANDARD LVCMOS18} [get_ports spi_mosi]                         ; ## G10  FMCP_HSPC_LA03_N          IO_L4N_T0U_N7_DBC_AD7N_43
+set_property  -dict {PACKAGE_PIN  AT39 IOSTANDARD LVCMOS18} [get_ports spi_clk]                          ; ## G09  FMCP_HSPC_LA03_P          IO_L4P_T0U_N6_DBC_AD7P_43
+set_property  -dict {PACKAGE_PIN  AR38 IOSTANDARD LVCMOS18} [get_ports spi_en]                           ; ## D12  FMCP_HSPC_LA05_N          IO_L1N_T0L_N1_DBC_43
+# For AD916(1,2,3,4)-FMC-EBZ
+set_property  -dict {PACKAGE_PIN  AJ33 IOSTANDARD LVCMOS18} [get_ports spi_csn_clk2]                     ; ## D14  FMCP_HSPC_LA09_P          IO_L19P_T3L_N0_DBC_AD9P_43 
+
+# For AD9135-FMC-EBZ, AD9136-FMC-EBZ, AD9144-FMC-EBZ, AD9152-FMC-EBZ, AD9154-FMC-EBZ
+set_property  -dict {PACKAGE_PIN  AP36 IOSTANDARD LVCMOS18} [get_ports dac_ctrl[0]]                      ; ## H13  FMCP_HSPC_LA07_P          IO_L5P_T0U_N8_AD14P_43
+set_property  -dict {PACKAGE_PIN  AP37 IOSTANDARD LVCMOS18} [get_ports dac_ctrl[3]]                      ; ## H14  FMCP_HSPC_LA07_N          IO_L5N_T0U_N9_AD14N_43
+
+# For AD9171-FMC-EBZ, AD9172-FMC-EBZ, AD9173-FMC-EBZ
+set_property  -dict {PACKAGE_PIN  AT35 IOSTANDARD LVCMOS18} [get_ports dac_ctrl[1]]                      ; ## C10  FMCP_HSPC_LA06_P          IO_L2P_T0L_N2_43
+set_property  -dict {PACKAGE_PIN  AT36 IOSTANDARD LVCMOS18} [get_ports dac_ctrl[2]]                      ; ## C11  FMCP_HSPC_LA06_N          IO_L2N_T0L_N3_43
+# For AD916(1,2,3,4)-FMC-EBZ
+set_property  -dict {PACKAGE_PIN  AK33 IOSTANDARD LVCMOS18} [get_ports dac_ctrl[4]]                      ; ## D15  FMCP_HSPC_LA09_N          IO_L19N_T3L_N1_DBC_AD9N_43
+
+set_property  -dict {PACKAGE_PIN  AK38} [get_ports tx_ref_clk_121_p]                                     ; ## D04  FMCP_HSPC_GBT0_0_P        MGTREFCLK0P_121
+set_property  -dict {PACKAGE_PIN  AK39} [get_ports tx_ref_clk_121_n]                                     ; ## D05  FMCP_HSPC_GBT0_0_N        MGTREFCLK0N_121
+set_property  -dict {PACKAGE_PIN  V38 } [get_ports tx_ref_clk_126_p]                                     ; ## D04  FMCP_HSPC_GBT0_1_P        MGTREFCLK0P_126
+set_property  -dict {PACKAGE_PIN  V39 } [get_ports tx_ref_clk_126_n]                                     ; ## D05  FMCP_HSPC_GBT0_1_N        MGTREFCLK0N_126
+
+set_property  -dict {PACKAGE_PIN  AT43} [get_ports tx_data_n[7]]                                         ; ## C03  FMCP_HSPC_DP0_C2M_N       MGTYTXN0_121
+set_property  -dict {PACKAGE_PIN  AT42} [get_ports tx_data_p[7]]                                         ; ## C02  FMCP_HSPC_DP0_C2M_P       MGTYTXP0_121
+set_property  -dict {PACKAGE_PIN  AP43} [get_ports tx_data_n[6]]                                         ; ## A23  FMCP_HSPC_DP1_C2M_N       MGTYTXN1_121
+set_property  -dict {PACKAGE_PIN  AP42} [get_ports tx_data_p[6]]                                         ; ## A22  FMCP_HSPC_DP1_C2M_P       MGTYTXP1_121
+set_property  -dict {PACKAGE_PIN  AM43} [get_ports tx_data_n[5]]                                         ; ## A27  FMCP_HSPC_DP2_C2M_N       MGTYTXN2_121
+set_property  -dict {PACKAGE_PIN  AM42} [get_ports tx_data_p[5]]                                         ; ## A26  FMCP_HSPC_DP2_C2M_P       MGTYTXP2_121
+set_property  -dict {PACKAGE_PIN  AL41} [get_ports tx_data_n[4]]                                         ; ## A31  FMCP_HSPC_DP3_C2M_N       MGTYTXN3_121
+set_property  -dict {PACKAGE_PIN  AL40} [get_ports tx_data_p[4]]                                         ; ## A30  FMCP_HSPC_DP3_C2M_P       MGTYTXP3_121
+set_property  -dict {PACKAGE_PIN  T42}  [get_ports tx_data_p[2]]                                         ; ## A34  FMCP_HSPC_DP4_C2M_P       MGTYTXP0_126
+set_property  -dict {PACKAGE_PIN  T43}  [get_ports tx_data_n[2]]                                         ; ## A35  FMCP_HSPC_DP4_C2M_N       MGTYTXN0_126
+set_property  -dict {PACKAGE_PIN  P42}  [get_ports tx_data_p[0]]                                         ; ## A38  FMCP_HSPC_DP5_C2M_P       MGTYTXP1_126
+set_property  -dict {PACKAGE_PIN  P43}  [get_ports tx_data_n[0]]                                         ; ## A39  FMCP_HSPC_DP5_C2M_N       MGTYTXN1_126
+set_property  -dict {PACKAGE_PIN  M42}  [get_ports tx_data_p[1]]                                         ; ## B36  FMCP_HSPC_DP6_C2M_P       MGTYTXP2_126
+set_property  -dict {PACKAGE_PIN  M43}  [get_ports tx_data_n[1]]                                         ; ## B37  FMCP_HSPC_DP6_C2M_N       MGTYTXN2_126
+set_property  -dict {PACKAGE_PIN  K42}  [get_ports tx_data_p[3]]                                         ; ## B32  FMCP_HSPC_DP7_C2M_P       MGTYTXP3_126
+set_property  -dict {PACKAGE_PIN  K43}  [get_ports tx_data_n[3]]                                         ; ## B33  FMCP_HSPC_DP7_C2M_N       MGTYTXN3_126
+
+# PL PMOD 1 header
+# set_property  -dict {PACKAGE_PIN  AY14 IOSTANDARD LVCMOS33} [get_ports pmod_spi_clk]                     ; ## PMOD0_0_LS                     IO_L10N_T1U_N7_QBC_AD4N_67
+# set_property  -dict {PACKAGE_PIN  AY15 IOSTANDARD LVCMOS33} [get_ports pmod_spi_csn]                     ; ## PMOD0_1_LS                     IO_L10P_T1U_N6_QBC_AD4P_67
+# set_property  -dict {PACKAGE_PIN  AW15 IOSTANDARD LVCMOS33} [get_ports pmod_spi_mosi]                    ; ## PMOD0_2_LS                     IO_L9N_T1L_N5_AD12N_67
+# set_property  -dict {PACKAGE_PIN  AV15 IOSTANDARD LVCMOS33} [get_ports pmod_spi_miso]                    ; ## PMOD0_3_LS                     IO_L9P_T1L_N4_AD12P_67
+# set_property  -dict {PACKAGE_PIN  AV16 IOSTANDARD LVCMOS18} [get_ports pmod_gpio[0]]                     ; ## PMOD0_4_LS                     IO_L8N_T1L_N3_AD5N_67
+# set_property  -dict {PACKAGE_PIN  AU16 IOSTANDARD LVCMOS18} [get_ports pmod_gpio[1]]                     ; ## PMOD0_5_LS                     IO_L8P_T1L_N2_AD5P_67
+# set_property  -dict {PACKAGE_PIN  AT15 IOSTANDARD LVCMOS18} [get_ports pmod_gpio[2]]                     ; ## PMOD0_6_LS                     IO_L7N_T1L_N1_QBC_AD13N_67
+# set_property  -dict {PACKAGE_PIN  AT16 IOSTANDARD LVCMOS18} [get_ports pmod_gpio[3]]                     ; ## PMOD0_7_LS                     IO_L7P_T1L_N0_QBC_AD13P_67
+
+# clocks
+
+# Max lane rate of 15.4 Gbps
+create_clock -name tx_ref_clk_121   -period  2.597 [get_ports tx_ref_clk_121_p]
+create_clock -name tx_ref_clk_126   -period  2.597 [get_ports tx_ref_clk_126_p]
+
+# For transceiver output clocks use reference clock
+# This will help autoderive the clocks correcly
+set_case_analysis -quiet 0 [get_pins -quiet -hier *_channel/TXSYSCLKSEL[0]]
+set_case_analysis -quiet 0 [get_pins -quiet -hier *_channel/TXSYSCLKSEL[1]]
+set_case_analysis -quiet 1 [get_pins -quiet -hier *_channel/TXOUTCLKSEL[0]]
+set_case_analysis -quiet 1 [get_pins -quiet -hier *_channel/TXOUTCLKSEL[1]]
+set_case_analysis -quiet 0 [get_pins -quiet -hier *_channel/TXOUTCLKSEL[2]]

--- a/projects/dac_fmc_ebz/vcu118/system_project.tcl
+++ b/projects/dac_fmc_ebz/vcu118/system_project.tcl
@@ -1,0 +1,23 @@
+
+source ../../scripts/adi_env.tcl
+source $ad_hdl_dir/projects/scripts/adi_project_xilinx.tcl
+source $ad_hdl_dir/projects/scripts/adi_board.tcl
+
+source ../common/config.tcl
+
+adi_project dac_fmc_ebz_vcu118 0 [list \
+  JESD_M    [get_config_param M] \
+  JESD_L    [get_config_param L] \
+  JESD_S    [get_config_param S] \
+  JESD_NP   [get_config_param NP] \
+  NUM_LINKS $num_links \
+  DEVICE_CODE $device_code \
+]
+
+adi_project_files dac_fmc_ebz_vcu118 [list \
+  "system_top.v" \
+  "system_constr.xdc"\
+  "$ad_hdl_dir/library/common/ad_iobuf.v" \
+  "$ad_hdl_dir/projects/common/vcu118/vcu118_system_constr.xdc" ]
+
+adi_project_run dac_fmc_ebz_vcu118

--- a/projects/dac_fmc_ebz/vcu118/system_top.v
+++ b/projects/dac_fmc_ebz/vcu118/system_top.v
@@ -1,0 +1,277 @@
+// ***************************************************************************
+// ***************************************************************************
+// Copyright 2014 - 2017 (c) Analog Devices, Inc. All rights reserved.
+//
+// In this HDL repository, there are many different and unique modules, consisting
+// of various HDL (Verilog or VHDL) components. The individual modules are
+// developed independently, and may be accompanied by separate and unique license
+// terms.
+//
+// The user should read each of these license terms, and understand the
+// freedoms and responsibilities that he or she has by using this source/core.
+//
+// This core is distributed in the hope that it will be useful, but WITHOUT ANY
+// WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+// A PARTICULAR PURPOSE.
+//
+// Redistribution and use of source or resulting binaries, with or without modification
+// of this file, are permitted under one of the following two license terms:
+//
+//   1. The GNU General Public License version 2 as published by the
+//      Free Software Foundation, which can be found in the top level directory
+//      of this repository (LICENSE_GPL2), and also online at:
+//      <https://www.gnu.org/licenses/old-licenses/gpl-2.0.html>
+//
+// OR
+//
+//   2. An ADI specific BSD license, which can be found in the top level directory
+//      of this repository (LICENSE_ADIBSD), and also on-line at:
+//      https://github.com/analogdevicesinc/hdl/blob/master/LICENSE_ADIBSD
+//      This will allow to generate bit files and not release the source code,
+//      as long as it attaches to an ADI device.
+//
+// ***************************************************************************
+// ***************************************************************************
+
+`timescale 1ns/100ps
+
+module system_top #(
+    parameter DEVICE_CODE = 0
+  ) (
+  
+  input                   sys_rst,
+  input                   sys_clk_p,
+  input                   sys_clk_n,
+        
+  input                   uart_sin,
+  output                  uart_sout,
+  
+  output                  ddr4_act_n,
+  output      [16:0]      ddr4_addr,
+  output      [ 1:0]      ddr4_ba,
+  output      [ 0:0]      ddr4_bg,
+  output                  ddr4_ck_p,
+  output                  ddr4_ck_n,
+  output      [ 0:0]      ddr4_cke,
+  output      [ 0:0]      ddr4_cs_n,
+  inout       [ 7:0]      ddr4_dm_n,
+  inout       [63:0]      ddr4_dq,
+  inout       [ 7:0]      ddr4_dqs_p,
+  inout       [ 7:0]      ddr4_dqs_n,
+  output      [ 0:0]      ddr4_odt,
+  output                  ddr4_reset_n,
+
+  output                  mdio_mdc,
+  inout                   mdio_mdio,
+  input                   phy_clk_p,
+  input                   phy_clk_n,
+  output                  phy_rst_n,
+  input                   phy_rx_p,
+  input                   phy_rx_n,
+  output                  phy_tx_p,
+  output                  phy_tx_n,
+
+  inout       [16:0]      gpio_bd,
+
+  output                  iic_rstn,
+  inout                   iic_scl,
+  inout                   iic_sda,
+
+  input                   tx_ref_clk_121_p,
+  input                   tx_ref_clk_121_n,
+  input                   tx_ref_clk_126_p,
+  input                   tx_ref_clk_126_n,
+  input                   tx_sysref_p,
+  input                   tx_sysref_n,
+  input       [ 1:0]      tx_sync_p,
+  input       [ 1:0]      tx_sync_n,
+  output      [ 7:0]      tx_data_p,
+  output      [ 7:0]      tx_data_n,
+
+  output                  spi_csn_dac,
+  output                  spi_csn_clk,
+  output                  spi_csn_clk2,
+  input                   spi_miso,
+  output                  spi_mosi,
+  output                  spi_clk,
+  output                  spi_en,
+
+  inout       [ 4:0]      dac_ctrl
+);
+
+  // internal signals
+
+  wire    [63:0]  gpio_i;
+  wire    [63:0]  gpio_o;
+  wire    [63:0]  gpio_t;
+  wire    [ 2:0]  spi_csn;
+  wire            tx_ref_clk;
+  wire            tx_sysref;
+  wire    [ 1:0]  tx_sync;
+  wire            tx_sysref_loc;
+
+  assign iic_rstn = 1'b1;
+  // spi
+
+  // spi_en is active ...
+  //   ... high for AD9135-FMC-EBZ, AD9136-FMC-EBZ, AD9144-FMC-EBZ,
+  //   ... low for AD9171-FMC-EBZ, AD9172-FMC-EBZ, AD9173-FMC-EBZ
+  // If you are planning to build a bitstream for just one of those boards you
+  // can hardwire the logic level here.
+  //
+  assign spi_en = (DEVICE_CODE <= 2);
+
+  //                                        9135/9144/9172    916(1,2,3,4)
+  assign spi_csn_dac  = spi_csn[1];
+  assign spi_csn_clk  = spi_csn[0];    //   HMC7044          AD9508
+  assign spi_csn_clk2 = spi_csn[2];    //   NC               ADF4355
+
+
+  /* JESD204 clocks and control signals */
+  IBUFDS_GTE4 i_ibufds_tx_ref_clk_121 (
+    .CEB (1'd0),
+    .I (tx_ref_clk_121_p),
+    .IB (tx_ref_clk_121_n),
+    .O (tx_ref_clk_121),
+    .ODIV2 ()
+  );
+
+  IBUFDS_GTE4 i_ibufds_tx_ref_clk_126 (
+    .CEB (1'd0),
+    .I (tx_ref_clk_126_p),
+    .IB (tx_ref_clk_126_n),
+    .O (tx_ref_clk_126),
+    .ODIV2 ()
+  );
+
+  IBUFDS i_ibufds_tx_sysref (
+    .I (tx_sysref_p),
+    .IB (tx_sysref_n),
+    .O (tx_sysref)
+  );
+
+  IBUFDS i_ibufds_tx_sync_0 (
+    .I (tx_sync_p[0]),
+    .IB (tx_sync_n[0]),
+    .O (tx_sync[0])
+  );
+
+  IBUFDS i_ibufds_tx_sync_1 (
+    .I (tx_sync_p[1]),
+    .IB (tx_sync_n[1]),
+    .O (tx_sync[1])
+  );
+
+  /* FMC GPIOs */
+  ad_iobuf #(
+    .DATA_WIDTH(5)
+  ) i_iobuf (
+    .dio_t (gpio_t[21+:5]),
+    .dio_i (gpio_o[21+:5]),
+    .dio_o (gpio_i[21+:5]),
+    .dio_p ({
+      dac_ctrl           /* 25 - 21 */
+    })
+  );
+
+  /*
+  * Control signals for different FMC boards:
+  *
+  * dac_ctrl  FMC   9144 like    9162 like       9172 like
+  *        0  H13   FMC_TXEN_0   FMC_TXEN_0      FMC_PE_CTRL
+  *        1  C10   NC           NC              FMC_TXEN_0
+  *        2  C11   NC           NC              FMC_TXEN_1
+  *        3  H14   FMC_TXEN_1   NC              NC
+  *        4  D15   NC           FMC_HMC849VCTL  NC          
+  */
+
+  assign dac_fifo_bypass = gpio_o[40];
+
+  /* Board GPIOS. Buttons, LEDs, etc... */
+  ad_iobuf #(
+    .DATA_WIDTH(17)
+  ) i_iobuf_bd (
+    .dio_t (gpio_t[0+:17]),
+    .dio_i (gpio_o[0+:17]),
+    .dio_o (gpio_i[0+:17]),
+    .dio_p (gpio_bd)
+  );
+
+  assign gpio_i[63:26] = gpio_o[63:26];
+  assign gpio_i[20:17] = gpio_o[20:17];
+
+  system_wrapper i_system_wrapper (
+    .ddr4_act_n (ddr4_act_n),
+    .ddr4_adr (ddr4_addr),
+    .ddr4_ba (ddr4_ba),
+    .ddr4_bg (ddr4_bg),
+    .ddr4_ck_c (ddr4_ck_n),
+    .ddr4_ck_t (ddr4_ck_p),
+    .ddr4_cke (ddr4_cke),
+    .ddr4_cs_n (ddr4_cs_n),
+    .ddr4_dm_n (ddr4_dm_n),
+    .ddr4_dq (ddr4_dq),
+    .ddr4_dqs_c (ddr4_dqs_n),
+    .ddr4_dqs_t (ddr4_dqs_p),
+    .ddr4_odt (ddr4_odt),
+    .ddr4_reset_n (ddr4_reset_n),
+    .gpio0_i (gpio_i[31:0]),
+    .gpio0_o (gpio_o[31:0]),
+    .gpio0_t (gpio_t[31:0]),
+    .gpio1_i (gpio_i[63:32]),
+    .gpio1_o (gpio_o[63:32]),
+    .gpio1_t (gpio_t[63:32]),
+    .iic_main_scl_io (iic_scl),
+    .iic_main_sda_io (iic_sda),
+    .mdio_mdc (mdio_mdc),
+    .mdio_mdio_io (mdio_mdio),
+    .sgmii_phyclk_clk_n (phy_clk_n),
+    .sgmii_phyclk_clk_p (phy_clk_p),
+    .phy_rst_n (phy_rst_n),
+    .phy_sd (1'b1),
+    .sgmii_rxn (phy_rx_n),
+    .sgmii_rxp (phy_rx_p),
+    .sgmii_txn (phy_tx_n),
+    .sgmii_txp (phy_tx_p),
+    .spi_clk_i (spi_clk),
+    .spi_clk_o (spi_clk),
+    .spi_csn_i (spi_csn),
+    .spi_csn_o (spi_csn),
+    .spi_sdi_i (spi_miso),
+    .spi_sdo_i (spi_mosi),
+    .spi_sdo_o (spi_mosi),
+    .sys_clk_clk_n (sys_clk_n),
+    .sys_clk_clk_p (sys_clk_p),
+    .sys_rst (sys_rst),
+    .tx_data_0_n (tx_data_n[0]),
+    .tx_data_0_p (tx_data_p[0]),
+    .tx_data_1_n (tx_data_n[1]),
+    .tx_data_1_p (tx_data_p[1]),
+    .tx_data_2_n (tx_data_n[2]),
+    .tx_data_2_p (tx_data_p[2]),
+    .tx_data_3_n (tx_data_n[3]),
+    .tx_data_3_p (tx_data_p[3]),
+    .tx_data_4_n (tx_data_n[4]),
+    .tx_data_4_p (tx_data_p[4]),
+    .tx_data_5_n (tx_data_n[5]),
+    .tx_data_5_p (tx_data_p[5]),
+    .tx_data_6_n (tx_data_n[6]),
+    .tx_data_6_p (tx_data_p[6]),
+    .tx_data_7_n (tx_data_n[7]),
+    .tx_data_7_p (tx_data_p[7]),
+    .tx_ref_clk_0 (tx_ref_clk_126),
+    .tx_ref_clk_4 (tx_ref_clk_121),
+    .tx_sync_0 (tx_sync),
+    .tx_sysref_0 (tx_sysref),
+    .uart_sin (uart_sin),
+    .uart_sout (uart_sout),
+    .dac_fifo_bypass (dac_fifo_bypass));
+
+  // AD9161/2/4-FMC-EBZ works only in single link,
+  // The FMC connector instead of SYNC1 has SYSREF connected to it
+  assign tx_sysref_loc = (DEVICE_CODE == 3) ? tx_sync[1] : tx_sysref;
+
+endmodule
+
+// ***************************************************************************
+// ***************************************************************************


### PR DESCRIPTION
- New VCU118 Block Design for AD9172(dac_fmc_ebz) eval board
- Tested on NO-OS software with this changes: https://github.com/analogdevicesinc/no-OS/commit/6b3aa74b96938a3c9ac1986378f159309d0cb82e 
