### PR TITLE
The memory interconnect was moved from HP0 to HP1 on Coraz7s projects

### DIFF
--- a/projects/cn0540/common/cn0540_bd.tcl
+++ b/projects/cn0540/common/cn0540_bd.tcl
@@ -155,5 +155,5 @@ ad_cpu_interrupt "ps-11" "mb-11" spi_adc/irq
 
 # memory interconnects
 
-ad_mem_hp0_interconnect $sys_cpu_clk sys_ps7/S_AXI_HP0
-ad_mem_hp0_interconnect $sys_cpu_clk axi_cn0540_dma/m_dest_axi
+ad_mem_hp1_interconnect $sys_cpu_clk sys_ps7/S_AXI_HP1
+ad_mem_hp1_interconnect $sys_cpu_clk axi_cn0540_dma/m_dest_axi

--- a/projects/cn0561/common/cn0561_bd.tcl
+++ b/projects/cn0561/common/cn0561_bd.tcl
@@ -126,6 +126,6 @@ ad_cpu_interconnect 0x44b10000 axi_cn0561_clkgen
 ad_cpu_interrupt "ps-13" "mb-13" axi_cn0561_dma/irq
 ad_cpu_interrupt "ps-12" "mb-12" cn0561_spi/irq
 
-ad_mem_hp0_interconnect $sys_cpu_clk sys_ps7/S_AXI_HP0
-ad_mem_hp0_interconnect $sys_cpu_clk axi_cn0561_dma/m_dest_axi
+ad_mem_hp1_interconnect $sys_cpu_clk sys_ps7/S_AXI_HP1
+ad_mem_hp1_interconnect $sys_cpu_clk axi_cn0561_dma/m_dest_axi
 

--- a/projects/pulsar_adc_pmdz/common/pulsar_adc_pmdz_bd.tcl
+++ b/projects/pulsar_adc_pmdz/common/pulsar_adc_pmdz_bd.tcl
@@ -58,5 +58,5 @@ ad_cpu_interconnect 0x44b00000 pulsar_adc_trigger_gen
 ad_cpu_interrupt "ps-13" "mb-13" axi_pulsar_adc_dma/irq
 ad_cpu_interrupt "ps-12" "mb-12" /spi_pulsar_adc/irq
 
-ad_mem_hp0_interconnect $sys_cpu_clk sys_ps7/S_AXI_HP0
-ad_mem_hp0_interconnect $sys_cpu_clk axi_pulsar_adc_dma/m_dest_axi
+ad_mem_hp1_interconnect $sys_cpu_clk sys_ps7/S_AXI_HP1
+ad_mem_hp1_interconnect $sys_cpu_clk axi_pulsar_adc_dma/m_dest_axi


### PR DESCRIPTION
V1: To maintain compatibility between carriers, the DMA memory interconnect was moved from HP0 to HP1.