### PR TITLE
lint: Update action to run only in PRs

### DIFF
--- a/.github/scripts/check_for_missing_readme_md.sh
+++ b/.github/scripts/check_for_missing_readme_md.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 #
 # Ensure there are Readme.md files in all the project directories
-#
+
 set -e
 #set -x
 
@@ -10,11 +10,11 @@ fail=0
 check_string(){
 	needle=$1
 	if [ "$(grep "${needle}" $file | wc -l)" -eq "0" ] ; then
-		echo missing \"${needle}\" in $file
+		echo In $file: missing \"${needle}\"
 		fail=1
 	else
 		if [ "$(grep "${needle}" $file | sed -e "s/${needle}//g" -e "s/ //g" | wc -c)" -lt "8" ] ; then
-			 echo missing link for \"${needle}\" in $file
+			 echo In $file: missing link for \"${needle}\"
 			 fail=1
 		fi
 	fi
@@ -22,7 +22,7 @@ check_string(){
 
 MISSING=$(find projects/ -mindepth 1 -maxdepth 1 \( -path projects/common -o -path projects/scripts \) -prune -o -type d '!' -exec test -e "{}/Readme.md" ';' -print)
 if [ "$(echo ${MISSING} | wc -c)" -gt "1" ] ; then
-	echo Missing Readme.md files in the ${MISSING}
+	echo "Missing Readme.md files in ${MISSING}"
 	fail=1
 fi
 
@@ -34,16 +34,17 @@ do
 	check_string "* Project Doc"
 	check_string "* HDL Doc"
 	check_string "* Linux Drivers"
+
 	if [ "$(grep "([[:space:]]*)" $file | wc -l)" -gt "0" ] ; then
-		echo "missing link [found ()] in $file"
+		echo "In $file: missing link; found ()"
 		fail=1
 	fi
 	if [ "$(grep https://wiki.analog.com/resources/tools-software/linux-drivers-all $file | wc -l)" -gt "0" ] ; then
-		echo "Do not link to https://wiki.analog.com/resources/tools-software/linux-drivers-all in $file"
+		echo "In $file: do not link to https://wiki.analog.com/resources/tools-software/linux-drivers-all"
 		fail=1
 	fi
 	if [ "$(grep https://wiki.analog.com/linux $file | wc -l)" -gt "0" ] ; then
-		echo "Do not link to https://wiki.analog.com/linux in $file"
+		echo "In $file: do not link to https://wiki.analog.com/linux"
 		fail=1
 	fi
 done

--- a/.github/workflows/test_n_lint.yml
+++ b/.github/workflows/test_n_lint.yml
@@ -1,13 +1,19 @@
 name: Lint
 
-on: [push, pull_request]
+on:
+  pull_request:
+    branches:
+      - master
+    paths:
+      - 'library/**'
+      - 'projects/**'
 
 jobs:
-  Lint:
+  lint:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
-      - name: Check Readmes
+      - uses: actions/checkout@v3
+      - name: Check for Readme.md
         run: |
           bash ./.github/scripts/check_for_missing_readme_md.sh


### PR DESCRIPTION
* Updated action to run only in PRs on master branch, on library/ and
  projects/ paths
* Edited the text for the printed warnings
* Updated the version for the checkout action from v2 to v3

Signed-off-by: Iulia Moldovan <iulia.moldovan@analog.com>