### PR TITLE
ad9081: vck190: Update default profile

### DIFF
--- a/projects/ad9081_fmca_ebz/common/versal_transceiver.tcl
+++ b/projects/ad9081_fmca_ebz/common/versal_transceiver.tcl
@@ -2,10 +2,10 @@
 # TODO: This works only up to 4 lanes on 64B66B
 proc create_versal_phy {
   {ip_name versal_phy}
-  {num_lanes 2}
-  {rx_lane_rate 11.88}
-  {tx_lane_rate 11.88}
-  {ref_clock 360}
+  {num_lanes 4}
+  {rx_lane_rate 24.75}
+  {tx_lane_rate 24.75}
+  {ref_clock 375}
 } {
 
 set num_quads [expr round(1.0*$num_lanes/4)]

--- a/projects/ad9081_fmca_ebz/vck190/system_project.tcl
+++ b/projects/ad9081_fmca_ebz/vck190/system_project.tcl
@@ -33,16 +33,16 @@ source $ad_hdl_dir/projects/scripts/adi_board.tcl
 
 adi_project ad9081_fmca_ebz_vck190 0 [list \
   JESD_MODE         [get_env_param JESD_MODE     64B66B ]\
-  RX_LANE_RATE      [get_env_param RX_LANE_RATE   11.88 ] \
-  TX_LANE_RATE      [get_env_param TX_LANE_RATE   11.88 ] \
-  REF_CLK_RATE      [get_env_param REF_CLK_RATE     360 ] \
-  RX_JESD_M         [get_env_param RX_JESD_M          2 ] \
-  RX_JESD_L         [get_env_param RX_JESD_L          2 ] \
-  RX_JESD_S         [get_env_param RX_JESD_S          4 ] \
+  RX_LANE_RATE      [get_env_param RX_LANE_RATE   24.75 ] \
+  TX_LANE_RATE      [get_env_param TX_LANE_RATE   24.75 ] \
+  REF_CLK_RATE      [get_env_param REF_CLK_RATE     375 ] \
+  RX_JESD_M         [get_env_param RX_JESD_M          4 ] \
+  RX_JESD_L         [get_env_param RX_JESD_L          4 ] \
+  RX_JESD_S         [get_env_param RX_JESD_S          2 ] \
   RX_JESD_NP        [get_env_param RX_JESD_NP        12 ] \
   RX_NUM_LINKS      [get_env_param RX_NUM_LINKS       1 ] \
-  TX_JESD_M         [get_env_param TX_JESD_M          2 ] \
-  TX_JESD_L         [get_env_param TX_JESD_L          2 ] \
+  TX_JESD_M         [get_env_param TX_JESD_M          4 ] \
+  TX_JESD_L         [get_env_param TX_JESD_L          4 ] \
   TX_JESD_S         [get_env_param TX_JESD_S          2 ] \
   TX_JESD_NP        [get_env_param TX_JESD_NP        12 ] \
   TX_NUM_LINKS      [get_env_param TX_NUM_LINKS       1 ] \

--- a/projects/ad9081_fmca_ebz/vck190/timing_constr.xdc
+++ b/projects/ad9081_fmca_ebz/vck190/timing_constr.xdc
@@ -1,9 +1,9 @@
 # Primary clock definitions
-create_clock -name refclk         -period  2.66 [get_ports fpga_refclk_in_p]
+create_clock -name refclk         -period  2.667 [get_ports fpga_refclk_in_p]
 
 # device clock
-create_clock -name tx_device_clk     -period  4 [get_ports clkin6_p]
-create_clock -name rx_device_clk     -period  4 [get_ports clkin10_p]
+create_clock -name tx_device_clk     -period  2.667 [get_ports clkin6_p]
+create_clock -name rx_device_clk     -period  2.667 [get_ports clkin10_p]
 
 # Constraint SYSREFs
 # Assumption is that REFCLK and SYSREF have similar propagation delay,


### PR DESCRIPTION
This profile corresponds to the default linux profile.
This design has tighter timing constraints so it may fail timing from time to time.
It met timing when I built it two times in a row.
