### PR TITLE
ad9083: Using variables instead of hard coded nets

### DIFF
--- a/projects/ad9083_evb/common/ad9083_evb_bd.tcl
+++ b/projects/ad9083_evb/common/ad9083_evb_bd.tcl
@@ -123,9 +123,11 @@ ad_ip_parameter dma_clk_generator CONFIG.PRIM_SOURCE No_buffer
 ad_connect $sys_cpu_clk dma_clk_generator/clk_in1
 ad_connect $sys_cpu_resetn dma_clk_generator/resetn
 
-ad_disconnect sys_250m_clk sys_ps8/pl_clk1
+set sys_dma_clk_pin [get_bd_pins -filter {DIR == O} -of [get_bd_nets $sys_dma_clk]]
+ad_disconnect $sys_dma_clk $sys_dma_clk_pin
 
-ad_connect $sys_dma_clk dma_clk_generator/clk_out1
+ad_connect $sys_dma_clk [get_bd_pins dma_clk_generator/clk_out1]
+
 ad_connect axi_ad9083_rx_dma/fifo_wr util_ad9083_rx_cpack/packed_fifo_wr
 
 # connections (adc)


### PR DESCRIPTION
The change is needed in order to support testbench variable redefine.