### PR TITLE
scripts: adi_board: Update ad_disconnect procedure

### DIFF
--- a/projects/scripts/adi_board.tcl
+++ b/projects/scripts/adi_board.tcl
@@ -275,9 +275,11 @@ proc ad_disconnect {p_name_1 p_name_2} {
   }
 
   if {[get_property CLASS $m_name_1] eq "bd_pin"} {
-    delete_bd_objs -quiet [get_bd_nets -quiet -of_objects \
-      [find_bd_objs -relation connected_to $m_name_1]]
-    delete_bd_objs -quiet $m_name_1
+
+    set p_net [get_bd_nets -of_objects [get_bd_pins $p_name_1]]
+    set p_pin [get_bd_pins $p_name_1]
+
+    disconnect_bd_net $p_net $p_pin
     return
   }
 }
@@ -420,7 +422,7 @@ proc ad_xcvrcon {u_xcvr a_xcvr a_jesd {lane_map {}} {link_clk {}} {device_clk {}
     for {set n 0} {$n < $no_of_lanes} {incr n} {
 
       set phys_lane [lindex $partial_lane_map $n]
-    
+
       if {$phys_lane != {}} {
         if {$jesd204_type == 0} {
           ad_connect  ${u_xcvr}/${txrx}_${phys_lane} ${a_jesd}/${txrx}_phy${n}
@@ -453,7 +455,7 @@ proc ad_xcvrcon {u_xcvr a_xcvr a_jesd {lane_map {}} {link_clk {}} {device_clk {}
       if {$tx_or_rx_n == 0} {
         ad_connect  ${a_xcvr}/up_es_${n} ${u_xcvr}/up_es_${phys_lane}
       }
-      
+
       if {(($n%4) == 0) && ($qpll_enable == 1)} {
         ad_connect  ${a_xcvr}/up_cm_${n} ${u_xcvr}/up_cm_${n}
       }
@@ -536,7 +538,7 @@ proc ad_xcvrcon {u_xcvr a_xcvr a_jesd {lane_map {}} {link_clk {}} {device_clk {}
       }
     }
   }
-  
+
   if {$jesd204_type == 0} {
     ad_connect  ${a_jesd}/sysref $m_sysref
     if {$link_mode == 1} {


### PR DESCRIPTION
The current procedure will remove the whole net connected to the pin, which is not ok in all cases.
After the update, the command will disconnect the target pin from the net, without modifying the rest of the design

Same as what was fixed on the hdl_2021_r1 branch