### PR TITLE
Fix fmcomms8 timing on zcu102 & adrv9009zu11eg

### DIFF
--- a/projects/adrv9009zu11eg/adrv2crr_fmcomms8/Makefile
+++ b/projects/adrv9009zu11eg/adrv2crr_fmcomms8/Makefile
@@ -7,7 +7,6 @@
 PROJECT_NAME := fmcomms8_adrv9009zu11eg
 
 M_DEPS += fmcomms8_constr.xdc
-M_DEPS += ../common/adrv9009zu11eg_spi.v
 M_DEPS += ../common/adrv9009zu11eg_constr.xdc
 M_DEPS += ../common/adrv9009zu11eg_bd.tcl
 M_DEPS += ../common/adrv2crr_fmc_constr.xdc
@@ -15,6 +14,7 @@ M_DEPS += ../common/adrv2crr_fmc_bd.tcl
 M_DEPS += ../../scripts/adi_pd.tcl
 M_DEPS += ../../../library/jesd204/scripts/jesd204.tcl
 M_DEPS += ../../../library/common/ad_iobuf.v
+M_DEPS += ../../../library/common/ad_3w_spi.v
 
 LIB_DEPS += axi_dmac
 LIB_DEPS += axi_fan_control

--- a/projects/adrv9009zu11eg/adrv2crr_fmcomms8/system_project.tcl
+++ b/projects/adrv9009zu11eg/adrv2crr_fmcomms8/system_project.tcl
@@ -18,9 +18,9 @@ adi_project_create fmcomms8_adrv9009zu11eg 0 [list \
 adi_project_files fmcomms8_adrv9009zu11eg [list \
   "system_top.v" \
   "fmcomms8_constr.xdc"\
-  "../common/adrv9009zu11eg_spi.v" \
   "../common/adrv9009zu11eg_constr.xdc" \
   "../common/adrv2crr_fmc_constr.xdc" \
+  "$ad_hdl_dir/library/common/ad_3w_spi.v" \
   "$ad_hdl_dir/library/common/ad_iobuf.v" \
  ]
 

--- a/projects/adrv9009zu11eg/adrv2crr_fmcomms8/system_top.v
+++ b/projects/adrv9009zu11eg/adrv2crr_fmcomms8/system_top.v
@@ -387,21 +387,25 @@ module system_top (
   assign spi_csn_adrv9009_d = spi_fmcomms8_3_to_8_csn[1];
   assign spi_csn_fmc_hmc7044 = spi_fmcomms8_3_to_8_csn[2];
 
-  adrv9009zu11eg_spi i_spi (
-    .spi_csn(spi_3_to_8_csn),
+  ad_3w_spi #(.NUM_OF_SLAVES(1)) i_spi (
+    .spi_csn(spi_3_to_8_csn[2]),
     .spi_clk(spi_clk),
     .spi_mosi(spi_mosi),
-    .spi_miso_i(spi_miso_s),
-    .spi_miso_o(spi0_miso),
+    .spi_miso(spi0_miso_3w),
     .spi_sdio(spi_sdio));
+    
+  assign spi0_miso = ~spi_3_to_8_csn[2] ? spi0_miso_3w : spi_miso_s;
+  assign spi_sdio =  ~&spi_3_to_8_csn[1:0] ? spi_mosi : 1'bz;
 
-  adrv9009zu11eg_spi fmcomms8_spi (
-    .spi_csn(spi_fmcomms8_3_to_8_csn),
+  ad_3w_spi #(.NUM_OF_SLAVES(1)) fmcomms8_spi (
+    .spi_csn(spi_fmcomms8_3_to_8_csn[2]),
     .spi_clk(spi_fmc_clk),
     .spi_mosi(fmcomms8_spi_mosi),
-    .spi_miso_i(spi_fmc_miso),
-    .spi_miso_o(fmcomms8_spi1_miso),
+    .spi_miso(fmcomms8_miso_3w),
     .spi_sdio(spi_fmc_sdio));
+    
+  assign fmcomms8_spi1_miso = ~spi_3_to_8_csn[2] ? fmcomms8_miso_3w : spi_fmc_miso;
+  assign spi_fmc_sdio =  ~&spi_3_to_8_csn[1:0] ? spi_mosi : 1'bz;
 
   assign tx_sync = tx_sync_a & tx_sync_b & tx_sync_c & tx_sync_d;
 

--- a/projects/fmcomms8/zcu102/Makefile
+++ b/projects/fmcomms8/zcu102/Makefile
@@ -6,7 +6,6 @@
 
 PROJECT_NAME := fmcomms8_zcu102
 
-M_DEPS += ../common/fmcomms8_spi.v
 M_DEPS += ../common/fmcomms8_bd.tcl
 M_DEPS += ../../scripts/adi_pd.tcl
 M_DEPS += ../../common/zcu102/zcu102_system_constr.xdc
@@ -14,6 +13,7 @@ M_DEPS += ../../common/zcu102/zcu102_system_bd.tcl
 M_DEPS += ../../common/xilinx/dacfifo_bd.tcl
 M_DEPS += ../../../library/jesd204/scripts/jesd204.tcl
 M_DEPS += ../../../library/common/ad_iobuf.v
+M_DEPS += ../../../library/common/ad_3w_spi.v
 
 LIB_DEPS += axi_dmac
 LIB_DEPS += axi_sysid

--- a/projects/fmcomms8/zcu102/system_project.tcl
+++ b/projects/fmcomms8/zcu102/system_project.tcl
@@ -16,7 +16,7 @@ adi_project fmcomms8_zcu102 0 [list \
 adi_project_files  fmcomms8_zcu102 [list \
   "system_top.v" \
   "system_constr.xdc"\
-  "../common/fmcomms8_spi.v" \
+  "$ad_hdl_dir/library/common/ad_3w_spi.v" \
   "$ad_hdl_dir/library/common/ad_iobuf.v" \
   "$ad_hdl_dir/projects/common/zcu102/zcu102_system_constr.xdc" ]
 

--- a/projects/fmcomms8/zcu102/system_top.v
+++ b/projects/fmcomms8/zcu102/system_top.v
@@ -176,13 +176,16 @@ module system_top (
   assign spi_csn_adrv9009_d = spi_3_to_8_csn[1];
   assign spi_csn_hmc7044 = spi_3_to_8_csn[2];
 
-  fmcomms8_spi i_spi (
-    .spi_csn(spi_3_to_8_csn),
-    .spi_clk(spi_clk),
-    .spi_mosi(spi_mosi),
-    .spi_miso_i(spi_miso),
-    .spi_miso_o(spi0_miso),
-    .spi_sdio(spi_sdio));
+  ad_3w_spi #(.NUM_OF_SLAVES(1)) fmcomms8_spi (
+    .spi_csn (spi_3_to_8_csn[2]),
+    .spi_clk (spi_clk),
+    .spi_mosi (spi_mosi),
+    .spi_miso (fmcomms8_miso_3w),
+    .spi_sdio (spi_sdio),
+    .spi_dir ());
+
+  assign spi0_miso = ~spi_3_to_8_csn[2] ? fmcomms8_miso_3w : spi_miso;
+  assign spi_sdio =  ~&spi_3_to_8_csn[1:0] ? spi_mosi : 1'bz;
 
   assign tx_sync = tx_sync_c & tx_sync_d;
 


### PR DESCRIPTION
The fail is caused by SPI interface timing