### PR TITLE
ad9083_evb/a10soc: Overwrite spi frequency

### DIFF
--- a/projects/ad9083_evb/a10soc/system_qsys.tcl
+++ b/projects/ad9083_evb/a10soc/system_qsys.tcl
@@ -7,6 +7,8 @@ source $ad_hdl_dir/projects/common/a10soc/a10soc_plddr4_dacfifo_qsys.tcl
 source $ad_hdl_dir/projects/common/intel/adcfifo_qsys.tcl
 source ../common/ad9083_evb_qsys.tcl
 
+set_instance_parameter_value sys_spi {targetClockRate} {1000000.0}
+
 #system ID
 set_instance_parameter_value axi_sysid_0 {ROM_ADDR_BITS} {9}
 set_instance_parameter_value rom_sys_0 {ROM_ADDR_BITS} {9}


### PR DESCRIPTION
Tested on hardware.
Works, but jesd_status reports "measured link clock" as being double the value of "reported link clock".
