### PR TITLE
.gitignore: Add the bd.tcl files from built IPs into gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -96,4 +96,5 @@ _vmake
 *.gen*
 *.xsa
 *.pdi
+library/*/bd/bd.tcl
 


### PR DESCRIPTION
Almost all the IPs found in library generate a bd folder when they are built. Updated the .gitignore so that it does not appear as an untracked file.
Also, changes to tracked bd.tcl files (ex:axi_dmac) will still appear as modified files.
Signed-off-by: Liviu.Iacob <liviu.iacob@analog.com>