### PR TITLE
adi_regmap_common.txt: Add missing RD_RAW_DATA field in regmap definition file

### DIFF
--- a/docs/regmap/adi_regmap_common.txt
+++ b/docs/regmap/adi_regmap_common.txt
@@ -137,6 +137,13 @@ EXT_SYNC
 RO
 If set the transport layer cores (ADC/DAC) have implemented the support for external synchronization signal.
 ENDFIELD
+
+FIELD
+[13] 0x0
+RD_RAW_DATA
+If set, the ADC has the capability to read raw data in register REG_CHAN_RAW_DATA from adc_channel.
+ENDFIELD
+
 ############################################################################################
 ############################################################################################
 


### PR DESCRIPTION
adi_regmap_common.txt: Add missing RD_RAW_DATA field in regmap definition file in commit [d9a861f](https://github.com/analogdevicesinc/hdl/commit/d9a861fb1339be7fa40b2757668d17330f664971);