### PR TITLE
PN mismatch DAQ2, DAQ3 and FMCJESDADC1 fix

### DIFF
--- a/projects/daq2/common/daq2_bd.tcl
+++ b/projects/daq2/common/daq2_bd.tcl
@@ -89,6 +89,8 @@ adi_tpl_jesd204_rx_create axi_ad9680_tpl $RX_NUM_OF_LANES \
                                          $RX_NUM_OF_CONVERTERS \
                                          $RX_SAMPLES_PER_FRAME \
                                          $RX_SAMPLE_WIDTH \
+ad_ip_parameter axi_ad9680_tpl/adc_tpl_core CONFIG.CONVERTER_RESOLUTION 14
+ad_ip_parameter axi_ad9680_tpl/adc_tpl_core CONFIG.TWOS_COMPLEMENT 0
 
 ad_ip_instance util_cpack2 axi_ad9680_cpack [list \
   NUM_OF_CHANNELS $RX_NUM_OF_CONVERTERS \

--- a/projects/daq2/common/daq2_qsys.tcl
+++ b/projects/daq2/common/daq2_qsys.tcl
@@ -136,8 +136,8 @@ set_instance_parameter_value axi_ad9680 {ID} {0}
 set_instance_parameter_value axi_ad9680 {NUM_CHANNELS} $RX_NUM_OF_CONVERTERS
 set_instance_parameter_value axi_ad9680 {NUM_LANES} $RX_NUM_OF_LANES
 set_instance_parameter_value axi_ad9680 {BITS_PER_SAMPLE} $RX_SAMPLE_WIDTH
-set_instance_parameter_value axi_ad9680 {CONVERTER_RESOLUTION} $RX_SAMPLE_WIDTH
-set_instance_parameter_value axi_ad9680 {TWOS_COMPLEMENT} {1}
+set_instance_parameter_value axi_ad9680 {CONVERTER_RESOLUTION} {14}
+set_instance_parameter_value axi_ad9680 {TWOS_COMPLEMENT} {0}
 
 add_connection ad9680_jesd204.link_clk axi_ad9680.link_clk
 add_connection ad9680_jesd204.link_sof axi_ad9680.if_link_sof

--- a/projects/daq3/common/daq3_bd.tcl
+++ b/projects/daq3/common/daq3_bd.tcl
@@ -81,6 +81,8 @@ adi_tpl_jesd204_rx_create axi_ad9680_tpl_core $RX_NUM_OF_LANES \
                                                $RX_NUM_OF_CONVERTERS \
                                                $RX_SAMPLES_PER_FRAME \
                                                $RX_SAMPLE_WIDTH
+ad_ip_parameter axi_ad9680_tpl_core/adc_tpl_core CONFIG.CONVERTER_RESOLUTION 14
+ad_ip_parameter axi_ad9680_tpl_core/adc_tpl_core CONFIG.TWOS_COMPLEMENT 0                                              
 
 ad_ip_instance util_cpack2 axi_ad9680_cpack [list \
   NUM_OF_CHANNELS $RX_NUM_OF_CONVERTERS \

--- a/projects/daq3/common/daq3_qsys.tcl
+++ b/projects/daq3/common/daq3_qsys.tcl
@@ -131,8 +131,8 @@ set_instance_parameter_value axi_ad9680_tpl {ID} {0}
 set_instance_parameter_value axi_ad9680_tpl {NUM_CHANNELS} $RX_NUM_OF_CONVERTERS
 set_instance_parameter_value axi_ad9680_tpl {NUM_LANES} $RX_NUM_OF_LANES
 set_instance_parameter_value axi_ad9680_tpl {BITS_PER_SAMPLE} $RX_SAMPLE_WIDTH
-set_instance_parameter_value axi_ad9680_tpl {CONVERTER_RESOLUTION} $RX_SAMPLE_WIDTH
-set_instance_parameter_value axi_ad9680_tpl {TWOS_COMPLEMENT} {1}
+set_instance_parameter_value axi_ad9680_tpl {CONVERTER_RESOLUTION} {14}
+set_instance_parameter_value axi_ad9680_tpl {TWOS_COMPLEMENT} {0}
 
 add_connection ad9680_jesd204.link_clk axi_ad9680_tpl.link_clk
 add_connection ad9680_jesd204.link_sof axi_ad9680_tpl.if_link_sof

--- a/projects/fmcjesdadc1/common/fmcjesdadc1_bd.tcl
+++ b/projects/fmcjesdadc1/common/fmcjesdadc1_bd.tcl
@@ -34,6 +34,7 @@ adi_tpl_jesd204_rx_create axi_ad9250_core $RX_NUM_OF_LANES \
                                           $RX_SAMPLES_PER_FRAME \
                                           $RX_SAMPLE_WIDTH
 ad_ip_parameter axi_ad9250_core/adc_tpl_core CONFIG.CONVERTER_RESOLUTION 14
+ad_ip_parameter axi_ad9250_core/adc_tpl_core CONFIG.TWOS_COMPLEMENT 0
 
 ad_ip_instance util_cpack2 axi_ad9250_cpack [list \
   NUM_OF_CHANNELS $RX_NUM_OF_CONVERTERS \


### PR DESCRIPTION
The AD9680 is a dual 14-bit ADC.
Software sets the output format to offset binary before performing the PN tests.