### PR TITLE
library/axi_clock_monitor: fixed bug involving xdc file

### DIFF
--- a/library/axi_clock_monitor/Makefile
+++ b/library/axi_clock_monitor/Makefile
@@ -10,7 +10,7 @@ GENERIC_DEPS += ../common/up_axi.v
 GENERIC_DEPS += axi_clock_monitor.v
 
 XILINX_DEPS += ../common/up_clock_mon.v
-XILINX_DEPS += axi_clock_monitor_constr.xdc
+XILINX_DEPS += ../xilinx/common/up_clock_mon_constr.xdc
 XILINX_DEPS += axi_clock_monitor_ip.tcl
 
 INTEL_DEPS += ../intel/common/up_clock_mon_constr.sdc

--- a/library/axi_clock_monitor/axi_clock_monitor.v
+++ b/library/axi_clock_monitor/axi_clock_monitor.v
@@ -87,7 +87,7 @@ module axi_clock_monitor #(
 
   // local parameters
 
-  localparam  PCORE_VERSION = 1
+  localparam  PCORE_VERSION = 1;
 
   // internal registers
 
@@ -100,24 +100,24 @@ module axi_clock_monitor #(
 
   // internal signals
 
-  wire                      up_clk;
-  wire                      up_rstn;
-  wire                      up_wreq_s;
-  wire                      up_rreq_s;
-  wire                      up_waddr_s;
-  wire                      up_raddr_s;
+  wire         up_clk;
+  wire         up_rstn;
+  wire         up_wreq_s;
+  wire         up_rreq_s;
+  wire         up_waddr_s;
+  wire         up_raddr_s;
 
-  wire                      clock         [0:15];
-  wire [20:0]               clk_mon_count [0:15];
+  wire         clock         [0:15];
+  wire [20:0]  clk_mon_count [0:15];
 
-  wire                      up_wreq_i_s;
-  wire [(PROC_ADDR_WD-1):0] up_waddr_i_s;
-  wire [31:0]               up_wdata_i_s;
-  wire                      up_wack_o_s;
-  wire                      up_rreq_i_s;
-  wire [(PROC_ADDR_WD-1):0] up_raddr_i_s;
-  wire [31:0]               up_rdata_o_s;
-  wire                      up_rack_o_s;
+  wire         up_wreq_i_s;
+  wire [13:0]  up_waddr_i_s;
+  wire [31:0]  up_wdata_i_s;
+  wire         up_wack_o_s;
+  wire         up_rreq_i_s;
+  wire [13:0]  up_raddr_i_s;
+  wire [31:0]  up_rdata_o_s;
+  wire         up_rack_o_s;
 
   // loop variables
 

--- a/library/axi_clock_monitor/axi_clock_monitor_ip.tcl
+++ b/library/axi_clock_monitor/axi_clock_monitor_ip.tcl
@@ -7,8 +7,8 @@ adi_ip_create axi_clock_monitor
 adi_ip_files axi_clock_monitor [list \
   "$ad_hdl_dir/library/common/up_axi.v" \
   "$ad_hdl_dir/library/common/up_clock_mon.v" \
-  "axi_clock_monitor.v" \
-  "axi_clock_monitor_constr.xdc" ]
+  "$ad_hdl_dir/library/xilinx/common/up_clock_mon_constr.xdc" \
+  "axi_clock_monitor.v" ]
 
 adi_ip_properties axi_clock_monitor
 


### PR DESCRIPTION
Fixed a bug: library fails on build and returns the following
make[2]: *** No rule to make target axi_clock_monitor_constr.xdc', needed by component.xml'. Stop.
make[1]: *** [lib] Error 2