### PR TITLE
ad7606x: Fix axi control module's data width and channels order, and up_cpack2 module's SAMPLE_DATA_WIDTH

### DIFF
--- a/library/axi_ad7606x/axi_ad7606x.v
+++ b/library/axi_ad7606x/axi_ad7606x.v
@@ -382,14 +382,14 @@ module axi_ad7606x #(
   endgenerate
 
   assign adc_data_s = {adc_data_0_s,adc_data_1_s,adc_data_2_s,adc_data_3_s,adc_data_4_s,adc_data_5_s,adc_data_6_s,adc_data_7_s};
-  assign adc_data_0 = dma_data[0*ADC_TO_DMA_N_BITS+(ADC_N_BITS-1):0*ADC_TO_DMA_N_BITS];
-  assign adc_data_1 = dma_data[1*ADC_TO_DMA_N_BITS+(ADC_N_BITS-1):1*ADC_TO_DMA_N_BITS];
-  assign adc_data_2 = dma_data[2*ADC_TO_DMA_N_BITS+(ADC_N_BITS-1):2*ADC_TO_DMA_N_BITS];
-  assign adc_data_3 = dma_data[3*ADC_TO_DMA_N_BITS+(ADC_N_BITS-1):3*ADC_TO_DMA_N_BITS];
-  assign adc_data_4 = dma_data[4*ADC_TO_DMA_N_BITS+(ADC_N_BITS-1):4*ADC_TO_DMA_N_BITS];
-  assign adc_data_5 = dma_data[5*ADC_TO_DMA_N_BITS+(ADC_N_BITS-1):5*ADC_TO_DMA_N_BITS];
-  assign adc_data_6 = dma_data[6*ADC_TO_DMA_N_BITS+(ADC_N_BITS-1):6*ADC_TO_DMA_N_BITS];
-  assign adc_data_7 = dma_data[7*ADC_TO_DMA_N_BITS+(ADC_N_BITS-1):7*ADC_TO_DMA_N_BITS];
+  assign adc_data_7 = dma_data[0*ADC_TO_DMA_N_BITS+(ADC_TO_DMA_N_BITS-1):0*ADC_TO_DMA_N_BITS];
+  assign adc_data_6 = dma_data[1*ADC_TO_DMA_N_BITS+(ADC_TO_DMA_N_BITS-1):1*ADC_TO_DMA_N_BITS];
+  assign adc_data_5 = dma_data[2*ADC_TO_DMA_N_BITS+(ADC_TO_DMA_N_BITS-1):2*ADC_TO_DMA_N_BITS];
+  assign adc_data_4 = dma_data[3*ADC_TO_DMA_N_BITS+(ADC_TO_DMA_N_BITS-1):3*ADC_TO_DMA_N_BITS];
+  assign adc_data_3 = dma_data[4*ADC_TO_DMA_N_BITS+(ADC_TO_DMA_N_BITS-1):4*ADC_TO_DMA_N_BITS];
+  assign adc_data_2 = dma_data[5*ADC_TO_DMA_N_BITS+(ADC_TO_DMA_N_BITS-1):5*ADC_TO_DMA_N_BITS];
+  assign adc_data_1 = dma_data[6*ADC_TO_DMA_N_BITS+(ADC_TO_DMA_N_BITS-1):6*ADC_TO_DMA_N_BITS];
+  assign adc_data_0 = dma_data[7*ADC_TO_DMA_N_BITS+(ADC_TO_DMA_N_BITS-1):7*ADC_TO_DMA_N_BITS];
 
   up_adc_common #(
     .ID (ID),

--- a/projects/ad7606x_fmc/common/ad7606x_bd.tcl
+++ b/projects/ad7606x_fmc/common/ad7606x_bd.tcl
@@ -56,7 +56,7 @@ ad_ip_parameter axi_ad7606x_dma CONFIG.DMA_DATA_WIDTH_DEST 64
 
 ad_ip_instance util_cpack2 ad7606x_adc_pack
 ad_ip_parameter ad7606x_adc_pack CONFIG.NUM_OF_CHANNELS 8
-ad_ip_parameter ad7606x_adc_pack CONFIG.SAMPLE_DATA_WIDTH $ADC_N_BITS
+ad_ip_parameter ad7606x_adc_pack CONFIG.SAMPLE_DATA_WIDTH $ADC_TO_DMA_N_BITS
 
 if {$EXT_CLK == 1} {
   # use Xilinx's clocking wizard in order to generate th clock from the CPU clock, this being then assigned to the adc_clk in the axi_ad7606x IP


### PR DESCRIPTION
- [axi_ad7606x: Fix data width and order of ADC channels](https://github.com/analogdevicesinc/hdl/commit/3af72779a2814841b27bbda7587b5485c179be03)
- [ad7606x_fmc: Fix up_cpack2 module's SAMPLE_DATA_WIDTH parameter](https://github.com/analogdevicesinc/hdl/commit/462ec6adfdd80067f4f7b0c2a5b9e5f535027f00)