### PR TITLE
scripts:adi_env: Change the default version of Quartus Standard to 21.1

### DIFF
--- a/projects/ad777x_ardz/de10nano/system_project.tcl
+++ b/projects/ad777x_ardz/de10nano/system_project.tcl
@@ -1,4 +1,4 @@
-set REQUIRED_QUARTUS_VERSION 20.1.1
+set REQUIRED_QUARTUS_VERSION 21.1.0
 set QUARTUS_PRO_ISUSED 0
 source ../../../scripts/adi_env.tcl
 source ../../scripts/adi_project_intel.tcl

--- a/projects/adv7513/de10nano/system_project.tcl
+++ b/projects/adv7513/de10nano/system_project.tcl
@@ -1,4 +1,4 @@
-set REQUIRED_QUARTUS_VERSION 20.1.1
+set REQUIRED_QUARTUS_VERSION 21.1.0
 set QUARTUS_PRO_ISUSED 0
 
 source ../../../scripts/adi_env.tcl

--- a/projects/arradio/c5soc/system_project.tcl
+++ b/projects/arradio/c5soc/system_project.tcl
@@ -1,4 +1,4 @@
-set REQUIRED_QUARTUS_VERSION 20.1.1
+set REQUIRED_QUARTUS_VERSION 21.1.0
 set QUARTUS_PRO_ISUSED 0
 source ../../../scripts/adi_env.tcl
 source ../../scripts/adi_project_intel.tcl

--- a/projects/cn0540/de10nano/system_project.tcl
+++ b/projects/cn0540/de10nano/system_project.tcl
@@ -1,4 +1,4 @@
-set REQUIRED_QUARTUS_VERSION 20.1.1
+set REQUIRED_QUARTUS_VERSION 21.1.0
 set QUARTUS_PRO_ISUSED 0
 
 source ../../../scripts/adi_env.tcl

--- a/projects/scripts/adi_project_intel.tcl
+++ b/projects/scripts/adi_project_intel.tcl
@@ -180,6 +180,9 @@ proc adi_project {project_name {parameter_list {}}} {
 
   # default assignments
 
+  if {$quartus_pro_isused != 1} {
+    set_global_assignment -name QIP_FILE $system_qip_file
+  }
   set_global_assignment -name VERILOG_FILE system_top.v
   set_global_assignment -name SDC_FILE system_constr.sdc
   set_global_assignment -name TOP_LEVEL_ENTITY system_top


### PR DESCRIPTION
New version of Quartus Standard for de10nano and sockit  was changed
to 21.1.

Signed-off-by: Liviu Adace <liviu.adace@analog.com>