### PR TITLE
scripts: Update Vivado version to 2021.2

### DIFF
--- a/library/scripts/adi_ip_xilinx.tcl
+++ b/library/scripts/adi_ip_xilinx.tcl
@@ -3,7 +3,7 @@ source $ad_hdl_dir/library/scripts/adi_xilinx_device_info_enc.tcl
 
 # check tool version
 
-set required_vivado_version "2021.1"
+set required_vivado_version "2021.2"
 if {[info exists ::env(REQUIRED_VIVADO_VERSION)]} {
   set required_vivado_version $::env(REQUIRED_VIVADO_VERSION)
 } elseif {[info exists REQUIRED_VIVADO_VERSION]} {

--- a/library/scripts/adi_ip_xilinx.tcl
+++ b/library/scripts/adi_ip_xilinx.tcl
@@ -1,20 +1,5 @@
-
 source $ad_hdl_dir/library/scripts/adi_xilinx_device_info_enc.tcl
-
-# check tool version
-
-set required_vivado_version "2021.2"
-if {[info exists ::env(REQUIRED_VIVADO_VERSION)]} {
-  set required_vivado_version $::env(REQUIRED_VIVADO_VERSION)
-} elseif {[info exists REQUIRED_VIVADO_VERSION]} {
-  set required_vivado_version $REQUIRED_VIVADO_VERSION
-}
-
-if {[info exists ::env(ADI_IGNORE_VERSION_CHECK)]} {
-  set IGNORE_VERSION_CHECK 1
-} elseif {![info exists IGNORE_VERSION_CHECK]} {
-  set IGNORE_VERSION_CHECK 0
-}
+source $ad_hdl_dir/scripts/adi_env.tcl
 
 if {[info exists ::env(ADI_VIVADO_IP_LIBRARY)]} {
   set VIVADO_IP_LIBRARY $::env(ADI_VIVADO_IP_LIBRARY)

--- a/projects/scripts/adi_project_xilinx.tcl
+++ b/projects/scripts/adi_project_xilinx.tcl
@@ -1,4 +1,3 @@
-
 ## Define the ADI_USE_OOC_SYNTHESIS environment variable to enable out of context
 #  synthesis
 if {[info exists ::env(ADI_USE_OOC_SYNTHESIS)]} {

--- a/scripts/adi_env.tcl
+++ b/scripts/adi_env.tcl
@@ -1,4 +1,3 @@
-
 # environment related stuff
 
 set ad_hdl_dir [file normalize [file join [file dirname [info script]] "../"]]
@@ -12,7 +11,7 @@ if [info exists ::env(ADI_GHDL_DIR)] {
 }
 
 # Define the supported tool version
-set required_vivado_version "2021.1"
+set required_vivado_version "2021.2"
 if {[info exists ::env(REQUIRED_VIVADO_VERSION)]} {
   set required_vivado_version $::env(REQUIRED_VIVADO_VERSION)
 } elseif {[info exists REQUIRED_VIVADO_VERSION]} {

--- a/scripts/adi_env.tcl
+++ b/scripts/adi_env.tcl
@@ -30,13 +30,6 @@ if {![info exists REQUIRED_QUARTUS_VERSION]} {
   set REQUIRED_QUARTUS_VERSION "21.2.0"
 }
 
-# Define the ADI_IGNORE_VERSION_CHECK environment variable to skip version check
-if {[info exists ::env(ADI_IGNORE_VERSION_CHECK)]} {
-  set IGNORE_VERSION_CHECK 1
-} elseif {![info exists IGNORE_VERSION_CHECK]} {
-  set IGNORE_VERSION_CHECK 0
-}
-
 # This helper pocedure retrieves the value of varible from environment if exists,
 # other case returns the provided default value
 #  name - name of the environment variable
@@ -49,4 +42,3 @@ proc get_env_param {name default_value} {
     return $default_value
   }
 }
-


### PR DESCRIPTION
Update the Vivado version to 2021.2 in 
- library/scripts/adi_ip_xilinx.tcl
- projects/scripts/adi_project_xilinx.tcl