### PR TITLE
run_tb.sh:don't run xsim if previous commands fail

### DIFF
--- a/library/common/tb/run_tb.sh
+++ b/library/common/tb/run_tb.sh
@@ -14,8 +14,8 @@ case "$SIMULATOR" in
 
 	xsim)
 		# XSim flow
-		xvlog -log ${NAME}_xvlog.log --sourcelibdir . ${SOURCE}
-		xelab -log ${NAME}_xelab.log -debug all ${NAME}
+		xvlog -log ${NAME}_xvlog.log --sourcelibdir . ${SOURCE} || exit 1
+		xelab -log ${NAME}_xelab.log -debug all ${NAME} || exit 1
 		if [[ "$MODE" == "-gui" ]]; then
 			echo "log_wave -r *" > xsim_gui_cmd.tcl
 			echo "run all" >> xsim_gui_cmd.tcl


### PR DESCRIPTION
If 'xvlog' or 'xelab' xilinx commands are failing, exit from run_tb.sh script without trying to run simulation.

Signed-off-by: stefan.raus <stefan.raus@analog.com>