### PR TITLE
Change reset for Versal transceivers and port ad9082 to vck190

### DIFF
--- a/projects/ad9081_fmca_ebz/common/ad9081_fmca_ebz_bd.tcl
+++ b/projects/ad9081_fmca_ebz/common/ad9081_fmca_ebz_bd.tcl
@@ -175,7 +175,9 @@ if {$ADI_PHY_SEL == 1} {
   source $ad_hdl_dir/projects/ad9081_fmca_ebz/common/versal_transceiver.tcl
 
   set REF_CLK_RATE [ expr { [info exists ad_project_params(REF_CLK_RATE)] \
-                            ? $ad_project_params(REF_CLK_RATE) : 360 } ]
+                            ? $ad_project_params(REF_CLK_RATE) : 375 } ]
+
+  create_bd_port -dir I gt_reset
 
   switch $INTF_CFG {
     "RXTX" {
@@ -188,7 +190,7 @@ if {$ADI_PHY_SEL == 1} {
     "TX" {
       create_versal_phy jesd204_phy $TX_NUM_OF_LANES $RX_LANE_RATE $TX_LANE_RATE $REF_CLK_RATE $INTF_CFG
     }
-  }  
+  }
 }
 
 # Instantiate ADC (Rx) path
@@ -346,13 +348,13 @@ if {$ADI_PHY_SEL == 1} {
   }
 } else {
   ad_connect ref_clk_q0 jesd204_phy/GT_REFCLK
+  ad_connect gt_reset jesd204_phy/gtreset_in
   if {$INTF_CFG != "TX"} {
     set rx_link_clock  jesd204_phy/rxusrclk_out
     # Connect PHY to Link Layer
     for {set j 0}  {$j < $RX_NUM_OF_LANES} {incr j} {
       ad_connect  axi_mxfe_rx_jesd/rx_phy${j} jesd204_phy/rx${j}
     }
-    ad_connect axi_mxfe_rx_jesd/rx_axi/device_reset jesd204_phy/reset_rx_pll_and_datapath_in
     ad_connect  $rx_link_clock /axi_mxfe_rx_jesd/link_clk
     ad_connect  rx_device_clk /axi_mxfe_rx_jesd/device_clk
 
@@ -367,7 +369,6 @@ if {$ADI_PHY_SEL == 1} {
     for {set j 0}  {$j < $TX_NUM_OF_LANES} {incr j} {
       ad_connect  axi_mxfe_tx_jesd/tx_phy${j} jesd204_phy/tx${j}
     }
-    ad_connect axi_mxfe_tx_jesd/tx_axi/device_reset jesd204_phy/reset_tx_pll_and_datapath_in
     ad_connect  $tx_link_clock /axi_mxfe_tx_jesd/link_clk
     ad_connect  tx_device_clk /axi_mxfe_tx_jesd/device_clk
 

--- a/projects/ad9081_fmca_ebz/vck190/system_project.tcl
+++ b/projects/ad9081_fmca_ebz/vck190/system_project.tcl
@@ -27,20 +27,20 @@ source $ad_hdl_dir/projects/scripts/adi_board.tcl
 #   [RX/TX]_NUM_LINKS : Number of links, matches numer of MxFE devices
 #   [RX/TX]_KS_PER_CHANNEL : Number of samples stored in internal buffers in kilosamples per converter (M)
 
-#      make JESD_MODE=64B66B RX_LANE_RATE=24.75 TX_LANE_RATE=24.75 RX_JESD_M=4 RX_JESD_L=4 RX_JESD_S=2 RX_JESD_NP=12 TX_JESD_M=4 TX_JESD_L=4 TX_JESD_S=2 TX_JESD_NP=12
+#      make JESD_MODE=64B66B RX_LANE_RATE=24.75 TX_LANE_RATE=24.75 RX_JESD_M=8 RX_JESD_L=8 RX_JESD_S=2 RX_JESD_NP=12 TX_JESD_M=8 TX_JESD_L=8 TX_JESD_S=2 TX_JESD_NP=12
 
 adi_project ad9081_fmca_ebz_vck190 0 [list \
   JESD_MODE         [get_env_param JESD_MODE     64B66B ]\
-  RX_LANE_RATE      [get_env_param RX_LANE_RATE   11.88 ] \
-  TX_LANE_RATE      [get_env_param TX_LANE_RATE   11.88 ] \
-  REF_CLK_RATE      [get_env_param REF_CLK_RATE     360 ] \
-  RX_JESD_M         [get_env_param RX_JESD_M          2 ] \
-  RX_JESD_L         [get_env_param RX_JESD_L          2 ] \
-  RX_JESD_S         [get_env_param RX_JESD_S          4 ] \
+  RX_LANE_RATE      [get_env_param RX_LANE_RATE   24.75 ] \
+  TX_LANE_RATE      [get_env_param TX_LANE_RATE   24.75 ] \
+  REF_CLK_RATE      [get_env_param REF_CLK_RATE     375 ] \
+  RX_JESD_M         [get_env_param RX_JESD_M          8 ] \
+  RX_JESD_L         [get_env_param RX_JESD_L          8 ] \
+  RX_JESD_S         [get_env_param RX_JESD_S          2 ] \
   RX_JESD_NP        [get_env_param RX_JESD_NP        12 ] \
   RX_NUM_LINKS      [get_env_param RX_NUM_LINKS       1 ] \
-  TX_JESD_M         [get_env_param TX_JESD_M          2 ] \
-  TX_JESD_L         [get_env_param TX_JESD_L          2 ] \
+  TX_JESD_M         [get_env_param TX_JESD_M          8 ] \
+  TX_JESD_L         [get_env_param TX_JESD_L          8 ] \
   TX_JESD_S         [get_env_param TX_JESD_S          2 ] \
   TX_JESD_NP        [get_env_param TX_JESD_NP        12 ] \
   TX_NUM_LINKS      [get_env_param TX_NUM_LINKS       1 ] \

--- a/projects/ad9081_fmca_ebz/vck190/system_top.v
+++ b/projects/ad9081_fmca_ebz/vck190/system_top.v
@@ -299,6 +299,7 @@ module system_top  #(
     .GT_Serial_1_0_grx_p (rx_data_p_loc[7:4]),
     .GT_Serial_1_0_grx_n (rx_data_n_loc[7:4]),
 
+    .gt_reset (~rstb),
     .ref_clk_q0 (ref_clk),
     .ref_clk_q1 (ref_clk),
 

--- a/projects/ad9081_fmca_ebz/vck190/timing_constr.xdc
+++ b/projects/ad9081_fmca_ebz/vck190/timing_constr.xdc
@@ -1,9 +1,9 @@
 # Primary clock definitions
-create_clock -name refclk         -period  2.66 [get_ports fpga_refclk_in_p]
+create_clock -name refclk         -period  2.667 [get_ports fpga_refclk_in_p]
 
 # device clock
-create_clock -name tx_device_clk     -period  4 [get_ports clkin6_p]
-create_clock -name rx_device_clk     -period  4 [get_ports clkin10_p]
+create_clock -name tx_device_clk  -period 4.000  [get_ports clkin6_p]
+create_clock -name rx_device_clk  -period 4.000  [get_ports clkin10_p]
 
 # Constraint SYSREFs
 # Assumption is that REFCLK and SYSREF have similar propagation delay,

--- a/projects/ad9082_fmca_ebz/vck190/Makefile
+++ b/projects/ad9082_fmca_ebz/vck190/Makefile
@@ -1,0 +1,50 @@
+####################################################################################
+## Copyright (c) 2018 - 2023 Analog Devices, Inc.
+### SPDX short identifier: BSD-1-Clause
+## Auto-generated, do not modify!
+####################################################################################
+
+PROJECT_NAME := ad9082_fmca_ebz_vck190
+
+M_DEPS += ../../scripts/adi_pd.tcl
+M_DEPS += ../../common/xilinx/data_offload_bd.tcl
+M_DEPS += ../../common/xilinx/dacfifo_bd.tcl
+M_DEPS += ../../common/xilinx/adcfifo_bd.tcl
+M_DEPS += ../../common/vmk180/vmk180_system_bd.tcl
+M_DEPS += ../../common/vck190/vck190_system_constr.xdc
+M_DEPS += ../../common/vck190/vck190_system_bd.tcl
+M_DEPS += ../../ad9081_fmca_ebz/vck190/timing_constr.xdc
+M_DEPS += ../../ad9081_fmca_ebz/vck190/system_top.v
+M_DEPS += ../../ad9081_fmca_ebz/vck190/system_constr.xdc
+M_DEPS += ../../ad9081_fmca_ebz/vck190/system_bd.tcl
+M_DEPS += ../../ad9081_fmca_ebz/common/versal_transceiver.tcl
+M_DEPS += ../../ad9081_fmca_ebz/common/ad9081_fmca_ebz_bd.tcl
+M_DEPS += ../../../library/util_hbm/scripts/adi_util_hbm.tcl
+M_DEPS += ../../../library/jesd204/scripts/jesd204.tcl
+M_DEPS += ../../../library/common/ad_iobuf.v
+M_DEPS += ../../../library/common/ad_3w_spi.v
+M_DEPS += ../../../library/axi_tdd/scripts/axi_tdd.tcl
+
+LIB_DEPS += axi_dmac
+LIB_DEPS += axi_sysid
+LIB_DEPS += axi_tdd
+LIB_DEPS += data_offload
+LIB_DEPS += jesd204/ad_ip_jesd204_tpl_adc
+LIB_DEPS += jesd204/ad_ip_jesd204_tpl_dac
+LIB_DEPS += jesd204/axi_jesd204_rx
+LIB_DEPS += jesd204/axi_jesd204_tx
+LIB_DEPS += jesd204/jesd204_rx
+LIB_DEPS += jesd204/jesd204_tx
+LIB_DEPS += jesd204/jesd204_versal_gt_adapter_rx
+LIB_DEPS += jesd204/jesd204_versal_gt_adapter_tx
+LIB_DEPS += sysid_rom
+LIB_DEPS += util_adcfifo
+LIB_DEPS += util_dacfifo
+LIB_DEPS += util_do_ram
+LIB_DEPS += util_hbm
+LIB_DEPS += util_pack/util_cpack2
+LIB_DEPS += util_pack/util_upack2
+LIB_DEPS += xilinx/axi_adxcvr
+LIB_DEPS += xilinx/util_adxcvr
+
+include ../../scripts/project-xilinx.mk

--- a/projects/ad9082_fmca_ebz/vck190/system_bd.tcl
+++ b/projects/ad9082_fmca_ebz/vck190/system_bd.tcl
@@ -1,0 +1,1 @@
+source $ad_hdl_dir/projects/ad9081_fmca_ebz/vck190/system_bd.tcl

--- a/projects/ad9082_fmca_ebz/vck190/system_project.tcl
+++ b/projects/ad9082_fmca_ebz/vck190/system_project.tcl
@@ -1,0 +1,61 @@
+source ../../../scripts/adi_env.tcl
+source $ad_hdl_dir/projects/scripts/adi_project_xilinx.tcl
+source $ad_hdl_dir/projects/scripts/adi_board.tcl
+
+# get_env_param retrieves parameter value from the environment if exists,
+# other case use the default value
+#
+#   Use over-writable parameters from the environment.
+#
+#    e.g.
+#      make RX_JESD_L=4 RX_JESD_M=8 RX_JESD_S=1 TX_JESD_L=4 TX_JESD_M=8 TX_JESD_S=1
+#      make RX_JESD_L=8 RX_JESD_M=4 RX_JESD_S=1 TX_JESD_L=8 TX_JESD_M=4 TX_JESD_S=1
+
+#
+# Parameter description:
+#   JESD_MODE : Used link layer encoder mode
+#      64B66B - 64b66b link layer defined in JESD 204C, uses Xilinx IP as Physical layer
+#      8B10B  - 8b10b link layer defined in JESD 204B, uses ADI IP as Physical layer
+#
+#   RX_LANE_RATE :  Line rate of the Rx link ( MxFE to FPGA )
+#   TX_LANE_RATE :  Line rate of the Tx link ( FPGA to MxFE )
+#   REF_CLK_RATE : Frequency of reference clock in MHz used in 64B66B mode
+#   [RX/TX]_JESD_M : Number of converters per link
+#   [RX/TX]_JESD_L : Number of lanes per link
+#   [RX/TX]_JESD_S : Number of samples per frame
+#   [RX/TX]_JESD_NP : Number of bits per sample, only 16 is supported
+#   [RX/TX]_NUM_LINKS : Number of links, matches numer of MxFE devices
+#   [RX/TX]_KS_PER_CHANNEL : Number of samples stored in internal buffers in kilosamples per converter (M)
+
+#      make JESD_MODE=64B66B RX_LANE_RATE=24.75 TX_LANE_RATE=24.75 RX_JESD_M=4 RX_JESD_L=8 RX_JESD_S=4 RX_JESD_NP=12 TX_JESD_M=4 TX_JESD_L=8 TX_JESD_S=4 TX_JESD_NP=12
+
+adi_project ad9082_fmca_ebz_vck190 0 [list \
+  JESD_MODE         [get_env_param JESD_MODE     64B66B ]\
+  RX_LANE_RATE      [get_env_param RX_LANE_RATE   24.75 ] \
+  TX_LANE_RATE      [get_env_param TX_LANE_RATE   24.75 ] \
+  REF_CLK_RATE      [get_env_param REF_CLK_RATE     375 ] \
+  RX_JESD_M         [get_env_param RX_JESD_M          4 ] \
+  RX_JESD_L         [get_env_param RX_JESD_L          8 ] \
+  RX_JESD_S         [get_env_param RX_JESD_S          4 ] \
+  RX_JESD_NP        [get_env_param RX_JESD_NP        12 ] \
+  RX_NUM_LINKS      [get_env_param RX_NUM_LINKS       1 ] \
+  TX_JESD_M         [get_env_param TX_JESD_M          4 ] \
+  TX_JESD_L         [get_env_param TX_JESD_L          8 ] \
+  TX_JESD_S         [get_env_param TX_JESD_S          4 ] \
+  TX_JESD_NP        [get_env_param TX_JESD_NP        12 ] \
+  TX_NUM_LINKS      [get_env_param TX_NUM_LINKS       1 ] \
+  RX_KS_PER_CHANNEL [get_env_param RX_KS_PER_CHANNEL 64 ] \
+  TX_KS_PER_CHANNEL [get_env_param TX_KS_PER_CHANNEL 64 ] \
+]
+
+adi_project_files ad9082_fmca_ebz_vck190 [list \
+  "../../ad9081_fmca_ebz/vck190/system_top.v" \
+  "../../ad9081_fmca_ebz/vck190/system_constr.xdc" \
+  "../../ad9081_fmca_ebz/vck190/timing_constr.xdc" \
+  "../../../library/common/ad_3w_spi.v" \
+  "$ad_hdl_dir/library/common/ad_iobuf.v" \
+  "$ad_hdl_dir/projects/common/vck190/vck190_system_constr.xdc" ]
+
+set_property strategy Performance_Explore [get_runs impl_1]
+
+adi_project_run ad9082_fmca_ebz_vck190

--- a/projects/ad9209_fmca_ebz/vck190/system_top.v
+++ b/projects/ad9209_fmca_ebz/vck190/system_top.v
@@ -250,6 +250,7 @@ module system_top  #(
     .GT_Serial_1_0_grx_p (rx_data_p_loc[7:4]),
     .GT_Serial_1_0_grx_n (rx_data_n_loc[7:4]),
 
+    .gt_reset (~rstb),
     .ref_clk_q0 (ref_clk),
     .ref_clk_q1 (ref_clk),
 


### PR DESCRIPTION
- Removes the _reset_tx_pll_and_datapath_in_ reset
- Connects _gtreset_in_ to make use of the master reset found inside the Transceiver Bridge IP
- Connects the necessary signals for the master reset between the Transceiver Wizard and Transceiver Bridge
- Fixes the TX link at higher lane rates (>13GSPS) on AD9081 & AD9209 with vck190.
- Adds vck190 support for the AD9082
Related to PR #1112 