### PR TITLE
m2k: Fix CW for slave segments without an address space

### DIFF
--- a/projects/m2k/common/m2k_bd.tcl
+++ b/projects/m2k/common/m2k_bd.tcl
@@ -335,6 +335,10 @@ ad_connect ad9963_dac_dmac_b/m_src_axi sys_ps7/S_AXI_HP3
 
 create_bd_addr_seg -range 0x20000000 -offset 0x00000000 [get_bd_addr_spaces ad9963_dac_dmac_b/m_src_axi] \
                     [get_bd_addr_segs sys_ps7/S_AXI_HP3/HP3_DDR_LOWOCM] SEG_sys_ps7_HP3_DDR_LOWOCM
+create_bd_addr_seg -range 0x20000000 -offset 0x00000000 [get_bd_addr_spaces axi_rd_wr_combiner_converter/m_axi] \
+                    [get_bd_addr_segs sys_ps7/S_AXI_HP2/HP2_DDR_LOWOCM] SEG_sys_ps7_HP2_DDR_LOWOCM
+create_bd_addr_seg -range 0x20000000 -offset 0x00000000 [get_bd_addr_spaces axi_rd_wr_combiner_logic/m_axi] \
+                    [get_bd_addr_segs sys_ps7/S_AXI_HP1/HP1_DDR_LOWOCM] SEG_sys_ps7_HP1_DDR_LOWOCM
 
 # Map rd-wr combiner
 assign_bd_address [get_bd_addr_segs { \


### PR DESCRIPTION
The following CWs appeared (even in Vivado version 2021.2):
 * CRITICAL WARNING: [BD 41-1356] Slave segment </sys_ps7/S_AXI_HP1/**HP1**_DDR_LOWOCM> is not assigned into address space </**axi_rd_wr_combiner_logic**/m_axi>. Please use Address Editor to either assign or exclude it.
 * CRITICAL WARNING: [BD 41-1356] Slave segment </sys_ps7/S_AXI_HP2/**HP2**_DDR_LOWOCM> is not assigned into address space </**axi_rd_wr_combiner_converte**r/m_axi>. Please use Address Editor to either assign or exclude it.