### PR TITLE
adi_pd.tcl: Fix sysid branch string

### DIFF
--- a/projects/scripts/adi_pd.tcl
+++ b/projects/scripts/adi_pd.tcl
@@ -114,7 +114,7 @@ proc sysid_gen_sys_init_file {{custom_string {}}} {
         set git_clean_string "t";
       }
     }
-    if {[catch {exec git branch} gitbranch_string] != 0} {
+    if {[catch {exec git branch --no-color} gitbranch_string] != 0} {
       set gitbranch_string "";
     } else {
       set gitbranch_string [lindex $gitbranch_string [expr [lsearch -exact $gitbranch_string "*"] + 1]];


### PR DESCRIPTION
For some newer versions of git where by default color.ui=always.
The colored string captured can result in some special characters
(ASCI escape codes for coloring the terminal output) before and after the string.
e.g:
$ git branch > test.txt
$ vim test.txt
"
* ^[[32mmaster^[[m
  dev_new_device^[[m"

The above escape codes will mess up a terminals color scheme  when this
information is read from sysid and displayed on a terminal.

Use --no-color flag to fix this issue.