### PR TITLE
library/scripts/library.mk: clean files form tb

### DIFF
--- a/library/scripts/library.mk
+++ b/library/scripts/library.mk
@@ -29,6 +29,16 @@ CLEAN_TARGET += *.sim
 CLEAN_TARGET += .Xil
 CLEAN_TARGET += .timestamp_intel
 CLEAN_TARGET += *.hbs
+CLEAN_TARGET += tb/*.log
+CLEAN_TARGET += tb/*.xml
+CLEAN_TARGET += tb/*.jou
+CLEAN_TARGET += tb/*.dir
+CLEAN_TARGET += tb/*.pb
+CLEAN_TARGET += tb/*.vcd
+CLEAN_TARGET += tb/vsim.wlf
+CLEAN_TARGET += tb/work
+CLEAN_TARGET += tb/vcd
+CLEAN_TARGET += tb/run
 
 GENERIC_DEPS += $(HDL_LIBRARY_PATH)../scripts/adi_env.tcl
 


### PR DESCRIPTION
Update clean command to delete also files generated by simulation, from 'tb' folders, covering cases for Xsim and ModelSim simulators.

Signed-off-by: stefan.raus <stefan.raus@analog.com>