### PR TITLE
projects/common: Add build files carriers

### DIFF
--- a/projects/common/Makefile
+++ b/projects/common/Makefile
@@ -1,0 +1,7 @@
+####################################################################################
+## Copyright (c) 2018 - 2021 Analog Devices, Inc.
+### SPDX short identifier: BSD-1-Clause
+## Auto-generated, do not modify!
+####################################################################################
+
+include ../scripts/project-toplevel.mk

--- a/projects/common/a10gx/Makefile
+++ b/projects/common/a10gx/Makefile
@@ -1,0 +1,16 @@
+####################################################################################
+## Copyright (c) 2018 - 2021 Analog Devices, Inc.
+### SPDX short identifier: BSD-1-Clause
+## Auto-generated, do not modify!
+####################################################################################
+
+PROJECT_NAME := template_a10gx
+
+M_DEPS += ../../scripts/adi_pd.tcl
+M_DEPS += ../../common/a10gx/a10gx_system_qsys.tcl
+M_DEPS += ../../common/a10gx/a10gx_system_assign.tcl
+
+LIB_DEPS += axi_sysid
+LIB_DEPS += sysid_rom
+
+include ../../scripts/project-intel.mk

--- a/projects/common/a10gx/system_constr.sdc
+++ b/projects/common/a10gx/system_constr.sdc
@@ -1,0 +1,8 @@
+create_clock -period "10.000 ns"  -name sys_clk_100mhz      [get_ports {sys_clk}]
+
+derive_pll_clocks
+derive_clock_uncertainty
+
+set_false_path -from [get_registers *altera_reset_synchronizer:alt_rst_sync_uq1|altera_reset_synchronizer_int_chain_out*]
+
+set_false_path -from * -to [get_ports {flash_resetn}]

--- a/projects/common/a10gx/system_qsys.tcl
+++ b/projects/common/a10gx/system_qsys.tcl
@@ -1,0 +1,11 @@
+source $ad_hdl_dir/projects/scripts/adi_pd.tcl
+source $ad_hdl_dir/projects/common/a10gx/a10gx_system_qsys.tcl
+
+#system ID
+
+set_instance_parameter_value axi_sysid_0 {ROM_ADDR_BITS} {9}
+set_instance_parameter_value rom_sys_0 {ROM_ADDR_BITS} {9}
+
+set_instance_parameter_value rom_sys_0 {PATH_TO_FILE} "[pwd]/mem_init_sys.txt"
+
+sysid_gen_sys_init_file;

--- a/projects/common/a10soc/Makefile
+++ b/projects/common/a10soc/Makefile
@@ -1,0 +1,16 @@
+####################################################################################
+## Copyright (c) 2018 - 2021 Analog Devices, Inc.
+### SPDX short identifier: BSD-1-Clause
+## Auto-generated, do not modify!
+####################################################################################
+
+PROJECT_NAME := template_a10soc
+
+M_DEPS += ../../scripts/adi_pd.tcl
+M_DEPS += ../../common/a10soc/a10soc_system_qsys.tcl
+M_DEPS += ../../common/a10soc/a10soc_system_assign.tcl
+
+LIB_DEPS += axi_sysid
+LIB_DEPS += sysid_rom
+
+include ../../scripts/project-intel.mk

--- a/projects/common/a10soc/system_constr.sdc
+++ b/projects/common/a10soc/system_constr.sdc
@@ -1,0 +1,6 @@
+create_clock -period "10.000 ns"  -name sys_clk_100mhz      [get_ports {sys_clk}]
+
+derive_pll_clocks
+derive_clock_uncertainty
+
+set_false_path -from [get_registers *altera_reset_synchronizer:alt_rst_sync_uq1|altera_reset_synchronizer_int_chain_out*]

--- a/projects/common/a10soc/system_qsys.tcl
+++ b/projects/common/a10soc/system_qsys.tcl
@@ -1,0 +1,10 @@
+source $ad_hdl_dir/projects/scripts/adi_pd.tcl
+source $ad_hdl_dir/projects/common/a10soc/a10soc_system_qsys.tcl
+
+#system ID
+set_instance_parameter_value axi_sysid_0 {ROM_ADDR_BITS} {9}
+set_instance_parameter_value rom_sys_0 {ROM_ADDR_BITS} {9}
+
+set_instance_parameter_value rom_sys_0 {PATH_TO_FILE} "[pwd]/mem_init_sys.txt"
+
+sysid_gen_sys_init_file;

--- a/projects/common/ac701/Makefile
+++ b/projects/common/ac701/Makefile
@@ -1,0 +1,18 @@
+####################################################################################
+## Copyright (c) 2018 - 2021 Analog Devices, Inc.
+### SPDX short identifier: BSD-1-Clause
+## Auto-generated, do not modify!
+####################################################################################
+
+PROJECT_NAME := template_ac701
+
+M_DEPS += ../../scripts/adi_pd.tcl
+M_DEPS += ../../common/ac701/ac701_system_mig.prj
+M_DEPS += ../../common/ac701/ac701_system_constr.xdc
+M_DEPS += ../../common/ac701/ac701_system_bd.tcl
+M_DEPS += ../../../library/common/ad_iobuf.v
+
+LIB_DEPS += axi_sysid
+LIB_DEPS += sysid_rom
+
+include ../../scripts/project-xilinx.mk

--- a/projects/common/ac701/system_bd.tcl
+++ b/projects/common/ac701/system_bd.tcl
@@ -1,0 +1,11 @@
+source $ad_hdl_dir/projects/scripts/adi_pd.tcl
+source $ad_hdl_dir/projects/common/ac701/ac701_system_bd.tcl
+
+#system ID
+ad_ip_parameter axi_sysid_0 CONFIG.ROM_ADDR_BITS 9
+ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "[pwd]/mem_init_sys.txt"
+ad_ip_parameter rom_sys_0 CONFIG.ROM_ADDR_BITS 9
+
+sysid_gen_sys_init_file
+
+set sys_dma_clk [get_bd_nets sys_dma_clk]

--- a/projects/common/c5soc/Makefile
+++ b/projects/common/c5soc/Makefile
@@ -1,0 +1,18 @@
+####################################################################################
+## Copyright (c) 2018 - 2021 Analog Devices, Inc.
+### SPDX short identifier: BSD-1-Clause
+## Auto-generated, do not modify!
+####################################################################################
+
+PROJECT_NAME := template_c5soc
+
+M_DEPS += ../../scripts/adi_pd.tcl
+M_DEPS += ../../common/c5soc/c5soc_system_qsys.tcl
+M_DEPS += ../../common/c5soc/c5soc_system_assign.tcl
+
+LIB_DEPS += axi_dmac
+LIB_DEPS += axi_hdmi_tx
+LIB_DEPS += axi_sysid
+LIB_DEPS += sysid_rom
+
+include ../../scripts/project-intel.mk

--- a/projects/common/c5soc/system_constr.sdc
+++ b/projects/common/c5soc/system_constr.sdc
@@ -1,0 +1,6 @@
+create_clock -period "20.000 ns" -name sys_clk  [get_ports {sys_clk}]
+
+derive_pll_clocks
+derive_clock_uncertainty
+
+set_false_path -from [get_registers *altera_reset_synchronizer:alt_rst_sync_uq1|altera_reset_synchronizer_int_chain_out*]

--- a/projects/common/c5soc/system_project.tcl
+++ b/projects/common/c5soc/system_project.tcl
@@ -1,4 +1,4 @@
-set REQUIRED_QUARTUS_VERSION 20.1.1
+set REQUIRED_QUARTUS_VERSION 21.1.0
 set QUARTUS_PRO_ISUSED 0
 source ../../../scripts/adi_env.tcl
 source ../../scripts/adi_project_intel.tcl

--- a/projects/common/c5soc/system_qsys.tcl
+++ b/projects/common/c5soc/system_qsys.tcl
@@ -1,0 +1,10 @@
+source $ad_hdl_dir/projects/scripts/adi_pd.tcl
+source $ad_hdl_dir/projects/common/c5soc/c5soc_system_qsys.tcl
+
+#system ID
+set_instance_parameter_value axi_sysid_0 {ROM_ADDR_BITS} {9}
+set_instance_parameter_value rom_sys_0 {ROM_ADDR_BITS} {9}
+
+set_instance_parameter_value rom_sys_0 {PATH_TO_FILE} "[pwd]/mem_init_sys.txt"
+
+sysid_gen_sys_init_file;

--- a/projects/common/coraz7s/Makefile
+++ b/projects/common/coraz7s/Makefile
@@ -1,0 +1,18 @@
+####################################################################################
+## Copyright (c) 2018 - 2021 Analog Devices, Inc.
+### SPDX short identifier: BSD-1-Clause
+## Auto-generated, do not modify!
+####################################################################################
+
+PROJECT_NAME := template_coraz7s
+
+M_DEPS += ../../scripts/adi_pd.tcl
+M_DEPS += ../../common/coraz7s/coraz7s_system_ps7.tcl
+M_DEPS += ../../common/coraz7s/coraz7s_system_constr.xdc
+M_DEPS += ../../common/coraz7s/coraz7s_system_bd.tcl
+M_DEPS += ../../../library/common/ad_iobuf.v
+
+LIB_DEPS += axi_sysid
+LIB_DEPS += sysid_rom
+
+include ../../scripts/project-xilinx.mk

--- a/projects/common/coraz7s/system_bd.tcl
+++ b/projects/common/coraz7s/system_bd.tcl
@@ -1,0 +1,11 @@
+source $ad_hdl_dir/projects/scripts/adi_pd.tcl
+source $ad_hdl_dir/projects/common/coraz7s/coraz7s_system_bd.tcl
+
+#system ID
+ad_ip_parameter axi_sysid_0 CONFIG.ROM_ADDR_BITS 9
+ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "[pwd]/mem_init_sys.txt"
+ad_ip_parameter rom_sys_0 CONFIG.ROM_ADDR_BITS 9
+
+sysid_gen_sys_init_file
+
+set sys_dma_clk [get_bd_nets sys_dma_clk]

--- a/projects/common/de10nano/Makefile
+++ b/projects/common/de10nano/Makefile
@@ -1,0 +1,18 @@
+####################################################################################
+## Copyright (c) 2018 - 2021 Analog Devices, Inc.
+### SPDX short identifier: BSD-1-Clause
+## Auto-generated, do not modify!
+####################################################################################
+
+PROJECT_NAME := template_de10nano
+
+M_DEPS += ../../scripts/adi_pd.tcl
+M_DEPS += ../../common/de10nano/de10nano_system_qsys.tcl
+M_DEPS += ../../common/de10nano/de10nano_system_assign.tcl
+
+LIB_DEPS += axi_dmac
+LIB_DEPS += axi_hdmi_tx
+LIB_DEPS += axi_sysid
+LIB_DEPS += sysid_rom
+
+include ../../scripts/project-intel.mk

--- a/projects/common/de10nano/system_constr.sdc
+++ b/projects/common/de10nano/system_constr.sdc
@@ -1,0 +1,5 @@
+create_clock -period "20.000 ns"  -name sys_clk_50mhz      [get_ports {sys_clk}]
+create_clock -period "16.666 ns"  -name usb_clk_60mhz      [get_ports {usb1_clk}]
+
+derive_pll_clocks
+derive_clock_uncertainty

--- a/projects/common/de10nano/system_project.tcl
+++ b/projects/common/de10nano/system_project.tcl
@@ -1,4 +1,4 @@
-set REQUIRED_QUARTUS_VERSION 20.1.0
+set REQUIRED_QUARTUS_VERSION 21.1.0
 set QUARTUS_PRO_ISUSED 0
 
 source ../../../scripts/adi_env.tcl

--- a/projects/common/de10nano/system_qsys.tcl
+++ b/projects/common/de10nano/system_qsys.tcl
@@ -1,0 +1,10 @@
+source $ad_hdl_dir/projects/scripts/adi_pd.tcl
+source $ad_hdl_dir/projects/common/de10nano/de10nano_system_qsys.tcl
+
+#system ID
+set_instance_parameter_value axi_sysid_0 {ROM_ADDR_BITS} {9}
+set_instance_parameter_value rom_sys_0 {ROM_ADDR_BITS} {9}
+
+set_instance_parameter_value rom_sys_0 {PATH_TO_FILE} "[pwd]/mem_init_sys.txt"
+
+sysid_gen_sys_init_file;

--- a/projects/common/kc705/Makefile
+++ b/projects/common/kc705/Makefile
@@ -1,0 +1,18 @@
+####################################################################################
+## Copyright (c) 2018 - 2021 Analog Devices, Inc.
+### SPDX short identifier: BSD-1-Clause
+## Auto-generated, do not modify!
+####################################################################################
+
+PROJECT_NAME := template_kc705
+
+M_DEPS += ../../scripts/adi_pd.tcl
+M_DEPS += ../../common/kc705/kc705_system_mig.prj
+M_DEPS += ../../common/kc705/kc705_system_constr.xdc
+M_DEPS += ../../common/kc705/kc705_system_bd.tcl
+M_DEPS += ../../../library/common/ad_iobuf.v
+
+LIB_DEPS += axi_sysid
+LIB_DEPS += sysid_rom
+
+include ../../scripts/project-xilinx.mk

--- a/projects/common/kc705/system_bd.tcl
+++ b/projects/common/kc705/system_bd.tcl
@@ -1,0 +1,9 @@
+source $ad_hdl_dir/projects/scripts/adi_pd.tcl
+source $ad_hdl_dir/projects/common/kc705/kc705_system_bd.tcl
+
+#system ID
+ad_ip_parameter axi_sysid_0 CONFIG.ROM_ADDR_BITS 9
+ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "[pwd]/mem_init_sys.txt"
+ad_ip_parameter rom_sys_0 CONFIG.ROM_ADDR_BITS 9
+
+sysid_gen_sys_init_file

--- a/projects/common/kcu105/Makefile
+++ b/projects/common/kcu105/Makefile
@@ -1,0 +1,18 @@
+####################################################################################
+## Copyright (c) 2018 - 2021 Analog Devices, Inc.
+### SPDX short identifier: BSD-1-Clause
+## Auto-generated, do not modify!
+####################################################################################
+
+PROJECT_NAME := template_kcu105
+
+M_DEPS += ../../scripts/adi_pd.tcl
+M_DEPS += ../../common/kcu105/kcu105_system_lutram_constr.xdc
+M_DEPS += ../../common/kcu105/kcu105_system_constr.xdc
+M_DEPS += ../../common/kcu105/kcu105_system_bd.tcl
+M_DEPS += ../../../library/common/ad_iobuf.v
+
+LIB_DEPS += axi_sysid
+LIB_DEPS += sysid_rom
+
+include ../../scripts/project-xilinx.mk

--- a/projects/common/kcu105/system_bd.tcl
+++ b/projects/common/kcu105/system_bd.tcl
@@ -1,0 +1,9 @@
+source $ad_hdl_dir/projects/scripts/adi_pd.tcl
+source $ad_hdl_dir/projects/common/kcu105/kcu105_system_bd.tcl
+
+#system ID
+ad_ip_parameter axi_sysid_0 CONFIG.ROM_ADDR_BITS 9
+ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "[pwd]/mem_init_sys.txt"
+ad_ip_parameter rom_sys_0 CONFIG.ROM_ADDR_BITS 9
+
+sysid_gen_sys_init_file

--- a/projects/common/s10soc/Makefile
+++ b/projects/common/s10soc/Makefile
@@ -1,0 +1,13 @@
+####################################################################################
+## Copyright (c) 2018 - 2021 Analog Devices, Inc.
+### SPDX short identifier: BSD-1-Clause
+## Auto-generated, do not modify!
+####################################################################################
+
+PROJECT_NAME := template_s10soc
+
+M_DEPS += ../../common/s10soc/s10soc_system_qsys.tcl
+M_DEPS += ../../common/s10soc/s10soc_system_assign.tcl
+
+
+include ../../scripts/project-intel.mk

--- a/projects/common/s10soc/system_constr.sdc
+++ b/projects/common/s10soc/system_constr.sdc
@@ -1,0 +1,6 @@
+create_clock -period "10.000 ns"  -name sys_clk_100mhz      [get_ports {sys_clk}]
+
+derive_pll_clocks
+derive_clock_uncertainty
+
+set_false_path -from [get_registers *altera_reset_synchronizer:alt_rst_sync_uq1|altera_reset_synchronizer_int_chain_out*]

--- a/projects/common/s10soc/system_qsys.tcl
+++ b/projects/common/s10soc/system_qsys.tcl
@@ -1,0 +1,1 @@
+source $ad_hdl_dir/projects/common/s10soc/s10soc_system_qsys.tcl

--- a/projects/common/vc707/Makefile
+++ b/projects/common/vc707/Makefile
@@ -1,0 +1,18 @@
+####################################################################################
+## Copyright (c) 2018 - 2021 Analog Devices, Inc.
+### SPDX short identifier: BSD-1-Clause
+## Auto-generated, do not modify!
+####################################################################################
+
+PROJECT_NAME := template_vc707
+
+M_DEPS += ../../scripts/adi_pd.tcl
+M_DEPS += ../../common/vc707/vc707_system_mig.prj
+M_DEPS += ../../common/vc707/vc707_system_constr.xdc
+M_DEPS += ../../common/vc707/vc707_system_bd.tcl
+M_DEPS += ../../../library/common/ad_iobuf.v
+
+LIB_DEPS += axi_sysid
+LIB_DEPS += sysid_rom
+
+include ../../scripts/project-xilinx.mk

--- a/projects/common/vc707/system_bd.tcl
+++ b/projects/common/vc707/system_bd.tcl
@@ -1,0 +1,9 @@
+source $ad_hdl_dir/projects/scripts/adi_pd.tcl
+source $ad_hdl_dir/projects/common/vc707/vc707_system_bd.tcl
+
+#system ID
+ad_ip_parameter axi_sysid_0 CONFIG.ROM_ADDR_BITS 9
+ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "[pwd]/mem_init_sys.txt"
+ad_ip_parameter rom_sys_0 CONFIG.ROM_ADDR_BITS 9
+
+sysid_gen_sys_init_file

--- a/projects/common/vc709/Makefile
+++ b/projects/common/vc709/Makefile
@@ -1,0 +1,18 @@
+####################################################################################
+## Copyright (c) 2018 - 2021 Analog Devices, Inc.
+### SPDX short identifier: BSD-1-Clause
+## Auto-generated, do not modify!
+####################################################################################
+
+PROJECT_NAME := template_vc709
+
+M_DEPS += ../../scripts/adi_pd.tcl
+M_DEPS += ../../common/vc709/vc709_system_mig.prj
+M_DEPS += ../../common/vc709/vc709_system_constr.xdc
+M_DEPS += ../../common/vc709/vc709_system_bd.tcl
+M_DEPS += ../../../library/common/ad_iobuf.v
+
+LIB_DEPS += axi_sysid
+LIB_DEPS += sysid_rom
+
+include ../../scripts/project-xilinx.mk

--- a/projects/common/vc709/system_bd.tcl
+++ b/projects/common/vc709/system_bd.tcl
@@ -1,0 +1,9 @@
+source $ad_hdl_dir/projects/scripts/adi_pd.tcl
+source $ad_hdl_dir/projects/common/vc709/vc709_system_bd.tcl
+
+#system ID
+ad_ip_parameter axi_sysid_0 CONFIG.ROM_ADDR_BITS 9
+ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "[pwd]/mem_init_sys.txt"
+ad_ip_parameter rom_sys_0 CONFIG.ROM_ADDR_BITS 9
+
+sysid_gen_sys_init_file

--- a/projects/common/vck190/Makefile
+++ b/projects/common/vck190/Makefile
@@ -1,0 +1,18 @@
+####################################################################################
+## Copyright (c) 2018 - 2021 Analog Devices, Inc.
+### SPDX short identifier: BSD-1-Clause
+## Auto-generated, do not modify!
+####################################################################################
+
+PROJECT_NAME := template_vck190
+
+M_DEPS += ../../scripts/adi_pd.tcl
+M_DEPS += ../../common/vmk180/vmk180_system_bd.tcl
+M_DEPS += ../../common/vck190/vck190_system_constr.xdc
+M_DEPS += ../../common/vck190/vck190_system_bd.tcl
+M_DEPS += ../../../library/common/ad_iobuf.v
+
+LIB_DEPS += axi_sysid
+LIB_DEPS += sysid_rom
+
+include ../../scripts/project-xilinx.mk

--- a/projects/common/vck190/system_bd.tcl
+++ b/projects/common/vck190/system_bd.tcl
@@ -1,0 +1,9 @@
+source $ad_hdl_dir/projects/scripts/adi_pd.tcl
+source $ad_hdl_dir/projects/common/vck190/vck190_system_bd.tcl
+
+#system ID
+ad_ip_parameter axi_sysid_0 CONFIG.ROM_ADDR_BITS 9
+ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "[pwd]/mem_init_sys.txt"
+ad_ip_parameter rom_sys_0 CONFIG.ROM_ADDR_BITS 9
+
+sysid_gen_sys_init_file

--- a/projects/common/vcu118/Makefile
+++ b/projects/common/vcu118/Makefile
@@ -1,0 +1,16 @@
+####################################################################################
+## Copyright (c) 2018 - 2021 Analog Devices, Inc.
+### SPDX short identifier: BSD-1-Clause
+## Auto-generated, do not modify!
+####################################################################################
+
+PROJECT_NAME := template_vcu118
+
+M_DEPS += ../../common/vcu118/vcu118_system_constr.xdc
+M_DEPS += ../../common/vcu118/vcu118_system_bd.tcl
+M_DEPS += ../../../library/common/ad_iobuf.v
+
+LIB_DEPS += axi_sysid
+LIB_DEPS += sysid_rom
+
+include ../../scripts/project-xilinx.mk

--- a/projects/common/vcu118/system_bd.tcl
+++ b/projects/common/vcu118/system_bd.tcl
@@ -1,0 +1,9 @@
+source $ad_hdl_dir/projects/scripts/adi_pd.tcl
+source $ad_hdl_dir/projects/common/vcu118/vcu118_system_bd.tcl
+
+#system ID
+ad_ip_parameter axi_sysid_0 CONFIG.ROM_ADDR_BITS 9
+ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "[pwd]/mem_init_sys.txt"
+ad_ip_parameter rom_sys_0 CONFIG.ROM_ADDR_BITS 9
+
+sysid_gen_sys_init_file

--- a/projects/common/vcu128/Makefile
+++ b/projects/common/vcu128/Makefile
@@ -1,0 +1,17 @@
+####################################################################################
+## Copyright (c) 2018 - 2021 Analog Devices, Inc.
+### SPDX short identifier: BSD-1-Clause
+## Auto-generated, do not modify!
+####################################################################################
+
+PROJECT_NAME := template_vcu128
+
+M_DEPS += ../../scripts/adi_pd.tcl
+M_DEPS += ../../common/vcu128/vcu128_system_constr.xdc
+M_DEPS += ../../common/vcu128/vcu128_system_bd.tcl
+M_DEPS += ../../../library/common/ad_iobuf.v
+
+LIB_DEPS += axi_sysid
+LIB_DEPS += sysid_rom
+
+include ../../scripts/project-xilinx.mk

--- a/projects/common/vcu128/system_bd.tcl
+++ b/projects/common/vcu128/system_bd.tcl
@@ -1,0 +1,9 @@
+source $ad_hdl_dir/projects/scripts/adi_pd.tcl
+source $ad_hdl_dir/projects/common/vcu128/vcu128_system_bd.tcl
+
+#system ID
+ad_ip_parameter axi_sysid_0 CONFIG.ROM_ADDR_BITS 9
+ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "[pwd]/mem_init_sys.txt"
+ad_ip_parameter rom_sys_0 CONFIG.ROM_ADDR_BITS 9
+
+sysid_gen_sys_init_file

--- a/projects/common/vmk180/Makefile
+++ b/projects/common/vmk180/Makefile
@@ -1,0 +1,17 @@
+####################################################################################
+## Copyright (c) 2018 - 2021 Analog Devices, Inc.
+### SPDX short identifier: BSD-1-Clause
+## Auto-generated, do not modify!
+####################################################################################
+
+PROJECT_NAME := template_vmk180
+
+M_DEPS += ../../scripts/adi_pd.tcl
+M_DEPS += ../../common/vmk180/vmk180_system_constr.xdc
+M_DEPS += ../../common/vmk180/vmk180_system_bd.tcl
+M_DEPS += ../../../library/common/ad_iobuf.v
+
+LIB_DEPS += axi_sysid
+LIB_DEPS += sysid_rom
+
+include ../../scripts/project-xilinx.mk

--- a/projects/common/vmk180/system_bd.tcl
+++ b/projects/common/vmk180/system_bd.tcl
@@ -1,0 +1,9 @@
+source $ad_hdl_dir/projects/scripts/adi_pd.tcl
+source $ad_hdl_dir/projects/common/vmk180/vmk180_system_bd.tcl
+
+#system ID
+ad_ip_parameter axi_sysid_0 CONFIG.ROM_ADDR_BITS 9
+ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "[pwd]/mem_init_sys.txt"
+ad_ip_parameter rom_sys_0 CONFIG.ROM_ADDR_BITS 9
+
+sysid_gen_sys_init_file

--- a/projects/common/zc702/Makefile
+++ b/projects/common/zc702/Makefile
@@ -1,0 +1,21 @@
+####################################################################################
+## Copyright (c) 2018 - 2021 Analog Devices, Inc.
+### SPDX short identifier: BSD-1-Clause
+## Auto-generated, do not modify!
+####################################################################################
+
+PROJECT_NAME := template_zc702
+
+M_DEPS += ../../scripts/adi_pd.tcl
+M_DEPS += ../../common/zc702/zc702_system_constr.xdc
+M_DEPS += ../../common/zc702/zc702_system_bd.tcl
+M_DEPS += ../../../library/common/ad_iobuf.v
+
+LIB_DEPS += axi_clkgen
+LIB_DEPS += axi_dmac
+LIB_DEPS += axi_hdmi_tx
+LIB_DEPS += axi_spdif_tx
+LIB_DEPS += axi_sysid
+LIB_DEPS += sysid_rom
+
+include ../../scripts/project-xilinx.mk

--- a/projects/common/zc702/system_bd.tcl
+++ b/projects/common/zc702/system_bd.tcl
@@ -1,0 +1,9 @@
+source $ad_hdl_dir/projects/scripts/adi_pd.tcl
+source $ad_hdl_dir/projects/common/zc702/zc702_system_bd.tcl
+
+#system ID
+ad_ip_parameter axi_sysid_0 CONFIG.ROM_ADDR_BITS 9
+ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "[pwd]/mem_init_sys.txt"
+ad_ip_parameter rom_sys_0 CONFIG.ROM_ADDR_BITS 9
+
+sysid_gen_sys_init_file

--- a/projects/common/zc706/Makefile
+++ b/projects/common/zc706/Makefile
@@ -1,0 +1,21 @@
+####################################################################################
+## Copyright (c) 2018 - 2021 Analog Devices, Inc.
+### SPDX short identifier: BSD-1-Clause
+## Auto-generated, do not modify!
+####################################################################################
+
+PROJECT_NAME := template_zc706
+
+M_DEPS += ../../scripts/adi_pd.tcl
+M_DEPS += ../../common/zc706/zc706_system_constr.xdc
+M_DEPS += ../../common/zc706/zc706_system_bd.tcl
+M_DEPS += ../../../library/common/ad_iobuf.v
+
+LIB_DEPS += axi_clkgen
+LIB_DEPS += axi_dmac
+LIB_DEPS += axi_hdmi_tx
+LIB_DEPS += axi_spdif_tx
+LIB_DEPS += axi_sysid
+LIB_DEPS += sysid_rom
+
+include ../../scripts/project-xilinx.mk

--- a/projects/common/zc706/system_bd.tcl
+++ b/projects/common/zc706/system_bd.tcl
@@ -1,0 +1,9 @@
+source $ad_hdl_dir/projects/scripts/adi_pd.tcl
+source $ad_hdl_dir/projects/common/zc706/zc706_system_bd.tcl
+
+#system ID
+ad_ip_parameter axi_sysid_0 CONFIG.ROM_ADDR_BITS 9
+ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "[pwd]/mem_init_sys.txt"
+ad_ip_parameter rom_sys_0 CONFIG.ROM_ADDR_BITS 9
+
+sysid_gen_sys_init_file

--- a/projects/common/zcu102/Makefile
+++ b/projects/common/zcu102/Makefile
@@ -1,0 +1,17 @@
+####################################################################################
+## Copyright (c) 2018 - 2021 Analog Devices, Inc.
+### SPDX short identifier: BSD-1-Clause
+## Auto-generated, do not modify!
+####################################################################################
+
+PROJECT_NAME := template_zcu102
+
+M_DEPS += ../../scripts/adi_pd.tcl
+M_DEPS += ../../common/zcu102/zcu102_system_constr.xdc
+M_DEPS += ../../common/zcu102/zcu102_system_bd.tcl
+M_DEPS += ../../../library/common/ad_iobuf.v
+
+LIB_DEPS += axi_sysid
+LIB_DEPS += sysid_rom
+
+include ../../scripts/project-xilinx.mk

--- a/projects/common/zcu102/system_bd.tcl
+++ b/projects/common/zcu102/system_bd.tcl
@@ -1,0 +1,9 @@
+source $ad_hdl_dir/projects/scripts/adi_pd.tcl
+source $ad_hdl_dir/projects/common/zcu102/zcu102_system_bd.tcl
+
+#system ID
+ad_ip_parameter axi_sysid_0 CONFIG.ROM_ADDR_BITS 9
+ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "[pwd]/mem_init_sys.txt"
+ad_ip_parameter rom_sys_0 CONFIG.ROM_ADDR_BITS 9
+
+sysid_gen_sys_init_file

--- a/projects/common/zed/Makefile
+++ b/projects/common/zed/Makefile
@@ -1,0 +1,23 @@
+####################################################################################
+## Copyright (c) 2018 - 2021 Analog Devices, Inc.
+### SPDX short identifier: BSD-1-Clause
+## Auto-generated, do not modify!
+####################################################################################
+
+PROJECT_NAME := template_zed
+
+M_DEPS += ../../scripts/adi_pd.tcl
+M_DEPS += ../../common/zed/zed_system_constr.xdc
+M_DEPS += ../../common/zed/zed_system_bd.tcl
+M_DEPS += ../../../library/common/ad_iobuf.v
+
+LIB_DEPS += axi_clkgen
+LIB_DEPS += axi_dmac
+LIB_DEPS += axi_hdmi_tx
+LIB_DEPS += axi_i2s_adi
+LIB_DEPS += axi_spdif_tx
+LIB_DEPS += axi_sysid
+LIB_DEPS += sysid_rom
+LIB_DEPS += util_i2c_mixer
+
+include ../../scripts/project-xilinx.mk

--- a/projects/common/zed/system_bd.tcl
+++ b/projects/common/zed/system_bd.tcl
@@ -1,0 +1,9 @@
+source $ad_hdl_dir/projects/scripts/adi_pd.tcl
+source $ad_hdl_dir/projects/common/zed/zed_system_bd.tcl
+
+#system ID
+ad_ip_parameter axi_sysid_0 CONFIG.ROM_ADDR_BITS 9
+ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "[pwd]/mem_init_sys.txt"
+ad_ip_parameter rom_sys_0 CONFIG.ROM_ADDR_BITS 9
+
+sysid_gen_sys_init_file


### PR DESCRIPTION
projects/common: Add build files xilinx intel carriers
* Added Makefiles, system_constr.sdc, system_qsys intel
* Added Makefiles, system_bd, system_constr xilinx
* de10nano, changed quartus version variable