### PR TITLE
Update Packer IPs to be more generic

### DIFF
--- a/library/common/ad_upack.v
+++ b/library/common/ad_upack.v
@@ -1,6 +1,6 @@
 // ***************************************************************************
 // ***************************************************************************
-// Copyright 2014 - 2020 (c) Analog Devices, Inc. All rights reserved.
+// Copyright 2014 - 2022 (c) Analog Devices, Inc. All rights reserved.
 //
 // In this HDL repository, there are many different and unique modules, consisting
 // of various HDL (Verilog or VHDL) components. The individual modules are
@@ -40,7 +40,7 @@
 //   - data unit defined in bits by UNIT_W e.g 8 is a byte
 //
 // Constraints:
-//   - O_W <= I_W
+//   - O_W < I_W
 //   - LATENCY 1
 //   - no backpressure
 //
@@ -73,9 +73,10 @@ module ad_upack #(
   output reg                  ovalid = 'b0
 );
 
-  // Width of shift reg is integer multiple of output data width
-  localparam SH_W = ((I_W/O_W)+1)*O_W;
-  localparam STEP = I_W % O_W;
+  // The Width of the shift reg is an integer multiple of output data width
+  localparam SH_W = ((I_W/O_W) + ((I_W%O_W) > 0) + ((O_W % (I_W - ((I_W/O_W)*O_W) + ((I_W%O_W) == 0))) > 0))*O_W;
+  // The Step of the algorithm is the greatest common divisor of I_W and O_W
+  localparam STEP = gcd(I_W, O_W);
 
   localparam LATENCY = 1; // Minimum input latency from iready to ivalid
 
@@ -93,6 +94,21 @@ module ad_upack #(
   wire [O_W*UNIT_W-1:0] odata_s;
   wire                  ovalid_s;
 
+  function [31:0] gcd;
+    input [31:0]  a;
+    input [31:0]  b;
+    begin
+      while (a != b) begin
+        if (a > b) begin
+          a = a-b;
+        end else begin
+          b = b-a;
+        end
+      end
+      gcd = a;
+    end
+  endfunction
+
   assign unit_valid = (in_use | inmask);
   assign in_use_nx = unit_valid >> O_W;
 
@@ -106,11 +122,9 @@ module ad_upack #(
 
   always @(*) begin
     inmask = {I_W{ivalid}};
-    if (STEP>0) begin
-      for (i = STEP; i < O_W; i=i+STEP) begin
-        if (in_use[i-1]) begin
-          inmask = {I_W{ivalid}} << i;
-        end
+    for (i = STEP; i < O_W; i=i+STEP) begin
+      if (in_use[i-1]) begin
+        inmask = {I_W{ivalid}} << i;
       end
     end
   end
@@ -119,11 +133,9 @@ module ad_upack #(
     idata_d_nx = idata_d;
     if (ivalid) begin
       idata_d_nx = {{(SH_W-I_W)*UNIT_W{1'b0}},idata};
-      if (STEP>0) begin
-        for (i = STEP; i < O_W; i=i+STEP) begin
-          if (in_use[i-1]) begin
-            idata_d_nx = (idata << UNIT_W*i) | idata_d;
-          end
+      for (i = STEP; i < O_W; i=i+STEP) begin
+        if (in_use[i-1]) begin
+          idata_d_nx = (idata << UNIT_W*i) | idata_d;
         end
       end
     end

--- a/library/common/tb/ad_pack_tb.v
+++ b/library/common/tb/ad_pack_tb.v
@@ -36,7 +36,7 @@ module ad_pack_tb;
     @(posedge clk);
     i = 0;
     j = 0;
-    while (i < VECT_W/(I_W*UNIT_W)) begin
+    while (i < (VECT_W/(I_W*UNIT_W) + (VECT_W%(I_W*UNIT_W)>0))) begin
       @(posedge clk);
       if ($urandom % 2 == 0) begin
         idata <= input_vector[i*(I_W*UNIT_W) +: (I_W*UNIT_W)];

--- a/library/common/tb/run_tb.sh
+++ b/library/common/tb/run_tb.sh
@@ -17,7 +17,8 @@ case "$SIMULATOR" in
 		xvlog -log ${NAME}_xvlog.log --sourcelibdir . ${SOURCE}
 		xelab -log ${NAME}_xelab.log -debug all ${NAME}
 		if [[ "$MODE" == "-gui" ]]; then
-			echo "run all" > xsim_gui_cmd.tcl
+			echo "log_wave -r *" > xsim_gui_cmd.tcl
+			echo "run all" >> xsim_gui_cmd.tcl
 			xsim work.${NAME} -gui -tclbatch xsim_gui_cmd.tcl -log ${NAME}_xsim.log
 		else
 			xsim work.${NAME} -R -log ${NAME}_xsim.log


### PR DESCRIPTION
This update is necessary in order to fix a bug found in simulation for a 3/8 packing ratio. The unpacker is updated in a symmetrical fashion.
By applying this update, the packing IPs should be able to compute every possible packing/unpacking ratio, while optimizing the synthesis output.