### PR TITLE
.gitignore: ignore files generated by Quartus & Platform Designer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -97,4 +97,10 @@ _vmake
 *.xsa
 *.pdi
 library/**/bd/bd.tcl
+*.syn.smsg
+*.syn.summary
+qdb
+tmp-clearbox
+*.bin
+.qsys_edit
 


### PR DESCRIPTION
Added the files generated by Quartus Pro 21.2, 20.1 and Platform Designer for each of the versions. The files added are generated and removed by make.

Signed-off-by: Liviu.Iacob <liviu.iacob@analog.com>