### PR TITLE
Ultrascale DMA via HPC

### DIFF
--- a/library/axi_dmac/address_generator.v
+++ b/library/axi_dmac/address_generator.v
@@ -42,7 +42,8 @@ module address_generator #(
   parameter DMA_ADDR_WIDTH = 32,
   parameter BEATS_PER_BURST_WIDTH = 4,
   parameter BYTES_PER_BEAT_WIDTH = $clog2(DMA_DATA_WIDTH/8),
-  parameter LENGTH_WIDTH = 8)(
+  parameter LENGTH_WIDTH = 8,
+  parameter CACHE_COHERENT = 0)(
 
   input                        clk,
   input                        resetn,
@@ -80,7 +81,9 @@ localparam MAX_LENGTH = {BEATS_PER_BURST_WIDTH{1'b1}};
 
 assign burst = 2'b01;
 assign prot = 3'b000;
-assign cache = 4'b0011;
+// If CACHE_COHERENT is set, signal downstream that this transaction must be
+// looked up in cache. Otherwise default to "normal non-cachable bufferable".
+assign cache = CACHE_COHERENT ? 4'b1110 : 4'b0011;
 assign size = DMA_DATA_WIDTH == 1024 ? 3'b111 :
               DMA_DATA_WIDTH ==  512 ? 3'b110 :
               DMA_DATA_WIDTH ==  256 ? 3'b101 :

--- a/library/axi_dmac/axi_dmac.v
+++ b/library/axi_dmac/axi_dmac.v
@@ -62,7 +62,8 @@ module axi_dmac #(
   parameter DMA_AXIS_DEST_W = 4,
   parameter DISABLE_DEBUG_REGISTERS = 0,
   parameter ENABLE_DIAGNOSTICS_IF = 0,
-  parameter ALLOW_ASYM_MEM = 0
+  parameter ALLOW_ASYM_MEM = 0,
+  parameter CACHE_COHERENT_DEST = 0
 ) (
   // Slave AXI interface
   input s_axi_aclk,
@@ -407,7 +408,8 @@ axi_dmac_regmap #(
   .HAS_DEST_ADDR(HAS_DEST_ADDR),
   .HAS_SRC_ADDR(HAS_SRC_ADDR),
   .DMA_2D_TRANSFER(DMA_2D_TRANSFER),
-  .SYNC_TRANSFER_START(SYNC_TRANSFER_START)
+  .SYNC_TRANSFER_START(SYNC_TRANSFER_START),
+  .CACHE_COHERENT_DEST(CACHE_COHERENT_DEST)
 ) i_regmap (
   .s_axi_aclk(s_axi_aclk),
   .s_axi_aresetn(s_axi_aresetn),
@@ -489,7 +491,8 @@ axi_dmac_transfer #(
   .AXI_LENGTH_WIDTH_SRC(8-(4*DMA_AXI_PROTOCOL_SRC)),
   .AXI_LENGTH_WIDTH_DEST(8-(4*DMA_AXI_PROTOCOL_DEST)),
   .ENABLE_DIAGNOSTICS_IF(ENABLE_DIAGNOSTICS_IF),
-  .ALLOW_ASYM_MEM(ALLOW_ASYM_MEM)
+  .ALLOW_ASYM_MEM(ALLOW_ASYM_MEM),
+  .CACHE_COHERENT_DEST(CACHE_COHERENT_DEST)
 ) i_transfer (
   .ctrl_clk(s_axi_aclk),
   .ctrl_resetn(s_axi_aresetn),

--- a/library/axi_dmac/axi_dmac_ip.tcl
+++ b/library/axi_dmac/axi_dmac_ip.tcl
@@ -239,6 +239,7 @@ foreach {k v} { \
 		"AXI_SLICE_DEST" "false" \
 		"DISABLE_DEBUG_REGISTERS" "false" \
     "ENABLE_DIAGNOSTICS_IF" "false" \
+    "CACHE_COHERENT_DEST" "false" \
 	} { \
 	set_property -dict [list \
 			"value_format" "bool" \
@@ -325,6 +326,18 @@ ipgui::move_param -component $cc -order 4 $p -parent $src_group
 set_property -dict [list \
 	"display_name" "Transfer Start Synchronization Support" \
 ] $p
+
+set p [ipgui::get_guiparamspec -name "CACHE_COHERENT_DEST" -component $cc]
+ipgui::move_param -component $cc -order 4 $p -parent $dest_group
+set_property -dict [list \
+	"tooltip" "Assume destination port ensures cache coherency (e.g. Ultrascale HPC port)" \
+] $p
+set_property -dict [list \
+	"display_name" "Assume cache coherent" \
+	"enablement_tcl_expr" "\$DMA_TYPE_DEST == 0 && \$DMA_AXI_PROTOCOL_DEST == 0" \
+	"value_tcl_expr" "\$DMA_TYPE_DEST == 0 && \$DMA_AXI_PROTOCOL_DEST == 0" \
+	"enablement_value" "false" \
+] [ipx::get_user_parameters CACHE_COHERENT_DEST -of_objects $cc]
 
 set general_group [ipgui::add_group -name "General Configuration" -component $cc \
 		-parent $page0 -display_name "General Configuration"]

--- a/library/axi_dmac/axi_dmac_regmap.v
+++ b/library/axi_dmac/axi_dmac_regmap.v
@@ -50,7 +50,8 @@ module axi_dmac_regmap #(
   parameter HAS_DEST_ADDR = 1,
   parameter HAS_SRC_ADDR = 1,
   parameter DMA_2D_TRANSFER = 0,
-  parameter SYNC_TRANSFER_START = 0
+  parameter SYNC_TRANSFER_START = 0,
+  parameter CACHE_COHERENT_DEST = 0
 ) (
   // Slave AXI interface
   input s_axi_aclk,
@@ -114,7 +115,7 @@ module axi_dmac_regmap #(
   input [31:0] dbg_ids1
 );
 
-localparam PCORE_VERSION = 'h00040361;
+localparam PCORE_VERSION = 'h00040461;
 
 // Register interface signals
 reg [31:0] up_rdata = 32'h00;
@@ -204,6 +205,7 @@ always @(posedge s_axi_aclk) begin
     9'h004: up_rdata <= {16'b0,
                          2'b0,DMA_TYPE_SRC[1:0],BYTES_PER_BEAT_WIDTH_SRC[3:0],
                          2'b0,DMA_TYPE_DEST[1:0],BYTES_PER_BEAT_WIDTH_DEST[3:0]};
+    9'h005: up_rdata <= {31'd0, CACHE_COHERENT_DEST};
     9'h020: up_rdata <= up_irq_mask;
     9'h021: up_rdata <= up_irq_pending;
     9'h022: up_rdata <= up_irq_source;

--- a/library/axi_dmac/axi_dmac_transfer.v
+++ b/library/axi_dmac/axi_dmac_transfer.v
@@ -58,7 +58,8 @@ module axi_dmac_transfer #(
   parameter AXI_LENGTH_WIDTH_SRC = 8,
   parameter AXI_LENGTH_WIDTH_DEST = 8,
   parameter ENABLE_DIAGNOSTICS_IF = 0,
-  parameter ALLOW_ASYM_MEM = 0
+  parameter ALLOW_ASYM_MEM = 0,
+  parameter CACHE_COHERENT_DEST = 0
 ) (
   input ctrl_clk,
   input ctrl_resetn,
@@ -337,7 +338,8 @@ request_arb #(
   .AXI_LENGTH_WIDTH_DEST (AXI_LENGTH_WIDTH_DEST),
   .AXI_LENGTH_WIDTH_SRC (AXI_LENGTH_WIDTH_SRC),
   .ENABLE_DIAGNOSTICS_IF(ENABLE_DIAGNOSTICS_IF),
-  .ALLOW_ASYM_MEM (ALLOW_ASYM_MEM)
+  .ALLOW_ASYM_MEM (ALLOW_ASYM_MEM),
+  .CACHE_COHERENT_DEST(CACHE_COHERENT_DEST)
 ) i_request_arb (
   .req_clk (req_clk),
   .req_resetn (req_resetn),

--- a/library/axi_dmac/dest_axi_mm.v
+++ b/library/axi_dmac/dest_axi_mm.v
@@ -44,7 +44,8 @@ module dest_axi_mm #(
   parameter BEATS_PER_BURST_WIDTH = 4,
   parameter MAX_BYTES_PER_BURST = 128,
   parameter BYTES_PER_BURST_WIDTH = $clog2(MAX_BYTES_PER_BURST),
-  parameter AXI_LENGTH_WIDTH = 8)(
+  parameter AXI_LENGTH_WIDTH = 8,
+  parameter CACHE_COHERENT = 0)(
 
   input                               m_axi_aclk,
   input                               m_axi_aresetn,
@@ -115,7 +116,8 @@ address_generator #(
   .BYTES_PER_BEAT_WIDTH(BYTES_PER_BEAT_WIDTH),
   .DMA_DATA_WIDTH(DMA_DATA_WIDTH),
   .LENGTH_WIDTH(AXI_LENGTH_WIDTH),
-  .DMA_ADDR_WIDTH(DMA_ADDR_WIDTH)
+  .DMA_ADDR_WIDTH(DMA_ADDR_WIDTH),
+  .CACHE_COHERENT(CACHE_COHERENT)
 ) i_addr_gen (
   .clk(m_axi_aclk),
   .resetn(m_axi_aresetn),

--- a/library/axi_dmac/request_arb.v
+++ b/library/axi_dmac/request_arb.v
@@ -57,7 +57,8 @@ module request_arb #(
   parameter AXI_LENGTH_WIDTH_SRC = 8,
   parameter AXI_LENGTH_WIDTH_DEST = 8,
   parameter ENABLE_DIAGNOSTICS_IF = 0,
-  parameter ALLOW_ASYM_MEM = 0
+  parameter ALLOW_ASYM_MEM = 0,
+  parameter CACHE_COHERENT_DEST = 0
 )(
   input req_clk,
   input req_resetn,
@@ -361,7 +362,8 @@ dest_axi_mm #(
   .BYTES_PER_BEAT_WIDTH(BYTES_PER_BEAT_WIDTH_DEST),
   .MAX_BYTES_PER_BURST(MAX_BYTES_PER_BURST),
   .BYTES_PER_BURST_WIDTH(BYTES_PER_BURST_WIDTH),
-  .AXI_LENGTH_WIDTH(AXI_LENGTH_WIDTH_DEST)
+  .AXI_LENGTH_WIDTH(AXI_LENGTH_WIDTH_DEST),
+  .CACHE_COHERENT(CACHE_COHERENT_DEST)
 ) i_dest_dma_mm (
   .m_axi_aclk(m_dest_axi_aclk),
   .m_axi_aresetn(dest_resetn),

--- a/projects/scripts/adi_board.tcl
+++ b/projects/scripts/adi_board.tcl
@@ -4,6 +4,8 @@ package require math
 ## Global variables for interconnect interface indexing
 #
 set sys_cpu_interconnect_index 0
+set sys_hpc0_interconnect_index -1
+set sys_hpc1_interconnect_index -1
 set sys_hp0_interconnect_index -1
 set sys_hp1_interconnect_index -1
 set sys_hp2_interconnect_index -1
@@ -521,6 +523,32 @@ proc ad_xcvrpll {m_src m_dst} {
 ###################################################################################################
 ###################################################################################################
 
+## Create an memory mapped interface connection to PS8 IP, using a
+#  HPC0 high speed interface.
+#
+#  \param[p_clk]  - name of the clock or reset source
+#  \param[p_name] - name or list of names of the clock or reset sink
+#
+proc ad_mem_hpc0_interconnect {p_clk p_name} {
+
+  global sys_zynq
+
+  if {$sys_zynq == 2} {ad_mem_hpx_interconnect "HPC0" $p_clk $p_name}
+}
+
+## Create an memory mapped interface connection to PS8 IP, using a
+#  HPC1 high speed interface.
+#
+#  \param[p_clk]  - name of the clock or reset source
+#  \param[p_name] - name or list of names of the clock or reset sink
+#
+proc ad_mem_hpc1_interconnect {p_clk p_name} {
+
+  global sys_zynq
+
+  if {$sys_zynq == 2} {ad_mem_hpx_interconnect "HPC1" $p_clk $p_name}
+}
+
 ## Create an memory mapped interface connection to a MIG or PS7/8 IP, using a
 #  HP0 high speed interface in case of PSx.
 #
@@ -606,6 +634,8 @@ proc ad_mem_hpx_interconnect {p_sel p_clk p_name} {
 
   global sys_zynq
   global sys_ddr_addr_seg
+  global sys_hpc0_interconnect_index
+  global sys_hpc1_interconnect_index
   global sys_hp0_interconnect_index
   global sys_hp1_interconnect_index
   global sys_hp2_interconnect_index
@@ -676,6 +706,30 @@ proc ad_mem_hpx_interconnect {p_sel p_clk p_name} {
     set m_interconnect_index $sys_hp3_interconnect_index
     set m_interconnect_cell [get_bd_cells axi_hp3_interconnect]
     set m_addr_seg [get_bd_addr_segs sys_ps7/S_AXI_HP3/HP3_DDR_LOWOCM]
+  }
+
+  if {($p_sel eq "HPC0") && ($sys_zynq == 2)} {
+    if {$sys_hpc0_interconnect_index < 0} {
+      set p_name_int sys_ps8/S_AXI_HPC0_FPD
+      set_property CONFIG.PSU__USE__S_AXI_GP0 {1} [get_bd_cells sys_ps8]
+      set_property CONFIG.PSU__AFI0_COHERENCY {1} [get_bd_cells sys_ps8]
+      ad_ip_instance smartconnect axi_hpc0_interconnect
+    }
+    set m_interconnect_index $sys_hpc0_interconnect_index
+    set m_interconnect_cell [get_bd_cells axi_hpc0_interconnect]
+    set m_addr_seg [get_bd_addr_segs sys_ps8/SAXIGP0/HPC0_DDR_*]
+  }
+
+  if {($p_sel eq "HPC1") && ($sys_zynq == 2)} {
+    if {$sys_hpc1_interconnect_index < 0} {
+      set p_name_int sys_ps8/S_AXI_HPC1_FPD
+      set_property CONFIG.PSU__USE__S_AXI_GP1 {1} [get_bd_cells sys_ps8]
+      set_property CONFIG.PSU__AFI1_COHERENCY {1} [get_bd_cells sys_ps8]
+      ad_ip_instance smartconnect axi_hpc1_interconnect
+    }
+    set m_interconnect_index $sys_hpc1_interconnect_index
+    set m_interconnect_cell [get_bd_cells axi_hpc1_interconnect]
+    set m_addr_seg [get_bd_addr_segs sys_ps8/SAXIGP1/HPC1_DDR_*]
   }
 
   if {($p_sel eq "HP0") && ($sys_zynq == 2)} {
@@ -806,6 +860,8 @@ proc ad_mem_hpx_interconnect {p_sel p_clk p_name} {
 
   if {$p_sel eq "SIM"} {set sys_mem_interconnect_index $m_interconnect_index}
   if {$p_sel eq "MEM"} {set sys_mem_interconnect_index $m_interconnect_index}
+  if {$p_sel eq "HPC0"} {set sys_hpc0_interconnect_index $m_interconnect_index}
+  if {$p_sel eq "HPC1"} {set sys_hpc1_interconnect_index $m_interconnect_index}
   if {$p_sel eq "HP0"} {set sys_hp0_interconnect_index $m_interconnect_index}
   if {$p_sel eq "HP1"} {set sys_hp1_interconnect_index $m_interconnect_index}
   if {$p_sel eq "HP2"} {set sys_hp2_interconnect_index $m_interconnect_index}


### PR DESCRIPTION
- Support connecting HPC ports on PS8
- Add register to `axi_dmac` controlling `AxCACHE`

I also have a patch for the `dma-axi-dmac` Linux driver, setting the register if the DMA node in the devicetree has the `dma-coherent` property. Will make a PR if this one is accepted.

The purpose here is to speed up transfers when the CPU should manipulate the samples immediately after transferring them from PL to main memory:

- Without the `dma-coherent` devicetree property, it is assumed that it is unsafe to read addresses from cache that the DMA may have written to (and rightfully so). This means all reads will be from main memory.
- Using the Ultrascale HPC port with `AxCACHE` set accordingly, DMA writes will invalidate the cache at those addresses. This means we can safely set the `dma-coherent` property and enjoy cache hits and speedup.

I've only tested transfers from PL to memory, not the other way around. In my testcase I use `iio_buffer_refill` and `memcpy` from the iio buffer to elsewhere in main memory. Without this patch, I'm limited to about 900 Mbps with one CPU core at 100%. After these changes, the limit is close to 6 Gbps.

Inspired by Xilinx' wiki page here:
https://xilinx-wiki.atlassian.net/wiki/spaces/A/pages/18842098/Zynq+UltraScale+MPSoC+Cache+Coherency

The wiki page suggests `AxPROT[1]` should be set on Linux, marking transactions as non-secure. In what little I have read about `AxPROT`, I haven't seen anything that suggests this is related to cache coherency, and during testing it seems to make no difference.

Thoughts? Anything I've missed?