### PR TITLE
library/util_pulse_gen.v: Fixed bug preventing pulse_period_cnt from incrementing

### DIFF
--- a/library/common/util_pulse_gen.v
+++ b/library/common/util_pulse_gen.v
@@ -73,7 +73,8 @@ module util_pulse_gen #(
         pulse_width_read <= pulse_width;
       end
       // update the current period/width at the end of the period
-      if (pulse_period_cnt == 32'h1) begin
+      // Change condition to 0 instead of 1 or the counter will never start counting!
+      if (pulse_period_cnt == 32'h0) begin
         pulse_period_d <= pulse_period_read;
         pulse_width_d <= pulse_width_read;
       end


### PR DESCRIPTION
Small change in util_pulse_gen to allow pwm counter reg to increment. Tested with adrv9009-rf-som fan controler.
Fan wasn't correctly controlled before. Works properly now.