### PR TITLE
Fix ad9081 vck190  for 2021_R1

### DIFF
--- a/projects/ad9081_fmca_ebz/common/ad9081_fmca_ebz_bd.tcl
+++ b/projects/ad9081_fmca_ebz/common/ad9081_fmca_ebz_bd.tcl
@@ -21,6 +21,7 @@ source $ad_hdl_dir/projects/common/xilinx/data_offload_bd.tcl
 set JESD_MODE  $ad_project_params(JESD_MODE)
 set RX_LANE_RATE $ad_project_params(RX_LANE_RATE)
 set TX_LANE_RATE $ad_project_params(TX_LANE_RATE)
+set REF_CLK_RATE $ad_project_params(REF_CLK_RATE)
 
 set TDD_SUPPORT [ expr { [info exists ad_project_params(TDD_SUPPORT)] \
                           ? $ad_project_params(TDD_SUPPORT) : 0 } ]
@@ -143,7 +144,9 @@ if {$ADI_PHY_SEL == 1} {
 } else {
   source $ad_hdl_dir/projects/ad9081_fmca_ebz/common/versal_transceiver.tcl
 
-  create_versal_phy jesd204_phy $TX_NUM_OF_LANES
+  # TODO: 
+  # Assumption is that number of Tx and Rx lane is the same
+  create_versal_phy jesd204_phy $TX_NUM_OF_LANES $RX_LANE_RATE $TX_LANE_RATE $REF_CLK_RATE
 
 }
 

--- a/projects/ad9081_fmca_ebz/common/ad9081_fmca_ebz_bd.tcl
+++ b/projects/ad9081_fmca_ebz/common/ad9081_fmca_ebz_bd.tcl
@@ -21,7 +21,6 @@ source $ad_hdl_dir/projects/common/xilinx/data_offload_bd.tcl
 set JESD_MODE  $ad_project_params(JESD_MODE)
 set RX_LANE_RATE $ad_project_params(RX_LANE_RATE)
 set TX_LANE_RATE $ad_project_params(TX_LANE_RATE)
-set REF_CLK_RATE $ad_project_params(REF_CLK_RATE)
 
 set TDD_SUPPORT [ expr { [info exists ad_project_params(TDD_SUPPORT)] \
                           ? $ad_project_params(TDD_SUPPORT) : 0 } ]
@@ -144,6 +143,8 @@ if {$ADI_PHY_SEL == 1} {
 } else {
   source $ad_hdl_dir/projects/ad9081_fmca_ebz/common/versal_transceiver.tcl
 
+  set REF_CLK_RATE [ expr { [info exists ad_project_params(REF_CLK_RATE)] \
+                            ? $ad_project_params(REF_CLK_RATE) : 360 } ]
   # TODO: 
   # Assumption is that number of Tx and Rx lane is the same
   create_versal_phy jesd204_phy $TX_NUM_OF_LANES $RX_LANE_RATE $TX_LANE_RATE $REF_CLK_RATE

--- a/projects/ad9081_fmca_ebz/common/versal_transceiver.tcl
+++ b/projects/ad9081_fmca_ebz/common/versal_transceiver.tcl
@@ -3,12 +3,14 @@
 proc create_versal_phy {
   {ip_name versal_phy}
   {num_lanes 2}
-  {lane_rate 11.88}
+  {rx_lane_rate 11.88}
+  {tx_lane_rate 11.88}
   {ref_clock 360}
 } {
 
 set num_quads [expr round(1.0*$num_lanes/4)]
-set progdiv_clock [format %.3f [expr $lane_rate * 1000 / 66]]
+set rx_progdiv_clock [format %.3f [expr $rx_lane_rate * 1000 / 66]]
+set tx_progdiv_clock [format %.3f [expr $tx_lane_rate * 1000 / 66]]
 
 create_bd_cell -type hier ${ip_name}
 
@@ -33,7 +35,7 @@ set_property -dict [list \
      INTERNAL_PRESET JESD204_64B66B \
      GT_TYPE GTY \
      GT_DIRECTION DUPLEX \
-     TX_LINE_RATE $lane_rate \
+     TX_LINE_RATE $tx_lane_rate \
      TX_PLL_TYPE LCPLL \
      TX_REFCLK_FREQUENCY $ref_clock \
      TX_ACTUAL_REFCLK_FREQUENCY $ref_clock \
@@ -49,13 +51,13 @@ set_property -dict [list \
      TX_OUTCLK_SOURCE TXPROGDIVCLK \
      TXPROGDIV_FREQ_ENABLE true \
      TXPROGDIV_FREQ_SOURCE LCPLL \
-     TXPROGDIV_FREQ_VAL $progdiv_clock \
+     TXPROGDIV_FREQ_VAL $tx_progdiv_clock \
      TX_DIFF_SWING_EMPH_MODE CUSTOM \
      TX_64B66B_SCRAMBLER false \
      TX_64B66B_ENCODER false \
      TX_64B66B_CRC false \
      TX_RATE_GROUP A \
-     RX_LINE_RATE $lane_rate \
+     RX_LINE_RATE $rx_lane_rate \
      RX_PLL_TYPE LCPLL \
      RX_REFCLK_FREQUENCY $ref_clock \
      RX_ACTUAL_REFCLK_FREQUENCY $ref_clock \
@@ -69,7 +71,7 @@ set_property -dict [list \
      RX_OUTCLK_SOURCE RXPROGDIVCLK \
      RXPROGDIV_FREQ_ENABLE true \
      RXPROGDIV_FREQ_SOURCE LCPLL \
-     RXPROGDIV_FREQ_VAL $progdiv_clock \
+     RXPROGDIV_FREQ_VAL $rx_progdiv_clock \
      INS_LOSS_NYQ 12 \
      RX_EQ_MODE LPM \
      RX_COUPLING AC \

--- a/projects/ad9081_fmca_ebz/vck190/system_project.tcl
+++ b/projects/ad9081_fmca_ebz/vck190/system_project.tcl
@@ -20,6 +20,7 @@ source $ad_hdl_dir/projects/scripts/adi_board.tcl
 #
 #   RX_RATE :  Line rate of the Rx link ( MxFE to FPGA )
 #   TX_RATE :  Line rate of the Tx link ( FPGA to MxFE )
+#   REF_CLK_RATE : Frequency of reference clock in MHz used in 64B66B mode
 #   [RX/TX]_JESD_M : Number of converters per link
 #   [RX/TX]_JESD_L : Number of lanes per link
 #   [RX/TX]_JESD_S : Number of samples per frame
@@ -34,6 +35,7 @@ adi_project ad9081_fmca_ebz_vck190 0 [list \
   JESD_MODE    [get_env_param JESD_MODE    64B66B ]\
   RX_LANE_RATE [get_env_param RX_RATE      11.88 ] \
   TX_LANE_RATE [get_env_param TX_RATE      11.88 ] \
+  REF_CLK_RATE [get_env_param REF_CLK_RATE 360 ] \
   RX_JESD_M    [get_env_param RX_JESD_M    2 ] \
   RX_JESD_L    [get_env_param RX_JESD_L    2 ] \
   RX_JESD_S    [get_env_param RX_JESD_S    4 ] \


### PR DESCRIPTION
This series of changes allows setting different lane rates and ref clocks for the Versal transceiver. 
Tested compile only.

