### PR TITLE
ADRV9371 & ADRV9009 ref clk updates

### DIFF
--- a/projects/adrv9009/common/adrv9009_bd.tcl
+++ b/projects/adrv9009/common/adrv9009_bd.tcl
@@ -45,6 +45,8 @@ source $ad_hdl_dir/projects/common/xilinx/adi_fir_filter_bd.tcl
 
 # adrv9009
 
+create_bd_port -dir I ref_clk
+
 create_bd_port -dir I dac_fifo_bypass
 create_bd_port -dir I adc_fir_filter_active
 create_bd_port -dir I dac_fir_filter_active
@@ -220,14 +222,14 @@ ad_connect  $sys_cpu_clk util_adrv9009_xcvr/up_clk
 # Tx
 ad_connect adrv9009_tx_device_clk axi_adrv9009_tx_clkgen/clk_0
 ad_xcvrcon util_adrv9009_xcvr axi_adrv9009_tx_xcvr axi_adrv9009_tx_jesd {0 3 2 1} adrv9009_tx_device_clk {} $MAX_TX_NUM_OF_LANES
-ad_connect util_adrv9009_xcvr/tx_out_clk_0 axi_adrv9009_tx_clkgen/clk
+ad_connect ref_clk axi_adrv9009_tx_clkgen/clk
 ad_xcvrpll $tx_ref_clk util_adrv9009_xcvr/qpll_ref_clk_0
 ad_xcvrpll axi_adrv9009_tx_xcvr/up_pll_rst util_adrv9009_xcvr/up_qpll_rst_0
 
 # Rx
 ad_connect adrv9009_rx_device_clk axi_adrv9009_rx_clkgen/clk_0
 ad_xcvrcon util_adrv9009_xcvr axi_adrv9009_rx_xcvr axi_adrv9009_rx_jesd {} adrv9009_rx_device_clk {} $MAX_RX_NUM_OF_LANES
-ad_connect util_adrv9009_xcvr/rx_out_clk_0 axi_adrv9009_rx_clkgen/clk
+ad_connect ref_clk axi_adrv9009_rx_clkgen/clk
 for {set i 0} {$i < $MAX_RX_NUM_OF_LANES} {incr i} {
   set ch [expr $i]
   ad_xcvrpll  $rx_ref_clk util_adrv9009_xcvr/cpll_ref_clk_$ch
@@ -237,7 +239,7 @@ for {set i 0} {$i < $MAX_RX_NUM_OF_LANES} {incr i} {
 # Rx - OBS
 ad_connect adrv9009_rx_os_device_clk axi_adrv9009_rx_os_clkgen/clk_0
 ad_xcvrcon util_adrv9009_xcvr axi_adrv9009_rx_os_xcvr axi_adrv9009_rx_os_jesd {} adrv9009_rx_os_device_clk {} $MAX_RX_OS_NUM_OF_LANES
-ad_connect util_adrv9009_xcvr/rx_out_clk_$MAX_RX_NUM_OF_LANES axi_adrv9009_rx_os_clkgen/clk
+ad_connect ref_clk axi_adrv9009_rx_os_clkgen/clk
 for {set i 0} {$i < $MAX_RX_OS_NUM_OF_LANES} {incr i} {
   # channel indexing starts from the last RX
   set ch [expr $MAX_RX_NUM_OF_LANES + $i]

--- a/projects/adrv9009/zc706/system_top.v
+++ b/projects/adrv9009/zc706/system_top.v
@@ -261,6 +261,10 @@ module system_top (
     .O (ref_clk1),
     .ODIV2 ());
 
+  BUFG i_bufg_ref_clk (
+    .I (ref_clk1),
+    .O (ref_clk1_bufg));
+
   OBUFDS i_obufds_rx_sync (
     .I (rx_sync),
     .O (rx_sync_p),
@@ -426,7 +430,8 @@ module system_top (
     .tx_data_3_p (tx_data_p[3]),
     .tx_ref_clk_0 (ref_clk1),
     .tx_sync_0 (tx_sync),
-    .tx_sysref_0 (sysref));
+    .tx_sysref_0 (sysref),
+    .ref_clk (ref_clk1_bufg));
 
 endmodule
 

--- a/projects/adrv9009/zcu102/system_top.v
+++ b/projects/adrv9009/zcu102/system_top.v
@@ -134,7 +134,11 @@ module system_top (
     .I (ref_clk1_p),
     .IB (ref_clk1_n),
     .O (ref_clk1),
-    .ODIV2 ());
+    .ODIV2 (ref_clk1_odiv2));
+
+  BUFG_GT i_bufg_ref_clk (
+    .I (ref_clk1_odiv2),
+    .O (ref_clk1_bufg));
 
   OBUFDS i_obufds_rx_sync (
     .I (rx_sync),
@@ -245,7 +249,8 @@ module system_top (
     .tx_data_3_p (tx_data_p[3]),
     .tx_ref_clk_0 (ref_clk1),
     .tx_sync_0 (tx_sync),
-    .tx_sysref_0 (sysref));
+    .tx_sysref_0 (sysref),
+    .ref_clk (ref_clk1_bufg));
 
 endmodule
 

--- a/projects/adrv9371x/common/adrv9371x_bd.tcl
+++ b/projects/adrv9371x/common/adrv9371x_bd.tcl
@@ -45,6 +45,8 @@ source $ad_hdl_dir/projects/common/xilinx/adi_fir_filter_bd.tcl
 
 # ad9371
 
+create_bd_port -dir I ref_clk
+
 create_bd_port -dir I dac_fifo_bypass
 create_bd_port -dir I adc_fir_filter_active
 create_bd_port -dir I dac_fir_filter_active
@@ -220,14 +222,14 @@ ad_connect  $sys_cpu_clk util_ad9371_xcvr/up_clk
 # Tx
 ad_connect  ad9371_tx_device_clk axi_ad9371_tx_clkgen/clk_0
 ad_xcvrcon  util_ad9371_xcvr axi_ad9371_tx_xcvr axi_ad9371_tx_jesd {1 2 3 0} ad9371_tx_device_clk {} $MAX_TX_NUM_OF_LANES
-ad_connect  util_ad9371_xcvr/tx_out_clk_0 axi_ad9371_tx_clkgen/clk
+ad_connect  ref_clk axi_ad9371_tx_clkgen/clk
 ad_xcvrpll  $tx_ref_clk util_ad9371_xcvr/qpll_ref_clk_0
 ad_xcvrpll  axi_ad9371_tx_xcvr/up_pll_rst util_ad9371_xcvr/up_qpll_rst_0
 
 # Rx
 ad_connect  ad9371_rx_device_clk axi_ad9371_rx_clkgen/clk_0
 ad_xcvrcon  util_ad9371_xcvr axi_ad9371_rx_xcvr axi_ad9371_rx_jesd {} ad9371_rx_device_clk {} $MAX_RX_NUM_OF_LANES
-ad_connect  util_ad9371_xcvr/rx_out_clk_0 axi_ad9371_rx_clkgen/clk
+ad_connect  ref_clk axi_ad9371_rx_clkgen/clk
 for {set i 0} {$i < $MAX_RX_NUM_OF_LANES} {incr i} {
   set ch [expr $i]
   ad_xcvrpll  $rx_ref_clk util_ad9371_xcvr/cpll_ref_clk_$ch
@@ -237,7 +239,7 @@ for {set i 0} {$i < $MAX_RX_NUM_OF_LANES} {incr i} {
 # Rx - OBS
 ad_connect  ad9371_rx_os_device_clk axi_ad9371_rx_os_clkgen/clk_0
 ad_xcvrcon  util_ad9371_xcvr axi_ad9371_rx_os_xcvr axi_ad9371_rx_os_jesd {} ad9371_rx_os_device_clk {} $MAX_RX_OS_NUM_OF_LANES
-ad_connect  util_ad9371_xcvr/rx_out_clk_$MAX_RX_NUM_OF_LANES axi_ad9371_rx_os_clkgen/clk
+ad_connect  ref_clk axi_ad9371_rx_os_clkgen/clk
 for {set i 0} {$i < $MAX_RX_OS_NUM_OF_LANES} {incr i} {
   # channel indexing starts from the last RX
   set ch [expr $MAX_RX_NUM_OF_LANES + $i]

--- a/projects/adrv9371x/kcu105/system_top.v
+++ b/projects/adrv9371x/kcu105/system_top.v
@@ -158,12 +158,18 @@ module system_top (
     .O (ref_clk0),
     .ODIV2 ());
 
-  IBUFDS_GTE3 i_ibufds_ref_clk1 (
+  IBUFDS_GTE3 #(
+    .REFCLK_HROW_CK_SEL(2'b00) // ODIV2 = O
+  ) i_ibufds_ref_clk1 (
     .CEB (1'd0),
     .I (ref_clk1_p),
     .IB (ref_clk1_n),
     .O (ref_clk1),
-    .ODIV2 ());
+    .ODIV2 (ref_clk1_odiv2));
+
+  BUFG_GT i_bufg_ref_clk (
+    .I (ref_clk1_odiv2),
+    .O (ref_clk1_bufg));
 
   OBUFDS i_obufds_rx_sync (
     .I (rx_sync),
@@ -299,7 +305,8 @@ module system_top (
     .tx_sync_0 (tx_sync),
     .tx_sysref_0 (sysref),
     .uart_sin (uart_sin),
-    .uart_sout (uart_sout));
+    .uart_sout (uart_sout),
+    .ref_clk (ref_clk1_bufg));
 
 endmodule
 

--- a/projects/adrv9371x/zc706/system_top.v
+++ b/projects/adrv9371x/zc706/system_top.v
@@ -174,6 +174,10 @@ module system_top (
     .O (ref_clk1),
     .ODIV2 ());
 
+  BUFG i_bufg_ref_clk (
+    .I (ref_clk1),
+    .O (ref_clk1_bufg));
+
   OBUFDS i_obufds_rx_sync (
     .I (rx_sync),
     .O (rx_sync_p),
@@ -332,7 +336,8 @@ module system_top (
     .tx_data_3_p (tx_data_p[3]),
     .tx_ref_clk_0 (ref_clk1),
     .tx_sync_0 (tx_sync),
-    .tx_sysref_0 (sysref));
+    .tx_sysref_0 (sysref),
+    .ref_clk (ref_clk1_bufg));
 
 endmodule
 

--- a/projects/adrv9371x/zcu102/system_top.v
+++ b/projects/adrv9371x/zcu102/system_top.v
@@ -119,12 +119,18 @@ module system_top (
     .O (ref_clk0),
     .ODIV2 ());
 
-  IBUFDS_GTE4 i_ibufds_ref_clk1 (
+  IBUFDS_GTE4  #(
+    .REFCLK_HROW_CK_SEL(2'b00) // ODIV2 = O
+  ) i_ibufds_ref_clk1 (
     .CEB (1'd0),
     .I (ref_clk1_p),
     .IB (ref_clk1_n),
     .O (ref_clk1),
-    .ODIV2 ());
+    .ODIV2 (ref_clk1_odiv2));
+
+  BUFG_GT i_bufg_ref_clk (
+    .I (ref_clk1_odiv2),
+    .O (ref_clk1_bufg));
 
   OBUFDS i_obufds_rx_sync (
     .I (rx_sync),
@@ -228,7 +234,8 @@ module system_top (
     .tx_data_3_p (tx_data_p[3]),
     .tx_ref_clk_0 (ref_clk1),
     .tx_sync_0 (tx_sync),
-    .tx_sysref_0 (sysref));
+    .tx_sysref_0 (sysref),
+    .ref_clk (ref_clk1_bufg));
 
 endmodule
 


### PR DESCRIPTION
Take the ref clock of internal clock generators directly from IBUFDS_GT instead of OUTCLK of the XCVR to remove circular dependency in case of the usage of JESD FSM.  

Tested in hardware on
 ADRV9371 + ZCU102
 ADRV9371 + ZC706

Tested compile only with all Xilinx projects. 