### PR TITLE
3. Add copyright and license to .sdc files

### DIFF
--- a/library/axi_ad9122/axi_ad9122_constr.sdc
+++ b/library/axi_ad9122/axi_ad9122_constr.sdc
@@ -1,3 +1,7 @@
+###############################################################################
+## Copyright (C) 2016-2023 Analog Devices, Inc. All rights reserved.
+### SPDX short identifier: ADIBSD
+###############################################################################
 
 set_false_path  -from [get_registers *up_drp_locked*] -to [get_registers *dac_status_m1*]
 

--- a/library/axi_ad9361/axi_ad9361_constr.sdc
+++ b/library/axi_ad9361/axi_ad9361_constr.sdc
@@ -1,3 +1,7 @@
+###############################################################################
+## Copyright (C) 2016-2023 Analog Devices, Inc. All rights reserved.
+### SPDX short identifier: ADIBSD
+###############################################################################
 
 set_false_path -from [get_registers *i_dev_if|up_enable_int*] -to [get_registers *i_dev_if|enable_up_m1*]
 set_false_path -from [get_registers *i_dev_if|up_txnrx_int*]  -to [get_registers *i_dev_if|txnrx_up_m1*]

--- a/library/axi_ad9684/axi_ad9684_constr.sdc
+++ b/library/axi_ad9684/axi_ad9684_constr.sdc
@@ -1,3 +1,7 @@
+###############################################################################
+## Copyright (C) 2016-2023 Analog Devices, Inc. All rights reserved.
+### SPDX short identifier: ADIBSD
+###############################################################################
 
 set_false_path  -to [get_registers *axi_ad9684_if:i_ad9684_if|adc_status_m1*]
 set_false_path  -to [get_registers *up_delay_cntrl:i_delay_cntrl|up_dlocked_m1*]

--- a/library/axi_adrv9001/axi_adrv9001_constr.sdc
+++ b/library/axi_adrv9001/axi_adrv9001_constr.sdc
@@ -1,3 +1,8 @@
+###############################################################################
+## Copyright (C) 2020-2023 Analog Devices, Inc. All rights reserved.
+### SPDX short identifier: ADIBSD
+###############################################################################
+
 set script_dir [file dirname [info script]]
 
 source "$script_dir/util_cdc_constr.tcl"

--- a/library/axi_dmac/axi_dmac_constr.sdc
+++ b/library/axi_dmac/axi_dmac_constr.sdc
@@ -1,4 +1,7 @@
-
+###############################################################################
+## Copyright (C) 2015-2023 Analog Devices, Inc. All rights reserved.
+### SPDX short identifier: ADIBSD
+###############################################################################
 
 set_false_path -to    [get_registers *axi_dmac*cdc_sync_stage1*]
 set_false_path -from  [get_registers *axi_dmac*cdc_sync_fifo_ram*]

--- a/library/axi_hdmi_tx/axi_hdmi_tx_constr.sdc
+++ b/library/axi_hdmi_tx/axi_hdmi_tx_constr.sdc
@@ -1,3 +1,7 @@
+###############################################################################
+## Copyright (C) 2015-2023 Analog Devices, Inc. All rights reserved.
+### SPDX short identifier: ADIBSD
+###############################################################################
 
 set_false_path  -from [get_registers *hdmi_fs_toggle*]                                    -to [get_registers *vdma_fs_toggle_m1]
 set_false_path  -from [get_registers *hdmi_raddr_g*]                                      -to [get_registers *vdma_raddr_g_m1*]

--- a/library/axi_laser_driver/axi_laser_driver_constr.sdc
+++ b/library/axi_laser_driver/axi_laser_driver_constr.sdc
@@ -1,3 +1,7 @@
+###############################################################################
+## Copyright (C) 2019-2023 Analog Devices, Inc. All rights reserved.
+### SPDX short identifier: ADIBSD
+###############################################################################
 
 set_false_path \
   -to [get_registers *i_driver_otw_sync|cdc_sync_stage1*]

--- a/library/axi_pulse_gen/axi_pulse_gen_constr.sdc
+++ b/library/axi_pulse_gen/axi_pulse_gen_constr.sdc
@@ -1,3 +1,7 @@
+###############################################################################
+## Copyright (C) 2019-2023 Analog Devices, Inc. All rights reserved.
+### SPDX short identifier: ADIBSD
+###############################################################################
 
 set_false_path -to [get_registers *axi_pulse_gen_regmap*cdc_sync_stage1*]
 set_false_path -to [get_registers *axi_pulse_gen_regmap*sync_data*out_data*]

--- a/library/axi_pwm_gen/axi_pwm_gen_constr.sdc
+++ b/library/axi_pwm_gen/axi_pwm_gen_constr.sdc
@@ -1,3 +1,8 @@
+###############################################################################
+## Copyright (C) 2021-2023 Analog Devices, Inc. All rights reserved.
+### SPDX short identifier: ADIBSD
+###############################################################################
+
 set script_dir [file dirname [info script]]
 
 source "$script_dir/util_cdc_constr.tcl"

--- a/library/axi_tdd/axi_tdd_constr.sdc
+++ b/library/axi_tdd/axi_tdd_constr.sdc
@@ -1,3 +1,8 @@
+###############################################################################
+## Copyright (C) 2022-2023 Analog Devices, Inc. All rights reserved.
+### SPDX short identifier: ADIBSD
+###############################################################################
+
 set_false_path \
   -from [get_registers {*|i_regmap|up_tdd_burst_count[*]}] \
   -to [get_registers {*|i_counter|tdd_burst_count[*]}]

--- a/library/intel/avl_dacfifo/avl_dacfifo_constr.sdc
+++ b/library/intel/avl_dacfifo/avl_dacfifo_constr.sdc
@@ -1,3 +1,8 @@
+###############################################################################
+## Copyright (C) 2017-2023 Analog Devices, Inc. All rights reserved.
+### SPDX short identifier: ADIBSD
+###############################################################################
+
 # CDC paths
 
 set_false_path  -from [get_registers *avl_dacfifo_rd:i_rd|dac_mem_raddr_g*] \

--- a/library/intel/common/up_clock_mon_constr.sdc
+++ b/library/intel/common/up_clock_mon_constr.sdc
@@ -1,3 +1,7 @@
+###############################################################################
+## Copyright (C) 2017-2023 Analog Devices, Inc. All rights reserved.
+### SPDX short identifier: ADIBSD
+###############################################################################
 
 set_false_path  -from [get_registers *up_clock_mon:*|d_count_run_m3*] -to [get_registers *up_clock_mon:*|up_count_running_m1*]
 set_false_path  -from [get_registers *up_clock_mon:*|up_count_run*]   -to [get_registers *up_clock_mon:*|d_count_run_m1*]

--- a/library/intel/common/up_rst_constr.sdc
+++ b/library/intel/common/up_rst_constr.sdc
@@ -1,3 +1,7 @@
+###############################################################################
+## Copyright (C) 2017-2023 Analog Devices, Inc. All rights reserved.
+### SPDX short identifier: ADIBSD
+###############################################################################
 
 set_false_path  -to [get_pins -hierarchical -nocase rst_async_d*|CLRN]
 set_false_path  -to [get_pins -hierarchical -nocase rst_sync|CLRN]

--- a/library/intel/common/up_xfer_cntrl_constr.sdc
+++ b/library/intel/common/up_xfer_cntrl_constr.sdc
@@ -1,3 +1,7 @@
+###############################################################################
+## Copyright (C) 2017-2023 Analog Devices, Inc. All rights reserved.
+### SPDX short identifier: ADIBSD
+###############################################################################
 
 set_false_path  -from [get_registers *up_xfer_cntrl:i_xfer_cntrl|d_xfer_toggle*]      -to [get_registers *up_xfer_cntrl:i_xfer_cntrl|up_xfer_state_m1*]
 set_false_path  -from [get_registers *up_xfer_cntrl:i_xfer_cntrl|up_xfer_toggle*]     -to [get_registers *up_xfer_cntrl:i_xfer_cntrl|d_xfer_toggle_m1*]

--- a/library/intel/common/up_xfer_status_constr.sdc
+++ b/library/intel/common/up_xfer_status_constr.sdc
@@ -1,3 +1,7 @@
+###############################################################################
+## Copyright (C) 2017-2023 Analog Devices, Inc. All rights reserved.
+### SPDX short identifier: ADIBSD
+###############################################################################
 
 set_false_path  -from [get_registers *up_xfer_status:i_xfer_status|up_xfer_toggle*]   -to [get_registers *up_xfer_status:i_xfer_status|d_xfer_state_m1*]
 set_false_path  -from [get_registers *up_xfer_status:i_xfer_status|d_xfer_toggle*]    -to [get_registers *up_xfer_status:i_xfer_status|up_xfer_toggle_m1*]

--- a/library/spi_engine/axi_spi_engine/axi_spi_engine_constr.sdc
+++ b/library/spi_engine/axi_spi_engine/axi_spi_engine_constr.sdc
@@ -1,3 +1,7 @@
+###############################################################################
+## Copyright (C) 2020-2023 Analog Devices, Inc. All rights reserved.
+### SPDX short identifier: ADIBSD
+###############################################################################
 
 set_false_path  \
   -to [get_registers  *cdc_sync_stage1*]

--- a/library/util_adcfifo/util_adcfifo_constr.sdc
+++ b/library/util_adcfifo/util_adcfifo_constr.sdc
@@ -1,3 +1,7 @@
+###############################################################################
+## Copyright (C) 2015-2023 Analog Devices, Inc. All rights reserved.
+### SPDX short identifier: ADIBSD
+###############################################################################
 
 set_false_path -to [get_registers *adc_xfer_req_m_reg[0]*]
 set_false_path -to [get_registers *adc_xfer_req_m[0]*]

--- a/library/util_dacfifo/util_dacfifo_constr.sdc
+++ b/library/util_dacfifo/util_dacfifo_constr.sdc
@@ -1,3 +1,7 @@
+###############################################################################
+## Copyright (C) 2017-2023 Analog Devices, Inc. All rights reserved.
+### SPDX short identifier: ADIBSD
+###############################################################################
 
 set_false_path -to [get_registers *dac_bypass_m1*]
 set_false_path -to [get_registers *dma_bypass_m1*]

--- a/library/util_rfifo/util_rfifo_constr.sdc
+++ b/library/util_rfifo/util_rfifo_constr.sdc
@@ -1,3 +1,7 @@
+###############################################################################
+## Copyright (C) 2016-2023 Analog Devices, Inc. All rights reserved.
+### SPDX short identifier: ADIBSD
+###############################################################################
 
 set_false_path -from [get_registers *dout_enable*]  -to [get_registers *din_enable_m1*]
 set_false_path -from [get_registers *dout_req_t*]   -to [get_registers *din_req_t_m1*]

--- a/library/util_wfifo/util_wfifo_constr.sdc
+++ b/library/util_wfifo/util_wfifo_constr.sdc
@@ -1,3 +1,7 @@
+###############################################################################
+## Copyright (C) 2016-2023 Analog Devices, Inc. All rights reserved.
+### SPDX short identifier: ADIBSD
+###############################################################################
 
 set_false_path -from [get_registers *din_enable*] -to [get_registers *dout_enable_m1*]
 set_false_path -from [get_registers *din_req_t*]  -to [get_registers *dout_req_t_m1*]

--- a/projects/ad777x_ardz/de10nano/system_constr.sdc
+++ b/projects/ad777x_ardz/de10nano/system_constr.sdc
@@ -1,3 +1,8 @@
+###############################################################################
+## Copyright (C) 2022-2023 Analog Devices, Inc. All rights reserved.
+### SPDX short identifier: ADIBSD
+###############################################################################
+
 create_clock -period "20.000 ns"  -name sys_clk     [get_ports {sys_clk}]
 create_clock -period "16.666 ns"  -name usb1_clk    [get_ports {usb1_clk}]
 create_clock -period "488.00 ns"  -name adc_clk     [get_ports {adc_clk_in}]

--- a/projects/ad9081_fmca_ebz/a10soc/system_constr.sdc
+++ b/projects/ad9081_fmca_ebz/a10soc/system_constr.sdc
@@ -1,3 +1,7 @@
+###############################################################################
+## Copyright (C) 2021-2023 Analog Devices, Inc. All rights reserved.
+### SPDX short identifier: ADIBSD
+###############################################################################
 
 create_clock -period "10.000 ns"  -name sys_clk_100mhz      [get_ports {sys_clk}]
 create_clock -period  "4.000 ns"  -name ref_clk             [get_ports {fpga_refclk_in}]

--- a/projects/ad9083_evb/a10soc/system_constr.sdc
+++ b/projects/ad9083_evb/a10soc/system_constr.sdc
@@ -1,3 +1,7 @@
+###############################################################################
+## Copyright (C) 2022-2023 Analog Devices, Inc. All rights reserved.
+### SPDX short identifier: ADIBSD
+###############################################################################
 
 create_clock -period "10.000 ns"  -name sys_clk_100mhz      [get_ports {sys_clk}]
 create_clock -period  "8.000 ns"  -name rx_device_clk       [get_ports {rx_device_clk}]

--- a/projects/ad9213_dual_ebz/s10soc/system_constr.sdc
+++ b/projects/ad9213_dual_ebz/s10soc/system_constr.sdc
@@ -1,3 +1,7 @@
+###############################################################################
+## Copyright (C) 2021-2023 Analog Devices, Inc. All rights reserved.
+### SPDX short identifier: ADIBSD
+###############################################################################
 
 create_clock -period  "10.000 ns"     -name sys_clk_100mhz      [get_ports {sys_clk}]
 create_clock -period  "3.2 ns"        -name ref_a_clk0          [get_ports {rx_ref_a_clk0}]

--- a/projects/ad_fmclidar1_ebz/a10soc/system_constr.sdc
+++ b/projects/ad_fmclidar1_ebz/a10soc/system_constr.sdc
@@ -1,3 +1,7 @@
+###############################################################################
+## Copyright (C) 2019-2023 Analog Devices, Inc. All rights reserved.
+### SPDX short identifier: ADIBSD
+###############################################################################
 
 create_clock -period "10.000 ns" -name sys_clk_100mhz    [get_ports {sys_clk}]
 create_clock -period "4.000 ns"  -name rx_device_clk     [get_ports {rx_device_clk}]

--- a/projects/adrv9001/a10soc/system_constr.sdc
+++ b/projects/adrv9001/a10soc/system_constr.sdc
@@ -1,3 +1,7 @@
+###############################################################################
+## Copyright (C) 2021-2023 Analog Devices, Inc. All rights reserved.
+### SPDX short identifier: ADIBSD
+###############################################################################
 
 create_clock -period "10.000 ns"  -name sys_clk_100mhz      [get_ports {sys_clk}]
 

--- a/projects/adrv9009/a10soc/system_constr.sdc
+++ b/projects/adrv9009/a10soc/system_constr.sdc
@@ -1,3 +1,7 @@
+###############################################################################
+## Copyright (C) 2018-2023 Analog Devices, Inc. All rights reserved.
+### SPDX short identifier: ADIBSD
+###############################################################################
 
 create_clock -period "10.000 ns"  -name sys_clk_100mhz      [get_ports {sys_clk}]
 create_clock -period  "4.06504065 ns"  -name ref_clk0            [get_ports {ref_clk0}]

--- a/projects/adrv9009/s10soc/system_constr.sdc
+++ b/projects/adrv9009/s10soc/system_constr.sdc
@@ -1,3 +1,7 @@
+###############################################################################
+## Copyright (C) 2020-2023 Analog Devices, Inc. All rights reserved.
+### SPDX short identifier: ADIBSD
+###############################################################################
 
 create_clock -period "10.000 ns"  -name sys_clk_100mhz      [get_ports {sys_clk}]
 create_clock -period  "4.069 ns"  -name ref_clk0            [get_ports {ref_clk0}]

--- a/projects/adrv9371x/a10soc/system_constr.sdc
+++ b/projects/adrv9371x/a10soc/system_constr.sdc
@@ -1,3 +1,7 @@
+###############################################################################
+## Copyright (C) 2016-2023 Analog Devices, Inc. All rights reserved.
+### SPDX short identifier: ADIBSD
+###############################################################################
 
 create_clock -period "10.000 ns"  -name sys_clk_100mhz      [get_ports {sys_clk}]
 create_clock -period  "8.1300813 ns"  -name ref_clk0            [get_ports {ref_clk0}]

--- a/projects/adv7513/de10nano/system_constr.sdc
+++ b/projects/adv7513/de10nano/system_constr.sdc
@@ -1,3 +1,7 @@
+###############################################################################
+## Copyright (C) 2020-2023 Analog Devices, Inc. All rights reserved.
+### SPDX short identifier: ADIBSD
+###############################################################################
 
 create_clock -period "20.000 ns"  -name sys_clk_50mhz      [get_ports {sys_clk}]
 create_clock -period "16.666 ns"  -name usb_clk_60mhz      [get_ports {usb1_clk}]

--- a/projects/arradio/c5soc/system_constr.sdc
+++ b/projects/arradio/c5soc/system_constr.sdc
@@ -1,3 +1,7 @@
+###############################################################################
+## Copyright (C) 2014-2023 Analog Devices, Inc. All rights reserved.
+### SPDX short identifier: ADIBSD
+###############################################################################
 
 create_clock -period "20.000 ns" -name sys_clk  [get_ports {sys_clk}]
 create_clock -period 4.0 -name rx_clk [get_ports {rx_clk_in}]

--- a/projects/cn0506/a10soc/system_constr.sdc
+++ b/projects/cn0506/a10soc/system_constr.sdc
@@ -1,3 +1,7 @@
+###############################################################################
+## Copyright (C) 2019-2023 Analog Devices, Inc. All rights reserved.
+### SPDX short identifier: ADIBSD
+###############################################################################
 
 create_clock -period  "40.000 ns"  -name mii_rx_clk_a          [get_ports {mii_rx_clk_a}]
 create_clock -period  "40.000 ns"  -name mii_rx_clk_b          [get_ports {mii_rx_clk_b}]

--- a/projects/cn0540/de10nano/system_constr.sdc
+++ b/projects/cn0540/de10nano/system_constr.sdc
@@ -1,3 +1,7 @@
+###############################################################################
+## Copyright (C) 2020-2023 Analog Devices, Inc. All rights reserved.
+### SPDX short identifier: ADIBSD
+###############################################################################
 
 create_clock -period "20.000 ns"  -name sys_clk     [get_ports {sys_clk}]
 create_clock -period "16.666 ns"  -name usb1_clk    [get_ports {usb1_clk}]

--- a/projects/cn0561/de10nano/system_constr.sdc
+++ b/projects/cn0561/de10nano/system_constr.sdc
@@ -1,3 +1,8 @@
+###############################################################################
+## Copyright (C) 2023 Analog Devices, Inc. All rights reserved.
+### SPDX short identifier: ADIBSD
+###############################################################################
+
 create_clock -period "20.000 ns"  -name sys_clk     [get_ports {sys_clk}]
 create_clock -period "16.666 ns"  -name usb1_clk    [get_ports {usb1_clk}]
 

--- a/projects/cn0579/de10nano/system_constr.sdc
+++ b/projects/cn0579/de10nano/system_constr.sdc
@@ -1,3 +1,8 @@
+###############################################################################
+## Copyright (C) 2023 Analog Devices, Inc. All rights reserved.
+### SPDX short identifier: ADIBSD
+###############################################################################
+
 create_clock -period "20.000 ns"  -name sys_clk     [get_ports {sys_clk}]
 create_clock -period "16.666 ns"  -name usb1_clk    [get_ports {usb1_clk}]
 create_clock -period "122.07 ns"  -name adc_clk     [get_ports {adc_clk_in}]

--- a/projects/common/a10gx/system_constr.sdc
+++ b/projects/common/a10gx/system_constr.sdc
@@ -1,3 +1,8 @@
+###############################################################################
+## Copyright (C) 2022-2023 Analog Devices, Inc. All rights reserved.
+### SPDX short identifier: ADIBSD
+###############################################################################
+
 create_clock -period "10.000 ns"  -name sys_clk_100mhz      [get_ports {sys_clk}]
 
 derive_pll_clocks

--- a/projects/common/a10soc/system_constr.sdc
+++ b/projects/common/a10soc/system_constr.sdc
@@ -1,3 +1,8 @@
+###############################################################################
+## Copyright (C) 2022-2023 Analog Devices, Inc. All rights reserved.
+### SPDX short identifier: ADIBSD
+###############################################################################
+
 create_clock -period "10.000 ns"  -name sys_clk_100mhz      [get_ports {sys_clk}]
 
 derive_pll_clocks

--- a/projects/common/c5soc/system_constr.sdc
+++ b/projects/common/c5soc/system_constr.sdc
@@ -1,3 +1,8 @@
+###############################################################################
+## Copyright (C) 2022-2023 Analog Devices, Inc. All rights reserved.
+### SPDX short identifier: ADIBSD
+###############################################################################
+
 create_clock -period "20.000 ns" -name sys_clk  [get_ports {sys_clk}]
 
 derive_pll_clocks

--- a/projects/common/de10nano/system_constr.sdc
+++ b/projects/common/de10nano/system_constr.sdc
@@ -1,3 +1,8 @@
+###############################################################################
+## Copyright (C) 2022-2023 Analog Devices, Inc. All rights reserved.
+### SPDX short identifier: ADIBSD
+###############################################################################
+
 create_clock -period "20.000 ns"  -name sys_clk_50mhz      [get_ports {sys_clk}]
 create_clock -period "16.666 ns"  -name usb_clk_60mhz      [get_ports {usb1_clk}]
 

--- a/projects/common/s10soc/system_constr.sdc
+++ b/projects/common/s10soc/system_constr.sdc
@@ -1,3 +1,8 @@
+###############################################################################
+## Copyright (C) 2022-2023 Analog Devices, Inc. All rights reserved.
+### SPDX short identifier: ADIBSD
+###############################################################################
+
 create_clock -period "10.000 ns"  -name sys_clk_100mhz      [get_ports {sys_clk}]
 
 derive_pll_clocks

--- a/projects/dac_fmc_ebz/a10soc/system_constr.sdc
+++ b/projects/dac_fmc_ebz/a10soc/system_constr.sdc
@@ -1,34 +1,7 @@
-#
-# Copyright 2018 (c) Analog Devices, Inc. All rights reserved.
-#
-# In this HDL repository, there are many different and unique modules, consisting
-# of various HDL (Verilog or VHDL) components. The individual modules are
-# developed independently, and may be accompanied by separate and unique license
-# terms.
-#
-# The user should read each of these license terms, and understand the
-# freedoms and responsibilities that he or she has by using this source/core.
-#
-# This core is distributed in the hope that it will be useful, but WITHOUT ANY
-# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
-# A PARTICULAR PURPOSE.
-#
-# Redistribution and use of source or resulting binaries, with or without modification
-# of this file, are permitted under one of the following two license terms:
-#
-#   1. The GNU General Public License version 2 as published by the
-#      Free Software Foundation, which can be found in the top level directory
-#      of this repository (LICENSE_GPL2), and also online at:
-#      <https://www.gnu.org/licenses/old-licenses/gpl-2.0.html>
-#
-# OR
-#
-#   2. An ADI specific BSD license, which can be found in the top level directory
-#      of this repository (LICENSE_ADIBSD), and also on-line at:
-#      https://github.com/analogdevicesinc/hdl/blob/master/LICENSE_ADIBSD
-#      This will allow to generate bit files and not release the source code,
-#      as long as it attaches to an ADI device.
-#
+###############################################################################
+## Copyright (C) 2019-2023 Analog Devices, Inc. All rights reserved.
+### SPDX short identifier: ADIBSD
+###############################################################################
 
 create_clock -period "10.000 ns"  -name sys_clk_100mhz      [get_ports {sys_clk}]
 

--- a/projects/daq2/a10soc/system_constr.sdc
+++ b/projects/daq2/a10soc/system_constr.sdc
@@ -1,3 +1,7 @@
+###############################################################################
+## Copyright (C) 2017-2023 Analog Devices, Inc. All rights reserved.
+### SPDX short identifier: ADIBSD
+###############################################################################
 
 create_clock -period "10.000 ns"  -name sys_clk_100mhz      [get_ports {sys_clk}]
 create_clock -period  "3.000 ns"  -name rx_ref_clk          [get_ports {rx_ref_clk}]

--- a/projects/fmcomms8/a10soc/system_constr.sdc
+++ b/projects/fmcomms8/a10soc/system_constr.sdc
@@ -1,3 +1,7 @@
+###############################################################################
+## Copyright (C) 2020-2023 Analog Devices, Inc. All rights reserved.
+### SPDX short identifier: ADIBSD
+###############################################################################
 
 create_clock -period "10.000 ns"  -name sys_clk_100mhz      [get_ports {sys_clk}]
 create_clock -period  "4.06504065 ns"  -name ref_clk_c      [get_ports {ref_clk_c}]


### PR DESCRIPTION
**Third PR** out of a series of PRs regarding updating the licenses and copyrights in all files. They should be merged in this order.

New format: `Copyright (C) year-year Analog Devices, Inc. All rights reserved.`

- Adds copyright and license header for all Intel board constraint files (.sdc)
- The starting year was determined and changed based on `git log --follow --format=%ad --date=format:'%Y' $file | tail -1` which returns the first year it was added