### PR TITLE
axi_dmac: Fix constraints coverage

### DIFF
--- a/library/axi_dmac/axi_dmac_constr.ttcl
+++ b/library/axi_dmac/axi_dmac_constr.ttcl
@@ -8,9 +8,27 @@
 <: set async_src_dest [getBooleanValue "ASYNC_CLK_SRC_DEST"] :>
 <: set disable_debug_registers [getBooleanValue "DISABLE_DEBUG_REGISTERS"] :>
 
-set req_clk [get_clocks -of_objects [get_ports s_axi_aclk]]
-set src_clk [get_clocks -of_objects [get_ports -quiet {fifo_wr_clk s_axis_aclk m_src_axi_aclk}]]
-set dest_clk [get_clocks -of_objects [get_ports -quiet {fifo_rd_clk m_axis_aclk m_dest_axi_aclk}]]
+set req_clk_ports_base {s_axi_aclk}
+set src_clk_ports_base {fifo_wr_clk s_axis_aclk m_src_axi_aclk}
+set dest_clk_ports_base {fifo_rd_clk m_axis_aclk m_dest_axi_aclk}
+set req_clk_ports $req_clk_ports_base
+set src_clk_ports $src_clk_ports_base
+set dest_clk_ports $dest_clk_ports_base
+<: if {[expr {!$async_req_src}]} { :>
+set req_clk_ports "$req_clk_ports $src_clk_ports_base"
+set src_clk_ports "$src_clk_ports $req_clk_ports_base"
+<: } :>
+<: if {[expr {!$async_src_dest}]} { :>
+set src_clk_ports "$src_clk_ports $dest_clk_ports_base"
+set dest_clk_ports "$dest_clk_ports $src_clk_ports_base"
+<: } :>
+<: if {[expr {!$async_dest_req}]} { :>
+set req_clk_ports "$req_clk_ports $dest_clk_ports_base"
+set dest_clk_ports "$dest_clk_ports $req_clk_ports_base"
+<: } :>
+set req_clk [get_clocks -of_objects [get_ports -quiet $req_clk_ports]]
+set src_clk [get_clocks -of_objects [get_ports -quiet $src_clk_ports]]
+set dest_clk [get_clocks -of_objects [get_ports -quiet $dest_clk_ports]]
 
 <: if {$async_req_src || $async_src_dest || $async_dest_req} { :>
 set_property ASYNC_REG TRUE \


### PR DESCRIPTION
Due to nets being optimized at IP-level during the no-OOC synthesis flow, constraints related to req_clk (request clock) were not being applied, causing the design to not meet timing.
Below, it is exemplified the difference between elaboration with and without OOC:

OOC elaboration result:
![image](https://github.com/analogdevicesinc/hdl/assets/2892061/6bed2c2b-3bb6-41a6-8e17-52a9780e155f)

no-OOC elaboration result:
![image](https://github.com/analogdevicesinc/hdl/assets/2892061/ea6eb00d-3ad5-4ab4-8a4e-9601177d9a6f)

The fix considers the synchronous modes, appending the possible resulting names after the synthesis flow.
In the example, the resulting name is "m_src_axi_aclk" since _request_ and _source_ are synchronous and they get merged into a single net.
The commit also considers others synchronous configurations, like _destination_ and _source_ synchronous.

Other solutions:
* Use of [dont_touch](https://docs.xilinx.com/r/en-US/ug901-vivado-synthesis/DONT_TOUCH) attribute at module level, however would disable any optimization for the module and in general it is defined at RTL level (.v).
* Use of [-flatten_hierarchy = none](https://support.xilinx.com/s/article/52257?language=en_US), however would disable optimizations for the whole design.
* Get the clock from a cell instead of a port, no functional drawbacks, but would worsen readability.