### PR TITLE
xilinx/common:ad_data_out.v: Fix typo

### DIFF
--- a/library/xilinx/common/ad_data_out.v
+++ b/library/xilinx/common/ad_data_out.v
@@ -113,7 +113,7 @@ module ad_data_out #(
 
   generate
   if (FPGA_TECHNOLOGY == SEVEN_SERIES) begin
-  ODDR #(.DDR_CLK_EDGE ("IDDR_CLK_EDGE")) i_tx_data_oddr (
+  ODDR #(.DDR_CLK_EDGE (IDDR_CLK_EDGE)) i_tx_data_oddr (
     .CE (1'b1),
     .R (1'b0),
     .S (1'b0),


### PR DESCRIPTION
In my previous commit I have a typo which generates critical warnings. This should fix it.