### PR TITLE
.gitignore: Fix to ignore imbricated bd.tcl files too

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -96,5 +96,5 @@ _vmake
 *.gen*
 *.xsa
 *.pdi
-library/*/bd/bd.tcl
+library/**/bd/bd.tcl
 


### PR DESCRIPTION
Fix gitignore commit 6a6c5ac that did not ignore imbricated bd files.
Signed-off-by: Liviu.Iacob <liviu.iacob@analog.com>