### PR TITLE
Fix naming consistency

### DIFF
--- a/projects/ad4630_fmc/zed/Makefile
+++ b/projects/ad4630_fmc/zed/Makefile
@@ -4,7 +4,7 @@
 ## Auto-generated, do not modify!
 ####################################################################################
 
-PROJECT_NAME := ad463x_fmc_zed
+PROJECT_NAME := ad4630_fmc_zed
 
 M_DEPS += system_constr_8sdi.xdc
 M_DEPS += system_constr_4sdi.xdc

--- a/projects/ad4630_fmc/zed/system_bd.tcl
+++ b/projects/ad4630_fmc/zed/system_bd.tcl
@@ -3,10 +3,9 @@ source $ad_hdl_dir/projects/scripts/adi_pd.tcl
 source $ad_hdl_dir/projects/common/zed/zed_system_bd.tcl
 
 # add RTL source that will be instantiated in system_bd directly
-adi_project_files ad463x_fmc_zed [list \
+adi_project_files ad4630_fmc_zed [list \
   "$ad_hdl_dir/library/common/ad_edge_detect.v" \
-  "$ad_hdl_dir/library/util_cdc/sync_bits.v" \
-]
+  "$ad_hdl_dir/library/util_cdc/sync_bits.v" ]
 
 # block design
 source ../common/ad463x_bd.tcl

--- a/projects/ad4630_fmc/zed/system_project.tcl
+++ b/projects/ad4630_fmc/zed/system_project.tcl
@@ -44,48 +44,41 @@ source $ad_hdl_dir/projects/scripts/adi_board.tcl
 #   make NUM_OF_SDI=2 CAPTURE_ZONE=2
 #
 
-adi_project ad463x_fmc_zed 0 [list \
+adi_project ad4630_fmc_zed 0 [list \
   CLK_MODE     [get_env_param CLK_MODE      0] \
   NUM_OF_SDI   [get_env_param NUM_OF_SDI    4] \
   CAPTURE_ZONE [get_env_param CAPTURE_ZONE  2] \
-  DDR_EN       [get_env_param DDR_EN  0] \
-]
+  DDR_EN       [get_env_param DDR_EN  0] ]
 
-adi_project_files ad463x_fmc_zed [list \
+adi_project_files ad4630_fmc_zed [list \
   "$ad_hdl_dir/library/common/ad_iobuf.v" \
   "$ad_hdl_dir/library/xilinx/common/ad_data_clk.v" \
   "$ad_hdl_dir/projects/common/zed/zed_system_constr.xdc" \
   "system_constr.xdc" \
-  "system_top.v" \
-]
+  "system_top.v" ]
 
 switch [get_env_param NUM_OF_SDI 4] {
   1 {
-    adi_project_files ad463x_fmc_zed [list \
-      "system_constr_1sdi.xdc"
-    ]
+    adi_project_files ad4630_fmc_zed [list \
+      "system_constr_1sdi.xdc" ]
   }
   2 {
-    adi_project_files ad463x_fmc_zed [list \
-      "system_constr_2sdi.xdc"
-    ]
+    adi_project_files ad4630_fmc_zed [list \
+      "system_constr_2sdi.xdc" ]
   }
   4 {
-    adi_project_files ad463x_fmc_zed [list \
-      "system_constr_4sdi.xdc"
-    ]
+    adi_project_files ad4630_fmc_zed [list \
+      "system_constr_4sdi.xdc" ]
   }
   8 {
-    adi_project_files ad463x_fmc_zed [list \
-      "system_constr_8sdi.xdc"
-    ]
+    adi_project_files ad4630_fmc_zed [list \
+      "system_constr_8sdi.xdc" ]
   }
   default {
-    adi_project_files ad463x_fmc_zed [list \
-      "system_constr_2sdi.xdc"
-    ]
+    adi_project_files ad4630_fmc_zed [list \
+      "system_constr_2sdi.xdc" ]
   }
 }
 
-adi_project_run ad463x_fmc_zed
+adi_project_run ad4630_fmc_zed
 

--- a/projects/ad4630_fmc/zed/system_top.v
+++ b/projects/ad4630_fmc/zed/system_top.v
@@ -1,6 +1,6 @@
 // ***************************************************************************
 // ***************************************************************************
-// Copyright 2014 - 2017 (c) Analog Devices, Inc. All rights reserved.
+// Copyright 2014 - 2022 (c) Analog Devices, Inc. All rights reserved.
 //
 // In this HDL repository, there are many different and unique modules, consisting
 // of various HDL (Verilog or VHDL) components. The individual modules are

--- a/projects/ad9783_ebz/zcu102/Makefile
+++ b/projects/ad9783_ebz/zcu102/Makefile
@@ -4,7 +4,7 @@
 ## Auto-generated, do not modify!
 ####################################################################################
 
-PROJECT_NAME := ad9783_zcu102
+PROJECT_NAME := ad9783_ebz_zcu102
 
 M_DEPS += ../common/ad9783_ebz_bd.tcl
 M_DEPS += ../../scripts/adi_pd.tcl

--- a/projects/ad9783_ebz/zcu102/system_project.tcl
+++ b/projects/ad9783_ebz/zcu102/system_project.tcl
@@ -3,10 +3,10 @@ source ../../../scripts/adi_env.tcl
 source $ad_hdl_dir/projects/scripts/adi_project_xilinx.tcl
 source $ad_hdl_dir/projects/scripts/adi_board.tcl
 
-adi_project ad9783_zcu102
-adi_project_files ad9783_zcu102 [list \
+adi_project ad9783_ebz_zcu102
+adi_project_files ad9783_ebz_zcu102 [list \
   "system_top.v" \
   "system_constr.xdc"\
   "$ad_hdl_dir/projects/common/zcu102/zcu102_system_constr.xdc" ]
 
-adi_project_run ad9783_zcu102
+adi_project_run ad9783_ebz_zcu102

--- a/projects/ad9783_ebz/zcu102/system_top.v
+++ b/projects/ad9783_ebz/zcu102/system_top.v
@@ -1,6 +1,6 @@
 // ***************************************************************************
 // ***************************************************************************
-// Copyright 2021 (c) Analog Devices, Inc. All rights reserved.
+// Copyright 2021 - 2022 (c) Analog Devices, Inc. All rights reserved.
 //
 // In this HDL repository, there are many different and unique modules, consisting
 // of various HDL (Verilog or VHDL) components. The individual modules are


### PR DESCRIPTION
Rename projects to be identical with the folder name.