### PR TITLE
ad_quadmxfe1_ebz: Fix external sync for ADC path

### DIFF
--- a/projects/ad_quadmxfe1_ebz/common/ad_quadmxfe1_ebz_bd.tcl
+++ b/projects/ad_quadmxfe1_ebz/common/ad_quadmxfe1_ebz_bd.tcl
@@ -197,6 +197,7 @@ adi_tpl_jesd204_rx_create rx_mxfe_tpl_core $RX_NUM_OF_LANES \
                                            $RX_DMA_SAMPLE_WIDTH
 
 ad_ip_parameter rx_mxfe_tpl_core/adc_tpl_core CONFIG.EN_FRAME_ALIGN 0
+ad_ip_parameter rx_mxfe_tpl_core/adc_tpl_core CONFIG.EXT_SYNC 1
 
 ad_ip_instance util_cpack2 util_mxfe_cpack [list \
   NUM_OF_CHANNELS $RX_NUM_OF_CONVERTERS \


### PR DESCRIPTION
External sync must be explicitly enabled also in case of ADC TPL. 


Tested compile only. 
VCU118+QuadMxFE