### PR TITLE
Parameterizable make build

### DIFF
--- a/projects/ad40xx_fmc/zed/system_bd.tcl
+++ b/projects/ad40xx_fmc/zed/system_bd.tcl
@@ -1,4 +1,3 @@
-
 source $ad_hdl_dir/projects/common/zed/zed_system_bd.tcl
 source $ad_hdl_dir/projects/scripts/adi_pd.tcl
 
@@ -17,9 +16,11 @@ set ADC_SAMPLING_RATE [get_env_param ADC_SAMPLING_RATE 1800000]
 
 source ../common/ad40xx_bd.tcl
 
+set mem_init_sys_path [get_env_param ADI_PROJECT_DIR ""]mem_init_sys.txt;
+
 #system ID
 ad_ip_parameter axi_sysid_0 CONFIG.ROM_ADDR_BITS 9
-ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "[pwd]/mem_init_sys.txt"
+ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "[pwd]/$mem_init_sys_path"
 ad_ip_parameter rom_sys_0 CONFIG.ROM_ADDR_BITS 9
 
 set AD40XX_ADAQ400X_N [get_env_param AD40XX_ADAQ400X_N 1]

--- a/projects/ad40xx_fmc/zed/system_project.tcl
+++ b/projects/ad40xx_fmc/zed/system_project.tcl
@@ -1,4 +1,3 @@
-
 source ../../../scripts/adi_env.tcl
 source $ad_hdl_dir/projects/scripts/adi_project_xilinx.tcl
 source $ad_hdl_dir/projects/scripts/adi_board.tcl

--- a/projects/ad4630_fmc/zed/system_bd.tcl
+++ b/projects/ad4630_fmc/zed/system_bd.tcl
@@ -1,4 +1,3 @@
-
 source $ad_hdl_dir/projects/scripts/adi_pd.tcl
 source $ad_hdl_dir/projects/common/zed/zed_system_bd.tcl
 
@@ -10,9 +9,11 @@ adi_project_files ad4630_fmc_zed [list \
 # block design
 source ../common/ad463x_bd.tcl
 
+set mem_init_sys_path [get_env_param ADI_PROJECT_DIR ""]mem_init_sys.txt;
+
 #system ID
 ad_ip_parameter axi_sysid_0 CONFIG.ROM_ADDR_BITS 9
-ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "[pwd]/mem_init_sys.txt"
+ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "[pwd]/$mem_init_sys_path"
 ad_ip_parameter rom_sys_0 CONFIG.ROM_ADDR_BITS 9
 set sys_cstring "sys rom custom string placeholder"
 sysid_gen_sys_init_file $sys_cstring

--- a/projects/ad4630_fmc/zed/system_project.tcl
+++ b/projects/ad4630_fmc/zed/system_project.tcl
@@ -1,4 +1,3 @@
-
 source ../../../scripts/adi_env.tcl
 source $ad_hdl_dir/projects/scripts/adi_project_xilinx.tcl
 source $ad_hdl_dir/projects/scripts/adi_board.tcl

--- a/projects/ad469x_fmc/zed/system_bd.tcl
+++ b/projects/ad469x_fmc/zed/system_bd.tcl
@@ -1,4 +1,3 @@
-
 source $ad_hdl_dir/projects/common/zed/zed_system_bd.tcl
 source $ad_hdl_dir/projects/scripts/adi_pd.tcl
 
@@ -18,9 +17,11 @@ adi_project_files ad469x_fmc_zed [list \
 
 source ../common/ad469x_bd.tcl
 
+set mem_init_sys_path [get_env_param ADI_PROJECT_DIR ""]mem_init_sys.txt;
+
 #system ID
 ad_ip_parameter axi_sysid_0 CONFIG.ROM_ADDR_BITS 9
-ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "[pwd]/mem_init_sys.txt"
+ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "[pwd]/$mem_init_sys_path"
 ad_ip_parameter rom_sys_0 CONFIG.ROM_ADDR_BITS 9
 
 sysid_gen_sys_init_file

--- a/projects/ad469x_fmc/zed/system_project.tcl
+++ b/projects/ad469x_fmc/zed/system_project.tcl
@@ -1,4 +1,3 @@
-
 source ../../../scripts/adi_env.tcl
 source ../../scripts/adi_project_xilinx.tcl
 source ../../scripts/adi_board.tcl

--- a/projects/ad5758_sdz/zed/system_bd.tcl
+++ b/projects/ad5758_sdz/zed/system_bd.tcl
@@ -1,10 +1,11 @@
-
 source $ad_hdl_dir/projects/common/zed/zed_system_bd.tcl
 source $ad_hdl_dir/projects/scripts/adi_pd.tcl
 
+set mem_init_sys_path [get_env_param ADI_PROJECT_DIR ""]mem_init_sys.txt;
+
 #system ID
 ad_ip_parameter axi_sysid_0 CONFIG.ROM_ADDR_BITS 9
-ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "[pwd]/mem_init_sys.txt"
+ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "[pwd]/$mem_init_sys_path"
 ad_ip_parameter rom_sys_0 CONFIG.ROM_ADDR_BITS 9
 
 sysid_gen_sys_init_file

--- a/projects/ad5758_sdz/zed/system_project.tcl
+++ b/projects/ad5758_sdz/zed/system_project.tcl
@@ -1,4 +1,3 @@
-
 source ../../../scripts/adi_env.tcl
 source $ad_hdl_dir/projects/scripts/adi_project_xilinx.tcl
 source $ad_hdl_dir/projects/scripts/adi_board.tcl

--- a/projects/ad5766_sdz/zed/system_bd.tcl
+++ b/projects/ad5766_sdz/zed/system_bd.tcl
@@ -1,10 +1,11 @@
-
 source $ad_hdl_dir/projects/common/zed/zed_system_bd.tcl
 source $ad_hdl_dir/projects/scripts/adi_pd.tcl
 
+set mem_init_sys_path [get_env_param ADI_PROJECT_DIR ""]mem_init_sys.txt;
+
 #system ID
 ad_ip_parameter axi_sysid_0 CONFIG.ROM_ADDR_BITS 9
-ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "[pwd]/mem_init_sys.txt"
+ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "[pwd]/$mem_init_sys_path"
 ad_ip_parameter rom_sys_0 CONFIG.ROM_ADDR_BITS 9
 
 sysid_gen_sys_init_file

--- a/projects/ad5766_sdz/zed/system_project.tcl
+++ b/projects/ad5766_sdz/zed/system_project.tcl
@@ -1,4 +1,3 @@
-
 source ../../../scripts/adi_env.tcl
 source $ad_hdl_dir/projects/scripts/adi_project_xilinx.tcl
 source $ad_hdl_dir/projects/scripts/adi_board.tcl

--- a/projects/ad6676evb/vc707/system_bd.tcl
+++ b/projects/ad6676evb/vc707/system_bd.tcl
@@ -1,11 +1,12 @@
-
 source $ad_hdl_dir/projects/common/vc707/vc707_system_bd.tcl
 source ../common/ad6676evb_bd.tcl
 source $ad_hdl_dir/projects/scripts/adi_pd.tcl
 
+set mem_init_sys_path [get_env_param ADI_PROJECT_DIR ""]mem_init_sys.txt;
+
 #system ID
 ad_ip_parameter axi_sysid_0 CONFIG.ROM_ADDR_BITS 9
-ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "[pwd]/mem_init_sys.txt"
+ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "[pwd]/$mem_init_sys_path"
 ad_ip_parameter rom_sys_0 CONFIG.ROM_ADDR_BITS 9
 
 sysid_gen_sys_init_file

--- a/projects/ad6676evb/vc707/system_project.tcl
+++ b/projects/ad6676evb/vc707/system_project.tcl
@@ -1,4 +1,3 @@
-
 source ../../../scripts/adi_env.tcl
 source $ad_hdl_dir/projects/scripts/adi_project_xilinx.tcl
 source $ad_hdl_dir/projects/scripts/adi_board.tcl

--- a/projects/ad6676evb/zc706/system_bd.tcl
+++ b/projects/ad6676evb/zc706/system_bd.tcl
@@ -1,11 +1,12 @@
-
 source $ad_hdl_dir/projects/common/zc706/zc706_system_bd.tcl
 source ../common/ad6676evb_bd.tcl
 source $ad_hdl_dir/projects/scripts/adi_pd.tcl
 
+set mem_init_sys_path [get_env_param ADI_PROJECT_DIR ""]mem_init_sys.txt;
+
 #system ID
 ad_ip_parameter axi_sysid_0 CONFIG.ROM_ADDR_BITS 9
-ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "[pwd]/mem_init_sys.txt"
+ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "[pwd]/$mem_init_sys_path"
 ad_ip_parameter rom_sys_0 CONFIG.ROM_ADDR_BITS 9
 
 sysid_gen_sys_init_file

--- a/projects/ad6676evb/zc706/system_project.tcl
+++ b/projects/ad6676evb/zc706/system_project.tcl
@@ -1,4 +1,3 @@
-
 source ../../../scripts/adi_env.tcl
 source $ad_hdl_dir/projects/scripts/adi_project_xilinx.tcl
 source $ad_hdl_dir/projects/scripts/adi_board.tcl

--- a/projects/ad7134_fmc/zed/system_bd.tcl
+++ b/projects/ad7134_fmc/zed/system_bd.tcl
@@ -1,4 +1,3 @@
-
 source $ad_hdl_dir/projects/common/zed/zed_system_bd.tcl
 source $ad_hdl_dir/projects/scripts/adi_pd.tcl
 
@@ -7,9 +6,11 @@ adi_project_files ad7134_fmc_zed [list \
   "$ad_hdl_dir/library/util_cdc/sync_bits.v" \
 ]
 
+set mem_init_sys_path [get_env_param ADI_PROJECT_DIR ""]mem_init_sys.txt;
+
 #system ID
 ad_ip_parameter axi_sysid_0 CONFIG.ROM_ADDR_BITS 9
-ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "[pwd]/mem_init_sys.txt"
+ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "[pwd]/$mem_init_sys_path"
 ad_ip_parameter rom_sys_0 CONFIG.ROM_ADDR_BITS 9
 
 sysid_gen_sys_init_file

--- a/projects/ad7134_fmc/zed/system_project.tcl
+++ b/projects/ad7134_fmc/zed/system_project.tcl
@@ -1,4 +1,3 @@
-
 source ../../../scripts/adi_env.tcl
 source $ad_hdl_dir/projects/scripts/adi_project_xilinx.tcl
 source $ad_hdl_dir/projects/scripts/adi_board.tcl

--- a/projects/ad738x_fmc/zed/system_bd.tcl
+++ b/projects/ad738x_fmc/zed/system_bd.tcl
@@ -1,10 +1,11 @@
-
 source $ad_hdl_dir/projects/common/zed/zed_system_bd.tcl
 source $ad_hdl_dir/projects/scripts/adi_pd.tcl
 
+set mem_init_sys_path [get_env_param ADI_PROJECT_DIR ""]mem_init_sys.txt;
+
 #system ID
 ad_ip_parameter axi_sysid_0 CONFIG.ROM_ADDR_BITS 9
-ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "[pwd]/mem_init_sys.txt"
+ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "[pwd]/$mem_init_sys_path"
 ad_ip_parameter rom_sys_0 CONFIG.ROM_ADDR_BITS 9
 
 sysid_gen_sys_init_file

--- a/projects/ad738x_fmc/zed/system_project.tcl
+++ b/projects/ad738x_fmc/zed/system_project.tcl
@@ -1,4 +1,3 @@
-
 source ../../../scripts/adi_env.tcl
 source $ad_hdl_dir/projects/scripts/adi_project_xilinx.tcl
 source $ad_hdl_dir/projects/scripts/adi_board.tcl

--- a/projects/ad7405_fmc/zed/system_bd.tcl
+++ b/projects/ad7405_fmc/zed/system_bd.tcl
@@ -1,10 +1,11 @@
-
 source $ad_hdl_dir/projects/common/zed/zed_system_bd.tcl
 source $ad_hdl_dir/projects/scripts/adi_pd.tcl
 
+set mem_init_sys_path [get_env_param ADI_PROJECT_DIR ""]mem_init_sys.txt;
+
 #system ID
 ad_ip_parameter axi_sysid_0 CONFIG.ROM_ADDR_BITS 9
-ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "[pwd]/mem_init_sys.txt"
+ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "[pwd]/$mem_init_sys_path"
 ad_ip_parameter rom_sys_0 CONFIG.ROM_ADDR_BITS 9
 
 sysid_gen_sys_init_file

--- a/projects/ad7405_fmc/zed/system_project.tcl
+++ b/projects/ad7405_fmc/zed/system_project.tcl
@@ -1,4 +1,3 @@
-
 source ../../../scripts/adi_env.tcl
 source $ad_hdl_dir/projects/scripts/adi_project_xilinx.tcl
 source $ad_hdl_dir/projects/scripts/adi_board.tcl

--- a/projects/ad7616_sdz/zc706/system_bd.tcl
+++ b/projects/ad7616_sdz/zc706/system_bd.tcl
@@ -1,10 +1,11 @@
-
 source $ad_hdl_dir/projects/common/zc706/zc706_system_bd.tcl
 source $ad_hdl_dir/projects/scripts/adi_pd.tcl
 
+set mem_init_sys_path [get_env_param ADI_PROJECT_DIR ""]mem_init_sys.txt;
+
 #system ID
 ad_ip_parameter axi_sysid_0 CONFIG.ROM_ADDR_BITS 9
-ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "[pwd]/mem_init_sys.txt"
+ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "[pwd]/$mem_init_sys_path"
 ad_ip_parameter rom_sys_0 CONFIG.ROM_ADDR_BITS 9
 
 sysid_gen_sys_init_file

--- a/projects/ad7616_sdz/zc706/system_project.tcl
+++ b/projects/ad7616_sdz/zc706/system_project.tcl
@@ -1,4 +1,3 @@
-
 source ../../../scripts/adi_env.tcl
 source $ad_hdl_dir/projects/scripts/adi_project_xilinx.tcl
 source $ad_hdl_dir/projects/scripts/adi_board.tcl

--- a/projects/ad7616_sdz/zed/system_bd.tcl
+++ b/projects/ad7616_sdz/zed/system_bd.tcl
@@ -1,10 +1,11 @@
-
 source $ad_hdl_dir/projects/common/zed/zed_system_bd.tcl
 source $ad_hdl_dir/projects/scripts/adi_pd.tcl
 
+set mem_init_sys_path [get_env_param ADI_PROJECT_DIR ""]mem_init_sys.txt;
+
 #system ID
 ad_ip_parameter axi_sysid_0 CONFIG.ROM_ADDR_BITS 9
-ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "[pwd]/mem_init_sys.txt"
+ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "[pwd]/$mem_init_sys_path"
 ad_ip_parameter rom_sys_0 CONFIG.ROM_ADDR_BITS 9
 
 sysid_gen_sys_init_file

--- a/projects/ad7616_sdz/zed/system_project.tcl
+++ b/projects/ad7616_sdz/zed/system_project.tcl
@@ -1,4 +1,3 @@
-
 source ../../../scripts/adi_env.tcl
 source $ad_hdl_dir/projects/scripts/adi_project_xilinx.tcl
 source $ad_hdl_dir/projects/scripts/adi_board.tcl

--- a/projects/ad77681evb/zed/system_bd.tcl
+++ b/projects/ad77681evb/zed/system_bd.tcl
@@ -1,10 +1,11 @@
-
 source $ad_hdl_dir/projects/common/zed/zed_system_bd.tcl
 source $ad_hdl_dir/projects/scripts/adi_pd.tcl
 
+set mem_init_sys_path [get_env_param ADI_PROJECT_DIR ""]mem_init_sys.txt;
+
 #system ID
 ad_ip_parameter axi_sysid_0 CONFIG.ROM_ADDR_BITS 9
-ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "[pwd]/mem_init_sys.txt"
+ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "[pwd]/$mem_init_sys_path"
 ad_ip_parameter rom_sys_0 CONFIG.ROM_ADDR_BITS 9
 
 sysid_gen_sys_init_file

--- a/projects/ad77681evb/zed/system_project.tcl
+++ b/projects/ad77681evb/zed/system_project.tcl
@@ -1,4 +1,3 @@
-
 source ../../../scripts/adi_env.tcl
 source $ad_hdl_dir/projects/scripts/adi_project_xilinx.tcl
 source $ad_hdl_dir/projects/scripts/adi_board.tcl

--- a/projects/ad7768evb/zed/system_bd.tcl
+++ b/projects/ad7768evb/zed/system_bd.tcl
@@ -1,10 +1,11 @@
-
 source $ad_hdl_dir/projects/common/zed/zed_system_bd.tcl
 source $ad_hdl_dir/projects/scripts/adi_pd.tcl
 
+set mem_init_sys_path [get_env_param ADI_PROJECT_DIR ""]mem_init_sys.txt;
+
 #system ID
 ad_ip_parameter axi_sysid_0 CONFIG.ROM_ADDR_BITS 9
-ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "[pwd]/mem_init_sys.txt"
+ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "[pwd]/$mem_init_sys_path"
 ad_ip_parameter rom_sys_0 CONFIG.ROM_ADDR_BITS 9
 
 sysid_gen_sys_init_file

--- a/projects/ad7768evb/zed/system_project.tcl
+++ b/projects/ad7768evb/zed/system_project.tcl
@@ -1,4 +1,3 @@
-
 source ../../../scripts/adi_env.tcl
 source $ad_hdl_dir/projects/scripts/adi_project_xilinx.tcl
 source $ad_hdl_dir/projects/scripts/adi_board.tcl

--- a/projects/ad777x_ardz/de10nano/system_qsys.tcl
+++ b/projects/ad777x_ardz/de10nano/system_qsys.tcl
@@ -1,8 +1,13 @@
 source $ad_hdl_dir/projects/scripts/adi_pd.tcl
 source $ad_hdl_dir/projects/common/de10nano/de10nano_system_qsys.tcl
-source ../common/ad777x_ardz_qsys.tcl
-set_instance_parameter_value sys_spi {clockPolarity} {0}
 
+if [info exists ad_project_dir] {
+  source ../../common/ad777x_ardz_qsys.tcl
+} else {
+  source ../common/ad777x_ardz_qsys.tcl
+}
+
+set_instance_parameter_value sys_spi {clockPolarity} {0}
 
 #system ID
 set_instance_parameter_value axi_sysid_0 {ROM_ADDR_BITS} {9}

--- a/projects/ad777x_ardz/zed/system_bd.tcl
+++ b/projects/ad777x_ardz/zed/system_bd.tcl
@@ -2,9 +2,11 @@ source $ad_hdl_dir/projects/common/zed/zed_system_bd.tcl
 source ../common/ad777x_ardz_bd.tcl
 source $ad_hdl_dir/projects/scripts/adi_pd.tcl
 
+set mem_init_sys_path [get_env_param ADI_PROJECT_DIR ""]mem_init_sys.txt;
+
 #system ID
 ad_ip_parameter axi_sysid_0 CONFIG.ROM_ADDR_BITS 9
-ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "[pwd]/mem_init_sys.txt"
+ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "[pwd]/$mem_init_sys_path"
 ad_ip_parameter rom_sys_0 CONFIG.ROM_ADDR_BITS 9
 
 sysid_gen_sys_init_file

--- a/projects/ad9081_fmca_ebz/a10soc/system_project.tcl
+++ b/projects/ad9081_fmca_ebz/a10soc/system_project.tcl
@@ -1,4 +1,3 @@
-
 source ../../../scripts/adi_env.tcl
 source ../../scripts/adi_project_intel.tcl
 
@@ -48,7 +47,7 @@ source $ad_hdl_dir/projects/common/a10soc/a10soc_system_assign.tcl
 
 # files
 
-set_global_assignment -name VERILOG_FILE ../../../library/common/ad_3w_spi.v
+set_global_assignment -name VERILOG_FILE $ad_hdl_dir/library/common/ad_3w_spi.v
 
 
 # Note: This projects requires a hardware rework to function correctly.

--- a/projects/ad9081_fmca_ebz/a10soc/system_qsys.tcl
+++ b/projects/ad9081_fmca_ebz/a10soc/system_qsys.tcl
@@ -8,7 +8,12 @@ source $ad_hdl_dir/projects/scripts/adi_pd.tcl
 source $ad_hdl_dir/projects/common/a10soc/a10soc_system_qsys.tcl
 source $ad_hdl_dir/projects/common/intel/dacfifo_qsys.tcl
 source $ad_hdl_dir/projects/common/intel/adcfifo_qsys.tcl
-source ../common/ad9081_fmca_ebz_qsys.tcl
+
+if [info exists ad_project_dir] {
+  source ../../common/ad9081_fmca_ebz_qsys.tcl
+} else {
+  source ../common/ad9081_fmca_ebz_qsys.tcl
+}
 
 #system ID
 set_instance_parameter_value axi_sysid_0 {ROM_ADDR_BITS} {9}

--- a/projects/ad9081_fmca_ebz/vck190/system_bd.tcl
+++ b/projects/ad9081_fmca_ebz/vck190/system_bd.tcl
@@ -1,4 +1,3 @@
-
 ## ADC FIFO depth in samples per converter
 set adc_fifo_samples_per_converter [expr $ad_project_params(RX_KS_PER_CHANNEL)*1024]
 ## DAC FIFO depth in samples per converter
@@ -14,9 +13,11 @@ set ADI_PHY_SEL 0
 source $ad_hdl_dir/projects/ad9081_fmca_ebz/common/ad9081_fmca_ebz_bd.tcl
 source $ad_hdl_dir/projects/scripts/adi_pd.tcl
 
+set mem_init_sys_path [get_env_param ADI_PROJECT_DIR ""]mem_init_sys.txt;
+
 #system ID
 ad_ip_parameter axi_sysid_0 CONFIG.ROM_ADDR_BITS 9
-ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "[pwd]/mem_init_sys.txt"
+ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "[pwd]/$mem_init_sys_path"
 ad_ip_parameter rom_sys_0 CONFIG.ROM_ADDR_BITS 9
 
 sysid_gen_sys_init_file

--- a/projects/ad9081_fmca_ebz/vck190/system_project.tcl
+++ b/projects/ad9081_fmca_ebz/vck190/system_project.tcl
@@ -1,4 +1,3 @@
-
 source ../../../scripts/adi_env.tcl
 source $ad_hdl_dir/projects/scripts/adi_project_xilinx.tcl
 source $ad_hdl_dir/projects/scripts/adi_board.tcl

--- a/projects/ad9081_fmca_ebz/vcu118/system_bd.tcl
+++ b/projects/ad9081_fmca_ebz/vcu118/system_bd.tcl
@@ -1,4 +1,3 @@
-
 ## ADC FIFO depth in samples per converter
 set adc_fifo_samples_per_converter [expr $ad_project_params(RX_KS_PER_CHANNEL)*1024]
 ## DAC FIFO depth in samples per converter
@@ -13,9 +12,11 @@ source $ad_hdl_dir/projects/scripts/adi_pd.tcl
 ad_ip_parameter axi_mxfe_rx_jesd/rx CONFIG.NUM_INPUT_PIPELINE 2
 ad_ip_parameter axi_mxfe_tx_jesd/tx CONFIG.NUM_OUTPUT_PIPELINE 1
 
+set mem_init_sys_path [get_env_param ADI_PROJECT_DIR ""]mem_init_sys.txt;
+
 #system ID
 ad_ip_parameter axi_sysid_0 CONFIG.ROM_ADDR_BITS 9
-ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "[pwd]/mem_init_sys.txt"
+ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "[pwd]/$mem_init_sys_path"
 ad_ip_parameter rom_sys_0 CONFIG.ROM_ADDR_BITS 9
 
 sysid_gen_sys_init_file

--- a/projects/ad9081_fmca_ebz/vcu118/system_project.tcl
+++ b/projects/ad9081_fmca_ebz/vcu118/system_project.tcl
@@ -1,4 +1,3 @@
-
 source ../../../scripts/adi_env.tcl
 source $ad_hdl_dir/projects/scripts/adi_project_xilinx.tcl
 source $ad_hdl_dir/projects/scripts/adi_board.tcl

--- a/projects/ad9081_fmca_ebz/vcu128/system_bd.tcl
+++ b/projects/ad9081_fmca_ebz/vcu128/system_bd.tcl
@@ -1,4 +1,3 @@
-
 ## ADC FIFO depth in samples per converter
 set adc_fifo_samples_per_converter [expr $ad_project_params(RX_KS_PER_CHANNEL)*1024]
 ## DAC FIFO depth in samples per converter
@@ -25,9 +24,11 @@ ad_connect HBM/APB_0_PRESET_N $sys_cpu_resetn
 ad_ip_parameter axi_mxfe_rx_jesd/rx CONFIG.NUM_INPUT_PIPELINE 2
 ad_ip_parameter axi_mxfe_tx_jesd/tx CONFIG.NUM_OUTPUT_PIPELINE 1
 
+set mem_init_sys_path [get_env_param ADI_PROJECT_DIR ""]mem_init_sys.txt;
+
 #system ID
 ad_ip_parameter axi_sysid_0 CONFIG.ROM_ADDR_BITS 9
-ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "[pwd]/mem_init_sys.txt"
+ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "[pwd]/$mem_init_sys_path"
 ad_ip_parameter rom_sys_0 CONFIG.ROM_ADDR_BITS 9
 
 sysid_gen_sys_init_file

--- a/projects/ad9081_fmca_ebz/vcu128/system_project.tcl
+++ b/projects/ad9081_fmca_ebz/vcu128/system_project.tcl
@@ -1,4 +1,3 @@
-
 source ../../../scripts/adi_env.tcl
 source $ad_hdl_dir/projects/scripts/adi_project_xilinx.tcl
 source $ad_hdl_dir/projects/scripts/adi_board.tcl

--- a/projects/ad9081_fmca_ebz/zc706/system_bd.tcl
+++ b/projects/ad9081_fmca_ebz/zc706/system_bd.tcl
@@ -1,4 +1,3 @@
-
 ## ADC FIFO depth in samples per converter
 set adc_fifo_samples_per_converter [expr 32*1024]
 ## DAC FIFO depth in samples per converter
@@ -11,9 +10,11 @@ source $ad_hdl_dir/projects/ad9081_fmca_ebz/common/ad9081_fmca_ebz_bd.tcl
 
 source $ad_hdl_dir/projects/scripts/adi_pd.tcl
 
+set mem_init_sys_path [get_env_param ADI_PROJECT_DIR ""]mem_init_sys.txt;
+
 #system ID
 ad_ip_parameter axi_sysid_0 CONFIG.ROM_ADDR_BITS 9
-ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "[pwd]/mem_init_sys.txt"
+ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "[pwd]/$mem_init_sys_path"
 ad_ip_parameter rom_sys_0 CONFIG.ROM_ADDR_BITS 9
 
 sysid_gen_sys_init_file

--- a/projects/ad9081_fmca_ebz/zcu102/system_bd.tcl
+++ b/projects/ad9081_fmca_ebz/zcu102/system_bd.tcl
@@ -1,4 +1,3 @@
-
 ## ADC FIFO depth in samples per converter
 set adc_fifo_samples_per_converter [expr 64*1024]
 ## DAC FIFO depth in samples per converter
@@ -14,9 +13,11 @@ ad_mem_hp0_interconnect $sys_cpu_clk sys_ps8/S_AXI_HP0
 source $ad_hdl_dir/projects/ad9081_fmca_ebz/common/ad9081_fmca_ebz_bd.tcl
 source $ad_hdl_dir/projects/scripts/adi_pd.tcl
 
+set mem_init_sys_path [get_env_param ADI_PROJECT_DIR ""]mem_init_sys.txt;
+
 #system ID
 ad_ip_parameter axi_sysid_0 CONFIG.ROM_ADDR_BITS 9
-ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "[pwd]/mem_init_sys.txt"
+ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "[pwd]/$mem_init_sys_path"
 ad_ip_parameter rom_sys_0 CONFIG.ROM_ADDR_BITS 9
 
 sysid_gen_sys_init_file

--- a/projects/ad9081_fmca_ebz/zcu102/system_project.tcl
+++ b/projects/ad9081_fmca_ebz/zcu102/system_project.tcl
@@ -1,4 +1,3 @@
-
 source ../../../scripts/adi_env.tcl
 source $ad_hdl_dir/projects/scripts/adi_project_xilinx.tcl
 source $ad_hdl_dir/projects/scripts/adi_board.tcl

--- a/projects/ad9082_fmca_ebz/vcu118/system_bd.tcl
+++ b/projects/ad9082_fmca_ebz/vcu118/system_bd.tcl
@@ -1,3 +1,1 @@
-
 source $ad_hdl_dir/projects/ad9081_fmca_ebz/vcu118/system_bd.tcl
-

--- a/projects/ad9082_fmca_ebz/vcu118/system_project.tcl
+++ b/projects/ad9082_fmca_ebz/vcu118/system_project.tcl
@@ -1,4 +1,3 @@
-
 source ../../../scripts/adi_env.tcl
 source $ad_hdl_dir/projects/scripts/adi_project_xilinx.tcl
 source $ad_hdl_dir/projects/scripts/adi_board.tcl

--- a/projects/ad9082_fmca_ebz/zcu102/system_bd.tcl
+++ b/projects/ad9082_fmca_ebz/zcu102/system_bd.tcl
@@ -1,3 +1,2 @@
-
 source $ad_hdl_dir/projects/ad9081_fmca_ebz/zcu102/system_bd.tcl
 

--- a/projects/ad9082_fmca_ebz/zcu102/system_project.tcl
+++ b/projects/ad9082_fmca_ebz/zcu102/system_project.tcl
@@ -1,4 +1,3 @@
-
 source ../../../scripts/adi_env.tcl
 source $ad_hdl_dir/projects/scripts/adi_project_xilinx.tcl
 source $ad_hdl_dir/projects/scripts/adi_board.tcl

--- a/projects/ad9083_evb/a10soc/system_project.tcl
+++ b/projects/ad9083_evb/a10soc/system_project.tcl
@@ -1,4 +1,3 @@
-
 source ../../../scripts/adi_env.tcl
 source ../../scripts/adi_project_intel.tcl
 
@@ -8,7 +7,7 @@ source $ad_hdl_dir/projects/common/a10soc/a10soc_system_assign.tcl
 
 # files
 
-set_global_assignment -name VERILOG_FILE ../../../library/common/ad_3w_spi.v
+set_global_assignment -name VERILOG_FILE $ad_hdl_dir/library/common/ad_3w_spi.v
 
 # lane interface
 

--- a/projects/ad9083_evb/a10soc/system_qsys.tcl
+++ b/projects/ad9083_evb/a10soc/system_qsys.tcl
@@ -1,11 +1,15 @@
-
 set adc_fifo_address_width 8
 
 source $ad_hdl_dir/projects/scripts/adi_pd.tcl
 source $ad_hdl_dir/projects/common/a10soc/a10soc_system_qsys.tcl
 source $ad_hdl_dir/projects/common/a10soc/a10soc_plddr4_dacfifo_qsys.tcl
 source $ad_hdl_dir/projects/common/intel/adcfifo_qsys.tcl
-source ../common/ad9083_evb_qsys.tcl
+
+if [info exists ad_project_dir] {
+  source ../../common/ad9083_evb_qsys.tcl
+} else {
+  source ../common/ad9083_evb_qsys.tcl
+}
 
 #system ID
 set_instance_parameter_value axi_sysid_0 {ROM_ADDR_BITS} {9}

--- a/projects/ad9083_evb/zcu102/system_bd.tcl
+++ b/projects/ad9083_evb/zcu102/system_bd.tcl
@@ -1,11 +1,12 @@
-
 source $ad_hdl_dir/projects/common/zcu102/zcu102_system_bd.tcl
 source ../common/ad9083_evb_bd.tcl
 source $ad_hdl_dir/projects/scripts/adi_pd.tcl
 
+set mem_init_sys_path [get_env_param ADI_PROJECT_DIR ""]mem_init_sys.txt;
+
 #system ID
 ad_ip_parameter axi_sysid_0 CONFIG.ROM_ADDR_BITS 9
-ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "[pwd]/mem_init_sys.txt"
+ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "[pwd]/$mem_init_sys_path"
 ad_ip_parameter rom_sys_0 CONFIG.ROM_ADDR_BITS 9
 set sys_cstring "RX_NUM_OF_LANES=$RX_NUM_OF_LANES \
 RX_NUM_OF_CONVERTERS=$RX_NUM_OF_CONVERTERS \

--- a/projects/ad9083_evb/zcu102/system_project.tcl
+++ b/projects/ad9083_evb/zcu102/system_project.tcl
@@ -1,4 +1,3 @@
-
 source ../../../scripts/adi_env.tcl
 source $ad_hdl_dir/projects/scripts/adi_project_xilinx.tcl
 source $ad_hdl_dir/projects/scripts/adi_board.tcl

--- a/projects/ad9208_dual_ebz/vcu118/system_bd.tcl
+++ b/projects/ad9208_dual_ebz/vcu118/system_bd.tcl
@@ -1,4 +1,3 @@
-
 ## FIFO depth is 4Mb - 250k samples (65k samples per converter)
 set adc_fifo_address_width 13
 
@@ -7,9 +6,11 @@ source $ad_hdl_dir/projects/common/xilinx/adcfifo_bd.tcl
 source ../common/dual_ad9208_bd.tcl
 source $ad_hdl_dir/projects/scripts/adi_pd.tcl
 
+set mem_init_sys_path [get_env_param ADI_PROJECT_DIR ""]mem_init_sys.txt;
+
 #system ID
 ad_ip_parameter axi_sysid_0 CONFIG.ROM_ADDR_BITS 9
-ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "[pwd]/mem_init_sys.txt"
+ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "[pwd]/$mem_init_sys_path"
 ad_ip_parameter rom_sys_0 CONFIG.ROM_ADDR_BITS 9
 
 sysid_gen_sys_init_file

--- a/projects/ad9208_dual_ebz/vcu118/system_project.tcl
+++ b/projects/ad9208_dual_ebz/vcu118/system_project.tcl
@@ -1,4 +1,3 @@
-
 source ../../../scripts/adi_env.tcl
 source $ad_hdl_dir/projects/scripts/adi_project_xilinx.tcl
 source $ad_hdl_dir/projects/scripts/adi_board.tcl

--- a/projects/ad9213_dual_ebz/s10soc/system_project.tcl
+++ b/projects/ad9213_dual_ebz/s10soc/system_project.tcl
@@ -1,4 +1,3 @@
-
 source ../../../scripts/adi_env.tcl
 source ../../scripts/adi_project_intel.tcl
 
@@ -8,7 +7,7 @@ source $ad_hdl_dir/projects/common/s10soc/s10soc_system_assign.tcl
 
 # verilog file for top instantiations
 
-set_global_assignment -name VERILOG_FILE ../../../library/common/ad_3w_spi.v
+set_global_assignment -name VERILOG_FILE $ad_hdl_dir/library/common/ad_3w_spi.v
 
 ################################################################################
 ## FMCB+ location assignments (connector P1 on the FMC board)

--- a/projects/ad9213_dual_ebz/s10soc/system_qsys.tcl
+++ b/projects/ad9213_dual_ebz/s10soc/system_qsys.tcl
@@ -3,4 +3,9 @@ set adc_fifo_address_width 15
 
 source $ad_hdl_dir/projects/common/s10soc/s10soc_system_qsys.tcl
 source $ad_hdl_dir/projects/common/intel/adcfifo_qsys.tcl
-source ../common/ad9213_dual_qsys.tcl
+
+if [info exists ad_project_dir] {
+  source ../../common/ad9213_dual_qsys.tcl
+} else {
+  source ../common/ad9213_dual_qsys.tcl
+}

--- a/projects/ad9265_fmc/zc706/system_bd.tcl
+++ b/projects/ad9265_fmc/zc706/system_bd.tcl
@@ -1,11 +1,12 @@
-
 source $ad_hdl_dir/projects/common/zc706/zc706_system_bd.tcl
 source ../common/ad9265_bd.tcl
 source $ad_hdl_dir/projects/scripts/adi_pd.tcl
 
+set mem_init_sys_path [get_env_param ADI_PROJECT_DIR ""]mem_init_sys.txt;
+
 #system ID
 ad_ip_parameter axi_sysid_0 CONFIG.ROM_ADDR_BITS 9
-ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "[pwd]/mem_init_sys.txt"
+ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "[pwd]/$mem_init_sys_path"
 ad_ip_parameter rom_sys_0 CONFIG.ROM_ADDR_BITS 9
 
 sysid_gen_sys_init_file

--- a/projects/ad9434_fmc/zc706/system_bd.tcl
+++ b/projects/ad9434_fmc/zc706/system_bd.tcl
@@ -1,11 +1,12 @@
-
 source $ad_hdl_dir/projects/common/zc706/zc706_system_bd.tcl
 source ../common/ad9434_bd.tcl
 source $ad_hdl_dir/projects/scripts/adi_pd.tcl
 
+set mem_init_sys_path [get_env_param ADI_PROJECT_DIR ""]mem_init_sys.txt;
+
 #system ID
 ad_ip_parameter axi_sysid_0 CONFIG.ROM_ADDR_BITS 9
-ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "[pwd]/mem_init_sys.txt"
+ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "[pwd]/$mem_init_sys_path"
 ad_ip_parameter rom_sys_0 CONFIG.ROM_ADDR_BITS 9
 
 sysid_gen_sys_init_file

--- a/projects/ad9434_fmc/zc706/system_project.tcl
+++ b/projects/ad9434_fmc/zc706/system_project.tcl
@@ -1,4 +1,3 @@
-
 source ../../../scripts/adi_env.tcl
 source $ad_hdl_dir/projects/scripts/adi_project_xilinx.tcl
 source $ad_hdl_dir/projects/scripts/adi_board.tcl

--- a/projects/ad9467_fmc/kc705/system_bd.tcl
+++ b/projects/ad9467_fmc/kc705/system_bd.tcl
@@ -1,11 +1,12 @@
-
 source $ad_hdl_dir/projects/common/kc705/kc705_system_bd.tcl
 source ../common/ad9467_bd.tcl
 source $ad_hdl_dir/projects/scripts/adi_pd.tcl
 
+set mem_init_sys_path [get_env_param ADI_PROJECT_DIR ""]mem_init_sys.txt;
+
 #system ID
 ad_ip_parameter axi_sysid_0 CONFIG.ROM_ADDR_BITS 9
-ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "[pwd]/mem_init_sys.txt"
+ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "[pwd]/$mem_init_sys_path"
 ad_ip_parameter rom_sys_0 CONFIG.ROM_ADDR_BITS 9
 
 sysid_gen_sys_init_file

--- a/projects/ad9467_fmc/zed/system_bd.tcl
+++ b/projects/ad9467_fmc/zed/system_bd.tcl
@@ -1,11 +1,12 @@
-
 source $ad_hdl_dir/projects/common/zed/zed_system_bd.tcl
 source ../common/ad9467_bd.tcl
 source $ad_hdl_dir/projects/scripts/adi_pd.tcl
 
+set mem_init_sys_path [get_env_param ADI_PROJECT_DIR ""]mem_init_sys.txt;
+
 #system ID
 ad_ip_parameter axi_sysid_0 CONFIG.ROM_ADDR_BITS 9
-ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "[pwd]/mem_init_sys.txt"
+ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "[pwd]/$mem_init_sys_path"
 ad_ip_parameter rom_sys_0 CONFIG.ROM_ADDR_BITS 9
 
 sysid_gen_sys_init_file

--- a/projects/ad9656_fmc/zcu102/system_bd.tcl
+++ b/projects/ad9656_fmc/zcu102/system_bd.tcl
@@ -1,10 +1,11 @@
-
 source $ad_hdl_dir/projects/common/zcu102/zcu102_system_bd.tcl
 source $ad_hdl_dir/projects/scripts/adi_pd.tcl
 
+set mem_init_sys_path [get_env_param ADI_PROJECT_DIR ""]mem_init_sys.txt;
+
 #system ID
 ad_ip_parameter axi_sysid_0 CONFIG.ROM_ADDR_BITS 9
-ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "[pwd]/mem_init_sys.txt"
+ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "[pwd]/$mem_init_sys_path"
 ad_ip_parameter rom_sys_0 CONFIG.ROM_ADDR_BITS 9
 sysid_gen_sys_init_file
 

--- a/projects/ad9656_fmc/zcu102/system_project.tcl
+++ b/projects/ad9656_fmc/zcu102/system_project.tcl
@@ -1,4 +1,3 @@
-
 source ../../../scripts/adi_env.tcl
 source $ad_hdl_dir/projects/scripts/adi_project_xilinx.tcl
 source $ad_hdl_dir/projects/scripts/adi_board.tcl

--- a/projects/ad9695_fmc/zcu102/system_bd.tcl
+++ b/projects/ad9695_fmc/zcu102/system_bd.tcl
@@ -1,11 +1,12 @@
-
 source $ad_hdl_dir/projects/common/zcu102/zcu102_system_bd.tcl
 source ../common/ad9695_fmc_bd.tcl
 source $ad_hdl_dir/projects/scripts/adi_pd.tcl
 
+set mem_init_sys_path [get_env_param ADI_PROJECT_DIR ""]mem_init_sys.txt;
+
 #system ID
 ad_ip_parameter axi_sysid_0 CONFIG.ROM_ADDR_BITS 9
-ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "[pwd]/mem_init_sys.txt"
+ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "[pwd]/$mem_init_sys_path"
 ad_ip_parameter rom_sys_0 CONFIG.ROM_ADDR_BITS 9
 set sys_cstring "sys rom custom string placeholder"
 sysid_gen_sys_init_file $sys_cstring

--- a/projects/ad9695_fmc/zcu102/system_project.tcl
+++ b/projects/ad9695_fmc/zcu102/system_project.tcl
@@ -1,4 +1,3 @@
-
 source ../../../scripts/adi_env.tcl
 source $ad_hdl_dir/projects/scripts/adi_project_xilinx.tcl
 source $ad_hdl_dir/projects/scripts/adi_board.tcl

--- a/projects/ad9739a_fmc/zc706/system_bd.tcl
+++ b/projects/ad9739a_fmc/zc706/system_bd.tcl
@@ -1,11 +1,12 @@
-
 source $ad_hdl_dir/projects/common/zc706/zc706_system_bd.tcl
 source ../common/ad9739a_fmc_bd.tcl
 source $ad_hdl_dir/projects/scripts/adi_pd.tcl
 
+set mem_init_sys_path [get_env_param ADI_PROJECT_DIR ""]mem_init_sys.txt;
+
 #system ID
 ad_ip_parameter axi_sysid_0 CONFIG.ROM_ADDR_BITS 9
-ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "[pwd]/mem_init_sys.txt"
+ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "[pwd]/$mem_init_sys_path"
 ad_ip_parameter rom_sys_0 CONFIG.ROM_ADDR_BITS 9
 
 sysid_gen_sys_init_file

--- a/projects/ad9739a_fmc/zc706/system_project.tcl
+++ b/projects/ad9739a_fmc/zc706/system_project.tcl
@@ -1,6 +1,3 @@
-
-
-
 source ../../../scripts/adi_env.tcl
 source $ad_hdl_dir/projects/scripts/adi_project_xilinx.tcl
 source $ad_hdl_dir/projects/scripts/adi_board.tcl

--- a/projects/ad9783_ebz/zcu102/system_bd.tcl
+++ b/projects/ad9783_ebz/zcu102/system_bd.tcl
@@ -1,11 +1,12 @@
-
 source $ad_hdl_dir/projects/common/zcu102/zcu102_system_bd.tcl
 source ../common/ad9783_ebz_bd.tcl
 source $ad_hdl_dir/projects/scripts/adi_pd.tcl
 
+set mem_init_sys_path [get_env_param ADI_PROJECT_DIR ""]mem_init_sys.txt;
+
 #system ID
 ad_ip_parameter axi_sysid_0 CONFIG.ROM_ADDR_BITS 9
-ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "[pwd]/mem_init_sys.txt"
+ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "[pwd]/$mem_init_sys_path"
 ad_ip_parameter rom_sys_0 CONFIG.ROM_ADDR_BITS 9
 
 sysid_gen_sys_init_file

--- a/projects/ad9783_ebz/zcu102/system_project.tcl
+++ b/projects/ad9783_ebz/zcu102/system_project.tcl
@@ -1,4 +1,3 @@
-
 source ../../../scripts/adi_env.tcl
 source $ad_hdl_dir/projects/scripts/adi_project_xilinx.tcl
 source $ad_hdl_dir/projects/scripts/adi_board.tcl

--- a/projects/ad_fmclidar1_ebz/a10soc/system_project.tcl
+++ b/projects/ad_fmclidar1_ebz/a10soc/system_project.tcl
@@ -1,4 +1,3 @@
-
 source ../../../scripts/adi_env.tcl
 source ../../scripts/adi_project_intel.tcl
 
@@ -8,9 +7,9 @@ source $ad_hdl_dir/projects/common/a10soc/a10soc_system_assign.tcl
 
 # files
 
-set_global_assignment -name VERILOG_FILE ../common/util_tia_chsel.v
-set_global_assignment -name VERILOG_FILE ../common/util_axis_syncgen.v
-set_global_assignment -name VERILOG_FILE ../../../library/util_cdc/sync_bits.v
+set_global_assignment -name VERILOG_FILE $ad_hdl_dir/projects/ad_fmclidar1_ebz/common/util_tia_chsel.v
+set_global_assignment -name VERILOG_FILE $ad_hdl_dir/projects/ad_fmclidar1_ebz/common/util_axis_syncgen.v
+set_global_assignment -name VERILOG_FILE $ad_hdl_dir/library/util_cdc/sync_bits.v
 
 #
 # Note: This project requires a hardware rework to function correctly.

--- a/projects/ad_fmclidar1_ebz/a10soc/system_qsys.tcl
+++ b/projects/ad_fmclidar1_ebz/a10soc/system_qsys.tcl
@@ -9,7 +9,13 @@ set ADC_RESOLUTION 8            ; # N & NP
 set LANE_RATE [expr {($ADC_RESOLUTION * $NUM_OF_CHANNELS *$SAMPLE_RATE_MHZ * 1.25) / $NUM_OF_LANES}]
 
 source $ad_hdl_dir/projects/common/a10soc/a10soc_system_qsys.tcl
-source ../common/ad_fmclidar1_ebz_qsys.tcl
+
+if [info exists ad_project_dir] {
+  source ../../common/ad_fmclidar1_ebz_qsys.tcl
+} else {
+  source ../common/ad_fmclidar1_ebz_qsys.tcl
+}
+
 source $ad_hdl_dir/projects/scripts/adi_pd.tcl
 
 #system ID

--- a/projects/ad_fmclidar1_ebz/zc706/system_bd.tcl
+++ b/projects/ad_fmclidar1_ebz/zc706/system_bd.tcl
@@ -1,4 +1,3 @@
-
 # Configurable parameters
 
 set SAMPLE_RATE_MHZ 1000.0
@@ -36,9 +35,11 @@ ad_ip_parameter sys_ps7 CONFIG.PCW_I2C1_PERIPHERAL_ENABLE 1
 
 ad_connect iic_dac sys_ps7/IIC_1
 
+set mem_init_sys_path [get_env_param ADI_PROJECT_DIR ""]mem_init_sys.txt;
+
 # System ID instance and configuration
 ad_ip_parameter axi_sysid_0 CONFIG.ROM_ADDR_BITS 9
-ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "[pwd]/mem_init_sys.txt"
+ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "[pwd]/$mem_init_sys_path"
 ad_ip_parameter rom_sys_0 CONFIG.ROM_ADDR_BITS 9
 
 sysid_gen_sys_init_file

--- a/projects/ad_fmclidar1_ebz/zcu102/system_bd.tcl
+++ b/projects/ad_fmclidar1_ebz/zcu102/system_bd.tcl
@@ -1,4 +1,3 @@
-
 # Configurable parameters
 
 set SAMPLE_RATE_MHZ 1000.0
@@ -38,9 +37,11 @@ ad_cpu_interconnect 0x7c800000 afe_dac_iic
 
 ad_cpu_interrupt ps-12  mb-14  afe_dac_iic/iic2intc_irpt
 
+set mem_init_sys_path [get_env_param ADI_PROJECT_DIR ""]mem_init_sys.txt;
+
 # System ID instance and configuration
 ad_ip_parameter axi_sysid_0 CONFIG.ROM_ADDR_BITS 9
-ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "[pwd]/mem_init_sys.txt"
+ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "[pwd]/$mem_init_sys_path"
 ad_ip_parameter rom_sys_0 CONFIG.ROM_ADDR_BITS 9
 
 sysid_gen_sys_init_file

--- a/projects/ad_quadmxfe1_ebz/vcu118/system_bd.tcl
+++ b/projects/ad_quadmxfe1_ebz/vcu118/system_bd.tcl
@@ -1,4 +1,3 @@
-
 ## ADC FIFO depth in samples per converter
 set adc_fifo_samples_per_converter [expr $ad_project_params(RX_KS_PER_CHANNEL)*1024]
 ## DAC FIFO depth in samples per converter
@@ -13,9 +12,11 @@ source $ad_hdl_dir/projects/scripts/adi_pd.tcl
 # Set SPI clock to 100/16 =  6.25 MHz
 ad_ip_parameter axi_spi CONFIG.C_SCK_RATIO 16
 
+set mem_init_sys_path [get_env_param ADI_PROJECT_DIR ""]mem_init_sys.txt;
+
 #system ID
 ad_ip_parameter axi_sysid_0 CONFIG.ROM_ADDR_BITS 9
-ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "[pwd]/mem_init_sys.txt"
+ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "[pwd]/$mem_init_sys_path"
 ad_ip_parameter rom_sys_0 CONFIG.ROM_ADDR_BITS 9
 set sys_cstring "sys rom custom string placeholder"
 sysid_gen_sys_init_file $sys_cstring

--- a/projects/ad_quadmxfe1_ebz/vcu118/system_project.tcl
+++ b/projects/ad_quadmxfe1_ebz/vcu118/system_project.tcl
@@ -1,4 +1,3 @@
-
 source ../../../scripts/adi_env.tcl
 source $ad_hdl_dir/projects/scripts/adi_project_xilinx.tcl
 source $ad_hdl_dir/projects/scripts/adi_board.tcl

--- a/projects/adaq7980_sdz/zed/system_bd.tcl
+++ b/projects/adaq7980_sdz/zed/system_bd.tcl
@@ -1,10 +1,11 @@
-
 source $ad_hdl_dir/projects/common/zed/zed_system_bd.tcl
 source $ad_hdl_dir/projects/scripts/adi_pd.tcl
 
+set mem_init_sys_path [get_env_param ADI_PROJECT_DIR ""]mem_init_sys.txt;
+
 #system ID
 ad_ip_parameter axi_sysid_0 CONFIG.ROM_ADDR_BITS 9
-ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "[pwd]/mem_init_sys.txt"
+ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "[pwd]/$mem_init_sys_path"
 ad_ip_parameter rom_sys_0 CONFIG.ROM_ADDR_BITS 9
 
 sysid_gen_sys_init_file

--- a/projects/adaq7980_sdz/zed/system_project.tcl
+++ b/projects/adaq7980_sdz/zed/system_project.tcl
@@ -1,4 +1,3 @@
-
 source ../../../scripts/adi_env.tcl
 source $ad_hdl_dir/projects/scripts/adi_project_xilinx.tcl
 source $ad_hdl_dir/projects/scripts/adi_board.tcl

--- a/projects/adaq8092_fmc/zed/system_bd.tcl
+++ b/projects/adaq8092_fmc/zed/system_bd.tcl
@@ -2,9 +2,11 @@ source $ad_hdl_dir/projects/common/zed/zed_system_bd.tcl
 source ../common/adaq8092_bd.tcl
 source $ad_hdl_dir/projects/scripts/adi_pd.tcl
 
+set mem_init_sys_path [get_env_param ADI_PROJECT_DIR ""]mem_init_sys.txt;
+
 #system ID
 ad_ip_parameter axi_sysid_0 CONFIG.ROM_ADDR_BITS 9
-ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "[pwd]/mem_init_sys.txt"
+ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "[pwd]/$mem_init_sys_path"
 ad_ip_parameter rom_sys_0 CONFIG.ROM_ADDR_BITS 9
 
 sysid_gen_sys_init_file

--- a/projects/adrv9001/a10soc/system_project.tcl
+++ b/projects/adrv9001/a10soc/system_project.tcl
@@ -1,4 +1,3 @@
-
 source ../../../scripts/adi_env.tcl
 source ../../scripts/adi_project_intel.tcl
 

--- a/projects/adrv9001/a10soc/system_qsys.tcl
+++ b/projects/adrv9001/a10soc/system_qsys.tcl
@@ -1,6 +1,11 @@
 source $ad_hdl_dir/projects/scripts/adi_pd.tcl
 source $ad_hdl_dir/projects/common/a10soc/a10soc_system_qsys.tcl
-source ../common/adrv9001_qsys.tcl
+
+if [info exists ad_project_dir] {
+  source ../../common/adrv9001_qsys.tcl
+} else {
+  source ../common/adrv9001_qsys.tcl
+}
 
 set_instance_parameter_value sys_spi {clockPolarity} {0}
 

--- a/projects/adrv9001/zc706/system_bd.tcl
+++ b/projects/adrv9001/zc706/system_bd.tcl
@@ -1,11 +1,12 @@
-
 source $ad_hdl_dir/projects/common/zc706/zc706_system_bd.tcl
 source ../common/adrv9001_bd.tcl
 source $ad_hdl_dir/projects/scripts/adi_pd.tcl
 
+set mem_init_sys_path [get_env_param ADI_PROJECT_DIR ""]mem_init_sys.txt;
+
 #system ID
 ad_ip_parameter axi_sysid_0 CONFIG.ROM_ADDR_BITS 9
-ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "[pwd]/mem_init_sys.txt"
+ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "[pwd]/$mem_init_sys_path"
 ad_ip_parameter rom_sys_0 CONFIG.ROM_ADDR_BITS 9
 set sys_cstring "CMOS_LVDS_N=${ad_project_params(CMOS_LVDS_N)}"
 sysid_gen_sys_init_file $sys_cstring

--- a/projects/adrv9001/zc706/system_project.tcl
+++ b/projects/adrv9001/zc706/system_project.tcl
@@ -1,4 +1,3 @@
-
 source ../../../scripts/adi_env.tcl
 source $ad_hdl_dir/projects/scripts/adi_project_xilinx.tcl
 source $ad_hdl_dir/projects/scripts/adi_board.tcl

--- a/projects/adrv9001/zcu102/system_bd.tcl
+++ b/projects/adrv9001/zcu102/system_bd.tcl
@@ -1,13 +1,14 @@
-
 source $ad_hdl_dir/projects/common/zcu102/zcu102_system_bd.tcl
 source ../common/adrv9001_bd.tcl
 source $ad_hdl_dir/projects/scripts/adi_pd.tcl
 
 ad_ip_parameter axi_adrv9001 CONFIG.USE_RX_CLK_FOR_TX [expr $ad_project_params(CMOS_LVDS_N) == 0]
 
+set mem_init_sys_path [get_env_param ADI_PROJECT_DIR ""]mem_init_sys.txt;
+
 #system ID
 ad_ip_parameter axi_sysid_0 CONFIG.ROM_ADDR_BITS 9
-ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "[pwd]/mem_init_sys.txt"
+ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "[pwd]/$mem_init_sys_path"
 ad_ip_parameter rom_sys_0 CONFIG.ROM_ADDR_BITS 9
 set sys_cstring "CMOS_LVDS_N=${ad_project_params(CMOS_LVDS_N)}"
 sysid_gen_sys_init_file $sys_cstring

--- a/projects/adrv9001/zcu102/system_project.tcl
+++ b/projects/adrv9001/zcu102/system_project.tcl
@@ -1,4 +1,3 @@
-
 source ../../../scripts/adi_env.tcl
 source $ad_hdl_dir/projects/scripts/adi_project_xilinx.tcl
 source $ad_hdl_dir/projects/scripts/adi_board.tcl

--- a/projects/adrv9001/zed/system_bd.tcl
+++ b/projects/adrv9001/zed/system_bd.tcl
@@ -1,4 +1,3 @@
-
 source $ad_hdl_dir/projects/common/zed/zed_system_bd.tcl
 source ../common/adrv9001_bd.tcl
 source $ad_hdl_dir/projects/scripts/adi_pd.tcl
@@ -6,9 +5,11 @@ source $ad_hdl_dir/projects/scripts/adi_pd.tcl
 ad_ip_parameter axi_adrv9001 CONFIG.RX_USE_BUFG 1
 ad_ip_parameter axi_adrv9001 CONFIG.TX_USE_BUFG 1
 
+set mem_init_sys_path [get_env_param ADI_PROJECT_DIR ""]mem_init_sys.txt;
+
 #system ID
 ad_ip_parameter axi_sysid_0 CONFIG.ROM_ADDR_BITS 9
-ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "[pwd]/mem_init_sys.txt"
+ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "[pwd]/$mem_init_sys_path"
 ad_ip_parameter rom_sys_0 CONFIG.ROM_ADDR_BITS 9
 
 sysid_gen_sys_init_file

--- a/projects/adrv9001/zed/system_project.tcl
+++ b/projects/adrv9001/zed/system_project.tcl
@@ -1,4 +1,3 @@
-
 source ../../../scripts/adi_env.tcl
 source $ad_hdl_dir/projects/scripts/adi_project_xilinx.tcl
 source $ad_hdl_dir/projects/scripts/adi_board.tcl

--- a/projects/adrv9009/a10gx/system_project.tcl
+++ b/projects/adrv9009/a10gx/system_project.tcl
@@ -1,4 +1,3 @@
-
 source ../../../scripts/adi_env.tcl
 source ../../scripts/adi_project_intel.tcl
 

--- a/projects/adrv9009/a10gx/system_qsys.tcl
+++ b/projects/adrv9009/a10gx/system_qsys.tcl
@@ -1,10 +1,14 @@
-
 set dac_fifo_address_width 10
 
 source $ad_hdl_dir/projects/scripts/adi_pd.tcl
 source $ad_hdl_dir/projects/common/a10gx/a10gx_system_qsys.tcl
 source $ad_hdl_dir/projects/common/intel/dacfifo_qsys.tcl
-source ../common/adrv9009_qsys.tcl
+
+if [info exists ad_project_dir] {
+  source ../../common/adrv9009_qsys.tcl
+} else {
+  source ../common/adrv9009_qsys.tcl
+}
 
 #system ID
 set_instance_parameter_value axi_sysid_0 {ROM_ADDR_BITS} {9}

--- a/projects/adrv9009/a10soc/system_project.tcl
+++ b/projects/adrv9009/a10soc/system_project.tcl
@@ -1,4 +1,3 @@
-
 source ../../../scripts/adi_env.tcl
 source ../../scripts/adi_project_intel.tcl
 

--- a/projects/adrv9009/a10soc/system_qsys.tcl
+++ b/projects/adrv9009/a10soc/system_qsys.tcl
@@ -1,10 +1,14 @@
-
 set dac_fifo_address_width 10
 
 source $ad_hdl_dir/projects/scripts/adi_pd.tcl
 source $ad_hdl_dir/projects/common/a10soc/a10soc_system_qsys.tcl
 source $ad_hdl_dir/projects/common/a10soc/a10soc_plddr4_dacfifo_qsys.tcl
-source ../common/adrv9009_qsys.tcl
+
+if [info exists ad_project_dir] {
+  source ../../common/adrv9009_qsys.tcl
+} else {
+  source ../common/adrv9009_qsys.tcl
+}
 
 #system ID
 set_instance_parameter_value axi_sysid_0 {ROM_ADDR_BITS} {9}

--- a/projects/adrv9009/s10soc/system_project.tcl
+++ b/projects/adrv9009/s10soc/system_project.tcl
@@ -1,4 +1,3 @@
-
 source ../../../scripts/adi_env.tcl
 source ../../scripts/adi_project_intel.tcl
 

--- a/projects/adrv9009/s10soc/system_qsys.tcl
+++ b/projects/adrv9009/s10soc/system_qsys.tcl
@@ -4,4 +4,9 @@ set xcvr_reconfig_addr_width 11
 
 source $ad_hdl_dir/projects/common/s10soc/s10soc_system_qsys.tcl
 source $ad_hdl_dir/projects/common/intel/dacfifo_qsys.tcl
-source ../common/adrv9009_qsys.tcl
+
+if [info exists ad_project_dir] {
+  source ../../common/adrv9009_qsys.tcl
+} else {
+  source ../common/adrv9009_qsys.tcl
+}

--- a/projects/adrv9009/zc706/system_bd.tcl
+++ b/projects/adrv9009/zc706/system_bd.tcl
@@ -1,13 +1,14 @@
-
 set dac_fifo_address_width 10
 
 source $ad_hdl_dir/projects/common/zc706/zc706_system_bd.tcl
 source $ad_hdl_dir/projects/common/zc706/zc706_plddr3_dacfifo_bd.tcl
 source $ad_hdl_dir/projects/scripts/adi_pd.tcl
 
+set mem_init_sys_path [get_env_param ADI_PROJECT_DIR ""]mem_init_sys.txt;
+
 #system ID
 ad_ip_parameter axi_sysid_0 CONFIG.ROM_ADDR_BITS 9
-ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "[pwd]/mem_init_sys.txt"
+ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "[pwd]/$mem_init_sys_path"
 ad_ip_parameter rom_sys_0 CONFIG.ROM_ADDR_BITS 9
 
 sysid_gen_sys_init_file

--- a/projects/adrv9009/zc706/system_project.tcl
+++ b/projects/adrv9009/zc706/system_project.tcl
@@ -1,6 +1,3 @@
-
-
-
 source ../../../scripts/adi_env.tcl
 source $ad_hdl_dir/projects/scripts/adi_project_xilinx.tcl
 source $ad_hdl_dir/projects/scripts/adi_board.tcl

--- a/projects/adrv9009/zcu102/system_bd.tcl
+++ b/projects/adrv9009/zcu102/system_bd.tcl
@@ -1,4 +1,3 @@
-
 ## FIFO depth is 18Mb - 1M samples
 set dac_fifo_address_width 17
 
@@ -8,9 +7,11 @@ source $ad_hdl_dir/projects/common/zcu102/zcu102_system_bd.tcl
 source $ad_hdl_dir/projects/common/xilinx/dacfifo_bd.tcl
 source $ad_hdl_dir/projects/scripts/adi_pd.tcl
 
+set mem_init_sys_path [get_env_param ADI_PROJECT_DIR ""]mem_init_sys.txt;
+
 #system ID
 ad_ip_parameter axi_sysid_0 CONFIG.ROM_ADDR_BITS 9
-ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "[pwd]/mem_init_sys.txt"
+ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "[pwd]/$mem_init_sys_path"
 ad_ip_parameter rom_sys_0 CONFIG.ROM_ADDR_BITS 9
 
 sysid_gen_sys_init_file

--- a/projects/adrv9009/zcu102/system_project.tcl
+++ b/projects/adrv9009/zcu102/system_project.tcl
@@ -1,4 +1,3 @@
-
 source ../../../scripts/adi_env.tcl
 source $ad_hdl_dir/projects/scripts/adi_project_xilinx.tcl
 source $ad_hdl_dir/projects/scripts/adi_board.tcl

--- a/projects/adrv9009zu11eg/adrv2crr_fmc/system_bd.tcl
+++ b/projects/adrv9009zu11eg/adrv2crr_fmc/system_bd.tcl
@@ -1,10 +1,11 @@
-
 source ../common/adrv9009zu11eg_bd.tcl
 source ../common/adrv2crr_fmc_bd.tcl
 source $ad_hdl_dir/projects/scripts/adi_pd.tcl
 
+set mem_init_sys_path [get_env_param ADI_PROJECT_DIR ""]mem_init_sys.txt;
+
 ad_ip_parameter axi_sysid_0 CONFIG.ROM_ADDR_BITS 9
-ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "[pwd]/mem_init_sys.txt"
+ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "[pwd]/$mem_init_sys_path"
 ad_ip_parameter rom_sys_0 CONFIG.ROM_ADDR_BITS 9
 
 sysid_gen_sys_init_file

--- a/projects/adrv9009zu11eg/adrv2crr_fmc/system_project.tcl
+++ b/projects/adrv9009zu11eg/adrv2crr_fmc/system_project.tcl
@@ -1,4 +1,3 @@
-
 source ../../../scripts/adi_env.tcl
 source $ad_hdl_dir/projects/scripts/adi_project_xilinx.tcl
 source $ad_hdl_dir/projects/scripts/adi_board.tcl

--- a/projects/adrv9009zu11eg/adrv2crr_fmcomms8/system_bd.tcl
+++ b/projects/adrv9009zu11eg/adrv2crr_fmcomms8/system_bd.tcl
@@ -75,8 +75,10 @@ ad_xcvrpll  axi_adrv9009_som_rx_xcvr/up_pll_rst util_adrv9009_som_xcvr/up_cpll_r
 ad_xcvrpll  axi_adrv9009_som_obs_xcvr/up_pll_rst util_adrv9009_som_xcvr/up_cpll_rst_14
 ad_xcvrpll  axi_adrv9009_som_obs_xcvr/up_pll_rst util_adrv9009_som_xcvr/up_cpll_rst_15
 
+set mem_init_sys_path [get_env_param ADI_PROJECT_DIR ""]mem_init_sys.txt;
+
 ad_ip_parameter axi_sysid_0 CONFIG.ROM_ADDR_BITS 9
-ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "[pwd]/mem_init_sys.txt"
+ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "[pwd]/$mem_init_sys_path"
 ad_ip_parameter rom_sys_0 CONFIG.ROM_ADDR_BITS 9
 
 sysid_gen_sys_init_file

--- a/projects/adrv9009zu11eg/adrv2crr_fmcomms8/system_project.tcl
+++ b/projects/adrv9009zu11eg/adrv2crr_fmcomms8/system_project.tcl
@@ -1,4 +1,3 @@
-
 source ../../../scripts/adi_env.tcl
 source $ad_hdl_dir/projects/scripts/adi_project_xilinx.tcl
 source $ad_hdl_dir/projects/scripts/adi_board.tcl
@@ -16,7 +15,7 @@ adi_project_create fmcomms8_adrv9009zu11eg 0 [list \
 ] "xczu11eg-ffvf1517-2-i"
 
 
-adi_project_files  fmcomms8_adrv9009zu11eg [list \
+adi_project_files fmcomms8_adrv9009zu11eg [list \
   "system_top.v" \
   "fmcomms8_constr.xdc"\
   "../common/adrv9009zu11eg_spi.v" \

--- a/projects/adrv9009zu11eg/adrv2crr_fmcxmwbr1/system_bd.tcl
+++ b/projects/adrv9009zu11eg/adrv2crr_fmcxmwbr1/system_bd.tcl
@@ -1,10 +1,11 @@
-
 source ../common/adrv9009zu11eg_bd.tcl
 source ../common/adrv2crr_fmc_bd.tcl
 source $ad_hdl_dir/projects/scripts/adi_pd.tcl
 
+set mem_init_sys_path [get_env_param ADI_PROJECT_DIR ""]mem_init_sys.txt;
+
 ad_ip_parameter axi_sysid_0 CONFIG.ROM_ADDR_BITS 9
-ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "[pwd]/mem_init_sys.txt"
+ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "[pwd]/$mem_init_sys_path"
 ad_ip_parameter rom_sys_0 CONFIG.ROM_ADDR_BITS 9
 
 sysid_gen_sys_init_file

--- a/projects/adrv9009zu11eg/adrv2crr_fmcxmwbr1/system_project.tcl
+++ b/projects/adrv9009zu11eg/adrv2crr_fmcxmwbr1/system_project.tcl
@@ -1,4 +1,3 @@
-
 source ../../../scripts/adi_env.tcl
 source $ad_hdl_dir/projects/scripts/adi_project_xilinx.tcl
 source $ad_hdl_dir/projects/scripts/adi_board.tcl

--- a/projects/adrv9009zu11eg/adrv2crr_xmicrowave/system_bd.tcl
+++ b/projects/adrv9009zu11eg/adrv2crr_xmicrowave/system_bd.tcl
@@ -1,10 +1,11 @@
-
 source ../common/adrv9009zu11eg_bd.tcl
 source ../common/adrv2crr_fmc_bd.tcl
 source $ad_hdl_dir/projects/scripts/adi_pd.tcl
 
+set mem_init_sys_path [get_env_param ADI_PROJECT_DIR ""]mem_init_sys.txt;
+
 ad_ip_parameter axi_sysid_0 CONFIG.ROM_ADDR_BITS 9
-ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "[pwd]/mem_init_sys.txt"
+ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "[pwd]/$mem_init_sys_path"
 ad_ip_parameter rom_sys_0 CONFIG.ROM_ADDR_BITS 9
 
 sysid_gen_sys_init_file

--- a/projects/adrv9009zu11eg/adrv2crr_xmicrowave/system_project.tcl
+++ b/projects/adrv9009zu11eg/adrv2crr_xmicrowave/system_project.tcl
@@ -1,4 +1,3 @@
-
 source ../../../scripts/adi_env.tcl
 source $ad_hdl_dir/projects/scripts/adi_project_xilinx.tcl
 source $ad_hdl_dir/projects/scripts/adi_board.tcl

--- a/projects/adrv9361z7035/ccbob_cmos/system_bd.tcl
+++ b/projects/adrv9361z7035/ccbob_cmos/system_bd.tcl
@@ -1,4 +1,3 @@
-
 source ../common/adrv9361z7035_bd.tcl
 source ../common/ccbob_bd.tcl
 source $ad_hdl_dir/projects/scripts/adi_pd.tcl
@@ -10,9 +9,11 @@ cfg_ad9361_interface CMOS
 
 ad_ip_parameter axi_ad9361 CONFIG.ADC_INIT_DELAY 29
 
+set mem_init_sys_path [get_env_param ADI_PROJECT_DIR ""]mem_init_sys.txt;
+
 #system ID
 ad_ip_parameter axi_sysid_0 CONFIG.ROM_ADDR_BITS 9
-ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "[pwd]/mem_init_sys.txt"
+ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "[pwd]/$mem_init_sys_path"
 ad_ip_parameter rom_sys_0 CONFIG.ROM_ADDR_BITS 9
 
 sysid_gen_sys_init_file

--- a/projects/adrv9361z7035/ccbob_cmos/system_project.tcl
+++ b/projects/adrv9361z7035/ccbob_cmos/system_project.tcl
@@ -1,4 +1,3 @@
-
 source ../../../scripts/adi_env.tcl
 source $ad_hdl_dir/projects/scripts/adi_project_xilinx.tcl
 source $ad_hdl_dir/projects/scripts/adi_board.tcl

--- a/projects/adrv9361z7035/ccbob_lvds/system_bd.tcl
+++ b/projects/adrv9361z7035/ccbob_lvds/system_bd.tcl
@@ -1,4 +1,3 @@
-
 source ../common/adrv9361z7035_bd.tcl
 source ../common/ccbob_bd.tcl
 source $ad_hdl_dir/projects/scripts/adi_pd.tcl
@@ -7,9 +6,11 @@ cfg_ad9361_interface LVDS
 
 ad_ip_parameter axi_ad9361 CONFIG.ADC_INIT_DELAY 29
 
+set mem_init_sys_path [get_env_param ADI_PROJECT_DIR ""]mem_init_sys.txt;
+
 #system ID
 ad_ip_parameter axi_sysid_0 CONFIG.ROM_ADDR_BITS 9
-ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "[pwd]/mem_init_sys.txt"
+ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "[pwd]/$mem_init_sys_path"
 ad_ip_parameter rom_sys_0 CONFIG.ROM_ADDR_BITS 9
 
 sysid_gen_sys_init_file

--- a/projects/adrv9361z7035/ccbob_lvds/system_project.tcl
+++ b/projects/adrv9361z7035/ccbob_lvds/system_project.tcl
@@ -1,4 +1,3 @@
-
 source ../../../scripts/adi_env.tcl
 source $ad_hdl_dir/projects/scripts/adi_project_xilinx.tcl
 source $ad_hdl_dir/projects/scripts/adi_board.tcl

--- a/projects/adrv9361z7035/ccfmc_lvds/system_bd.tcl
+++ b/projects/adrv9361z7035/ccfmc_lvds/system_bd.tcl
@@ -1,4 +1,3 @@
-
 source ../common/adrv9361z7035_bd.tcl
 source ../common/ccfmc_bd.tcl
 source $ad_hdl_dir/projects/scripts/adi_pd.tcl
@@ -10,9 +9,11 @@ ad_connect  sys_cpu_clk sys_cpu_clk_out
 
 ad_ip_parameter axi_ad9361 CONFIG.ADC_INIT_DELAY 29
 
+set mem_init_sys_path [get_env_param ADI_PROJECT_DIR ""]mem_init_sys.txt;
+
 #system ID
 ad_ip_parameter axi_sysid_0 CONFIG.ROM_ADDR_BITS 9
-ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "[pwd]/mem_init_sys.txt"
+ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "[pwd]/$mem_init_sys_path"
 ad_ip_parameter rom_sys_0 CONFIG.ROM_ADDR_BITS 9
 
 sysid_gen_sys_init_file

--- a/projects/adrv9361z7035/ccfmc_lvds/system_project.tcl
+++ b/projects/adrv9361z7035/ccfmc_lvds/system_project.tcl
@@ -1,4 +1,3 @@
-
 source ../../../scripts/adi_env.tcl
 source $ad_hdl_dir/projects/scripts/adi_project_xilinx.tcl
 source $ad_hdl_dir/projects/scripts/adi_board.tcl

--- a/projects/adrv9361z7035/ccpackrf_lvds/system_bd.tcl
+++ b/projects/adrv9361z7035/ccpackrf_lvds/system_bd.tcl
@@ -1,4 +1,3 @@
-
 source ../common/adrv9361z7035_bd.tcl
 source ../common/ccpackrf_bd.tcl
 source $ad_hdl_dir/projects/scripts/adi_pd.tcl
@@ -10,9 +9,11 @@ ad_connect  sys_cpu_clk sys_cpu_clk_out
 
 set_property CONFIG.ADC_INIT_DELAY 29 [get_bd_cells axi_ad9361]
 
+set mem_init_sys_path [get_env_param ADI_PROJECT_DIR ""]mem_init_sys.txt;
+
 #system ID
 ad_ip_parameter axi_sysid_0 CONFIG.ROM_ADDR_BITS 9
-ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "[pwd]/mem_init_sys.txt"
+ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "[pwd]/$mem_init_sys_path"
 ad_ip_parameter rom_sys_0 CONFIG.ROM_ADDR_BITS 9
 
 sysid_gen_sys_init_file

--- a/projects/adrv9361z7035/ccpackrf_lvds/system_project.tcl
+++ b/projects/adrv9361z7035/ccpackrf_lvds/system_project.tcl
@@ -1,4 +1,3 @@
-
 source ../../../scripts/adi_env.tcl
 source $ad_hdl_dir/projects/scripts/adi_project_xilinx.tcl
 source $ad_hdl_dir/projects/scripts/adi_board.tcl

--- a/projects/adrv9364z7020/ccbob_cmos/system_bd.tcl
+++ b/projects/adrv9364z7020/ccbob_cmos/system_bd.tcl
@@ -1,4 +1,3 @@
-
 source ../common/adrv9364z7020_bd.tcl
 source ../common/ccbob_bd.tcl
 source $ad_hdl_dir/projects/scripts/adi_pd.tcl
@@ -10,9 +9,11 @@ cfg_ad9361_interface CMOS
 
 set_property CONFIG.ADC_INIT_DELAY 30 [get_bd_cells axi_ad9361]
 
+set mem_init_sys_path [get_env_param ADI_PROJECT_DIR ""]mem_init_sys.txt;
+
 #system ID
 ad_ip_parameter axi_sysid_0 CONFIG.ROM_ADDR_BITS 9
-ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "[pwd]/mem_init_sys.txt"
+ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "[pwd]/$mem_init_sys_path"
 ad_ip_parameter rom_sys_0 CONFIG.ROM_ADDR_BITS 9
 
 sysid_gen_sys_init_file

--- a/projects/adrv9364z7020/ccbob_cmos/system_project.tcl
+++ b/projects/adrv9364z7020/ccbob_cmos/system_project.tcl
@@ -1,4 +1,3 @@
-
 source ../../../scripts/adi_env.tcl
 source $ad_hdl_dir/projects/scripts/adi_project_xilinx.tcl
 source $ad_hdl_dir/projects/scripts/adi_board.tcl

--- a/projects/adrv9364z7020/ccbob_lvds/system_bd.tcl
+++ b/projects/adrv9364z7020/ccbob_lvds/system_bd.tcl
@@ -1,4 +1,3 @@
-
 source ../common/adrv9364z7020_bd.tcl
 source ../common/ccbob_bd.tcl
 source $ad_hdl_dir/projects/scripts/adi_pd.tcl
@@ -7,9 +6,11 @@ cfg_ad9361_interface LVDS
 
 set_property CONFIG.ADC_INIT_DELAY 30 [get_bd_cells axi_ad9361]
 
+set mem_init_sys_path [get_env_param ADI_PROJECT_DIR ""]mem_init_sys.txt;
+
 #system ID
 ad_ip_parameter axi_sysid_0 CONFIG.ROM_ADDR_BITS 9
-ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "[pwd]/mem_init_sys.txt"
+ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "[pwd]/$mem_init_sys_path"
 ad_ip_parameter rom_sys_0 CONFIG.ROM_ADDR_BITS 9
 
 sysid_gen_sys_init_file

--- a/projects/adrv9364z7020/ccbob_lvds/system_project.tcl
+++ b/projects/adrv9364z7020/ccbob_lvds/system_project.tcl
@@ -1,4 +1,3 @@
-
 source ../../../scripts/adi_env.tcl
 source $ad_hdl_dir/projects/scripts/adi_project_xilinx.tcl
 source $ad_hdl_dir/projects/scripts/adi_board.tcl

--- a/projects/adrv9364z7020/ccpackrf_lvds/system_bd.tcl
+++ b/projects/adrv9364z7020/ccpackrf_lvds/system_bd.tcl
@@ -1,4 +1,3 @@
-
 source ../common/adrv9364z7020_bd.tcl
 source ../common/ccpackrf_bd.tcl
 source $ad_hdl_dir/projects/scripts/adi_pd.tcl
@@ -10,9 +9,11 @@ ad_connect  sys_cpu_clk sys_cpu_clk_out
 
 set_property CONFIG.ADC_INIT_DELAY 30 [get_bd_cells axi_ad9361]
 
+set mem_init_sys_path [get_env_param ADI_PROJECT_DIR ""]mem_init_sys.txt;
+
 #system ID
 ad_ip_parameter axi_sysid_0 CONFIG.ROM_ADDR_BITS 9
-ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "[pwd]/mem_init_sys.txt"
+ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "[pwd]/$mem_init_sys_path"
 ad_ip_parameter rom_sys_0 CONFIG.ROM_ADDR_BITS 9
 
 sysid_gen_sys_init_file

--- a/projects/adrv9364z7020/ccpackrf_lvds/system_project.tcl
+++ b/projects/adrv9364z7020/ccpackrf_lvds/system_project.tcl
@@ -1,4 +1,3 @@
-
 source ../../../scripts/adi_env.tcl
 source $ad_hdl_dir/projects/scripts/adi_project_xilinx.tcl
 source $ad_hdl_dir/projects/scripts/adi_board.tcl

--- a/projects/adrv9371x/a10gx/system_project.tcl
+++ b/projects/adrv9371x/a10gx/system_project.tcl
@@ -1,4 +1,3 @@
-
 source ../../../scripts/adi_env.tcl
 source ../../scripts/adi_project_intel.tcl
 

--- a/projects/adrv9371x/a10gx/system_qsys.tcl
+++ b/projects/adrv9371x/a10gx/system_qsys.tcl
@@ -4,7 +4,12 @@ set dac_fifo_address_width 10
 source $ad_hdl_dir/projects/scripts/adi_pd.tcl
 source $ad_hdl_dir/projects/common/a10gx/a10gx_system_qsys.tcl
 source $ad_hdl_dir/projects/common/intel/dacfifo_qsys.tcl
-source ../common/adrv9371x_qsys.tcl
+
+if [info exists ad_project_dir] {
+  source ../../common/adrv9371x_qsys.tcl
+} else {
+  source ../common/adrv9371x_qsys.tcl
+}
 
 #system ID
 

--- a/projects/adrv9371x/a10soc/system_project.tcl
+++ b/projects/adrv9371x/a10soc/system_project.tcl
@@ -1,4 +1,3 @@
-
 source ../../../scripts/adi_env.tcl
 source ../../scripts/adi_project_intel.tcl
 

--- a/projects/adrv9371x/a10soc/system_qsys.tcl
+++ b/projects/adrv9371x/a10soc/system_qsys.tcl
@@ -4,7 +4,12 @@ set dac_fifo_address_width 10
 source $ad_hdl_dir/projects/scripts/adi_pd.tcl
 source $ad_hdl_dir/projects/common/a10soc/a10soc_system_qsys.tcl
 source $ad_hdl_dir/projects/common/a10soc/a10soc_plddr4_dacfifo_qsys.tcl
-source ../common/adrv9371x_qsys.tcl
+
+if [info exists ad_project_dir] {
+  source ../../common/adrv9371x_qsys.tcl
+} else {
+  source ../common/adrv9371x_qsys.tcl
+}
 
 #system ID
 set_instance_parameter_value axi_sysid_0 {ROM_ADDR_BITS} {9}

--- a/projects/adrv9371x/kcu105/system_bd.tcl
+++ b/projects/adrv9371x/kcu105/system_bd.tcl
@@ -1,4 +1,3 @@
-
 ## FIFO depth is 8Mb - 500k samples
 set dac_fifo_address_width 16
 
@@ -9,9 +8,11 @@ source $ad_hdl_dir/projects/common/kcu105/kcu105_system_mig.tcl
 source $ad_hdl_dir/projects/common/xilinx/dacfifo_bd.tcl
 source $ad_hdl_dir/projects/scripts/adi_pd.tcl
 
+set mem_init_sys_path [get_env_param ADI_PROJECT_DIR ""]mem_init_sys.txt;
+
 #system ID
 ad_ip_parameter axi_sysid_0 CONFIG.ROM_ADDR_BITS 9
-ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "[pwd]/mem_init_sys.txt"
+ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "[pwd]/$mem_init_sys_path"
 ad_ip_parameter rom_sys_0 CONFIG.ROM_ADDR_BITS 9
 
 sysid_gen_sys_init_file

--- a/projects/adrv9371x/kcu105/system_project.tcl
+++ b/projects/adrv9371x/kcu105/system_project.tcl
@@ -1,4 +1,3 @@
-
 source ../../../scripts/adi_env.tcl
 source $ad_hdl_dir/projects/scripts/adi_project_xilinx.tcl
 source $ad_hdl_dir/projects/scripts/adi_board.tcl

--- a/projects/adrv9371x/zc706/system_bd.tcl
+++ b/projects/adrv9371x/zc706/system_bd.tcl
@@ -1,13 +1,14 @@
-
 set dac_fifo_address_width 10
 
 source $ad_hdl_dir/projects/common/zc706/zc706_system_bd.tcl
 source $ad_hdl_dir/projects/common/zc706/zc706_plddr3_dacfifo_bd.tcl
 source $ad_hdl_dir/projects/scripts/adi_pd.tcl
 
+set mem_init_sys_path [get_env_param ADI_PROJECT_DIR ""]mem_init_sys.txt;
+
 #system ID
 ad_ip_parameter axi_sysid_0 CONFIG.ROM_ADDR_BITS 9
-ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "[pwd]/mem_init_sys.txt"
+ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "[pwd]/$mem_init_sys_path"
 ad_ip_parameter rom_sys_0 CONFIG.ROM_ADDR_BITS 9
 
 sysid_gen_sys_init_file

--- a/projects/adrv9371x/zc706/system_project.tcl
+++ b/projects/adrv9371x/zc706/system_project.tcl
@@ -1,6 +1,3 @@
-
-
-
 source ../../../scripts/adi_env.tcl
 source $ad_hdl_dir/projects/scripts/adi_project_xilinx.tcl
 source $ad_hdl_dir/projects/scripts/adi_board.tcl

--- a/projects/adrv9371x/zcu102/system_bd.tcl
+++ b/projects/adrv9371x/zcu102/system_bd.tcl
@@ -1,4 +1,3 @@
-
 ## FIFO depth is 16Mb - 1M samples
 set dac_fifo_address_width 17
 
@@ -8,9 +7,11 @@ source $ad_hdl_dir/projects/common/zcu102/zcu102_system_bd.tcl
 source $ad_hdl_dir/projects/common/xilinx/dacfifo_bd.tcl
 source $ad_hdl_dir/projects/scripts/adi_pd.tcl
 
+set mem_init_sys_path [get_env_param ADI_PROJECT_DIR ""]mem_init_sys.txt;
+
 #system ID
 ad_ip_parameter axi_sysid_0 CONFIG.ROM_ADDR_BITS 9
-ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "[pwd]/mem_init_sys.txt"
+ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "[pwd]/$mem_init_sys_path"
 ad_ip_parameter rom_sys_0 CONFIG.ROM_ADDR_BITS 9
 
 sysid_gen_sys_init_file

--- a/projects/adrv9371x/zcu102/system_project.tcl
+++ b/projects/adrv9371x/zcu102/system_project.tcl
@@ -1,4 +1,3 @@
-
 source ../../../scripts/adi_env.tcl
 source $ad_hdl_dir/projects/scripts/adi_project_xilinx.tcl
 source $ad_hdl_dir/projects/scripts/adi_board.tcl

--- a/projects/adv7511/zc702/system_bd.tcl
+++ b/projects/adv7511/zc702/system_bd.tcl
@@ -1,10 +1,11 @@
-
 source $ad_hdl_dir/projects/common/zc702/zc702_system_bd.tcl
 source $ad_hdl_dir/projects/scripts/adi_pd.tcl
 
+set mem_init_sys_path [get_env_param ADI_PROJECT_DIR ""]mem_init_sys.txt;
+
 #system ID
 ad_ip_parameter axi_sysid_0 CONFIG.ROM_ADDR_BITS 9
-ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "[pwd]/mem_init_sys.txt"
+ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "[pwd]/$mem_init_sys_path"
 ad_ip_parameter rom_sys_0 CONFIG.ROM_ADDR_BITS 9
 
 sysid_gen_sys_init_file

--- a/projects/adv7511/zc702/system_project.tcl
+++ b/projects/adv7511/zc702/system_project.tcl
@@ -1,4 +1,3 @@
-
 source ../../../scripts/adi_env.tcl
 source $ad_hdl_dir/projects/scripts/adi_project_xilinx.tcl
 source $ad_hdl_dir/projects/scripts/adi_board.tcl

--- a/projects/adv7511/zc706/system_bd.tcl
+++ b/projects/adv7511/zc706/system_bd.tcl
@@ -1,10 +1,11 @@
-
 source $ad_hdl_dir/projects/common/zc706/zc706_system_bd.tcl
 source $ad_hdl_dir/projects/scripts/adi_pd.tcl
 
+set mem_init_sys_path [get_env_param ADI_PROJECT_DIR ""]mem_init_sys.txt;
+
 #system ID
 ad_ip_parameter axi_sysid_0 CONFIG.ROM_ADDR_BITS 9
-ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "[pwd]/mem_init_sys.txt"
+ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "[pwd]/$mem_init_sys_path"
 ad_ip_parameter rom_sys_0 CONFIG.ROM_ADDR_BITS 9
 
 sysid_gen_sys_init_file

--- a/projects/adv7511/zc706/system_project.tcl
+++ b/projects/adv7511/zc706/system_project.tcl
@@ -1,4 +1,3 @@
-
 source ../../../scripts/adi_env.tcl
 source $ad_hdl_dir/projects/scripts/adi_project_xilinx.tcl
 source $ad_hdl_dir/projects/scripts/adi_board.tcl

--- a/projects/adv7511/zed/system_bd.tcl
+++ b/projects/adv7511/zed/system_bd.tcl
@@ -1,10 +1,11 @@
-
 source $ad_hdl_dir/projects/common/zed/zed_system_bd.tcl
 source $ad_hdl_dir/projects/scripts/adi_pd.tcl
 
+set mem_init_sys_path [get_env_param ADI_PROJECT_DIR ""]mem_init_sys.txt;
+
 #system ID
 ad_ip_parameter axi_sysid_0 CONFIG.ROM_ADDR_BITS 9
-ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "[pwd]/mem_init_sys.txt"
+ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "[pwd]/$mem_init_sys_path"
 ad_ip_parameter rom_sys_0 CONFIG.ROM_ADDR_BITS 9
 
 sysid_gen_sys_init_file

--- a/projects/adv7511/zed/system_project.tcl
+++ b/projects/adv7511/zed/system_project.tcl
@@ -1,6 +1,3 @@
-
-
-
 source ../../../scripts/adi_env.tcl
 source $ad_hdl_dir/projects/scripts/adi_project_xilinx.tcl
 source $ad_hdl_dir/projects/scripts/adi_board.tcl

--- a/projects/adv7513/de10nano/system_project.tcl
+++ b/projects/adv7513/de10nano/system_project.tcl
@@ -1,6 +1,5 @@
 set REQUIRED_QUARTUS_VERSION 21.1.0
 set QUARTUS_PRO_ISUSED 0
-
 source ../../../scripts/adi_env.tcl
 source ../../scripts/adi_project_intel.tcl
 

--- a/projects/adv7513/de10nano/system_qsys.tcl
+++ b/projects/adv7513/de10nano/system_qsys.tcl
@@ -1,4 +1,3 @@
-
 source $ad_hdl_dir/projects/scripts/adi_pd.tcl
 source $ad_hdl_dir/projects/common/de10nano/de10nano_system_qsys.tcl
 

--- a/projects/arradio/c5soc/system_qsys.tcl
+++ b/projects/arradio/c5soc/system_qsys.tcl
@@ -1,7 +1,11 @@
-
 source $ad_hdl_dir/projects/scripts/adi_pd.tcl
 source $ad_hdl_dir/projects/common/c5soc/c5soc_system_qsys.tcl
-source ../common/arradio_qsys.tcl
+
+if [info exists ad_project_dir] {
+  source ../../common/arradio_qsys.tcl
+} else {
+  source ../common/arradio_qsys.tcl
+}
 
 #system ID
 set_instance_parameter_value axi_sysid_0 {ROM_ADDR_BITS} {9}

--- a/projects/cn0363/zed/system_bd.tcl
+++ b/projects/cn0363/zed/system_bd.tcl
@@ -1,11 +1,12 @@
-
 source $ad_hdl_dir/projects/common/zed/zed_system_bd.tcl
 source ../common/cn0363_bd.tcl
 source $ad_hdl_dir/projects/scripts/adi_pd.tcl
 
+set mem_init_sys_path [get_env_param ADI_PROJECT_DIR ""]mem_init_sys.txt;
+
 #system ID
 ad_ip_parameter axi_sysid_0 CONFIG.ROM_ADDR_BITS 9
-ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "[pwd]/mem_init_sys.txt"
+ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "[pwd]/$mem_init_sys_path"
 ad_ip_parameter rom_sys_0 CONFIG.ROM_ADDR_BITS 9
 
 sysid_gen_sys_init_file

--- a/projects/cn0501/coraz7s/system_bd.tcl
+++ b/projects/cn0501/coraz7s/system_bd.tcl
@@ -2,9 +2,11 @@ source $ad_hdl_dir/projects/common/coraz7s/coraz7s_system_bd.tcl
 source ../common/cn0501_bd.tcl
 source $ad_hdl_dir/projects/scripts/adi_pd.tcl
 
+set mem_init_sys_path [get_env_param ADI_PROJECT_DIR ""]mem_init_sys.txt;
+
 #system ID
 ad_ip_parameter axi_sysid_0 CONFIG.ROM_ADDR_BITS 9
-ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "[pwd]/mem_init_sys.txt"
+ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "[pwd]/$mem_init_sys_path"
 ad_ip_parameter rom_sys_0 CONFIG.ROM_ADDR_BITS 9
 set sys_cstring "sys rom custom string placeholder"
 

--- a/projects/cn0506/a10soc/system_qsys.tcl
+++ b/projects/cn0506/a10soc/system_qsys.tcl
@@ -1,4 +1,3 @@
-
 source $ad_hdl_dir/projects/scripts/adi_pd.tcl
 source $ad_hdl_dir/projects/common/a10soc/a10soc_system_qsys.tcl
 

--- a/projects/cn0506/zc706/system_bd.tcl
+++ b/projects/cn0506/zc706/system_bd.tcl
@@ -1,4 +1,3 @@
-
 source $ad_hdl_dir/projects/common/zc706/zc706_system_bd.tcl
 
 ##--------------------------------------------------------------
@@ -113,9 +112,11 @@ switch $INTF_CFG {
 
 source $ad_hdl_dir/projects/scripts/adi_pd.tcl
 
+set mem_init_sys_path [get_env_param ADI_PROJECT_DIR ""]mem_init_sys.txt;
+
 #system ID
 ad_ip_parameter axi_sysid_0 CONFIG.ROM_ADDR_BITS 9
-ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "[pwd]/mem_init_sys.txt"
+ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "[pwd]/$mem_init_sys_path"
 ad_ip_parameter rom_sys_0 CONFIG.ROM_ADDR_BITS 9
 set INTF_CFG $::env(INTF_CFG)
 set sys_cstring "$INTF_CFG"

--- a/projects/cn0506/zc706/system_project.tcl
+++ b/projects/cn0506/zc706/system_project.tcl
@@ -1,4 +1,3 @@
-
 source ../../../scripts/adi_env.tcl
 source $ad_hdl_dir/projects/scripts/adi_project_xilinx.tcl
 source $ad_hdl_dir/projects/scripts/adi_board.tcl
@@ -34,7 +33,7 @@ adi_project cn0506_zc706 0 [list \
   INTF_CFG  $intf \
 ]
 
-adi_project_files  cn0506_zc706 [list \
+adi_project_files cn0506_zc706 [list \
   "$ad_hdl_dir/projects/common/zc706/zc706_system_constr.xdc" \
   "$ad_hdl_dir/library/common/ad_iobuf.v" \
   "system_constr.tcl"

--- a/projects/cn0506/zcu102/system_bd.tcl
+++ b/projects/cn0506/zcu102/system_bd.tcl
@@ -1,4 +1,3 @@
-
 source $ad_hdl_dir/projects/common/zcu102/zcu102_system_bd.tcl
 
 ##--------------------------------------------------------------
@@ -127,9 +126,11 @@ switch $INTF_CFG {
 
 source $ad_hdl_dir/projects/scripts/adi_pd.tcl
 
+set mem_init_sys_path [get_env_param ADI_PROJECT_DIR ""]mem_init_sys.txt;
+
 #system ID
 ad_ip_parameter axi_sysid_0 CONFIG.ROM_ADDR_BITS 9
-ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "[pwd]/mem_init_sys.txt"
+ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "[pwd]/$mem_init_sys_path"
 ad_ip_parameter rom_sys_0 CONFIG.ROM_ADDR_BITS 9
 set INTF_CFG $::env(INTF_CFG)
 set sys_cstring "$INTF_CFG"

--- a/projects/cn0506/zcu102/system_project.tcl
+++ b/projects/cn0506/zcu102/system_project.tcl
@@ -1,4 +1,3 @@
-
 source ../../../scripts/adi_env.tcl
 source $ad_hdl_dir/projects/scripts/adi_project_xilinx.tcl
 source $ad_hdl_dir/projects/scripts/adi_board.tcl
@@ -34,7 +33,7 @@ adi_project cn0506_zcu102 0 [list \
   INTF_CFG  $intf \
 ]
 
-adi_project_files  cn0506_zcu102 [list \
+adi_project_files cn0506_zcu102 [list \
   "$ad_hdl_dir/projects/common/zcu102/zcu102_system_constr.xdc" \
   "system_constr.tcl"
   ]

--- a/projects/cn0506/zed/system_bd.tcl
+++ b/projects/cn0506/zed/system_bd.tcl
@@ -1,4 +1,3 @@
-
 source $ad_hdl_dir/projects/common/zed/zed_system_bd.tcl
 
 ##--------------------------------------------------------------
@@ -113,9 +112,11 @@ switch $INTF_CFG {
 
 source $ad_hdl_dir/projects/scripts/adi_pd.tcl
 
+set mem_init_sys_path [get_env_param ADI_PROJECT_DIR ""]mem_init_sys.txt;
+
 #system ID
 ad_ip_parameter axi_sysid_0 CONFIG.ROM_ADDR_BITS 9
-ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "[pwd]/mem_init_sys.txt"
+ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "[pwd]/$mem_init_sys_path"
 ad_ip_parameter rom_sys_0 CONFIG.ROM_ADDR_BITS 9
 set INTF_CFG $::env(INTF_CFG)
 set sys_cstring "$INTF_CFG"

--- a/projects/cn0506/zed/system_project.tcl
+++ b/projects/cn0506/zed/system_project.tcl
@@ -1,4 +1,3 @@
-
 source ../../../scripts/adi_env.tcl
 source $ad_hdl_dir/projects/scripts/adi_project_xilinx.tcl
 source $ad_hdl_dir/projects/scripts/adi_board.tcl
@@ -34,7 +33,7 @@ adi_project cn0506_zed 0 [list \
   INTF_CFG  $intf \
 ]
 
-adi_project_files  cn0506_rmii_zed [list \
+adi_project_files cn0506_zed [list \
   "$ad_hdl_dir/projects/common/zed/zed_system_constr.xdc" \
   "$ad_hdl_dir/library/common/ad_iobuf.v" \
   "system_constr.tcl"

--- a/projects/cn0540/coraz7s/system_bd.tcl
+++ b/projects/cn0540/coraz7s/system_bd.tcl
@@ -1,9 +1,11 @@
 source $ad_hdl_dir/projects/common/coraz7s/coraz7s_system_bd.tcl
 source $ad_hdl_dir/projects/scripts/adi_pd.tcl
 
+set mem_init_sys_path [get_env_param ADI_PROJECT_DIR ""]mem_init_sys.txt;
+
 #system ID
 ad_ip_parameter axi_sysid_0 CONFIG.ROM_ADDR_BITS 9
-ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "[pwd]/mem_init_sys.txt"
+ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "[pwd]/$mem_init_sys_path"
 ad_ip_parameter rom_sys_0 CONFIG.ROM_ADDR_BITS 9
 
 sysid_gen_sys_init_file

--- a/projects/cn0540/coraz7s/system_project.tcl
+++ b/projects/cn0540/coraz7s/system_project.tcl
@@ -1,4 +1,3 @@
-
 source ../../../scripts/adi_env.tcl
 source $ad_hdl_dir/projects/scripts/adi_project_xilinx.tcl
 source $ad_hdl_dir/projects/scripts/adi_board.tcl

--- a/projects/cn0540/de10nano/system_project.tcl
+++ b/projects/cn0540/de10nano/system_project.tcl
@@ -1,6 +1,5 @@
 set REQUIRED_QUARTUS_VERSION 21.1.0
 set QUARTUS_PRO_ISUSED 0
-
 source ../../../scripts/adi_env.tcl
 source ../../scripts/adi_project_intel.tcl
 

--- a/projects/cn0540/de10nano/system_qsys.tcl
+++ b/projects/cn0540/de10nano/system_qsys.tcl
@@ -3,7 +3,12 @@ set dac_fifo_address_width 10
 
 source $ad_hdl_dir/projects/scripts/adi_pd.tcl
 source $ad_hdl_dir/projects/common/de10nano/de10nano_system_qsys.tcl
-source ../common/cn0540_qsys.tcl
+
+if [info exists ad_project_dir] {
+  source ../../common/cn0540_qsys.tcl
+} else {
+  source ../common/cn0540_qsys.tcl
+}
 
 #system ID
 set_instance_parameter_value axi_sysid_0 {ROM_ADDR_BITS} {9}

--- a/projects/cn0561/coraz7s/system_bd.tcl
+++ b/projects/cn0561/coraz7s/system_bd.tcl
@@ -1,4 +1,3 @@
-
 source $ad_hdl_dir/projects/common/coraz7s/coraz7s_system_bd.tcl
 source $ad_hdl_dir/projects/scripts/adi_pd.tcl
 
@@ -7,9 +6,11 @@ adi_project_files cn0561_coraz7s [list \
   "$ad_hdl_dir/library/util_cdc/sync_bits.v" \
 ]
 
+set mem_init_sys_path [get_env_param ADI_PROJECT_DIR ""]mem_init_sys.txt;
+
 #system ID
 ad_ip_parameter axi_sysid_0 CONFIG.ROM_ADDR_BITS 9
-ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "[pwd]/mem_init_sys.txt"
+ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "[pwd]/$mem_init_sys_path"
 ad_ip_parameter rom_sys_0 CONFIG.ROM_ADDR_BITS 9
 
 sysid_gen_sys_init_file

--- a/projects/cn0561/coraz7s/system_project.tcl
+++ b/projects/cn0561/coraz7s/system_project.tcl
@@ -1,4 +1,3 @@
-
 source ../../../scripts/adi_env.tcl
 source $ad_hdl_dir/projects/scripts/adi_project_xilinx.tcl
 source $ad_hdl_dir/projects/scripts/adi_board.tcl

--- a/projects/cn0561/zed/system_bd.tcl
+++ b/projects/cn0561/zed/system_bd.tcl
@@ -1,10 +1,11 @@
-
 source $ad_hdl_dir/projects/common/zed/zed_system_bd.tcl
 source $ad_hdl_dir/projects/scripts/adi_pd.tcl
 
+set mem_init_sys_path [get_env_param ADI_PROJECT_DIR ""]mem_init_sys.txt;
+
 #system ID
 ad_ip_parameter axi_sysid_0 CONFIG.ROM_ADDR_BITS 9
-ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "[pwd]/mem_init_sys.txt"
+ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "[pwd]/$mem_init_sys_path"
 ad_ip_parameter rom_sys_0 CONFIG.ROM_ADDR_BITS 9
 
 adi_project_files cn0561_fmc_zed [list \

--- a/projects/cn0561/zed/system_project.tcl
+++ b/projects/cn0561/zed/system_project.tcl
@@ -1,4 +1,3 @@
-
 source ../../../scripts/adi_env.tcl
 source $ad_hdl_dir/projects/scripts/adi_project_xilinx.tcl
 source $ad_hdl_dir/projects/scripts/adi_board.tcl

--- a/projects/cn0577/zed/system_bd.tcl
+++ b/projects/cn0577/zed/system_bd.tcl
@@ -5,9 +5,11 @@ source $ad_hdl_dir/projects/common/zed/zed_system_bd.tcl
 source $ad_hdl_dir/projects/scripts/adi_pd.tcl
 source ../common/cn0577_bd.tcl
 
-# system ID
+set mem_init_sys_path [get_env_param ADI_PROJECT_DIR ""]mem_init_sys.txt;
+
+#system ID
 ad_ip_parameter axi_sysid_0 CONFIG.ROM_ADDR_BITS 9
-ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "[pwd]/mem_init_sys.txt"
+ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "[pwd]/$mem_init_sys_path"
 ad_ip_parameter rom_sys_0 CONFIG.ROM_ADDR_BITS 9
 set sys_cstring "sys rom custom string placeholder"
 sysid_gen_sys_init_file $sys_cstring

--- a/projects/common/de10nano/system_project.tcl
+++ b/projects/common/de10nano/system_project.tcl
@@ -1,6 +1,5 @@
 set REQUIRED_QUARTUS_VERSION 21.1.0
 set QUARTUS_PRO_ISUSED 0
-
 source ../../../scripts/adi_env.tcl
 source ../../scripts/adi_project_intel.tcl
 

--- a/projects/dac_fmc_ebz/a10soc/system_project.tcl
+++ b/projects/dac_fmc_ebz/a10soc/system_project.tcl
@@ -29,7 +29,6 @@
 #      This will allow to generate bit files and not release the source code,
 #      as long as it attaches to an ADI device.
 #
-
 source ../../../scripts/adi_env.tcl
 source ../../scripts/adi_project_intel.tcl
 

--- a/projects/dac_fmc_ebz/a10soc/system_qsys.tcl
+++ b/projects/dac_fmc_ebz/a10soc/system_qsys.tcl
@@ -35,7 +35,12 @@ set dac_fifo_address_width 13
 source $ad_hdl_dir/projects/scripts/adi_pd.tcl
 source $ad_hdl_dir/projects/common/a10soc/a10soc_system_qsys.tcl
 source $ad_hdl_dir/projects/common/a10soc/a10soc_plddr4_dacfifo_qsys.tcl
-source ../common/dac_fmc_ebz_qsys.tcl
+
+if [info exists ad_project_dir] {
+  source ../../common/dac_fmc_ebz_qsys.tcl
+} else {
+  source ../common/dac_fmc_ebz_qsys.tcl
+}
 
 #system ID
 set_instance_parameter_value axi_sysid_0 {ROM_ADDR_BITS} {9}

--- a/projects/dac_fmc_ebz/vcu118/system_bd.tcl
+++ b/projects/dac_fmc_ebz/vcu118/system_bd.tcl
@@ -1,4 +1,3 @@
-
 set dac_fifo_address_width 14
 
 source $ad_hdl_dir/projects/common/vcu118/vcu118_system_bd.tcl
@@ -6,9 +5,11 @@ source $ad_hdl_dir/projects/common/xilinx/dacfifo_bd.tcl
 source ../common/dac_fmc_ebz_bd.tcl
 source $ad_hdl_dir/projects/scripts/adi_pd.tcl
 
+set mem_init_sys_path [get_env_param ADI_PROJECT_DIR ""]mem_init_sys.txt;
+
 #system ID
 ad_ip_parameter axi_sysid_0 CONFIG.ROM_ADDR_BITS 9
-ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "[pwd]/mem_init_sys.txt"
+ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "[pwd]/$mem_init_sys_path"
 ad_ip_parameter rom_sys_0 CONFIG.ROM_ADDR_BITS 9
 set ADI_DAC_DEVICE $::env(ADI_DAC_DEVICE)
 set ADI_DAC_MODE $::env(ADI_DAC_MODE)

--- a/projects/dac_fmc_ebz/vcu118/system_project.tcl
+++ b/projects/dac_fmc_ebz/vcu118/system_project.tcl
@@ -1,4 +1,3 @@
-
 source ../../../scripts/adi_env.tcl
 source $ad_hdl_dir/projects/scripts/adi_project_xilinx.tcl
 source $ad_hdl_dir/projects/scripts/adi_board.tcl

--- a/projects/dac_fmc_ebz/zc706/system_bd.tcl
+++ b/projects/dac_fmc_ebz/zc706/system_bd.tcl
@@ -40,9 +40,11 @@ source $ad_hdl_dir/projects/common/xilinx/dacfifo_bd.tcl
 source ../common/dac_fmc_ebz_bd.tcl
 source $ad_hdl_dir/projects/scripts/adi_pd.tcl
 
+set mem_init_sys_path [get_env_param ADI_PROJECT_DIR ""]mem_init_sys.txt;
+
 #system ID
 ad_ip_parameter axi_sysid_0 CONFIG.ROM_ADDR_BITS 9
-ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "[pwd]/mem_init_sys.txt"
+ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "[pwd]/$mem_init_sys_path"
 ad_ip_parameter rom_sys_0 CONFIG.ROM_ADDR_BITS 9
 set ADI_DAC_DEVICE $::env(ADI_DAC_DEVICE)
 set ADI_DAC_MODE $::env(ADI_DAC_MODE)

--- a/projects/dac_fmc_ebz/zc706/system_project.tcl
+++ b/projects/dac_fmc_ebz/zc706/system_project.tcl
@@ -32,7 +32,6 @@
 #
 # ***************************************************************************
 # ***************************************************************************
-
 source ../../../scripts/adi_env.tcl
 source $ad_hdl_dir/projects/scripts/adi_project_xilinx.tcl
 source $ad_hdl_dir/projects/scripts/adi_board.tcl

--- a/projects/dac_fmc_ebz/zcu102/system_bd.tcl
+++ b/projects/dac_fmc_ebz/zcu102/system_bd.tcl
@@ -1,4 +1,3 @@
-
 set dac_fifo_address_width 13
 
 source $ad_hdl_dir/projects/common/zcu102/zcu102_system_bd.tcl
@@ -28,9 +27,11 @@ ad_ip_parameter util_dac_jesd204_xcvr CONFIG.QPLL_LPF 0x31D
 
 ad_ip_parameter dac_jesd204_link/tx CONFIG.SYSREF_IOB false
 
+set mem_init_sys_path [get_env_param ADI_PROJECT_DIR ""]mem_init_sys.txt;
+
 #system ID
 ad_ip_parameter axi_sysid_0 CONFIG.ROM_ADDR_BITS 9
-ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "[pwd]/mem_init_sys.txt"
+ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "[pwd]/$mem_init_sys_path"
 ad_ip_parameter rom_sys_0 CONFIG.ROM_ADDR_BITS 9
 set ADI_DAC_DEVICE $::env(ADI_DAC_DEVICE)
 set ADI_DAC_MODE $::env(ADI_DAC_MODE)

--- a/projects/dac_fmc_ebz/zcu102/system_project.tcl
+++ b/projects/dac_fmc_ebz/zcu102/system_project.tcl
@@ -1,4 +1,3 @@
-
 source ../../../scripts/adi_env.tcl
 source $ad_hdl_dir/projects/scripts/adi_project_xilinx.tcl
 source $ad_hdl_dir/projects/scripts/adi_board.tcl

--- a/projects/daq2/a10gx/system_project.tcl
+++ b/projects/daq2/a10gx/system_project.tcl
@@ -1,4 +1,3 @@
-
 source ../../../scripts/adi_env.tcl
 source ../../scripts/adi_project_intel.tcl
 
@@ -8,7 +7,7 @@ source $ad_hdl_dir/projects/common/a10gx/a10gx_system_assign.tcl
 
 # files
 
-set_global_assignment -name VERILOG_FILE ../common/daq2_spi.v
+set_global_assignment -name VERILOG_FILE $ad_hdl_dir/projects/daq2/common/daq2_spi.v
 
 # lane interface
 

--- a/projects/daq2/a10gx/system_qsys.tcl
+++ b/projects/daq2/a10gx/system_qsys.tcl
@@ -1,10 +1,14 @@
-
 set dac_fifo_address_width 10
 
 source $ad_hdl_dir/projects/scripts/adi_pd.tcl
 source $ad_hdl_dir/projects/common/a10gx/a10gx_system_qsys.tcl
 source $ad_hdl_dir/projects/common/intel/dacfifo_qsys.tcl
-source ../common/daq2_qsys.tcl
+
+if [info exists ad_project_dir] {
+  source ../../common/daq2_qsys.tcl
+} else {
+  source ../common/daq2_qsys.tcl
+}
 
 #system ID
 

--- a/projects/daq2/a10soc/system_project.tcl
+++ b/projects/daq2/a10soc/system_project.tcl
@@ -1,4 +1,3 @@
-
 source ../../../scripts/adi_env.tcl
 source ../../scripts/adi_project_intel.tcl
 
@@ -9,7 +8,7 @@ source $ad_hdl_dir/projects/common/a10soc/a10soc_plddr4_assign.tcl
 
 # files
 
-set_global_assignment -name VERILOG_FILE ../common/daq2_spi.v
+set_global_assignment -name VERILOG_FILE $ad_hdl_dir/projects/daq2/common/daq2_spi.v
 
 # lane interface
 

--- a/projects/daq2/a10soc/system_qsys.tcl
+++ b/projects/daq2/a10soc/system_qsys.tcl
@@ -1,10 +1,14 @@
-
 set dac_fifo_address_width 10
 
 source $ad_hdl_dir/projects/scripts/adi_pd.tcl
 source $ad_hdl_dir/projects/common/a10soc/a10soc_system_qsys.tcl
 source $ad_hdl_dir/projects/common/a10soc/a10soc_plddr4_dacfifo_qsys.tcl
-source ../common/daq2_qsys.tcl
+
+if [info exists ad_project_dir] {
+  source ../../common/daq2_qsys.tcl
+} else {
+  source ../common/daq2_qsys.tcl
+}
 
 #system ID
 set_instance_parameter_value axi_sysid_0 {ROM_ADDR_BITS} {9}

--- a/projects/daq2/kc705/system_bd.tcl
+++ b/projects/daq2/kc705/system_bd.tcl
@@ -13,9 +13,11 @@ source $ad_hdl_dir/projects/common/kc705/kc705_system_bd.tcl
 source ../common/daq2_bd.tcl
 source $ad_hdl_dir/projects/scripts/adi_pd.tcl
 
+set mem_init_sys_path [get_env_param ADI_PROJECT_DIR ""]mem_init_sys.txt;
+
 #system ID
 ad_ip_parameter axi_sysid_0 CONFIG.ROM_ADDR_BITS 9
-ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "[pwd]/mem_init_sys.txt"
+ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "[pwd]/$mem_init_sys_path"
 ad_ip_parameter rom_sys_0 CONFIG.ROM_ADDR_BITS 9
 
 set sys_cstring "ADC_OFFLOAD_TYPE=$adc_offload_type\nDAC_OFFLOAD_TYPE=$dac_offload_type"

--- a/projects/daq2/kc705/system_project.tcl
+++ b/projects/daq2/kc705/system_project.tcl
@@ -1,4 +1,3 @@
-
 source ../../../scripts/adi_env.tcl
 source $ad_hdl_dir/projects/scripts/adi_project_xilinx.tcl
 source $ad_hdl_dir/projects/scripts/adi_board.tcl

--- a/projects/daq2/kcu105/system_bd.tcl
+++ b/projects/daq2/kcu105/system_bd.tcl
@@ -13,9 +13,11 @@ source $ad_hdl_dir/projects/common/kcu105/kcu105_system_bd.tcl
 source ../common/daq2_bd.tcl
 source $ad_hdl_dir/projects/scripts/adi_pd.tcl
 
+set mem_init_sys_path [get_env_param ADI_PROJECT_DIR ""]mem_init_sys.txt;
+
 #system ID
 ad_ip_parameter axi_sysid_0 CONFIG.ROM_ADDR_BITS 9
-ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "[pwd]/mem_init_sys.txt"
+ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "[pwd]/$mem_init_sys_path"
 ad_ip_parameter rom_sys_0 CONFIG.ROM_ADDR_BITS 9
 
 set sys_cstring "ADC_OFFLOAD_TYPE=$adc_offload_type\nDAC_OFFLOAD_TYPE=$dac_offload_type"

--- a/projects/daq2/kcu105/system_project.tcl
+++ b/projects/daq2/kcu105/system_project.tcl
@@ -1,4 +1,3 @@
-
 source ../../../scripts/adi_env.tcl
 source $ad_hdl_dir/projects/scripts/adi_project_xilinx.tcl
 source $ad_hdl_dir/projects/scripts/adi_board.tcl

--- a/projects/daq2/zc706/system_bd.tcl
+++ b/projects/daq2/zc706/system_bd.tcl
@@ -1,4 +1,3 @@
-
 ## Offload attributes
 set adc_offload_type 1                              ; ## PL_DDR
 set adc_offload_size [expr 1 * 1024 * 1024 * 1024]  ; ## 1 Gbyte
@@ -61,8 +60,10 @@ if {$adc_offload_type || $dac_offload_type} {
 # System ID
 ################################################################################
 
+set mem_init_sys_path [get_env_param ADI_PROJECT_DIR ""]mem_init_sys.txt;
+
 ad_ip_parameter axi_sysid_0 CONFIG.ROM_ADDR_BITS 9
-ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "[pwd]/mem_init_sys.txt"
+ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "[pwd]/$mem_init_sys_path"
 ad_ip_parameter rom_sys_0 CONFIG.ROM_ADDR_BITS 9
 
 set sys_cstring "ADC_OFFLOAD_TYPE=$adc_offload_type\nDAC_OFFLOAD_TYPE=$dac_offload_type"

--- a/projects/daq2/zc706/system_project.tcl
+++ b/projects/daq2/zc706/system_project.tcl
@@ -1,4 +1,3 @@
-
 source ../../../scripts/adi_env.tcl
 source $ad_hdl_dir/projects/scripts/adi_project_xilinx.tcl
 source $ad_hdl_dir/projects/scripts/adi_board.tcl

--- a/projects/daq2/zcu102/system_bd.tcl
+++ b/projects/daq2/zcu102/system_bd.tcl
@@ -13,9 +13,11 @@ source $ad_hdl_dir/projects/common/zcu102/zcu102_system_bd.tcl
 source ../common/daq2_bd.tcl
 source $ad_hdl_dir/projects/scripts/adi_pd.tcl
 
+set mem_init_sys_path [get_env_param ADI_PROJECT_DIR ""]mem_init_sys.txt;
+
 #system ID
 ad_ip_parameter axi_sysid_0 CONFIG.ROM_ADDR_BITS 9
-ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "[pwd]/mem_init_sys.txt"
+ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "[pwd]/$mem_init_sys_path"
 ad_ip_parameter rom_sys_0 CONFIG.ROM_ADDR_BITS 9
 
 set sys_cstring "ADC_OFFLOAD_TYPE=$adc_offload_type\nDAC_OFFLOAD_TYPE=$dac_offload_type"

--- a/projects/daq2/zcu102/system_project.tcl
+++ b/projects/daq2/zcu102/system_project.tcl
@@ -1,4 +1,3 @@
-
 source ../../../scripts/adi_env.tcl
 source $ad_hdl_dir/projects/scripts/adi_project_xilinx.tcl
 source $ad_hdl_dir/projects/scripts/adi_board.tcl

--- a/projects/daq3/a10gx/system_project.tcl
+++ b/projects/daq3/a10gx/system_project.tcl
@@ -1,4 +1,3 @@
-
 source ../../../scripts/adi_env.tcl
 source ../../scripts/adi_project_intel.tcl
 
@@ -8,7 +7,7 @@ source $ad_hdl_dir/projects/common/a10gx/a10gx_system_assign.tcl
 
 # files
 
-set_global_assignment -name VERILOG_FILE ../common/daq3_spi.v
+set_global_assignment -name VERILOG_FILE $ad_hdl_dir/projects/daq3/common/daq3_spi.v
 
 # lane interface
 

--- a/projects/daq3/a10gx/system_qsys.tcl
+++ b/projects/daq3/a10gx/system_qsys.tcl
@@ -1,10 +1,14 @@
-
 set dac_fifo_address_width 10
 
 source $ad_hdl_dir/projects/scripts/adi_pd.tcl
 source $ad_hdl_dir/projects/common/a10gx/a10gx_system_qsys.tcl
 source $ad_hdl_dir/projects/common/intel/dacfifo_qsys.tcl
-source ../common/daq3_qsys.tcl
+
+if [info exists ad_project_dir] {
+  source ../../common/daq3_qsys.tcl
+} else {
+  source ../common/daq3_qsys.tcl
+}
 
 #system ID
 set_instance_parameter_value axi_sysid_0 {ROM_ADDR_BITS} {9}

--- a/projects/daq3/kcu105/system_bd.tcl
+++ b/projects/daq3/kcu105/system_bd.tcl
@@ -1,4 +1,3 @@
-
 ## FIFO depth is 4Mb - 250k samples
 set adc_fifo_address_width 16
 
@@ -13,9 +12,11 @@ source $ad_hdl_dir/projects/common/xilinx/dacfifo_bd.tcl
 source ../common/daq3_bd.tcl
 source $ad_hdl_dir/projects/scripts/adi_pd.tcl
 
+set mem_init_sys_path [get_env_param ADI_PROJECT_DIR ""]mem_init_sys.txt;
+
 #system ID
 ad_ip_parameter axi_sysid_0 CONFIG.ROM_ADDR_BITS 9
-ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "[pwd]/mem_init_sys.txt"
+ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "[pwd]/$mem_init_sys_path"
 ad_ip_parameter rom_sys_0 CONFIG.ROM_ADDR_BITS 9
 
 sysid_gen_sys_init_file

--- a/projects/daq3/kcu105/system_project.tcl
+++ b/projects/daq3/kcu105/system_project.tcl
@@ -1,4 +1,3 @@
-
 source ../../../scripts/adi_env.tcl
 source $ad_hdl_dir/projects/scripts/adi_project_xilinx.tcl
 source $ad_hdl_dir/projects/scripts/adi_board.tcl

--- a/projects/daq3/vcu118/system_bd.tcl
+++ b/projects/daq3/vcu118/system_bd.tcl
@@ -1,4 +1,3 @@
-
 ## FIFO depth is 4Mb - 250k samples
 set adc_fifo_address_width 16
 
@@ -12,9 +11,11 @@ source $ad_hdl_dir/projects/common/xilinx/dacfifo_bd.tcl
 source ../common/daq3_bd.tcl
 source $ad_hdl_dir/projects/scripts/adi_pd.tcl
 
+set mem_init_sys_path [get_env_param ADI_PROJECT_DIR ""]mem_init_sys.txt;
+
 #system ID
 ad_ip_parameter axi_sysid_0 CONFIG.ROM_ADDR_BITS 9
-ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "[pwd]/mem_init_sys.txt"
+ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "[pwd]/$mem_init_sys_path"
 ad_ip_parameter rom_sys_0 CONFIG.ROM_ADDR_BITS 9
 
 sysid_gen_sys_init_file

--- a/projects/daq3/vcu118/system_project.tcl
+++ b/projects/daq3/vcu118/system_project.tcl
@@ -1,4 +1,3 @@
-
 source ../../../scripts/adi_env.tcl
 source $ad_hdl_dir/projects/scripts/adi_project_xilinx.tcl
 source $ad_hdl_dir/projects/scripts/adi_board.tcl

--- a/projects/daq3/zc706/system_bd.tcl
+++ b/projects/daq3/zc706/system_bd.tcl
@@ -1,4 +1,3 @@
-
 ## FIFO depth is 1GB, PL_DDR is used
 set adc_fifo_address_width 16
 
@@ -13,9 +12,11 @@ source $ad_hdl_dir/projects/common/xilinx/dacfifo_bd.tcl
 source ../common/daq3_bd.tcl
 source $ad_hdl_dir/projects/scripts/adi_pd.tcl
 
+set mem_init_sys_path [get_env_param ADI_PROJECT_DIR ""]mem_init_sys.txt;
+
 #system ID
 ad_ip_parameter axi_sysid_0 CONFIG.ROM_ADDR_BITS 9
-ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "[pwd]/mem_init_sys.txt"
+ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "[pwd]/$mem_init_sys_path"
 ad_ip_parameter rom_sys_0 CONFIG.ROM_ADDR_BITS 9
 
 sysid_gen_sys_init_file

--- a/projects/daq3/zc706/system_project.tcl
+++ b/projects/daq3/zc706/system_project.tcl
@@ -1,4 +1,3 @@
-
 source ../../../scripts/adi_env.tcl
 source $ad_hdl_dir/projects/scripts/adi_project_xilinx.tcl
 source $ad_hdl_dir/projects/scripts/adi_board.tcl

--- a/projects/daq3/zcu102/system_bd.tcl
+++ b/projects/daq3/zcu102/system_bd.tcl
@@ -1,4 +1,3 @@
-
 ## FIFO depth is 8Mb - 500k samples
 set dac_fifo_address_width 16
 
@@ -9,9 +8,11 @@ source $ad_hdl_dir/projects/common/xilinx/dacfifo_bd.tcl
 source ../common/daq3_bd.tcl
 source $ad_hdl_dir/projects/scripts/adi_pd.tcl
 
+set mem_init_sys_path [get_env_param ADI_PROJECT_DIR ""]mem_init_sys.txt;
+
 #system ID
 ad_ip_parameter axi_sysid_0 CONFIG.ROM_ADDR_BITS 9
-ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "[pwd]/mem_init_sys.txt"
+ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "[pwd]/$mem_init_sys_path"
 ad_ip_parameter rom_sys_0 CONFIG.ROM_ADDR_BITS 9
 
 sysid_gen_sys_init_file

--- a/projects/daq3/zcu102/system_project.tcl
+++ b/projects/daq3/zcu102/system_project.tcl
@@ -1,4 +1,3 @@
-
 source ../../../scripts/adi_env.tcl
 source $ad_hdl_dir/projects/scripts/adi_project_xilinx.tcl
 source $ad_hdl_dir/projects/scripts/adi_board.tcl

--- a/projects/fmcadc2/vc707/system_bd.tcl
+++ b/projects/fmcadc2/vc707/system_bd.tcl
@@ -1,4 +1,3 @@
-
 ## FIFO depth is 16Mb - 1M samples
 set adc_fifo_address_width 18
 
@@ -9,9 +8,11 @@ source $ad_hdl_dir/projects/common/xilinx/adcfifo_bd.tcl
 source ../common/fmcadc2_bd.tcl
 source $ad_hdl_dir/projects/scripts/adi_pd.tcl
 
+set mem_init_sys_path [get_env_param ADI_PROJECT_DIR ""]mem_init_sys.txt;
+
 #system ID
 ad_ip_parameter axi_sysid_0 CONFIG.ROM_ADDR_BITS 9
-ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "[pwd]/mem_init_sys.txt"
+ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "[pwd]/$mem_init_sys_path"
 ad_ip_parameter rom_sys_0 CONFIG.ROM_ADDR_BITS 9
 
 sysid_gen_sys_init_file

--- a/projects/fmcadc2/vc707/system_project.tcl
+++ b/projects/fmcadc2/vc707/system_project.tcl
@@ -1,6 +1,3 @@
-
-
-
 source ../../../scripts/adi_env.tcl
 source $ad_hdl_dir/projects/scripts/adi_project_xilinx.tcl
 source $ad_hdl_dir/projects/scripts/adi_board.tcl

--- a/projects/fmcadc2/zc706/system_bd.tcl
+++ b/projects/fmcadc2/zc706/system_bd.tcl
@@ -1,4 +1,3 @@
-
 set adc_fifo_address_width 18
 
 source $ad_hdl_dir/projects/common/zc706/zc706_system_bd.tcl
@@ -6,9 +5,11 @@ source $ad_hdl_dir/projects/common/zc706/zc706_plddr3_adcfifo_bd.tcl
 source ../common/fmcadc2_bd.tcl
 source $ad_hdl_dir/projects/scripts/adi_pd.tcl
 
+set mem_init_sys_path [get_env_param ADI_PROJECT_DIR ""]mem_init_sys.txt;
+
 #system ID
 ad_ip_parameter axi_sysid_0 CONFIG.ROM_ADDR_BITS 9
-ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "[pwd]/mem_init_sys.txt"
+ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "[pwd]/$mem_init_sys_path"
 ad_ip_parameter rom_sys_0 CONFIG.ROM_ADDR_BITS 9
 
 sysid_gen_sys_init_file

--- a/projects/fmcadc2/zc706/system_project.tcl
+++ b/projects/fmcadc2/zc706/system_project.tcl
@@ -1,4 +1,3 @@
-
 source ../../../scripts/adi_env.tcl
 source $ad_hdl_dir/projects/scripts/adi_project_xilinx.tcl
 source $ad_hdl_dir/projects/scripts/adi_board.tcl

--- a/projects/fmcadc5/vc707/system_bd.tcl
+++ b/projects/fmcadc5/vc707/system_bd.tcl
@@ -1,4 +1,3 @@
-
 ## FIFO depth is 16Mb - 1M Samples
 set adc_fifo_address_width 18
 
@@ -9,9 +8,11 @@ source $ad_hdl_dir/projects/common/xilinx/adcfifo_bd.tcl
 source ../common/fmcadc5_bd.tcl
 source $ad_hdl_dir/projects/scripts/adi_pd.tcl
 
+set mem_init_sys_path [get_env_param ADI_PROJECT_DIR ""]mem_init_sys.txt;
+
 #system ID
 ad_ip_parameter axi_sysid_0 CONFIG.ROM_ADDR_BITS 9
-ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "[pwd]/mem_init_sys.txt"
+ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "[pwd]/$mem_init_sys_path"
 ad_ip_parameter rom_sys_0 CONFIG.ROM_ADDR_BITS 9
 
 sysid_gen_sys_init_file

--- a/projects/fmcadc5/vc707/system_project.tcl
+++ b/projects/fmcadc5/vc707/system_project.tcl
@@ -1,6 +1,3 @@
-
-
-
 source ../../../scripts/adi_env.tcl
 source $ad_hdl_dir/projects/scripts/adi_project_xilinx.tcl
 source $ad_hdl_dir/projects/scripts/adi_board.tcl

--- a/projects/fmcjesdadc1/kc705/system_bd.tcl
+++ b/projects/fmcjesdadc1/kc705/system_bd.tcl
@@ -1,11 +1,12 @@
-
 source $ad_hdl_dir/projects/common/kc705/kc705_system_bd.tcl
 source ../common/fmcjesdadc1_bd.tcl
 source $ad_hdl_dir/projects/scripts/adi_pd.tcl
 
+set mem_init_sys_path [get_env_param ADI_PROJECT_DIR ""]mem_init_sys.txt;
+
 #system ID
 ad_ip_parameter axi_sysid_0 CONFIG.ROM_ADDR_BITS 9
-ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "[pwd]/mem_init_sys.txt"
+ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "[pwd]/$mem_init_sys_path"
 ad_ip_parameter rom_sys_0 CONFIG.ROM_ADDR_BITS 9
 
 sysid_gen_sys_init_file

--- a/projects/fmcjesdadc1/kc705/system_project.tcl
+++ b/projects/fmcjesdadc1/kc705/system_project.tcl
@@ -1,4 +1,3 @@
-
 source ../../../scripts/adi_env.tcl
 source $ad_hdl_dir/projects/scripts/adi_board.tcl
 source $ad_hdl_dir/projects/scripts/adi_project_xilinx.tcl

--- a/projects/fmcjesdadc1/vc707/system_bd.tcl
+++ b/projects/fmcjesdadc1/vc707/system_bd.tcl
@@ -1,11 +1,12 @@
-
 source $ad_hdl_dir/projects/common/vc707/vc707_system_bd.tcl
 source ../common/fmcjesdadc1_bd.tcl
 source $ad_hdl_dir/projects/scripts/adi_pd.tcl
 
+set mem_init_sys_path [get_env_param ADI_PROJECT_DIR ""]mem_init_sys.txt;
+
 #system ID
 ad_ip_parameter axi_sysid_0 CONFIG.ROM_ADDR_BITS 9
-ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "[pwd]/mem_init_sys.txt"
+ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "[pwd]/$mem_init_sys_path"
 ad_ip_parameter rom_sys_0 CONFIG.ROM_ADDR_BITS 9
 
 sysid_gen_sys_init_file

--- a/projects/fmcjesdadc1/vc707/system_project.tcl
+++ b/projects/fmcjesdadc1/vc707/system_project.tcl
@@ -1,4 +1,3 @@
-
 source ../../../scripts/adi_env.tcl
 source $ad_hdl_dir/projects/scripts/adi_project_xilinx.tcl
 source $ad_hdl_dir/projects/scripts/adi_board.tcl

--- a/projects/fmcjesdadc1/zc706/system_bd.tcl
+++ b/projects/fmcjesdadc1/zc706/system_bd.tcl
@@ -1,11 +1,12 @@
-
 source $ad_hdl_dir/projects/common/zc706/zc706_system_bd.tcl
 source ../common/fmcjesdadc1_bd.tcl
 source $ad_hdl_dir/projects/scripts/adi_pd.tcl
 
+set mem_init_sys_path [get_env_param ADI_PROJECT_DIR ""]mem_init_sys.txt;
+
 #system ID
 ad_ip_parameter axi_sysid_0 CONFIG.ROM_ADDR_BITS 9
-ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "[pwd]/mem_init_sys.txt"
+ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "[pwd]/$mem_init_sys_path"
 ad_ip_parameter rom_sys_0 CONFIG.ROM_ADDR_BITS 9
 
 sysid_gen_sys_init_file

--- a/projects/fmcjesdadc1/zc706/system_project.tcl
+++ b/projects/fmcjesdadc1/zc706/system_project.tcl
@@ -1,4 +1,3 @@
-
 source ../../../scripts/adi_env.tcl
 source $ad_hdl_dir/projects/scripts/adi_project_xilinx.tcl
 source $ad_hdl_dir/projects/scripts/adi_board.tcl

--- a/projects/fmcomms11/zc706/system_bd.tcl
+++ b/projects/fmcomms11/zc706/system_bd.tcl
@@ -1,4 +1,3 @@
-
 # instantiate the base design
 source $ad_hdl_dir/projects/common/zc706/zc706_system_bd.tcl
 
@@ -18,9 +17,11 @@ set adc_fifo_address_width 15
 source ../common/fmcomms11_bd.tcl
 source $ad_hdl_dir/projects/scripts/adi_pd.tcl
 
+set mem_init_sys_path [get_env_param ADI_PROJECT_DIR ""]mem_init_sys.txt;
+
 #system ID
 ad_ip_parameter axi_sysid_0 CONFIG.ROM_ADDR_BITS 9
-ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "[pwd]/mem_init_sys.txt"
+ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "[pwd]/$mem_init_sys_path"
 ad_ip_parameter rom_sys_0 CONFIG.ROM_ADDR_BITS 9
 
 sysid_gen_sys_init_file

--- a/projects/fmcomms11/zc706/system_project.tcl
+++ b/projects/fmcomms11/zc706/system_project.tcl
@@ -1,4 +1,3 @@
-
 source ../../../scripts/adi_env.tcl
 source $ad_hdl_dir/projects/scripts/adi_project_xilinx.tcl
 source $ad_hdl_dir/projects/scripts/adi_board.tcl

--- a/projects/fmcomms2/kc705/system_bd.tcl
+++ b/projects/fmcomms2/kc705/system_bd.tcl
@@ -1,11 +1,12 @@
-
 source $ad_hdl_dir/projects/common/kc705/kc705_system_bd.tcl
 source ../common/fmcomms2_bd.tcl
 source $ad_hdl_dir/projects/scripts/adi_pd.tcl
 
+set mem_init_sys_path [get_env_param ADI_PROJECT_DIR ""]mem_init_sys.txt;
+
 #system ID
 ad_ip_parameter axi_sysid_0 CONFIG.ROM_ADDR_BITS 9
-ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "[pwd]/mem_init_sys.txt"
+ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "[pwd]/$mem_init_sys_path"
 ad_ip_parameter rom_sys_0 CONFIG.ROM_ADDR_BITS 9
 
 sysid_gen_sys_init_file

--- a/projects/fmcomms2/kc705/system_project.tcl
+++ b/projects/fmcomms2/kc705/system_project.tcl
@@ -1,4 +1,3 @@
-
 source ../../../scripts/adi_env.tcl
 source $ad_hdl_dir/projects/scripts/adi_project_xilinx.tcl
 source $ad_hdl_dir/projects/scripts/adi_board.tcl

--- a/projects/fmcomms2/kcu105/system_bd.tcl
+++ b/projects/fmcomms2/kcu105/system_bd.tcl
@@ -1,12 +1,13 @@
-
 source $ad_hdl_dir/projects/common/kcu105/kcu105_system_bd.tcl
 source $ad_hdl_dir/projects/common/kcu105/kcu105_system_mig.tcl
 source ../common/fmcomms2_bd.tcl
 source $ad_hdl_dir/projects/scripts/adi_pd.tcl
 
+set mem_init_sys_path [get_env_param ADI_PROJECT_DIR ""]mem_init_sys.txt;
+
 #system ID
 ad_ip_parameter axi_sysid_0 CONFIG.ROM_ADDR_BITS 9
-ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "[pwd]/mem_init_sys.txt"
+ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "[pwd]/$mem_init_sys_path"
 ad_ip_parameter rom_sys_0 CONFIG.ROM_ADDR_BITS 9
 
 sysid_gen_sys_init_file

--- a/projects/fmcomms2/kcu105/system_project.tcl
+++ b/projects/fmcomms2/kcu105/system_project.tcl
@@ -1,4 +1,3 @@
-
 source ../../../scripts/adi_env.tcl
 source $ad_hdl_dir/projects/scripts/adi_project_xilinx.tcl
 source $ad_hdl_dir/projects/scripts/adi_board.tcl

--- a/projects/fmcomms2/vc707/system_bd.tcl
+++ b/projects/fmcomms2/vc707/system_bd.tcl
@@ -1,11 +1,12 @@
-
 source $ad_hdl_dir/projects/common/vc707/vc707_system_bd.tcl
 source ../common/fmcomms2_bd.tcl
 source $ad_hdl_dir/projects/scripts/adi_pd.tcl
 
+set mem_init_sys_path [get_env_param ADI_PROJECT_DIR ""]mem_init_sys.txt;
+
 #system ID
 ad_ip_parameter axi_sysid_0 CONFIG.ROM_ADDR_BITS 9
-ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "[pwd]/mem_init_sys.txt"
+ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "[pwd]/$mem_init_sys_path"
 ad_ip_parameter rom_sys_0 CONFIG.ROM_ADDR_BITS 9
 
 sysid_gen_sys_init_file

--- a/projects/fmcomms2/vc707/system_project.tcl
+++ b/projects/fmcomms2/vc707/system_project.tcl
@@ -1,4 +1,3 @@
-
 source ../../../scripts/adi_env.tcl
 source $ad_hdl_dir/projects/scripts/adi_project_xilinx.tcl
 source $ad_hdl_dir/projects/scripts/adi_board.tcl

--- a/projects/fmcomms2/zc702/system_bd.tcl
+++ b/projects/fmcomms2/zc702/system_bd.tcl
@@ -1,11 +1,12 @@
-
 source $ad_hdl_dir/projects/common/zc702/zc702_system_bd.tcl
 source ../common/fmcomms2_bd.tcl
 source $ad_hdl_dir/projects/scripts/adi_pd.tcl
 
+set mem_init_sys_path [get_env_param ADI_PROJECT_DIR ""]mem_init_sys.txt;
+
 #system ID
 ad_ip_parameter axi_sysid_0 CONFIG.ROM_ADDR_BITS 9
-ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "[pwd]/mem_init_sys.txt"
+ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "[pwd]/$mem_init_sys_path"
 ad_ip_parameter rom_sys_0 CONFIG.ROM_ADDR_BITS 9
 
 sysid_gen_sys_init_file

--- a/projects/fmcomms2/zc702/system_project.tcl
+++ b/projects/fmcomms2/zc702/system_project.tcl
@@ -1,4 +1,3 @@
-
 source ../../../scripts/adi_env.tcl
 source $ad_hdl_dir/projects/scripts/adi_project_xilinx.tcl
 source $ad_hdl_dir/projects/scripts/adi_board.tcl

--- a/projects/fmcomms2/zc706/system_bd.tcl
+++ b/projects/fmcomms2/zc706/system_bd.tcl
@@ -1,11 +1,12 @@
-
 source $ad_hdl_dir/projects/common/zc706/zc706_system_bd.tcl
 source ../common/fmcomms2_bd.tcl
 source $ad_hdl_dir/projects/scripts/adi_pd.tcl
 
+set mem_init_sys_path [get_env_param ADI_PROJECT_DIR ""]mem_init_sys.txt;
+
 #system ID
 ad_ip_parameter axi_sysid_0 CONFIG.ROM_ADDR_BITS 9
-ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "[pwd]/mem_init_sys.txt"
+ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "[pwd]/$mem_init_sys_path"
 ad_ip_parameter rom_sys_0 CONFIG.ROM_ADDR_BITS 9
 
 sysid_gen_sys_init_file

--- a/projects/fmcomms2/zc706/system_project.tcl
+++ b/projects/fmcomms2/zc706/system_project.tcl
@@ -1,4 +1,3 @@
-
 source ../../../scripts/adi_env.tcl
 source $ad_hdl_dir/projects/scripts/adi_project_xilinx.tcl
 source $ad_hdl_dir/projects/scripts/adi_board.tcl

--- a/projects/fmcomms2/zcu102/system_bd.tcl
+++ b/projects/fmcomms2/zcu102/system_bd.tcl
@@ -1,11 +1,12 @@
-
 source $ad_hdl_dir/projects/common/zcu102/zcu102_system_bd.tcl
 source ../common/fmcomms2_bd.tcl
 source $ad_hdl_dir/projects/scripts/adi_pd.tcl
 
+set mem_init_sys_path [get_env_param ADI_PROJECT_DIR ""]mem_init_sys.txt;
+
 #system ID
 ad_ip_parameter axi_sysid_0 CONFIG.ROM_ADDR_BITS 9
-ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "[pwd]/mem_init_sys.txt"
+ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "[pwd]/$mem_init_sys_path"
 ad_ip_parameter rom_sys_0 CONFIG.ROM_ADDR_BITS 9
 
 sysid_gen_sys_init_file

--- a/projects/fmcomms2/zcu102/system_project.tcl
+++ b/projects/fmcomms2/zcu102/system_project.tcl
@@ -1,4 +1,3 @@
-
 source ../../../scripts/adi_env.tcl
 source $ad_hdl_dir/projects/scripts/adi_project_xilinx.tcl
 source $ad_hdl_dir/projects/scripts/adi_board.tcl

--- a/projects/fmcomms2/zed/system_bd.tcl
+++ b/projects/fmcomms2/zed/system_bd.tcl
@@ -1,11 +1,12 @@
-
 source $ad_hdl_dir/projects/common/zed/zed_system_bd.tcl
 source ../common/fmcomms2_bd.tcl
 source $ad_hdl_dir/projects/scripts/adi_pd.tcl
 
+set mem_init_sys_path [get_env_param ADI_PROJECT_DIR ""]mem_init_sys.txt;
+
 #system ID
 ad_ip_parameter axi_sysid_0 CONFIG.ROM_ADDR_BITS 9
-ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "[pwd]/mem_init_sys.txt"
+ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "[pwd]/$mem_init_sys_path"
 ad_ip_parameter rom_sys_0 CONFIG.ROM_ADDR_BITS 9
 
 sysid_gen_sys_init_file

--- a/projects/fmcomms2/zed/system_project.tcl
+++ b/projects/fmcomms2/zed/system_project.tcl
@@ -1,4 +1,3 @@
-
 source ../../../scripts/adi_env.tcl
 source $ad_hdl_dir/projects/scripts/adi_project_xilinx.tcl
 source $ad_hdl_dir/projects/scripts/adi_board.tcl

--- a/projects/fmcomms5/zc702/system_bd.tcl
+++ b/projects/fmcomms5/zc702/system_bd.tcl
@@ -1,10 +1,11 @@
-
 source $ad_hdl_dir/projects/common/zc702/zc702_system_bd.tcl
 source $ad_hdl_dir/projects/scripts/adi_pd.tcl
 
+set mem_init_sys_path [get_env_param ADI_PROJECT_DIR ""]mem_init_sys.txt;
+
 #system ID
 ad_ip_parameter axi_sysid_0 CONFIG.ROM_ADDR_BITS 9
-ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "[pwd]/mem_init_sys.txt"
+ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "[pwd]/$mem_init_sys_path"
 ad_ip_parameter rom_sys_0 CONFIG.ROM_ADDR_BITS 9
 
 sysid_gen_sys_init_file

--- a/projects/fmcomms5/zc702/system_project.tcl
+++ b/projects/fmcomms5/zc702/system_project.tcl
@@ -1,4 +1,3 @@
-
 source ../../../scripts/adi_env.tcl
 source $ad_hdl_dir/projects/scripts/adi_project_xilinx.tcl
 source $ad_hdl_dir/projects/scripts/adi_board.tcl

--- a/projects/fmcomms5/zc706/system_bd.tcl
+++ b/projects/fmcomms5/zc706/system_bd.tcl
@@ -1,10 +1,11 @@
-
 source $ad_hdl_dir/projects/common/zc706/zc706_system_bd.tcl
 source $ad_hdl_dir/projects/scripts/adi_pd.tcl
 
+set mem_init_sys_path [get_env_param ADI_PROJECT_DIR ""]mem_init_sys.txt;
+
 #system ID
 ad_ip_parameter axi_sysid_0 CONFIG.ROM_ADDR_BITS 9
-ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "[pwd]/mem_init_sys.txt"
+ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "[pwd]/$mem_init_sys_path"
 ad_ip_parameter rom_sys_0 CONFIG.ROM_ADDR_BITS 9
 
 sysid_gen_sys_init_file

--- a/projects/fmcomms5/zc706/system_project.tcl
+++ b/projects/fmcomms5/zc706/system_project.tcl
@@ -1,4 +1,3 @@
-
 source ../../../scripts/adi_env.tcl
 source $ad_hdl_dir/projects/scripts/adi_project_xilinx.tcl
 source $ad_hdl_dir/projects/scripts/adi_board.tcl

--- a/projects/fmcomms5/zcu102/system_bd.tcl
+++ b/projects/fmcomms5/zcu102/system_bd.tcl
@@ -1,11 +1,12 @@
-
 source $ad_hdl_dir/projects/common/zcu102/zcu102_system_bd.tcl
 source ../common/fmcomms5_bd.tcl
 source $ad_hdl_dir/projects/scripts/adi_pd.tcl
 
+set mem_init_sys_path [get_env_param ADI_PROJECT_DIR ""]mem_init_sys.txt;
+
 #system ID
 ad_ip_parameter axi_sysid_0 CONFIG.ROM_ADDR_BITS 9
-ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "[pwd]/mem_init_sys.txt"
+ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "[pwd]/$mem_init_sys_path"
 ad_ip_parameter rom_sys_0 CONFIG.ROM_ADDR_BITS 9
 
 sysid_gen_sys_init_file

--- a/projects/fmcomms5/zcu102/system_project.tcl
+++ b/projects/fmcomms5/zcu102/system_project.tcl
@@ -1,4 +1,3 @@
-
 source ../../../scripts/adi_env.tcl
 source $ad_hdl_dir/projects/scripts/adi_project_xilinx.tcl
 source $ad_hdl_dir/projects/scripts/adi_board.tcl

--- a/projects/fmcomms8/a10soc/system_project.tcl
+++ b/projects/fmcomms8/a10soc/system_project.tcl
@@ -1,4 +1,3 @@
-
 source ../../../scripts/adi_env.tcl
 source ../../scripts/adi_project_intel.tcl
 
@@ -9,7 +8,7 @@ source $ad_hdl_dir/projects/common/a10soc/a10soc_plddr4_assign.tcl
 
 # files
 
-set_global_assignment -name VERILOG_FILE ../common/fmcomms8_spi.v
+set_global_assignment -name VERILOG_FILE $ad_hdl_dir/projects/fmcomms8/common/fmcomms8_spi.v
 set_global_assignment -name VERILOG_FILE $ad_hdl_dir/library/common/ad_iobuf.v
 
 # fmcomms8

--- a/projects/fmcomms8/a10soc/system_qsys.tcl
+++ b/projects/fmcomms8/a10soc/system_qsys.tcl
@@ -1,10 +1,14 @@
-
 set dac_fifo_address_width 16
 
 source $ad_hdl_dir/projects/scripts/adi_pd.tcl
 source $ad_hdl_dir/projects/common/a10soc/a10soc_system_qsys.tcl
 source $ad_hdl_dir/projects/common/a10soc/a10soc_plddr4_dacfifo_qsys.tcl
-source ../common/fmcomms8_qsys.tcl
+
+if [info exists ad_project_dir] {
+  source ../../common/fmcomms8_qsys.tcl
+} else {
+  source ../common/fmcomms8_qsys.tcl
+}
 
 #system ID
 set_instance_parameter_value axi_sysid_0 {ROM_ADDR_BITS} {9}

--- a/projects/fmcomms8/zcu102/system_bd.tcl
+++ b/projects/fmcomms8/zcu102/system_bd.tcl
@@ -1,4 +1,3 @@
-
 source $ad_hdl_dir/projects/common/zcu102/zcu102_system_bd.tcl
 source $ad_hdl_dir/projects/common/xilinx/dacfifo_bd.tcl
 source $ad_hdl_dir/projects/scripts/adi_pd.tcl
@@ -6,9 +5,11 @@ source $ad_hdl_dir/projects/scripts/adi_pd.tcl
 ## FIFO depth is 8Mb - 500k samples
 set dac_fifo_address_width 16
 
+set mem_init_sys_path [get_env_param ADI_PROJECT_DIR ""]mem_init_sys.txt;
+
 #system ID
 ad_ip_parameter axi_sysid_0 CONFIG.ROM_ADDR_BITS 9
-ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "[pwd]/mem_init_sys.txt"
+ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "[pwd]/$mem_init_sys_path"
 ad_ip_parameter rom_sys_0 CONFIG.ROM_ADDR_BITS 9
 
 sysid_gen_sys_init_file

--- a/projects/fmcomms8/zcu102/system_project.tcl
+++ b/projects/fmcomms8/zcu102/system_project.tcl
@@ -1,4 +1,3 @@
-
 source ../../../scripts/adi_env.tcl
 source $ad_hdl_dir/projects/scripts/adi_project_xilinx.tcl
 source $ad_hdl_dir/projects/scripts/adi_board.tcl

--- a/projects/imageon/zed/system_bd.tcl
+++ b/projects/imageon/zed/system_bd.tcl
@@ -1,11 +1,12 @@
-
 source $ad_hdl_dir/projects/common/zed/zed_system_bd.tcl
 source ../common/imageon_bd.tcl
 source $ad_hdl_dir/projects/scripts/adi_pd.tcl
 
+set mem_init_sys_path [get_env_param ADI_PROJECT_DIR ""]mem_init_sys.txt;
+
 #system ID
 ad_ip_parameter axi_sysid_0 CONFIG.ROM_ADDR_BITS 9
-ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "[pwd]/mem_init_sys.txt"
+ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "[pwd]/$mem_init_sys_path"
 ad_ip_parameter rom_sys_0 CONFIG.ROM_ADDR_BITS 9
 
 sysid_gen_sys_init_file

--- a/projects/imageon/zed/system_project.tcl
+++ b/projects/imageon/zed/system_project.tcl
@@ -1,5 +1,4 @@
 # load script
-
 source ../../../scripts/adi_env.tcl
 source $ad_hdl_dir/projects/scripts/adi_project_xilinx.tcl
 source $ad_hdl_dir/projects/scripts/adi_board.tcl

--- a/projects/m2k/standalone/system_bd.tcl
+++ b/projects/m2k/standalone/system_bd.tcl
@@ -1,4 +1,3 @@
-
 set_msg_config -id {PSU-1} -new_severity {WARNING}
 
 set DEBUG_BUILD 0

--- a/projects/m2k/standalone/system_project.tcl
+++ b/projects/m2k/standalone/system_project.tcl
@@ -1,4 +1,3 @@
-
 source ../../../scripts/adi_env.tcl
 source $ad_hdl_dir/projects/scripts/adi_project_xilinx.tcl
 source $ad_hdl_dir/projects/scripts/adi_board.tcl

--- a/projects/pluto/system_bd.tcl
+++ b/projects/pluto/system_bd.tcl
@@ -1,6 +1,5 @@
 # create board design
 
-
 source $ad_hdl_dir/projects/common/xilinx/adi_fir_filter_bd.tcl
 
 # default ports

--- a/projects/pluto/system_project.tcl
+++ b/projects/pluto/system_project.tcl
@@ -1,4 +1,3 @@
-
 source ../../scripts/adi_env.tcl
 source $ad_hdl_dir/projects/scripts/adi_project_xilinx.tcl
 source $ad_hdl_dir/projects/scripts/adi_board.tcl

--- a/projects/pluto_ng/system_bd.tcl
+++ b/projects/pluto_ng/system_bd.tcl
@@ -1,5 +1,4 @@
 # create board design
-
 source $ad_hdl_dir/projects/common/xilinx/adi_fir_filter_bd.tcl
 source $ad_hdl_dir/projects/scripts/adi_pd.tcl
 
@@ -595,9 +594,11 @@ ad_cpu_interrupt ps-12 mb-11 axi_adrv9001_rx2_dma/irq
 ad_cpu_interrupt ps-11 mb-6 axi_adrv9001_tx1_dma/irq
 ad_cpu_interrupt ps-10 mb-5 axi_adrv9001_tx2_dma/irq
 
+set mem_init_sys_path [get_env_param ADI_PROJECT_DIR ""]mem_init_sys.txt;
+
 #system ID
 ad_ip_parameter axi_sysid_0 CONFIG.ROM_ADDR_BITS 9
-ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "[pwd]/mem_init_sys.txt"
+ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "[pwd]/$mem_init_sys_path"
 ad_ip_parameter rom_sys_0 CONFIG.ROM_ADDR_BITS 9
 
 sysid_gen_sys_init_file

--- a/projects/pluto_ng/system_project.tcl
+++ b/projects/pluto_ng/system_project.tcl
@@ -1,4 +1,3 @@
-
 source ../../scripts/adi_env.tcl
 source $ad_hdl_dir/projects/scripts/adi_project_xilinx.tcl
 source $ad_hdl_dir/projects/scripts/adi_board.tcl

--- a/projects/pulsar_adc_pmdz/coraz7s/system_bd.tcl
+++ b/projects/pulsar_adc_pmdz/coraz7s/system_bd.tcl
@@ -2,9 +2,11 @@ source $ad_hdl_dir/projects/common/coraz7s/coraz7s_system_bd.tcl
 source $ad_hdl_dir/projects/scripts/adi_pd.tcl
 source ../common/pulsar_adc_pmdz_bd.tcl
 
+set mem_init_sys_path [get_env_param ADI_PROJECT_DIR ""]mem_init_sys.txt;
+
 #system ID
 ad_ip_parameter axi_sysid_0 CONFIG.ROM_ADDR_BITS 9
-ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "[pwd]/mem_init_sys.txt"
+ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "[pwd]/$mem_init_sys_path";
 ad_ip_parameter rom_sys_0 CONFIG.ROM_ADDR_BITS 9
 
 sysid_gen_sys_init_file

--- a/projects/pulsar_adc_pmdz/coraz7s/system_project.tcl
+++ b/projects/pulsar_adc_pmdz/coraz7s/system_project.tcl
@@ -1,4 +1,3 @@
-
 source ../../../scripts/adi_env.tcl
 source $ad_hdl_dir/projects/scripts/adi_project_xilinx.tcl
 source $ad_hdl_dir/projects/scripts/adi_board.tcl

--- a/projects/scripts/adi_pd.tcl
+++ b/projects/scripts/adi_pd.tcl
@@ -194,7 +194,13 @@ proc sysid_gen_sys_init_file {{custom_string {}}} {
 
   set sys_mem_hex [format %0-[expr 512 * 8]s [concat $comh_hex$verh_hex$projname_hex$boardname_hex$custom_hex]];
 
-  set sys_mem_file [open "mem_init_sys.txt" "w"];
+  if {[info exists ::env(ADI_PROJECT_DIR)]} {
+    set mem_init_sys_file_path "$::env(ADI_PROJECT_DIR)mem_init_sys.txt";
+  } else {
+    set mem_init_sys_file_path "mem_init_sys.txt";
+  }
+
+  set sys_mem_file [open $mem_init_sys_file_path "w"];
 
   for {set i 0} {$i < [string length $sys_mem_hex]} {incr i} {
     if { ($i+1) % 8 == 0} {

--- a/projects/scripts/adi_project_xilinx.tcl
+++ b/projects/scripts/adi_project_xilinx.tcl
@@ -49,59 +49,59 @@ proc adi_project {project_name {mode 0} {parameter_list {}} } {
   set board ""
 
   # Determine the device based on the board name
-  if [regexp "_ac701$" $project_name] {
+  if [regexp "_ac701" $project_name] {
     set device "xc7a200tfbg676-2"
     set board [lindex [lsearch -all -inline [get_board_parts] *ac701*] end]
   }
-  if [regexp "_kc705$" $project_name] {
+  if [regexp "_kc705" $project_name] {
     set device "xc7k325tffg900-2"
     set board [lindex [lsearch -all -inline [get_board_parts] *kc705*] end]
   }
-  if [regexp "_vc707$" $project_name] {
+  if [regexp "_vc707" $project_name] {
     set device "xc7vx485tffg1761-2"
     set board [lindex [lsearch -all -inline [get_board_parts] *vc707*] end]
   }
-  if [regexp "_vcu118$" $project_name] {
+  if [regexp "_vcu118" $project_name] {
     set device "xcvu9p-flga2104-2L-e"
     set board [lindex [lsearch -all -inline [get_board_parts] *vcu118*] end]
   }
-  if [regexp "_vcu128$" $project_name] {
+  if [regexp "_vcu128" $project_name] {
     set device "xcvu37p-fsvh2892-2L-e"
     set board [lindex [lsearch -all -inline [get_board_parts] *vcu128:part0*] end]
   }
-  if [regexp "_kcu105$" $project_name] {
+  if [regexp "_kcu105" $project_name] {
     set device "xcku040-ffva1156-2-e"
     set board [lindex [lsearch -all -inline [get_board_parts] *kcu105*] end]
   }
-  if [regexp "_zed$" $project_name] {
+  if [regexp "_zed" $project_name] {
     set device "xc7z020clg484-1"
     set board [lindex [lsearch -all -inline [get_board_parts] *zed*] end]
   }
-  if [regexp "_coraz7s$" $project_name] {
+  if [regexp "_coraz7s" $project_name] {
     set device "xc7z007sclg400-1"
     set board "not-applicable"
   }
-  if [regexp "_microzed$" $project_name] {
+  if [regexp "_microzed" $project_name] {
     set device "xc7z010clg400-1"
     set board "not-applicable"
   }
-  if [regexp "_zc702$" $project_name] {
+  if [regexp "_zc702" $project_name] {
     set device "xc7z020clg484-1"
     set board [lindex [lsearch -all -inline [get_board_parts] *zc702*] end]
   }
-  if [regexp "_zc706$" $project_name] {
+  if [regexp "_zc706" $project_name] {
     set device "xc7z045ffg900-2"
     set board [lindex [lsearch -all -inline [get_board_parts] *zc706*] end]
   }
-  if [regexp "_mitx045$" $project_name] {
+  if [regexp "_mitx045" $project_name] {
     set device "xc7z045ffg900-2"
     set board "not-applicable"
   }
-  if [regexp "_zcu102$" $project_name] {
+  if [regexp "_zcu102" $project_name] {
     set device "xczu9eg-ffvb1156-2-e"
     set board [lindex [lsearch -all -inline [get_board_parts] *zcu102*] end]
   }
-  if [regexp "_vmk180_es1$" $project_name] {
+  if [regexp "_vmk180_es1" $project_name] {
     enable_beta_device xcvm*
     xhub::refresh_catalog [xhub::get_xstores xilinx_board_store]
     xhub::install [xhub::get_xitems xilinx.com:xilinx_board_store:vmk180_es:*] -quiet
@@ -109,15 +109,15 @@ proc adi_project {project_name {mode 0} {parameter_list {}} } {
     set device "xcvm1802-vsva2197-2MP-e-S-es1"
     set board [lindex [lsearch -all -inline [get_board_parts] *vmk180_es*] end]
   }
-  if [regexp "_vmk180$" $project_name] {
+  if [regexp "_vmk180" $project_name] {
     set device "xcvm1802-vsva2197-2MP-e-S"
     set board [lindex [lsearch -all -inline [get_board_parts] *vmk180*] end]
   }
-  if [regexp "_vck190$" $project_name] {
+  if [regexp "_vck190" $project_name] {
     set device "xcvc1902-vsva2197-2MP-e-S"
     set board [lindex [lsearch -all -inline [get_board_parts] *vck190*] end]
   }
-  if [regexp "_vc709$" $project_name] {
+  if [regexp "_vc709" $project_name] {
     set device "xc7vx690tffg1761-2"
     set board [lindex [lsearch -all -inline [get_board_parts] *vc709*] end]
   }
@@ -140,6 +140,7 @@ proc adi_project_create {project_name mode parameter_list device {board "not-app
 
   global ad_hdl_dir
   global ad_ghdl_dir
+  global ad_project_dir
   global p_board
   global p_device
   global sys_zynq
@@ -147,6 +148,12 @@ proc adi_project_create {project_name mode parameter_list device {board "not-app
   global IGNORE_VERSION_CHECK
   global ADI_USE_OOC_SYNTHESIS
   global ADI_USE_INCR_COMP
+
+  if {![info exists ::env(ADI_PROJECT_DIR)]} {
+    set actual_project_name $project_name
+  } else {
+    set actual_project_name "$::env(ADI_PROJECT_DIR)${project_name}"
+  }
 
   ## update the value of $p_device only if it was not already updated elsewhere
   if {$p_device eq "none"} {
@@ -182,15 +189,15 @@ proc adi_project_create {project_name mode parameter_list device {board "not-app
   }
 
   if {$mode == 0} {
-    set project_system_dir "./$project_name.srcs/sources_1/bd/system"
-    create_project $project_name . -part $p_device -force
+    set project_system_dir "${actual_project_name}.srcs/sources_1/bd/system"
+    create_project ${actual_project_name} . -part $p_device -force
   } else {
-    set project_system_dir ".srcs/sources_1/bd/system"
+    set project_system_dir "${actual_project_name}.srcs/sources_1/bd/system"
     create_project -in_memory -part $p_device
   }
 
   if {$mode == 1} {
-    file mkdir $project_name.data
+    file mkdir ${actual_project_name}.data
   }
 
   if {$p_board ne "not-applicable"} {
@@ -259,7 +266,7 @@ proc adi_project_create {project_name mode parameter_list device {board "not-app
   if {$mode == 0} {
     import_files -force -norecurse -fileset sources_1 $project_system_dir/hdl/system_wrapper.v
   } else {
-    write_hwdef -file "$project_name.data/$project_name.hwdef"
+    write_hwdef -file "${actual_project_name}.data/$project_name.hwdef"
   }
 
   if {$ADI_USE_INCR_COMP == 1} {
@@ -297,9 +304,18 @@ proc adi_project_files {project_name project_files} {
 #
 proc adi_project_run {project_name} {
 
+  global ad_project_dir
   global ADI_POWER_OPTIMIZATION
   global ADI_USE_OOC_SYNTHESIS
   global ADI_MAX_OOC_JOBS
+
+  if {![info exists ::env(ADI_PROJECT_DIR)]} {
+    set actual_project_name $project_name
+    set ad_project_dir ""
+  } else {
+    set actual_project_name "$::env(ADI_PROJECT_DIR)${project_name}"
+    set ad_project_dir "$::env(ADI_PROJECT_DIR)"
+  }
 
   if {$ADI_USE_OOC_SYNTHESIS == 1} {
     launch_runs -jobs $ADI_MAX_OOC_JOBS system_*_synth_1 synth_1
@@ -308,7 +324,7 @@ proc adi_project_run {project_name} {
   }
   wait_on_run synth_1
   open_run synth_1
-  report_timing_summary -file timing_synth.log
+  report_timing_summary -file ${ad_project_dir}timing_synth.log
 
   if {![info exists ::env(ADI_NO_BITSTREAM_COMPRESSION)] && ![info exists ADI_NO_BITSTREAM_COMPRESSION]} {
     set_property BITSTREAM.GENERAL.COMPRESS TRUE [current_design]
@@ -324,10 +340,10 @@ proc adi_project_run {project_name} {
   launch_runs impl_1 -to_step write_bitstream
   wait_on_run impl_1
   open_run impl_1
-  report_timing_summary -warn_on_violation -file timing_impl.log
+  report_timing_summary -warn_on_violation -file ${ad_project_dir}timing_impl.log
 
   if {[info exists ::env(ADI_GENERATE_UTILIZATION)]} {
-    set csv_file resource_utilization.csv
+    set csv_file ${ad_project_dir}resource_utilization.csv
     if {[ catch {
       xilinx::designutils::report_failfast -csv -file $csv_file -transpose -no_header -ignore_pr -quiet
       set MMCM [llength [get_cells -hierarchical -filter { PRIMITIVE_TYPE =~ *MMCM* }]]
@@ -365,7 +381,7 @@ proc adi_project_run {project_name} {
       }
 
       foreach IP_name $IP_list {
-	set output_file ${IP_name}_resource_utilization.log
+	set output_file ${ad_project_dir}${IP_name}_resource_utilization.log
         file delete $output_file
         foreach IP_instance [ get_cells -quiet -hierarchical -filter " ORIG_REF_NAME =~ $IP_name || REF_NAME =~ $IP_name " ] {
           report_utilization -hierarchical -hierarchical_depth 1 -cells $IP_instance -file $output_file -append -quiet
@@ -380,7 +396,7 @@ proc adi_project_run {project_name} {
   }
 
   if {[info exists ::env(ADI_GENERATE_XPA)]} {
-    set csv_file power_analysis.csv
+    set csv_file ${ad_project_dir}power_analysis.csv
     set Layers "8to11"
     set CapLoad "20"
     set ToggleRate "15.00000"
@@ -429,7 +445,7 @@ proc adi_project_run {project_name} {
     if {[info exist num_regs]} {
       if {$num_regs > 0} {
         puts "CRITICAL WARNING: There are $num_regs registers with no clocks !!! See no_clock.log for details."
-        check_timing -override_defaults no_clock -verbose -file no_clock.log
+        check_timing -override_defaults no_clock -verbose -file ${ad_project_dir}no_clock.log
       }
     }
 
@@ -437,15 +453,15 @@ proc adi_project_run {project_name} {
     puts "CRITICAL WARNING: The search for undefined clocks failed !!!"
   }
 
-  file mkdir $project_name.sdk
+  file mkdir ${actual_project_name}.sdk
 
   set timing_string $[report_timing_summary -return_string]
   if { [string match "*VIOLATED*" $timing_string] == 1 ||
        [string match "*Timing constraints are not met*" $timing_string] == 1} {
-    write_hw_platform -fixed -force  -include_bit -file $project_name.sdk/system_top_bad_timing.xsa
+    write_hw_platform -fixed -force  -include_bit -file ${actual_project_name}.sdk/system_top_bad_timing.xsa
     return -code error [format "ERROR: Timing Constraints NOT met!"]
   } else {
-    write_hw_platform -fixed -force  -include_bit -file $project_name.sdk/system_top.xsa
+    write_hw_platform -fixed -force  -include_bit -file ${actual_project_name}.sdk/system_top.xsa
   }
 }
 
@@ -459,8 +475,15 @@ proc adi_project_run {project_name} {
 proc adi_project_synth {project_name prcfg_name hdl_files {xdc_files ""}} {
 
   global p_device
+  global ad_project_dir
 
-  set p_prefix "$project_name.data/$project_name"
+  if {![info exists ::env(ADI_PROJECT_DIR)]} {
+    set actual_project_name $project_name
+  } else {
+    set actual_project_name "$::env(ADI_PROJECT_DIR)${project_name}"
+  }
+
+  set p_prefix "${actual_project_name}.data/$project_name"
 
   if {$prcfg_name eq ""} {
 
@@ -495,8 +518,15 @@ proc adi_project_impl {project_name prcfg_name {xdc_files ""}} {
   global p_prcfg_init
   global p_prcfg_list
   global p_prcfg_status
+  global ad_project_dir
 
-  set p_prefix "$project_name.data/$project_name"
+  if {![info exists ::env(ADI_PROJECT_DIR)]} {
+    set actual_project_name $project_name
+  } else {
+    set actual_project_name "$::env(ADI_PROJECT_DIR)${project_name}"
+  }
+
+  set p_prefix "${actual_project_name}.data/$project_name"
 
   if {$prcfg_name eq "default"} {
     set p_prcfg_status 0
@@ -566,7 +596,7 @@ proc adi_project_verify {project_name} {
   global p_prcfg_list
   global p_prcfg_status
 
-  set p_prefix "$project_name.data/$project_name"
+  set p_prefix "${actual_project_name}.data/$project_name"
 
   pr_verify -full_check -initial $p_prcfg_init \
     -additional $p_prcfg_list \

--- a/projects/scripts/project-intel.mk
+++ b/projects/scripts/project-intel.mk
@@ -15,9 +15,33 @@ endif
 
 export NIOS_MMU_ENABLED := $(NIOS2_MMU)
 
+# Parse the config file and convert it to environment variables
+PARAMS_REPLACE_LIST := JESD LANE # list of words that should be removed from the parameter names
+GEN_SED := '$(foreach name, $(PARAMS_REPLACE_LIST), s/$(name)//g;);s/_//g'
+ifdef CFG
+    include $(CFG)
+    export $(shell sed 's/=.*//' $(CFG) | tr '\n' ' ')
+    PARAMS := $(shell cat $(CFG) | tr '\n' ' ')
+    DIR_NAME := $(basename $(notdir $(CFG)))
+endif
+
+# Parse the variables passed to make and convert them to the filename format
+CMD_VARIABLES := $(shell echo $(-*-command-variables-*-) | tac -s ' ')
+ifneq ($(strip $(CMD_VARIABLES)), )
+    PARAMS := $(shell echo $(CMD_VARIABLES) | sed -e 's/[=]/_/g')
+    GEN_NAME := $(shell echo $(PARAMS) | sed -e $(GEN_SED) | sed -e 's/[ .]/_/g')
+    DIR_NAME := $(if $(strip $(DIR_NAME)),$(DIR_NAME)_$(GEN_NAME),$(GEN_NAME))
+endif
+
+ifneq ($(strip $(DIR_NAME)), )
+    PROJECT_NAME := $(DIR_NAME)/$(PROJECT_NAME)
+    $(shell test -d $(DIR_NAME) || mkdir $(DIR_NAME))
+    ADI_PROJECT_DIR := $(DIR_NAME)/
+    export ADI_PROJECT_DIR
+endif
+
 INTEL := quartus_sh --64bit -t
 
-CLEAN_TARGET += *.log
 CLEAN_TARGET += *_INFO.txt
 CLEAN_TARGET += *_dump.txt
 CLEAN_TARGET += db
@@ -63,6 +87,12 @@ CLEAN_TARGET += *.summary
 CLEAN_TARGET += ip
 CLEAN_TARGET += qdb
 CLEAN_TARGET += tmp-clearbox
+CLEAN_TARGET += *.log
+ifneq ($(strip $(DIR_NAME)),)
+    CLEAN_TARGET := $(addprefix $(DIR_NAME)/,$(CLEAN_TARGET))
+endif
+
+CLEAN_DIRS := $(dir $(wildcard */*_quartus.log))
 
 M_DEPS += system_top.v
 M_DEPS += system_qsys.tcl
@@ -77,15 +107,18 @@ M_DEPS += $(foreach dep,$(LIB_DEPS),$(HDL_LIBRARY_PATH)$(dep)/.timestamp_intel)
 .PHONY: all lib clean clean-all
 all: lib $(PROJECT_NAME).sof
 
-
 clean:
 	$(call clean, \
 		$(CLEAN_TARGET), \
 		$(HL)$(PROJECT_NAME)$(NC) project)
+	-rm -Rf ${DIR_NAME}
 
 clean-all: clean
 	@for lib in $(LIB_DEPS); do \
 		$(MAKE) -C $(HDL_LIBRARY_PATH)$${lib} clean; \
+	done
+	@for dir in ${CLEAN_DIRS}; do \
+		rm -Rf $${dir}; \
 	done
 
 $(PROJECT_NAME).sof: $(M_DEPS)

--- a/projects/scripts/project-xilinx.mk
+++ b/projects/scripts/project-xilinx.mk
@@ -9,20 +9,43 @@ HDL_LIBRARY_PATH := $(HDL_PROJECT_PATH)../library/
 
 include $(HDL_PROJECT_PATH)../quiet.mk
 
+# Parse the config file and convert it to environment variables
+PARAMS_REPLACE_LIST := JESD LANE # list of words that should be removed from the parameter names
+GEN_SED := '$(foreach name, $(PARAMS_REPLACE_LIST), s/$(name)//g;);s/_//g'
+ifdef CFG
+    include $(CFG)
+    export $(shell sed 's/=.*//' $(CFG) | tr '\n' ' ')
+    PARAMS := $(shell cat $(CFG) | tr '\n' ' ')
+    DIR_NAME := $(basename $(notdir $(CFG)))
+endif
+
 VIVADO := vivado -mode batch -source
+
+# Parse the variables passed to make and convert them to the filename format
+CMD_VARIABLES := $(shell echo $(-*-command-variables-*-) | tac -s ' ')
+ifneq ($(strip $(CMD_VARIABLES)), )
+    PARAMS := $(shell echo $(CMD_VARIABLES) | sed -e 's/[=]/_/g')
+    GEN_NAME := $(shell echo $(PARAMS) | sed -e $(GEN_SED) | sed -e 's/[ .]/_/g')
+    DIR_NAME := $(if $(strip $(DIR_NAME)),$(DIR_NAME)_$(GEN_NAME),$(GEN_NAME))
+endif
+
+ifneq ($(strip $(DIR_NAME)), )
+    PROJECT_NAME := $(DIR_NAME)/$(PROJECT_NAME)
+    $(shell test -d $(DIR_NAME) || mkdir $(DIR_NAME))
+    ADI_PROJECT_DIR := $(DIR_NAME)/
+    export ADI_PROJECT_DIR
+	VIVADO := vivado -log $(DIR_NAME)/vivado.log -journal $(DIR_NAME)/vivado.jou -mode batch -source 
+endif
 
 CLEAN_TARGET := *.cache
 CLEAN_TARGET += *.data
 CLEAN_TARGET += *.xpr
-CLEAN_TARGET += *.log
-CLEAN_TARGET += *.jou
-CLEAN_TARGET +=  xgui
+CLEAN_TARGET += xgui
 CLEAN_TARGET += *.runs
 CLEAN_TARGET += *.srcs
 CLEAN_TARGET += *.sdk
 CLEAN_TARGET += *.hw
 CLEAN_TARGET += *.sim
-CLEAN_TARGET += .Xil
 CLEAN_TARGET += *.ip_user_files
 CLEAN_TARGET += *.str
 CLEAN_TARGET += mem_init_sys.txt
@@ -31,6 +54,14 @@ CLEAN_TARGET += *.hbs
 CLEAN_TARGET += *.gen
 CLEAN_TARGET += *.xpe
 CLEAN_TARGET += *.xsa
+CLEAN_TARGET += *.log
+CLEAN_TARGET += *.jou
+ifneq ($(strip $(DIR_NAME)), )
+    CLEAN_TARGET := $(addprefix $(DIR_NAME)/,$(CLEAN_TARGET))
+endif
+CLEAN_TARGET += .Xil
+
+CLEAN_DIRS := $(dir $(wildcard */*_vivado.log))
 
 # Common dependencies that all projects have
 M_DEPS += system_project.tcl
@@ -44,6 +75,7 @@ M_DEPS += $(HDL_PROJECT_PATH)scripts/adi_board.tcl
 M_DEPS += $(foreach dep,$(LIB_DEPS),$(HDL_LIBRARY_PATH)$(dep)/component.xml)
 
 .PHONY: all lib clean clean-all
+
 all: lib $(PROJECT_NAME).sdk/system_top.xsa
 
 clean:
@@ -51,10 +83,14 @@ clean:
 	$(call clean, \
 		$(CLEAN_TARGET), \
 		$(HL)$(PROJECT_NAME)$(NC) project)
+	-rm -Rf ${DIR_NAME}
 
 clean-all: clean
 	@for lib in $(LIB_DEPS); do \
 		$(MAKE) -C $(HDL_LIBRARY_PATH)$${lib} clean; \
+	done
+	@for dir in ${CLEAN_DIRS}; do \
+		rm -Rf $${dir}; \
 	done
 
 MODE ?= "default"

--- a/projects/sidekiqz2/system_project.tcl
+++ b/projects/sidekiqz2/system_project.tcl
@@ -1,4 +1,3 @@
-
 source ../../scripts/adi_env.tcl
 source $ad_hdl_dir/projects/scripts/adi_project_xilinx.tcl
 source $ad_hdl_dir/projects/scripts/adi_board.tcl

--- a/projects/usrpe31x/system_project.tcl
+++ b/projects/usrpe31x/system_project.tcl
@@ -1,4 +1,3 @@
-
 source ../../scripts/adi_env.tcl
 source $ad_hdl_dir/projects/scripts/adi_project_xilinx.tcl
 source $ad_hdl_dir/projects/scripts/adi_board.tcl


### PR DESCRIPTION
Updated the makefiles to support building projects with different configurations (or parameters) in different subdirectories.

For example:
- running 'make' will build the default project directly in the project folder (like it did before)
- running 'make RX_LANE_RATE=15 TX_LANE_RATE=15' will build the project inside the 'RXRATE15_TXRATE15' subdirectory.

Note that the 'JESD' and 'LANE' words from the parameter names are stripped in order to make the folder paths a little bit shorter.