### PR TITLE
axi_adrv9001: set mssi_sync cross-domain signals as ASYNC_REG.

### DIFF
--- a/library/axi_adrv9001/axi_adrv9001_constr.xdc
+++ b/library/axi_adrv9001/axi_adrv9001_constr.xdc
@@ -34,3 +34,8 @@ set_false_path \
 set_false_path \
   -to [get_cells -quiet -hier *mssi_sync_d_reg* \
     -filter {NAME =~ *i_*_phy* && IS_SEQUENTIAL}]
+set_property ASYNC_REG TRUE [get_cells -quiet -hier *mssi_sync_d_reg* -filter {NAME =~ *i_*_phy* && IS_SEQUENTIAL}]
+set_false_path \
+  -to [get_cells -quiet -hier *mssi_sync_2d_reg* \
+    -filter {NAME =~ *i_*_phy* && IS_SEQUENTIAL}]
+set_property ASYNC_REG TRUE [get_cells -quiet -hier *mssi_sync_2d_reg* -filter {NAME =~ *i_*_phy* && IS_SEQUENTIAL}]


### PR DESCRIPTION
mssi_sync_2d signal was giving timing errors on an Ultrascale+ design with multiple axi_adrv9001s.

Signed-off-by: Nick Pillitteri <njpillitteri@gmail.com>