### PR TITLE
Update CLEAN_TARGET list for "make clean" command

### DIFF
--- a/library/scripts/library.mk
+++ b/library/scripts/library.mk
@@ -1,5 +1,5 @@
 ####################################################################################
-## Copyright (c) 2018 - 2021 Analog Devices, Inc.
+## Copyright (c) 2018 - 2023 Analog Devices, Inc.
 ## SPDX short identifier: BSD-1-Clause
 ####################################################################################
 
@@ -22,6 +22,9 @@ CLEAN_TARGET += *.log
 CLEAN_TARGET += component.xml
 CLEAN_TARGET += *.jou
 CLEAN_TARGET +=  xgui
+CLEAN_TARGET +=  gui
+CLEAN_TARGET += *.runs
+CLEAN_TARGET += *.gen
 CLEAN_TARGET += *.ip_user_files
 CLEAN_TARGET += *.srcs
 CLEAN_TARGET += *.hw

--- a/projects/scripts/project-xilinx.mk
+++ b/projects/scripts/project-xilinx.mk
@@ -1,5 +1,5 @@
 ####################################################################################
-## Copyright (c) 2018 -2021 Analog Devices, Inc.
+## Copyright (c) 2018 - 2023 Analog Devices, Inc.
 ## SPDX short identifier: BSD-1-Clause
 ####################################################################################
 
@@ -41,6 +41,7 @@ CLEAN_TARGET := *.cache
 CLEAN_TARGET += *.data
 CLEAN_TARGET += *.xpr
 CLEAN_TARGET += xgui
+CLEAN_TARGET +=  gui
 CLEAN_TARGET += *.runs
 CLEAN_TARGET += *.srcs
 CLEAN_TARGET += *.sdk


### PR DESCRIPTION
Added `gui`, `*.runs` and `*.gen` for _library_ IP's to be removed when running `make clean`.
As for _projects_, added `gui` only (as the others exist already).