### PR TITLE
SPI Engine: Update spi_engine.tcl

### DIFF
--- a/projects/ad4630_fmc/common/ad463x_bd.tcl
+++ b/projects/ad4630_fmc/common/ad463x_bd.tcl
@@ -23,9 +23,7 @@ create_bd_port -dir O ad463x_spi_sclk
 create_bd_port -dir O ad463x_spi_cs
 create_bd_port -dir O ad463x_spi_sdo
 create_bd_port -dir I -from [expr $NUM_OF_SDI-1] -to 0 ad463x_spi_sdi
-
 create_bd_port -dir I ad463x_echo_sclk
-
 create_bd_port -dir I ad463x_busy
 create_bd_port -dir O ad463x_cnv
 create_bd_port -dir I ad463x_ext_clk
@@ -40,8 +38,6 @@ ad_connect $sys_cpu_clk spi_clkgen/clk
 ad_connect spi_clk spi_clkgen/clk_0
 
 # create a SPI Engine architecture
-
-#spi_engine_create "spi_ad463x" 32         1             1       $NUM_OF_SDI 0          1
 
 set data_width    32
 set async_spi_clk 1
@@ -152,7 +148,6 @@ if {$CAPTURE_ZONE == 1} {
       ad_connect ad463x_spi_sdi data_capture/data_in
 
       ad_connect data_capture/m_axis data_reorder/s_axis
-
     }
     default {
       puts "ERROR: Invalid value for CLK_MODE. (valid values are 0 or 1 or 2)"
@@ -186,12 +181,12 @@ ad_connect $sys_cpu_resetn axi_ad463x_dma/m_dest_axi_aresetn
 
 # data path
 
-ad_connect  $hier_spi_engine/${hier_spi_engine}_execution/cs ad463x_spi_cs
-ad_connect  $hier_spi_engine/${hier_spi_engine}_execution/sclk ad463x_spi_sclk
-ad_connect  $hier_spi_engine/${hier_spi_engine}_execution/sdo ad463x_spi_sdo
-ad_connect  $hier_spi_engine/${hier_spi_engine}_execution/sdi ad463x_spi_sdi
+ad_connect $hier_spi_engine/${hier_spi_engine}_execution/cs ad463x_spi_cs
+ad_connect $hier_spi_engine/${hier_spi_engine}_execution/sclk ad463x_spi_sclk
+ad_connect $hier_spi_engine/${hier_spi_engine}_execution/sdo ad463x_spi_sdo
+ad_connect $hier_spi_engine/${hier_spi_engine}_execution/sdi ad463x_spi_sdi
 
-ad_connect  axi_ad463x_dma/s_axis data_reorder/m_axis
+ad_connect axi_ad463x_dma/s_axis data_reorder/m_axis
 
 # AXI memory mapped address space
 

--- a/projects/ad738x_fmc/common/ad738x_bd.tcl
+++ b/projects/ad738x_fmc/common/ad738x_bd.tcl
@@ -1,90 +1,24 @@
 
-create_bd_intf_port -mode Master -vlnv analog.com:interface:spi_master_rtl:1.0 spi
+create_bd_intf_port -mode Master -vlnv analog.com:interface:spi_master_rtl:1.0 ad738x_spi
 
-# create a SPI Engine architecture
+source $ad_hdl_dir/library/spi_engine/scripts/spi_engine.tcl
 
-create_bd_cell -type hier spi
-current_bd_instance /spi
+set data_width    16
+set async_spi_clk 1
+set num_cs        1
+set num_sdi       2
+set num_sdo       1
+set sdi_delay     1
+set echo_sclk     0
 
-  create_bd_pin -dir I -type clk clk
-  create_bd_pin -dir I -type rst resetn
-  create_bd_pin -dir O irq
-  create_bd_intf_pin -mode Master -vlnv analog.com:interface:spi_master_rtl:1.0 m_spi
-  create_bd_intf_pin -mode Master -vlnv xilinx.com:interface:axis_rtl:1.0 M_AXIS_SAMPLE
+set hier_spi_engine spi_ad738x_adc
 
-  ad_ip_instance spi_engine_execution execution
-  ad_ip_parameter execution CONFIG.DATA_WIDTH $adc_resolution
-  ad_ip_parameter execution CONFIG.NUM_OF_CS 1
-  ad_ip_parameter execution CONFIG.NUM_OF_SDI $adc_num_of_channels
+spi_engine_create $hier_spi_engine $data_width $async_spi_clk $num_cs $num_sdi $num_sdo $sdi_delay $echo_sclk
 
-  ad_ip_instance axi_spi_engine axi
-  ad_ip_parameter axi CONFIG.DATA_WIDTH $adc_resolution
-  ad_ip_parameter axi CONFIG.NUM_OF_SDI $adc_num_of_channels
-  ad_ip_parameter axi CONFIG.NUM_OFFLOAD 1
-
-  ad_ip_instance spi_engine_offload offload
-  ad_ip_parameter offload CONFIG.DATA_WIDTH $adc_resolution
-  ad_ip_parameter offload CONFIG.NUM_OF_SDI $adc_num_of_channels
-
-  ad_ip_instance spi_engine_interconnect interconnect
-  ad_ip_parameter interconnect CONFIG.DATA_WIDTH $adc_resolution
-  ad_ip_parameter interconnect CONFIG.NUM_OF_SDI $adc_num_of_channels
-
-  ad_ip_instance util_pulse_gen trigger_gen
-
-  ## to setup the sample rate of the system change the PULSE_PERIOD value
-  ## the acutal sample rate will be PULSE_PERIOD * (1/sys_cpu_clk)
-  ## fsys_cpu_clk is defined to 100 MHZ
-  set cycle_per_sec_100mhz 100000000
-  set sampling_cycle [expr int(ceil(double($cycle_per_sec_100mhz) / $adc_sampling_rate))]
-  ad_ip_parameter trigger_gen CONFIG.PULSE_PERIOD $sampling_cycle
-  ad_ip_parameter trigger_gen CONFIG.PULSE_WIDTH 1
-
-  if {$adc_resolution < 16} {
-    ad_ip_instance util_axis_upscale axis_upscaler
-    ad_ip_parameter axis_upscaler CONFIG.NUM_OF_CHANNELS $adc_num_of_channels
-    ad_ip_parameter axis_upscaler CONFIG.DATA_WIDTH $adc_resolution
-    ad_ip_parameter axis_upscaler CONFIG.UDATA_WIDTH 16
-    ad_connect clk axis_upscaler/clk
-    ad_connect axi/spi_resetn axis_upscaler/resetn
-    ad_connect offload/offload_sdi axis_upscaler/s_axis
-    ad_connect axis_upscaler/m_axis M_AXIS_SAMPLE
-    ad_connect axis_upscaler/dfmt_enable GND
-    ad_connect axis_upscaler/dfmt_type GND
-    ad_connect axis_upscaler/dfmt_se GND
-  } else {
-    ad_connect offload/offload_sdi M_AXIS_SAMPLE
-  }
-
-  ad_connect axi/spi_engine_offload_ctrl0 offload/spi_engine_offload_ctrl
-  ad_connect offload/spi_engine_ctrl interconnect/s0_ctrl
-  ad_connect axi/spi_engine_ctrl interconnect/s1_ctrl
-  ad_connect interconnect/m_ctrl execution/ctrl
-
-  ad_connect execution/spi m_spi
-
-  ad_connect clk offload/spi_clk
-  ad_connect clk offload/ctrl_clk
-  ad_connect clk execution/clk
-  ad_connect clk axi/s_axi_aclk
-  ad_connect clk axi/spi_clk
-  ad_connect clk interconnect/clk
-  ad_connect clk trigger_gen/clk
-
-  ad_connect axi/spi_resetn offload/spi_resetn
-  ad_connect axi/spi_resetn execution/resetn
-  ad_connect axi/spi_resetn interconnect/resetn
-  ad_connect axi/spi_resetn trigger_gen/rstn
-  ad_connect trigger_gen/load_config GND
-  ad_connect trigger_gen/pulse_width GND
-  ad_connect trigger_gen/pulse_period GND
-
-  ad_connect trigger_gen/pulse offload/trigger
-
-  ad_connect resetn axi/s_axi_aresetn
-  ad_connect irq axi/irq
-
-current_bd_instance /
+ad_ip_instance axi_pwm_gen spi_trigger_gen
+# 300ns pwm period
+ad_ip_parameter spi_trigger_gen CONFIG.PULSE_0_PERIOD 48
+ad_ip_parameter spi_trigger_gen CONFIG.PULSE_0_WIDTH 1
 
 ad_ip_instance axi_dmac axi_ad738x_dma
 ad_ip_parameter axi_ad738x_dma CONFIG.DMA_TYPE_SRC 1
@@ -94,24 +28,38 @@ ad_ip_parameter axi_ad738x_dma CONFIG.SYNC_TRANSFER_START 0
 ad_ip_parameter axi_ad738x_dma CONFIG.AXI_SLICE_SRC 0
 ad_ip_parameter axi_ad738x_dma CONFIG.AXI_SLICE_DEST 1
 ad_ip_parameter axi_ad738x_dma CONFIG.DMA_2D_TRANSFER 0
-ad_ip_parameter axi_ad738x_dma CONFIG.DMA_DATA_WIDTH_SRC [expr $adc_num_of_channels * 16]
+ad_ip_parameter axi_ad738x_dma CONFIG.DMA_DATA_WIDTH_SRC 32
 ad_ip_parameter axi_ad738x_dma CONFIG.DMA_DATA_WIDTH_DEST 64
 
-ad_connect  sys_cpu_clk spi/clk
-ad_connect  sys_cpu_resetn spi/resetn
-ad_connect  sys_cpu_resetn axi_ad738x_dma/m_dest_axi_aresetn
+ad_ip_instance axi_clkgen spi_clkgen
+ad_ip_parameter spi_clkgen CONFIG.CLK0_DIV 5
+ad_ip_parameter spi_clkgen CONFIG.VCO_DIV 1
+ad_ip_parameter spi_clkgen CONFIG.VCO_MUL 8
 
-ad_connect  spi/m_spi spi
-ad_connect  axi_ad738x_dma/s_axis spi/M_AXIS_SAMPLE
+ad_connect $sys_cpu_clk spi_clkgen/clk
+ad_connect spi_clk spi_clkgen/clk_0
 
-ad_cpu_interconnect 0x44a00000 spi/axi
+ad_connect spi_clk spi_trigger_gen/ext_clk
+ad_connect $sys_cpu_clk spi_trigger_gen/s_axi_aclk
+ad_connect sys_cpu_resetn spi_trigger_gen/s_axi_aresetn
+ad_connect spi_trigger_gen/pwm_0 $hier_spi_engine/trigger
+
+ad_connect axi_ad738x_dma/s_axis $hier_spi_engine/M_AXIS_SAMPLE
+ad_connect $hier_spi_engine/m_spi ad738x_spi
+
+ad_connect $sys_cpu_clk $hier_spi_engine/clk
+ad_connect spi_clk $hier_spi_engine/spi_clk
+ad_connect spi_clk axi_ad738x_dma/s_axis_aclk
+ad_connect sys_cpu_resetn $hier_spi_engine/resetn
+ad_connect sys_cpu_resetn axi_ad738x_dma/m_dest_axi_aresetn
+
+ad_cpu_interconnect 0x44a00000 $hier_spi_engine/${hier_spi_engine}_axi_regmap
 ad_cpu_interconnect 0x44a30000 axi_ad738x_dma
-
-ad_connect sys_cpu_clk axi_ad738x_dma/s_axis_aclk
+ad_cpu_interconnect 0x44a70000 spi_clkgen
+ad_cpu_interconnect 0x44b00000 spi_trigger_gen
 
 ad_cpu_interrupt "ps-13" "mb-13" axi_ad738x_dma/irq
-ad_cpu_interrupt "ps-12" "mb-12" spi/irq
+ad_cpu_interrupt "ps-12" "mb-12" $hier_spi_engine/irq
 
 ad_mem_hp2_interconnect sys_cpu_clk sys_ps7/S_AXI_HP2
 ad_mem_hp2_interconnect sys_cpu_clk axi_ad738x_dma/m_dest_axi
-

--- a/projects/ad738x_fmc/zed/system_bd.tcl
+++ b/projects/ad738x_fmc/zed/system_bd.tcl
@@ -10,17 +10,4 @@ ad_ip_parameter rom_sys_0 CONFIG.ROM_ADDR_BITS 9
 
 sysid_gen_sys_init_file
 
-# specify ADC resolution -- the design supports 16/14/12 bit resolutions
-
-set adc_resolution 16
-
-# specify the number of active channel -- 1 or 2 or 4
-
-set adc_num_of_channels 2
-
-# specify ADC sampling rate in sample/seconds -- default is 3 MSPS
-
-set adc_sampling_rate 3000000
-
 source ../common/ad738x_bd.tcl
-

--- a/projects/ad738x_fmc/zed/system_top.v
+++ b/projects/ad738x_fmc/zed/system_top.v
@@ -1,6 +1,6 @@
 // ***************************************************************************
 // ***************************************************************************
-// Copyright 2014 - 2017 (c) Analog Devices, Inc. All rights reserved.
+// Copyright 2018 - 2023 (c) Analog Devices, Inc. All rights reserved.
 //
 // In this HDL repository, there are many different and unique modules, consisting
 // of various HDL (Verilog or VHDL) components. The individual modules are
@@ -172,11 +172,11 @@ module system_top (
     .iic_mux_sda_i (iic_mux_sda_i_s),
     .iic_mux_sda_o (iic_mux_sda_o_s),
     .iic_mux_sda_t (iic_mux_sda_t_s),
-    .spi_sdo (spi_sdo),
-    .spi_sdo_t (),
-    .spi_sdi ({spi_sdib, spi_sdia}),
-    .spi_cs (spi_cs),
-    .spi_sclk (spi_sclk),
+    .ad738x_spi_sdo (spi_sdo),
+    .ad738x_spi_sdo_t (),
+    .ad738x_spi_sdi ({spi_sdib, spi_sdia}),
+    .ad738x_spi_cs (spi_cs),
+    .ad738x_spi_sclk (spi_sclk),
     .otg_vbusoc (otg_vbusoc),
     .spdif (spdif));
 

--- a/projects/ad77681evb/common/ad77681evb_bd.tcl
+++ b/projects/ad77681evb/common/ad77681evb_bd.tcl
@@ -1,74 +1,27 @@
 
 create_bd_intf_port -mode Master -vlnv analog.com:interface:spi_master_rtl:1.0 adc_spi
-
 create_bd_port -dir I adc_data_ready
+
+# create a SPI Engine architecture for ADC
+
+source $ad_hdl_dir/library/spi_engine/scripts/spi_engine.tcl
+
+set data_width    32
+set async_spi_clk 1
+set num_cs        1
+set num_sdi       1
+set num_sdo       1
+set sdi_delay     0
+set echo_sclk     0
+
+set hier_spi_engine spi_ad77681
+
+spi_engine_create $hier_spi_engine $data_width $async_spi_clk $num_cs $num_sdi $num_sdo $sdi_delay $echo_sclk
 
 ad_ip_instance axi_clkgen spi_clkgen
 ad_ip_parameter spi_clkgen CONFIG.CLK0_DIV 10
 ad_ip_parameter spi_clkgen CONFIG.VCO_DIV 1
 ad_ip_parameter spi_clkgen CONFIG.VCO_MUL 8
-ad_connect sys_cpu_clk spi_clkgen/clk
-
-# create a SPI Engine architecture for ADC
-
-create_bd_cell -type hier spi_adc
-current_bd_instance /spi_adc
-
-  create_bd_pin -dir I -type clk clk
-  create_bd_pin -dir I -type clk spi_clk
-  create_bd_pin -dir I -type rst resetn
-  create_bd_pin -dir I drdy
-  create_bd_pin -dir O irq
-  create_bd_intf_pin -mode Master -vlnv analog.com:interface:spi_master_rtl:1.0 m_spi
-  create_bd_intf_pin -mode Master -vlnv xilinx.com:interface:axis_rtl:1.0 M_AXIS_SAMPLE
-
-  # DATA_WIDTH is set to 32
-
-  ad_ip_instance spi_engine_execution execution
-  ad_ip_parameter execution CONFIG.DATA_WIDTH 32
-  ad_ip_parameter execution CONFIG.NUM_OF_CS 1
-
-  ad_ip_instance axi_spi_engine axi_regmap
-  ad_ip_parameter axi_regmap CONFIG.DATA_WIDTH 32
-  ad_ip_parameter axi_regmap CONFIG.NUM_OFFLOAD 1
-  ad_ip_parameter axi_regmap CONFIG.ASYNC_SPI_CLK 1
-
-  ad_ip_instance spi_engine_offload offload
-  ad_ip_parameter offload CONFIG.DATA_WIDTH 32
-  ad_ip_parameter offload CONFIG.ASYNC_TRIG 1
-  ad_ip_parameter offload CONFIG.ASYNC_SPI_CLK 1
-
-  ad_ip_instance spi_engine_interconnect interconnect
-  ad_ip_parameter interconnect CONFIG.DATA_WIDTH 32
-
-  ad_connect axi_regmap/spi_engine_offload_ctrl0 offload/spi_engine_offload_ctrl
-  ad_connect offload/spi_engine_ctrl interconnect/s0_ctrl
-  ad_connect axi_regmap/spi_engine_ctrl interconnect/s1_ctrl
-  ad_connect interconnect/m_ctrl execution/ctrl
-  ad_connect offload/offload_sdi M_AXIS_SAMPLE
-
-  ad_connect execution/spi m_spi
-
-  ad_connect spi_clk offload/spi_clk
-  ad_connect spi_clk offload/ctrl_clk
-  ad_connect spi_clk execution/clk
-  ad_connect clk axi_regmap/s_axi_aclk
-  ad_connect spi_clk axi_regmap/spi_clk
-  ad_connect spi_clk interconnect/clk
-
-  ad_connect axi_regmap/spi_resetn offload/spi_resetn
-  ad_connect axi_regmap/spi_resetn execution/resetn
-  ad_connect axi_regmap/spi_resetn interconnect/resetn
-
-  ad_connect drdy offload/trigger
-
-  ad_connect resetn axi_regmap/s_axi_aresetn
-  ad_connect irq axi_regmap/irq
-
-
-current_bd_instance /
-
-ad_connect adc_data_ready spi_adc/drdy
 
 # dma for the ADC
 
@@ -83,30 +36,29 @@ ad_ip_parameter axi_ad77681_dma CONFIG.DMA_2D_TRANSFER 0
 ad_ip_parameter axi_ad77681_dma CONFIG.DMA_DATA_WIDTH_SRC 32
 ad_ip_parameter axi_ad77681_dma CONFIG.DMA_DATA_WIDTH_DEST 64
 
-ad_connect  sys_cpu_clk spi_adc/clk
-ad_connect  spi_adc/spi_clk spi_clkgen/clk_0
-
-ad_connect  sys_cpu_resetn spi_adc/resetn
-ad_connect  sys_cpu_resetn axi_ad77681_dma/m_dest_axi_aresetn
-
-ad_connect  spi_adc/m_spi adc_spi
-ad_connect  axi_ad77681_dma/s_axis spi_adc/M_AXIS_SAMPLE
+ad_connect $sys_cpu_clk spi_clkgen/clk
+ad_connect spi_clk spi_clkgen/clk_0
+ad_connect adc_data_ready $hier_spi_engine/trigger
+ad_connect axi_ad77681_dma/s_axis $hier_spi_engine/M_AXIS_SAMPLE
+ad_connect $hier_spi_engine/m_spi adc_spi
+ad_connect $sys_cpu_clk $hier_spi_engine/clk
+ad_connect spi_clk $hier_spi_engine/spi_clk
+ad_connect spi_clk axi_ad77681_dma/s_axis_aclk
+ad_connect sys_cpu_resetn $hier_spi_engine/resetn
+ad_connect sys_cpu_resetn axi_ad77681_dma/m_dest_axi_aresetn
 
 # AXI address definitions
 
-ad_cpu_interconnect 0x44a00000 spi_adc/axi_regmap
+ad_cpu_interconnect 0x44a00000 $hier_spi_engine/${hier_spi_engine}_axi_regmap
 ad_cpu_interconnect 0x44a30000 axi_ad77681_dma
 ad_cpu_interconnect 0x44a70000 spi_clkgen
-
-ad_connect spi_adc/spi_clk axi_ad77681_dma/s_axis_aclk
 
 # interrupts
 
 ad_cpu_interrupt "ps-13" "mb-13" axi_ad77681_dma/irq
-ad_cpu_interrupt "ps-12" "mb-12" spi_adc/irq
+ad_cpu_interrupt "ps-12" "mb-12" $hier_spi_engine/irq
 
 # memory interconnects
 
 ad_mem_hp2_interconnect sys_cpu_clk sys_ps7/S_AXI_HP0
 ad_mem_hp2_interconnect sys_cpu_clk axi_ad77681_dma/m_dest_axi
-

--- a/projects/ad77681evb/zed/Makefile
+++ b/projects/ad77681evb/zed/Makefile
@@ -11,6 +11,7 @@ M_DEPS += ../../scripts/adi_pd.tcl
 M_DEPS += ../../common/zed/zed_system_constr.xdc
 M_DEPS += ../../common/zed/zed_system_bd.tcl
 M_DEPS += ../../../library/xilinx/common/ad_data_clk.v
+M_DEPS += ../../../library/spi_engine/scripts/spi_engine.tcl
 M_DEPS += ../../../library/common/ad_iobuf.v
 
 LIB_DEPS += axi_clkgen

--- a/projects/ad77681evb/zed/system_constr.xdc
+++ b/projects/ad77681evb/zed/system_constr.xdc
@@ -3,8 +3,8 @@
 
 set_property -dict {PACKAGE_PIN  N19 IOSTANDARD LVCMOS25 IOB TRUE}                  [get_ports ad7768_spi_sclk]    ; ## FMC_LPC_LA01_CC_P
 set_property -dict {PACKAGE_PIN  P17 IOSTANDARD LVCMOS25 IOB TRUE PULLTYPE PULLUP}  [get_ports ad7768_spi_miso]    ; ## FMC_LPC_LA02_P
-set_property -dict {PACKAGE_PIN  N22 IOSTANDARD LVCMOS25}                           [get_ports ad7768_spi_mosi]    ; ## FMC_LPC_LA03_P
-set_property -dict {PACKAGE_PIN  M21 IOSTANDARD LVCMOS25}                           [get_ports ad7768_spi_cs]      ; ## FMC_LPC_LA04_P
+set_property -dict {PACKAGE_PIN  N22 IOSTANDARD LVCMOS25 IOB TRUE}                  [get_ports ad7768_spi_mosi]    ; ## FMC_LPC_LA03_P
+set_property -dict {PACKAGE_PIN  M21 IOSTANDARD LVCMOS25 IOB TRUE}                  [get_ports ad7768_spi_cs]      ; ## FMC_LPC_LA04_P
 
 # reset and GPIO signals
 
@@ -16,7 +16,6 @@ set_property -dict {PACKAGE_PIN  N17 IOSTANDARD LVCMOS25}                       
 
 # syncronization and timing
 
-set_property -dict {PACKAGE_PIN  J18 IOSTANDARD LVCMOS25 IOB TRUE}                  [get_ports ad7768_drdy]        ; ## FMC_LPC_LA05_P
+set_property -dict {PACKAGE_PIN  J18 IOSTANDARD LVCMOS25}                           [get_ports ad7768_drdy]        ; ## FMC_LPC_LA05_P
 set_property -dict {PACKAGE_PIN  L19 IOSTANDARD LVCMOS25}                           [get_ports ad7768_sync_out]    ; ## FMC_LPC_CLK0_M2C_N
 set_property -dict {PACKAGE_PIN  L21 IOSTANDARD LVCMOS25}                           [get_ports ad7768_sync_in]     ; ## FMC_LPC_LA06_P
-

--- a/projects/cn0363/zed/Makefile
+++ b/projects/cn0363/zed/Makefile
@@ -10,6 +10,7 @@ M_DEPS += ../common/cn0363_bd.tcl
 M_DEPS += ../../scripts/adi_pd.tcl
 M_DEPS += ../../common/zed/zed_system_constr.xdc
 M_DEPS += ../../common/zed/zed_system_bd.tcl
+M_DEPS += ../../../library/spi_engine/scripts/spi_engine.tcl
 M_DEPS += ../../../library/common/ad_iobuf.v
 
 LIB_DEPS += axi_clkgen

--- a/projects/cn0540/coraz7s/Makefile
+++ b/projects/cn0540/coraz7s/Makefile
@@ -11,6 +11,7 @@ M_DEPS += ../../scripts/adi_pd.tcl
 M_DEPS += ../../common/coraz7s/coraz7s_system_ps7.tcl
 M_DEPS += ../../common/coraz7s/coraz7s_system_constr.xdc
 M_DEPS += ../../common/coraz7s/coraz7s_system_bd.tcl
+M_DEPS += ../../../library/spi_engine/scripts/spi_engine.tcl
 M_DEPS += ../../../library/common/ad_iobuf.v
 
 LIB_DEPS += axi_clkgen

--- a/projects/cn0540/coraz7s/system_constr.xdc
+++ b/projects/cn0540/coraz7s/system_constr.xdc
@@ -4,7 +4,7 @@
 set_property -dict {PACKAGE_PIN  G15 IOSTANDARD LVCMOS33 IOB TRUE}                  [get_ports cn0540_spi_sclk]    ; ## CK_IO13
 set_property -dict {PACKAGE_PIN  J18 IOSTANDARD LVCMOS33 IOB TRUE PULLTYPE PULLUP}  [get_ports cn0540_spi_miso]    ; ## CK_IO12
 set_property -dict {PACKAGE_PIN  K18 IOSTANDARD LVCMOS33 IOB TRUE PULLTYPE PULLUP}  [get_ports cn0540_spi_mosi]    ; ## CK_IO11
-set_property -dict {PACKAGE_PIN  U15 IOSTANDARD LVCMOS33}                           [get_ports cn0540_spi_cs]      ; ## CK_IO10
+set_property -dict {PACKAGE_PIN  U15 IOSTANDARD LVCMOS33 IOB TRUE}                  [get_ports cn0540_spi_cs]      ; ## CK_IO10
 
 # reset and GPIO signals
 

--- a/projects/pulsar_adc_pmdz/common/pulsar_adc_pmdz_bd.tcl
+++ b/projects/pulsar_adc_pmdz/common/pulsar_adc_pmdz_bd.tcl
@@ -58,7 +58,7 @@ ad_cpu_interconnect 0x44a70000 spi_clkgen
 ad_cpu_interconnect 0x44b00000 pulsar_adc_trigger_gen
 
 ad_cpu_interrupt "ps-13" "mb-13" axi_pulsar_adc_dma/irq
-ad_cpu_interrupt "ps-12" "mb-12" /$hier_spi_engine/irq
+ad_cpu_interrupt "ps-12" "mb-12" $hier_spi_engine/irq
 
 ad_mem_hp1_interconnect $sys_cpu_clk sys_ps7/S_AXI_HP1
 ad_mem_hp1_interconnect $sys_cpu_clk axi_pulsar_adc_dma/m_dest_axi


### PR DESCRIPTION
The SPI Engine cores were named directly inside the script and this would mean that for multiple SPI Engine instances IPs with the same name would appear. These updates will introduce the hierarchy name into the name given to the cores and will therefore allow for multiple instances of SPI Engine to be added to the same Xilinx project.

Projects which use spi_engine.tcl will be updated to account for these changes.