### PR TITLE
adrv9009/a10soc: Fix timing

### DIFF
--- a/projects/adrv9009/a10soc/system_project.tcl
+++ b/projects/adrv9009/a10soc/system_project.tcl
@@ -137,5 +137,6 @@ set_instance_assignment -name IO_STANDARD "1.8 V" -to adrv9009_gpio[18]
 
 # set optimization to get a better timing closure
 set_global_assignment -name OPTIMIZATION_MODE "HIGH PERFORMANCE EFFORT"
+set_global_assignment -name PLACEMENT_EFFORT_MULTIPLIER 1.2
 
 execute_flow -compile


### PR DESCRIPTION
Fix: Set PLACEMENT_EFFORT_MULTIPLIER value to 1.2 (fitter spends slightly more time in placement in order to improve placement quality)