### PR TITLE
ad_data_out: Revert change (issue) inserted in commit 075ee05189cb285…

### DIFF
--- a/library/xilinx/common/ad_data_out.v
+++ b/library/xilinx/common/ad_data_out.v
@@ -176,8 +176,8 @@ module ad_data_out #(
     ) i_tx_data_oddr (
       .SR (1'b0),
       .C (tx_clk),
-      .D1 (tx_data_p),
-      .D2 (tx_data_n),
+      .D1 (tx_data_n),
+      .D2 (tx_data_p),
       .Q (tx_data_oddr_s));
   end
   endgenerate
@@ -191,8 +191,8 @@ module ad_data_out #(
       .R (1'b0),
       .S (1'b0),
       .C (tx_clk),
-      .D1 (tx_data_p),
-      .D2 (tx_data_n),
+      .D1 (tx_data_n),
+      .D2 (tx_data_p),
       .Q (tx_data_oddr_s));
   end
   endgenerate


### PR DESCRIPTION
…d66a35496c7eb9b044c380b11

From PR #1060 
 * Issue is with ODDR inputs D1 and D2, now is reverted to how it was before the mentioned commit