### PR TITLE
adi_board.tcl: add some optional parameters to ad_xcvrcon and ad_cpu_interconnect to support hierarchal designs

### DIFF
--- a/projects/scripts/adi_board.tcl
+++ b/projects/scripts/adi_board.tcl
@@ -934,8 +934,9 @@ proc ad_mem_hpx_interconnect {p_sel p_clk p_name} {
 #  \param[p_address] - address offset of the IP register map
 #  \param[p_name] - name of the IP
 #  \param[p_intf_name] - name of the AXI MM Slave interface (optional)
+#  \param[segment_prefix] - prefix to add to the segment name to avoid namespace clashes (optional)
 #
-proc ad_cpu_interconnect {p_address p_name {p_intf_name {}}} {
+proc ad_cpu_interconnect {p_address p_name {p_intf_name {}} {segment_prefix {}}} {
 
   global sys_zynq
   global sys_cpu_interconnect_index
@@ -1131,7 +1132,7 @@ proc ad_cpu_interconnect {p_address p_name {p_intf_name {}}} {
       }
       create_bd_addr_seg -range $p_seg_range \
         -offset $p_address $sys_addr_cntrl_space \
-        $p_seg_name "SEG_data_${p_name}"
+        $p_seg_name "SEG_data_${segment_prefix}_${p_name}"
     } else {
       assign_bd_address $p_seg_name
     }


### PR DESCRIPTION
### ad_xcvrcon
The `port_prefix` parameter allows an optional prefix to be applied to
port names created by ad_xcvrcon. This is useful when created large
hierarchical designs where all ports are prefixed by their hierarchical
name to avoid name clashes at the top level (for example: slot_a,
slot_b, slot_c, etc).

The `resetn` parameter sets the net name to be connected to ext_reset_in
on the reset generator. This parameter defaults to 'sys_cpu_resetn'.

### ad_cpu_interconnect
Add an optional prefix, `segment_prefix`,  to be applied to the segment to avoid name clashes. This is used when creating a block design in the root, and then moved to a hierarchical cell using move_bd_cells. Without the prefix, a second instance of this block design will have segment name conflicts because it uses the instance name before moving.
