### PR TITLE
Fix data frmt

### DIFF
--- a/library/axi_ltc2387/axi_ltc2387_channel.v
+++ b/library/axi_ltc2387/axi_ltc2387_channel.v
@@ -132,7 +132,7 @@ module axi_ltc2387_channel #(
   if (ADC_RES == 18) begin
     ad_datafmt #(
       .DATA_WIDTH (18),
-      .OCTETS_PER_SAMPLE (4),
+      .BITS_PER_SAMPLE (32),
       .DISABLE (DATAFORMAT_DISABLE)
     ) i_ad_datafmt (
       .clk (adc_clk),

--- a/library/common/ad_datafmt.v
+++ b/library/common/ad_datafmt.v
@@ -41,7 +41,7 @@ module ad_datafmt #(
   // data bus width
 
   parameter   DATA_WIDTH = 16,
-  parameter   OCTETS_PER_SAMPLE = 2,
+  parameter   BITS_PER_SAMPLE = 16,
   parameter   DISABLE = 0
 ) (
 
@@ -51,7 +51,7 @@ module ad_datafmt #(
   input                       valid,
   input   [(DATA_WIDTH-1):0]  data,
   output                      valid_out,
-  output  [(8*OCTETS_PER_SAMPLE-1):0]  data_out,
+  output  [(BITS_PER_SAMPLE-1):0]  data_out,
 
   // control signals
 
@@ -63,12 +63,12 @@ module ad_datafmt #(
   // internal registers
 
   reg                         valid_int = 'd0;
-  reg     [(8*OCTETS_PER_SAMPLE-1):0]  data_int = 'd0;
+  reg     [(BITS_PER_SAMPLE-1):0]  data_int = 'd0;
 
   // internal signals
 
   wire                        type_s;
-  wire    [(8*OCTETS_PER_SAMPLE-1):0]  data_out_s;
+  wire    [(BITS_PER_SAMPLE-1):0]  data_out_s;
 
   // data-path disable
 
@@ -87,13 +87,13 @@ module ad_datafmt #(
   assign type_s = dfmt_enable & dfmt_type;
 
   generate
-  if (DATA_WIDTH < 8*OCTETS_PER_SAMPLE) begin
+  if (DATA_WIDTH < BITS_PER_SAMPLE) begin
     wire signext_s;
     wire sign_s;
 
     assign signext_s = dfmt_enable & dfmt_se;
     assign sign_s = signext_s & (type_s ^ data[(DATA_WIDTH-1)]);
-    assign data_out_s[(8*OCTETS_PER_SAMPLE-1):DATA_WIDTH] = {((8*OCTETS_PER_SAMPLE)-DATA_WIDTH){sign_s}};
+    assign data_out_s[(BITS_PER_SAMPLE-1):DATA_WIDTH] = {((BITS_PER_SAMPLE)-DATA_WIDTH){sign_s}};
   end
   endgenerate
 

--- a/library/jesd204/ad_ip_jesd204_tpl_adc/ad_ip_jesd204_tpl_adc_channel.v
+++ b/library/jesd204/ad_ip_jesd204_tpl_adc/ad_ip_jesd204_tpl_adc_channel.v
@@ -45,8 +45,6 @@ module ad_ip_jesd204_tpl_adc_channel #(
   output pn_err
 );
 
-  localparam OCTETS_PER_SAMPLE = BITS_PER_SAMPLE / 8;
-
   // instantiations
 
   ad_ip_jesd204_tpl_adc_pnmon #(
@@ -66,7 +64,7 @@ module ad_ip_jesd204_tpl_adc_channel #(
   for (n = 0; n < DATA_PATH_WIDTH; n = n + 1) begin: g_datafmt
     ad_datafmt #(
       .DATA_WIDTH (CONVERTER_RESOLUTION),
-      .OCTETS_PER_SAMPLE (OCTETS_PER_SAMPLE)
+      .BITS_PER_SAMPLE (BITS_PER_SAMPLE)
     ) i_ad_datafmt (
       .clk (clk),
 


### PR DESCRIPTION
Currently the data format-er is working in octets which does not suits the JESD N' 12 use cases where the interface towards the DMA/application layer is not 16. 

Tested compile only. 