### PR TITLE
Fix vcu118 vcu128 eth clk

### DIFF
--- a/projects/common/vcu118/vcu118_system_constr.xdc
+++ b/projects/common/vcu118/vcu118_system_constr.xdc
@@ -15,8 +15,8 @@ set_property PACKAGE_PIN AV21 [get_ports phy_tx_n]
 set_property PACKAGE_PIN AU24 [get_ports phy_rx_p]
 set_property PACKAGE_PIN AV24 [get_ports phy_rx_n]
 
-set_property -dict  {PACKAGE_PIN  AT22  IOSTANDARD LVDS} [get_ports phy_clk_p]
-set_property -dict  {PACKAGE_PIN  AU22  IOSTANDARD LVDS} [get_ports phy_clk_n]
+set_property -dict  {PACKAGE_PIN  AT22  IOSTANDARD LVDS  DIFF_TERM_ADV TERM_100} [get_ports phy_clk_p]
+set_property -dict  {PACKAGE_PIN  AU22  IOSTANDARD LVDS  DIFF_TERM_ADV TERM_100} [get_ports phy_clk_n]
 
 set_property -dict  {PACKAGE_PIN  BA21  IOSTANDARD  LVCMOS18} [get_ports phy_rst_n]
 set_property -dict  {PACKAGE_PIN  AV23  IOSTANDARD  LVCMOS18} [get_ports mdio_mdc]

--- a/projects/common/vcu128/vcu128_system_constr.xdc
+++ b/projects/common/vcu128/vcu128_system_constr.xdc
@@ -16,8 +16,8 @@ set_property PACKAGE_PIN BH22 [get_ports phy_tx_n]
 set_property PACKAGE_PIN BJ22 [get_ports phy_rx_p]
 set_property PACKAGE_PIN BK21 [get_ports phy_rx_n]
 
-set_property -dict  {PACKAGE_PIN  BH27  IOSTANDARD LVDS} [get_ports phy_clk_p]
-set_property -dict  {PACKAGE_PIN  BJ27  IOSTANDARD LVDS} [get_ports phy_clk_n]
+set_property -dict  {PACKAGE_PIN  BH27  IOSTANDARD LVDS  DIFF_TERM_ADV TERM_100} [get_ports phy_clk_p]
+set_property -dict  {PACKAGE_PIN  BJ27  IOSTANDARD LVDS  DIFF_TERM_ADV TERM_100} [get_ports phy_clk_n]
 
 set_property -dict  {PACKAGE_PIN  BN27  IOSTANDARD  LVCMOS18} [get_ports mdio_mdc]
 set_property -dict  {PACKAGE_PIN  BG23  IOSTANDARD  LVCMOS18} [get_ports mdio_mdio]


### PR DESCRIPTION
There are no external termination resistors on the VCU118 for the SGMII
clock lines. The board files enables them, but this was not reflected in the
constraint files.

See: https://ez.analog.com/fpga/f/q-a/551237/unable-to-get-ad9208-dual-ebz-to-acquire-dhcp-address-and-communication-using-static-ip-also-not-working

Tested compile only.