### PR TITLE
axi_adrv9001/intel: Add dummy parameter IODELAY_ENABLE in adrv9001_rx

### DIFF
--- a/library/axi_adrv9001/intel/adrv9001_rx.v
+++ b/library/axi_adrv9001/intel/adrv9001_rx.v
@@ -1,6 +1,6 @@
 // ***************************************************************************
 // ***************************************************************************
-// Copyright 2014 - 2020 (c) Analog Devices, Inc. All rights reserved.
+// Copyright 2014 - 2023 (c) Analog Devices, Inc. All rights reserved.
 //
 // In this HDL repository, there are many different and unique modules, consisting
 // of various HDL (Verilog or VHDL) components. The individual modules are
@@ -40,6 +40,7 @@ module adrv9001_rx #(
   parameter FPGA_TECHNOLOGY = 0,
   parameter NUM_LANES = 3,
   parameter DRP_WIDTH = 5,
+  parameter IODELAY_ENABLE = 0,
   parameter IODELAY_CTRL = 0,
   parameter USE_BUFG = 0,
   parameter IO_DELAY_GROUP = "dev_if_delay_group"


### PR DESCRIPTION
 - Issue introduced by [this commit](https://github.com/analogdevicesinc/hdl/commit/173f4a83d492365dad6ca7ad111f952884041a95)
 - When IODELAY_ENABLE was inserted in axi_adrv9001_if for adrv9001_rx (Xilinx instance), for Intel instance (intel/adrv9001_rx.v) was omitted and caused a build error for adrv9001/a10soc
 - Now it built ok

Signed-off-by: Iulia Moldovan <Iulia.Moldovan@analog.com>