### PR TITLE
External sync at TPL level

### DIFF
--- a/library/common/up_adc_common.v
+++ b/library/common/up_adc_common.v
@@ -69,6 +69,9 @@ module up_adc_common #(
   output      [31:0]  adc_start_code,
   output              adc_sref_sync,
   output              adc_sync,
+  output              adc_ext_sync_arm,
+  output              adc_ext_sync_disarm,
+  output              adc_ext_sync_manual_req,
   output       [4:0]  adc_num_lanes,
   output              adc_sdr_ddr_n,
   output              adc_symb_op,
@@ -130,6 +133,9 @@ module up_adc_common #(
   reg                 up_mmcm_resetn = 'd0;
   reg                 up_resetn = 'd0;
   reg                 up_adc_sync = 'd0;
+  reg                 up_adc_ext_sync_arm = 'd0;
+  reg                 up_adc_ext_sync_disarm = 'd0;
+  reg                 up_adc_ext_sync_manual_req = 'd0;
   reg                 up_adc_sref_sync = 'd0;
   reg         [4:0]   up_adc_num_lanes = 'd0;
   reg                 up_adc_sdr_ddr_n = 'd0;
@@ -182,6 +188,9 @@ module up_adc_common #(
       up_mmcm_resetn <= 'd0;
       up_resetn <= 'd0;
       up_adc_sync <= 'd0;
+      up_adc_ext_sync_arm <= 'd0;
+      up_adc_ext_sync_disarm <= 'd0;
+      up_adc_ext_sync_manual_req <= 'd0;
       up_adc_sref_sync <= 'd0;
       up_adc_num_lanes <= 'd0;
       up_adc_sdr_ddr_n <= 'd0;
@@ -213,6 +222,27 @@ module up_adc_common #(
         end
       end else if ((up_wreq_s == 1'b1) && (up_waddr[6:0] == 7'h11)) begin
         up_adc_sync <= up_wdata[3];
+      end
+      if (up_adc_ext_sync_arm == 1'b1) begin
+        if (up_cntrl_xfer_done_s == 1'b1) begin
+          up_adc_ext_sync_arm <= 1'b0;
+        end
+      end else if ((up_wreq_s == 1'b1) && (up_waddr[6:0] == 7'h12)) begin
+        up_adc_ext_sync_arm <= up_wdata[1];
+      end
+      if (up_adc_ext_sync_disarm == 1'b1) begin
+        if (up_cntrl_xfer_done_s == 1'b1) begin
+          up_adc_ext_sync_disarm <= 1'b0;
+        end
+      end else if ((up_wreq_s == 1'b1) && (up_waddr[6:0] == 7'h12)) begin
+        up_adc_ext_sync_disarm <= up_wdata[2];
+      end
+      if (up_adc_ext_sync_manual_req == 1'b1) begin
+        if (up_cntrl_xfer_done_s == 1'b1) begin
+          up_adc_ext_sync_manual_req <= 1'b0;
+        end
+      end else if ((up_wreq_s == 1'b1) && (up_waddr[6:0] == 7'h12)) begin
+        up_adc_ext_sync_manual_req <= up_wdata[8];
       end
       if ((up_wreq_s == 1'b1) && (up_waddr[6:0] == 7'h11)) begin
         up_adc_sdr_ddr_n <= up_wdata[16];
@@ -403,6 +433,10 @@ module up_adc_common #(
                                   1'd0, up_adc_num_lanes,
                                   3'd0, up_adc_sref_sync,
                                   up_adc_sync, up_adc_r1_mode, up_adc_ddr_edgesel, up_adc_pin_mode};
+          7'h12: up_rdata_int <= {20'd0,
+                                  3'b0, up_adc_ext_sync_manual_req,
+                                  4'b0,
+                                  1'b0, up_adc_ext_sync_disarm, up_adc_ext_sync_arm, 1'b0};
           7'h15: up_rdata_int <= up_adc_clk_count_s;
           7'h16: up_rdata_int <= adc_clk_ratio;
           7'h17: up_rdata_int <= {28'd0, up_status_pn_err, up_status_pn_oos, up_status_or, up_status_s};
@@ -435,7 +469,7 @@ module up_adc_common #(
 
   // adc control & status
 
-  up_xfer_cntrl #(.DATA_WIDTH(46)) i_xfer_cntrl (
+  up_xfer_cntrl #(.DATA_WIDTH(49)) i_xfer_cntrl (
     .up_rstn (up_rstn),
     .up_clk (up_clk),
     .up_data_cntrl ({ up_adc_sdr_ddr_n,
@@ -443,6 +477,9 @@ module up_adc_common #(
                       up_adc_symb_8_16b,
                       up_adc_num_lanes,
                       up_adc_sref_sync,
+                      up_adc_ext_sync_arm,
+                      up_adc_ext_sync_disarm,
+                      up_adc_ext_sync_manual_req,
                       up_adc_sync,
                       up_adc_start_code,
                       up_adc_r1_mode,
@@ -457,6 +494,9 @@ module up_adc_common #(
                       adc_symb_8_16b,
                       adc_num_lanes,
                       adc_sref_sync,
+                      adc_ext_sync_arm,
+                      adc_ext_sync_disarm,
+                      adc_ext_sync_manual_req,
                       adc_sync,
                       adc_start_code,
                       adc_r1_mode,

--- a/library/common/up_dac_common.v
+++ b/library/common/up_dac_common.v
@@ -65,6 +65,7 @@ module up_dac_common #(
   output              dac_symb_8_16b,
   output              dac_sync,
   output              dac_ext_sync_arm,
+  output              dac_ext_sync_disarm,
   output              dac_frame,
   output              dac_clksel,
   output              dac_par_type,
@@ -128,6 +129,7 @@ module up_dac_common #(
   reg             up_resetn = 'd0;
   reg             up_dac_sync = 'd0;
   reg             up_dac_ext_sync_arm = 'd0;
+  reg             up_dac_ext_sync_disarm = 'd0;
   reg      [4:0]  up_dac_num_lanes = 'd0;
   reg             up_dac_sdr_ddr_n = 'd0;
   reg             up_dac_symb_op = 'd0;
@@ -193,6 +195,7 @@ module up_dac_common #(
       up_resetn <= 'd0;
       up_dac_sync <= 'd0;
       up_dac_ext_sync_arm <= 'd0;
+      up_dac_ext_sync_disarm <= 'd0;
       up_dac_num_lanes <= 'd0;
       up_dac_sdr_ddr_n <= 'd0;
       up_dac_symb_op <= 'd0;
@@ -234,6 +237,13 @@ module up_dac_common #(
         end
       end else if ((up_wreq_s == 1'b1) && (up_waddr[6:0] == 7'h11)) begin
         up_dac_ext_sync_arm <= up_wdata[1];
+      end
+      if (up_dac_ext_sync_disarm == 1'b1) begin
+        if (up_xfer_done_s == 1'b1) begin
+          up_dac_ext_sync_disarm <= 1'b0;
+        end
+      end else if ((up_wreq_s == 1'b1) && (up_waddr[6:0] == 7'h11)) begin
+        up_dac_ext_sync_disarm <= up_wdata[2];
       end
       if ((up_wreq_s == 1'b1) && (up_waddr[6:0] == 7'h12)) begin
         up_dac_sdr_ddr_n <= up_wdata[16];
@@ -413,7 +423,7 @@ module up_dac_common #(
           7'h03: up_rdata_int <= CONFIG;
           7'h07: up_rdata_int <= {FPGA_TECHNOLOGY,FPGA_FAMILY,SPEED_GRADE,DEV_PACKAGE}; // [8,8,8,8]
           7'h10: up_rdata_int <= {29'd0, up_dac_clk_enb, up_mmcm_resetn, up_resetn};
-          7'h11: up_rdata_int <= {30'd0, up_dac_ext_sync_arm, up_dac_sync};
+          7'h11: up_rdata_int <= {29'd0, up_dac_ext_sync_disarm, up_dac_ext_sync_arm, up_dac_sync};
           7'h12: up_rdata_int <= {15'd0, up_dac_sdr_ddr_n,
                                   up_dac_symb_op, up_dac_symb_8_16b,
                                   1'd0, up_dac_num_lanes,
@@ -452,7 +462,7 @@ module up_dac_common #(
 
   // dac control & status
 
-  up_xfer_cntrl #(.DATA_WIDTH(33)) i_xfer_cntrl (
+  up_xfer_cntrl #(.DATA_WIDTH(34)) i_xfer_cntrl (
     .up_rstn (up_rstn),
     .up_clk (up_clk),
     .up_data_cntrl ({ up_dac_sdr_ddr_n,
@@ -460,6 +470,7 @@ module up_dac_common #(
                       up_dac_symb_8_16b,
                       up_dac_num_lanes,
                       up_dac_ext_sync_arm,
+                      up_dac_ext_sync_disarm,
                       up_dac_sync,
                       up_dac_clksel,
                       up_dac_frame,
@@ -477,6 +488,7 @@ module up_dac_common #(
                       dac_symb_8_16b,
                       dac_num_lanes,
                       dac_ext_sync_arm,
+                      dac_ext_sync_disarm,
                       dac_sync_s,
                       dac_clksel,
                       dac_frame_s,

--- a/library/common/up_xfer_cntrl.v
+++ b/library/common/up_xfer_cntrl.v
@@ -91,7 +91,7 @@ module up_xfer_cntrl #(
       up_xfer_state_m2 <= up_xfer_state_m1;
       up_xfer_state <= up_xfer_state_m2;
       up_xfer_count <= up_xfer_count + 1'd1;
-      up_xfer_done_int <= (up_xfer_count == 6'd1) ? ~up_xfer_enable_s : 1'b0;
+      up_xfer_done_int <= (up_xfer_count == 6'd0) ? ~up_xfer_enable_s : 1'b0;
       if ((up_xfer_count == 6'd1) && (up_xfer_enable_s == 1'b0)) begin
         up_xfer_toggle <= ~up_xfer_toggle;
         up_xfer_data <= up_data_cntrl;

--- a/library/common/util_ext_sync.v
+++ b/library/common/util_ext_sync.v
@@ -1,0 +1,65 @@
+// ***************************************************************************
+// ***************************************************************************
+// Copyright 2018 (c) Analog Devices, Inc. All rights reserved.
+//
+// Each core or library found in this collection may have its own licensing terms.
+// The user should keep this in in mind while exploring these cores.
+//
+// Redistribution and use in source and binary forms,
+// with or without modification of this file, are permitted under the terms of either
+//  (at the option of the user):
+//
+//   1. The GNU General Public License version 2 as published by the
+//      Free Software Foundation, which can be found in the top level directory, or at:
+// https://www.gnu.org/licenses/old-licenses/gpl-2.0.en.html
+//
+// OR
+//
+//   2.  An ADI specific BSD license as noted in the top level directory, or on-line at:
+// https://github.com/analogdevicesinc/hdl/blob/dev/LICENSE
+//
+// ***************************************************************************
+// ***************************************************************************
+
+`timescale 1ns/100ps
+
+module util_ext_sync #(
+  parameter ENABLED = 1
+) (
+  input clk,
+
+  input ext_sync_arm,
+  input ext_sync_disarm,
+
+  input sync_in,
+
+  output reg sync_armed = 1'b0
+
+);
+
+  reg sync_in_d1 = 1'b0;
+  reg sync_in_d2 = 1'b0;
+  reg ext_sync_arm_d1 = 1'b0;
+  reg ext_sync_disarm_d1 = 1'b0;
+
+  // External sync
+  always @(posedge clk) begin
+    ext_sync_arm_d1 <= ext_sync_arm;
+    ext_sync_disarm_d1 <= ext_sync_disarm;
+
+    sync_in_d1 <= sync_in ;
+    sync_in_d2 <= sync_in_d1;
+
+    if (ENABLED == 1'b0) begin
+      sync_armed <= 1'b0;
+    end else if (~ext_sync_disarm_d1 & ext_sync_disarm) begin
+      sync_armed <= 1'b0;
+    end else if (~ext_sync_arm_d1 & ext_sync_arm) begin
+      sync_armed <= 1'b1;
+    end else if (~sync_in_d2 & sync_in_d1) begin
+      sync_armed <= 1'b0;
+    end
+  end
+
+endmodule
+

--- a/library/jesd204/ad_ip_jesd204_tpl_adc/Makefile
+++ b/library/jesd204/ad_ip_jesd204_tpl_adc/Makefile
@@ -17,6 +17,7 @@ GENERIC_DEPS += ../../common/up_axi.v
 GENERIC_DEPS += ../../common/up_clock_mon.v
 GENERIC_DEPS += ../../common/up_xfer_cntrl.v
 GENERIC_DEPS += ../../common/up_xfer_status.v
+GENERIC_DEPS += ../../common/util_ext_sync.v
 GENERIC_DEPS += ad_ip_jesd204_tpl_adc.v
 GENERIC_DEPS += ad_ip_jesd204_tpl_adc_channel.v
 GENERIC_DEPS += ad_ip_jesd204_tpl_adc_core.v

--- a/library/jesd204/ad_ip_jesd204_tpl_adc/ad_ip_jesd204_tpl_adc.v
+++ b/library/jesd204/ad_ip_jesd204_tpl_adc/ad_ip_jesd204_tpl_adc.v
@@ -37,7 +37,8 @@ module ad_ip_jesd204_tpl_adc #(
   parameter DMA_BITS_PER_SAMPLE = 16,
   parameter OCTETS_PER_BEAT = 4,
   parameter EN_FRAME_ALIGN = 1,
-  parameter TWOS_COMPLEMENT = 1
+  parameter TWOS_COMPLEMENT = 1,
+  parameter EXT_SYNC = 0
 ) (
   // jesd interface
   // link_clk is (line-rate/40)
@@ -57,6 +58,9 @@ module ad_ip_jesd204_tpl_adc #(
   input adc_dovf,
 
   input adc_sync_in,
+  output adc_sync_manual_req_out,
+  input adc_sync_manual_req_in,
+
   output adc_rst,
 
   // axi interface
@@ -120,7 +124,8 @@ module ad_ip_jesd204_tpl_adc #(
     .DEV_PACKAGE (DEV_PACKAGE),
     .NUM_CHANNELS (NUM_CHANNELS),
     .DATA_PATH_WIDTH (DATA_PATH_WIDTH),
-    .NUM_PROFILES(1)
+    .NUM_PROFILES(1),
+    .EXT_SYNC (EXT_SYNC)
   ) i_regmap (
     .s_axi_aclk (s_axi_aclk),
     .s_axi_aresetn (s_axi_aresetn),
@@ -158,6 +163,9 @@ module ad_ip_jesd204_tpl_adc #(
 
     .adc_sync (adc_sync),
     .adc_sync_status (adc_sync_status),
+    .adc_ext_sync_arm (adc_ext_sync_arm),
+    .adc_ext_sync_disarm (adc_ext_sync_disarm),
+    .adc_ext_sync_manual_req (adc_sync_manual_req_out),
 
     .adc_rst (adc_rst_s),
 
@@ -184,7 +192,8 @@ module ad_ip_jesd204_tpl_adc #(
     .DMA_DATA_WIDTH (DMA_DATA_WIDTH),
     .TWOS_COMPLEMENT (TWOS_COMPLEMENT),
     .DATA_PATH_WIDTH (DATA_PATH_WIDTH),
-    .DMA_BITS_PER_SAMPLE (DMA_BITS_PER_SAMPLE)
+    .DMA_BITS_PER_SAMPLE (DMA_BITS_PER_SAMPLE),
+    .EXT_SYNC (EXT_SYNC)
   ) i_core (
     .clk (link_clk),
 
@@ -204,7 +213,11 @@ module ad_ip_jesd204_tpl_adc #(
     .adc_sync (adc_sync),
     .adc_sync_status (adc_sync_status),
     .adc_sync_in (adc_sync_in),
+    .adc_ext_sync_arm (adc_ext_sync_arm),
+    .adc_ext_sync_disarm (adc_ext_sync_disarm),
+    .adc_sync_manual_req (adc_sync_manual_req_in),
     .adc_rst_sync (adc_rst_sync_s),
+
 
     .adc_valid (adc_valid),
     .adc_data (adc_data)

--- a/library/jesd204/ad_ip_jesd204_tpl_adc/ad_ip_jesd204_tpl_adc_hw.tcl
+++ b/library/jesd204/ad_ip_jesd204_tpl_adc/ad_ip_jesd204_tpl_adc_hw.tcl
@@ -38,6 +38,7 @@ ad_ip_files ad_ip_jesd204_tpl_adc [list \
   $ad_hdl_dir/library/common/up_clock_mon.v \
   $ad_hdl_dir/library/common/up_adc_common.v \
   $ad_hdl_dir/library/common/up_adc_channel.v \
+  $ad_hdl_dir/library/common/util_ext_sync.v \
   $ad_hdl_dir/library/common/ad_xcvr_rx_if.v \
   $ad_hdl_dir/library/jesd204/ad_ip_jesd204_tpl_common/up_tpl_common.v \
   $ad_hdl_dir/library/jesd204/ad_ip_jesd204_tpl_adc/ad_ip_jesd204_tpl_adc_regmap.v \

--- a/library/jesd204/ad_ip_jesd204_tpl_adc/ad_ip_jesd204_tpl_adc_ip.tcl
+++ b/library/jesd204/ad_ip_jesd204_tpl_adc/ad_ip_jesd204_tpl_adc_ip.tcl
@@ -36,6 +36,7 @@ adi_ip_files ad_ip_jesd204_tpl_adc [list \
   "$ad_hdl_dir/library/common/up_clock_mon.v" \
   "$ad_hdl_dir/library/common/up_adc_common.v" \
   "$ad_hdl_dir/library/common/up_adc_channel.v" \
+  "$ad_hdl_dir/library/common/util_ext_sync.v" \
   "$ad_hdl_dir/library/common/ad_xcvr_rx_if.v" \
   "$ad_hdl_dir/library/xilinx/common/up_xfer_cntrl_constr.xdc" \
   "$ad_hdl_dir/library/xilinx/common/ad_rst_constr.xdc" \
@@ -71,6 +72,10 @@ adi_add_bus "link" "master" \
     {"link_data" "TDATA"} \
   ]
 adi_add_bus_clock "link_clk" "link"
+
+adi_set_ports_dependency "adc_sync_in"             "EXT_SYNC == 1"
+adi_set_ports_dependency "adc_sync_manual_req_out" "EXT_SYNC == 1"
+adi_set_ports_dependency "adc_sync_manual_req_in"  "EXT_SYNC == 1"
 
 foreach {p v} {
   "NUM_LANES" "1 2 3 4 6 8 12 16" \
@@ -128,6 +133,7 @@ set i 0
 
 foreach {k v w} {
   "TWOS_COMPLEMENT" "Use twos complement" "checkBox" \
+  "EXT_SYNC" "Enable external sync" "checkBox" \
   } { \
   set p [ipgui::get_guiparamspec -name $k -component $cc]
   ipgui::move_param -component $cc -order $i $p -parent $datapath_group

--- a/library/jesd204/ad_ip_jesd204_tpl_adc/ad_ip_jesd204_tpl_adc_regmap.v
+++ b/library/jesd204/ad_ip_jesd204_tpl_adc/ad_ip_jesd204_tpl_adc_regmap.v
@@ -31,7 +31,8 @@ module ad_ip_jesd204_tpl_adc_regmap #(
   parameter DEV_PACKAGE = 0,
   parameter NUM_CHANNELS = 1,
   parameter DATA_PATH_WIDTH = 1,
-  parameter NUM_PROFILES = 1    // Number of supported JESD profiles
+  parameter NUM_PROFILES = 1,    // Number of supported JESD profiles
+  parameter EXT_SYNC = 0
 ) (
   // axi interface
   input s_axi_aclk,
@@ -73,6 +74,9 @@ module ad_ip_jesd204_tpl_adc_regmap #(
 
   input adc_sync_status,
   output adc_sync,
+  output adc_ext_sync_arm,
+  output adc_ext_sync_disarm,
+  output adc_ext_sync_manual_req,
   output adc_rst,
 
   // Underflow
@@ -195,6 +199,9 @@ module ad_ip_jesd204_tpl_adc_regmap #(
   end
 
   // common processor control
+  //
+  localparam CONFIG = (EXT_SYNC << 12);
+
 
   up_adc_common #(
     .COMMON_ID (6'h0),
@@ -206,7 +213,8 @@ module ad_ip_jesd204_tpl_adc_regmap #(
     .DRP_DISABLE (1),
     .USERPORTS_DISABLE (1),
     .GPIO_DISABLE (1),
-    .START_CODE_DISABLE (1)
+    .START_CODE_DISABLE (1),
+    .CONFIG (CONFIG)
   ) i_up_adc_common (
     .mmcm_rst (),
     .adc_clk (link_clk),
@@ -221,6 +229,9 @@ module ad_ip_jesd204_tpl_adc_regmap #(
     .adc_start_code (),
     .adc_sref_sync (),
     .adc_sync (adc_sync),
+    .adc_ext_sync_arm (adc_ext_sync_arm),
+    .adc_ext_sync_disarm (adc_ext_sync_disarm),
+    .adc_ext_sync_manual_req (adc_ext_sync_manual_req),
 
     .up_status_pn_err (up_status_pn_err),
     .up_status_pn_oos (up_status_pn_oos),

--- a/library/jesd204/ad_ip_jesd204_tpl_dac/Makefile
+++ b/library/jesd204/ad_ip_jesd204_tpl_dac/Makefile
@@ -23,6 +23,7 @@ GENERIC_DEPS += ../../common/up_dac_channel.v
 GENERIC_DEPS += ../../common/up_dac_common.v
 GENERIC_DEPS += ../../common/up_xfer_cntrl.v
 GENERIC_DEPS += ../../common/up_xfer_status.v
+GENERIC_DEPS += ../../common/util_ext_sync.v
 GENERIC_DEPS += ../ad_ip_jesd204_tpl_common/up_tpl_common.v
 GENERIC_DEPS += ad_ip_jesd204_tpl_dac.v
 GENERIC_DEPS += ad_ip_jesd204_tpl_dac_channel.v

--- a/library/jesd204/ad_ip_jesd204_tpl_dac/ad_ip_jesd204_tpl_dac.v
+++ b/library/jesd204/ad_ip_jesd204_tpl_dac/ad_ip_jesd204_tpl_dac.v
@@ -60,9 +60,13 @@ module ad_ip_jesd204_tpl_dac #(
   input [DMA_BITS_PER_SAMPLE * OCTETS_PER_BEAT * 8 * NUM_LANES / BITS_PER_SAMPLE-1:0] dac_ddata,
   input dac_dunf,
 
+  output dac_rst,
+
   // external sync, should be on the link_clk clock domain
 
   input dac_sync_in,
+  output dac_sync_manual_req_out,
+  input dac_sync_manual_req_in,
 
   // axi interface
 
@@ -138,7 +142,8 @@ module ad_ip_jesd204_tpl_dac #(
     .NUM_CHANNELS (NUM_CHANNELS),
     .DATA_PATH_WIDTH (DATA_PATH_WIDTH),
     .PADDING_TO_MSB_LSB_N (PADDING_TO_MSB_LSB_N),
-    .NUM_PROFILES(1)
+    .NUM_PROFILES(1),
+    .EXT_SYNC (EXT_SYNC)
   ) i_regmap (
     .s_axi_aclk (s_axi_aclk),
     .s_axi_aresetn (s_axi_aresetn),
@@ -169,6 +174,8 @@ module ad_ip_jesd204_tpl_dac #(
 
     .dac_sync (dac_sync),
     .dac_ext_sync_arm (dac_ext_sync_arm),
+    .dac_ext_sync_disarm (dac_ext_sync_disarm),
+    .dac_ext_sync_manual_req (dac_sync_manual_req_out),
     .dac_sync_in_status (dac_sync_in_status),
     .dac_dds_format (dac_dds_format),
 
@@ -227,11 +234,14 @@ module ad_ip_jesd204_tpl_dac #(
 
     .dac_valid (dac_valid),
     .dac_ddata (dac_ddata_cr),
+    .dac_rst (dac_rst),
 
     .dac_sync (dac_sync),
     .dac_ext_sync_arm (dac_ext_sync_arm),
+    .dac_ext_sync_disarm (dac_ext_sync_disarm),
     .dac_sync_in_status (dac_sync_in_status),
     .dac_sync_in (dac_sync_in),
+    .dac_sync_manual_req (dac_sync_manual_req_in),
     .dac_dds_format (dac_dds_format),
 
     .dac_dds_scale_0 (dac_dds_scale_0_s),

--- a/library/jesd204/ad_ip_jesd204_tpl_dac/ad_ip_jesd204_tpl_dac_core.v
+++ b/library/jesd204/ad_ip_jesd204_tpl_dac/ad_ip_jesd204_tpl_dac_core.v
@@ -50,13 +50,16 @@ module ad_ip_jesd204_tpl_dac_core #(
   // dma interface
   output [NUM_CHANNELS-1:0] dac_valid,
   input [LINK_DATA_WIDTH-1:0] dac_ddata,
+  output dac_rst,
 
   // Configuration interface
 
   input dac_sync,
   input dac_ext_sync_arm,
+  input dac_ext_sync_disarm,
 
   input dac_sync_in,
+  input dac_sync_manual_req,
 
   output dac_sync_in_status,
 
@@ -93,32 +96,23 @@ module ad_ip_jesd204_tpl_dac_core #(
   wire [DAC_CDW-1:0] pn7_data;
   wire [DAC_CDW-1:0] pn15_data;
 
-  reg dac_sync_in_d1 ='d0;
-  reg dac_sync_in_d2 ='d0;
-  reg dac_sync_in_armed ='d0;
-  reg dac_ext_sync_arm_d1 = 'd0;
+  wire [LINK_DATA_WIDTH-1:0] dac_ddata_int;
 
   assign link_valid = 1'b1;
-  assign dac_sync_in_status = dac_sync_in_armed;
+  assign dac_sync_in_status = dac_sync_armed;
 
-  // External sync
-  always @(posedge clk) begin
-    dac_ext_sync_arm_d1 <= dac_ext_sync_arm;
-
-    dac_sync_in_d1 <= dac_sync_in;
-    dac_sync_in_d2 <= dac_sync_in_d1;
-
-    if (EXT_SYNC == 1'b0) begin
-      dac_sync_in_armed <= 1'b0;
-    end else if (~dac_ext_sync_arm_d1 & dac_ext_sync_arm) begin
-      dac_sync_in_armed <= ~dac_sync_in_armed;
-    end else if (~dac_sync_in_d2 & dac_sync_in_d1) begin
-      dac_sync_in_armed <= 1'b0;
-    end
-  end
+  util_ext_sync #(
+    .ENABLED (EXT_SYNC)
+  ) i_util_ext_sync (
+    .clk (clk),
+    .ext_sync_arm (dac_ext_sync_arm),
+    .ext_sync_disarm (dac_ext_sync_disarm),
+    .sync_in (dac_sync_in | dac_sync_manual_req),
+    .sync_armed (dac_sync_armed)
+  );
 
   // Sync either from external or software source
-  assign dac_sync_int = dac_sync_in_armed | dac_sync;
+  assign dac_sync_int = dac_sync_armed | dac_sync;
 
   // device interface
 
@@ -150,7 +144,11 @@ module ad_ip_jesd204_tpl_dac_core #(
 
   // dac valid
 
-  assign dac_valid = {NUM_CHANNELS{~dac_sync_int}};
+  assign dac_valid = {NUM_CHANNELS{~dac_sync_armed}};
+  assign dac_rst = dac_sync_armed;
+
+  // Gate input data 
+  assign dac_ddata_int = dac_sync_armed ? {LINK_DATA_WIDTH{1'b0}} : dac_ddata;
 
   generate
   genvar i;
@@ -171,13 +169,13 @@ module ad_ip_jesd204_tpl_dac_core #(
         .EN_REG (1)
       ) channel_mux (
         .clk (clk),
-        .data_in (dac_ddata),
+        .data_in (dac_ddata_int),
         .ch_sel (dac_src_chan_sel[8*i+:8]),
         .data_out (dac_ddata_muxed[DAC_CDW*i+:DAC_CDW])
       );
 
     end else begin
-      assign dac_ddata_muxed[DAC_CDW*i+:DAC_CDW] = dac_ddata[DAC_CDW*i+:DAC_CDW];
+      assign dac_ddata_muxed[DAC_CDW*i+:DAC_CDW] = dac_ddata_int[DAC_CDW*i+:DAC_CDW];
     end
 
     ad_ip_jesd204_tpl_dac_channel #(

--- a/library/jesd204/ad_ip_jesd204_tpl_dac/ad_ip_jesd204_tpl_dac_hw.tcl
+++ b/library/jesd204/ad_ip_jesd204_tpl_dac/ad_ip_jesd204_tpl_dac_hw.tcl
@@ -46,6 +46,7 @@ ad_ip_files ad_ip_jesd204_tpl_dac [list \
   $ad_hdl_dir/library/common/up_clock_mon.v \
   $ad_hdl_dir/library/common/up_dac_common.v \
   $ad_hdl_dir/library/common/up_dac_channel.v \
+  $ad_hdl_dir/library/common/util_ext_sync.v \
   \
   $ad_hdl_dir/library/intel/common/up_xfer_cntrl_constr.sdc \
   $ad_hdl_dir/library/intel/common/up_xfer_status_constr.sdc \

--- a/library/jesd204/ad_ip_jesd204_tpl_dac/ad_ip_jesd204_tpl_dac_ip.tcl
+++ b/library/jesd204/ad_ip_jesd204_tpl_dac/ad_ip_jesd204_tpl_dac_ip.tcl
@@ -44,6 +44,7 @@ adi_ip_files ad_ip_jesd204_tpl_dac [list \
   "$ad_hdl_dir/library/common/up_clock_mon.v" \
   "$ad_hdl_dir/library/common/up_dac_common.v" \
   "$ad_hdl_dir/library/common/up_dac_channel.v" \
+  "$ad_hdl_dir/library/common/util_ext_sync.v" \
   "$ad_hdl_dir/library/xilinx/common/up_xfer_cntrl_constr.xdc" \
   "$ad_hdl_dir/library/xilinx/common/ad_rst_constr.xdc" \
   "$ad_hdl_dir/library/xilinx/common/up_xfer_status_constr.xdc" \
@@ -79,6 +80,10 @@ adi_add_bus "link" "master" \
     {"link_data" "TDATA"} \
   ]
 adi_add_bus_clock "link_clk" "link"
+
+adi_set_ports_dependency "dac_sync_in"             "EXT_SYNC == 1"
+adi_set_ports_dependency "dac_sync_manual_req_out" "EXT_SYNC == 1"
+adi_set_ports_dependency "dac_sync_manual_req_in"  "EXT_SYNC == 1"
 
 set_property -dict [list \
   "value_validation_type" "pairs" \

--- a/library/jesd204/ad_ip_jesd204_tpl_dac/ad_ip_jesd204_tpl_dac_regmap.v
+++ b/library/jesd204/ad_ip_jesd204_tpl_dac/ad_ip_jesd204_tpl_dac_regmap.v
@@ -35,7 +35,8 @@ module ad_ip_jesd204_tpl_dac_regmap #(
   parameter NUM_CHANNELS = 2,
   parameter DATA_PATH_WIDTH = 16,
   parameter PADDING_TO_MSB_LSB_N = 0,
-  parameter NUM_PROFILES = 1    // Number of supported JESD profiles
+  parameter NUM_PROFILES = 1,    // Number of supported JESD profiles
+  parameter EXT_SYNC = 0
 ) (
   input s_axi_aclk,
   input s_axi_aresetn,
@@ -70,6 +71,8 @@ module ad_ip_jesd204_tpl_dac_regmap #(
 
   output dac_sync,
   output dac_ext_sync_arm,
+  output dac_ext_sync_disarm,
+  output dac_ext_sync_manual_req,
 
   input dac_sync_in_status,
 
@@ -190,7 +193,8 @@ module ad_ip_jesd204_tpl_dac_regmap #(
 
   // dac common processor interface
   //
-  localparam CONFIG = (PADDING_TO_MSB_LSB_N << 11) |
+  localparam CONFIG = (EXT_SYNC << 12) |
+                      (PADDING_TO_MSB_LSB_N << 11) |
                       (XBAR_ENABLE << 10) |
                       (DATAPATH_DISABLE << 6) |
                       (IQCORRECTION_DISABLE << 0);
@@ -212,6 +216,8 @@ module ad_ip_jesd204_tpl_dac_regmap #(
     .dac_rst (dac_rst),
     .dac_sync (dac_sync),
     .dac_ext_sync_arm (dac_ext_sync_arm),
+    .dac_ext_sync_disarm (dac_ext_sync_disarm),
+    .dac_ext_sync_manual_req (dac_ext_sync_manual_req),
     .dac_sync_in_status (dac_sync_in_status),
     .dac_frame (),
     .dac_clksel (),

--- a/projects/adrv9009zu11eg/common/adrv9009zu11eg_bd.tcl
+++ b/projects/adrv9009zu11eg/common/adrv9009zu11eg_bd.tcl
@@ -372,7 +372,7 @@ ad_connect  core_clk_a tx_adrv9009_som_tpl_core/link_clk
 ad_connect  axi_adrv9009_som_tx_jesd/tx_data tx_adrv9009_som_tpl_core/link
 
 ad_connect  core_clk_a util_som_tx_upack/clk
-ad_connect  core_clk_a_rstgen/peripheral_reset util_som_tx_upack/reset
+ad_connect  tx_adrv9009_som_tpl_core/dac_tpl_core/dac_rst util_som_tx_upack/reset
 
 ad_connect  tx_adrv9009_som_tpl_core/dac_valid_0 util_som_tx_upack/fifo_rd_en
 for {set i 0} {$i < $TX_NUM_OF_CONVERTERS} {incr i} {
@@ -408,7 +408,7 @@ ad_connect  axi_adrv9009_som_obs_jesd/rx_sof obs_adrv9009_som_tpl_core/link_sof
 ad_connect  axi_adrv9009_som_obs_jesd/rx_data_tdata obs_adrv9009_som_tpl_core/link_data
 ad_connect  axi_adrv9009_som_obs_jesd/rx_data_tvalid obs_adrv9009_som_tpl_core/link_valid
 ad_connect  core_clk_a util_som_obs_cpack/clk
-ad_connect  core_clk_a_rstgen/peripheral_reset util_som_obs_cpack/reset
+ad_connect  obs_adrv9009_som_tpl_core/adc_tpl_core/adc_rst util_som_obs_cpack/reset
 ad_connect  core_clk_a axi_adrv9009_som_obs_dma/fifo_wr_clk
 
 ad_connect  obs_adrv9009_som_tpl_core/adc_valid_0 util_som_obs_cpack/fifo_wr_en

--- a/projects/adrv9009zu11eg/common/adrv9009zu11eg_bd.tcl
+++ b/projects/adrv9009zu11eg/common/adrv9009zu11eg_bd.tcl
@@ -272,6 +272,8 @@ adi_tpl_jesd204_rx_create rx_adrv9009_som_tpl_core $RX_NUM_OF_LANES \
                                                $RX_SAMPLES_PER_FRAME \
                                                $RX_SAMPLE_WIDTH
 
+ad_ip_parameter rx_adrv9009_som_tpl_core/adc_tpl_core CONFIG.EXT_SYNC 1
+
 ad_ip_instance axi_dmac axi_adrv9009_som_rx_dma
 ad_ip_parameter axi_adrv9009_som_rx_dma CONFIG.DMA_TYPE_SRC 2
 ad_ip_parameter axi_adrv9009_som_rx_dma CONFIG.DMA_TYPE_DEST 0
@@ -302,6 +304,8 @@ adi_tpl_jesd204_rx_create obs_adrv9009_som_tpl_core $OBS_NUM_OF_LANES \
                                                   $OBS_NUM_OF_CONVERTERS \
                                                   $OBS_SAMPLES_PER_FRAME \
                                                   $OBS_SAMPLE_WIDTH
+
+ad_ip_parameter obs_adrv9009_som_tpl_core/adc_tpl_core CONFIG.EXT_SYNC 1
 
 ad_ip_instance axi_dmac axi_adrv9009_som_obs_dma
 ad_ip_parameter axi_adrv9009_som_obs_dma CONFIG.DMA_TYPE_SRC 2
@@ -454,6 +458,11 @@ ad_connect sys_dma_clk dma_clk_wiz/clk_out1
 ad_connect sys_dma_rstgen/ext_reset_in sys_rstgen/peripheral_reset
 ad_connect sys_dma_clk sys_dma_rstgen/slowest_sync_clk
 ad_connect sys_dma_resetn sys_dma_rstgen/peripheral_aresetn
+
+# Loop back manual sync lines for each TPL
+ad_connect tx_adrv9009_som_tpl_core/dac_tpl_core/dac_sync_manual_req_out tx_adrv9009_som_tpl_core/dac_tpl_core/dac_sync_manual_req_in
+ad_connect rx_adrv9009_som_tpl_core/adc_tpl_core/adc_sync_manual_req_out rx_adrv9009_som_tpl_core/adc_tpl_core/adc_sync_manual_req_in
+ad_connect obs_adrv9009_som_tpl_core/adc_tpl_core/adc_sync_manual_req_out obs_adrv9009_som_tpl_core/adc_tpl_core/adc_sync_manual_req_in
 
 # interconnect (cpu)
 


### PR DESCRIPTION
This series of changes refactors the external sync support at the TPL level and applies it to AD9081 and ADRV9009ZU11 designs.
Fixes issue with up_xfer_cntrl that made 1 of 64 transfers fail when used with self clearing bits.

Tested hardware on both platforms. 
VCK190 + AD9082
ZCU102 + AD9081
ADRV9009ZU11 + FMCOMMS8