### PR TITLE
cn0577/zed: Update adc_valid logic

### DIFF
--- a/library/axi_ltc2387/axi_ltc2387.v
+++ b/library/axi_ltc2387/axi_ltc2387.v
@@ -1,6 +1,6 @@
 // ***************************************************************************
 // ***************************************************************************
-// Copyright 2021 (c) Analog Devices, Inc. All rights reserved.
+// Copyright 2021 - 2022 (c) Analog Devices, Inc. All rights reserved.
 //
 // In this HDL repository, there are many different and unique modules, consisting
 // of various HDL (Verilog or VHDL) components. The individual modules are
@@ -56,70 +56,70 @@ module axi_ltc2387 #(
 
   // adc interface
 
-  input                     ref_clk,
-  input                     clk_gate,
-  input                     dco_p,
-  input                     dco_n,
-  input                     da_p,
-  input                     da_n,
-  input                     db_p,
-  input                     db_n,
+  input                    ref_clk,
+  input                    clk_gate,
+  input                    dco_p,
+  input                    dco_n,
+  input                    da_p,
+  input                    da_n,
+  input                    db_p,
+  input                    db_n,
 
   // dma interface
 
-  output                    adc_valid,
-  output     [OUT_RES-1:0]  adc_data,
-  input                     adc_dovf,
+  output                   adc_valid,
+  output   [OUT_RES-1:0]   adc_data,
+  input                    adc_dovf,
 
   // axi interface
 
-  input                     s_axi_aclk,
-  input                     s_axi_aresetn,
-  input                     s_axi_awvalid,
-  input       [15:0]        s_axi_awaddr,
-  output                    s_axi_awready,
-  input                     s_axi_wvalid,
-  input       [31:0]        s_axi_wdata,
-  input       [ 3:0]        s_axi_wstrb,
-  output                    s_axi_wready,
-  output                    s_axi_bvalid,
-  output      [ 1:0]        s_axi_bresp,
-  input                     s_axi_bready,
-  input                     s_axi_arvalid,
-  input       [15:0]        s_axi_araddr,
-  output                    s_axi_arready,
-  output                    s_axi_rvalid,
-  output      [ 1:0]        s_axi_rresp,
-  output      [31:0]        s_axi_rdata,
-  input                     s_axi_rready,
-  input       [ 2:0]        s_axi_awprot,
-  input       [ 2:0]        s_axi_arprot
+  input                    s_axi_aclk,
+  input                    s_axi_aresetn,
+  input                    s_axi_awvalid,
+  input       [15:0]       s_axi_awaddr,
+  output                   s_axi_awready,
+  input                    s_axi_wvalid,
+  input       [31:0]       s_axi_wdata,
+  input       [ 3:0]       s_axi_wstrb,
+  output                   s_axi_wready,
+  output                   s_axi_bvalid,
+  output      [ 1:0]       s_axi_bresp,
+  input                    s_axi_bready,
+  input                    s_axi_arvalid,
+  input       [15:0]       s_axi_araddr,
+  output                   s_axi_arready,
+  output                   s_axi_rvalid,
+  output      [ 1:0]       s_axi_rresp,
+  output      [31:0]       s_axi_rdata,
+  input                    s_axi_rready,
+  input       [ 2:0]       s_axi_awprot,
+  input       [ 2:0]       s_axi_arprot
 );
 
   // internal signals
 
-  wire    [15:0]  adc_data_s;
+  wire   [15:0]   adc_data_s;
   wire            adc_or_s;
-  wire    [ 1:0]  up_dld_s;
-  wire    [ 9:0]  up_dwdata_s;
-  wire    [ 9:0]  up_drdata_s;
+  wire   [ 1:0]   up_dld_s;
+  wire   [ 9:0]   up_dwdata_s;
+  wire   [ 9:0]   up_drdata_s;
   wire            delay_locked_s;
   wire            up_status_pn_err_s;
   wire            up_status_pn_oos_s;
   wire            up_status_or_s;
   wire            up_rreq_s;
-  wire    [13:0]  up_raddr_s;
-  wire    [31:0]  up_rdata_s[0:2];
+  wire   [13:0]   up_raddr_s;
+  wire   [31:0]   up_rdata_s[0:2];
   wire            up_rack_s[0:2];
   wire            up_wack_s[0:2];
   wire            up_wreq_s;
-  wire    [13:0]  up_waddr_s;
-  wire    [31:0]  up_wdata_s;
+  wire   [13:0]   up_waddr_s;
+  wire   [31:0]   up_wdata_s;
 
   // internal registers
 
   reg             up_wack = 'd0;
-  reg     [31:0]  up_rdata = 'd0;
+  reg    [31:0]   up_rdata = 'd0;
   reg             up_rack = 'd0;
 
   // internal signals
@@ -130,8 +130,8 @@ module axi_ltc2387 #(
   wire            up_clk;
   wire            up_rstn;
   wire            delay_rst;
-  wire     [ADC_RES-1:0]  adc_data_ch_s;
   wire            adc_valid_ch_s;
+  wire [ADC_RES-1:0] adc_data_ch_s;
 
   // signal name changes
 
@@ -160,7 +160,7 @@ module axi_ltc2387 #(
     .IO_DELAY_GROUP (IO_DELAY_GROUP),
     .DELAY_REFCLK_FREQUENCY (DELAY_REFCLK_FREQUENCY),
     .RESOLUTION (ADC_RES),
-    .IODELAY_CTRL(IODELAY_CTRL),
+    .IODELAY_CTRL (IODELAY_CTRL),
     .TWOLANES (TWOLANES)
   ) i_if (
     .clk (ref_clk),
@@ -215,8 +215,8 @@ module axi_ltc2387 #(
 
   up_delay_cntrl #(
     .INIT_DELAY (ADC_INIT_DELAY),
-    .DATA_WIDTH(2),
-    .BASE_ADDRESS(6'h02)
+    .DATA_WIDTH (2),
+    .BASE_ADDRESS (6'h02)
   ) i_delay_cntrl (
     .delay_clk (delay_clk),
     .delay_rst (delay_rst),
@@ -248,7 +248,7 @@ module axi_ltc2387 #(
     .DRP_DISABLE (6'h00),
     .USERPORTS_DISABLE (USERPORTS_DISABLE),
     .GPIO_DISABLE (0),
-    .START_CODE_DISABLE(0)
+    .START_CODE_DISABLE (0)
   ) i_up_adc_common (
     .mmcm_rst (),
     .adc_clk (adc_clk),
@@ -268,6 +268,7 @@ module axi_ltc2387 #(
     .adc_ext_sync_manual_req(),
     .adc_num_lanes (),
     .adc_custom_control(),
+    .adc_crc_enable (),
     .adc_sdr_ddr_n (),
     .adc_symb_op (),
     .adc_symb_8_16b (),

--- a/library/axi_ltc2387/axi_ltc2387_channel.v
+++ b/library/axi_ltc2387/axi_ltc2387_channel.v
@@ -1,6 +1,6 @@
 // ***************************************************************************
 // ***************************************************************************
-// Copyright 2021 (c) Analog Devices, Inc. All rights reserved.
+// Copyright 2021 - 2022 (c) Analog Devices, Inc. All rights reserved.
 //
 // In this HDL repository, there are many different and unique modules, consisting
 // of various HDL (Verilog or VHDL) components. The individual modules are
@@ -37,69 +37,67 @@
 
 module axi_ltc2387_channel #(
 
-  // parameters
-
-  parameter   ADC_RES = 16,
-  parameter   OUT_RES = 16,
-  parameter   TWOLANES = 1,
-  parameter   USERPORTS_DISABLE = 0,
-  parameter   DATAFORMAT_DISABLE = 0
+  parameter ADC_RES = 16,
+  parameter OUT_RES = 16,
+  parameter TWOLANES = 1,
+  parameter USERPORTS_DISABLE = 0,
+  parameter DATAFORMAT_DISABLE = 0
 ) (
 
   // adc interface
 
-  input                   adc_clk,
-  input                   adc_rst,
-  input                   adc_valid_in,
-  input     [ADC_RES-1:0] adc_data_in,
+  input                  adc_clk,
+  input                  adc_rst,
+  input                  adc_valid_in,
+  input   [ADC_RES-1:0]  adc_data_in,
 
   // dma interface
 
-  output                  adc_enable,
-  output                  adc_valid,
-  output    [OUT_RES-1:0] adc_data,
+  output                 adc_enable,
+  output                 adc_valid,
+  output  [OUT_RES-1:0]  adc_data,
 
   // error monitoring
 
-  output                  up_adc_pn_err,
-  output                  up_adc_pn_oos,
-  output                  up_adc_or,
+  output                 up_adc_pn_err,
+  output                 up_adc_pn_oos,
+  output                 up_adc_or,
 
   // processor interface
 
-  input                   up_rstn,
-  input                   up_clk,
-  input                   up_wreq,
-  input            [13:0] up_waddr,
-  input            [31:0] up_wdata,
-  output                  up_wack,
-  input                   up_rreq,
-  input            [13:0] up_raddr,
-  output           [31:0] up_rdata,
-  output                  up_rack
+  input                  up_rstn,
+  input                  up_clk,
+  input                  up_wreq,
+  input      [13:0]      up_waddr,
+  input      [31:0]      up_wdata,
+  output                 up_wack,
+  input                  up_rreq,
+  input      [13:0]      up_raddr,
+  output     [31:0]      up_rdata,
+  output                 up_rack
 );
 
   // internal signals
 
-  wire                  adc_dfmt_valid_s;
-  wire           [15:0] adc_dfmt_data_s;
-  wire                  adc_dcfilter_valid_s;
-  wire                  adc_iqcor_enb_s;
-  wire                  adc_dcfilt_enb_s;
-  wire                  adc_dfmt_se_s;
-  wire                  adc_dfmt_type_s;
-  wire                  adc_dfmt_enable_s;
-  wire           [15:0] adc_dcfilt_offset_s;
-  wire           [15:0] adc_dcfilt_coeff_s;
-  wire           [15:0] adc_iqcor_coeff_1_s;
-  wire           [15:0] adc_iqcor_coeff_2_s;
-  wire           [ 3:0] adc_pnseq_sel_s;
-  wire           [ 3:0] adc_data_sel_s;
-  reg                   adc_pn_err;
-  wire                  adc_pn_err_s;
+  wire          adc_dfmt_valid_s;
+  wire  [15:0]  adc_dfmt_data_s;
+  wire          adc_dcfilter_valid_s;
+  wire          adc_iqcor_enb_s;
+  wire          adc_dcfilt_enb_s;
+  wire          adc_dfmt_se_s;
+  wire          adc_dfmt_type_s;
+  wire          adc_dfmt_enable_s;
+  wire  [15:0]  adc_dcfilt_offset_s;
+  wire  [15:0]  adc_dcfilt_coeff_s;
+  wire  [15:0]  adc_iqcor_coeff_1_s;
+  wire  [15:0]  adc_iqcor_coeff_2_s;
+  wire  [ 3:0]  adc_pnseq_sel_s;
+  wire  [ 3:0]  adc_data_sel_s;
+  reg           adc_pn_err;
+  wire          adc_pn_err_s;
 
-  wire           [15:0] expected_pattern;
-  wire    [ADC_RES-1:0] test_pattern;
+  wire  [ADC_RES-1:0]  test_pattern;
+  wire  [15:0]         expected_pattern;
 
   assign adc_pn_err_s = adc_pn_err;
 
@@ -178,6 +176,8 @@ module axi_ltc2387_channel #(
     .adc_pn_err (adc_pn_err_s),
     .adc_pn_oos (1'b0),
     .adc_or (1'b0),
+    .adc_status_header (8'd0),
+    .adc_crc_err (1'b0),
     .up_adc_pn_err (up_adc_pn_err),
     .up_adc_pn_oos (up_adc_pn_oos),
     .up_adc_or (up_adc_or),

--- a/library/axi_ltc2387/axi_ltc2387_if.v
+++ b/library/axi_ltc2387/axi_ltc2387_if.v
@@ -96,7 +96,8 @@ module axi_ltc2387_if #(
 
   // assignments
 
-  assign adc_valid = ~clk_gate_d[2] & clk_gate_d[1];
+  // adc_valid is 1 for the current sample that is sent
+  assign adc_valid = clk_gate_d[1] & ~clk_gate_d[0];
 
   always @(posedge clk) begin
     clk_gate_d <= {clk_gate_d[1:0], clk_gate};

--- a/library/axi_ltc2387/axi_ltc2387_if.v
+++ b/library/axi_ltc2387/axi_ltc2387_if.v
@@ -1,6 +1,6 @@
 // ***************************************************************************
 // ***************************************************************************
-// Copyright 2021 (c) Analog Devices, Inc. All rights reserved.
+// Copyright 2021 - 2022 (c) Analog Devices, Inc. All rights reserved.
 //
 // In this HDL repository, there are many different and unique modules, consisting
 // of various HDL (Verilog or VHDL) components. The individual modules are
@@ -49,50 +49,50 @@ module axi_ltc2387_if #(
 
   // delay interface
 
-  input                    up_clk,
-  input   [ 1:0]           up_dld,
-  input   [ 9:0]           up_dwdata,
-  output  [ 9:0]           up_drdata,
-  input                    delay_clk,
-  input                    delay_rst,
-  output                   delay_locked,
+  input             up_clk,
+  input    [ 1:0]   up_dld,
+  input    [ 9:0]   up_dwdata,
+  output   [ 9:0]   up_drdata,
+  input             delay_clk,
+  input             delay_rst,
+  output            delay_locked,
 
   // adc interface
 
-  input                    clk,
-  input                    clk_gate,
-  input                    dco_p,
-  input                    dco_n,
-  input                    da_p,
-  input                    da_n,
-  input                    db_p,
-  input                    db_n,
+  input             clk,
+  input             clk_gate,
+  input             dco_p,
+  input             dco_n,
+  input             da_p,
+  input             da_n,
+  input             db_p,
+  input             db_n,
 
-  output                      adc_valid,
+  output            adc_valid,
   output reg [RESOLUTION-1:0] adc_data
 );
 
-  localparam   ONE_L_WIDTH = (RESOLUTION == 18) ? 9 : 8;
-  localparam   TWO_L_WIDTH = (RESOLUTION == 18) ? 5 : 4;
-  localparam   WIDTH = (TWOLANES == 0) ? ONE_L_WIDTH : TWO_L_WIDTH;
+  localparam ONE_L_WIDTH = (RESOLUTION == 18) ? 9 : 8;
+  localparam TWO_L_WIDTH = (RESOLUTION == 18) ? 5 : 4;
+  localparam WIDTH = (TWOLANES == 0) ? ONE_L_WIDTH : TWO_L_WIDTH;
 
   // internal wires
 
-  wire          da_p_int_s;
-  wire          da_n_int_s;
-  wire          db_p_int_s;
-  wire          db_n_int_s;
-  wire          dco;
-  wire          dco_s;
-  wire  [17:0]  adc_data_int;
+  wire            da_p_int_s;
+  wire            da_n_int_s;
+  wire            db_p_int_s;
+  wire            db_n_int_s;
+  wire            dco;
+  wire            dco_s;
+  wire   [17:0]   adc_data_int;
 
   // internal registers
 
-  reg [WIDTH:0] adc_data_da_p = 'b0;
-  reg [WIDTH:0] adc_data_da_n = 'b0;
-  reg [WIDTH:0] adc_data_db_p = 'b0;
-  reg [WIDTH:0] adc_data_db_n = 'b0;
-  reg [2:0]     clk_gate_d = 'b0;
+  reg  [WIDTH:0]  adc_data_da_p = 'b0;
+  reg  [WIDTH:0]  adc_data_da_n = 'b0;
+  reg  [WIDTH:0]  adc_data_db_p = 'b0;
+  reg  [WIDTH:0]  adc_data_db_n = 'b0;
+  reg      [2:0]  clk_gate_d = 'b0;
 
   // assignments
 
@@ -118,6 +118,7 @@ module axi_ltc2387_if #(
   end
 
   // bits rearrangement
+
   if (!TWOLANES) begin
     assign adc_data_int[17] = adc_data_da_p[7];
     assign adc_data_int[16] = adc_data_da_n[7];
@@ -181,7 +182,7 @@ module axi_ltc2387_if #(
 
   ad_data_in #(
     .FPGA_TECHNOLOGY (FPGA_TECHNOLOGY),
-    .IDDR_CLK_EDGE("OPPOSITE_EDGE"),
+    .IDDR_CLK_EDGE ("OPPOSITE_EDGE"),
     .IODELAY_CTRL (IODELAY_CTRL),
     .IODELAY_GROUP (IO_DELAY_GROUP),
     .REFCLK_FREQUENCY (DELAY_REFCLK_FREQUENCY)
@@ -201,7 +202,7 @@ module axi_ltc2387_if #(
 
   ad_data_in #(
     .FPGA_TECHNOLOGY (FPGA_TECHNOLOGY),
-    .IDDR_CLK_EDGE("OPPOSITE_EDGE"),
+    .IDDR_CLK_EDGE ("OPPOSITE_EDGE"),
     .IODELAY_CTRL (0),
     .IODELAY_GROUP (IO_DELAY_GROUP),
     .REFCLK_FREQUENCY (DELAY_REFCLK_FREQUENCY)

--- a/library/axi_ltc2387/axi_ltc2387_ip.tcl
+++ b/library/axi_ltc2387/axi_ltc2387_ip.tcl
@@ -1,5 +1,3 @@
-# ip
-
 source ../../scripts/adi_env.tcl
 source $ad_hdl_dir/library/scripts/adi_ip_xilinx.tcl
 

--- a/projects/cn0577/common/cn0577_bd.tcl
+++ b/projects/cn0577/common/cn0577_bd.tcl
@@ -48,26 +48,25 @@ ad_connect ref_clk sampling_clk
 
 ad_connect sys_200m_clk axi_ltc2387/delay_clk
 
-ad_connect ref_clk  axi_ltc2387/ref_clk
-ad_connect clk_gate          axi_ltc2387/clk_gate
-ad_connect dco_p             axi_ltc2387/dco_p
-ad_connect dco_n             axi_ltc2387/dco_n
-ad_connect da_n              axi_ltc2387/da_n
-ad_connect da_p              axi_ltc2387/da_p
-ad_connect db_n              axi_ltc2387/db_n
-ad_connect db_p              axi_ltc2387/db_p
+ad_connect ref_clk    axi_ltc2387/ref_clk
+ad_connect clk_gate   axi_ltc2387/clk_gate
+ad_connect dco_p      axi_ltc2387/dco_p
+ad_connect dco_n      axi_ltc2387/dco_n
+ad_connect da_p       axi_ltc2387/da_p
+ad_connect da_n       axi_ltc2387/da_n
+ad_connect db_p       axi_ltc2387/db_p
+ad_connect db_n       axi_ltc2387/db_n
 
-ad_connect cnv        axi_pwm_gen/pwm_0
-ad_connect clk_gate   axi_pwm_gen/pwm_1
-
-ad_connect ref_clk       axi_pwm_gen/ext_clk
-ad_connect sys_cpu_resetn         axi_pwm_gen/s_axi_aresetn
-ad_connect sys_cpu_clk            axi_pwm_gen/s_axi_aclk
-ad_connect ref_clk       axi_ltc2387_dma/fifo_wr_clk
-
+ad_connect ref_clk                axi_ltc2387_dma/fifo_wr_clk
 ad_connect axi_ltc2387/adc_valid  axi_ltc2387_dma/fifo_wr_en
 ad_connect axi_ltc2387/adc_data   axi_ltc2387_dma/fifo_wr_din
 ad_connect axi_ltc2387/adc_dovf   axi_ltc2387_dma/fifo_wr_overflow
+
+ad_connect cnv               axi_pwm_gen/pwm_0
+ad_connect clk_gate          axi_pwm_gen/pwm_1
+ad_connect ref_clk           axi_pwm_gen/ext_clk
+ad_connect sys_cpu_resetn    axi_pwm_gen/s_axi_aresetn
+ad_connect sys_cpu_clk       axi_pwm_gen/s_axi_aclk
 
 # address mapping
 
@@ -79,7 +78,7 @@ ad_cpu_interconnect 0x44A60000 axi_pwm_gen
 
 ad_mem_hp2_interconnect $sys_cpu_clk sys_ps7/S_AXI_HP2
 ad_mem_hp2_interconnect $sys_cpu_clk axi_ltc2387_dma/m_dest_axi
-ad_connect  $sys_cpu_resetn axi_ltc2387_dma/m_dest_axi_aresetn
+ad_connect $sys_cpu_resetn axi_ltc2387_dma/m_dest_axi_aresetn
 
 # interrupts
 

--- a/projects/cn0577/zed/system_bd.tcl
+++ b/projects/cn0577/zed/system_bd.tcl
@@ -1,11 +1,11 @@
-# specify number of channels -- the design supports one lane/two lanes
+# specify number of channels - the design supports one lane/two lanes
 set two_lanes 1
 
 source $ad_hdl_dir/projects/common/zed/zed_system_bd.tcl
 source $ad_hdl_dir/projects/scripts/adi_pd.tcl
 source ../common/cn0577_bd.tcl
 
-#system ID
+# system ID
 ad_ip_parameter axi_sysid_0 CONFIG.ROM_ADDR_BITS 9
 ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "[pwd]/mem_init_sys.txt"
 ad_ip_parameter rom_sys_0 CONFIG.ROM_ADDR_BITS 9

--- a/projects/cn0577/zed/system_constr.xdc
+++ b/projects/cn0577/zed/system_constr.xdc
@@ -1,24 +1,32 @@
-
 # cn0577
 
-# pin connections
+# clocks
 
-set_property -dict {PACKAGE_PIN D18 IOSTANDARD LVDS_25 DIFF_TERM 1} [get_ports ref_clk_p]; #G02  FMC_LPC_CLK1_M2C_P
-set_property -dict {PACKAGE_PIN C19 IOSTANDARD LVDS_25 DIFF_TERM 1} [get_ports ref_clk_n]; #G03  FMC_LPC_CLK1_M2C_N
-set_property -dict {PACKAGE_PIN L18 IOSTANDARD LVDS_25 DIFF_TERM 1} [get_ports dco_p];     #H04  FMC_LPC_CLK0_M2C_P
-set_property -dict {PACKAGE_PIN L19 IOSTANDARD LVDS_25 DIFF_TERM 1} [get_ports dco_n];     #H05  FMC_LPC_CLK0_M2C_N
-set_property -dict {PACKAGE_PIN P17 IOSTANDARD LVDS_25 DIFF_TERM 1} [get_ports da_p];      #H07  FMC_LPC_LA02_P
-set_property -dict {PACKAGE_PIN P18 IOSTANDARD LVDS_25 DIFF_TERM 1} [get_ports da_n];      #H08  FMC_LPC_LA02_N
-set_property -dict {PACKAGE_PIN M21 IOSTANDARD LVDS_25 DIFF_TERM 1} [get_ports db_p];      #H10  FMC_LPC_LA04_P
-set_property -dict {PACKAGE_PIN M22 IOSTANDARD LVDS_25 DIFF_TERM 1} [get_ports db_n];      #H11  FMC_LPC_LA04_N
-set_property -dict {PACKAGE_PIN M19 IOSTANDARD LVDS_25} [get_ports clk_p];                 #G06  FMC_LPC_LA00_CC_P
-set_property -dict {PACKAGE_PIN M20 IOSTANDARD LVDS_25} [get_ports clk_n];                 #G07  FMC_LPC_LA00_CC_N
-set_property -dict {PACKAGE_PIN N19 IOSTANDARD LVDS_25} [get_ports cnv_p];                 #D08  FMC_LPC_LA01_CC_P
-set_property -dict {PACKAGE_PIN N20 IOSTANDARD LVDS_25} [get_ports cnv_n];                 #D09  FMC_LPC_LA01_CC_N
-set_property -dict {PACKAGE_PIN P22 IOSTANDARD LVCMOS25} [get_ports cnv_en];               #G10  FMC_LPC_LA03_N
-set_property -dict {PACKAGE_PIN J20 IOSTANDARD LVCMOS25} [get_ports pd_cntrl];             #G18  FMC_LPC_LA16_P
-set_property -dict {PACKAGE_PIN G20 IOSTANDARD LVCMOS25} [get_ports testpat_cntrl];        #G21  FMC_LPC_LA20_P
-set_property -dict {PACKAGE_PIN G19 IOSTANDARD LVCMOS25} [get_ports twolanes_cntrl];       #G24  FMC_LPC_LA22_P
+set_property -dict {PACKAGE_PIN D18 IOSTANDARD LVDS_25 DIFF_TERM TRUE} [get_ports ref_clk_p]      ; ## G2   FMC_CLK1_M2C_P  IO_L12P_T1_MRCC_35
+set_property -dict {PACKAGE_PIN C19 IOSTANDARD LVDS_25 DIFF_TERM TRUE} [get_ports ref_clk_n]      ; ## G3   FMC_CLK1_M2C_N  IO_L12N_T1_MRCC_35
+set_property -dict {PACKAGE_PIN M19 IOSTANDARD LVDS_25} [get_ports clk_p]                         ; ## G6   FMC_LA00_CC_P   IO_L13P_T2_MRCC_34
+set_property -dict {PACKAGE_PIN M20 IOSTANDARD LVDS_25} [get_ports clk_n]                         ; ## G7   FMC_LA00_CC_N   IO_L13N_T2_MRCC_34
+
+# cnv
+
+set_property -dict {PACKAGE_PIN N19 IOSTANDARD LVDS_25} [get_ports cnv_p]                         ; ## D8   FMC_LA01_CC_P   IO_L14P_T2_SRCC_34
+set_property -dict {PACKAGE_PIN N20 IOSTANDARD LVDS_25} [get_ports cnv_n]                         ; ## D9   FMC_LA01_CC_N   IO_L14N_T2_SRCC_34
+set_property -dict {PACKAGE_PIN P22 IOSTANDARD LVCMOS25} [get_ports cnv_en]                       ; ## G10  FMC_LA03_N      IO_L16N_T2_34
+
+# dco, da, db
+
+set_property -dict {PACKAGE_PIN L18 IOSTANDARD LVDS_25 DIFF_TERM TRUE} [get_ports dco_p]          ; ## H4   FMC_CLK0_M2C_P  IO_L12P_T1_MRCC_34
+set_property -dict {PACKAGE_PIN L19 IOSTANDARD LVDS_25 DIFF_TERM TRUE} [get_ports dco_n]          ; ## H5   FMC_CLK0_M2C_N  IO_L12N_T1_MRCC_34
+set_property -dict {PACKAGE_PIN P17 IOSTANDARD LVDS_25 DIFF_TERM TRUE} [get_ports da_p]           ; ## H7   FMC_LA02_P      IO_L20P_T3_34
+set_property -dict {PACKAGE_PIN P18 IOSTANDARD LVDS_25 DIFF_TERM TRUE} [get_ports da_n]           ; ## H8   FMC_LA02_N      IO_L20N_T3_34
+set_property -dict {PACKAGE_PIN M21 IOSTANDARD LVDS_25 DIFF_TERM TRUE} [get_ports db_p]           ; ## H10  FMC_LA04_P      IO_L15P_T2_DQS_34
+set_property -dict {PACKAGE_PIN M22 IOSTANDARD LVDS_25 DIFF_TERM TRUE} [get_ports db_n]           ; ## H11  FMC_LA04_N      IO_L15N_T2_DQS_34
+
+# control signals
+
+set_property -dict {PACKAGE_PIN J20 IOSTANDARD LVCMOS25} [get_ports pd_cntrl]                     ; ## G18  FMC_LA16_P      IO_L9P_T1_DQS_34
+set_property -dict {PACKAGE_PIN G20 IOSTANDARD LVCMOS25} [get_ports testpat_cntrl]                ; ## G21  FMC_LA20_P      IO_L22P_T3_AD7P_35
+set_property -dict {PACKAGE_PIN G19 IOSTANDARD LVCMOS25} [get_ports twolanes_cntrl]               ; ## G24  FMC_LA22_P      IO_L20P_T3_AD6P_35
 
 # 120MHz clock
 set clk_period  8.333

--- a/projects/cn0577/zed/system_top.v
+++ b/projects/cn0577/zed/system_top.v
@@ -103,25 +103,28 @@ module system_top (
 
   // internal signals
 
-  wire    [63:0]  gpio_i;
-  wire    [63:0]  gpio_o;
-  wire    [63:0]  gpio_t;
+  wire  [63:0]  gpio_i;
+  wire  [63:0]  gpio_o;
+  wire  [63:0]  gpio_t;
 
-  wire    [ 1:0]  iic_mux_scl_i_s;
-  wire    [ 1:0]  iic_mux_scl_o_s;
-  wire            iic_mux_scl_t_s;
-  wire    [ 1:0]  iic_mux_sda_i_s;
-  wire    [ 1:0]  iic_mux_sda_o_s;
-  wire            iic_mux_sda_t_s;
+  wire  [ 1:0]  iic_mux_scl_i_s;
+  wire  [ 1:0]  iic_mux_scl_o_s;
+  wire          iic_mux_scl_t_s;
+  wire  [ 1:0]  iic_mux_sda_i_s;
+  wire  [ 1:0]  iic_mux_sda_o_s;
+  wire          iic_mux_sda_t_s;
 
-  wire            clk_s;
-  wire            cnv_s;
-  wire            cnv;
-  wire            clk_gate;
-  wire            sampling_clk_s;
-  wire            ltc_clk;
+  wire          clk_s;
+  wire          cnv_s;
+  wire          cnv;
+  wire          clk_gate;
+  wire          sampling_clk_s;
+  wire          ltc_clk;
 
   assign gpio_i[63:34] = gpio_o[63:34];
+
+  // hardcode GPIO to always use two lanes configuration
+
   assign twolanes_cntrl = 1'b1;
   assign cnv_en = cnv;
 
@@ -169,7 +172,7 @@ module system_top (
     .I (cnv_s));
 
   ad_iobuf #(
-    .DATA_WIDTH(2)
+    .DATA_WIDTH (2)
   ) iobuf_gpio_cn0577 (
     .dio_i (gpio_o[33:32]),
     .dio_o (gpio_i[33:32]),
@@ -177,7 +180,7 @@ module system_top (
     .dio_p ({pd_cntrl, testpat_cntrl}));
 
   ad_iobuf #(
-    .DATA_WIDTH(32)
+    .DATA_WIDTH (32)
   ) iobuf_gpio_bd (
     .dio_i (gpio_o[31:0]),
     .dio_o (gpio_i[31:0]),
@@ -185,7 +188,7 @@ module system_top (
     .dio_p (gpio_bd));
 
   ad_iobuf #(
-    .DATA_WIDTH(2)
+    .DATA_WIDTH (2)
   ) i_iic_mux_scl (
     .dio_t ({iic_mux_scl_t_s, iic_mux_scl_t_s}),
     .dio_i (iic_mux_scl_o_s),
@@ -193,7 +196,7 @@ module system_top (
     .dio_p (iic_mux_scl));
 
   ad_iobuf #(
-    .DATA_WIDTH(2)
+    .DATA_WIDTH (2)
   ) i_iic_mux_sda (
     .dio_t ({iic_mux_sda_t_s, iic_mux_sda_t_s}),
     .dio_i (iic_mux_sda_o_s),
@@ -260,7 +263,7 @@ module system_top (
     .spi0_csn_0_o (),
     .spi0_csn_1_o (),
     .spi0_csn_2_o (),
-    .spi0_csn_i (1'b0),
+    .spi0_csn_i (1'b1),
     .spi0_sdi_i (1'b0),
     .spi0_sdo_i (1'b0),
     .spi0_sdo_o (),
@@ -269,7 +272,7 @@ module system_top (
     .spi1_csn_0_o (),
     .spi1_csn_1_o (),
     .spi1_csn_2_o (),
-    .spi1_csn_i (1'b0),
+    .spi1_csn_i (1'b1),
     .spi1_sdi_i (1'b0),
     .spi1_sdo_i (1'b0),
     .spi1_sdo_o ());


### PR DESCRIPTION
- Update how adc_valid is made: now it represents the current data sample, as opposed to the earlier version where it was for the previous sample. This caused the first conversion sample to be invalid, but now it's fixed and checked in hardware
- Minor change in constraints file to use now DIFF_TERM TRUE instead of DIFF_TERM 1; it was generated using ad_fmc_constr_generator.tcl
- Aspect changes in the rest of the files, nothing regarding logic