### PR TITLE
JESD fixes

### DIFF
--- a/library/jesd204/axi_jesd204_common/jesd204_up_sysref.v
+++ b/library/jesd204/axi_jesd204_common/jesd204_up_sysref.v
@@ -44,9 +44,7 @@
 
 `timescale 1ns/100ps
 
-module jesd204_up_sysref #(
-  parameter DATA_PATH_WIDTH_LOG2 = 2
-) (
+module jesd204_up_sysref (
   input up_clk,
   input up_reset,
 

--- a/library/jesd204/axi_jesd204_rx/axi_jesd204_rx.v
+++ b/library/jesd204/axi_jesd204_rx/axi_jesd204_rx.v
@@ -130,8 +130,6 @@ module axi_jesd204_rx #(
   localparam PCORE_VERSION = 32'h00010761; // 1.07.a
   localparam PCORE_MAGIC = 32'h32303452; // 204R
 
-  localparam DATA_PATH_WIDTH_LOG2 = (DATA_PATH_WIDTH == 8) ? 3 : 2;
-
   /* Register interface signals */
   reg [31:0] up_rdata = 'h0;
   reg up_wack = 1'b0;
@@ -279,9 +277,7 @@ module axi_jesd204_rx #(
     .status_synth_params1(status_synth_params1),
     .status_synth_params2(status_synth_params2));
 
-  jesd204_up_sysref #(
-    .DATA_PATH_WIDTH_LOG2(DATA_PATH_WIDTH_LOG2)
-  ) i_up_sysref (
+  jesd204_up_sysref i_up_sysref (
     .up_clk(s_axi_aclk),
     .up_reset(up_reset),
 
@@ -304,8 +300,7 @@ module axi_jesd204_rx #(
 
   jesd204_up_rx #(
     .NUM_LANES(NUM_LANES),
-    .DATA_PATH_WIDTH(DATA_PATH_WIDTH),
-    .DATA_PATH_WIDTH_LOG2(DATA_PATH_WIDTH_LOG2)
+    .DATA_PATH_WIDTH(DATA_PATH_WIDTH)
   ) i_up_rx (
     .up_clk(s_axi_aclk),
     .up_reset(up_reset),

--- a/library/jesd204/axi_jesd204_rx/jesd204_up_rx.v
+++ b/library/jesd204/axi_jesd204_rx/jesd204_up_rx.v
@@ -188,7 +188,7 @@ module jesd204_up_rx #(
       /* JESD RX configuraton */
       12'h090: begin
         up_cfg_buffer_early_release <= up_wdata[16];
-        up_cfg_buffer_delay <= up_wdata[9:DATA_PATH_WIDTH_LOG2];
+        up_cfg_buffer_delay <= up_wdata[7:0];
       end
       endcase
     end else if (up_wreq == 1'b1) begin

--- a/library/jesd204/axi_jesd204_rx/jesd204_up_rx.v
+++ b/library/jesd204/axi_jesd204_rx/jesd204_up_rx.v
@@ -46,8 +46,7 @@
 
 module jesd204_up_rx #(
   parameter NUM_LANES = 1,
-  parameter DATA_PATH_WIDTH = 4,
-  parameter DATA_PATH_WIDTH_LOG2 = 2
+  parameter DATA_PATH_WIDTH = 4
 ) (
   input up_clk,
   input up_reset,

--- a/library/jesd204/axi_jesd204_tx/axi_jesd204_tx.v
+++ b/library/jesd204/axi_jesd204_tx/axi_jesd204_tx.v
@@ -122,8 +122,6 @@ module axi_jesd204_tx #(
   localparam PCORE_VERSION = 32'h00010661; // 1.06.a
   localparam PCORE_MAGIC = 32'h32303454; // 204T
 
-  localparam DATA_PATH_WIDTH_LOG2 = (DATA_PATH_WIDTH == 8) ? 3 : 2;
-
   wire up_reset;
 
   /* Register interface signals */
@@ -259,9 +257,7 @@ module axi_jesd204_tx #(
     .status_synth_params1(status_synth_params1),
     .status_synth_params2(status_synth_params2));
 
-  jesd204_up_sysref #(
-    .DATA_PATH_WIDTH_LOG2(DATA_PATH_WIDTH_LOG2)
-  ) i_up_sysref (
+  jesd204_up_sysref i_up_sysref (
     .up_clk(s_axi_aclk),
     .up_reset(up_reset),
 

--- a/library/jesd204/jesd204_rx/Makefile
+++ b/library/jesd204/jesd204_rx/Makefile
@@ -7,6 +7,7 @@
 LIBRARY_NAME := jesd204_rx
 
 GENERIC_DEPS += ../../common/ad_pack.v
+GENERIC_DEPS += ../../common/ad_upack.v
 GENERIC_DEPS += align_mux.v
 GENERIC_DEPS += elastic_buffer.v
 GENERIC_DEPS += jesd204_ilas_monitor.v

--- a/library/jesd204/jesd204_rx/elastic_buffer.v
+++ b/library/jesd204/jesd204_rx/elastic_buffer.v
@@ -58,7 +58,7 @@ module elastic_buffer #(
 
   input [IWIDTH-1:0] wr_data,
 
-  output reg [OWIDTH-1:0] rd_data,
+  output [OWIDTH-1:0] rd_data,
 
   input ready_n,
   input do_release_n
@@ -77,45 +77,103 @@ module elastic_buffer #(
   reg [ADDR_WIDTH:0] wr_addr = 'h00;
   reg [ADDR_WIDTH:0] rd_addr = 'h00;
   (* ram_style = "distributed" *) reg [WIDTH-1:0] mem[0:SIZE - 1];
+  reg             mem_rd_valid = 'b0;
+  reg [WIDTH-1:0] mem_rd_data;
 
   wire mem_wr;
   wire [WIDTH-1:0] mem_wr_data;
+  wire unpacker_ready;
 
-  generate if ((OWIDTH > IWIDTH) && ASYNC_CLK) begin
-    ad_pack #(
+  generate if ((OWIDTH < IWIDTH) && ASYNC_CLK) begin
+
+    assign mem_wr = 1'b1;
+
+    always @(posedge clk) begin
+      if (ready_n) begin
+        wr_addr <= 'h00;
+      end else if (mem_wr) begin
+        wr_addr <= wr_addr + 1;
+      end
+    end
+
+    always @(posedge clk) begin
+      if (mem_wr) begin
+        mem[wr_addr] <= wr_data;
+      end
+    end
+
+    assign mem_rd_en = ~do_release_n & unpacker_ready;
+
+    always @(posedge device_clk) begin
+      if (mem_rd_en) begin
+        mem_rd_data <= mem[rd_addr];
+      end
+      mem_rd_valid <= mem_rd_en;
+    end
+
+    always @(posedge device_clk) begin
+      if (do_release_n) begin
+        rd_addr <= 'b0;
+      end else if (mem_rd_en) begin
+        rd_addr <= rd_addr + 1;
+      end
+    end
+
+    ad_upack #(
       .I_W(IWIDTH/8),
       .O_W(OWIDTH/8),
-      .UNIT_W(8)
-    ) i_ad_pack (
-      .clk(clk),
-      .reset(ready_n),
-      .idata(wr_data),
-      .ivalid(1'b1),
+      .UNIT_W(8),
+      .O_REG(0)
+    ) i_ad_upack (
+      .clk(device_clk),
+      .reset(do_release_n),
+      .idata(mem_rd_data),
+      .ivalid(mem_rd_valid),
+      .iready(unpacker_ready),
 
-      .odata(mem_wr_data),
-      .ovalid(mem_wr));
-  end else begin
-    assign mem_wr = 1'b1;
-    assign mem_wr_data = wr_data;
-  end
-  endgenerate
+      .odata(rd_data),
+      .ovalid());
 
-  always @(posedge clk) begin
-    if (ready_n == 1'b1) begin
-      wr_addr <= 'h00;
-    end else if (mem_wr) begin
-      mem[wr_addr] <= mem_wr_data;
-      wr_addr <= wr_addr + 1'b1;
-    end
-  end
-
-  always @(posedge device_clk) begin
-    if (do_release_n == 1'b1) begin
-      rd_addr <= 'h00;
     end else begin
-      rd_addr <= rd_addr + 1'b1;
-      rd_data <= mem[rd_addr];
+      if ((OWIDTH > IWIDTH) && ASYNC_CLK) begin
+        ad_pack #(
+          .I_W(IWIDTH/8),
+          .O_W(OWIDTH/8),
+          .UNIT_W(8)
+        ) i_ad_pack (
+          .clk(clk),
+          .reset(ready_n),
+          .idata(wr_data),
+          .ivalid(1'b1),
+
+          .odata(mem_wr_data),
+          .ovalid(mem_wr));
+      end else begin
+        assign mem_wr = 1'b1;
+        assign mem_wr_data = wr_data;
+      end
+
+      always @(posedge clk) begin
+        if (ready_n == 1'b1) begin
+          wr_addr <= 'h00;
+        end else if (mem_wr) begin
+          mem[wr_addr] <= mem_wr_data;
+          wr_addr <= wr_addr + 1'b1;
+        end
+      end
+
+      always @(posedge device_clk) begin
+        if (do_release_n == 1'b1) begin
+          rd_addr <= 'h00;
+        end else begin
+          rd_addr <= rd_addr + 1'b1;
+          mem_rd_data <= mem[rd_addr];
+        end
+      end
+
+      assign rd_data = mem_rd_data;
+
     end
-  end
+  endgenerate
 
 endmodule

--- a/library/jesd204/jesd204_rx/jesd204_rx_hw.tcl
+++ b/library/jesd204/jesd204_rx/jesd204_rx_hw.tcl
@@ -75,6 +75,7 @@ ad_ip_files jesd204_rx [list \
   $ad_hdl_dir/library/util_cdc/sync_event.v \
   $ad_hdl_dir/library/util_cdc/util_cdc_constr.tcl \
   ../../common/ad_pack.v \
+  ../../common/ad_upack.v \
 ]
 
 # parameters

--- a/library/jesd204/jesd204_rx/jesd204_rx_ip.tcl
+++ b/library/jesd204/jesd204_rx/jesd204_rx_ip.tcl
@@ -65,6 +65,7 @@ adi_ip_files jesd204_rx [list \
   "jesd204_rx_ooc.ttcl" \
   "jesd204_rx.v" \
   "../../common/ad_pack.v" \
+  "../../common/ad_upack.v" \
   "bd/bd.tcl"
 ]
 

--- a/library/jesd204/jesd204_tx/Makefile
+++ b/library/jesd204/jesd204_tx/Makefile
@@ -6,6 +6,7 @@
 
 LIBRARY_NAME := jesd204_tx
 
+GENERIC_DEPS += ../../common/ad_pack.v
 GENERIC_DEPS += ../../common/ad_upack.v
 GENERIC_DEPS += jesd204_tx.v
 GENERIC_DEPS += jesd204_tx_ctrl.v

--- a/library/jesd204/jesd204_tx/jesd204_tx.v
+++ b/library/jesd204/jesd204_tx/jesd204_tx.v
@@ -208,7 +208,6 @@ module jesd204_tx #(
   if (ASYNC_CLK) begin : dual_lmfc_mode
 
     reg link_lmfc_reset = 1'b1;
-    reg device_lmfc_edge_d1 = 1'b0;
     reg device_tx_ready = 1'b0;
 
     jesd204_lmfc #(
@@ -272,13 +271,9 @@ module jesd204_tx #(
       .device_clk(device_clk),
       .device_reset(device_reset),
       .device_data(tx_data),
-      .device_lmfc_edge(device_lmfc_edge_d1),
+      .device_lmfc_edge(device_lmfc_edge),
       .link_data(gearbox_data),
       .output_ready(tx_ready_nx));
-
-    always @(posedge device_clk) begin
-      device_lmfc_edge_d1 <= device_lmfc_edge;
-    end
 
     sync_bits #(
       .NUM_OF_BITS (1),

--- a/library/jesd204/jesd204_tx/jesd204_tx_gearbox.v
+++ b/library/jesd204/jesd204_tx/jesd204_tx_gearbox.v
@@ -64,21 +64,26 @@ module jesd204_tx_gearbox #(
   input output_ready
 );
 
-  localparam MEM_W = IN_DATA_PATH_WIDTH*8*NUM_LANES;
+  localparam MEM_W = (OUT_DATA_PATH_WIDTH <= IN_DATA_PATH_WIDTH) ?
+                      IN_DATA_PATH_WIDTH*8*NUM_LANES :
+                      OUT_DATA_PATH_WIDTH*8*NUM_LANES;
   localparam D_LOG2 = $clog2(DEPTH);
 
   reg [MEM_W-1:0] mem [0:DEPTH-1];
   reg [D_LOG2-1:0]  in_addr ='h00;
   reg [D_LOG2-1:0]  out_addr = 'b0;
   reg               mem_rd_valid = 'b0;
-  reg [MEM_W-1:0]  mem_rd_data;
+  reg [MEM_W-1:0]  mem_rd_data = 'b0;
 
-  wire                mem_wr_en = 1'b1;
   wire                mem_rd_en;
+  wire                mem_wr_en;
   wire [D_LOG2-1:0]  in_out_addr;
   wire [D_LOG2-1:0]  out_in_addr;
-  wire [NUM_LANES-1:0] unpacker_ready;
+  wire [MEM_W-1:0]  mem_wr_data;
+  wire [NUM_LANES-1:0] data_ready;
   wire output_ready_sync;
+  wire addr_reset;
+  wire packer_reset;
 
   sync_bits i_sync_ready (
     .in_bits(output_ready),
@@ -86,54 +91,104 @@ module jesd204_tx_gearbox #(
     .out_clk(device_clk),
     .out_bits(output_ready_sync));
 
-  always @(posedge device_clk) begin
-    if (device_lmfc_edge & ~output_ready_sync) begin
-      in_addr <= 'h01;
-    end else if (mem_wr_en) begin
-      in_addr <= in_addr + 1;
-    end
-  end
-
-  always @(posedge device_clk) begin
-    if (mem_wr_en) begin
-      mem[in_addr] <= device_data;
-    end
-  end
-
-  assign mem_rd_en = output_ready&unpacker_ready[0];
-
-  always @(posedge link_clk) begin
-    if (mem_rd_en) begin
-      mem_rd_data <= mem[out_addr];
-    end
-    mem_rd_valid <= mem_rd_en;
-  end
-
-  always @(posedge link_clk) begin
-    if (reset) begin
-      out_addr <= 'b0;
-    end else if (mem_rd_en) begin
-      out_addr <= out_addr + 1;
-    end
-  end
+  assign addr_reset   = device_lmfc_edge & ~output_ready_sync;
+  assign packer_reset = device_reset | addr_reset;
 
   genvar i;
-  generate for (i = 0; i < NUM_LANES; i=i+1) begin: unpacker
+  generate if (OUT_DATA_PATH_WIDTH < IN_DATA_PATH_WIDTH) begin
 
-  ad_upack #(
-    .I_W(IN_DATA_PATH_WIDTH),
-    .O_W(OUT_DATA_PATH_WIDTH),
-    .UNIT_W(8),
-    .O_REG(0)
-  ) i_ad_upack (
-    .clk(link_clk),
-    .reset(reset),
-    .idata(mem_rd_data[i*IN_DATA_PATH_WIDTH*8+:IN_DATA_PATH_WIDTH*8]),
-    .ivalid(mem_rd_valid),
-    .iready(unpacker_ready[i]),
+    assign mem_wr_en = 1'b1;
 
-    .odata(link_data[i*OUT_DATA_PATH_WIDTH*8+:OUT_DATA_PATH_WIDTH*8]),
-    .ovalid());
+    always @(posedge device_clk) begin
+      if (addr_reset) begin
+        in_addr <= 'h00;
+      end else if (mem_wr_en) begin
+        in_addr <= in_addr + 1;
+      end
+    end
+
+    always @(posedge device_clk) begin
+      if (mem_wr_en) begin
+        mem[in_addr] <= device_data;
+      end
+    end
+
+    assign mem_rd_en = output_ready&data_ready[0];
+
+    always @(posedge link_clk) begin
+      if (mem_rd_en) begin
+        mem_rd_data <= mem[out_addr];
+      end
+      mem_rd_valid <= mem_rd_en;
+    end
+
+    always @(posedge link_clk) begin
+      if (reset) begin
+        out_addr <= 'b0;
+      end else if (mem_rd_en) begin
+        out_addr <= out_addr + 1;
+      end
+    end
+
+    for (i = 0; i < NUM_LANES; i=i+1) begin: unpacker
+      ad_upack #(
+        .I_W(IN_DATA_PATH_WIDTH),
+        .O_W(OUT_DATA_PATH_WIDTH),
+        .UNIT_W(8),
+        .O_REG(0)
+      ) i_ad_upack (
+        .clk(link_clk),
+        .reset(reset),
+        .idata(mem_rd_data[i*IN_DATA_PATH_WIDTH*8+:IN_DATA_PATH_WIDTH*8]),
+        .ivalid(mem_rd_valid),
+        .iready(data_ready[i]),
+
+        .odata(link_data[i*OUT_DATA_PATH_WIDTH*8+:OUT_DATA_PATH_WIDTH*8]),
+        .ovalid());
+    end
+
+  end else begin
+    if (OUT_DATA_PATH_WIDTH > IN_DATA_PATH_WIDTH) begin
+      for (i = 0; i < NUM_LANES; i=i+1) begin: packer
+        ad_pack #(
+          .I_W(IN_DATA_PATH_WIDTH),
+          .O_W(OUT_DATA_PATH_WIDTH),
+          .UNIT_W(8),
+          .O_REG(0)
+        ) i_ad_pack (
+          .clk(device_clk),
+          .reset(packer_reset),
+          .idata(device_data[i*IN_DATA_PATH_WIDTH*8+:IN_DATA_PATH_WIDTH*8]),
+          .ivalid(1'b1),
+
+          .odata(mem_wr_data[i*OUT_DATA_PATH_WIDTH*8+:OUT_DATA_PATH_WIDTH*8]),
+          .ovalid(data_ready[i]));
+      end
+      assign mem_wr_en = data_ready[0];
+    end else begin
+      assign mem_wr_en = 1'b1;
+      assign mem_wr_data = device_data;
+    end
+
+    always @(posedge device_clk) begin
+      if (addr_reset) begin
+        in_addr <= 'h00;
+      end else if (mem_wr_en) begin
+        mem[in_addr] <= mem_wr_data;
+        in_addr <= in_addr + 1'b1;
+      end
+    end
+
+    always @(posedge link_clk) begin
+      if (output_ready == 1'b0) begin
+        out_addr <= 'h00;
+      end else begin
+        out_addr <= out_addr + 1'b1;
+        mem_rd_data <= mem[out_addr];
+      end
+    end
+
+    assign link_data = mem_rd_data;
 
   end
   endgenerate

--- a/library/jesd204/jesd204_tx/jesd204_tx_hw.tcl
+++ b/library/jesd204/jesd204_tx/jesd204_tx_hw.tcl
@@ -68,6 +68,7 @@ ad_ip_files jesd204_tx [list \
   $ad_hdl_dir/library/util_cdc/sync_bits.v \
   $ad_hdl_dir/library/util_cdc/sync_event.v \
   $ad_hdl_dir/library/util_cdc/util_cdc_constr.tcl \
+  $ad_hdl_dir/library/common/ad_pack.v \
   $ad_hdl_dir/library/common/ad_upack.v \
 ]
 

--- a/library/jesd204/jesd204_tx/jesd204_tx_ip.tcl
+++ b/library/jesd204/jesd204_tx/jesd204_tx_ip.tcl
@@ -56,6 +56,7 @@ adi_ip_files jesd204_tx [list \
   "jesd204_tx_ctrl.v" \
   "jesd204_tx_constr.ttcl" \
   "jesd204_tx_ooc.ttcl" \
+  "../../common/ad_pack.v" \
   "../../common/ad_upack.v" \
   "jesd204_tx.v" \
   "bd/bd.tcl"

--- a/library/jesd204/scripts/jesd204.tcl
+++ b/library/jesd204/scripts/jesd204.tcl
@@ -462,12 +462,22 @@ proc adi_tpl_jesd204_rx_create {ip_name num_of_lanes num_of_converters samples_p
 
 # Calculate Link Layer interface width towards Transport Layer
 # TPL width must be set to an integer multiple of F
-proc adi_jesd204_calc_tpl_width {link_datapath_width jesd_l jesd_m jesd_s jesd_np} {
+proc adi_jesd204_calc_tpl_width {link_datapath_width jesd_l jesd_m jesd_s jesd_np {tpl_datapath_width {}}} {
 
   set jesd_f [expr ($jesd_m*$jesd_s*$jesd_np)/(8*$jesd_l)]
 
+  if {$tpl_datapath_width != ""} {
+    set tpl_div [expr $tpl_datapath_width / $jesd_f]
+    set tpl_mod [expr $tpl_datapath_width % $jesd_f]
+
+    if {$tpl_div < 1 || $tpl_mod != 0 || (($tpl_div > 1) && ([expr $tpl_div % 2] != 0))} {
+      return -code 1 "ERROR: Invalid custom TPL width. Must be a power of 2 multiple of F"
+    } else {
+      return $tpl_datapath_width
+    }
+
   # For F=3,6,12 get first pow 2 multiple of F greater than link_datapath_width
-  if {$jesd_f % 3 == 0} {
+  } elseif {$jesd_f % 3 == 0} {
     set np12_datapath_width $jesd_f
     while {$np12_datapath_width < $link_datapath_width} {
         set np12_datapath_width [expr 2*$np12_datapath_width]

--- a/projects/ad9081_fmca_ebz/common/ad9081_fmca_ebz_bd.tcl
+++ b/projects/ad9081_fmca_ebz/common/ad9081_fmca_ebz_bd.tcl
@@ -23,6 +23,11 @@ set JESD_MODE  $ad_project_params(JESD_MODE)
 set RX_LANE_RATE $ad_project_params(RX_LANE_RATE)
 set TX_LANE_RATE $ad_project_params(TX_LANE_RATE)
 
+set RX_TPL_WIDTH [ expr { [info exists ad_project_params(RX_TPL_WIDTH)] \
+                          ? $ad_project_params(RX_TPL_WIDTH) : {} } ]
+set TX_TPL_WIDTH [ expr { [info exists ad_project_params(TX_TPL_WIDTH)] \
+                          ? $ad_project_params(TX_TPL_WIDTH) : {} } ]
+
 set TDD_SUPPORT [ expr { [info exists ad_project_params(TDD_SUPPORT)] \
                           ? $ad_project_params(TDD_SUPPORT) : 0 } ]
 set SHARED_DEVCLK [ expr { [info exists ad_project_params(SHARED_DEVCLK)] \
@@ -77,7 +82,7 @@ if {$RX_DMA_SAMPLE_WIDTH == 12} {
   set RX_DMA_SAMPLE_WIDTH 16
 }
 
-set RX_DATAPATH_WIDTH [adi_jesd204_calc_tpl_width $DATAPATH_WIDTH $RX_JESD_L $RX_JESD_M $RX_JESD_S $RX_JESD_NP]
+set RX_DATAPATH_WIDTH [adi_jesd204_calc_tpl_width $DATAPATH_WIDTH $RX_JESD_L $RX_JESD_M $RX_JESD_S $RX_JESD_NP $RX_TPL_WIDTH]
 
 set RX_SAMPLES_PER_CHANNEL [expr $RX_NUM_OF_LANES * 8* $RX_DATAPATH_WIDTH / ($RX_NUM_OF_CONVERTERS * $RX_SAMPLE_WIDTH)]
 
@@ -100,7 +105,7 @@ if {$TX_DMA_SAMPLE_WIDTH == 12} {
   set TX_DMA_SAMPLE_WIDTH 16
 }
 
-set TX_DATAPATH_WIDTH [adi_jesd204_calc_tpl_width $DATAPATH_WIDTH $TX_JESD_L $TX_JESD_M $TX_JESD_S $TX_JESD_NP]
+set TX_DATAPATH_WIDTH [adi_jesd204_calc_tpl_width $DATAPATH_WIDTH $TX_JESD_L $TX_JESD_M $TX_JESD_S $TX_JESD_NP $TX_TPL_WIDTH]
 
 set TX_SAMPLES_PER_CHANNEL [expr $TX_NUM_OF_LANES * 8* $TX_DATAPATH_WIDTH / ($TX_NUM_OF_CONVERTERS * $TX_SAMPLE_WIDTH)]
 

--- a/projects/ad9081_fmca_ebz/common/ad9081_fmca_ebz_bd.tcl
+++ b/projects/ad9081_fmca_ebz/common/ad9081_fmca_ebz_bd.tcl
@@ -16,6 +16,7 @@ if {![info exists ADI_PHY_SEL]} {
 }
 
 source $ad_hdl_dir/projects/common/xilinx/data_offload_bd.tcl
+source $ad_hdl_dir/library/jesd204/scripts/jesd204.tcl
 
 # Common parameter for TX and RX
 set JESD_MODE  $ad_project_params(JESD_MODE)
@@ -76,13 +77,7 @@ if {$RX_DMA_SAMPLE_WIDTH == 12} {
   set RX_DMA_SAMPLE_WIDTH 16
 }
 
-set RX_JESD_F [expr ($RX_JESD_M*$RX_JESD_S*$RX_JESD_NP)/(8*$RX_JESD_L)]
-# For F=3,6,12 use dual clock
-if {$RX_JESD_F % 3 == 0} {
-  set RX_DATAPATH_WIDTH [expr max($RX_JESD_F,$NP12_DATAPATH_WIDTH)]
-} else {
-  set RX_DATAPATH_WIDTH [expr max($RX_JESD_F,$DATAPATH_WIDTH)]
-}
+set RX_DATAPATH_WIDTH [adi_jesd204_calc_tpl_width $DATAPATH_WIDTH $RX_JESD_L $RX_JESD_M $RX_JESD_S $RX_JESD_NP]
 
 set RX_SAMPLES_PER_CHANNEL [expr $RX_NUM_OF_LANES * 8* $RX_DATAPATH_WIDTH / ($RX_NUM_OF_CONVERTERS * $RX_SAMPLE_WIDTH)]
 
@@ -105,13 +100,7 @@ if {$TX_DMA_SAMPLE_WIDTH == 12} {
   set TX_DMA_SAMPLE_WIDTH 16
 }
 
-set TX_JESD_F [expr ($TX_JESD_M*$TX_JESD_S*$TX_JESD_NP)/(8*$TX_JESD_L)]
-# For F=3,6,12 use dual clock
-if {$TX_JESD_F % 3 == 0} {
-  set TX_DATAPATH_WIDTH [expr max($TX_JESD_F,$NP12_DATAPATH_WIDTH)]
-} else {
-  set TX_DATAPATH_WIDTH [expr max($TX_JESD_F,$DATAPATH_WIDTH)]
-}
+set TX_DATAPATH_WIDTH [adi_jesd204_calc_tpl_width $DATAPATH_WIDTH $TX_JESD_L $TX_JESD_M $TX_JESD_S $TX_JESD_NP]
 
 set TX_SAMPLES_PER_CHANNEL [expr $TX_NUM_OF_LANES * 8* $TX_DATAPATH_WIDTH / ($TX_NUM_OF_CONVERTERS * $TX_SAMPLE_WIDTH)]
 

--- a/projects/ad9081_fmca_ebz/zcu102/system_project.tcl
+++ b/projects/ad9081_fmca_ebz/zcu102/system_project.tcl
@@ -36,11 +36,13 @@ adi_project ad9081_fmca_ebz_zcu102 0 [list \
   RX_JESD_S     [get_env_param RX_JESD_S      1     ] \
   RX_JESD_NP    [get_env_param RX_JESD_NP     16    ] \
   RX_NUM_LINKS  [get_env_param RX_NUM_LINKS   1     ] \
+  RX_TPL_WIDTH  [get_env_param RX_TPL_WIDTH   {}    ] \
   TX_JESD_M     [get_env_param TX_JESD_M      8     ] \
   TX_JESD_L     [get_env_param TX_JESD_L      4     ] \
   TX_JESD_S     [get_env_param TX_JESD_S      1     ] \
   TX_JESD_NP    [get_env_param TX_JESD_NP     16    ] \
   TX_NUM_LINKS  [get_env_param TX_NUM_LINKS   1     ] \
+  TX_TPL_WIDTH  [get_env_param TX_TPL_WIDTH   {}    ] \
   TDD_SUPPORT   [get_env_param TDD_SUPPORT    0     ] \
   SHARED_DEVCLK [get_env_param SHARED_DEVCLK  0     ] \
 ]

--- a/projects/ad9082_fmca_ebz/zcu102/system_project.tcl
+++ b/projects/ad9082_fmca_ebz/zcu102/system_project.tcl
@@ -38,11 +38,13 @@ adi_project ad9082_fmca_ebz_zcu102 0 [list \
   RX_JESD_S    [get_env_param RX_JESD_S    1 ] \
   RX_JESD_NP   [get_env_param RX_JESD_NP   16] \
   RX_NUM_LINKS [get_env_param RX_NUM_LINKS 1 ] \
+  RX_TPL_WIDTH [get_env_param RX_TPL_WIDTH {}] \
   TX_JESD_M    [get_env_param TX_JESD_M    4 ] \
   TX_JESD_L    [get_env_param TX_JESD_L    8 ] \
   TX_JESD_S    [get_env_param TX_JESD_S    1 ] \
   TX_JESD_NP   [get_env_param TX_JESD_NP   16] \
   TX_NUM_LINKS [get_env_param TX_NUM_LINKS 1 ] \
+  TX_TPL_WIDTH [get_env_param TX_TPL_WIDTH {}] \
 ]
 
 adi_project_files ad9082_fmca_ebz_zcu102 [list \


### PR DESCRIPTION
- fix for JESD Tx links where gearbox is used with 1:1 ratio  (output data was 0)
- allow narrower TPL width than PHY width for better resource utilization in application layer
- fix buffer adjustment register for reducing Rx link latency

Tested on ZCU102 + AD9082