### PR TITLE
cn0506_mii/rgmii on a10soc: update to Quartus 21.2

### DIFF
--- a/projects/cn0506_mii/a10soc/system_project.tcl
+++ b/projects/cn0506_mii/a10soc/system_project.tcl
@@ -1,6 +1,3 @@
-set REQUIRED_QUARTUS_VERSION 18.1.0
-set QUARTUS_PRO_ISUSED 0
-
 source ../../scripts/adi_env.tcl
 source ../../scripts/adi_project_intel.tcl
 

--- a/projects/cn0506_rgmii/a10soc/system_project.tcl
+++ b/projects/cn0506_rgmii/a10soc/system_project.tcl
@@ -1,6 +1,3 @@
-set REQUIRED_QUARTUS_VERSION 18.1.0
-set QUARTUS_PRO_ISUSED 0
-
 source ../../scripts/adi_env.tcl
 source ../../scripts/adi_project_intel.tcl
 


### PR DESCRIPTION
Remove contraints related to quartus version so that
cn0506_mii and cn0506_rgmii on arria10 to be built
with default quartus version.

Signed-off-by: stefan.raus <stefan.raus@analog.com>