### PR TITLE
ad_fmclidar1_ebz:a10soc Fixed problems with SPI communication with AD…

### DIFF
--- a/projects/ad_fmclidar1_ebz/a10soc/system_qsys.tcl
+++ b/projects/ad_fmclidar1_ebz/a10soc/system_qsys.tcl
@@ -22,4 +22,4 @@ sysid_gen_sys_init_file;
 
 #spi
 set_instance_parameter_value sys_spi {clockPhase} {1}
-set_instance_parameter_value sys_spi {targetClockRate} {1000000.0}
+set_instance_parameter_value sys_spi {clockPolarity} {1}


### PR DESCRIPTION
…9093

Now CPH and CPOL are set to 1, also the SPI clock is set to 10MHz

Signed-off-by: Liviu Adace <liviu.adace@analog.com>