### PR TITLE
MxFE FFH suppor for rest of the carriers

### DIFF
--- a/projects/ad9081_fmca_ebz/a10soc/system_project.tcl
+++ b/projects/ad9081_fmca_ebz/a10soc/system_project.tcl
@@ -109,14 +109,14 @@ set_location_assignment PIN_J36   -to "tx_data[4](n)"       ; ## A35  DP4_C2M_N
 set_location_assignment PIN_J37   -to "tx_data[4]"          ; ## A34  DP4_C2M_P
 set_location_assignment PIN_K38   -to "tx_data[3](n)"       ; ## A31  DP3_C2M_N
 set_location_assignment PIN_K39   -to "tx_data[3]"          ; ## A30  DP3_C2M_P
-set_location_assignment PIN_D13   -to "fpga_syncin[0](n)"   ; ## H08  LA02_N
-set_location_assignment PIN_C13   -to "fpga_syncin[0]"      ; ## H07  LA02_P
-set_location_assignment PIN_D14   -to "fpga_syncin[1](n)"   ; ## G10  LA03_N
-set_location_assignment PIN_C14   -to "fpga_syncin[1]"      ; ## G09  LA03_P
-set_location_assignment PIN_E13   -to "fpga_syncout[0](n)"  ; ## D09  LA01_CC_N
-set_location_assignment PIN_E12   -to "fpga_syncout[0]"     ; ## D08  LA01_CC_P
-set_location_assignment PIN_B10   -to "fpga_syncout[1](n)"  ; ## C11  LA06_N
-set_location_assignment PIN_A10   -to "fpga_syncout[1]"     ; ## C10  LA06_P
+set_location_assignment PIN_D13   -to "fpga_syncin_0(n)"    ; ## H08  LA02_N
+set_location_assignment PIN_C13   -to "fpga_syncin_0"       ; ## H07  LA02_P
+set_location_assignment PIN_D14   -to "fpga_syncin_1_n"     ; ## G10  LA03_N
+set_location_assignment PIN_C14   -to "fpga_syncin_1_p"     ; ## G09  LA03_P
+set_location_assignment PIN_E13   -to "fpga_syncout_0(n)"   ; ## D09  LA01_CC_N
+set_location_assignment PIN_E12   -to "fpga_syncout_0"      ; ## D08  LA01_CC_P
+set_location_assignment PIN_B10   -to "fpga_syncout_1_n"    ; ## C11  LA06_N
+set_location_assignment PIN_A10   -to "fpga_syncout_1_p"    ; ## C10  LA06_P
 set_location_assignment PIN_D4    -to "gpio[0]"             ; ## H19  LA15_P
 set_location_assignment PIN_D5    -to "gpio[1]"             ; ## H20  LA15_N
 set_location_assignment PIN_G5    -to "gpio[2]"             ; ## H22  LA19_P
@@ -168,13 +168,10 @@ for {set i 0} {$i < $common_lanes} {incr i} {
   set_instance_assignment -name XCVR_RECONFIG_GROUP xcvr_${i} -to tx_data[${i}]
 }
 
-set_instance_assignment -name IO_STANDARD LVDS -to fpga_syncin[0]
-set_instance_assignment -name IO_STANDARD LVDS -to fpga_syncin[1]
-set_instance_assignment -name IO_STANDARD LVDS -to fpga_syncout[0]
-set_instance_assignment -name IO_STANDARD LVDS -to fpga_syncout[1]
+set_instance_assignment -name IO_STANDARD LVDS -to fpga_syncin_0
+set_instance_assignment -name IO_STANDARD LVDS -to fpga_syncout_0
 set_instance_assignment -name IO_STANDARD LVDS -to sysref2
-set_instance_assignment -name INPUT_TERMINATION DIFFERENTIAL -to fpga_syncin[0]
-set_instance_assignment -name INPUT_TERMINATION DIFFERENTIAL -to fpga_syncin[1]
+set_instance_assignment -name INPUT_TERMINATION DIFFERENTIAL -to fpga_syncin_0
 set_instance_assignment -name INPUT_TERMINATION DIFFERENTIAL -to sysref2
 
 set_instance_assignment -name IO_STANDARD "1.8 V" -to agc0[0]

--- a/projects/ad9081_fmca_ebz/a10soc/system_top.v
+++ b/projects/ad9081_fmca_ebz/a10soc/system_top.v
@@ -130,8 +130,12 @@ module system_top #(
   input         fpga_refclk_in,
   input  [7:0]  rx_data,
   output [7:0]  tx_data,
-  input  [1:0]  fpga_syncin,
-  output [1:0]  fpga_syncout,
+  input         fpga_syncin_0,
+  inout         fpga_syncin_1_n,
+  inout         fpga_syncin_1_p,
+  output        fpga_syncout_0,
+  inout         fpga_syncout_1_n,
+  inout         fpga_syncout_1_p,
   input         sysref2,
 
   // spi
@@ -211,6 +215,7 @@ module system_top #(
   assign txen[0]          = gpio_o[58];
   assign txen[1]          = gpio_o[59];
 
+
   // board stuff (max-v-u21)
 
   assign gpio_i[31:14] = gpio_o[31:14];
@@ -231,7 +236,11 @@ module system_top #(
   // instantiations
 
   system_bd i_system_bd (
-    .mxfe_gpio_export (gpio),
+    .mxfe_gpio_export ({fpga_syncout_1_n,  // 14
+                        fpga_syncout_1_p,  // 13
+                        fpga_syncin_1_n,   // 12
+                        fpga_syncin_1_p,   // 11
+                        gpio}),            // 10 :0
     .sys_clk_clk (sys_clk),
     .sys_gpio_bd_in_port (gpio_i[31:0]),
     .sys_gpio_bd_out_port (gpio_o[31:0]),
@@ -311,12 +320,12 @@ module system_top #(
     .sys_spi_SS_n (spi_csn_s),
     .tx_serial_data_tx_serial_data (tx_data[7:0]),
     .tx_ref_clk_clk (fpga_refclk_in),
-    .tx_sync_export (fpga_syncin),
+    .tx_sync_export (fpga_syncin_0),
     .tx_sysref_export (sysref2),
     .tx_device_clk_clk (clkin6),
     .rx_serial_data_rx_serial_data (rx_data[7:0]),
     .rx_ref_clk_clk (fpga_refclk_in),
-    .rx_sync_export (fpga_syncout),
+    .rx_sync_export (fpga_syncout_0),
     .rx_sysref_export (sysref2),
     .rx_device_clk_clk (clkin6)
 

--- a/projects/ad9081_fmca_ebz/vck190/system_constr.xdc
+++ b/projects/ad9081_fmca_ebz/vck190/system_constr.xdc
@@ -48,14 +48,14 @@ set_property  -quiet -dict {PACKAGE_PIN V6                                      
 set_property  -quiet -dict {PACKAGE_PIN V7                                                            } [get_ports tx_data_p[4]     ]    ; ## FMC0_DP4_C2M_P      MGTHTXP3_228    FPGA_SERDOUT_6_P
 set_property  -quiet -dict {PACKAGE_PIN W8                                                            } [get_ports tx_data_n[3]     ]    ; ## FMC0_DP3_C2M_N      MGTHTXN0_229    FPGA_SERDOUT_7_N
 set_property  -quiet -dict {PACKAGE_PIN W9                                                            } [get_ports tx_data_p[3]     ]    ; ## FMC0_DP3_C2M_P      MGTHTXP0_229    FPGA_SERDOUT_7_P
-set_property  -quiet -dict {PACKAGE_PIN AY25  IOSTANDARD LVDS15   DIFF_TERM_ADV TERM_100              } [get_ports fpga_syncin_n[0] ]    ; ## FMC0_LA02_N         IO_L23N_T3U_N9_66
-set_property  -quiet -dict {PACKAGE_PIN AW24  IOSTANDARD LVDS15   DIFF_TERM_ADV TERM_100              } [get_ports fpga_syncin_p[0] ]    ; ## FMC0_LA02_P         IO_L23P_T3U_N8_66
-set_property  -quiet -dict {PACKAGE_PIN AW21  IOSTANDARD LVDS15   DIFF_TERM_ADV TERM_100              } [get_ports fpga_syncin_n[1] ]    ; ## FMC0_LA03_N         IO_L22N_T3U_N7_DBC_AD0N_66
-set_property  -quiet -dict {PACKAGE_PIN AV22  IOSTANDARD LVDS15   DIFF_TERM_ADV TERM_100              } [get_ports fpga_syncin_p[1] ]    ; ## FMC0_LA03_P         IO_L22P_T3U_N6_DBC_AD0P_66
-set_property  -quiet -dict {PACKAGE_PIN BD22  IOSTANDARD LVDS15                                       } [get_ports fpga_syncout_n[0]]    ; ## FMC0_LA01_CC_N      IO_L16N_T2U_N7_QBC_AD3N_66
-set_property  -quiet -dict {PACKAGE_PIN BC23  IOSTANDARD LVDS15                                       } [get_ports fpga_syncout_p[0]]    ; ## FMC0_LA01_CC_P      IO_L16P_T2U_N6_QBC_AD3P_66
-set_property  -quiet -dict {PACKAGE_PIN BD20  IOSTANDARD LVDS15                                       } [get_ports fpga_syncout_n[1]]    ; ## FMC0_LA06_N         IO_L19N_T3L_N1_DBC_AD9N_66
-set_property  -quiet -dict {PACKAGE_PIN BC20  IOSTANDARD LVDS15                                       } [get_ports fpga_syncout_p[1]]    ; ## FMC0_LA06_P         IO_L19P_T3L_N0_DBC_AD9P_66
+set_property  -quiet -dict {PACKAGE_PIN AY25  IOSTANDARD LVDS15   DIFF_TERM_ADV TERM_100              } [get_ports fpga_syncin_0_n  ]    ; ## FMC0_LA02_N         IO_L23N_T3U_N9_66
+set_property  -quiet -dict {PACKAGE_PIN AW24  IOSTANDARD LVDS15   DIFF_TERM_ADV TERM_100              } [get_ports fpga_syncin_0_p  ]    ; ## FMC0_LA02_P         IO_L23P_T3U_N8_66
+set_property  -quiet -dict {PACKAGE_PIN AW21  IOSTANDARD LVCMOS15                                     } [get_ports fpga_syncin_1_n  ]    ; ## FMC0_LA03_N         IO_L22N_T3U_N7_DBC_AD0N_66
+set_property  -quiet -dict {PACKAGE_PIN AV22  IOSTANDARD LVCMOS15                                     } [get_ports fpga_syncin_1_p  ]    ; ## FMC0_LA03_P         IO_L22P_T3U_N6_DBC_AD0P_66
+set_property  -quiet -dict {PACKAGE_PIN BD22  IOSTANDARD LVDS15                                       } [get_ports fpga_syncout_0_n ]    ; ## FMC0_LA01_CC_N      IO_L16N_T2U_N7_QBC_AD3N_66
+set_property  -quiet -dict {PACKAGE_PIN BC23  IOSTANDARD LVDS15                                       } [get_ports fpga_syncout_0_p ]    ; ## FMC0_LA01_CC_P      IO_L16P_T2U_N6_QBC_AD3P_66
+set_property  -quiet -dict {PACKAGE_PIN BD20  IOSTANDARD LVCMOS15                                     } [get_ports fpga_syncout_1_n ]    ; ## FMC0_LA06_N         IO_L19N_T3L_N1_DBC_AD9N_66
+set_property  -quiet -dict {PACKAGE_PIN BC20  IOSTANDARD LVCMOS15                                     } [get_ports fpga_syncout_1_p ]    ; ## FMC0_LA06_P         IO_L19P_T3L_N0_DBC_AD9P_66
 set_property         -dict {PACKAGE_PIN AY22  IOSTANDARD LVCMOS15                                     } [get_ports gpio[0]          ]    ; ## FMC0_LA15_P         IO_L6P_T0U_N10_AD6P_66
 set_property         -dict {PACKAGE_PIN AY23  IOSTANDARD LVCMOS15                                     } [get_ports gpio[1]          ]    ; ## FMC0_LA15_N         IO_L6N_T0U_N11_AD6N_66
 set_property         -dict {PACKAGE_PIN BA17  IOSTANDARD LVCMOS15                                     } [get_ports gpio[2]          ]    ; ## FMC0_LA19_P         IO_L23P_T3U_N8_67

--- a/projects/ad9081_fmca_ebz/vck190/system_top.v
+++ b/projects/ad9081_fmca_ebz/vck190/system_top.v
@@ -39,7 +39,8 @@ module system_top  #(
     parameter TX_JESD_L = 4,
     parameter TX_NUM_LINKS = 1,
     parameter RX_JESD_L = 4,
-    parameter RX_NUM_LINKS = 1
+    parameter RX_NUM_LINKS = 1,
+    parameter JESD_MODE = "8B10B"
   ) (
   input         sys_clk_n,
   input         sys_clk_p,
@@ -77,10 +78,14 @@ module system_top  #(
   input  [RX_JESD_L*RX_NUM_LINKS-1:0]  rx_data_p,
   output [TX_JESD_L*TX_NUM_LINKS-1:0]  tx_data_n,
   output [TX_JESD_L*TX_NUM_LINKS-1:0]  tx_data_p,
-  input  [TX_NUM_LINKS-1:0]  fpga_syncin_n,
-  input  [TX_NUM_LINKS-1:0]  fpga_syncin_p,
-  output [RX_NUM_LINKS-1:0]  fpga_syncout_n,
-  output [RX_NUM_LINKS-1:0]  fpga_syncout_p,
+  input                                fpga_syncin_0_n,
+  input                                fpga_syncin_0_p,
+  inout                                fpga_syncin_1_n,
+  inout                                fpga_syncin_1_p,
+  output                               fpga_syncout_0_n,
+  output                               fpga_syncout_0_p,
+  inout                                fpga_syncout_1_n,
+  inout                                fpga_syncout_1_p,
   inout  [10:0] gpio,
   inout         hmc_gpio1,
   output        hmc_sync,
@@ -149,22 +154,15 @@ module system_top  #(
     .IB (clkin10_n),
     .O (clkin10));
 
-  genvar i;
-  generate
-  for(i=0;i<TX_NUM_LINKS;i=i+1) begin : g_tx_buffers
-    IBUFDS i_ibufds_syncin (
-      .I (fpga_syncin_p[i]),
-      .IB (fpga_syncin_n[i]),
-      .O (tx_syncin[i]));
-  end
+  IBUFDS i_ibufds_syncin_0 (
+    .I (fpga_syncin_0_p),
+    .IB (fpga_syncin_0_n),
+    .O (tx_syncin[0]));
 
-  for(i=0;i<RX_NUM_LINKS;i=i+1) begin : g_rx_buffers
-    OBUFDS i_obufds_syncout (
-      .I (rx_syncout[i]),
-      .O (fpga_syncout_p[i]),
-      .OB (fpga_syncout_n[i]));
-  end
-  endgenerate
+  OBUFDS i_obufds_syncout_0 (
+    .I (rx_syncout[0]),
+    .O (fpga_syncout_0_p),
+    .OB (fpga_syncout_0_n));
 
   BUFG i_tx_device_clk (
     .I (clkin6),
@@ -215,6 +213,31 @@ module system_top  #(
   assign txen[0]    = gpio_o[58];
   assign txen[1]    = gpio_o[59];
 
+  generate
+  if (TX_NUM_LINKS > 1 & JESD_MODE == "8B10B") begin
+    assign tx_syncin[1] = fpga_syncin_1_p;
+  end else begin
+    ad_iobuf #(.DATA_WIDTH(2)) i_syncin_iobuf (
+      .dio_t (gpio_t[61:60]),
+      .dio_i (gpio_o[61:60]),
+      .dio_o (gpio_i[61:60]),
+      .dio_p ({fpga_syncin_1_n,      // 61
+               fpga_syncin_1_p}));   // 60
+  end
+
+  if (RX_NUM_LINKS > 1 & JESD_MODE == "8B10B") begin
+    assign fpga_syncout_1_p = rx_syncout[1];
+    assign fpga_syncout_1_n = 0;
+  end else begin
+    ad_iobuf #(.DATA_WIDTH(2)) i_syncout_iobuf (
+      .dio_t (gpio_t[63:62]),
+      .dio_i (gpio_o[63:62]),
+      .dio_o (gpio_i[63:62]),
+      .dio_p ({fpga_syncout_1_n,      // 63
+               fpga_syncout_1_p}));   // 62
+  end
+  endgenerate
+
   /* Board GPIOS. Buttons, LEDs, etc... */
   assign gpio_led = gpio_o[3:0];
   assign gpio_i[3:0] = gpio_o[3:0];
@@ -222,7 +245,8 @@ module system_top  #(
   assign gpio_i[9: 8] = gpio_pb;
 
   // Unused GPIOs
-  assign gpio_i[94:54] = gpio_o[94:54];
+  assign gpio_i[59:54] = gpio_o[59:54];
+  assign gpio_i[94:64] = gpio_o[94:64];
   assign gpio_i[31:10] = gpio_o[31:10];
 
   system_wrapper i_system_wrapper (

--- a/projects/ad9081_fmca_ebz/vcu128/system_constr.xdc
+++ b/projects/ad9081_fmca_ebz/vcu128/system_constr.xdc
@@ -48,14 +48,14 @@ set_property  -quiet -dict {PACKAGE_PIN AY47                                    
 set_property  -quiet -dict {PACKAGE_PIN AY46                                           } [get_ports tx_data_p[4]              ]    ; ## MGTYTXP0_125              FPGA_SERDOUT_6_P
 set_property  -quiet -dict {PACKAGE_PIN BA45                                           } [get_ports tx_data_n[3]              ]    ; ## MGTYTXN3_124              FPGA_SERDOUT_7_N
 set_property  -quiet -dict {PACKAGE_PIN BA44                                           } [get_ports tx_data_p[3]              ]    ; ## MGTYTXP3_124              FPGA_SERDOUT_7_P
-set_property  -quiet -dict {PACKAGE_PIN K22  IOSTANDARD LVDS     DIFF_TERM_ADV TERM_100} [get_ports fpga_syncin_n[0]          ]    ; ## IO_L4N_T0U_N7_DBC_AD7N_72 
-set_property  -quiet -dict {PACKAGE_PIN L23  IOSTANDARD LVDS     DIFF_TERM_ADV TERM_100} [get_ports fpga_syncin_p[0]          ]    ; ## IO_L4P_T0U_N6_DBC_AD7P_72 
-set_property  -quiet -dict {PACKAGE_PIN A26  IOSTANDARD LVDS     DIFF_TERM_ADV TERM_100} [get_ports fpga_syncin_n[1]          ]    ; ## IO_L23N_T3U_N9_72         
-set_property  -quiet -dict {PACKAGE_PIN B27  IOSTANDARD LVDS     DIFF_TERM_ADV TERM_100} [get_ports fpga_syncin_p[1]          ]    ; ## IO_L23P_T3U_N8_72         
-set_property  -quiet -dict {PACKAGE_PIN F25  IOSTANDARD LVDS                           } [get_ports fpga_syncout_n[0]         ]    ; ## IO_L14N_T2L_N3_GC_72      
-set_property  -quiet -dict {PACKAGE_PIN F26  IOSTANDARD LVDS                           } [get_ports fpga_syncout_p[0]         ]    ; ## IO_L14P_T2L_N2_GC_72      
-set_property  -quiet -dict {PACKAGE_PIN D22  IOSTANDARD LVDS                           } [get_ports fpga_syncout_n[1]         ]    ; ## IO_L15N_T2L_N5_AD11N_72   
-set_property  -quiet -dict {PACKAGE_PIN E22  IOSTANDARD LVDS                           } [get_ports fpga_syncout_p[1]         ]    ; ## IO_L15P_T2L_N4_AD11P_72   
+set_property  -quiet -dict {PACKAGE_PIN K22  IOSTANDARD LVDS     DIFF_TERM_ADV TERM_100} [get_ports fpga_syncin_0_n           ]    ; ## IO_L4N_T0U_N7_DBC_AD7N_72 
+set_property  -quiet -dict {PACKAGE_PIN L23  IOSTANDARD LVDS     DIFF_TERM_ADV TERM_100} [get_ports fpga_syncin_0_p           ]    ; ## IO_L4P_T0U_N6_DBC_AD7P_72 
+set_property  -quiet -dict {PACKAGE_PIN A26  IOSTANDARD LVCMOS18                       } [get_ports fpga_syncin_1_n           ]    ; ## IO_L23N_T3U_N9_72         
+set_property  -quiet -dict {PACKAGE_PIN B27  IOSTANDARD LVCMOS18                       } [get_ports fpga_syncin_1_p           ]    ; ## IO_L23P_T3U_N8_72         
+set_property  -quiet -dict {PACKAGE_PIN F25  IOSTANDARD LVDS                           } [get_ports fpga_syncout_0_n          ]    ; ## IO_L14N_T2L_N3_GC_72      
+set_property  -quiet -dict {PACKAGE_PIN F26  IOSTANDARD LVDS                           } [get_ports fpga_syncout_0_p          ]    ; ## IO_L14P_T2L_N2_GC_72      
+set_property  -quiet -dict {PACKAGE_PIN D22  IOSTANDARD LVCMOS18                       } [get_ports fpga_syncout_1_n          ]    ; ## IO_L15N_T2L_N5_AD11N_72   
+set_property  -quiet -dict {PACKAGE_PIN E22  IOSTANDARD LVCMOS18                       } [get_ports fpga_syncout_1_p          ]    ; ## IO_L15P_T2L_N4_AD11P_72   
 set_property         -dict {PACKAGE_PIN J26  IOSTANDARD LVCMOS18                       } [get_ports gpio[0]                   ]    ; ## IO_L6P_T0U_N10_AD6P_72    
 set_property         -dict {PACKAGE_PIN J25  IOSTANDARD LVCMOS18                       } [get_ports gpio[1]                   ]    ; ## IO_L6N_T0U_N11_AD6N_72    
 set_property         -dict {PACKAGE_PIN B18  IOSTANDARD LVCMOS18                       } [get_ports gpio[2]                   ]    ; ## IO_L21P_T3L_N4_AD8P_71    

--- a/projects/ad9081_fmca_ebz/zc706/system_constr.xdc
+++ b/projects/ad9081_fmca_ebz/zc706/system_constr.xdc
@@ -48,14 +48,14 @@ set_property  -quiet -dict {PACKAGE_PIN AH1                                     
 set_property  -quiet -dict {PACKAGE_PIN AH2                                     } [get_ports tx_data_p[4]     ]    ; ## FMC0_DP4_C2M_P      MGTXTXP0_110     FPGA_SERDOUT_6_P
 set_property  -quiet -dict {PACKAGE_PIN AK1                                     } [get_ports tx_data_n[3]     ]    ; ## FMC0_DP3_C2M_N      MGTXTXN3_109     FPGA_SERDOUT_7_N
 set_property  -quiet -dict {PACKAGE_PIN AK2                                     } [get_ports tx_data_p[3]     ]    ; ## FMC0_DP3_C2M_P      MGTXTXP3_109     FPGA_SERDOUT_7_P
-set_property  -quiet -dict {PACKAGE_PIN AK18  IOSTANDARD LVDS_25  DIFF_TERM TRUE} [get_ports fpga_syncin_n[0] ]    ; ## FMC0_LA02_N         IO_L16N_T2_11
-set_property  -quiet -dict {PACKAGE_PIN AK17  IOSTANDARD LVDS_25  DIFF_TERM TRUE} [get_ports fpga_syncin_p[0] ]    ; ## FMC0_LA02_P         IO_L16P_T2_11
-set_property  -quiet -dict {PACKAGE_PIN AJ19  IOSTANDARD LVDS_25  DIFF_TERM TRUE} [get_ports fpga_syncin_n[1] ]    ; ## FMC0_LA03_N         IO_L17N_T2_11
-set_property  -quiet -dict {PACKAGE_PIN AH19  IOSTANDARD LVDS_25  DIFF_TERM TRUE} [get_ports fpga_syncin_p[1] ]    ; ## FMC0_LA03_P         IO_L17P_T2_11
-set_property  -quiet -dict {PACKAGE_PIN AH21  IOSTANDARD LVDS_25                } [get_ports fpga_syncout_n[0]]    ; ## FMC0_LA01_CC_N      IO_L13N_T2_MRCC_11
-set_property  -quiet -dict {PACKAGE_PIN AG21  IOSTANDARD LVDS_25                } [get_ports fpga_syncout_p[0]]    ; ## FMC0_LA01_CC_P      IO_L13P_T2_MRCC_11
-set_property  -quiet -dict {PACKAGE_PIN AH22  IOSTANDARD LVDS_25                } [get_ports fpga_syncout_n[1]]    ; ## FMC0_LA06_N         IO_L6N_T0_VREF_11
-set_property  -quiet -dict {PACKAGE_PIN AG22  IOSTANDARD LVDS_25                } [get_ports fpga_syncout_p[1]]    ; ## FMC0_LA06_P         IO_L6P_T0_11
+set_property  -quiet -dict {PACKAGE_PIN AK18  IOSTANDARD LVDS_25  DIFF_TERM TRUE} [get_ports fpga_syncin_0_n  ]    ; ## FMC0_LA02_N         IO_L16N_T2_11
+set_property  -quiet -dict {PACKAGE_PIN AK17  IOSTANDARD LVDS_25  DIFF_TERM TRUE} [get_ports fpga_syncin_0_p  ]    ; ## FMC0_LA02_P         IO_L16P_T2_11
+set_property  -quiet -dict {PACKAGE_PIN AJ19  IOSTANDARD LVCMOS25               } [get_ports fpga_syncin_1_n  ]    ; ## FMC0_LA03_N         IO_L17N_T2_11
+set_property  -quiet -dict {PACKAGE_PIN AH19  IOSTANDARD LVCMOS25               } [get_ports fpga_syncin_1_p  ]    ; ## FMC0_LA03_P         IO_L17P_T2_11
+set_property  -quiet -dict {PACKAGE_PIN AH21  IOSTANDARD LVDS_25                } [get_ports fpga_syncout_0_n ]    ; ## FMC0_LA01_CC_N      IO_L13N_T2_MRCC_11
+set_property  -quiet -dict {PACKAGE_PIN AG21  IOSTANDARD LVDS_25                } [get_ports fpga_syncout_0_p ]    ; ## FMC0_LA01_CC_P      IO_L13P_T2_MRCC_11
+set_property  -quiet -dict {PACKAGE_PIN AH22  IOSTANDARD LVCMOS25               } [get_ports fpga_syncout_1_n ]    ; ## FMC0_LA06_N         IO_L6N_T0_VREF_11
+set_property  -quiet -dict {PACKAGE_PIN AG22  IOSTANDARD LVCMOS25               } [get_ports fpga_syncout_1_p ]    ; ## FMC0_LA06_P         IO_L6P_T0_11
 set_property         -dict {PACKAGE_PIN Y22   IOSTANDARD LVCMOS25               } [get_ports gpio[0]          ]    ; ## FMC0_LA15_P         IO_L21P_T3_DQS_11
 set_property         -dict {PACKAGE_PIN Y23   IOSTANDARD LVCMOS25               } [get_ports gpio[1]          ]    ; ## FMC0_LA15_N         IO_L21N_T3_DQS_11
 set_property         -dict {PACKAGE_PIN T24   IOSTANDARD LVCMOS25               } [get_ports gpio[2]          ]    ; ## FMC0_LA19_P         IO_L17P_T2_13

--- a/projects/ad9081_fmca_ebz/zc706/system_top.v
+++ b/projects/ad9081_fmca_ebz/zc706/system_top.v
@@ -39,7 +39,8 @@ module system_top  #(
     parameter TX_JESD_L = 8,
     parameter TX_NUM_LINKS = 1,
     parameter RX_JESD_L = 8,
-    parameter RX_NUM_LINKS = 1
+    parameter RX_NUM_LINKS = 1,
+    parameter JESD_MODE = "8B10B"
   ) (
 
   inout       [14:0]      ddr_addr,
@@ -93,10 +94,14 @@ module system_top  #(
   input  [RX_JESD_L*RX_NUM_LINKS-1:0]  rx_data_p,
   output [TX_JESD_L*TX_NUM_LINKS-1:0]  tx_data_n,
   output [TX_JESD_L*TX_NUM_LINKS-1:0]  tx_data_p,
-  input  [TX_NUM_LINKS-1:0]            fpga_syncin_n,
-  input  [TX_NUM_LINKS-1:0]            fpga_syncin_p,
-  output [RX_NUM_LINKS-1:0]            fpga_syncout_n,
-  output [RX_NUM_LINKS-1:0]            fpga_syncout_p,
+  input                                fpga_syncin_0_n,
+  input                                fpga_syncin_0_p,
+  inout                                fpga_syncin_1_n,
+  inout                                fpga_syncin_1_p,
+  output                               fpga_syncout_0_n,
+  output                               fpga_syncout_0_p,
+  inout                                fpga_syncout_1_n,
+  inout                                fpga_syncout_1_p,
   inout  [10:0]                        gpio,
   inout                                hmc_gpio1,
   output                               hmc_sync,
@@ -168,22 +173,15 @@ module system_top  #(
     .IB (clkin10_n),
     .O (clkin10));
 
-  genvar i;
-  generate
-  for(i=0;i<TX_NUM_LINKS;i=i+1) begin : g_tx_buffers
-    IBUFDS i_ibufds_syncin (
-      .I (fpga_syncin_p[i]),
-      .IB (fpga_syncin_n[i]),
-      .O (tx_syncin[i]));
-  end
+  IBUFDS i_ibufds_syncin_0 (
+    .I (fpga_syncin_0_p),
+    .IB (fpga_syncin_0_n),
+    .O (tx_syncin[0]));
 
-  for(i=0;i<RX_NUM_LINKS;i=i+1) begin : g_rx_buffers
-    OBUFDS i_obufds_syncout (
-      .I (rx_syncout[i]),
-      .O (fpga_syncout_p[i]),
-      .OB (fpga_syncout_n[i]));
-  end
-  endgenerate
+  OBUFDS i_obufds_syncout_0 (
+    .I (rx_syncout[0]),
+    .O (fpga_syncout_0_p),
+    .OB (fpga_syncout_0_n));
 
   BUFG i_tx_device_clk (
     .I (clkin6),
@@ -234,6 +232,31 @@ module system_top  #(
   assign txen[0]          = gpio_o[58];
   assign txen[1]          = gpio_o[59];
 
+  generate
+  if (TX_NUM_LINKS > 1 & JESD_MODE == "8B10B") begin
+    assign tx_syncin[1] = fpga_syncin_1_p;
+  end else begin
+    ad_iobuf #(.DATA_WIDTH(2)) i_syncin_iobuf (
+      .dio_t (gpio_t[61:60]),
+      .dio_i (gpio_o[61:60]),
+      .dio_o (gpio_i[61:60]),
+      .dio_p ({fpga_syncin_1_n,      // 61
+               fpga_syncin_1_p}));   // 60
+  end
+
+  if (RX_NUM_LINKS > 1 & JESD_MODE == "8B10B") begin
+    assign fpga_syncout_1_p = rx_syncout[1];
+    assign fpga_syncout_1_n = 0;
+  end else begin
+    ad_iobuf #(.DATA_WIDTH(2)) i_syncout_iobuf (
+      .dio_t (gpio_t[63:62]),
+      .dio_i (gpio_o[63:62]),
+      .dio_o (gpio_i[63:62]),
+      .dio_p ({fpga_syncout_1_n,      // 63
+               fpga_syncout_1_p}));   // 62
+  end
+  endgenerate
+
   /* Board GPIOS. Buttons, LEDs, etc... */
   ad_iobuf #(
     .DATA_WIDTH(15)
@@ -245,7 +268,7 @@ module system_top  #(
   );
 
   // Unused GPIOs
-  assign gpio_i[63:54] = gpio_o[63:54];
+  assign gpio_i[59:54] = gpio_o[59:54];
   assign gpio_i[31:16] = gpio_o[31:16];
 
   system_wrapper i_system_wrapper (


### PR DESCRIPTION

The https://github.com/analogdevicesinc/hdl/pull/922 added support for ZCU102 and VCU118.  This series of changes extends the support for other carriers too. 

The MxFE supports two links, so two pairs of SYNC signals are available. One of them can be used for fast frequency hopping in single link mode or in 64b/66b 204C mode.


Tested compile only for all affected carriers.