### PR TITLE
Add support for AD719x

### DIFF
--- a/projects/ad719x_asdz/Makefile
+++ b/projects/ad719x_asdz/Makefile
@@ -1,0 +1,7 @@
+####################################################################################
+## Copyright (c) 2018 - 2021 Analog Devices, Inc.
+### SPDX short identifier: BSD-1-Clause
+## Auto-generated, do not modify!
+####################################################################################
+
+include ../scripts/project-toplevel.mk

--- a/projects/ad719x_asdz/README.md
+++ b/projects/ad719x_asdz/README.md
@@ -1,0 +1,14 @@
+# EVAL-AD719X-ASDZ HDL Project
+
+This project supports EVAL-AD7190, EVAL-AD7193 and EVAL-AD7195.
+
+Here are some pointers to help you:
+  * [EVAL-AD7190 Board Product Page](https://www.analog.com/eval-ad7190)
+  * [EVAL-AD7193 Board Product Page](https://www.analog.com/eval-ad7193)
+  * [EVAL-AD7195 Board Product Page](https://www.analog.com/eval-ad7195)
+  * Parts: AD7190 [Sigma-Delta ADC, SPI interface, 24-bit resolution, Data rate between 4.7Hz - 4.8kHz](https://www.analog.com/ad7190)
+  * Parts: AD7193 [4-channel Sigma-Delta ADC, SPI interface, 24-bit resolution, Data rate between 4.7Hz - 4.8kHz](https://www.analog.com/ad7193)
+  * Parts: AD7195 [Sigma-Delta ADC, SPI interface, 24-bit resolution, Data rate between 4.7Hz - 4.8kHz](https://www.analog.com/ad7195)
+  * Project Doc: https://wiki.analog.com/resources/eval/adc/ad719x_asdz
+  * HDL Doc: https://wiki.analog.com/resources/eval/adc/ad719x_asdz 
+  * Linux Drivers: https://wiki.analog.com/resources/tools-software/linux-drivers-all

--- a/projects/ad719x_asdz/coraz7s/Makefile
+++ b/projects/ad719x_asdz/coraz7s/Makefile
@@ -1,0 +1,18 @@
+####################################################################################
+## Copyright (c) 2018 - 2021 Analog Devices, Inc.
+### SPDX short identifier: BSD-1-Clause
+## Auto-generated, do not modify!
+####################################################################################
+
+PROJECT_NAME := ad719x_asdz_coraz7s
+
+M_DEPS += ../../scripts/adi_pd.tcl
+M_DEPS += ../../common/coraz7s/coraz7s_system_ps7.tcl
+M_DEPS += ../../common/coraz7s/coraz7s_system_constr.xdc
+M_DEPS += ../../common/coraz7s/coraz7s_system_bd.tcl
+M_DEPS += ../../../library/common/ad_iobuf.v
+
+LIB_DEPS += axi_sysid
+LIB_DEPS += sysid_rom
+
+include ../../scripts/project-xilinx.mk

--- a/projects/ad719x_asdz/coraz7s/system_bd.tcl
+++ b/projects/ad719x_asdz/coraz7s/system_bd.tcl
@@ -1,0 +1,10 @@
+source $ad_hdl_dir/projects/common/coraz7s/coraz7s_system_bd.tcl
+source $ad_hdl_dir/projects/scripts/adi_pd.tcl
+
+# system ID
+ad_ip_parameter axi_sysid_0 CONFIG.ROM_ADDR_BITS 9
+ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "[pwd]/mem_init_sys.txt"
+ad_ip_parameter rom_sys_0 CONFIG.ROM_ADDR_BITS 9
+set sys_cstring "sys rom custom string placeholder"
+
+sysid_gen_sys_init_file

--- a/projects/ad719x_asdz/coraz7s/system_constr.xdc
+++ b/projects/ad719x_asdz/coraz7s/system_constr.xdc
@@ -1,0 +1,8 @@
+# coraz7s
+
+# ad719x spi connections
+
+set_property -dict {PACKAGE_PIN Y17 IOSTANDARD LVCMOS33} [get_ports {adc_spi_sclk}];      # IO_L7N_T1_34  Sch=ja_n[2]
+set_property -dict {PACKAGE_PIN Y16 IOSTANDARD LVCMOS33} [get_ports {adc_spi_miso_rdyn}]; # IO_L7P_T1_34  Sch=ja_p[2]; AD719X sch=DOUT/RDY_N
+set_property -dict {PACKAGE_PIN Y19 IOSTANDARD LVCMOS33} [get_ports {adc_spi_mosi}];      # IO_L17N_T2_34 Sch=ja_n[1]; AD719X sch=DIN
+set_property -dict {PACKAGE_PIN Y18 IOSTANDARD LVCMOS33} [get_ports {adc_spi_csn}];       # IO_L17P_T2_34 Sch=ja_p[1]

--- a/projects/ad719x_asdz/coraz7s/system_project.tcl
+++ b/projects/ad719x_asdz/coraz7s/system_project.tcl
@@ -1,0 +1,14 @@
+source ../../../scripts/adi_env.tcl
+source $ad_hdl_dir/projects/scripts/adi_project_xilinx.tcl
+source $ad_hdl_dir/projects/scripts/adi_board.tcl
+
+adi_project ad719x_asdz_coraz7s
+
+adi_project_files ad719x_asdz_coraz7s [list \
+    "$ad_hdl_dir/library/common/ad_iobuf.v" \
+    "$ad_hdl_dir/projects/common/coraz7s/coraz7s_system_constr.xdc" \
+    "system_constr.xdc" \
+    "system_top.v"
+]
+
+adi_project_run ad719x_asdz_coraz7s

--- a/projects/ad719x_asdz/coraz7s/system_top.v
+++ b/projects/ad719x_asdz/coraz7s/system_top.v
@@ -1,0 +1,155 @@
+// ***************************************************************************
+// ***************************************************************************
+// Copyright 2022 (c) Analog Devices, Inc. All rights reserved.
+//
+// In this HDL repository, there are many different and unique modules, consisting
+// of various HDL (Verilog or VHDL) components. The individual modules are
+// developed independently, and may be accompanied by separate and unique license
+// terms.
+//
+// The user should read each of these license terms, and understand the
+// freedoms and responsabilities that he or she has by using this source/core.
+//
+// This core is distributed in the hope that it will be useful, but WITHOUT ANY
+// WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+// A PARTICULAR PURPOSE.
+//
+// Redistribution and use of source or resulting binaries, with or without modification
+// of this file, are permitted under one of the following two license terms:
+//
+//   1. The GNU General Public License version 2 as published by the
+//      Free Software Foundation, which can be found in the top level directory
+//      of this repository (LICENSE_GPL2), and also online at:
+//      <https://www.gnu.org/licenses/old-licenses/gpl-2.0.html>
+//
+// OR
+//
+//   2. An ADI specific BSD license, which can be found in the top level directory
+//      of this repository (LICENSE_ADIBSD), and also on-line at:
+//      https://github.com/analogdevicesinc/hdl/blob/master/LICENSE_ADIBSD
+//      This will allow to generate bit files and not release the source code,
+//      as long as it attaches to an ADI device.
+//
+// ***************************************************************************
+// ***************************************************************************
+
+`timescale 1ns/100ps
+
+module system_top (
+
+  inout   [14:0]  ddr_addr,
+  inout   [ 2:0]  ddr_ba,
+  inout           ddr_cas_n,
+  inout           ddr_ck_n,
+  inout           ddr_ck_p,
+  inout           ddr_cke,
+  inout           ddr_cs_n,
+  inout   [ 3:0]  ddr_dm,
+  inout   [31:0]  ddr_dq,
+  inout   [ 3:0]  ddr_dqs_n,
+  inout   [ 3:0]  ddr_dqs_p,
+  inout           ddr_odt,
+  inout           ddr_ras_n,
+  inout           ddr_reset_n,
+  inout           ddr_we_n,
+
+  inout           fixed_io_ddr_vrn,
+  inout           fixed_io_ddr_vrp,
+  inout   [53:0]  fixed_io_mio,
+  inout           fixed_io_ps_clk,
+  inout           fixed_io_ps_porb,
+  inout           fixed_io_ps_srstb,
+
+  inout   [ 1:0]  btn,
+  inout   [ 5:0]  led,
+
+  // ad7190 spi pins
+
+  output          adc_spi_sclk,
+  input           adc_spi_miso_rdyn,
+  output          adc_spi_mosi,
+  output          adc_spi_csn
+);
+
+  // internal signals
+
+  wire    [63:0]  gpio_i;
+  wire    [63:0]  gpio_o;
+  wire    [63:0]  gpio_t;
+
+  // instantiations
+
+  ad_iobuf #(
+    .DATA_WIDTH (2)
+  ) i_iobuf_buttons (
+    .dio_t (gpio_t[1:0]),
+    .dio_i (gpio_o[1:0]),
+    .dio_o (gpio_i[1:0]),
+    .dio_p (btn));
+
+  ad_iobuf #(
+    .DATA_WIDTH (6)
+  ) i_iobuf_leds (
+    .dio_t (gpio_t[7:2]),
+    .dio_i (gpio_o[7:2]),
+    .dio_o (gpio_i[7:2]),
+    .dio_p (led));
+
+  // project specific gpios
+
+  assign gpio_i[63:33] = gpio_o[63:33];
+  assign gpio_i[32] = adc_spi_miso_rdyn;
+
+  // board specific gpios
+
+  assign gpio_i[31:8] = gpio_o[31:8];
+
+  system_wrapper i_system_wrapper (
+    .ddr_addr (ddr_addr),
+    .ddr_ba (ddr_ba),
+    .ddr_cas_n (ddr_cas_n),
+    .ddr_ck_n (ddr_ck_n),
+    .ddr_ck_p (ddr_ck_p),
+    .ddr_cke (ddr_cke),
+    .ddr_cs_n (ddr_cs_n),
+    .ddr_dm (ddr_dm),
+    .ddr_dq (ddr_dq),
+    .ddr_dqs_n (ddr_dqs_n),
+    .ddr_dqs_p (ddr_dqs_p),
+    .ddr_odt (ddr_odt),
+    .ddr_ras_n (ddr_ras_n),
+    .ddr_reset_n (ddr_reset_n),
+    .ddr_we_n (ddr_we_n),
+
+    .fixed_io_ddr_vrn (fixed_io_ddr_vrn),
+    .fixed_io_ddr_vrp (fixed_io_ddr_vrp),
+    .fixed_io_mio (fixed_io_mio),
+    .fixed_io_ps_clk (fixed_io_ps_clk),
+    .fixed_io_ps_porb (fixed_io_ps_porb),
+    .fixed_io_ps_srstb (fixed_io_ps_srstb),
+
+    .gpio_i (gpio_i),
+    .gpio_o (gpio_o),
+    .gpio_t (gpio_t),
+
+    .spi0_clk_i (1'b0),
+    .spi0_clk_o (adc_spi_sclk),
+    .spi0_csn_0_o (adc_spi_csn),
+    .spi0_csn_1_o (),
+    .spi0_csn_2_o (),
+    .spi0_csn_i (1'b0),
+    .spi0_sdi_i (adc_spi_miso_rdyn),
+    .spi0_sdo_i (1'b0),
+    .spi0_sdo_o (adc_spi_mosi),
+
+    .spi1_clk_i (1'b0),
+    .spi1_clk_o (),
+    .spi1_csn_0_o (),
+    .spi1_csn_1_o (),
+    .spi1_csn_2_o (),
+    .spi1_csn_i (1'b1),
+    .spi1_sdi_i (1'b0),
+    .spi1_sdo_i (1'b0),
+    .spi1_sdo_o ());
+
+endmodule


### PR DESCRIPTION
- For AD7190, AD7193, AD7195
- This PR should not be merged until the issue with Cora Z7S' board design is fixed