### PR TITLE
Single/Quad MxFE SYNC refactor

### DIFF
--- a/projects/ad9081_fmca_ebz/zcu102/system_constr.xdc
+++ b/projects/ad9081_fmca_ebz/zcu102/system_constr.xdc
@@ -48,14 +48,14 @@ set_property  -quiet -dict {PACKAGE_PIN M5                                      
 set_property  -quiet -dict {PACKAGE_PIN M6                                                            } [get_ports tx_data_p[4]     ]    ; ## FMC0_DP4_C2M_P      MGTHTXP3_228    FPGA_SERDOUT_6_P
 set_property  -quiet -dict {PACKAGE_PIN K5                                                            } [get_ports tx_data_n[3]     ]    ; ## FMC0_DP3_C2M_N      MGTHTXN0_229    FPGA_SERDOUT_7_N
 set_property  -quiet -dict {PACKAGE_PIN K6                                                            } [get_ports tx_data_p[3]     ]    ; ## FMC0_DP3_C2M_P      MGTHTXP0_229    FPGA_SERDOUT_7_P
-set_property  -quiet -dict {PACKAGE_PIN V1    IOSTANDARD LVDS     DIFF_TERM_ADV TERM_100              } [get_ports fpga_syncin_n[0] ]    ; ## FMC0_LA02_N         IO_L23N_T3U_N9_66
-set_property  -quiet -dict {PACKAGE_PIN V2    IOSTANDARD LVDS     DIFF_TERM_ADV TERM_100              } [get_ports fpga_syncin_p[0] ]    ; ## FMC0_LA02_P         IO_L23P_T3U_N8_66
-set_property  -quiet -dict {PACKAGE_PIN Y1    IOSTANDARD LVDS     DIFF_TERM_ADV TERM_100              } [get_ports fpga_syncin_n[1] ]    ; ## FMC0_LA03_N         IO_L22N_T3U_N7_DBC_AD0N_66
-set_property  -quiet -dict {PACKAGE_PIN Y2    IOSTANDARD LVDS     DIFF_TERM_ADV TERM_100              } [get_ports fpga_syncin_p[1] ]    ; ## FMC0_LA03_P         IO_L22P_T3U_N6_DBC_AD0P_66
-set_property  -quiet -dict {PACKAGE_PIN AC4   IOSTANDARD LVDS                                         } [get_ports fpga_syncout_n[0]]    ; ## FMC0_LA01_CC_N      IO_L16N_T2U_N7_QBC_AD3N_66
-set_property  -quiet -dict {PACKAGE_PIN AB4   IOSTANDARD LVDS                                         } [get_ports fpga_syncout_p[0]]    ; ## FMC0_LA01_CC_P      IO_L16P_T2U_N6_QBC_AD3P_66
-set_property  -quiet -dict {PACKAGE_PIN AC1   IOSTANDARD LVDS                                         } [get_ports fpga_syncout_n[1]]    ; ## FMC0_LA06_N         IO_L19N_T3L_N1_DBC_AD9N_66
-set_property  -quiet -dict {PACKAGE_PIN AC2   IOSTANDARD LVDS                                         } [get_ports fpga_syncout_p[1]]    ; ## FMC0_LA06_P         IO_L19P_T3L_N0_DBC_AD9P_66
+set_property  -quiet -dict {PACKAGE_PIN V1    IOSTANDARD LVDS     DIFF_TERM_ADV TERM_100              } [get_ports fpga_syncin_0_n  ]    ; ## FMC0_LA02_N         IO_L23N_T3U_N9_66
+set_property  -quiet -dict {PACKAGE_PIN V2    IOSTANDARD LVDS     DIFF_TERM_ADV TERM_100              } [get_ports fpga_syncin_0_p  ]    ; ## FMC0_LA02_P         IO_L23P_T3U_N8_66
+set_property  -quiet -dict {PACKAGE_PIN Y1    IOSTANDARD LVCMOS18                                     } [get_ports fpga_syncin_1_n  ]    ; ## FMC0_LA03_N         IO_L22N_T3U_N7_DBC_AD0N_66
+set_property  -quiet -dict {PACKAGE_PIN Y2    IOSTANDARD LVCMOS18                                     } [get_ports fpga_syncin_1_p  ]    ; ## FMC0_LA03_P         IO_L22P_T3U_N6_DBC_AD0P_66
+set_property  -quiet -dict {PACKAGE_PIN AC4   IOSTANDARD LVDS                                         } [get_ports fpga_syncout_0_n ]    ; ## FMC0_LA01_CC_N      IO_L16N_T2U_N7_QBC_AD3N_66
+set_property  -quiet -dict {PACKAGE_PIN AB4   IOSTANDARD LVDS                                         } [get_ports fpga_syncout_0_p ]    ; ## FMC0_LA01_CC_P      IO_L16P_T2U_N6_QBC_AD3P_66
+set_property  -quiet -dict {PACKAGE_PIN AC1   IOSTANDARD LVCMOS18                                     } [get_ports fpga_syncout_1_n ]    ; ## FMC0_LA06_N         IO_L19N_T3L_N1_DBC_AD9N_66
+set_property  -quiet -dict {PACKAGE_PIN AC2   IOSTANDARD LVCMOS18                                     } [get_ports fpga_syncout_1_p ]    ; ## FMC0_LA06_P         IO_L19P_T3L_N0_DBC_AD9P_66
 set_property         -dict {PACKAGE_PIN Y10   IOSTANDARD LVCMOS18                                     } [get_ports gpio[0]          ]    ; ## FMC0_LA15_P         IO_L6P_T0U_N10_AD6P_66
 set_property         -dict {PACKAGE_PIN Y9    IOSTANDARD LVCMOS18                                     } [get_ports gpio[1]          ]    ; ## FMC0_LA15_N         IO_L6N_T0U_N11_AD6N_66
 set_property         -dict {PACKAGE_PIN L13   IOSTANDARD LVCMOS18                                     } [get_ports gpio[2]          ]    ; ## FMC0_LA19_P         IO_L23P_T3U_N8_67

--- a/projects/ad9081_fmca_ebz/zcu102/system_top.v
+++ b/projects/ad9081_fmca_ebz/zcu102/system_top.v
@@ -41,7 +41,8 @@ module system_top  #(
     parameter TX_NUM_LINKS = 1,
     parameter RX_JESD_L = 8,
     parameter RX_NUM_LINKS = 1,
-    parameter SHARED_DEVCLK = 0
+    parameter SHARED_DEVCLK = 0,
+    parameter JESD_MODE = "8B10B"
   ) (
 
   input  [12:0] gpio_bd_i,
@@ -63,10 +64,14 @@ module system_top  #(
   input  [RX_JESD_L*RX_NUM_LINKS-1:0]  rx_data_p,
   output [TX_JESD_L*TX_NUM_LINKS-1:0]  tx_data_n,
   output [TX_JESD_L*TX_NUM_LINKS-1:0]  tx_data_p,
-  input  [TX_NUM_LINKS-1:0]  fpga_syncin_n,
-  input  [TX_NUM_LINKS-1:0]  fpga_syncin_p,
-  output [RX_NUM_LINKS-1:0]  fpga_syncout_n,
-  output [RX_NUM_LINKS-1:0]  fpga_syncout_p,
+  input    fpga_syncin_0_n,
+  input    fpga_syncin_0_p,
+  inout    fpga_syncin_1_n,
+  inout    fpga_syncin_1_p,
+  output   fpga_syncout_0_n,
+  output   fpga_syncout_0_p,
+  inout    fpga_syncout_1_n,
+  inout    fpga_syncout_1_p,
   inout  [10:0] gpio,
   inout         hmc_gpio1,
   output        hmc_sync,
@@ -139,22 +144,15 @@ module system_top  #(
     .IB (clkin10_n),
     .O (clkin10));
 
-  genvar i;
-  generate
-  for(i=0;i<TX_NUM_LINKS;i=i+1) begin : g_tx_buffers
-    IBUFDS i_ibufds_syncin (
-      .I (fpga_syncin_p[i]),
-      .IB (fpga_syncin_n[i]),
-      .O (tx_syncin[i]));
-  end
+  IBUFDS i_ibufds_syncin_0 (
+    .I (fpga_syncin_0_p),
+    .IB (fpga_syncin_0_n),
+    .O (tx_syncin[0]));
 
-  for(i=0;i<RX_NUM_LINKS;i=i+1) begin : g_rx_buffers
-    OBUFDS i_obufds_syncout (
-      .I (rx_syncout[i]),
-      .O (fpga_syncout_p[i]),
-      .OB (fpga_syncout_n[i]));
-  end
-  endgenerate
+  OBUFDS i_obufds_syncout_0 (
+    .I (rx_syncout[0]),
+    .O (fpga_syncout_0_p),
+    .OB (fpga_syncout_0_n));
 
   BUFG i_tx_device_clk (
     .I (clkin6),
@@ -209,12 +207,37 @@ module system_top  #(
   assign txen[0]          = gpio_o[58];
   assign txen[1]          = gpio_o[59];
 
+  generate 
+  if (TX_NUM_LINKS > 1 & JESD_MODE == "8B10B") begin
+    assign tx_syncin[1] = fpga_syncin_1_p;
+  end else begin
+    ad_iobuf #(.DATA_WIDTH(2)) i_syncin_iobuf (
+      .dio_t (gpio_t[61:60]),
+      .dio_i (gpio_o[61:60]),
+      .dio_o (gpio_i[61:60]),
+      .dio_p ({fpga_syncin_1_n,      // 61
+               fpga_syncin_1_p}));   // 60
+  end
+
+  if (RX_NUM_LINKS > 1 & JESD_MODE == "8B10B") begin
+    assign fpga_syncout_1_p = rx_syncout[1];
+    assign fpga_syncout_1_n = 0; 
+  end else begin
+    ad_iobuf #(.DATA_WIDTH(2)) i_syncout_iobuf (
+      .dio_t (gpio_t[63:62]),
+      .dio_i (gpio_o[63:62]),
+      .dio_o (gpio_i[63:62]),
+      .dio_p ({fpga_syncout_1_n,      // 63
+               fpga_syncout_1_p}));   // 62
+  end
+  endgenerate
   /* Board GPIOS. Buttons, LEDs, etc... */
   assign gpio_i[20: 8] = gpio_bd_i;
   assign gpio_bd_o = gpio_o[7:0];
 
   // Unused GPIOs
-  assign gpio_i[94:54] = gpio_o[94:54];
+  assign gpio_i[59:54] = gpio_o[59:54];
+  assign gpio_i[94:64] = gpio_o[94:64];
   assign gpio_i[31:21] = gpio_o[31:21];
   assign gpio_i[7:0] = gpio_o[7:0];
 

--- a/projects/ad_quadmxfe1_ebz/common/quad_mxfe_gpio_mux.v
+++ b/projects/ad_quadmxfe1_ebz/common/quad_mxfe_gpio_mux.v
@@ -37,10 +37,61 @@
 
 module quad_mxfe_gpio_mux #() (
 
-  inout  [8:0] mxfe0_gpio,
-  inout  [8:0] mxfe1_gpio,
-  inout  [8:0] mxfe2_gpio,
-  inout  [8:0] mxfe3_gpio,
+  inout         mxfe0_gpio0,
+  inout         mxfe0_gpio1,
+  inout         mxfe0_gpio2,
+  inout         mxfe0_gpio5,
+  inout         mxfe0_gpio6,
+  inout         mxfe0_gpio7,
+  inout         mxfe0_gpio8,
+  inout         mxfe0_gpio9,
+  inout         mxfe0_gpio10,
+  inout         mxfe0_syncin_1_n,
+  inout         mxfe0_syncin_1_p,
+  inout         mxfe0_syncout_1_n,
+  inout         mxfe0_syncout_1_p,
+
+  inout         mxfe1_gpio0,
+  inout         mxfe1_gpio1,
+  inout         mxfe1_gpio2,
+  inout         mxfe1_gpio5,
+  inout         mxfe1_gpio6,
+  inout         mxfe1_gpio7,
+  inout         mxfe1_gpio8,
+  inout         mxfe1_gpio9,
+  inout         mxfe1_gpio10,
+  inout         mxfe1_syncin_1_n,
+  inout         mxfe1_syncin_1_p,
+  inout         mxfe1_syncout_1_n,
+  inout         mxfe1_syncout_1_p,
+
+  inout         mxfe2_gpio0,
+  inout         mxfe2_gpio1,
+  inout         mxfe2_gpio2,
+  inout         mxfe2_gpio5,
+  inout         mxfe2_gpio6,
+  inout         mxfe2_gpio7,
+  inout         mxfe2_gpio8,
+  inout         mxfe2_gpio9,
+  inout         mxfe2_gpio10,
+  inout         mxfe2_syncin_1_n,
+  inout         mxfe2_syncin_1_p,
+  inout         mxfe2_syncout_1_n,
+  inout         mxfe2_syncout_1_p,
+
+  inout         mxfe3_gpio0,
+  inout         mxfe3_gpio1,
+  inout         mxfe3_gpio2,
+  inout         mxfe3_gpio5,
+  inout         mxfe3_gpio6,
+  inout         mxfe3_gpio7,
+  inout         mxfe3_gpio8,
+  inout         mxfe3_gpio9,
+  inout         mxfe3_gpio10,
+  inout         mxfe3_syncin_1_n,
+  inout         mxfe3_syncin_1_p,
+  inout         mxfe3_syncout_1_n,
+  inout         mxfe3_syncout_1_p,
 
   input  [127:64] gpio_t,
   output [127:64] gpio_i,
@@ -49,104 +100,434 @@ module quad_mxfe_gpio_mux #() (
 );
 
   wire gpio0_mode;
-  wire mxfe3_gpio0_in;
-  wire mxfe3_gpio1_in;
-  wire mxfe3_gpio2_in;
-  wire mxfe3_gpio3_in;
-  wire mxfe3_gpio4_in;
-  wire mxfe3_gpio5_in;
-  wire [5:0] gpio_t_69_64;
-  wire [5:0] gpio_o_69_64;
-  wire [5:0] gpio_t_80_75;
-  wire [5:0] gpio_o_80_75;
-  wire [5:0] gpio_t_91_86;
-  wire [5:0] gpio_o_91_86;
-  wire [5:0] gpio_t_102_97;
 
-  ad_iobuf #(.DATA_WIDTH(9)) i_iobuf_mxfe_0 (
-    .dio_t ({gpio_t[72:70],gpio_t_69_64}),
-    .dio_i ({gpio_o[72:70],gpio_o_69_64}),
-    .dio_o (gpio_i[72:64]),
-    .dio_p (mxfe0_gpio)); // 72-64
+  ad_iobuf #(.DATA_WIDTH(13)) i_iobuf_mxfe_0 (
+    .dio_t ( {mxfe0_gpio0_t,
+              mxfe0_gpio1_t,
+              mxfe0_gpio2_t,
+              mxfe0_gpio5_t,
+              mxfe0_gpio6_t,
+              mxfe0_gpio7_t,
+              mxfe0_gpio8_t,
+              mxfe0_gpio9_t,
+              mxfe0_gpio10_t,
+              mxfe0_syncin_1_n_t,
+              mxfe0_syncin_1_p_t,
+              mxfe0_syncout_1_n_t,
+              mxfe0_syncout_1_p_t}),
+    .dio_i ( {mxfe0_gpio0_o,
+              mxfe0_gpio1_o,
+              mxfe0_gpio2_o,
+              mxfe0_gpio5_o,
+              mxfe0_gpio6_o,
+              mxfe0_gpio7_o,
+              mxfe0_gpio8_o,
+              mxfe0_gpio9_o,
+              mxfe0_gpio10_o,
+              mxfe0_syncin_1_n_o,
+              mxfe0_syncin_1_p_o,
+              mxfe0_syncout_1_n_o,
+              mxfe0_syncout_1_p_o}),
+    .dio_o ( {mxfe0_gpio0_i,
+              mxfe0_gpio1_i,
+              mxfe0_gpio2_i,
+              mxfe0_gpio5_i,
+              mxfe0_gpio6_i,
+              mxfe0_gpio7_i,
+              mxfe0_gpio8_i,
+              mxfe0_gpio9_i,
+              mxfe0_gpio10_i,
+              mxfe0_syncin_1_n_i,
+              mxfe0_syncin_1_p_i,
+              mxfe0_syncout_1_n_i,
+              mxfe0_syncout_1_p_i}),
+    .dio_p ( {mxfe0_gpio0,
+              mxfe0_gpio1,
+              mxfe0_gpio2,
+              mxfe0_gpio5,
+              mxfe0_gpio6,
+              mxfe0_gpio7,
+              mxfe0_gpio8,
+              mxfe0_gpio9,
+              mxfe0_gpio10,
+              mxfe0_syncin_1_n,
+              mxfe0_syncin_1_p,
+              mxfe0_syncout_1_n,
+              mxfe0_syncout_1_p})
+  );
 
-  assign gpio_t_69_64[0] = gpio0_mode ? 1'b0 : gpio_t[64];
-  assign gpio_t_69_64[1] = gpio1_mode ? 1'b0 : gpio_t[65];
-  assign gpio_t_69_64[2] = gpio2_mode ? 1'b0 : gpio_t[66];
-  assign gpio_t_69_64[3] = gpio3_mode ? 1'b0 : gpio_t[67];
-  assign gpio_t_69_64[4] = gpio4_mode ? 1'b0 : gpio_t[68];
-  assign gpio_t_69_64[5] = gpio5_mode ? 1'b0 : gpio_t[69];
-  assign gpio_o_69_64[0] = gpio0_mode ? mxfe3_gpio0_in : gpio_o[64];
-  assign gpio_o_69_64[1] = gpio1_mode ? mxfe3_gpio1_in : gpio_o[65];
-  assign gpio_o_69_64[2] = gpio2_mode ? mxfe3_gpio2_in : gpio_o[66];
-  assign gpio_o_69_64[3] = gpio3_mode ? mxfe3_gpio3_in : gpio_o[67];
-  assign gpio_o_69_64[4] = gpio4_mode ? mxfe3_gpio4_in : gpio_o[68];
-  assign gpio_o_69_64[5] = gpio5_mode ? mxfe3_gpio5_in : gpio_o[69];
+  ad_iobuf #(.DATA_WIDTH(13)) i_iobuf_mxfe_1 (
+    .dio_t ( {mxfe1_gpio0_t,
+              mxfe1_gpio1_t,
+              mxfe1_gpio2_t,
+              mxfe1_gpio5_t,
+              mxfe1_gpio6_t,
+              mxfe1_gpio7_t,
+              mxfe1_gpio8_t,
+              mxfe1_gpio9_t,
+              mxfe1_gpio10_t,
+              mxfe1_syncin_1_n_t,
+              mxfe1_syncin_1_p_t,
+              mxfe1_syncout_1_n_t,
+              mxfe1_syncout_1_p_t}),
+    .dio_i ( {mxfe1_gpio0_o,
+              mxfe1_gpio1_o,
+              mxfe1_gpio2_o,
+              mxfe1_gpio5_o,
+              mxfe1_gpio6_o,
+              mxfe1_gpio7_o,
+              mxfe1_gpio8_o,
+              mxfe1_gpio9_o,
+              mxfe1_gpio10_o,
+              mxfe1_syncin_1_n_o,
+              mxfe1_syncin_1_p_o,
+              mxfe1_syncout_1_n_o,
+              mxfe1_syncout_1_p_o}),
+    .dio_o ( {mxfe1_gpio0_i,
+              mxfe1_gpio1_i,
+              mxfe1_gpio2_i,
+              mxfe1_gpio5_i,
+              mxfe1_gpio6_i,
+              mxfe1_gpio7_i,
+              mxfe1_gpio8_i,
+              mxfe1_gpio9_i,
+              mxfe1_gpio10_i,
+              mxfe1_syncin_1_n_i,
+              mxfe1_syncin_1_p_i,
+              mxfe1_syncout_1_n_i,
+              mxfe1_syncout_1_p_i}),
+    .dio_p ( {mxfe1_gpio0,
+              mxfe1_gpio1,
+              mxfe1_gpio2,
+              mxfe1_gpio5,
+              mxfe1_gpio6,
+              mxfe1_gpio7,
+              mxfe1_gpio8,
+              mxfe1_gpio9,
+              mxfe1_gpio10,
+              mxfe1_syncin_1_n,
+              mxfe1_syncin_1_p,
+              mxfe1_syncout_1_n,
+              mxfe1_syncout_1_p})
+  );
 
-  ad_iobuf #(.DATA_WIDTH(9)) i_iobuf_mxfe_1 (
-    .dio_t ({gpio_t[83:81],gpio_t_80_75}),
-    .dio_i ({gpio_o[83:81],gpio_o_80_75}),
-    .dio_o (gpio_i[83:75]),
-    .dio_p (mxfe1_gpio)); // 83-75
+  ad_iobuf #(.DATA_WIDTH(13)) i_iobuf_mxfe_2 (
+    .dio_t ( {mxfe2_gpio0_t,
+              mxfe2_gpio1_t,
+              mxfe2_gpio2_t,
+              mxfe2_gpio5_t,
+              mxfe2_gpio6_t,
+              mxfe2_gpio7_t,
+              mxfe2_gpio8_t,
+              mxfe2_gpio9_t,
+              mxfe2_gpio10_t,
+              mxfe2_syncin_1_n_t,
+              mxfe2_syncin_1_p_t,
+              mxfe2_syncout_1_n_t,
+              mxfe2_syncout_1_p_t}),
+    .dio_i ( {mxfe2_gpio0_o,
+              mxfe2_gpio1_o,
+              mxfe2_gpio2_o,
+              mxfe2_gpio5_o,
+              mxfe2_gpio6_o,
+              mxfe2_gpio7_o,
+              mxfe2_gpio8_o,
+              mxfe2_gpio9_o,
+              mxfe2_gpio10_o,
+              mxfe2_syncin_1_n_o,
+              mxfe2_syncin_1_p_o,
+              mxfe2_syncout_1_n_o,
+              mxfe2_syncout_1_p_o}),
+    .dio_o ( {mxfe2_gpio0_i,
+              mxfe2_gpio1_i,
+              mxfe2_gpio2_i,
+              mxfe2_gpio5_i,
+              mxfe2_gpio6_i,
+              mxfe2_gpio7_i,
+              mxfe2_gpio8_i,
+              mxfe2_gpio9_i,
+              mxfe2_gpio10_i,
+              mxfe2_syncin_1_n_i,
+              mxfe2_syncin_1_p_i,
+              mxfe2_syncout_1_n_i,
+              mxfe2_syncout_1_p_i}),
+    .dio_p ( {mxfe2_gpio0,
+              mxfe2_gpio1,
+              mxfe2_gpio2,
+              mxfe2_gpio5,
+              mxfe2_gpio6,
+              mxfe2_gpio7,
+              mxfe2_gpio8,
+              mxfe2_gpio9,
+              mxfe2_gpio10,
+              mxfe2_syncin_1_n,
+              mxfe2_syncin_1_p,
+              mxfe2_syncout_1_n,
+              mxfe2_syncout_1_p}));
 
-  assign gpio_t_80_75[0] = gpio0_mode ? 1'b0 : gpio_t[75];
-  assign gpio_t_80_75[1] = gpio1_mode ? 1'b0 : gpio_t[76];
-  assign gpio_t_80_75[2] = gpio2_mode ? 1'b0 : gpio_t[77];
-  assign gpio_t_80_75[3] = gpio3_mode ? 1'b0 : gpio_t[78];
-  assign gpio_t_80_75[4] = gpio4_mode ? 1'b0 : gpio_t[79];
-  assign gpio_t_80_75[5] = gpio5_mode ? 1'b0 : gpio_t[80];
-  assign gpio_o_80_75[0] = gpio0_mode ? mxfe3_gpio0_in : gpio_o[75];
-  assign gpio_o_80_75[1] = gpio1_mode ? mxfe3_gpio1_in : gpio_o[76];
-  assign gpio_o_80_75[2] = gpio2_mode ? mxfe3_gpio2_in : gpio_o[77];
-  assign gpio_o_80_75[3] = gpio3_mode ? mxfe3_gpio3_in : gpio_o[78];
-  assign gpio_o_80_75[4] = gpio4_mode ? mxfe3_gpio4_in : gpio_o[79];
-  assign gpio_o_80_75[5] = gpio5_mode ? mxfe3_gpio5_in : gpio_o[80];
+  ad_iobuf #(.DATA_WIDTH(13)) i_iobuf_mxfe_3 (
+    .dio_t ( {mxfe3_gpio0_t,
+              mxfe3_gpio1_t,
+              mxfe3_gpio2_t,
+              mxfe3_gpio5_t,
+              mxfe3_gpio6_t,
+              mxfe3_gpio7_t,
+              mxfe3_gpio8_t,
+              mxfe3_gpio9_t,
+              mxfe3_gpio10_t,
+              mxfe3_syncin_1_n_t,
+              mxfe3_syncin_1_p_t,
+              mxfe3_syncout_1_n_t,
+              mxfe3_syncout_1_p_t}),
+    .dio_i ( {mxfe3_gpio0_o,
+              mxfe3_gpio1_o,
+              mxfe3_gpio2_o,
+              mxfe3_gpio5_o,
+              mxfe3_gpio6_o,
+              mxfe3_gpio7_o,
+              mxfe3_gpio8_o,
+              mxfe3_gpio9_o,
+              mxfe3_gpio10_o,
+              mxfe3_syncin_1_n_o,
+              mxfe3_syncin_1_p_o,
+              mxfe3_syncout_1_n_o,
+              mxfe3_syncout_1_p_o}),
+    .dio_o ( {mxfe3_gpio0_i,
+              mxfe3_gpio1_i,
+              mxfe3_gpio2_i,
+              mxfe3_gpio5_i,
+              mxfe3_gpio6_i,
+              mxfe3_gpio7_i,
+              mxfe3_gpio8_i,
+              mxfe3_gpio9_i,
+              mxfe3_gpio10_i,
+              mxfe3_syncin_1_n_i,
+              mxfe3_syncin_1_p_i,
+              mxfe3_syncout_1_n_i,
+              mxfe3_syncout_1_p_i}),
+    .dio_p ( {mxfe3_gpio0,
+              mxfe3_gpio1,
+              mxfe3_gpio2,
+              mxfe3_gpio5,
+              mxfe3_gpio6,
+              mxfe3_gpio7,
+              mxfe3_gpio8,
+              mxfe3_gpio9,
+              mxfe3_gpio10,
+              mxfe3_syncin_1_n,
+              mxfe3_syncin_1_p,
+              mxfe3_syncout_1_n,
+              mxfe3_syncout_1_p})
+    );
 
-  ad_iobuf #(.DATA_WIDTH(9)) i_iobuf_mxfe_2 (
-    .dio_t ({gpio_t[94:92],gpio_t_91_86}),
-    .dio_i ({gpio_o[94:92],gpio_o_91_86}),
-    .dio_o (gpio_i[94:86]),
-    .dio_p (mxfe2_gpio)); // 94-86
 
-  assign gpio_t_91_86[0] = gpio0_mode ? 1'b0 : gpio_t[86];
-  assign gpio_t_91_86[1] = gpio1_mode ? 1'b0 : gpio_t[87];
-  assign gpio_t_91_86[2] = gpio2_mode ? 1'b0 : gpio_t[88];
-  assign gpio_t_91_86[3] = gpio3_mode ? 1'b0 : gpio_t[89];
-  assign gpio_t_91_86[4] = gpio4_mode ? 1'b0 : gpio_t[90];
-  assign gpio_t_91_86[5] = gpio5_mode ? 1'b0 : gpio_t[91];
-  assign gpio_o_91_86[0] = gpio0_mode ? mxfe3_gpio0_in : gpio_o[86];
-  assign gpio_o_91_86[1] = gpio1_mode ? mxfe3_gpio1_in : gpio_o[87];
-  assign gpio_o_91_86[2] = gpio2_mode ? mxfe3_gpio2_in : gpio_o[88];
-  assign gpio_o_91_86[3] = gpio3_mode ? mxfe3_gpio3_in : gpio_o[89];
-  assign gpio_o_91_86[4] = gpio4_mode ? mxfe3_gpio4_in : gpio_o[90];
-  assign gpio_o_91_86[5] = gpio5_mode ? mxfe3_gpio5_in : gpio_o[91];
+// Bidirectional buffer output enables
+assign {mxfe0_gpio0_t,
+        mxfe1_gpio0_t,
+        mxfe2_gpio0_t,
+        mxfe3_gpio0_t} = gpio0_mode ? 4'b0001 : {4{gpio_t[64]}};
 
-  ad_iobuf #(.DATA_WIDTH(9)) i_iobuf_mxfe_3 (
-    .dio_t ({gpio_t[105:103],gpio_t_102_97}),
-    .dio_i (gpio_o[105:97]),
-    .dio_o (gpio_i[105:97]),
-    .dio_p (mxfe3_gpio)); // 105-97
+assign {mxfe0_gpio1_t,
+        mxfe1_gpio1_t,
+        mxfe2_gpio1_t,
+        mxfe3_gpio1_t} = {4{gpio_t[65]}};
 
-  assign gpio_t_102_97[0] = gpio0_mode ? 1'b1 : gpio_t[97];
-  assign gpio_t_102_97[1] = gpio1_mode ? 1'b1 : gpio_t[98];
-  assign gpio_t_102_97[2] = gpio2_mode ? 1'b1 : gpio_t[99];
-  assign gpio_t_102_97[3] = gpio3_mode ? 1'b1 : gpio_t[100];
-  assign gpio_t_102_97[4] = gpio4_mode ? 1'b1 : gpio_t[101];
-  assign gpio_t_102_97[5] = gpio5_mode ? 1'b1 : gpio_t[102];
-  assign mxfe3_gpio0_in = gpio_i[97];
-  assign mxfe3_gpio1_in = gpio_i[98];
-  assign mxfe3_gpio2_in = gpio_i[99];
-  assign mxfe3_gpio3_in = gpio_i[100];
-  assign mxfe3_gpio4_in = gpio_i[101];
-  assign mxfe3_gpio5_in = gpio_i[102];
+assign {mxfe0_gpio2_t,
+        mxfe1_gpio2_t,
+        mxfe2_gpio2_t,
+        mxfe3_gpio2_t} = {4{gpio_t[66]}};
+
+assign {mxfe0_gpio5_t,
+        mxfe1_gpio5_t,
+        mxfe2_gpio5_t,
+        mxfe3_gpio5_t} = {4{gpio_t[69]}};
+
+assign {mxfe0_gpio6_t,
+        mxfe1_gpio6_t,
+        mxfe2_gpio6_t,
+        mxfe3_gpio6_t} = {4{gpio_t[70]}};
+
+assign {mxfe0_gpio7_t,
+        mxfe1_gpio7_t,
+        mxfe2_gpio7_t,
+        mxfe3_gpio7_t} = {4{gpio_t[71]}};
+
+assign {mxfe0_gpio8_t,
+        mxfe1_gpio8_t,
+        mxfe2_gpio8_t,
+        mxfe3_gpio8_t} = {4{gpio_t[72]}};
+
+assign {mxfe0_gpio9_t,
+        mxfe1_gpio9_t,
+        mxfe2_gpio9_t,
+        mxfe3_gpio9_t} = {4{gpio_t[73]}};
+
+assign {mxfe0_gpio10_t,
+        mxfe1_gpio10_t,
+        mxfe2_gpio10_t,
+        mxfe3_gpio10_t} = {4{gpio_t[74]}};
+
+assign {mxfe0_syncin_1_n_t,
+        mxfe1_syncin_1_n_t,
+        mxfe2_syncin_1_n_t,
+        mxfe3_syncin_1_n_t} = {4{gpio_t[75]}};
+
+assign {mxfe0_syncin_1_p_t,
+        mxfe1_syncin_1_p_t,
+        mxfe2_syncin_1_p_t,
+        mxfe3_syncin_1_p_t} = {4{gpio_t[76]}};
+
+assign {mxfe0_syncout_1_n_t,
+        mxfe1_syncout_1_n_t,
+        mxfe2_syncout_1_n_t,
+        mxfe3_syncout_1_n_t} = {4{gpio_t[77]}};
+
+assign {mxfe0_syncout_1_p_t,
+        mxfe1_syncout_1_p_t,
+        mxfe2_syncout_1_p_t,
+        mxfe3_syncout_1_p_t} = {4{gpio_t[78]}};
+
+// Bidirectional buffer output values
+assign {mxfe0_gpio0_o,
+        mxfe1_gpio0_o,
+        mxfe2_gpio0_o,
+        mxfe3_gpio0_o} = gpio0_mode ? {4{mxfe3_gpio0_i}} : {4{gpio_o[64]}};
+
+assign {mxfe0_gpio1_o,
+        mxfe1_gpio1_o,
+        mxfe2_gpio1_o,
+        mxfe3_gpio1_o} = {4{gpio_o[65]}};
+
+assign {mxfe0_gpio2_o,
+        mxfe1_gpio2_o,
+        mxfe2_gpio2_o,
+        mxfe3_gpio2_o} = {4{gpio_o[66]}};
+
+assign {mxfe0_gpio5_o,
+        mxfe1_gpio5_o,
+        mxfe2_gpio5_o,
+        mxfe3_gpio5_o} = {4{gpio_o[69]}};
+
+assign {mxfe0_gpio6_o,
+        mxfe1_gpio6_o,
+        mxfe2_gpio6_o,
+        mxfe3_gpio6_o} = {4{gpio_o[70]}};
+
+assign {mxfe0_gpio7_o,
+        mxfe1_gpio7_o,
+        mxfe2_gpio7_o,
+        mxfe3_gpio7_o} = {4{gpio_o[71]}};
+
+assign {mxfe0_gpio8_o,
+        mxfe1_gpio8_o,
+        mxfe2_gpio8_o,
+        mxfe3_gpio8_o} = {4{gpio_o[72]}};
+
+assign {mxfe0_gpio9_o,
+        mxfe1_gpio9_o,
+        mxfe2_gpio9_o,
+        mxfe3_gpio9_o} = {4{gpio_o[73]}};
+
+assign {mxfe0_gpio10_o,
+        mxfe1_gpio10_o,
+        mxfe2_gpio10_o,
+        mxfe3_gpio10_o} = {4{gpio_o[74]}};
+
+assign {mxfe0_syncin_1_n_o,
+        mxfe1_syncin_1_n_o,
+        mxfe2_syncin_1_n_o,
+        mxfe3_syncin_1_n_o} = {4{gpio_o[75]}};
+
+assign {mxfe0_syncin_1_p_o,
+        mxfe1_syncin_1_p_o,
+        mxfe2_syncin_1_p_o,
+        mxfe3_syncin_1_p_o} = {4{gpio_o[76]}};
+
+assign {mxfe0_syncout_1_n_o,
+        mxfe1_syncout_1_n_o,
+        mxfe2_syncout_1_n_o,
+        mxfe3_syncout_1_n_o} = {4{gpio_o[77]}};
+
+assign {mxfe0_syncout_1_p_o,
+        mxfe1_syncout_1_p_o,
+        mxfe2_syncout_1_p_o,
+        mxfe3_syncout_1_p_o} = {4{gpio_o[78]}};
+
+
+// GPIO inputs
+
+assign gpio_i[64] = gpio0_mode ? gpio_o[64] : |{mxfe0_gpio0_i,
+                                                mxfe1_gpio0_i,
+                                                mxfe2_gpio0_i,
+                                                mxfe3_gpio0_i};
+
+assign gpio_i[65] = |{mxfe0_gpio1_i,
+                      mxfe1_gpio1_i,
+                      mxfe2_gpio1_i,
+                      mxfe3_gpio1_i};
+
+assign gpio_i[66] = |{mxfe0_gpio2_i,
+                      mxfe1_gpio2_i,
+                      mxfe2_gpio2_i,
+                      mxfe3_gpio2_i};
+
+assign gpio_i[69] = |{mxfe0_gpio5_i,
+                      mxfe1_gpio5_i,
+                      mxfe2_gpio5_i,
+                      mxfe3_gpio5_i};
+
+assign gpio_i[70] = |{mxfe0_gpio6_i,
+                      mxfe1_gpio6_i,
+                      mxfe2_gpio6_i,
+                      mxfe3_gpio6_i};
+
+assign gpio_i[71] = |{mxfe0_gpio7_i,
+                      mxfe1_gpio7_i,
+                      mxfe2_gpio7_i,
+                      mxfe3_gpio7_i};
+
+assign gpio_i[72] = |{mxfe0_gpio8_i,
+                      mxfe1_gpio8_i,
+                      mxfe2_gpio8_i,
+                      mxfe3_gpio8_i};
+
+assign gpio_i[73] = |{mxfe0_gpio9_i,
+                      mxfe1_gpio9_i,
+                      mxfe2_gpio9_i,
+                      mxfe3_gpio9_i};
+
+assign gpio_i[74] = |{mxfe0_gpio10_i,
+                      mxfe1_gpio10_i,
+                      mxfe2_gpio10_i,
+                      mxfe3_gpio10_i};
+
+assign gpio_i[75] = |{mxfe0_syncin_1_n_i,
+                      mxfe1_syncin_1_n_i,
+                      mxfe2_syncin_1_n_i,
+                      mxfe3_syncin_1_n_i};
+
+assign gpio_i[76] = |{mxfe0_syncin_1_p_i,
+                      mxfe1_syncin_1_p_i,
+                      mxfe2_syncin_1_p_i,
+                      mxfe3_syncin_1_p_i};
+
+assign gpio_i[77] = |{mxfe0_syncout_1_n_i,
+                      mxfe1_syncout_1_n_i,
+                      mxfe2_syncout_1_n_i,
+                      mxfe3_syncout_1_n_i};
+
+assign gpio_i[78] = |{mxfe0_syncout_1_p_i,
+                      mxfe1_syncout_1_p_i,
+                      mxfe2_syncout_1_p_i,
+                      mxfe3_syncout_1_p_i};
+
+  //loopback unused gpios
+  assign gpio_i[68:67] = gpio_o[68:67];
+  assign gpio_i[107:79] = gpio_o[107:79];
 
   // 0 - Software controlled GPIO
   // 1 - LMFC based Master-Slave NCO Sync
   assign gpio0_mode = gpio_o[108];
-  assign gpio1_mode = gpio_o[110];
-  assign gpio2_mode = gpio_o[112];
-  assign gpio3_mode = gpio_o[114];
-  assign gpio4_mode = gpio_o[116];
-  assign gpio5_mode = gpio_o[118];
 
   //loopback unused gpios
   assign gpio_i[127:108] = gpio_o[127:108];

--- a/projects/ad_quadmxfe1_ebz/vcu118/system_constr.xdc
+++ b/projects/ad_quadmxfe1_ebz/vcu118/system_constr.xdc
@@ -121,30 +121,30 @@ set_property  -dict {PACKAGE_PIN N14   IOSTANDARD LVCMOS18                      
 set_property  -dict {PACKAGE_PIN AT39  IOSTANDARD LVCMOS18                       } [get_ports mxfe_sclk[1]             ]; ## LA03_P         G09  IO_L4P_T0U_N6_DBC_AD7P_43
 set_property  -dict {PACKAGE_PIN R11   IOSTANDARD LVCMOS18                       } [get_ports mxfe_sclk[2]             ]; ## HA17_P_CC      K16  IO_L16P_T2U_N6_QBC_AD3P_70
 set_property  -dict {PACKAGE_PIN AL30  IOSTANDARD LVCMOS18                       } [get_ports mxfe_sclk[3]             ]; ## LA01_P_CC      D08  IO_L16P_T2U_N6_QBC_AD3P_43
-set_property  -dict {PACKAGE_PIN T36   IOSTANDARD LVDS                           } [get_ports mxfe_syncin_n[0]         ]; ## LA29_N         G31  IO_L4N_T0U_N7_DBC_AD7N_45
-set_property  -dict {PACKAGE_PIN AJ31  IOSTANDARD LVDS                           } [get_ports mxfe_syncin_n[1]         ]; ## LA11_N         H17  IO_L17N_T2U_N9_AD10N_43
-set_property  -dict {PACKAGE_PIN Y12   IOSTANDARD LVDS                           } [get_ports mxfe_syncin_n[2]         ]; ## HA02_N         K08  IO_L5N_T0U_N9_AD14N_70
-set_property  -dict {PACKAGE_PIN U12   IOSTANDARD LVDS                           } [get_ports mxfe_syncin_n[3]         ]; ## HA13_N         E13  IO_L4N_T0U_N7_DBC_AD7N_70
-set_property  -dict {PACKAGE_PIN W34   IOSTANDARD LVCMOS18                       } [get_ports mxfe_syncin_p[0]         ]; ## LA25_N         G28  IO_L3N_T0L_N5_AD15N_45
-set_property  -dict {PACKAGE_PIN U35   IOSTANDARD LVDS                           } [get_ports mxfe_syncin_p[1]         ]; ## LA29_P         G30  IO_L4P_T0U_N6_DBC_AD7P_45
-set_property  -dict {PACKAGE_PIN K33   IOSTANDARD LVCMOS18                       } [get_ports mxfe_syncin_p[2]         ]; ## LA32_N         H38  IO_L21N_T3L_N5_AD8N_45
-set_property  -dict {PACKAGE_PIN AJ30  IOSTANDARD LVDS                           } [get_ports mxfe_syncin_p[3]         ]; ## LA11_P         H16  IO_L17P_T2U_N8_AD10P_43
-set_property  -dict {PACKAGE_PIN J12   IOSTANDARD LVCMOS18                       } [get_ports mxfe_syncin_p[4]         ]; ## HA22_N         J22  IO_L24N_T3U_N11_70
-set_property  -dict {PACKAGE_PIN AA12  IOSTANDARD LVDS                           } [get_ports mxfe_syncin_p[5]         ]; ## HA02_P         K07  IO_L5P_T0U_N8_AD14P_70
-set_property  -dict {PACKAGE_PIN V14   IOSTANDARD LVCMOS18                       } [get_ports mxfe_syncin_p[6]         ]; ## HA09_N         E10  IO_L6N_T0U_N11_AD6N_70
-set_property  -dict {PACKAGE_PIN V13   IOSTANDARD LVDS                           } [get_ports mxfe_syncin_p[7]         ]; ## HA13_P         E12  IO_L4P_T0U_N6_DBC_AD7P_70
-set_property  -dict {PACKAGE_PIN N37   IOSTANDARD LVDS     DIFF_TERM_ADV TERM_100} [get_ports mxfe_syncout_n[0]        ]; ## LA31_N         G34  IO_L16N_T2U_N7_QBC_AD3N_45
-set_property  -dict {PACKAGE_PIN AG33  IOSTANDARD LVDS     DIFF_TERM_ADV TERM_100} [get_ports mxfe_syncout_n[1]        ]; ## LA15_N         H20  IO_L24N_T3U_N11_43
-set_property  -dict {PACKAGE_PIN T13   IOSTANDARD LVDS     DIFF_TERM_ADV TERM_100} [get_ports mxfe_syncout_n[2]        ]; ## HA06_N         K11  IO_L12N_T1U_N11_GC_70
-set_property  -dict {PACKAGE_PIN R13   IOSTANDARD LVDS     DIFF_TERM_ADV TERM_100} [get_ports mxfe_syncout_n[3]        ]; ## HA16_N         E16  IO_L11N_T1U_N9_GC_70
-set_property  -dict {PACKAGE_PIN Y34   IOSTANDARD LVCMOS18                       } [get_ports mxfe_syncout_p[0]        ]; ## LA25_P         G27  IO_L3P_T0L_N4_AD15P_45
-set_property  -dict {PACKAGE_PIN P37   IOSTANDARD LVDS     DIFF_TERM_ADV TERM_100} [get_ports mxfe_syncout_p[1]        ]; ## LA31_P         G33  IO_L16P_T2U_N6_QBC_AD3P_45
-set_property  -dict {PACKAGE_PIN L33   IOSTANDARD LVCMOS18                       } [get_ports mxfe_syncout_p[2]        ]; ## LA32_P         H37  IO_L21P_T3L_N4_AD8P_45
-set_property  -dict {PACKAGE_PIN AG32  IOSTANDARD LVDS     DIFF_TERM_ADV TERM_100} [get_ports mxfe_syncout_p[3]        ]; ## LA15_P         H19  IO_L24P_T3U_N10_43
-set_property  -dict {PACKAGE_PIN K12   IOSTANDARD LVCMOS18                       } [get_ports mxfe_syncout_p[4]        ]; ## HA22_P         J21  IO_L24P_T3U_N10_70
-set_property  -dict {PACKAGE_PIN U13   IOSTANDARD LVDS     DIFF_TERM_ADV TERM_100} [get_ports mxfe_syncout_p[5]        ]; ## HA06_P         K10  IO_L12P_T1U_N10_GC_70
-set_property  -dict {PACKAGE_PIN W14   IOSTANDARD LVCMOS18                       } [get_ports mxfe_syncout_p[6]        ]; ## HA09_P         E09  IO_L6P_T0U_N10_AD6P_70
-set_property  -dict {PACKAGE_PIN T14   IOSTANDARD LVDS     DIFF_TERM_ADV TERM_100} [get_ports mxfe_syncout_p[7]        ]; ## HA16_P         E15  IO_L11P_T1U_N8_GC_70
+set_property  -dict {PACKAGE_PIN T36   IOSTANDARD LVCMOS18                       } [get_ports mxfe_syncin_0_n          ]; ## LA29_N         G31  IO_L4N_T0U_N7_DBC_AD7N_45
+set_property  -dict {PACKAGE_PIN AJ31  IOSTANDARD LVCMOS18                       } [get_ports mxfe_syncin_1_n          ]; ## LA11_N         H17  IO_L17N_T2U_N9_AD10N_43
+set_property  -dict {PACKAGE_PIN Y12   IOSTANDARD LVCMOS18                       } [get_ports mxfe_syncin_2_n          ]; ## HA02_N         K08  IO_L5N_T0U_N9_AD14N_70
+set_property  -dict {PACKAGE_PIN U12   IOSTANDARD LVCMOS18                       } [get_ports mxfe_syncin_3_n          ]; ## HA13_N         E13  IO_L4N_T0U_N7_DBC_AD7N_70
+set_property  -dict {PACKAGE_PIN W34   IOSTANDARD LVCMOS18                       } [get_ports mxfe_syncin_0_p          ]; ## LA25_N         G28  IO_L3N_T0L_N5_AD15N_45
+set_property  -dict {PACKAGE_PIN U35   IOSTANDARD LVCMOS18                       } [get_ports mxfe_syncin_1_p          ]; ## LA29_P         G30  IO_L4P_T0U_N6_DBC_AD7P_45
+set_property  -dict {PACKAGE_PIN K33   IOSTANDARD LVCMOS18                       } [get_ports mxfe_syncin_2_p          ]; ## LA32_N         H38  IO_L21N_T3L_N5_AD8N_45
+set_property  -dict {PACKAGE_PIN AJ30  IOSTANDARD LVCMOS18                       } [get_ports mxfe_syncin_3_p          ]; ## LA11_P         H16  IO_L17P_T2U_N8_AD10P_43
+set_property  -dict {PACKAGE_PIN J12   IOSTANDARD LVCMOS18                       } [get_ports mxfe_syncin_4_p          ]; ## HA22_N         J22  IO_L24N_T3U_N11_70
+set_property  -dict {PACKAGE_PIN AA12  IOSTANDARD LVCMOS18                       } [get_ports mxfe_syncin_5_p          ]; ## HA02_P         K07  IO_L5P_T0U_N8_AD14P_70
+set_property  -dict {PACKAGE_PIN V14   IOSTANDARD LVCMOS18                       } [get_ports mxfe_syncin_6_p          ]; ## HA09_N         E10  IO_L6N_T0U_N11_AD6N_70
+set_property  -dict {PACKAGE_PIN V13   IOSTANDARD LVCMOS18                       } [get_ports mxfe_syncin_7_p          ]; ## HA13_P         E12  IO_L4P_T0U_N6_DBC_AD7P_70
+set_property  -dict {PACKAGE_PIN N37   IOSTANDARD LVCMOS18                       } [get_ports mxfe_syncout_0_n         ]; ## LA31_N         G34  IO_L16N_T2U_N7_QBC_AD3N_45
+set_property  -dict {PACKAGE_PIN AG33  IOSTANDARD LVCMOS18                       } [get_ports mxfe_syncout_1_n         ]; ## LA15_N         H20  IO_L24N_T3U_N11_43
+set_property  -dict {PACKAGE_PIN T13   IOSTANDARD LVCMOS18                       } [get_ports mxfe_syncout_2_n         ]; ## HA06_N         K11  IO_L12N_T1U_N11_GC_70
+set_property  -dict {PACKAGE_PIN R13   IOSTANDARD LVCMOS18                       } [get_ports mxfe_syncout_3_n         ]; ## HA16_N         E16  IO_L11N_T1U_N9_GC_70
+set_property  -dict {PACKAGE_PIN Y34   IOSTANDARD LVCMOS18                       } [get_ports mxfe_syncout_0_p         ]; ## LA25_P         G27  IO_L3P_T0L_N4_AD15P_45
+set_property  -dict {PACKAGE_PIN P37   IOSTANDARD LVCMOS18                       } [get_ports mxfe_syncout_1_p         ]; ## LA31_P         G33  IO_L16P_T2U_N6_QBC_AD3P_45
+set_property  -dict {PACKAGE_PIN L33   IOSTANDARD LVCMOS18                       } [get_ports mxfe_syncout_2_p         ]; ## LA32_P         H37  IO_L21P_T3L_N4_AD8P_45
+set_property  -dict {PACKAGE_PIN AG32  IOSTANDARD LVCMOS18                       } [get_ports mxfe_syncout_3_p         ]; ## LA15_P         H19  IO_L24P_T3U_N10_43
+set_property  -dict {PACKAGE_PIN K12   IOSTANDARD LVCMOS18                       } [get_ports mxfe_syncout_4_p         ]; ## HA22_P         J21  IO_L24P_T3U_N10_70
+set_property  -dict {PACKAGE_PIN U13   IOSTANDARD LVCMOS18                       } [get_ports mxfe_syncout_5_p         ]; ## HA06_P         K10  IO_L12P_T1U_N10_GC_70
+set_property  -dict {PACKAGE_PIN W14   IOSTANDARD LVCMOS18                       } [get_ports mxfe_syncout_6_p         ]; ## HA09_P         E09  IO_L6P_T0U_N10_AD6P_70
+set_property  -dict {PACKAGE_PIN T14   IOSTANDARD LVCMOS18                       } [get_ports mxfe_syncout_7_p         ]; ## HA16_P         E15  IO_L11P_T1U_N8_GC_70
 set_property  -dict {PACKAGE_PIN U11   IOSTANDARD LVCMOS18                       } [get_ports mxfe_tx_en0[0]           ]; ## HA08_P         F10  IO_L10P_T1U_N6_QBC_AD4P_70
 set_property  -dict {PACKAGE_PIN AJ32  IOSTANDARD LVCMOS18                       } [get_ports mxfe_tx_en0[1]           ]; ## LA02_P         H07  IO_L14P_T2L_N2_GC_43
 set_property  -dict {PACKAGE_PIN K11   IOSTANDARD LVCMOS18                       } [get_ports mxfe_tx_en0[2]           ]; ## HA23_P         K22  IO_L21P_T3L_N4_AD8P_70


### PR DESCRIPTION
The MxFE supports two links, so two pairs of SYNC signals are available.  One of them can be used for fast frequency hopping in single link mode or in 64b/66b 204C mode.  

Tested on :
ZCU102 + MxFE
VCU118 + QuadMxFE Rev C