### PR TITLE
7. Add copyright & license for all files with ADI JESD specific license

### DIFF
--- a/LICENSE_ADIBSD
+++ b/LICENSE_ADIBSD
@@ -1,5 +1,7 @@
 Copyright (C) 2011-2023 Analog Devices, Inc. All rights reserved.
 
+SPDX short identifier: ADIBSD
+
 Redistribution and use in source and binary forms, with or without modification,
 are permitted provided that the following conditions are met:
     - Redistributions of source code must retain the above copyright

--- a/LICENSE_ADIJESD204
+++ b/LICENSE_ADIJESD204
@@ -1,6 +1,4 @@
-# Analog Devices JESD204B HDL Support
-
-## Licensing
+SPDX short identifier: ADIJESD204
 
 The ADI JESD204 Core is released under the following license, which is
 different than all other HDL cores in this repository.
@@ -8,7 +6,7 @@ different than all other HDL cores in this repository.
 Please read this, and understand the freedoms and responsibilities you have by
 using this source code/core.
 
-The JESD204 HDL, is copyright © 2016-2023 Analog Devices Inc.
+The JESD204 HDL, is copyright (c) 2016-2023 Analog Devices Inc.
 
 This core is free software, you can use run, copy, study, change, ask questions
 about and improve this core. Distribution of source, or resulting binaries
@@ -22,13 +20,13 @@ WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
 PARTICULAR PURPOSE. See the GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License version 2
-along with this source code, and binary.  If not, see
+along with this source code, and binary. If not, see
 <http://www.gnu.org/licenses/>.
 
 Commercial licenses (with commercial support) of this JESD204 core are also
-available under terms different than the General Public License. (e.g. they do
+available under terms different than the General Public License (e.g. they do
 not require you to accompany any image (FPGA or ASIC) using the JESD204 core
-with any corresponding source code.) For these alternate terms you must
+with any corresponding source code). For these alternate terms you must
 purchase a license from Analog Devices Technology Licensing Office. Users
 interested in such a license should contact jesd204-licensing@analog.com for
 more information. This commercial license is sub-licensable (if you purchase
@@ -39,24 +37,6 @@ to use this core in a commercial setting without releasing their source code).
 In addition, we kindly ask you to acknowledge ADI in any program, application
 or publication in which you use this JESD204 HDL core. (You are not required to
 do so; it is up to your common sense to decide whether you want to comply with
-this request or not.) For general publications, we suggest referencing : “The
+this request or not.) For general publications, we suggest referencing: "The
 design and implementation of the JESD204 HDL Core used in this project is
-copyright © 2016-2023, Analog Devices, Inc.”
-
-## Support
-
-Analog Devices will provide limited online support for anyone using the core
-with Analog Devices components (ADC, DAC, Clock, etc) via
-https://ez.analog.com/community/fpga under the GPL license. If you would like
-deterministic support when using this core with an ADI component, please
-investigate a commercial license. Using a non-ADI JESD204 device with this core
-is possible under the GPL, but Analog Devices will not help with issues you may
-encounter.
-
-## Documenation
-
- - [JESD204B/C overview](https://wiki.analog.com/resources/fpga/peripherals/jesd204)
- - [Analog Devices JESD204B/C Transmit Peripheral](https://wiki.analog.com/resources/fpga/peripherals/jesd204/axi_jesd204_tx)
- - [Analog Devices JESD204B/C Receive Peripheral](https://wiki.analog.com/resources/fpga/peripherals/jesd204/axi_jesd204_rx)
-
-
+copyright (c) 2016-2023, Analog Devices, Inc."

--- a/library/common/tb/tb_base.v
+++ b/library/common/tb/tb_base.v
@@ -1,46 +1,37 @@
+// ***************************************************************************
+// ***************************************************************************
+// Copyright (C) 2017-2023 Analog Devices, Inc. All rights reserved.
 //
-// The ADI JESD204 Core is released under the following license, which is
-// different than all other HDL cores in this repository.
+// In this HDL repository, there are many different and unique modules, consisting
+// of various HDL (Verilog or VHDL) components. The individual modules are
+// developed independently, and may be accompanied by separate and unique license
+// terms.
 //
-// Please read this, and understand the freedoms and responsibilities you have
-// by using this source code/core.
+// The user should read each of these license terms, and understand the
+// freedoms and responsibilities that he or she has by using this source/core.
 //
-// The JESD204 HDL, is copyright © 2016-2017 Analog Devices Inc.
-//
-// This core is free software, you can use run, copy, study, change, ask
-// questions about and improve this core. Distribution of source, or resulting
-// binaries (including those inside an FPGA or ASIC) require you to release the
-// source of the entire project (excluding the system libraries provide by the
-// tools/compiler/FPGA vendor). These are the terms of the GNU General Public
-// License version 2 as published by the Free Software Foundation.
-//
-// This core  is distributed in the hope that it will be useful, but WITHOUT ANY
+// This core is distributed in the hope that it will be useful, but WITHOUT ANY
 // WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
-// A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+// A PARTICULAR PURPOSE.
 //
-// You should have received a copy of the GNU General Public License version 2
-// along with this source code, and binary.  If not, see
-// <http://www.gnu.org/licenses/>.
+// Redistribution and use of source or resulting binaries, with or without modification
+// of this file, are permitted under one of the following two license terms:
 //
-// Commercial licenses (with commercial support) of this JESD204 core are also
-// available under terms different than the General Public License. (e.g. they
-// do not require you to accompany any image (FPGA or ASIC) using the JESD204
-// core with any corresponding source code.) For these alternate terms you must
-// purchase a license from Analog Devices Technology Licensing Office. Users
-// interested in such a license should contact jesd204-licensing@analog.com for
-// more information. This commercial license is sub-licensable (if you purchase
-// chips from Analog Devices, incorporate them into your PCB level product, and
-// purchase a JESD204 license, end users of your product will also have a
-// license to use this core in a commercial setting without releasing their
-// source code).
+//   1. The GNU General Public License version 2 as published by the
+//      Free Software Foundation, which can be found in the top level directory
+//      of this repository (LICENSE_GPL2), and also online at:
+//      <https://www.gnu.org/licenses/old-licenses/gpl-2.0.html>
 //
-// In addition, we kindly ask you to acknowledge ADI in any program, application
-// or publication in which you use this JESD204 HDL core. (You are not required
-// to do so; it is up to your common sense to decide whether you want to comply
-// with this request or not.) For general publications, we suggest referencing :
-// “The design and implementation of the JESD204 HDL Core used in this project
-// is copyright © 2016-2017, Analog Devices, Inc.”
+// OR
 //
+//   2. An ADI specific BSD license, which can be found in the top level directory
+//      of this repository (LICENSE_ADIBSD), and also on-line at:
+//      https://github.com/analogdevicesinc/hdl/blob/master/LICENSE_ADIBSD
+//      This will allow to generate bit files and not release the source code,
+//      as long as it attaches to an ADI device.
+//
+// ***************************************************************************
+// ***************************************************************************
 
   reg clk = 1'b0;
   reg [3:0] reset_shift = 4'b1111;

--- a/library/intel/adi_jesd204/adi_jesd204_glue_hw.tcl
+++ b/library/intel/adi_jesd204/adi_jesd204_glue_hw.tcl
@@ -1,46 +1,7 @@
-#
-# The ADI JESD204 Core is released under the following license, which is
-# different than all other HDL cores in this repository.
-#
-# Please read this, and understand the freedoms and responsibilities you have
-# by using this source code/core.
-#
-# The JESD204 HDL, is copyright © 2016-2017 Analog Devices Inc.
-#
-# This core is free software, you can use run, copy, study, change, ask
-# questions about and improve this core. Distribution of source, or resulting
-# binaries (including those inside an FPGA or ASIC) require you to release the
-# source of the entire project (excluding the system libraries provide by the
-# tools/compiler/FPGA vendor). These are the terms of the GNU General Public
-# License version 2 as published by the Free Software Foundation.
-#
-# This core  is distributed in the hope that it will be useful, but WITHOUT ANY
-# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
-# A PARTICULAR PURPOSE. See the GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License version 2
-# along with this source code, and binary.  If not, see
-# <http://www.gnu.org/licenses/>.
-#
-# Commercial licenses (with commercial support) of this JESD204 core are also
-# available under terms different than the General Public License. (e.g. they
-# do not require you to accompany any image (FPGA or ASIC) using the JESD204
-# core with any corresponding source code.) For these alternate terms you must
-# purchase a license from Analog Devices Technology Licensing Office. Users
-# interested in such a license should contact jesd204-licensing@analog.com for
-# more information. This commercial license is sub-licensable (if you purchase
-# chips from Analog Devices, incorporate them into your PCB level product, and
-# purchase a JESD204 license, end users of your product will also have a
-# license to use this core in a commercial setting without releasing their
-# source code).
-#
-# In addition, we kindly ask you to acknowledge ADI in any program, application
-# or publication in which you use this JESD204 HDL core. (You are not required
-# to do so; it is up to your common sense to decide whether you want to comply
-# with this request or not.) For general publications, we suggest referencing :
-# “The design and implementation of the JESD204 HDL Core used in this project
-# is copyright © 2016-2017, Analog Devices, Inc.”
-#
+###############################################################################
+## Copyright (C) 2016, 2018, 2019, 2020, 2021, 2022 Analog Devices, Inc. All rights reserved.
+### SPDX short identifier: ADIJESD204
+###############################################################################
 
 package require qsys 14.0
 source ../../../scripts/adi_env.tcl

--- a/library/intel/adi_jesd204/adi_jesd204_hw.tcl
+++ b/library/intel/adi_jesd204/adi_jesd204_hw.tcl
@@ -1,46 +1,7 @@
-#
-# The ADI JESD204 Core is released under the following license, which is
-# different than all other HDL cores in this repository.
-#
-# Please read this, and understand the freedoms and responsibilities you have
-# by using this source code/core.
-#
-# The JESD204 HDL, is copyright © 2016-2017 Analog Devices Inc.
-#
-# This core is free software, you can use run, copy, study, change, ask
-# questions about and improve this core. Distribution of source, or resulting
-# binaries (including those inside an FPGA or ASIC) require you to release the
-# source of the entire project (excluding the system libraries provide by the
-# tools/compiler/FPGA vendor). These are the terms of the GNU General Public
-# License version 2 as published by the Free Software Foundation.
-#
-# This core  is distributed in the hope that it will be useful, but WITHOUT ANY
-# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
-# A PARTICULAR PURPOSE. See the GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License version 2
-# along with this source code, and binary.  If not, see
-# <http://www.gnu.org/licenses/>.
-#
-# Commercial licenses (with commercial support) of this JESD204 core are also
-# available under terms different than the General Public License. (e.g. they
-# do not require you to accompany any image (FPGA or ASIC) using the JESD204
-# core with any corresponding source code.) For these alternate terms you must
-# purchase a license from Analog Devices Technology Licensing Office. Users
-# interested in such a license should contact jesd204-licensing@analog.com for
-# more information. This commercial license is sub-licensable (if you purchase
-# chips from Analog Devices, incorporate them into your PCB level product, and
-# purchase a JESD204 license, end users of your product will also have a
-# license to use this core in a commercial setting without releasing their
-# source code).
-#
-# In addition, we kindly ask you to acknowledge ADI in any program, application
-# or publication in which you use this JESD204 HDL core. (You are not required
-# to do so; it is up to your common sense to decide whether you want to comply
-# with this request or not.) For general publications, we suggest referencing :
-# “The design and implementation of the JESD204 HDL Core used in this project
-# is copyright © 2016-2017, Analog Devices, Inc.”
-#
+###############################################################################
+## Copyright (C) 2016-2023 Analog Devices, Inc. All rights reserved.
+### SPDX short identifier: ADIJESD204
+###############################################################################
 
 package require qsys 14.0
 source ../../../scripts/adi_env.tcl

--- a/library/intel/jesd204_phy/jesd204_phy_glue_hw.tcl
+++ b/library/intel/jesd204_phy/jesd204_phy_glue_hw.tcl
@@ -1,46 +1,7 @@
-#
-# The ADI JESD204 Core is released under the following license, which is
-# different than all other HDL cores in this repository.
-#
-# Please read this, and understand the freedoms and responsibilities you have
-# by using this source code/core.
-#
-# The JESD204 HDL, is copyright © 2016-2017 Analog Devices Inc.
-#
-# This core is free software, you can use run, copy, study, change, ask
-# questions about and improve this core. Distribution of source, or resulting
-# binaries (including those inside an FPGA or ASIC) require you to release the
-# source of the entire project (excluding the system libraries provide by the
-# tools/compiler/FPGA vendor). These are the terms of the GNU General Public
-# License version 2 as published by the Free Software Foundation.
-#
-# This core  is distributed in the hope that it will be useful, but WITHOUT ANY
-# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
-# A PARTICULAR PURPOSE. See the GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License version 2
-# along with this source code, and binary.  If not, see
-# <http://www.gnu.org/licenses/>.
-#
-# Commercial licenses (with commercial support) of this JESD204 core are also
-# available under terms different than the General Public License. (e.g. they
-# do not require you to accompany any image (FPGA or ASIC) using the JESD204
-# core with any corresponding source code.) For these alternate terms you must
-# purchase a license from Analog Devices Technology Licensing Office. Users
-# interested in such a license should contact jesd204-licensing@analog.com for
-# more information. This commercial license is sub-licensable (if you purchase
-# chips from Analog Devices, incorporate them into your PCB level product, and
-# purchase a JESD204 license, end users of your product will also have a
-# license to use this core in a commercial setting without releasing their
-# source code).
-#
-# In addition, we kindly ask you to acknowledge ADI in any program, application
-# or publication in which you use this JESD204 HDL core. (You are not required
-# to do so; it is up to your common sense to decide whether you want to comply
-# with this request or not.) For general publications, we suggest referencing :
-# “The design and implementation of the JESD204 HDL Core used in this project
-# is copyright © 2016-2017, Analog Devices, Inc.”
-#
+###############################################################################
+## Copyright (C) 2016-2022 Analog Devices, Inc. All rights reserved.
+### SPDX short identifier: ADIJESD204
+###############################################################################
 
 package require qsys 14.0
 source ../../../scripts/adi_env.tcl

--- a/library/intel/jesd204_phy/jesd204_phy_hw.tcl
+++ b/library/intel/jesd204_phy/jesd204_phy_hw.tcl
@@ -1,46 +1,7 @@
-#
-# The ADI JESD204 Core is released under the following license, which is
-# different than all other HDL cores in this repository.
-#
-# Please read this, and understand the freedoms and responsibilities you have
-# by using this source code/core.
-#
-# The JESD204 HDL, is copyright © 2016-2017 Analog Devices Inc.
-#
-# This core is free software, you can use run, copy, study, change, ask
-# questions about and improve this core. Distribution of source, or resulting
-# binaries (including those inside an FPGA or ASIC) require you to release the
-# source of the entire project (excluding the system libraries provide by the
-# tools/compiler/FPGA vendor). These are the terms of the GNU General Public
-# License version 2 as published by the Free Software Foundation.
-#
-# This core  is distributed in the hope that it will be useful, but WITHOUT ANY
-# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
-# A PARTICULAR PURPOSE. See the GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License version 2
-# along with this source code, and binary.  If not, see
-# <http://www.gnu.org/licenses/>.
-#
-# Commercial licenses (with commercial support) of this JESD204 core are also
-# available under terms different than the General Public License. (e.g. they
-# do not require you to accompany any image (FPGA or ASIC) using the JESD204
-# core with any corresponding source code.) For these alternate terms you must
-# purchase a license from Analog Devices Technology Licensing Office. Users
-# interested in such a license should contact jesd204-licensing@analog.com for
-# more information. This commercial license is sub-licensable (if you purchase
-# chips from Analog Devices, incorporate them into your PCB level product, and
-# purchase a JESD204 license, end users of your product will also have a
-# license to use this core in a commercial setting without releasing their
-# source code).
-#
-# In addition, we kindly ask you to acknowledge ADI in any program, application
-# or publication in which you use this JESD204 HDL core. (You are not required
-# to do so; it is up to your common sense to decide whether you want to comply
-# with this request or not.) For general publications, we suggest referencing :
-# “The design and implementation of the JESD204 HDL Core used in this project
-# is copyright © 2016-2017, Analog Devices, Inc.”
-#
+###############################################################################
+## Copyright (C) 2016-2022 Analog Devices, Inc. All rights reserved.
+### SPDX short identifier: ADIJESD204
+###############################################################################
 
 package require qsys 14.0
 

--- a/library/jesd204/README.md
+++ b/library/jesd204/README.md
@@ -8,7 +8,7 @@ different than all other HDL cores in this repository.
 Please read this, and understand the freedoms and responsibilities you have by
 using this source code/core.
 
-The JESD204 HDL, is copyright © 2016-2017 Analog Devices Inc.
+The JESD204 HDL, is copyright © 2016-2023 Analog Devices Inc.
 
 This core is free software, you can use run, copy, study, change, ask questions
 about and improve this core. Distribution of source, or resulting binaries
@@ -41,7 +41,7 @@ or publication in which you use this JESD204 HDL core. (You are not required to
 do so; it is up to your common sense to decide whether you want to comply with
 this request or not.) For general publications, we suggest referencing : “The
 design and implementation of the JESD204 HDL Core used in this project is
-copyright © 2016-2017, Analog Devices, Inc.”
+copyright © 2016-2023, Analog Devices, Inc.”
 
 ## Support
 

--- a/library/jesd204/ad_ip_jesd204_tpl_adc/ad_ip_jesd204_tpl_adc_hw.tcl
+++ b/library/jesd204/ad_ip_jesd204_tpl_adc/ad_ip_jesd204_tpl_adc_hw.tcl
@@ -1,25 +1,7 @@
-# ***************************************************************************
-# ***************************************************************************
-# Copyright 2018 (c) Analog Devices, Inc. All rights reserved.
-#
-# Each core or library found in this collection may have its own licensing terms.
-# The user should keep this in in mind while exploring these cores.
-#
-# Redistribution and use in source and binary forms,
-# with or without modification of this file, are permitted under the terms of either
-#  (at the option of the user):
-#
-#   1. The GNU General Public License version 2 as published by the
-#      Free Software Foundation, which can be found in the top level directory, or at:
-# https://www.gnu.org/licenses/old-licenses/gpl-2.0.en.html
-#
-# OR
-#
-#   2.  An ADI specific BSD license as noted in the top level directory, or on-line at:
-# https://github.com/analogdevicesinc/hdl/blob/dev/LICENSE
-#
-# ***************************************************************************
-# ***************************************************************************
+###############################################################################
+## Copyright (C) 2018-2022 Analog Devices, Inc. All rights reserved.
+### SPDX short identifier: ADIJESD204
+###############################################################################
 
 package require qsys 14.0
 source ../../../scripts/adi_env.tcl

--- a/library/jesd204/ad_ip_jesd204_tpl_adc/ad_ip_jesd204_tpl_adc_ip.tcl
+++ b/library/jesd204/ad_ip_jesd204_tpl_adc/ad_ip_jesd204_tpl_adc_ip.tcl
@@ -1,25 +1,7 @@
-# ***************************************************************************
-# ***************************************************************************
-# Copyright 2018 (c) Analog Devices, Inc. All rights reserved.
-#
-# Each core or library found in this collection may have its own licensing terms.
-# The user should keep this in in mind while exploring these cores.
-#
-# Redistribution and use in source and binary forms,
-# with or without modification of this file, are permitted under the terms of either
-#  (at the option of the user):
-#
-#   1. The GNU General Public License version 2 as published by the
-#      Free Software Foundation, which can be found in the top level directory, or at:
-# https://www.gnu.org/licenses/old-licenses/gpl-2.0.en.html
-#
-# OR
-#
-#   2. An ADI specific BSD license as noted in the top level directory, or on-line at:
-# https://github.com/analogdevicesinc/hdl/blob/dev/LICENSE
-#
-# ***************************************************************************
-# ***************************************************************************
+###############################################################################
+## Copyright (C) 2018-2022 Analog Devices, Inc. All rights reserved.
+### SPDX short identifier: ADIJESD204
+###############################################################################
 
 source ../../../scripts/adi_env.tcl
 source $ad_hdl_dir/library/scripts/adi_ip_xilinx.tcl

--- a/library/jesd204/ad_ip_jesd204_tpl_dac/ad_ip_jesd204_tpl_dac_hw.tcl
+++ b/library/jesd204/ad_ip_jesd204_tpl_dac/ad_ip_jesd204_tpl_dac_hw.tcl
@@ -1,25 +1,7 @@
-# ***************************************************************************
-# ***************************************************************************
-# Copyright 2018 (c) Analog Devices, Inc. All rights reserved.
-#
-# Each core or library found in this collection may have its own licensing terms.
-# The user should keep this in in mind while exploring these cores.
-#
-# Redistribution and use in source and binary forms,
-# with or without modification of this file, are permitted under the terms of either
-#  (at the option of the user):
-#
-#   1. The GNU General Public License version 2 as published by the
-#      Free Software Foundation, which can be found in the top level directory, or at:
-# https://www.gnu.org/licenses/old-licenses/gpl-2.0.en.html
-#
-# OR
-#
-#   2. An ADI specific BSD license as noted in the top level directory, or on-line at:
-# https://github.com/analogdevicesinc/hdl/blob/dev/LICENSE
-#
-# ***************************************************************************
-# ***************************************************************************
+###############################################################################
+## Copyright (C) 2018-2022 Analog Devices, Inc. All rights reserved.
+### SPDX short identifier: ADIJESD204
+###############################################################################
 
 package require qsys 14.0
 source ../../../scripts/adi_env.tcl
@@ -501,7 +483,7 @@ proc p_ad_ip_jesd204_tpl_dac_elab {} {
   set DMA_BPS [get_parameter_value "DMA_BITS_PER_SAMPLE"]
 
   # The DMA interface is rounded to nearest power of two bytes per sample,
-  # e.g NP=12 is padded into 16 bits 
+  # e.g NP=12 is padded into 16 bits
   set samples_per_beat_per_channel [expr ($OPB * 8 * $L / ($M * $NP))]
   set channel_bus_width [expr $samples_per_beat_per_channel*$DMA_BPS]
 

--- a/library/jesd204/ad_ip_jesd204_tpl_dac/ad_ip_jesd204_tpl_dac_ip.tcl
+++ b/library/jesd204/ad_ip_jesd204_tpl_dac/ad_ip_jesd204_tpl_dac_ip.tcl
@@ -1,25 +1,7 @@
-# ***************************************************************************
-# ***************************************************************************
-# Copyright 2018 (c) Analog Devices, Inc. All rights reserved.
-#
-# Each core or library found in this collection may have its own licensing terms.
-# The user should keep this in in mind while exploring these cores.
-#
-# Redistribution and use in source and binary forms,
-# with or without modification of this file, are permitted under the terms of either
-#  (at the option of the user):
-#
-#   1. The GNU General Public License version 2 as published by the
-#      Free Software Foundation, which can be found in the top level directory, or at:
-# https://www.gnu.org/licenses/old-licenses/gpl-2.0.en.html
-#
-# OR
-#
-#   2.  An ADI specific BSD license as noted in the top level directory, or on-line at:
-# https://github.com/analogdevicesinc/hdl/blob/dev/LICENSE
-#
-# ***************************************************************************
-# ***************************************************************************
+###############################################################################
+## Copyright (C) 2018-2022 Analog Devices, Inc. All rights reserved.
+### SPDX short identifier: ADIJESD204
+###############################################################################
 
 source ../../../scripts/adi_env.tcl
 source $ad_hdl_dir/library/scripts/adi_ip_xilinx.tcl

--- a/library/jesd204/ad_ip_jesd204_tpl_dac/scripts/generate_presets.py
+++ b/library/jesd204/ad_ip_jesd204_tpl_dac/scripts/generate_presets.py
@@ -1,5 +1,10 @@
 #!/usr/bin/env python3
 
+###############################################################################
+## Copyright (C) 2018 Analog Devices, Inc. All rights reserved.
+### SPDX short identifier: ADIJESD204
+###############################################################################
+
 import math
 import os
 import sys

--- a/library/jesd204/axi_jesd204_common/axi_jesd204_common_ip.tcl
+++ b/library/jesd204/axi_jesd204_common/axi_jesd204_common_ip.tcl
@@ -1,46 +1,7 @@
-#
-# The ADI JESD204 Core is released under the following license, which is
-# different than all other HDL cores in this repository.
-#
-# Please read this, and understand the freedoms and responsibilities you have
-# by using this source code/core.
-#
-# The JESD204 HDL, is copyright © 2016-2017 Analog Devices Inc.
-#
-# This core is free software, you can use run, copy, study, change, ask
-# questions about and improve this core. Distribution of source, or resulting
-# binaries (including those inside an FPGA or ASIC) require you to release the
-# source of the entire project (excluding the system libraries provide by the
-# tools/compiler/FPGA vendor). These are the terms of the GNU General Public
-# License version 2 as published by the Free Software Foundation.
-#
-# This core  is distributed in the hope that it will be useful, but WITHOUT ANY
-# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
-# A PARTICULAR PURPOSE. See the GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License version 2
-# along with this source code, and binary.  If not, see
-# <http://www.gnu.org/licenses/>.
-#
-# Commercial licenses (with commercial support) of this JESD204 core are also
-# available under terms different than the General Public License. (e.g. they
-# do not require you to accompany any image (FPGA or ASIC) using the JESD204
-# core with any corresponding source code.) For these alternate terms you must
-# purchase a license from Analog Devices Technology Licensing Office. Users
-# interested in such a license should contact jesd204-licensing@analog.com for
-# more information. This commercial license is sub-licensable (if you purchase
-# chips from Analog Devices, incorporate them into your PCB level product, and
-# purchase a JESD204 license, end users of your product will also have a
-# license to use this core in a commercial setting without releasing their
-# source code).
-#
-# In addition, we kindly ask you to acknowledge ADI in any program, application
-# or publication in which you use this JESD204 HDL core. (You are not required
-# to do so; it is up to your common sense to decide whether you want to comply
-# with this request or not.) For general publications, we suggest referencing :
-# “The design and implementation of the JESD204 HDL Core used in this project
-# is copyright © 2016-2017, Analog Devices, Inc.”
-#
+###############################################################################
+## Copyright (C) 2016, 2017, 2019, 2022, 2023 Analog Devices, Inc. All rights reserved.
+### SPDX short identifier: ADIJESD204
+###############################################################################
 
 source ../../../scripts/adi_env.tcl
 source $ad_hdl_dir/library/scripts/adi_ip_xilinx.tcl

--- a/library/jesd204/axi_jesd204_common/jesd204_up_common.v
+++ b/library/jesd204/axi_jesd204_common/jesd204_up_common.v
@@ -1,46 +1,9 @@
-//
-// The ADI JESD204 Core is released under the following license, which is
-// different than all other HDL cores in this repository.
-//
-// Please read this, and understand the freedoms and responsibilities you have
-// by using this source code/core.
-//
-// The JESD204 HDL, is copyright © 2016-2017 Analog Devices Inc.
-//
-// This core is free software, you can use run, copy, study, change, ask
-// questions about and improve this core. Distribution of source, or resulting
-// binaries (including those inside an FPGA or ASIC) require you to release the
-// source of the entire project (excluding the system libraries provide by the
-// tools/compiler/FPGA vendor). These are the terms of the GNU General Public
-// License version 2 as published by the Free Software Foundation.
-//
-// This core  is distributed in the hope that it will be useful, but WITHOUT ANY
-// WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
-// A PARTICULAR PURPOSE. See the GNU General Public License for more details.
-//
-// You should have received a copy of the GNU General Public License version 2
-// along with this source code, and binary.  If not, see
-// <http://www.gnu.org/licenses/>.
-//
-// Commercial licenses (with commercial support) of this JESD204 core are also
-// available under terms different than the General Public License. (e.g. they
-// do not require you to accompany any image (FPGA or ASIC) using the JESD204
-// core with any corresponding source code.) For these alternate terms you must
-// purchase a license from Analog Devices Technology Licensing Office. Users
-// interested in such a license should contact jesd204-licensing@analog.com for
-// more information. This commercial license is sub-licensable (if you purchase
-// chips from Analog Devices, incorporate them into your PCB level product, and
-// purchase a JESD204 license, end users of your product will also have a
-// license to use this core in a commercial setting without releasing their
-// source code).
-//
-// In addition, we kindly ask you to acknowledge ADI in any program, application
-// or publication in which you use this JESD204 HDL core. (You are not required
-// to do so; it is up to your common sense to decide whether you want to comply
-// with this request or not.) For general publications, we suggest referencing :
-// “The design and implementation of the JESD204 HDL Core used in this project
-// is copyright © 2016-2017, Analog Devices, Inc.”
-//
+// ***************************************************************************
+// ***************************************************************************
+// Copyright (C) 2016-2022 Analog Devices, Inc. All rights reserved.
+// SPDX short identifier: ADIJESD204
+// ***************************************************************************
+// ***************************************************************************
 
 `timescale 1ns/100ps
 

--- a/library/jesd204/axi_jesd204_common/jesd204_up_sysref.v
+++ b/library/jesd204/axi_jesd204_common/jesd204_up_sysref.v
@@ -1,46 +1,9 @@
-//
-// The ADI JESD204 Core is released under the following license, which is
-// different than all other HDL cores in this repository.
-//
-// Please read this, and understand the freedoms and responsibilities you have
-// by using this source code/core.
-//
-// The JESD204 HDL, is copyright © 2016-2017 Analog Devices Inc.
-//
-// This core is free software, you can use run, copy, study, change, ask
-// questions about and improve this core. Distribution of source, or resulting
-// binaries (including those inside an FPGA or ASIC) require you to release the
-// source of the entire project (excluding the system libraries provide by the
-// tools/compiler/FPGA vendor). These are the terms of the GNU General Public
-// License version 2 as published by the Free Software Foundation.
-//
-// This core  is distributed in the hope that it will be useful, but WITHOUT ANY
-// WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
-// A PARTICULAR PURPOSE. See the GNU General Public License for more details.
-//
-// You should have received a copy of the GNU General Public License version 2
-// along with this source code, and binary.  If not, see
-// <http://www.gnu.org/licenses/>.
-//
-// Commercial licenses (with commercial support) of this JESD204 core are also
-// available under terms different than the General Public License. (e.g. they
-// do not require you to accompany any image (FPGA or ASIC) using the JESD204
-// core with any corresponding source code.) For these alternate terms you must
-// purchase a license from Analog Devices Technology Licensing Office. Users
-// interested in such a license should contact jesd204-licensing@analog.com for
-// more information. This commercial license is sub-licensable (if you purchase
-// chips from Analog Devices, incorporate them into your PCB level product, and
-// purchase a JESD204 license, end users of your product will also have a
-// license to use this core in a commercial setting without releasing their
-// source code).
-//
-// In addition, we kindly ask you to acknowledge ADI in any program, application
-// or publication in which you use this JESD204 HDL core. (You are not required
-// to do so; it is up to your common sense to decide whether you want to comply
-// with this request or not.) For general publications, we suggest referencing :
-// “The design and implementation of the JESD204 HDL Core used in this project
-// is copyright © 2016-2017, Analog Devices, Inc.”
-//
+// ***************************************************************************
+// ***************************************************************************
+// Copyright (C) 2016-2018, 2020-2022 Analog Devices, Inc. All rights reserved.
+// SPDX short identifier: ADIJESD204
+// ***************************************************************************
+// ***************************************************************************
 
 `timescale 1ns/100ps
 

--- a/library/jesd204/axi_jesd204_rx/axi_jesd204_rx.v
+++ b/library/jesd204/axi_jesd204_rx/axi_jesd204_rx.v
@@ -1,46 +1,9 @@
-//
-// The ADI JESD204 Core is released under the following license, which is
-// different than all other HDL cores in this repository.
-//
-// Please read this, and understand the freedoms and responsibilities you have
-// by using this source code/core.
-//
-// The JESD204 HDL, is copyright © 2016-2017 Analog Devices Inc.
-//
-// This core is free software, you can use run, copy, study, change, ask
-// questions about and improve this core. Distribution of source, or resulting
-// binaries (including those inside an FPGA or ASIC) require you to release the
-// source of the entire project (excluding the system libraries provide by the
-// tools/compiler/FPGA vendor). These are the terms of the GNU General Public
-// License version 2 as published by the Free Software Foundation.
-//
-// This core  is distributed in the hope that it will be useful, but WITHOUT ANY
-// WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
-// A PARTICULAR PURPOSE. See the GNU General Public License for more details.
-//
-// You should have received a copy of the GNU General Public License version 2
-// along with this source code, and binary.  If not, see
-// <http://www.gnu.org/licenses/>.
-//
-// Commercial licenses (with commercial support) of this JESD204 core are also
-// available under terms different than the General Public License. (e.g. they
-// do not require you to accompany any image (FPGA or ASIC) using the JESD204
-// core with any corresponding source code.) For these alternate terms you must
-// purchase a license from Analog Devices Technology Licensing Office. Users
-// interested in such a license should contact jesd204-licensing@analog.com for
-// more information. This commercial license is sub-licensable (if you purchase
-// chips from Analog Devices, incorporate them into your PCB level product, and
-// purchase a JESD204 license, end users of your product will also have a
-// license to use this core in a commercial setting without releasing their
-// source code).
-//
-// In addition, we kindly ask you to acknowledge ADI in any program, application
-// or publication in which you use this JESD204 HDL core. (You are not required
-// to do so; it is up to your common sense to decide whether you want to comply
-// with this request or not.) For general publications, we suggest referencing :
-// “The design and implementation of the JESD204 HDL Core used in this project
-// is copyright © 2016-2017, Analog Devices, Inc.”
-//
+// ***************************************************************************
+// ***************************************************************************
+// Copyright (C) 2016-2022 Analog Devices, Inc. All rights reserved.
+// SPDX short identifier: ADIJESD204
+// ***************************************************************************
+// ***************************************************************************
 
 `timescale 1ns/100ps
 

--- a/library/jesd204/axi_jesd204_rx/axi_jesd204_rx_constr.sdc
+++ b/library/jesd204/axi_jesd204_rx/axi_jesd204_rx_constr.sdc
@@ -1,46 +1,7 @@
-#
-# The ADI JESD204 Core is released under the following license, which is
-# different than all other HDL cores in this repository.
-#
-# Please read this, and understand the freedoms and responsibilities you have
-# by using this source code/core.
-#
-# The JESD204 HDL, is copyright © 2016-2017 Analog Devices Inc.
-#
-# This core is free software, you can use run, copy, study, change, ask
-# questions about and improve this core. Distribution of source, or resulting
-# binaries (including those inside an FPGA or ASIC) require you to release the
-# source of the entire project (excluding the system libraries provide by the
-# tools/compiler/FPGA vendor). These are the terms of the GNU General Public
-# License version 2 as published by the Free Software Foundation.
-#
-# This core  is distributed in the hope that it will be useful, but WITHOUT ANY
-# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
-# A PARTICULAR PURPOSE. See the GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License version 2
-# along with this source code, and binary.  If not, see
-# <http://www.gnu.org/licenses/>.
-#
-# Commercial licenses (with commercial support) of this JESD204 core are also
-# available under terms different than the General Public License. (e.g. they
-# do not require you to accompany any image (FPGA or ASIC) using the JESD204
-# core with any corresponding source code.) For these alternate terms you must
-# purchase a license from Analog Devices Technology Licensing Office. Users
-# interested in such a license should contact jesd204-licensing@analog.com for
-# more information. This commercial license is sub-licensable (if you purchase
-# chips from Analog Devices, incorporate them into your PCB level product, and
-# purchase a JESD204 license, end users of your product will also have a
-# license to use this core in a commercial setting without releasing their
-# source code).
-#
-# In addition, we kindly ask you to acknowledge ADI in any program, application
-# or publication in which you use this JESD204 HDL core. (You are not required
-# to do so; it is up to your common sense to decide whether you want to comply
-# with this request or not.) For general publications, we suggest referencing :
-# “The design and implementation of the JESD204 HDL Core used in this project
-# is copyright © 2016-2017, Analog Devices, Inc.”
-#
+###############################################################################
+## Copyright (C) 2016-2018, 2021 Analog Devices, Inc. All rights reserved.
+### SPDX short identifier: ADIJESD204
+###############################################################################
 
 set script_dir [file dirname [info script]]
 

--- a/library/jesd204/axi_jesd204_rx/axi_jesd204_rx_constr.xdc
+++ b/library/jesd204/axi_jesd204_rx/axi_jesd204_rx_constr.xdc
@@ -1,46 +1,7 @@
-#
-# The ADI JESD204 Core is released under the following license, which is
-# different than all other HDL cores in this repository.
-#
-# Please read this, and understand the freedoms and responsibilities you have
-# by using this source code/core.
-#
-# The JESD204 HDL, is copyright © 2016-2017 Analog Devices Inc.
-#
-# This core is free software, you can use run, copy, study, change, ask
-# questions about and improve this core. Distribution of source, or resulting
-# binaries (including those inside an FPGA or ASIC) require you to release the
-# source of the entire project (excluding the system libraries provide by the
-# tools/compiler/FPGA vendor). These are the terms of the GNU General Public
-# License version 2 as published by the Free Software Foundation.
-#
-# This core  is distributed in the hope that it will be useful, but WITHOUT ANY
-# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
-# A PARTICULAR PURPOSE. See the GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License version 2
-# along with this source code, and binary.  If not, see
-# <http://www.gnu.org/licenses/>.
-#
-# Commercial licenses (with commercial support) of this JESD204 core are also
-# available under terms different than the General Public License. (e.g. they
-# do not require you to accompany any image (FPGA or ASIC) using the JESD204
-# core with any corresponding source code.) For these alternate terms you must
-# purchase a license from Analog Devices Technology Licensing Office. Users
-# interested in such a license should contact jesd204-licensing@analog.com for
-# more information. This commercial license is sub-licensable (if you purchase
-# chips from Analog Devices, incorporate them into your PCB level product, and
-# purchase a JESD204 license, end users of your product will also have a
-# license to use this core in a commercial setting without releasing their
-# source code).
-#
-# In addition, we kindly ask you to acknowledge ADI in any program, application
-# or publication in which you use this JESD204 HDL core. (You are not required
-# to do so; it is up to your common sense to decide whether you want to comply
-# with this request or not.) For general publications, we suggest referencing :
-# “The design and implementation of the JESD204 HDL Core used in this project
-# is copyright © 2016-2017, Analog Devices, Inc.”
-#
+###############################################################################
+## Copyright (C) 2016-2018, 2020-2021 Analog Devices, Inc. All rights reserved.
+### SPDX short identifier: ADIJESD204
+###############################################################################
 
 set axi_clk [get_clocks -of_objects [get_ports s_axi_aclk]]
 set core_clk [get_clocks -of_objects [get_ports core_clk]]

--- a/library/jesd204/axi_jesd204_rx/axi_jesd204_rx_hw.tcl
+++ b/library/jesd204/axi_jesd204_rx/axi_jesd204_rx_hw.tcl
@@ -1,46 +1,7 @@
-#
-# The ADI JESD204 Core is released under the following license, which is
-# different than all other HDL cores in this repository.
-#
-# Please read this, and understand the freedoms and responsibilities you have
-# by using this source code/core.
-#
-# The JESD204 HDL, is copyright © 2016-2017 Analog Devices Inc.
-#
-# This core is free software, you can use run, copy, study, change, ask
-# questions about and improve this core. Distribution of source, or resulting
-# binaries (including those inside an FPGA or ASIC) require you to release the
-# source of the entire project (excluding the system libraries provide by the
-# tools/compiler/FPGA vendor). These are the terms of the GNU General Public
-# License version 2 as published by the Free Software Foundation.
-#
-# This core  is distributed in the hope that it will be useful, but WITHOUT ANY
-# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
-# A PARTICULAR PURPOSE. See the GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License version 2
-# along with this source code, and binary.  If not, see
-# <http://www.gnu.org/licenses/>.
-#
-# Commercial licenses (with commercial support) of this JESD204 core are also
-# available under terms different than the General Public License. (e.g. they
-# do not require you to accompany any image (FPGA or ASIC) using the JESD204
-# core with any corresponding source code.) For these alternate terms you must
-# purchase a license from Analog Devices Technology Licensing Office. Users
-# interested in such a license should contact jesd204-licensing@analog.com for
-# more information. This commercial license is sub-licensable (if you purchase
-# chips from Analog Devices, incorporate them into your PCB level product, and
-# purchase a JESD204 license, end users of your product will also have a
-# license to use this core in a commercial setting without releasing their
-# source code).
-#
-# In addition, we kindly ask you to acknowledge ADI in any program, application
-# or publication in which you use this JESD204 HDL core. (You are not required
-# to do so; it is up to your common sense to decide whether you want to comply
-# with this request or not.) For general publications, we suggest referencing :
-# “The design and implementation of the JESD204 HDL Core used in this project
-# is copyright © 2016-2017, Analog Devices, Inc.”
-#
+###############################################################################
+## Copyright (C) 2016-2022 Analog Devices, Inc. All rights reserved.
+### SPDX short identifier: ADIJESD204
+###############################################################################
 
 package require qsys 14.0
 

--- a/library/jesd204/axi_jesd204_rx/axi_jesd204_rx_ip.tcl
+++ b/library/jesd204/axi_jesd204_rx/axi_jesd204_rx_ip.tcl
@@ -1,46 +1,7 @@
-#
-# The ADI JESD204 Core is released under the following license, which is
-# different than all other HDL cores in this repository.
-#
-# Please read this, and understand the freedoms and responsibilities you have
-# by using this source code/core.
-#
-# The JESD204 HDL, is copyright © 2016-2017 Analog Devices Inc.
-#
-# This core is free software, you can use run, copy, study, change, ask
-# questions about and improve this core. Distribution of source, or resulting
-# binaries (including those inside an FPGA or ASIC) require you to release the
-# source of the entire project (excluding the system libraries provide by the
-# tools/compiler/FPGA vendor). These are the terms of the GNU General Public
-# License version 2 as published by the Free Software Foundation.
-#
-# This core  is distributed in the hope that it will be useful, but WITHOUT ANY
-# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
-# A PARTICULAR PURPOSE. See the GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License version 2
-# along with this source code, and binary.  If not, see
-# <http://www.gnu.org/licenses/>.
-#
-# Commercial licenses (with commercial support) of this JESD204 core are also
-# available under terms different than the General Public License. (e.g. they
-# do not require you to accompany any image (FPGA or ASIC) using the JESD204
-# core with any corresponding source code.) For these alternate terms you must
-# purchase a license from Analog Devices Technology Licensing Office. Users
-# interested in such a license should contact jesd204-licensing@analog.com for
-# more information. This commercial license is sub-licensable (if you purchase
-# chips from Analog Devices, incorporate them into your PCB level product, and
-# purchase a JESD204 license, end users of your product will also have a
-# license to use this core in a commercial setting without releasing their
-# source code).
-#
-# In addition, we kindly ask you to acknowledge ADI in any program, application
-# or publication in which you use this JESD204 HDL core. (You are not required
-# to do so; it is up to your common sense to decide whether you want to comply
-# with this request or not.) For general publications, we suggest referencing :
-# “The design and implementation of the JESD204 HDL Core used in this project
-# is copyright © 2016-2017, Analog Devices, Inc.”
-#
+###############################################################################
+## Copyright (C) 2016-2023 Analog Devices, Inc. All rights reserved.
+### SPDX short identifier: ADIJESD204
+###############################################################################
 
 source ../../../scripts/adi_env.tcl
 source $ad_hdl_dir/library/scripts/adi_ip_xilinx.tcl

--- a/library/jesd204/axi_jesd204_rx/axi_jesd204_rx_ooc.ttcl
+++ b/library/jesd204/axi_jesd204_rx/axi_jesd204_rx_ooc.ttcl
@@ -1,46 +1,7 @@
-#
-# The ADI JESD204 Core is released under the following license, which is
-# different than all other HDL cores in this repository.
-#
-# Please read this, and understand the freedoms and responsibilities you have
-# by using this source code/core.
-#
-# The JESD204 HDL, is copyright © 2016-2017 Analog Devices Inc.
-#
-# This core is free software, you can use run, copy, study, change, ask
-# questions about and improve this core. Distribution of source, or resulting
-# binaries (including those inside an FPGA or ASIC) require you to release the
-# source of the entire project (excluding the system libraries provide by the
-# tools/compiler/FPGA vendor). These are the terms of the GNU General Public
-# License version 2 as published by the Free Software Foundation.
-#
-# This core  is distributed in the hope that it will be useful, but WITHOUT ANY
-# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
-# A PARTICULAR PURPOSE. See the GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License version 2
-# along with this source code, and binary.  If not, see
-# <http://www.gnu.org/licenses/>.
-#
-# Commercial licenses (with commercial support) of this JESD204 core are also
-# available under terms different than the General Public License. (e.g. they
-# do not require you to accompany any image (FPGA or ASIC) using the JESD204
-# core with any corresponding source code.) For these alternate terms you must
-# purchase a license from Analog Devices Technology Licensing Office. Users
-# interested in such a license should contact jesd204-licensing@analog.com for
-# more information. This commercial license is sub-licensable (if you purchase
-# chips from Analog Devices, incorporate them into your PCB level product, and
-# purchase a JESD204 license, end users of your product will also have a
-# license to use this core in a commercial setting without releasing their
-# source code).
-#
-# In addition, we kindly ask you to acknowledge ADI in any program, application
-# or publication in which you use this JESD204 HDL core. (You are not required
-# to do so; it is up to your common sense to decide whether you want to comply
-# with this request or not.) For general publications, we suggest referencing :
-# “The design and implementation of the JESD204 HDL Core used in this project
-# is copyright © 2016-2017, Analog Devices, Inc.”
-#
+###############################################################################
+## Copyright (C) 2017-2019, 2021 Analog Devices, Inc. All rights reserved.
+### SPDX short identifier: ADIJESD204
+###############################################################################
 
 <: setFileUsedIn { out_of_context synthesis implementation } :>
 <: ;#Component and file information :>

--- a/library/jesd204/axi_jesd204_rx/jesd204_up_ilas_mem.v
+++ b/library/jesd204/axi_jesd204_rx/jesd204_up_ilas_mem.v
@@ -1,46 +1,9 @@
-//
-// The ADI JESD204 Core is released under the following license, which is
-// different than all other HDL cores in this repository.
-//
-// Please read this, and understand the freedoms and responsibilities you have
-// by using this source code/core.
-//
-// The JESD204 HDL, is copyright © 2016-2017 Analog Devices Inc.
-//
-// This core is free software, you can use run, copy, study, change, ask
-// questions about and improve this core. Distribution of source, or resulting
-// binaries (including those inside an FPGA or ASIC) require you to release the
-// source of the entire project (excluding the system libraries provide by the
-// tools/compiler/FPGA vendor). These are the terms of the GNU General Public
-// License version 2 as published by the Free Software Foundation.
-//
-// This core  is distributed in the hope that it will be useful, but WITHOUT ANY
-// WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
-// A PARTICULAR PURPOSE. See the GNU General Public License for more details.
-//
-// You should have received a copy of the GNU General Public License version 2
-// along with this source code, and binary.  If not, see
-// <http://www.gnu.org/licenses/>.
-//
-// Commercial licenses (with commercial support) of this JESD204 core are also
-// available under terms different than the General Public License. (e.g. they
-// do not require you to accompany any image (FPGA or ASIC) using the JESD204
-// core with any corresponding source code.) For these alternate terms you must
-// purchase a license from Analog Devices Technology Licensing Office. Users
-// interested in such a license should contact jesd204-licensing@analog.com for
-// more information. This commercial license is sub-licensable (if you purchase
-// chips from Analog Devices, incorporate them into your PCB level product, and
-// purchase a JESD204 license, end users of your product will also have a
-// license to use this core in a commercial setting without releasing their
-// source code).
-//
-// In addition, we kindly ask you to acknowledge ADI in any program, application
-// or publication in which you use this JESD204 HDL core. (You are not required
-// to do so; it is up to your common sense to decide whether you want to comply
-// with this request or not.) For general publications, we suggest referencing :
-// “The design and implementation of the JESD204 HDL Core used in this project
-// is copyright © 2016-2017, Analog Devices, Inc.”
-//
+// ***************************************************************************
+// ***************************************************************************
+// Copyright (C) 2016-2019, 2021-2022 Analog Devices, Inc. All rights reserved.
+// SPDX short identifier: ADIJESD204
+// ***************************************************************************
+// ***************************************************************************
 
 `timescale 1ns/100ps
 

--- a/library/jesd204/axi_jesd204_rx/jesd204_up_rx.v
+++ b/library/jesd204/axi_jesd204_rx/jesd204_up_rx.v
@@ -1,46 +1,9 @@
-//
-// The ADI JESD204 Core is released under the following license, which is
-// different than all other HDL cores in this repository.
-//
-// Please read this, and understand the freedoms and responsibilities you have
-// by using this source code/core.
-//
-// The JESD204 HDL, is copyright © 2016-2017 Analog Devices Inc.
-//
-// This core is free software, you can use run, copy, study, change, ask
-// questions about and improve this core. Distribution of source, or resulting
-// binaries (including those inside an FPGA or ASIC) require you to release the
-// source of the entire project (excluding the system libraries provide by the
-// tools/compiler/FPGA vendor). These are the terms of the GNU General Public
-// License version 2 as published by the Free Software Foundation.
-//
-// This core  is distributed in the hope that it will be useful, but WITHOUT ANY
-// WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
-// A PARTICULAR PURPOSE. See the GNU General Public License for more details.
-//
-// You should have received a copy of the GNU General Public License version 2
-// along with this source code, and binary.  If not, see
-// <http://www.gnu.org/licenses/>.
-//
-// Commercial licenses (with commercial support) of this JESD204 core are also
-// available under terms different than the General Public License. (e.g. they
-// do not require you to accompany any image (FPGA or ASIC) using the JESD204
-// core with any corresponding source code.) For these alternate terms you must
-// purchase a license from Analog Devices Technology Licensing Office. Users
-// interested in such a license should contact jesd204-licensing@analog.com for
-// more information. This commercial license is sub-licensable (if you purchase
-// chips from Analog Devices, incorporate them into your PCB level product, and
-// purchase a JESD204 license, end users of your product will also have a
-// license to use this core in a commercial setting without releasing their
-// source code).
-//
-// In addition, we kindly ask you to acknowledge ADI in any program, application
-// or publication in which you use this JESD204 HDL core. (You are not required
-// to do so; it is up to your common sense to decide whether you want to comply
-// with this request or not.) For general publications, we suggest referencing :
-// “The design and implementation of the JESD204 HDL Core used in this project
-// is copyright © 2016-2017, Analog Devices, Inc.”
-//
+// ***************************************************************************
+// ***************************************************************************
+// Copyright (C) 2016-2018, 2020-2022 Analog Devices, Inc. All rights reserved.
+// SPDX short identifier: ADIJESD204
+// ***************************************************************************
+// ***************************************************************************
 
 `timescale 1ns/100ps
 

--- a/library/jesd204/axi_jesd204_rx/jesd204_up_rx_lane.v
+++ b/library/jesd204/axi_jesd204_rx/jesd204_up_rx_lane.v
@@ -1,46 +1,9 @@
-//
-// The ADI JESD204 Core is released under the following license, which is
-// different than all other HDL cores in this repository.
-//
-// Please read this, and understand the freedoms and responsibilities you have
-// by using this source code/core.
-//
-// The JESD204 HDL, is copyright © 2016-2017 Analog Devices Inc.
-//
-// This core is free software, you can use run, copy, study, change, ask
-// questions about and improve this core. Distribution of source, or resulting
-// binaries (including those inside an FPGA or ASIC) require you to release the
-// source of the entire project (excluding the system libraries provide by the
-// tools/compiler/FPGA vendor). These are the terms of the GNU General Public
-// License version 2 as published by the Free Software Foundation.
-//
-// This core  is distributed in the hope that it will be useful, but WITHOUT ANY
-// WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
-// A PARTICULAR PURPOSE. See the GNU General Public License for more details.
-//
-// You should have received a copy of the GNU General Public License version 2
-// along with this source code, and binary.  If not, see
-// <http://www.gnu.org/licenses/>.
-//
-// Commercial licenses (with commercial support) of this JESD204 core are also
-// available under terms different than the General Public License. (e.g. they
-// do not require you to accompany any image (FPGA or ASIC) using the JESD204
-// core with any corresponding source code.) For these alternate terms you must
-// purchase a license from Analog Devices Technology Licensing Office. Users
-// interested in such a license should contact jesd204-licensing@analog.com for
-// more information. This commercial license is sub-licensable (if you purchase
-// chips from Analog Devices, incorporate them into your PCB level product, and
-// purchase a JESD204 license, end users of your product will also have a
-// license to use this core in a commercial setting without releasing their
-// source code).
-//
-// In addition, we kindly ask you to acknowledge ADI in any program, application
-// or publication in which you use this JESD204 HDL core. (You are not required
-// to do so; it is up to your common sense to decide whether you want to comply
-// with this request or not.) For general publications, we suggest referencing :
-// “The design and implementation of the JESD204 HDL Core used in this project
-// is copyright © 2016-2017, Analog Devices, Inc.”
-//
+// ***************************************************************************
+// ***************************************************************************
+// Copyright (C) 2016-2022 Analog Devices, Inc. All rights reserved.
+// SPDX short identifier: ADIJESD204
+// ***************************************************************************
+// ***************************************************************************
 
 `timescale 1ns/100ps
 

--- a/library/jesd204/axi_jesd204_tx/axi_jesd204_tx.v
+++ b/library/jesd204/axi_jesd204_tx/axi_jesd204_tx.v
@@ -1,46 +1,9 @@
-//
-// The ADI JESD204 Core is released under the following license, which is
-// different than all other HDL cores in this repository.
-//
-// Please read this, and understand the freedoms and responsibilities you have
-// by using this source code/core.
-//
-// The JESD204 HDL, is copyright © 2016-2017 Analog Devices Inc.
-//
-// This core is free software, you can use run, copy, study, change, ask
-// questions about and improve this core. Distribution of source, or resulting
-// binaries (including those inside an FPGA or ASIC) require you to release the
-// source of the entire project (excluding the system libraries provide by the
-// tools/compiler/FPGA vendor). These are the terms of the GNU General Public
-// License version 2 as published by the Free Software Foundation.
-//
-// This core  is distributed in the hope that it will be useful, but WITHOUT ANY
-// WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
-// A PARTICULAR PURPOSE. See the GNU General Public License for more details.
-//
-// You should have received a copy of the GNU General Public License version 2
-// along with this source code, and binary.  If not, see
-// <http://www.gnu.org/licenses/>.
-//
-// Commercial licenses (with commercial support) of this JESD204 core are also
-// available under terms different than the General Public License. (e.g. they
-// do not require you to accompany any image (FPGA or ASIC) using the JESD204
-// core with any corresponding source code.) For these alternate terms you must
-// purchase a license from Analog Devices Technology Licensing Office. Users
-// interested in such a license should contact jesd204-licensing@analog.com for
-// more information. This commercial license is sub-licensable (if you purchase
-// chips from Analog Devices, incorporate them into your PCB level product, and
-// purchase a JESD204 license, end users of your product will also have a
-// license to use this core in a commercial setting without releasing their
-// source code).
-//
-// In addition, we kindly ask you to acknowledge ADI in any program, application
-// or publication in which you use this JESD204 HDL core. (You are not required
-// to do so; it is up to your common sense to decide whether you want to comply
-// with this request or not.) For general publications, we suggest referencing :
-// “The design and implementation of the JESD204 HDL Core used in this project
-// is copyright © 2016-2017, Analog Devices, Inc.”
-//
+// ***************************************************************************
+// ***************************************************************************
+// Copyright (C) 2016-2022 Analog Devices, Inc. All rights reserved.
+// SPDX short identifier: ADIJESD204
+// ***************************************************************************
+// ***************************************************************************
 
 `timescale 1ns/100ps
 

--- a/library/jesd204/axi_jesd204_tx/axi_jesd204_tx_constr.sdc
+++ b/library/jesd204/axi_jesd204_tx/axi_jesd204_tx_constr.sdc
@@ -1,46 +1,7 @@
-#
-# The ADI JESD204 Core is released under the following license, which is
-# different than all other HDL cores in this repository.
-#
-# Please read this, and understand the freedoms and responsibilities you have
-# by using this source code/core.
-#
-# The JESD204 HDL, is copyright © 2016-2017 Analog Devices Inc.
-#
-# This core is free software, you can use run, copy, study, change, ask
-# questions about and improve this core. Distribution of source, or resulting
-# binaries (including those inside an FPGA or ASIC) require you to release the
-# source of the entire project (excluding the system libraries provide by the
-# tools/compiler/FPGA vendor). These are the terms of the GNU General Public
-# License version 2 as published by the Free Software Foundation.
-#
-# This core  is distributed in the hope that it will be useful, but WITHOUT ANY
-# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
-# A PARTICULAR PURPOSE. See the GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License version 2
-# along with this source code, and binary.  If not, see
-# <http://www.gnu.org/licenses/>.
-#
-# Commercial licenses (with commercial support) of this JESD204 core are also
-# available under terms different than the General Public License. (e.g. they
-# do not require you to accompany any image (FPGA or ASIC) using the JESD204
-# core with any corresponding source code.) For these alternate terms you must
-# purchase a license from Analog Devices Technology Licensing Office. Users
-# interested in such a license should contact jesd204-licensing@analog.com for
-# more information. This commercial license is sub-licensable (if you purchase
-# chips from Analog Devices, incorporate them into your PCB level product, and
-# purchase a JESD204 license, end users of your product will also have a
-# license to use this core in a commercial setting without releasing their
-# source code).
-#
-# In addition, we kindly ask you to acknowledge ADI in any program, application
-# or publication in which you use this JESD204 HDL core. (You are not required
-# to do so; it is up to your common sense to decide whether you want to comply
-# with this request or not.) For general publications, we suggest referencing :
-# “The design and implementation of the JESD204 HDL Core used in this project
-# is copyright © 2016-2017, Analog Devices, Inc.”
-#
+###############################################################################
+## Copyright (C) 2016-2018, 2021 Analog Devices, Inc. All rights reserved.
+### SPDX short identifier: ADIJESD204
+###############################################################################
 
 set script_dir [file dirname [info script]]
 

--- a/library/jesd204/axi_jesd204_tx/axi_jesd204_tx_constr.xdc
+++ b/library/jesd204/axi_jesd204_tx/axi_jesd204_tx_constr.xdc
@@ -1,46 +1,7 @@
-#
-# The ADI JESD204 Core is released under the following license, which is
-# different than all other HDL cores in this repository.
-#
-# Please read this, and understand the freedoms and responsibilities you have
-# by using this source code/core.
-#
-# The JESD204 HDL, is copyright © 2016-2017 Analog Devices Inc.
-#
-# This core is free software, you can use run, copy, study, change, ask
-# questions about and improve this core. Distribution of source, or resulting
-# binaries (including those inside an FPGA or ASIC) require you to release the
-# source of the entire project (excluding the system libraries provide by the
-# tools/compiler/FPGA vendor). These are the terms of the GNU General Public
-# License version 2 as published by the Free Software Foundation.
-#
-# This core  is distributed in the hope that it will be useful, but WITHOUT ANY
-# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
-# A PARTICULAR PURPOSE. See the GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License version 2
-# along with this source code, and binary.  If not, see
-# <http://www.gnu.org/licenses/>.
-#
-# Commercial licenses (with commercial support) of this JESD204 core are also
-# available under terms different than the General Public License. (e.g. they
-# do not require you to accompany any image (FPGA or ASIC) using the JESD204
-# core with any corresponding source code.) For these alternate terms you must
-# purchase a license from Analog Devices Technology Licensing Office. Users
-# interested in such a license should contact jesd204-licensing@analog.com for
-# more information. This commercial license is sub-licensable (if you purchase
-# chips from Analog Devices, incorporate them into your PCB level product, and
-# purchase a JESD204 license, end users of your product will also have a
-# license to use this core in a commercial setting without releasing their
-# source code).
-#
-# In addition, we kindly ask you to acknowledge ADI in any program, application
-# or publication in which you use this JESD204 HDL core. (You are not required
-# to do so; it is up to your common sense to decide whether you want to comply
-# with this request or not.) For general publications, we suggest referencing :
-# “The design and implementation of the JESD204 HDL Core used in this project
-# is copyright © 2016-2017, Analog Devices, Inc.”
-#
+###############################################################################
+## Copyright (C) 2017, 2018, 2021 Analog Devices, Inc. All rights reserved.
+### SPDX short identifier: ADIJESD204
+###############################################################################
 
 set axi_clk [get_clocks -of_objects [get_ports s_axi_aclk]]
 set core_clk [get_clocks -of_objects [get_ports core_clk]]

--- a/library/jesd204/axi_jesd204_tx/axi_jesd204_tx_hw.tcl
+++ b/library/jesd204/axi_jesd204_tx/axi_jesd204_tx_hw.tcl
@@ -1,46 +1,7 @@
-#
-# The ADI JESD204 Core is released under the following license, which is
-# different than all other HDL cores in this repository.
-#
-# Please read this, and understand the freedoms and responsibilities you have
-# by using this source code/core.
-#
-# The JESD204 HDL, is copyright © 2016-2017 Analog Devices Inc.
-#
-# This core is free software, you can use run, copy, study, change, ask
-# questions about and improve this core. Distribution of source, or resulting
-# binaries (including those inside an FPGA or ASIC) require you to release the
-# source of the entire project (excluding the system libraries provide by the
-# tools/compiler/FPGA vendor). These are the terms of the GNU General Public
-# License version 2 as published by the Free Software Foundation.
-#
-# This core  is distributed in the hope that it will be useful, but WITHOUT ANY
-# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
-# A PARTICULAR PURPOSE. See the GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License version 2
-# along with this source code, and binary.  If not, see
-# <http://www.gnu.org/licenses/>.
-#
-# Commercial licenses (with commercial support) of this JESD204 core are also
-# available under terms different than the General Public License. (e.g. they
-# do not require you to accompany any image (FPGA or ASIC) using the JESD204
-# core with any corresponding source code.) For these alternate terms you must
-# purchase a license from Analog Devices Technology Licensing Office. Users
-# interested in such a license should contact jesd204-licensing@analog.com for
-# more information. This commercial license is sub-licensable (if you purchase
-# chips from Analog Devices, incorporate them into your PCB level product, and
-# purchase a JESD204 license, end users of your product will also have a
-# license to use this core in a commercial setting without releasing their
-# source code).
-#
-# In addition, we kindly ask you to acknowledge ADI in any program, application
-# or publication in which you use this JESD204 HDL core. (You are not required
-# to do so; it is up to your common sense to decide whether you want to comply
-# with this request or not.) For general publications, we suggest referencing :
-# “The design and implementation of the JESD204 HDL Core used in this project
-# is copyright © 2016-2017, Analog Devices, Inc.”
-#
+###############################################################################
+## Copyright (C) 2016-2019, 2021-2022 Analog Devices, Inc. All rights reserved.
+### SPDX short identifier: ADIJESD204
+###############################################################################
 
 package require qsys 14.0
 

--- a/library/jesd204/axi_jesd204_tx/axi_jesd204_tx_ip.tcl
+++ b/library/jesd204/axi_jesd204_tx/axi_jesd204_tx_ip.tcl
@@ -1,46 +1,7 @@
-#
-# The ADI JESD204 Core is released under the following license, which is
-# different than all other HDL cores in this repository.
-#
-# Please read this, and understand the freedoms and responsibilities you have
-# by using this source code/core.
-#
-# The JESD204 HDL, is copyright © 2016-2017 Analog Devices Inc.
-#
-# This core is free software, you can use run, copy, study, change, ask
-# questions about and improve this core. Distribution of source, or resulting
-# binaries (including those inside an FPGA or ASIC) require you to release the
-# source of the entire project (excluding the system libraries provide by the
-# tools/compiler/FPGA vendor). These are the terms of the GNU General Public
-# License version 2 as published by the Free Software Foundation.
-#
-# This core  is distributed in the hope that it will be useful, but WITHOUT ANY
-# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
-# A PARTICULAR PURPOSE. See the GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License version 2
-# along with this source code, and binary.  If not, see
-# <http://www.gnu.org/licenses/>.
-#
-# Commercial licenses (with commercial support) of this JESD204 core are also
-# available under terms different than the General Public License. (e.g. they
-# do not require you to accompany any image (FPGA or ASIC) using the JESD204
-# core with any corresponding source code.) For these alternate terms you must
-# purchase a license from Analog Devices Technology Licensing Office. Users
-# interested in such a license should contact jesd204-licensing@analog.com for
-# more information. This commercial license is sub-licensable (if you purchase
-# chips from Analog Devices, incorporate them into your PCB level product, and
-# purchase a JESD204 license, end users of your product will also have a
-# license to use this core in a commercial setting without releasing their
-# source code).
-#
-# In addition, we kindly ask you to acknowledge ADI in any program, application
-# or publication in which you use this JESD204 HDL core. (You are not required
-# to do so; it is up to your common sense to decide whether you want to comply
-# with this request or not.) For general publications, we suggest referencing :
-# “The design and implementation of the JESD204 HDL Core used in this project
-# is copyright © 2016-2017, Analog Devices, Inc.”
-#
+###############################################################################
+## Copyright (C) 2017-2023 Analog Devices, Inc. All rights reserved.
+### SPDX short identifier: ADIJESD204
+###############################################################################
 
 source ../../../scripts/adi_env.tcl
 source $ad_hdl_dir/library/scripts/adi_ip_xilinx.tcl

--- a/library/jesd204/axi_jesd204_tx/axi_jesd204_tx_ooc.ttcl
+++ b/library/jesd204/axi_jesd204_tx/axi_jesd204_tx_ooc.ttcl
@@ -1,46 +1,7 @@
-#
-# The ADI JESD204 Core is released under the following license, which is
-# different than all other HDL cores in this repository.
-#
-# Please read this, and understand the freedoms and responsibilities you have
-# by using this source code/core.
-#
-# The JESD204 HDL, is copyright © 2016-2017 Analog Devices Inc.
-#
-# This core is free software, you can use run, copy, study, change, ask
-# questions about and improve this core. Distribution of source, or resulting
-# binaries (including those inside an FPGA or ASIC) require you to release the
-# source of the entire project (excluding the system libraries provide by the
-# tools/compiler/FPGA vendor). These are the terms of the GNU General Public
-# License version 2 as published by the Free Software Foundation.
-#
-# This core  is distributed in the hope that it will be useful, but WITHOUT ANY
-# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
-# A PARTICULAR PURPOSE. See the GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License version 2
-# along with this source code, and binary.  If not, see
-# <http://www.gnu.org/licenses/>.
-#
-# Commercial licenses (with commercial support) of this JESD204 core are also
-# available under terms different than the General Public License. (e.g. they
-# do not require you to accompany any image (FPGA or ASIC) using the JESD204
-# core with any corresponding source code.) For these alternate terms you must
-# purchase a license from Analog Devices Technology Licensing Office. Users
-# interested in such a license should contact jesd204-licensing@analog.com for
-# more information. This commercial license is sub-licensable (if you purchase
-# chips from Analog Devices, incorporate them into your PCB level product, and
-# purchase a JESD204 license, end users of your product will also have a
-# license to use this core in a commercial setting without releasing their
-# source code).
-#
-# In addition, we kindly ask you to acknowledge ADI in any program, application
-# or publication in which you use this JESD204 HDL core. (You are not required
-# to do so; it is up to your common sense to decide whether you want to comply
-# with this request or not.) For general publications, we suggest referencing :
-# “The design and implementation of the JESD204 HDL Core used in this project
-# is copyright © 2016-2017, Analog Devices, Inc.”
-#
+###############################################################################
+## Copyright (C) 2017-2019, 2021 Analog Devices, Inc. All rights reserved.
+### SPDX short identifier: ADIJESD204
+###############################################################################
 
 <: setFileUsedIn { out_of_context synthesis implementation } :>
 <: ;#Component and file information :>

--- a/library/jesd204/axi_jesd204_tx/jesd204_up_tx.v
+++ b/library/jesd204/axi_jesd204_tx/jesd204_up_tx.v
@@ -1,46 +1,9 @@
-//
-// The ADI JESD204 Core is released under the following license, which is
-// different than all other HDL cores in this repository.
-//
-// Please read this, and understand the freedoms and responsibilities you have
-// by using this source code/core.
-//
-// The JESD204 HDL, is copyright © 2016-2017 Analog Devices Inc.
-//
-// This core is free software, you can use run, copy, study, change, ask
-// questions about and improve this core. Distribution of source, or resulting
-// binaries (including those inside an FPGA or ASIC) require you to release the
-// source of the entire project (excluding the system libraries provide by the
-// tools/compiler/FPGA vendor). These are the terms of the GNU General Public
-// License version 2 as published by the Free Software Foundation.
-//
-// This core  is distributed in the hope that it will be useful, but WITHOUT ANY
-// WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
-// A PARTICULAR PURPOSE. See the GNU General Public License for more details.
-//
-// You should have received a copy of the GNU General Public License version 2
-// along with this source code, and binary.  If not, see
-// <http://www.gnu.org/licenses/>.
-//
-// Commercial licenses (with commercial support) of this JESD204 core are also
-// available under terms different than the General Public License. (e.g. they
-// do not require you to accompany any image (FPGA or ASIC) using the JESD204
-// core with any corresponding source code.) For these alternate terms you must
-// purchase a license from Analog Devices Technology Licensing Office. Users
-// interested in such a license should contact jesd204-licensing@analog.com for
-// more information. This commercial license is sub-licensable (if you purchase
-// chips from Analog Devices, incorporate them into your PCB level product, and
-// purchase a JESD204 license, end users of your product will also have a
-// license to use this core in a commercial setting without releasing their
-// source code).
-//
-// In addition, we kindly ask you to acknowledge ADI in any program, application
-// or publication in which you use this JESD204 HDL core. (You are not required
-// to do so; it is up to your common sense to decide whether you want to comply
-// with this request or not.) For general publications, we suggest referencing :
-// “The design and implementation of the JESD204 HDL Core used in this project
-// is copyright © 2016-2017, Analog Devices, Inc.”
-//
+// ***************************************************************************
+// ***************************************************************************
+// Copyright (C) 2017-2022 Analog Devices, Inc. All rights reserved.
+// SPDX short identifier: ADIJESD204
+// ***************************************************************************
+// ***************************************************************************
 
 `timescale 1ns/100ps
 

--- a/library/jesd204/interfaces/interfaces_ip.tcl
+++ b/library/jesd204/interfaces/interfaces_ip.tcl
@@ -1,46 +1,7 @@
-#
-# The ADI JESD204 Core is released under the following license, which is
-# different than all other HDL cores in this repository.
-#
-# Please read this, and understand the freedoms and responsibilities you have
-# by using this source code/core.
-#
-# The JESD204 HDL, is copyright © 2016-2017 Analog Devices Inc.
-#
-# This core is free software, you can use run, copy, study, change, ask
-# questions about and improve this core. Distribution of source, or resulting
-# binaries (including those inside an FPGA or ASIC) require you to release the
-# source of the entire project (excluding the system libraries provide by the
-# tools/compiler/FPGA vendor). These are the terms of the GNU General Public
-# License version 2 as published by the Free Software Foundation.
-#
-# This core  is distributed in the hope that it will be useful, but WITHOUT ANY
-# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
-# A PARTICULAR PURPOSE. See the GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License version 2
-# along with this source code, and binary.  If not, see
-# <http://www.gnu.org/licenses/>.
-#
-# Commercial licenses (with commercial support) of this JESD204 core are also
-# available under terms different than the General Public License. (e.g. they
-# do not require you to accompany any image (FPGA or ASIC) using the JESD204
-# core with any corresponding source code.) For these alternate terms you must
-# purchase a license from Analog Devices Technology Licensing Office. Users
-# interested in such a license should contact jesd204-licensing@analog.com for
-# more information. This commercial license is sub-licensable (if you purchase
-# chips from Analog Devices, incorporate them into your PCB level product, and
-# purchase a JESD204 license, end users of your product will also have a
-# license to use this core in a commercial setting without releasing their
-# source code).
-#
-# In addition, we kindly ask you to acknowledge ADI in any program, application
-# or publication in which you use this JESD204 HDL core. (You are not required
-# to do so; it is up to your common sense to decide whether you want to comply
-# with this request or not.) For general publications, we suggest referencing :
-# “The design and implementation of the JESD204 HDL Core used in this project
-# is copyright © 2016-2017, Analog Devices, Inc.”
-#
+###############################################################################
+## Copyright (C) 2017-2022 Analog Devices, Inc. All rights reserved.
+### SPDX short identifier: ADIJESD204
+###############################################################################
 
 source ../../../scripts/adi_env.tcl
 source $ad_hdl_dir/library/scripts/adi_ip_xilinx.tcl

--- a/library/jesd204/jesd204_common/jesd204_common_ip.tcl
+++ b/library/jesd204/jesd204_common/jesd204_common_ip.tcl
@@ -1,46 +1,7 @@
-#
-# The ADI JESD204 Core is released under the following license, which is
-# different than all other HDL cores in this repository.
-#
-# Please read this, and understand the freedoms and responsibilities you have
-# by using this source code/core.
-#
-# The JESD204 HDL, is copyright © 2016-2017 Analog Devices Inc.
-#
-# This core is free software, you can use run, copy, study, change, ask
-# questions about and improve this core. Distribution of source, or resulting
-# binaries (including those inside an FPGA or ASIC) require you to release the
-# source of the entire project (excluding the system libraries provide by the
-# tools/compiler/FPGA vendor). These are the terms of the GNU General Public
-# License version 2 as published by the Free Software Foundation.
-#
-# This core  is distributed in the hope that it will be useful, but WITHOUT ANY
-# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
-# A PARTICULAR PURPOSE. See the GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License version 2
-# along with this source code, and binary.  If not, see
-# <http://www.gnu.org/licenses/>.
-#
-# Commercial licenses (with commercial support) of this JESD204 core are also
-# available under terms different than the General Public License. (e.g. they
-# do not require you to accompany any image (FPGA or ASIC) using the JESD204
-# core with any corresponding source code.) For these alternate terms you must
-# purchase a license from Analog Devices Technology Licensing Office. Users
-# interested in such a license should contact jesd204-licensing@analog.com for
-# more information. This commercial license is sub-licensable (if you purchase
-# chips from Analog Devices, incorporate them into your PCB level product, and
-# purchase a JESD204 license, end users of your product will also have a
-# license to use this core in a commercial setting without releasing their
-# source code).
-#
-# In addition, we kindly ask you to acknowledge ADI in any program, application
-# or publication in which you use this JESD204 HDL core. (You are not required
-# to do so; it is up to your common sense to decide whether you want to comply
-# with this request or not.) For general publications, we suggest referencing :
-# “The design and implementation of the JESD204 HDL Core used in this project
-# is copyright © 2016-2017, Analog Devices, Inc.”
-#
+###############################################################################
+## Copyright (C) 2017-2023 Analog Devices, Inc. All rights reserved.
+### SPDX short identifier: ADIJESD204
+###############################################################################
 
 source ../../../scripts/adi_env.tcl
 source $ad_hdl_dir/library/scripts/adi_ip_xilinx.tcl

--- a/library/jesd204/jesd204_common/jesd204_crc12.v
+++ b/library/jesd204/jesd204_common/jesd204_crc12.v
@@ -1,46 +1,9 @@
-//
-// The ADI JESD204 Core is released under the following license, which is
-// different than all other HDL cores in this repository.
-//
-// Please read this, and understand the freedoms and responsibilities you have
-// by using this source code/core.
-//
-// The JESD204 HDL, is copyright © 2016-2017 Analog Devices Inc.
-//
-// This core is free software, you can use run, copy, study, change, ask
-// questions about and improve this core. Distribution of source, or resulting
-// binaries (including those inside an FPGA or ASIC) require you to release the
-// source of the entire project (excluding the system libraries provide by the
-// tools/compiler/FPGA vendor). These are the terms of the GNU General Public
-// License version 2 as published by the Free Software Foundation.
-//
-// This core  is distributed in the hope that it will be useful, but WITHOUT ANY
-// WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
-// A PARTICULAR PURPOSE. See the GNU General Public License for more details.
-//
-// You should have received a copy of the GNU General Public License version 2
-// along with this source code, and binary.  If not, see
-// <http://www.gnu.org/licenses/>.
-//
-// Commercial licenses (with commercial support) of this JESD204 core are also
-// available under terms different than the General Public License. (e.g. they
-// do not require you to accompany any image (FPGA or ASIC) using the JESD204
-// core with any corresponding source code.) For these alternate terms you must
-// purchase a license from Analog Devices Technology Licensing Office. Users
-// interested in such a license should contact jesd204-licensing@analog.com for
-// more information. This commercial license is sub-licensable (if you purchase
-// chips from Analog Devices, incorporate them into your PCB level product, and
-// purchase a JESD204 license, end users of your product will also have a
-// license to use this core in a commercial setting without releasing their
-// source code).
-//
-// In addition, we kindly ask you to acknowledge ADI in any program, application
-// or publication in which you use this JESD204 HDL core. (You are not required
-// to do so; it is up to your common sense to decide whether you want to comply
-// with this request or not.) For general publications, we suggest referencing :
-// “The design and implementation of the JESD204 HDL Core used in this project
-// is copyright © 2016-2017, Analog Devices, Inc.”
-//
+// ***************************************************************************
+// ***************************************************************************
+// Copyright (C) 2017, 2018, 2020, 2022 Analog Devices, Inc. All rights reserved.
+// SPDX short identifier: ADIJESD204
+// ***************************************************************************
+// ***************************************************************************
 
 `timescale 1ns/100ps
 

--- a/library/jesd204/jesd204_common/jesd204_eof_generator.v
+++ b/library/jesd204/jesd204_common/jesd204_eof_generator.v
@@ -1,46 +1,9 @@
-//
-// The ADI JESD204 Core is released under the following license, which is
-// different than all other HDL cores in this repository.
-//
-// Please read this, and understand the freedoms and responsibilities you have
-// by using this source code/core.
-//
-// The JESD204 HDL, is copyright © 2016-2017 Analog Devices Inc.
-//
-// This core is free software, you can use run, copy, study, change, ask
-// questions about and improve this core. Distribution of source, or resulting
-// binaries (including those inside an FPGA or ASIC) require you to release the
-// source of the entire project (excluding the system libraries provide by the
-// tools/compiler/FPGA vendor). These are the terms of the GNU General Public
-// License version 2 as published by the Free Software Foundation.
-//
-// This core  is distributed in the hope that it will be useful, but WITHOUT ANY
-// WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
-// A PARTICULAR PURPOSE. See the GNU General Public License for more details.
-//
-// You should have received a copy of the GNU General Public License version 2
-// along with this source code, and binary.  If not, see
-// <http://www.gnu.org/licenses/>.
-//
-// Commercial licenses (with commercial support) of this JESD204 core are also
-// available under terms different than the General Public License. (e.g. they
-// do not require you to accompany any image (FPGA or ASIC) using the JESD204
-// core with any corresponding source code.) For these alternate terms you must
-// purchase a license from Analog Devices Technology Licensing Office. Users
-// interested in such a license should contact jesd204-licensing@analog.com for
-// more information. This commercial license is sub-licensable (if you purchase
-// chips from Analog Devices, incorporate them into your PCB level product, and
-// purchase a JESD204 license, end users of your product will also have a
-// license to use this core in a commercial setting without releasing their
-// source code).
-//
-// In addition, we kindly ask you to acknowledge ADI in any program, application
-// or publication in which you use this JESD204 HDL core. (You are not required
-// to do so; it is up to your common sense to decide whether you want to comply
-// with this request or not.) For general publications, we suggest referencing :
-// “The design and implementation of the JESD204 HDL Core used in this project
-// is copyright © 2016-2017, Analog Devices, Inc.”
-//
+// ***************************************************************************
+// ***************************************************************************
+// Copyright (C) 2017, 2018, 2022 Analog Devices, Inc. All rights reserved.
+// SPDX short identifier: ADIJESD204
+// ***************************************************************************
+// ***************************************************************************
 
 `timescale 1ns/100ps
 

--- a/library/jesd204/jesd204_common/jesd204_frame_align_replace.v
+++ b/library/jesd204/jesd204_common/jesd204_frame_align_replace.v
@@ -1,46 +1,9 @@
-//
-// The ADI JESD204 Core is released under the following license, which is
-// different than all other HDL cores in this repository.
-//
-// Please read this, and understand the freedoms and responsibilities you have
-// by using this source code/core.
-//
-// The JESD204 HDL, is copyright © 2016-2017 Analog Devices Inc.
-//
-// This core is free software, you can use run, copy, study, change, ask
-// questions about and improve this core. Distribution of source, or resulting
-// binaries (including those inside an FPGA or ASIC) require you to release the
-// source of the entire project (excluding the system libraries provide by the
-// tools/compiler/FPGA vendor). These are the terms of the GNU General Public
-// License version 2 as published by the Free Software Foundation.
-//
-// This core  is distributed in the hope that it will be useful, but WITHOUT ANY
-// WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
-// A PARTICULAR PURPOSE. See the GNU General Public License for more details.
-//
-// You should have received a copy of the GNU General Public License version 2
-// along with this source code, and binary.  If not, see
-// <http://www.gnu.org/licenses/>.
-//
-// Commercial licenses (with commercial support) of this JESD204 core are also
-// available under terms different than the General Public License. (e.g. they
-// do not require you to accompany any image (FPGA or ASIC) using the JESD204
-// core with any corresponding source code.) For these alternate terms you must
-// purchase a license from Analog Devices Technology Licensing Office. Users
-// interested in such a license should contact jesd204-licensing@analog.com for
-// more information. This commercial license is sub-licensable (if you purchase
-// chips from Analog Devices, incorporate them into your PCB level product, and
-// purchase a JESD204 license, end users of your product will also have a
-// license to use this core in a commercial setting without releasing their
-// source code).
-//
-// In addition, we kindly ask you to acknowledge ADI in any program, application
-// or publication in which you use this JESD204 HDL core. (You are not required
-// to do so; it is up to your common sense to decide whether you want to comply
-// with this request or not.) For general publications, we suggest referencing :
-// “The design and implementation of the JESD204 HDL Core used in this project
-// is copyright © 2016-2017, Analog Devices, Inc.”
-//
+// ***************************************************************************
+// ***************************************************************************
+// Copyright (C) 2021, 2022 Analog Devices, Inc. All rights reserved.
+// SPDX short identifier: ADIJESD204
+// ***************************************************************************
+// ***************************************************************************
 
 // Limitations:
 //   DATA_PATH_WIDTH = 4, 8

--- a/library/jesd204/jesd204_common/jesd204_frame_mark.v
+++ b/library/jesd204/jesd204_common/jesd204_frame_mark.v
@@ -1,46 +1,9 @@
-//
-// The ADI JESD204 Core is released under the following license, which is
-// different than all other HDL cores in this repository.
-//
-// Please read this, and understand the freedoms and responsibilities you have
-// by using this source code/core.
-//
-// The JESD204 HDL, is copyright © 2016-2017 Analog Devices Inc.
-//
-// This core is free software, you can use run, copy, study, change, ask
-// questions about and improve this core. Distribution of source, or resulting
-// binaries (including those inside an FPGA or ASIC) require you to release the
-// source of the entire project (excluding the system libraries provide by the
-// tools/compiler/FPGA vendor). These are the terms of the GNU General Public
-// License version 2 as published by the Free Software Foundation.
-//
-// This core  is distributed in the hope that it will be useful, but WITHOUT ANY
-// WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
-// A PARTICULAR PURPOSE. See the GNU General Public License for more details.
-//
-// You should have received a copy of the GNU General Public License version 2
-// along with this source code, and binary.  If not, see
-// <http://www.gnu.org/licenses/>.
-//
-// Commercial licenses (with commercial support) of this JESD204 core are also
-// available under terms different than the General Public License. (e.g. they
-// do not require you to accompany any image (FPGA or ASIC) using the JESD204
-// core with any corresponding source code.) For these alternate terms you must
-// purchase a license from Analog Devices Technology Licensing Office. Users
-// interested in such a license should contact jesd204-licensing@analog.com for
-// more information. This commercial license is sub-licensable (if you purchase
-// chips from Analog Devices, incorporate them into your PCB level product, and
-// purchase a JESD204 license, end users of your product will also have a
-// license to use this core in a commercial setting without releasing their
-// source code).
-//
-// In addition, we kindly ask you to acknowledge ADI in any program, application
-// or publication in which you use this JESD204 HDL core. (You are not required
-// to do so; it is up to your common sense to decide whether you want to comply
-// with this request or not.) For general publications, we suggest referencing :
-// “The design and implementation of the JESD204 HDL Core used in this project
-// is copyright © 2016-2017, Analog Devices, Inc.”
-//
+// ***************************************************************************
+// ***************************************************************************
+// Copyright (C) 2020-2022 Analog Devices, Inc. All rights reserved.
+// SPDX short identifier: ADIJESD204
+// ***************************************************************************
+// ***************************************************************************
 
 // Limitations:
 //  for DATA_PATH_WIDTH = 4, 8

--- a/library/jesd204/jesd204_common/jesd204_lmfc.v
+++ b/library/jesd204/jesd204_common/jesd204_lmfc.v
@@ -1,46 +1,9 @@
-//
-// The ADI JESD204 Core is released under the following license, which is
-// different than all other HDL cores in this repository.
-//
-// Please read this, and understand the freedoms and responsibilities you have
-// by using this source code/core.
-//
-// The JESD204 HDL, is copyright © 2016-2017 Analog Devices Inc.
-//
-// This core is free software, you can use run, copy, study, change, ask
-// questions about and improve this core. Distribution of source, or resulting
-// binaries (including those inside an FPGA or ASIC) require you to release the
-// source of the entire project (excluding the system libraries provide by the
-// tools/compiler/FPGA vendor). These are the terms of the GNU General Public
-// License version 2 as published by the Free Software Foundation.
-//
-// This core  is distributed in the hope that it will be useful, but WITHOUT ANY
-// WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
-// A PARTICULAR PURPOSE. See the GNU General Public License for more details.
-//
-// You should have received a copy of the GNU General Public License version 2
-// along with this source code, and binary.  If not, see
-// <http://www.gnu.org/licenses/>.
-//
-// Commercial licenses (with commercial support) of this JESD204 core are also
-// available under terms different than the General Public License. (e.g. they
-// do not require you to accompany any image (FPGA or ASIC) using the JESD204
-// core with any corresponding source code.) For these alternate terms you must
-// purchase a license from Analog Devices Technology Licensing Office. Users
-// interested in such a license should contact jesd204-licensing@analog.com for
-// more information. This commercial license is sub-licensable (if you purchase
-// chips from Analog Devices, incorporate them into your PCB level product, and
-// purchase a JESD204 license, end users of your product will also have a
-// license to use this core in a commercial setting without releasing their
-// source code).
-//
-// In addition, we kindly ask you to acknowledge ADI in any program, application
-// or publication in which you use this JESD204 HDL core. (You are not required
-// to do so; it is up to your common sense to decide whether you want to comply
-// with this request or not.) For general publications, we suggest referencing :
-// “The design and implementation of the JESD204 HDL Core used in this project
-// is copyright © 2016-2017, Analog Devices, Inc.”
-//
+// ***************************************************************************
+// ***************************************************************************
+// Copyright (C) 2017, 2018, 2020-2022 Analog Devices, Inc. All rights reserved.
+// SPDX short identifier: ADIJESD204
+// ***************************************************************************
+// ***************************************************************************
 
 `timescale 1ns/100ps
 

--- a/library/jesd204/jesd204_common/jesd204_scrambler.v
+++ b/library/jesd204/jesd204_common/jesd204_scrambler.v
@@ -1,46 +1,9 @@
-//
-// The ADI JESD204 Core is released under the following license, which is
-// different than all other HDL cores in this repository.
-//
-// Please read this, and understand the freedoms and responsibilities you have
-// by using this source code/core.
-//
-// The JESD204 HDL, is copyright © 2016-2017 Analog Devices Inc.
-//
-// This core is free software, you can use run, copy, study, change, ask
-// questions about and improve this core. Distribution of source, or resulting
-// binaries (including those inside an FPGA or ASIC) require you to release the
-// source of the entire project (excluding the system libraries provide by the
-// tools/compiler/FPGA vendor). These are the terms of the GNU General Public
-// License version 2 as published by the Free Software Foundation.
-//
-// This core  is distributed in the hope that it will be useful, but WITHOUT ANY
-// WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
-// A PARTICULAR PURPOSE. See the GNU General Public License for more details.
-//
-// You should have received a copy of the GNU General Public License version 2
-// along with this source code, and binary.  If not, see
-// <http://www.gnu.org/licenses/>.
-//
-// Commercial licenses (with commercial support) of this JESD204 core are also
-// available under terms different than the General Public License. (e.g. they
-// do not require you to accompany any image (FPGA or ASIC) using the JESD204
-// core with any corresponding source code.) For these alternate terms you must
-// purchase a license from Analog Devices Technology Licensing Office. Users
-// interested in such a license should contact jesd204-licensing@analog.com for
-// more information. This commercial license is sub-licensable (if you purchase
-// chips from Analog Devices, incorporate them into your PCB level product, and
-// purchase a JESD204 license, end users of your product will also have a
-// license to use this core in a commercial setting without releasing their
-// source code).
-//
-// In addition, we kindly ask you to acknowledge ADI in any program, application
-// or publication in which you use this JESD204 HDL core. (You are not required
-// to do so; it is up to your common sense to decide whether you want to comply
-// with this request or not.) For general publications, we suggest referencing :
-// “The design and implementation of the JESD204 HDL Core used in this project
-// is copyright © 2016-2017, Analog Devices, Inc.”
-//
+// ***************************************************************************
+// ***************************************************************************
+// Copyright (C) 2017, 2018, 2020, 2022 Analog Devices, Inc. All rights reserved.
+// SPDX short identifier: ADIJESD204
+// ***************************************************************************
+// ***************************************************************************
 
 `timescale 1ns/100ps
 

--- a/library/jesd204/jesd204_common/jesd204_scrambler_64b.v
+++ b/library/jesd204/jesd204_common/jesd204_scrambler_64b.v
@@ -1,46 +1,9 @@
-//
-// The ADI JESD204 Core is released under the following license, which is
-// different than all other HDL cores in this repository.
-//
-// Please read this, and understand the freedoms and responsibilities you have
-// by using this source code/core.
-//
-// The JESD204 HDL, is copyright © 2016-2017 Analog Devices Inc.
-//
-// This core is free software, you can use run, copy, study, change, ask
-// questions about and improve this core. Distribution of source, or resulting
-// binaries (including those inside an FPGA or ASIC) require you to release the
-// source of the entire project (excluding the system libraries provide by the
-// tools/compiler/FPGA vendor). These are the terms of the GNU General Public
-// License version 2 as published by the Free Software Foundation.
-//
-// This core  is distributed in the hope that it will be useful, but WITHOUT ANY
-// WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
-// A PARTICULAR PURPOSE. See the GNU General Public License for more details.
-//
-// You should have received a copy of the GNU General Public License version 2
-// along with this source code, and binary.  If not, see
-// <http://www.gnu.org/licenses/>.
-//
-// Commercial licenses (with commercial support) of this JESD204 core are also
-// available under terms different than the General Public License. (e.g. they
-// do not require you to accompany any image (FPGA or ASIC) using the JESD204
-// core with any corresponding source code.) For these alternate terms you must
-// purchase a license from Analog Devices Technology Licensing Office. Users
-// interested in such a license should contact jesd204-licensing@analog.com for
-// more information. This commercial license is sub-licensable (if you purchase
-// chips from Analog Devices, incorporate them into your PCB level product, and
-// purchase a JESD204 license, end users of your product will also have a
-// license to use this core in a commercial setting without releasing their
-// source code).
-//
-// In addition, we kindly ask you to acknowledge ADI in any program, application
-// or publication in which you use this JESD204 HDL core. (You are not required
-// to do so; it is up to your common sense to decide whether you want to comply
-// with this request or not.) For general publications, we suggest referencing :
-// “The design and implementation of the JESD204 HDL Core used in this project
-// is copyright © 2016-2017, Analog Devices, Inc.”
-//
+// ***************************************************************************
+// ***************************************************************************
+// Copyright (C) 2017, 2018, 2020, 2022 Analog Devices, Inc. All rights reserved.
+// SPDX short identifier: ADIJESD204
+// ***************************************************************************
+// ***************************************************************************
 
 `timescale 1ns/100ps
 

--- a/library/jesd204/jesd204_common/pipeline_stage.v
+++ b/library/jesd204/jesd204_common/pipeline_stage.v
@@ -1,46 +1,9 @@
-//
-// The ADI JESD204 Core is released under the following license, which is
-// different than all other HDL cores in this repository.
-//
-// Please read this, and understand the freedoms and responsibilities you have
-// by using this source code/core.
-//
-// The JESD204 HDL, is copyright © 2016-2017 Analog Devices Inc.
-//
-// This core is free software, you can use run, copy, study, change, ask
-// questions about and improve this core. Distribution of source, or resulting
-// binaries (including those inside an FPGA or ASIC) require you to release the
-// source of the entire project (excluding the system libraries provide by the
-// tools/compiler/FPGA vendor). These are the terms of the GNU General Public
-// License version 2 as published by the Free Software Foundation.
-//
-// This core  is distributed in the hope that it will be useful, but WITHOUT ANY
-// WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
-// A PARTICULAR PURPOSE. See the GNU General Public License for more details.
-//
-// You should have received a copy of the GNU General Public License version 2
-// along with this source code, and binary.  If not, see
-// <http://www.gnu.org/licenses/>.
-//
-// Commercial licenses (with commercial support) of this JESD204 core are also
-// available under terms different than the General Public License. (e.g. they
-// do not require you to accompany any image (FPGA or ASIC) using the JESD204
-// core with any corresponding source code.) For these alternate terms you must
-// purchase a license from Analog Devices Technology Licensing Office. Users
-// interested in such a license should contact jesd204-licensing@analog.com for
-// more information. This commercial license is sub-licensable (if you purchase
-// chips from Analog Devices, incorporate them into your PCB level product, and
-// purchase a JESD204 license, end users of your product will also have a
-// license to use this core in a commercial setting without releasing their
-// source code).
-//
-// In addition, we kindly ask you to acknowledge ADI in any program, application
-// or publication in which you use this JESD204 HDL core. (You are not required
-// to do so; it is up to your common sense to decide whether you want to comply
-// with this request or not.) For general publications, we suggest referencing :
-// “The design and implementation of the JESD204 HDL Core used in this project
-// is copyright © 2016-2017, Analog Devices, Inc.”
-//
+// ***************************************************************************
+// ***************************************************************************
+// Copyright (C) 2017, 2018, 2020, 2022 Analog Devices, Inc. All rights reserved.
+// SPDX short identifier: ADIJESD204
+// ***************************************************************************
+// ***************************************************************************
 
 `timescale 1ns/100ps
 

--- a/library/jesd204/jesd204_common/sync_header_align.v
+++ b/library/jesd204/jesd204_common/sync_header_align.v
@@ -1,46 +1,9 @@
-//
-// The ADI JESD204 Core is released under the following license, which is
-// different than all other HDL cores in this repository.
-//
-// Please read this, and understand the freedoms and responsibilities you have
-// by using this source code/core.
-//
-// The JESD204 HDL, is copyright © 2016-2017 Analog Devices Inc.
-//
-// This core is free software, you can use run, copy, study, change, ask
-// questions about and improve this core. Distribution of source, or resulting
-// binaries (including those inside an FPGA or ASIC) require you to release the
-// source of the entire project (excluding the system libraries provide by the
-// tools/compiler/FPGA vendor). These are the terms of the GNU General Public
-// License version 2 as published by the Free Software Foundation.
-//
-// This core  is distributed in the hope that it will be useful, but WITHOUT ANY
-// WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
-// A PARTICULAR PURPOSE. See the GNU General Public License for more details.
-//
-// You should have received a copy of the GNU General Public License version 2
-// along with this source code, and binary.  If not, see
-// <http://www.gnu.org/licenses/>.
-//
-// Commercial licenses (with commercial support) of this JESD204 core are also
-// available under terms different than the General Public License. (e.g. they
-// do not require you to accompany any image (FPGA or ASIC) using the JESD204
-// core with any corresponding source code.) For these alternate terms you must
-// purchase a license from Analog Devices Technology Licensing Office. Users
-// interested in such a license should contact jesd204-licensing@analog.com for
-// more information. This commercial license is sub-licensable (if you purchase
-// chips from Analog Devices, incorporate them into your PCB level product, and
-// purchase a JESD204 license, end users of your product will also have a
-// license to use this core in a commercial setting without releasing their
-// source code).
-//
-// In addition, we kindly ask you to acknowledge ADI in any program, application
-// or publication in which you use this JESD204 HDL core. (You are not required
-// to do so; it is up to your common sense to decide whether you want to comply
-// with this request or not.) For general publications, we suggest referencing :
-// The design and implementation of the JESD204 HDL Core used in this project
-// is copyright © 2016-2017, Analog Devices, Inc.
-//
+// ***************************************************************************
+// ***************************************************************************
+// Copyright (C) 2017, 2018, 2021, 2022 Analog Devices, Inc. All rights reserved.
+// SPDX short identifier: ADIJESD204
+// ***************************************************************************
+// ***************************************************************************
 
 `timescale 1ns/100ps
 

--- a/library/jesd204/jesd204_rx/align_mux.v
+++ b/library/jesd204/jesd204_rx/align_mux.v
@@ -1,46 +1,9 @@
-//
-// The ADI JESD204 Core is released under the following license, which is
-// different than all other HDL cores in this repository.
-//
-// Please read this, and understand the freedoms and responsibilities you have
-// by using this source code/core.
-//
-// The JESD204 HDL, is copyright © 2016-2017 Analog Devices Inc.
-//
-// This core is free software, you can use run, copy, study, change, ask
-// questions about and improve this core. Distribution of source, or resulting
-// binaries (including those inside an FPGA or ASIC) require you to release the
-// source of the entire project (excluding the system libraries provide by the
-// tools/compiler/FPGA vendor). These are the terms of the GNU General Public
-// License version 2 as published by the Free Software Foundation.
-//
-// This core  is distributed in the hope that it will be useful, but WITHOUT ANY
-// WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
-// A PARTICULAR PURPOSE. See the GNU General Public License for more details.
-//
-// You should have received a copy of the GNU General Public License version 2
-// along with this source code, and binary.  If not, see
-// <http://www.gnu.org/licenses/>.
-//
-// Commercial licenses (with commercial support) of this JESD204 core are also
-// available under terms different than the General Public License. (e.g. they
-// do not require you to accompany any image (FPGA or ASIC) using the JESD204
-// core with any corresponding source code.) For these alternate terms you must
-// purchase a license from Analog Devices Technology Licensing Office. Users
-// interested in such a license should contact jesd204-licensing@analog.com for
-// more information. This commercial license is sub-licensable (if you purchase
-// chips from Analog Devices, incorporate them into your PCB level product, and
-// purchase a JESD204 license, end users of your product will also have a
-// license to use this core in a commercial setting without releasing their
-// source code).
-//
-// In addition, we kindly ask you to acknowledge ADI in any program, application
-// or publication in which you use this JESD204 HDL core. (You are not required
-// to do so; it is up to your common sense to decide whether you want to comply
-// with this request or not.) For general publications, we suggest referencing :
-// “The design and implementation of the JESD204 HDL Core used in this project
-// is copyright © 2016-2017, Analog Devices, Inc.”
-//
+// ***************************************************************************
+// ***************************************************************************
+// Copyright (C) 2017, 2018, 2021, 2022 Analog Devices, Inc. All rights reserved.
+// SPDX short identifier: ADIJESD204
+// ***************************************************************************
+// ***************************************************************************
 
 `timescale 1ns/100ps
 

--- a/library/jesd204/jesd204_rx/bd/bd.tcl
+++ b/library/jesd204/jesd204_rx/bd/bd.tcl
@@ -1,3 +1,8 @@
+###############################################################################
+## Copyright (C) 2021 Analog Devices, Inc. All rights reserved.
+### SPDX short identifier: ADIJESD204
+###############################################################################
+
 proc init {cellpath otherInfo} {
   set ip [get_bd_cells $cellpath]
 

--- a/library/jesd204/jesd204_rx/elastic_buffer.v
+++ b/library/jesd204/jesd204_rx/elastic_buffer.v
@@ -1,46 +1,9 @@
-//
-// The ADI JESD204 Core is released under the following license, which is
-// different than all other HDL cores in this repository.
-//
-// Please read this, and understand the freedoms and responsibilities you have
-// by using this source code/core.
-//
-// The JESD204 HDL, is copyright © 2016-2017 Analog Devices Inc.
-//
-// This core is free software, you can use run, copy, study, change, ask
-// questions about and improve this core. Distribution of source, or resulting
-// binaries (including those inside an FPGA or ASIC) require you to release the
-// source of the entire project (excluding the system libraries provide by the
-// tools/compiler/FPGA vendor). These are the terms of the GNU General Public
-// License version 2 as published by the Free Software Foundation.
-//
-// This core  is distributed in the hope that it will be useful, but WITHOUT ANY
-// WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
-// A PARTICULAR PURPOSE. See the GNU General Public License for more details.
-//
-// You should have received a copy of the GNU General Public License version 2
-// along with this source code, and binary.  If not, see
-// <http://www.gnu.org/licenses/>.
-//
-// Commercial licenses (with commercial support) of this JESD204 core are also
-// available under terms different than the General Public License. (e.g. they
-// do not require you to accompany any image (FPGA or ASIC) using the JESD204
-// core with any corresponding source code.) For these alternate terms you must
-// purchase a license from Analog Devices Technology Licensing Office. Users
-// interested in such a license should contact jesd204-licensing@analog.com for
-// more information. This commercial license is sub-licensable (if you purchase
-// chips from Analog Devices, incorporate them into your PCB level product, and
-// purchase a JESD204 license, end users of your product will also have a
-// license to use this core in a commercial setting without releasing their
-// source code).
-//
-// In addition, we kindly ask you to acknowledge ADI in any program, application
-// or publication in which you use this JESD204 HDL core. (You are not required
-// to do so; it is up to your common sense to decide whether you want to comply
-// with this request or not.) For general publications, we suggest referencing :
-// “The design and implementation of the JESD204 HDL Core used in this project
-// is copyright © 2016-2017, Analog Devices, Inc.”
-//
+// ***************************************************************************
+// ***************************************************************************
+// Copyright (C) 2017, 2018, 2021, 2022 Analog Devices, Inc. All rights reserved.
+// SPDX short identifier: ADIJESD204
+// ***************************************************************************
+// ***************************************************************************
 
 `timescale 1ns/100ps
 

--- a/library/jesd204/jesd204_rx/error_monitor.v
+++ b/library/jesd204/jesd204_rx/error_monitor.v
@@ -1,46 +1,9 @@
-//
-// The ADI JESD204 Core is released under the following license, which is
-// different than all other HDL cores in this repository.
-//
-// Please read this, and understand the freedoms and responsibilities you have
-// by using this source code/core.
-//
-// The JESD204 HDL, is copyright © 2016-2017 Analog Devices Inc.
-//
-// This core is free software, you can use run, copy, study, change, ask
-// questions about and improve this core. Distribution of source, or resulting
-// binaries (including those inside an FPGA or ASIC) require you to release the
-// source of the entire project (excluding the system libraries provide by the
-// tools/compiler/FPGA vendor). These are the terms of the GNU General Public
-// License version 2 as published by the Free Software Foundation.
-//
-// This core  is distributed in the hope that it will be useful, but WITHOUT ANY
-// WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
-// A PARTICULAR PURPOSE. See the GNU General Public License for more details.
-//
-// You should have received a copy of the GNU General Public License version 2
-// along with this source code, and binary.  If not, see
-// <http://www.gnu.org/licenses/>.
-//
-// Commercial licenses (with commercial support) of this JESD204 core are also
-// available under terms different than the General Public License. (e.g. they
-// do not require you to accompany any image (FPGA or ASIC) using the JESD204
-// core with any corresponding source code.) For these alternate terms you must
-// purchase a license from Analog Devices Technology Licensing Office. Users
-// interested in such a license should contact jesd204-licensing@analog.com for
-// more information. This commercial license is sub-licensable (if you purchase
-// chips from Analog Devices, incorporate them into your PCB level product, and
-// purchase a JESD204 license, end users of your product will also have a
-// license to use this core in a commercial setting without releasing their
-// source code).
-//
-// In addition, we kindly ask you to acknowledge ADI in any program, application
-// or publication in which you use this JESD204 HDL core. (You are not required
-// to do so; it is up to your common sense to decide whether you want to comply
-// with this request or not.) For general publications, we suggest referencing :
-// “The design and implementation of the JESD204 HDL Core used in this project
-// is copyright © 2016-2017, Analog Devices, Inc.”
-//
+// ***************************************************************************
+// ***************************************************************************
+// Copyright (C) 2017, 2018, 2020, 2022 Analog Devices, Inc. All rights reserved.
+// SPDX short identifier: ADIJESD204
+// ***************************************************************************
+// ***************************************************************************
 
 `timescale 1ns/100ps
 

--- a/library/jesd204/jesd204_rx/jesd204_ilas_monitor.v
+++ b/library/jesd204/jesd204_rx/jesd204_ilas_monitor.v
@@ -1,46 +1,9 @@
-//
-// The ADI JESD204 Core is released under the following license, which is
-// different than all other HDL cores in this repository.
-//
-// Please read this, and understand the freedoms and responsibilities you have
-// by using this source code/core.
-//
-// The JESD204 HDL, is copyright © 2016-2017 Analog Devices Inc.
-//
-// This core is free software, you can use run, copy, study, change, ask
-// questions about and improve this core. Distribution of source, or resulting
-// binaries (including those inside an FPGA or ASIC) require you to release the
-// source of the entire project (excluding the system libraries provide by the
-// tools/compiler/FPGA vendor). These are the terms of the GNU General Public
-// License version 2 as published by the Free Software Foundation.
-//
-// This core  is distributed in the hope that it will be useful, but WITHOUT ANY
-// WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
-// A PARTICULAR PURPOSE. See the GNU General Public License for more details.
-//
-// You should have received a copy of the GNU General Public License version 2
-// along with this source code, and binary.  If not, see
-// <http://www.gnu.org/licenses/>.
-//
-// Commercial licenses (with commercial support) of this JESD204 core are also
-// available under terms different than the General Public License. (e.g. they
-// do not require you to accompany any image (FPGA or ASIC) using the JESD204
-// core with any corresponding source code.) For these alternate terms you must
-// purchase a license from Analog Devices Technology Licensing Office. Users
-// interested in such a license should contact jesd204-licensing@analog.com for
-// more information. This commercial license is sub-licensable (if you purchase
-// chips from Analog Devices, incorporate them into your PCB level product, and
-// purchase a JESD204 license, end users of your product will also have a
-// license to use this core in a commercial setting without releasing their
-// source code).
-//
-// In addition, we kindly ask you to acknowledge ADI in any program, application
-// or publication in which you use this JESD204 HDL core. (You are not required
-// to do so; it is up to your common sense to decide whether you want to comply
-// with this request or not.) For general publications, we suggest referencing :
-// “The design and implementation of the JESD204 HDL Core used in this project
-// is copyright © 2016-2017, Analog Devices, Inc.”
-//
+// ***************************************************************************
+// ***************************************************************************
+// Copyright (C) 2017, 2018, 2020-2022 Analog Devices, Inc. All rights reserved.
+// SPDX short identifier: ADIJESD204
+// ***************************************************************************
+// ***************************************************************************
 
 `timescale 1ns/100ps
 

--- a/library/jesd204/jesd204_rx/jesd204_lane_latency_monitor.v
+++ b/library/jesd204/jesd204_rx/jesd204_lane_latency_monitor.v
@@ -1,46 +1,9 @@
-//
-// The ADI JESD204 Core is released under the following license, which is
-// different than all other HDL cores in this repository.
-//
-// Please read this, and understand the freedoms and responsibilities you have
-// by using this source code/core.
-//
-// The JESD204 HDL, is copyright © 2016-2017 Analog Devices Inc.
-//
-// This core is free software, you can use run, copy, study, change, ask
-// questions about and improve this core. Distribution of source, or resulting
-// binaries (including those inside an FPGA or ASIC) require you to release the
-// source of the entire project (excluding the system libraries provide by the
-// tools/compiler/FPGA vendor). These are the terms of the GNU General Public
-// License version 2 as published by the Free Software Foundation.
-//
-// This core  is distributed in the hope that it will be useful, but WITHOUT ANY
-// WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
-// A PARTICULAR PURPOSE. See the GNU General Public License for more details.
-//
-// You should have received a copy of the GNU General Public License version 2
-// along with this source code, and binary.  If not, see
-// <http://www.gnu.org/licenses/>.
-//
-// Commercial licenses (with commercial support) of this JESD204 core are also
-// available under terms different than the General Public License. (e.g. they
-// do not require you to accompany any image (FPGA or ASIC) using the JESD204
-// core with any corresponding source code.) For these alternate terms you must
-// purchase a license from Analog Devices Technology Licensing Office. Users
-// interested in such a license should contact jesd204-licensing@analog.com for
-// more information. This commercial license is sub-licensable (if you purchase
-// chips from Analog Devices, incorporate them into your PCB level product, and
-// purchase a JESD204 license, end users of your product will also have a
-// license to use this core in a commercial setting without releasing their
-// source code).
-//
-// In addition, we kindly ask you to acknowledge ADI in any program, application
-// or publication in which you use this JESD204 HDL core. (You are not required
-// to do so; it is up to your common sense to decide whether you want to comply
-// with this request or not.) For general publications, we suggest referencing :
-// “The design and implementation of the JESD204 HDL Core used in this project
-// is copyright © 2016-2017, Analog Devices, Inc.”
-//
+// ***************************************************************************
+// ***************************************************************************
+// Copyright (C) 2017, 2018, 2021, 2022 Analog Devices, Inc. All rights reserved.
+// SPDX short identifier: ADIJESD204
+// ***************************************************************************
+// ***************************************************************************
 
 `timescale 1ns/100ps
 

--- a/library/jesd204/jesd204_rx/jesd204_rx.v
+++ b/library/jesd204/jesd204_rx/jesd204_rx.v
@@ -1,46 +1,9 @@
-//
-// The ADI JESD204 Core is released under the following license, which is
-// different than all other HDL cores in this repository.
-//
-// Please read this, and understand the freedoms and responsibilities you have
-// by using this source code/core.
-//
-// The JESD204 HDL, is copyright © 2016-2017 Analog Devices Inc.
-//
-// This core is free software, you can use run, copy, study, change, ask
-// questions about and improve this core. Distribution of source, or resulting
-// binaries (including those inside an FPGA or ASIC) require you to release the
-// source of the entire project (excluding the system libraries provide by the
-// tools/compiler/FPGA vendor). These are the terms of the GNU General Public
-// License version 2 as published by the Free Software Foundation.
-//
-// This core  is distributed in the hope that it will be useful, but WITHOUT ANY
-// WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
-// A PARTICULAR PURPOSE. See the GNU General Public License for more details.
-//
-// You should have received a copy of the GNU General Public License version 2
-// along with this source code, and binary.  If not, see
-// <http://www.gnu.org/licenses/>.
-//
-// Commercial licenses (with commercial support) of this JESD204 core are also
-// available under terms different than the General Public License. (e.g. they
-// do not require you to accompany any image (FPGA or ASIC) using the JESD204
-// core with any corresponding source code.) For these alternate terms you must
-// purchase a license from Analog Devices Technology Licensing Office. Users
-// interested in such a license should contact jesd204-licensing@analog.com for
-// more information. This commercial license is sub-licensable (if you purchase
-// chips from Analog Devices, incorporate them into your PCB level product, and
-// purchase a JESD204 license, end users of your product will also have a
-// license to use this core in a commercial setting without releasing their
-// source code).
-//
-// In addition, we kindly ask you to acknowledge ADI in any program, application
-// or publication in which you use this JESD204 HDL core. (You are not required
-// to do so; it is up to your common sense to decide whether you want to comply
-// with this request or not.) For general publications, we suggest referencing :
-// “The design and implementation of the JESD204 HDL Core used in this project
-// is copyright © 2016-2017, Analog Devices, Inc.”
-//
+// ***************************************************************************
+// ***************************************************************************
+// Copyright (C) 2017-2022 Analog Devices, Inc. All rights reserved.
+// SPDX short identifier: ADIJESD204
+// ***************************************************************************
+// ***************************************************************************
 
 `timescale 1ns/100ps
 

--- a/library/jesd204/jesd204_rx/jesd204_rx_cgs.v
+++ b/library/jesd204/jesd204_rx/jesd204_rx_cgs.v
@@ -1,46 +1,9 @@
-//
-// The ADI JESD204 Core is released under the following license, which is
-// different than all other HDL cores in this repository.
-//
-// Please read this, and understand the freedoms and responsibilities you have
-// by using this source code/core.
-//
-// The JESD204 HDL, is copyright © 2016-2017 Analog Devices Inc.
-//
-// This core is free software, you can use run, copy, study, change, ask
-// questions about and improve this core. Distribution of source, or resulting
-// binaries (including those inside an FPGA or ASIC) require you to release the
-// source of the entire project (excluding the system libraries provide by the
-// tools/compiler/FPGA vendor). These are the terms of the GNU General Public
-// License version 2 as published by the Free Software Foundation.
-//
-// This core  is distributed in the hope that it will be useful, but WITHOUT ANY
-// WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
-// A PARTICULAR PURPOSE. See the GNU General Public License for more details.
-//
-// You should have received a copy of the GNU General Public License version 2
-// along with this source code, and binary.  If not, see
-// <http://www.gnu.org/licenses/>.
-//
-// Commercial licenses (with commercial support) of this JESD204 core are also
-// available under terms different than the General Public License. (e.g. they
-// do not require you to accompany any image (FPGA or ASIC) using the JESD204
-// core with any corresponding source code.) For these alternate terms you must
-// purchase a license from Analog Devices Technology Licensing Office. Users
-// interested in such a license should contact jesd204-licensing@analog.com for
-// more information. This commercial license is sub-licensable (if you purchase
-// chips from Analog Devices, incorporate them into your PCB level product, and
-// purchase a JESD204 license, end users of your product will also have a
-// license to use this core in a commercial setting without releasing their
-// source code).
-//
-// In addition, we kindly ask you to acknowledge ADI in any program, application
-// or publication in which you use this JESD204 HDL core. (You are not required
-// to do so; it is up to your common sense to decide whether you want to comply
-// with this request or not.) For general publications, we suggest referencing :
-// “The design and implementation of the JESD204 HDL Core used in this project
-// is copyright © 2016-2017, Analog Devices, Inc.”
-//
+// ***************************************************************************
+// ***************************************************************************
+// Copyright (C) 2017, 2018, 2022 Analog Devices, Inc. All rights reserved.
+// SPDX short identifier: ADIJESD204
+// ***************************************************************************
+// ***************************************************************************
 
 `timescale 1ns/100ps
 

--- a/library/jesd204/jesd204_rx/jesd204_rx_constr.sdc
+++ b/library/jesd204/jesd204_rx/jesd204_rx_constr.sdc
@@ -1,46 +1,7 @@
-#
-# The ADI JESD204 Core is released under the following license, which is
-# different than all other HDL cores in this repository.
-#
-# Please read this, and understand the freedoms and responsibilities you have
-# by using this source code/core.
-#
-# The JESD204 HDL, is copyright © 2016-2017 Analog Devices Inc.
-#
-# This core is free software, you can use run, copy, study, change, ask
-# questions about and improve this core. Distribution of source, or resulting
-# binaries (including those inside an FPGA or ASIC) require you to release the
-# source of the entire project (excluding the system libraries provide by the
-# tools/compiler/FPGA vendor). These are the terms of the GNU General Public
-# License version 2 as published by the Free Software Foundation.
-#
-# This core  is distributed in the hope that it will be useful, but WITHOUT ANY
-# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
-# A PARTICULAR PURPOSE. See the GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License version 2
-# along with this source code, and binary.  If not, see
-# <http://www.gnu.org/licenses/>.
-#
-# Commercial licenses (with commercial support) of this JESD204 core are also
-# available under terms different than the General Public License. (e.g. they
-# do not require you to accompany any image (FPGA or ASIC) using the JESD204
-# core with any corresponding source code.) For these alternate terms you must
-# purchase a license from Analog Devices Technology Licensing Office. Users
-# interested in such a license should contact jesd204-licensing@analog.com for
-# more information. This commercial license is sub-licensable (if you purchase
-# chips from Analog Devices, incorporate them into your PCB level product, and
-# purchase a JESD204 license, end users of your product will also have a
-# license to use this core in a commercial setting without releasing their
-# source code).
-#
-# In addition, we kindly ask you to acknowledge ADI in any program, application
-# or publication in which you use this JESD204 HDL core. (You are not required
-# to do so; it is up to your common sense to decide whether you want to comply
-# with this request or not.) For general publications, we suggest referencing :
-# “The design and implementation of the JESD204 HDL Core used in this project
-# is copyright © 2016-2017, Analog Devices, Inc.”
-#
+###############################################################################
+## Copyright (C) 2017, 2020, 2021 Analog Devices, Inc. All rights reserved.
+### SPDX short identifier: ADIJESD204
+###############################################################################
 
 set script_dir [file dirname [info script]]
 

--- a/library/jesd204/jesd204_rx/jesd204_rx_constr.ttcl
+++ b/library/jesd204/jesd204_rx/jesd204_rx_constr.ttcl
@@ -1,46 +1,8 @@
-#
-# The ADI JESD204 Core is released under the following license, which is
-# different than all other HDL cores in this repository.
-#
-# Please read this, and understand the freedoms and responsibilities you have
-# by using this source code/core.
-#
-# The JESD204 HDL, is copyright © 2016-2017 Analog Devices Inc.
-#
-# This core is free software, you can use run, copy, study, change, ask
-# questions about and improve this core. Distribution of source, or resulting
-# binaries (including those inside an FPGA or ASIC) require you to release the
-# source of the entire project (excluding the system libraries provide by the
-# tools/compiler/FPGA vendor). These are the terms of the GNU General Public
-# License version 2 as published by the Free Software Foundation.
-#
-# This core  is distributed in the hope that it will be useful, but WITHOUT ANY
-# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
-# A PARTICULAR PURPOSE. See the GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License version 2
-# along with this source code, and binary.  If not, see
-# <http://www.gnu.org/licenses/>.
-#
-# Commercial licenses (with commercial support) of this JESD204 core are also
-# available under terms different than the General Public License. (e.g. they
-# do not require you to accompany any image (FPGA or ASIC) using the JESD204
-# core with any corresponding source code.) For these alternate terms you must
-# purchase a license from Analog Devices Technology Licensing Office. Users
-# interested in such a license should contact jesd204-licensing@analog.com for
-# more information. This commercial license is sub-licensable (if you purchase
-# chips from Analog Devices, incorporate them into your PCB level product, and
-# purchase a JESD204 license, end users of your product will also have a
-# license to use this core in a commercial setting without releasing their
-# source code).
-#
-# In addition, we kindly ask you to acknowledge ADI in any program, application
-# or publication in which you use this JESD204 HDL core. (You are not required
-# to do so; it is up to your common sense to decide whether you want to comply
-# with this request or not.) For general publications, we suggest referencing :
-# “The design and implementation of the JESD204 HDL Core used in this project
-# is copyright © 2016-2017, Analog Devices, Inc.”
-#
+###############################################################################
+## Copyright (C) 2017, 2018, 2021 Analog Devices, Inc. All rights reserved.
+### SPDX short identifier: ADIJESD204
+###############################################################################
+
 <: set ComponentName [getComponentNameString] :>
 <: setOutputDirectory "./" :>
 <: setFileName [ttcl_add $ComponentName "_constr"] :>

--- a/library/jesd204/jesd204_rx/jesd204_rx_ctrl.v
+++ b/library/jesd204/jesd204_rx/jesd204_rx_ctrl.v
@@ -1,46 +1,9 @@
-//
-// The ADI JESD204 Core is released under the following license, which is
-// different than all other HDL cores in this repository.
-//
-// Please read this, and understand the freedoms and responsibilities you have
-// by using this source code/core.
-//
-// The JESD204 HDL, is copyright © 2016-2017 Analog Devices Inc.
-//
-// This core is free software, you can use run, copy, study, change, ask
-// questions about and improve this core. Distribution of source, or resulting
-// binaries (including those inside an FPGA or ASIC) require you to release the
-// source of the entire project (excluding the system libraries provide by the
-// tools/compiler/FPGA vendor). These are the terms of the GNU General Public
-// License version 2 as published by the Free Software Foundation.
-//
-// This core  is distributed in the hope that it will be useful, but WITHOUT ANY
-// WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
-// A PARTICULAR PURPOSE. See the GNU General Public License for more details.
-//
-// You should have received a copy of the GNU General Public License version 2
-// along with this source code, and binary.  If not, see
-// <http://www.gnu.org/licenses/>.
-//
-// Commercial licenses (with commercial support) of this JESD204 core are also
-// available under terms different than the General Public License. (e.g. they
-// do not require you to accompany any image (FPGA or ASIC) using the JESD204
-// core with any corresponding source code.) For these alternate terms you must
-// purchase a license from Analog Devices Technology Licensing Office. Users
-// interested in such a license should contact jesd204-licensing@analog.com for
-// more information. This commercial license is sub-licensable (if you purchase
-// chips from Analog Devices, incorporate them into your PCB level product, and
-// purchase a JESD204 license, end users of your product will also have a
-// license to use this core in a commercial setting without releasing their
-// source code).
-//
-// In addition, we kindly ask you to acknowledge ADI in any program, application
-// or publication in which you use this JESD204 HDL core. (You are not required
-// to do so; it is up to your common sense to decide whether you want to comply
-// with this request or not.) For general publications, we suggest referencing :
-// “The design and implementation of the JESD204 HDL Core used in this project
-// is copyright © 2016-2017, Analog Devices, Inc.”
-//
+// ***************************************************************************
+// ***************************************************************************
+// Copyright (C) 2017, 2018, 2020-2022 Analog Devices, Inc. All rights reserved.
+// SPDX short identifier: ADIJESD204
+// ***************************************************************************
+// ***************************************************************************
 
 `timescale 1ns/100ps
 

--- a/library/jesd204/jesd204_rx/jesd204_rx_ctrl_64b.v
+++ b/library/jesd204/jesd204_rx/jesd204_rx_ctrl_64b.v
@@ -1,46 +1,9 @@
-//
-// The ADI JESD204 Core is released under the following license, which is
-// different than all other HDL cores in this repository.
-//
-// Please read this, and understand the freedoms and responsibilities you have
-// by using this source code/core.
-//
-// The JESD204 HDL, is copyright © 2016-2017 Analog Devices Inc.
-//
-// This core is free software, you can use run, copy, study, change, ask
-// questions about and improve this core. Distribution of source, or resulting
-// binaries (including those inside an FPGA or ASIC) require you to release the
-// source of the entire project (excluding the system libraries provide by the
-// tools/compiler/FPGA vendor). These are the terms of the GNU General Public
-// License version 2 as published by the Free Software Foundation.
-//
-// This core  is distributed in the hope that it will be useful, but WITHOUT ANY
-// WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
-// A PARTICULAR PURPOSE. See the GNU General Public License for more details.
-//
-// You should have received a copy of the GNU General Public License version 2
-// along with this source code, and binary.  If not, see
-// <http://www.gnu.org/licenses/>.
-//
-// Commercial licenses (with commercial support) of this JESD204 core are also
-// available under terms different than the General Public License. (e.g. they
-// do not require you to accompany any image (FPGA or ASIC) using the JESD204
-// core with any corresponding source code.) For these alternate terms you must
-// purchase a license from Analog Devices Technology Licensing Office. Users
-// interested in such a license should contact jesd204-licensing@analog.com for
-// more information. This commercial license is sub-licensable (if you purchase
-// chips from Analog Devices, incorporate them into your PCB level product, and
-// purchase a JESD204 license, end users of your product will also have a
-// license to use this core in a commercial setting without releasing their
-// source code).
-//
-// In addition, we kindly ask you to acknowledge ADI in any program, application
-// or publication in which you use this JESD204 HDL core. (You are not required
-// to do so; it is up to your common sense to decide whether you want to comply
-// with this request or not.) For general publications, we suggest referencing :
-// “The design and implementation of the JESD204 HDL Core used in this project
-// is copyright © 2016-2017, Analog Devices, Inc.”
-//
+// ***************************************************************************
+// ***************************************************************************
+// Copyright (C) 2017, 2018, 2020-2022 Analog Devices, Inc. All rights reserved.
+// SPDX short identifier: ADIJESD204
+// ***************************************************************************
+// ***************************************************************************
 
 `timescale 1ns/100ps
 

--- a/library/jesd204/jesd204_rx/jesd204_rx_frame_align.v
+++ b/library/jesd204/jesd204_rx/jesd204_rx_frame_align.v
@@ -1,46 +1,9 @@
-//
-// The ADI JESD204 Core is released under the following license, which is
-// different than all other HDL cores in this repository.
-//
-// Please read this, and understand the freedoms and responsibilities you have
-// by using this source code/core.
-//
-// The JESD204 HDL, is copyright © 2016-2017 Analog Devices Inc.
-//
-// This core is free software, you can use run, copy, study, change, ask
-// questions about and improve this core. Distribution of source, or resulting
-// binaries (including those inside an FPGA or ASIC) require you to release the
-// source of the entire project (excluding the system libraries provide by the
-// tools/compiler/FPGA vendor). These are the terms of the GNU General Public
-// License version 2 as published by the Free Software Foundation.
-//
-// This core  is distributed in the hope that it will be useful, but WITHOUT ANY
-// WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
-// A PARTICULAR PURPOSE. See the GNU General Public License for more details.
-//
-// You should have received a copy of the GNU General Public License version 2
-// along with this source code, and binary.  If not, see
-// <http://www.gnu.org/licenses/>.
-//
-// Commercial licenses (with commercial support) of this JESD204 core are also
-// available under terms different than the General Public License. (e.g. they
-// do not require you to accompany any image (FPGA or ASIC) using the JESD204
-// core with any corresponding source code.) For these alternate terms you must
-// purchase a license from Analog Devices Technology Licensing Office. Users
-// interested in such a license should contact jesd204-licensing@analog.com for
-// more information. This commercial license is sub-licensable (if you purchase
-// chips from Analog Devices, incorporate them into your PCB level product, and
-// purchase a JESD204 license, end users of your product will also have a
-// license to use this core in a commercial setting without releasing their
-// source code).
-//
-// In addition, we kindly ask you to acknowledge ADI in any program, application
-// or publication in which you use this JESD204 HDL core. (You are not required
-// to do so; it is up to your common sense to decide whether you want to comply
-// with this request or not.) For general publications, we suggest referencing :
-// “The design and implementation of the JESD204 HDL Core used in this project
-// is copyright © 2016-2017, Analog Devices, Inc.”
-//
+// ***************************************************************************
+// ***************************************************************************
+// Copyright (C) 2020-2022 Analog Devices, Inc. All rights reserved.
+// SPDX short identifier: ADIJESD204
+// ***************************************************************************
+// ***************************************************************************
 
 `timescale 1ns/100ps
 

--- a/library/jesd204/jesd204_rx/jesd204_rx_header.v
+++ b/library/jesd204/jesd204_rx/jesd204_rx_header.v
@@ -1,46 +1,9 @@
-//
-// The ADI JESD204 Core is released under the following license, which is
-// different than all other HDL cores in this repository.
-//
-// Please read this, and understand the freedoms and responsibilities you have
-// by using this source code/core.
-//
-// The JESD204 HDL, is copyright © 2016-2017 Analog Devices Inc.
-//
-// This core is free software, you can use run, copy, study, change, ask
-// questions about and improve this core. Distribution of source, or resulting
-// binaries (including those inside an FPGA or ASIC) require you to release the
-// source of the entire project (excluding the system libraries provide by the
-// tools/compiler/FPGA vendor). These are the terms of the GNU General Public
-// License version 2 as published by the Free Software Foundation.
-//
-// This core  is distributed in the hope that it will be useful, but WITHOUT ANY
-// WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
-// A PARTICULAR PURPOSE. See the GNU General Public License for more details.
-//
-// You should have received a copy of the GNU General Public License version 2
-// along with this source code, and binary.  If not, see
-// <http://www.gnu.org/licenses/>.
-//
-// Commercial licenses (with commercial support) of this JESD204 core are also
-// available under terms different than the General Public License. (e.g. they
-// do not require you to accompany any image (FPGA or ASIC) using the JESD204
-// core with any corresponding source code.) For these alternate terms you must
-// purchase a license from Analog Devices Technology Licensing Office. Users
-// interested in such a license should contact jesd204-licensing@analog.com for
-// more information. This commercial license is sub-licensable (if you purchase
-// chips from Analog Devices, incorporate them into your PCB level product, and
-// purchase a JESD204 license, end users of your product will also have a
-// license to use this core in a commercial setting without releasing their
-// source code).
-//
-// In addition, we kindly ask you to acknowledge ADI in any program, application
-// or publication in which you use this JESD204 HDL core. (You are not required
-// to do so; it is up to your common sense to decide whether you want to comply
-// with this request or not.) For general publications, we suggest referencing :
-// “The design and implementation of the JESD204 HDL Core used in this project
-// is copyright © 2016-2017, Analog Devices, Inc.”
-//
+// ***************************************************************************
+// ***************************************************************************
+// Copyright (C) 2020, 2022 Analog Devices, Inc. All rights reserved.
+// SPDX short identifier: ADIJESD204
+// ***************************************************************************
+// ***************************************************************************
 
 `timescale 1ns/100ps
 

--- a/library/jesd204/jesd204_rx/jesd204_rx_hw.tcl
+++ b/library/jesd204/jesd204_rx/jesd204_rx_hw.tcl
@@ -1,46 +1,7 @@
-#
-# The ADI JESD204 Core is released under the following license, which is
-# different than all other HDL cores in this repository.
-#
-# Please read this, and understand the freedoms and responsibilities you have
-# by using this source code/core.
-#
-# The JESD204 HDL, is copyright © 2016-2017 Analog Devices Inc.
-#
-# This core is free software, you can use run, copy, study, change, ask
-# questions about and improve this core. Distribution of source, or resulting
-# binaries (including those inside an FPGA or ASIC) require you to release the
-# source of the entire project (excluding the system libraries provide by the
-# tools/compiler/FPGA vendor). These are the terms of the GNU General Public
-# License version 2 as published by the Free Software Foundation.
-#
-# This core  is distributed in the hope that it will be useful, but WITHOUT ANY
-# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
-# A PARTICULAR PURPOSE. See the GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License version 2
-# along with this source code, and binary.  If not, see
-# <http://www.gnu.org/licenses/>.
-#
-# Commercial licenses (with commercial support) of this JESD204 core are also
-# available under terms different than the General Public License. (e.g. they
-# do not require you to accompany any image (FPGA or ASIC) using the JESD204
-# core with any corresponding source code.) For these alternate terms you must
-# purchase a license from Analog Devices Technology Licensing Office. Users
-# interested in such a license should contact jesd204-licensing@analog.com for
-# more information. This commercial license is sub-licensable (if you purchase
-# chips from Analog Devices, incorporate them into your PCB level product, and
-# purchase a JESD204 license, end users of your product will also have a
-# license to use this core in a commercial setting without releasing their
-# source code).
-#
-# In addition, we kindly ask you to acknowledge ADI in any program, application
-# or publication in which you use this JESD204 HDL core. (You are not required
-# to do so; it is up to your common sense to decide whether you want to comply
-# with this request or not.) For general publications, we suggest referencing :
-# “The design and implementation of the JESD204 HDL Core used in this project
-# is copyright © 2016-2017, Analog Devices, Inc.”
-#
+###############################################################################
+## Copyright (C) 2017-2022 Analog Devices, Inc. All rights reserved.
+### SPDX short identifier: ADIJESD204
+###############################################################################
 
 package require qsys 14.0
 

--- a/library/jesd204/jesd204_rx/jesd204_rx_ip.tcl
+++ b/library/jesd204/jesd204_rx/jesd204_rx_ip.tcl
@@ -1,46 +1,7 @@
-#
-# The ADI JESD204 Core is released under the following license, which is
-# different than all other HDL cores in this repository.
-#
-# Please read this, and understand the freedoms and responsibilities you have
-# by using this source code/core.
-#
-# The JESD204 HDL, is copyright © 2016-2017 Analog Devices Inc.
-#
-# This core is free software, you can use run, copy, study, change, ask
-# questions about and improve this core. Distribution of source, or resulting
-# binaries (including those inside an FPGA or ASIC) require you to release the
-# source of the entire project (excluding the system libraries provide by the
-# tools/compiler/FPGA vendor). These are the terms of the GNU General Public
-# License version 2 as published by the Free Software Foundation.
-#
-# This core  is distributed in the hope that it will be useful, but WITHOUT ANY
-# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
-# A PARTICULAR PURPOSE. See the GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License version 2
-# along with this source code, and binary.  If not, see
-# <http://www.gnu.org/licenses/>.
-#
-# Commercial licenses (with commercial support) of this JESD204 core are also
-# available under terms different than the General Public License. (e.g. they
-# do not require you to accompany any image (FPGA or ASIC) using the JESD204
-# core with any corresponding source code.) For these alternate terms you must
-# purchase a license from Analog Devices Technology Licensing Office. Users
-# interested in such a license should contact jesd204-licensing@analog.com for
-# more information. This commercial license is sub-licensable (if you purchase
-# chips from Analog Devices, incorporate them into your PCB level product, and
-# purchase a JESD204 license, end users of your product will also have a
-# license to use this core in a commercial setting without releasing their
-# source code).
-#
-# In addition, we kindly ask you to acknowledge ADI in any program, application
-# or publication in which you use this JESD204 HDL core. (You are not required
-# to do so; it is up to your common sense to decide whether you want to comply
-# with this request or not.) For general publications, we suggest referencing :
-# “The design and implementation of the JESD204 HDL Core used in this project
-# is copyright © 2016-2017, Analog Devices, Inc.”
-#
+###############################################################################
+## Copyright (C) 2017-2023 Analog Devices, Inc. All rights reserved.
+### SPDX short identifier: ADIJESD204
+###############################################################################
 
 source ../../../scripts/adi_env.tcl
 source $ad_hdl_dir/library/scripts/adi_ip_xilinx.tcl

--- a/library/jesd204/jesd204_rx/jesd204_rx_lane.v
+++ b/library/jesd204/jesd204_rx/jesd204_rx_lane.v
@@ -1,46 +1,9 @@
-//
-// The ADI JESD204 Core is released under the following license, which is
-// different than all other HDL cores in this repository.
-//
-// Please read this, and understand the freedoms and responsibilities you have
-// by using this source code/core.
-//
-// The JESD204 HDL, is copyright © 2016-2017 Analog Devices Inc.
-//
-// This core is free software, you can use run, copy, study, change, ask
-// questions about and improve this core. Distribution of source, or resulting
-// binaries (including those inside an FPGA or ASIC) require you to release the
-// source of the entire project (excluding the system libraries provide by the
-// tools/compiler/FPGA vendor). These are the terms of the GNU General Public
-// License version 2 as published by the Free Software Foundation.
-//
-// This core  is distributed in the hope that it will be useful, but WITHOUT ANY
-// WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
-// A PARTICULAR PURPOSE. See the GNU General Public License for more details.
-//
-// You should have received a copy of the GNU General Public License version 2
-// along with this source code, and binary.  If not, see
-// <http://www.gnu.org/licenses/>.
-//
-// Commercial licenses (with commercial support) of this JESD204 core are also
-// available under terms different than the General Public License. (e.g. they
-// do not require you to accompany any image (FPGA or ASIC) using the JESD204
-// core with any corresponding source code.) For these alternate terms you must
-// purchase a license from Analog Devices Technology Licensing Office. Users
-// interested in such a license should contact jesd204-licensing@analog.com for
-// more information. This commercial license is sub-licensable (if you purchase
-// chips from Analog Devices, incorporate them into your PCB level product, and
-// purchase a JESD204 license, end users of your product will also have a
-// license to use this core in a commercial setting without releasing their
-// source code).
-//
-// In addition, we kindly ask you to acknowledge ADI in any program, application
-// or publication in which you use this JESD204 HDL core. (You are not required
-// to do so; it is up to your common sense to decide whether you want to comply
-// with this request or not.) For general publications, we suggest referencing :
-// “The design and implementation of the JESD204 HDL Core used in this project
-// is copyright © 2016-2017, Analog Devices, Inc.”
-//
+// ***************************************************************************
+// ***************************************************************************
+// Copyright (C) 2017, 2018, 2020-2022 Analog Devices, Inc. All rights reserved.
+// SPDX short identifier: ADIJESD204
+// ***************************************************************************
+// ***************************************************************************
 
 `timescale 1ns/100ps
 

--- a/library/jesd204/jesd204_rx/jesd204_rx_lane_64b.v
+++ b/library/jesd204/jesd204_rx/jesd204_rx_lane_64b.v
@@ -1,46 +1,9 @@
-//
-// The ADI JESD204 Core is released under the following license, which is
-// different than all other HDL cores in this repository.
-//
-// Please read this, and understand the freedoms and responsibilities you have
-// by using this source code/core.
-//
-// The JESD204 HDL, is copyright © 2016-2017 Analog Devices Inc.
-//
-// This core is free software, you can use run, copy, study, change, ask
-// questions about and improve this core. Distribution of source, or resulting
-// binaries (including those inside an FPGA or ASIC) require you to release the
-// source of the entire project (excluding the system libraries provide by the
-// tools/compiler/FPGA vendor). These are the terms of the GNU General Public
-// License version 2 as published by the Free Software Foundation.
-//
-// This core  is distributed in the hope that it will be useful, but WITHOUT ANY
-// WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
-// A PARTICULAR PURPOSE. See the GNU General Public License for more details.
-//
-// You should have received a copy of the GNU General Public License version 2
-// along with this source code, and binary.  If not, see
-// <http://www.gnu.org/licenses/>.
-//
-// Commercial licenses (with commercial support) of this JESD204 core are also
-// available under terms different than the General Public License. (e.g. they
-// do not require you to accompany any image (FPGA or ASIC) using the JESD204
-// core with any corresponding source code.) For these alternate terms you must
-// purchase a license from Analog Devices Technology Licensing Office. Users
-// interested in such a license should contact jesd204-licensing@analog.com for
-// more information. This commercial license is sub-licensable (if you purchase
-// chips from Analog Devices, incorporate them into your PCB level product, and
-// purchase a JESD204 license, end users of your product will also have a
-// license to use this core in a commercial setting without releasing their
-// source code).
-//
-// In addition, we kindly ask you to acknowledge ADI in any program, application
-// or publication in which you use this JESD204 HDL core. (You are not required
-// to do so; it is up to your common sense to decide whether you want to comply
-// with this request or not.) For general publications, we suggest referencing :
-// “The design and implementation of the JESD204 HDL Core used in this project
-// is copyright © 2016-2017, Analog Devices, Inc.”
-//
+// ***************************************************************************
+// ***************************************************************************
+// Copyright (C) 2020-2022 Analog Devices, Inc. All rights reserved.
+// SPDX short identifier: ADIJESD204
+// ***************************************************************************
+// ***************************************************************************
 
 `timescale 1ns/100ps
 

--- a/library/jesd204/jesd204_rx/jesd204_rx_ooc.ttcl
+++ b/library/jesd204/jesd204_rx/jesd204_rx_ooc.ttcl
@@ -1,25 +1,7 @@
-# along with this source code, and binary.  If not, see
-# <http://www.gnu.org/licenses/>.
-#
-# Commercial licenses (with commercial support) of this JESD204 core are also
-# available under terms different than the General Public License. (e.g. they
-# do not require you to accompany any image (FPGA or ASIC) using the JESD204
-# core with any corresponding source code.) For these alternate terms you must
-# purchase a license from Analog Devices Technology Licensing Office. Users
-# interested in such a license should contact jesd204-licensing@analog.com for
-# more information. This commercial license is sub-licensable (if you purchase
-# chips from Analog Devices, incorporate them into your PCB level product, and
-# purchase a JESD204 license, end users of your product will also have a
-# license to use this core in a commercial setting without releasing their
-# source code).
-#
-# In addition, we kindly ask you to acknowledge ADI in any program, application
-# or publication in which you use this JESD204 HDL core. (You are not required
-# to do so; it is up to your common sense to decide whether you want to comply
-# with this request or not.) For general publications, we suggest referencing :
-# “The design and implementation of the JESD204 HDL Core used in this project
-# is copyright © 2016-2017, Analog Devices, Inc.”
-#
+###############################################################################
+## Copyright (C) 2017-2019, 2021 Analog Devices, Inc. All rights reserved.
+### SPDX short identifier: ADIJESD204
+###############################################################################
 
 <: setFileUsedIn { out_of_context synthesis implementation } :>
 <: ;#Component and file information :>

--- a/library/jesd204/jesd204_rx_static_config/jesd204_rx_static_config.v
+++ b/library/jesd204/jesd204_rx_static_config/jesd204_rx_static_config.v
@@ -1,46 +1,9 @@
-//
-// The ADI JESD204 Core is released under the following license, which is
-// different than all other HDL cores in this repository.
-//
-// Please read this, and understand the freedoms and responsibilities you have
-// by using this source code/core.
-//
-// The JESD204 HDL, is copyright © 2016-2017 Analog Devices Inc.
-//
-// This core is free software, you can use run, copy, study, change, ask
-// questions about and improve this core. Distribution of source, or resulting
-// binaries (including those inside an FPGA or ASIC) require you to release the
-// source of the entire project (excluding the system libraries provide by the
-// tools/compiler/FPGA vendor). These are the terms of the GNU General Public
-// License version 2 as published by the Free Software Foundation.
-//
-// This core  is distributed in the hope that it will be useful, but WITHOUT ANY
-// WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
-// A PARTICULAR PURPOSE. See the GNU General Public License for more details.
-//
-// You should have received a copy of the GNU General Public License version 2
-// along with this source code, and binary.  If not, see
-// <http://www.gnu.org/licenses/>.
-//
-// Commercial licenses (with commercial support) of this JESD204 core are also
-// available under terms different than the General Public License. (e.g. they
-// do not require you to accompany any image (FPGA or ASIC) using the JESD204
-// core with any corresponding source code.) For these alternate terms you must
-// purchase a license from Analog Devices Technology Licensing Office. Users
-// interested in such a license should contact jesd204-licensing@analog.com for
-// more information. This commercial license is sub-licensable (if you purchase
-// chips from Analog Devices, incorporate them into your PCB level product, and
-// purchase a JESD204 license, end users of your product will also have a
-// license to use this core in a commercial setting without releasing their
-// source code).
-//
-// In addition, we kindly ask you to acknowledge ADI in any program, application
-// or publication in which you use this JESD204 HDL core. (You are not required
-// to do so; it is up to your common sense to decide whether you want to comply
-// with this request or not.) For general publications, we suggest referencing :
-// “The design and implementation of the JESD204 HDL Core used in this project
-// is copyright © 2016-2017, Analog Devices, Inc.”
-//
+// ***************************************************************************
+// ***************************************************************************
+// Copyright (C) 2017, 2018, 2020-2022 Analog Devices, Inc. All rights reserved.
+// SPDX short identifier: ADIJESD204
+// ***************************************************************************
+// ***************************************************************************
 
 `timescale 1ns/100ps
 

--- a/library/jesd204/jesd204_rx_static_config/jesd204_rx_static_config_ip.tcl
+++ b/library/jesd204/jesd204_rx_static_config/jesd204_rx_static_config_ip.tcl
@@ -1,46 +1,7 @@
-#
-# The ADI JESD204 Core is released under the following license, which is
-# different than all other HDL cores in this repository.
-#
-# Please read this, and understand the freedoms and responsibilities you have
-# by using this source code/core.
-#
-# The JESD204 HDL, is copyright © 2016-2017 Analog Devices Inc.
-#
-# This core is free software, you can use run, copy, study, change, ask
-# questions about and improve this core. Distribution of source, or resulting
-# binaries (including those inside an FPGA or ASIC) require you to release the
-# source of the entire project (excluding the system libraries provide by the
-# tools/compiler/FPGA vendor). These are the terms of the GNU General Public
-# License version 2 as published by the Free Software Foundation.
-#
-# This core  is distributed in the hope that it will be useful, but WITHOUT ANY
-# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
-# A PARTICULAR PURPOSE. See the GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License version 2
-# along with this source code, and binary.  If not, see
-# <http://www.gnu.org/licenses/>.
-#
-# Commercial licenses (with commercial support) of this JESD204 core are also
-# available under terms different than the General Public License. (e.g. they
-# do not require you to accompany any image (FPGA or ASIC) using the JESD204
-# core with any corresponding source code.) For these alternate terms you must
-# purchase a license from Analog Devices Technology Licensing Office. Users
-# interested in such a license should contact jesd204-licensing@analog.com for
-# more information. This commercial license is sub-licensable (if you purchase
-# chips from Analog Devices, incorporate them into your PCB level product, and
-# purchase a JESD204 license, end users of your product will also have a
-# license to use this core in a commercial setting without releasing their
-# source code).
-#
-# In addition, we kindly ask you to acknowledge ADI in any program, application
-# or publication in which you use this JESD204 HDL core. (You are not required
-# to do so; it is up to your common sense to decide whether you want to comply
-# with this request or not.) For general publications, we suggest referencing :
-# “The design and implementation of the JESD204 HDL Core used in this project
-# is copyright © 2016-2017, Analog Devices, Inc.”
-#
+###############################################################################
+## Copyright (C) 2017-2022 Analog Devices, Inc. All rights reserved.
+### SPDX short identifier: ADIJESD204
+###############################################################################
 
 source ../../../scripts/adi_env.tcl
 source $ad_hdl_dir/library/scripts/adi_ip_xilinx.tcl

--- a/library/jesd204/jesd204_soft_pcs_rx/jesd204_8b10b_decoder.v
+++ b/library/jesd204/jesd204_soft_pcs_rx/jesd204_8b10b_decoder.v
@@ -1,46 +1,9 @@
-//
-// The ADI JESD204 Core is released under the following license, which is
-// different than all other HDL cores in this repository.
-//
-// Please read this, and understand the freedoms and responsibilities you have
-// by using this source code/core.
-//
-// The JESD204 HDL, is copyright © 2016-2017 Analog Devices Inc.
-//
-// This core is free software, you can use run, copy, study, change, ask
-// questions about and improve this core. Distribution of source, or resulting
-// binaries (including those inside an FPGA or ASIC) require you to release the
-// source of the entire project (excluding the system libraries provide by the
-// tools/compiler/FPGA vendor). These are the terms of the GNU General Public
-// License version 2 as published by the Free Software Foundation.
-//
-// This core  is distributed in the hope that it will be useful, but WITHOUT ANY
-// WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
-// A PARTICULAR PURPOSE. See the GNU General Public License for more details.
-//
-// You should have received a copy of the GNU General Public License version 2
-// along with this source code, and binary.  If not, see
-// <http://www.gnu.org/licenses/>.
-//
-// Commercial licenses (with commercial support) of this JESD204 core are also
-// available under terms different than the General Public License. (e.g. they
-// do not require you to accompany any image (FPGA or ASIC) using the JESD204
-// core with any corresponding source code.) For these alternate terms you must
-// purchase a license from Analog Devices Technology Licensing Office. Users
-// interested in such a license should contact jesd204-licensing@analog.com for
-// more information. This commercial license is sub-licensable (if you purchase
-// chips from Analog Devices, incorporate them into your PCB level product, and
-// purchase a JESD204 license, end users of your product will also have a
-// license to use this core in a commercial setting without releasing their
-// source code).
-//
-// In addition, we kindly ask you to acknowledge ADI in any program, application
-// or publication in which you use this JESD204 HDL core. (You are not required
-// to do so; it is up to your common sense to decide whether you want to comply
-// with this request or not.) For general publications, we suggest referencing :
-// “The design and implementation of the JESD204 HDL Core used in this project
-// is copyright © 2016-2017, Analog Devices, Inc.”
-//
+// ***************************************************************************
+// ***************************************************************************
+// Copyright (C) 2017, 2018, 2020, 2022 Analog Devices, Inc. All rights reserved.
+// SPDX short identifier: ADIJESD204
+// ***************************************************************************
+// ***************************************************************************
 
 `timescale 1ns/100ps
 

--- a/library/jesd204/jesd204_soft_pcs_rx/jesd204_pattern_align.v
+++ b/library/jesd204/jesd204_soft_pcs_rx/jesd204_pattern_align.v
@@ -1,46 +1,9 @@
-//
-// The ADI JESD204 Core is released under the following license, which is
-// different than all other HDL cores in this repository.
-//
-// Please read this, and understand the freedoms and responsibilities you have
-// by using this source code/core.
-//
-// The JESD204 HDL, is copyright © 2016-2017 Analog Devices Inc.
-//
-// This core is free software, you can use run, copy, study, change, ask
-// questions about and improve this core. Distribution of source, or resulting
-// binaries (including those inside an FPGA or ASIC) require you to release the
-// source of the entire project (excluding the system libraries provide by the
-// tools/compiler/FPGA vendor). These are the terms of the GNU General Public
-// License version 2 as published by the Free Software Foundation.
-//
-// This core  is distributed in the hope that it will be useful, but WITHOUT ANY
-// WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
-// A PARTICULAR PURPOSE. See the GNU General Public License for more details.
-//
-// You should have received a copy of the GNU General Public License version 2
-// along with this source code, and binary.  If not, see
-// <http://www.gnu.org/licenses/>.
-//
-// Commercial licenses (with commercial support) of this JESD204 core are also
-// available under terms different than the General Public License. (e.g. they
-// do not require you to accompany any image (FPGA or ASIC) using the JESD204
-// core with any corresponding source code.) For these alternate terms you must
-// purchase a license from Analog Devices Technology Licensing Office. Users
-// interested in such a license should contact jesd204-licensing@analog.com for
-// more information. This commercial license is sub-licensable (if you purchase
-// chips from Analog Devices, incorporate them into your PCB level product, and
-// purchase a JESD204 license, end users of your product will also have a
-// license to use this core in a commercial setting without releasing their
-// source code).
-//
-// In addition, we kindly ask you to acknowledge ADI in any program, application
-// or publication in which you use this JESD204 HDL core. (You are not required
-// to do so; it is up to your common sense to decide whether you want to comply
-// with this request or not.) For general publications, we suggest referencing :
-// “The design and implementation of the JESD204 HDL Core used in this project
-// is copyright © 2016-2017, Analog Devices, Inc.”
-//
+// ***************************************************************************
+// ***************************************************************************
+// Copyright (C) 2017, 2018, 2020, 2022 Analog Devices, Inc. All rights reserved.
+// SPDX short identifier: ADIJESD204
+// ***************************************************************************
+// ***************************************************************************
 
 `timescale 1ns/100ps
 

--- a/library/jesd204/jesd204_soft_pcs_rx/jesd204_soft_pcs_rx.v
+++ b/library/jesd204/jesd204_soft_pcs_rx/jesd204_soft_pcs_rx.v
@@ -1,46 +1,9 @@
-//
-// The ADI JESD204 Core is released under the following license, which is
-// different than all other HDL cores in this repository.
-//
-// Please read this, and understand the freedoms and responsibilities you have
-// by using this source code/core.
-//
-// The JESD204 HDL, is copyright © 2016-2017 Analog Devices Inc.
-//
-// This core is free software, you can use run, copy, study, change, ask
-// questions about and improve this core. Distribution of source, or resulting
-// binaries (including those inside an FPGA or ASIC) require you to release the
-// source of the entire project (excluding the system libraries provide by the
-// tools/compiler/FPGA vendor). These are the terms of the GNU General Public
-// License version 2 as published by the Free Software Foundation.
-//
-// This core  is distributed in the hope that it will be useful, but WITHOUT ANY
-// WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
-// A PARTICULAR PURPOSE. See the GNU General Public License for more details.
-//
-// You should have received a copy of the GNU General Public License version 2
-// along with this source code, and binary.  If not, see
-// <http://www.gnu.org/licenses/>.
-//
-// Commercial licenses (with commercial support) of this JESD204 core are also
-// available under terms different than the General Public License. (e.g. they
-// do not require you to accompany any image (FPGA or ASIC) using the JESD204
-// core with any corresponding source code.) For these alternate terms you must
-// purchase a license from Analog Devices Technology Licensing Office. Users
-// interested in such a license should contact jesd204-licensing@analog.com for
-// more information. This commercial license is sub-licensable (if you purchase
-// chips from Analog Devices, incorporate them into your PCB level product, and
-// purchase a JESD204 license, end users of your product will also have a
-// license to use this core in a commercial setting without releasing their
-// source code).
-//
-// In addition, we kindly ask you to acknowledge ADI in any program, application
-// or publication in which you use this JESD204 HDL core. (You are not required
-// to do so; it is up to your common sense to decide whether you want to comply
-// with this request or not.) For general publications, we suggest referencing :
-// “The design and implementation of the JESD204 HDL Core used in this project
-// is copyright © 2016-2017, Analog Devices, Inc.”
-//
+// ***************************************************************************
+// ***************************************************************************
+// Copyright (C) 2017, 2018, 2020, 2022 Analog Devices, Inc. All rights reserved.
+// SPDX short identifier: ADIJESD204
+// ***************************************************************************
+// ***************************************************************************
 
 `timescale 1ns/100ps
 

--- a/library/jesd204/jesd204_soft_pcs_rx/jesd204_soft_pcs_rx_hw.tcl
+++ b/library/jesd204/jesd204_soft_pcs_rx/jesd204_soft_pcs_rx_hw.tcl
@@ -1,46 +1,7 @@
-#
-# The ADI JESD204 Core is released under the following license, which is
-# different than all other HDL cores in this repository.
-#
-# Please read this, and understand the freedoms and responsibilities you have
-# by using this source code/core.
-#
-# The JESD204 HDL, is copyright © 2016-2017 Analog Devices Inc.
-#
-# This core is free software, you can use run, copy, study, change, ask
-# questions about and improve this core. Distribution of source, or resulting
-# binaries (including those inside an FPGA or ASIC) require you to release the
-# source of the entire project (excluding the system libraries provide by the
-# tools/compiler/FPGA vendor). These are the terms of the GNU General Public
-# License version 2 as published by the Free Software Foundation.
-#
-# This core  is distributed in the hope that it will be useful, but WITHOUT ANY
-# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
-# A PARTICULAR PURPOSE. See the GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License version 2
-# along with this source code, and binary.  If not, see
-# <http://www.gnu.org/licenses/>.
-#
-# Commercial licenses (with commercial support) of this JESD204 core are also
-# available under terms different than the General Public License. (e.g. they
-# do not require you to accompany any image (FPGA or ASIC) using the JESD204
-# core with any corresponding source code.) For these alternate terms you must
-# purchase a license from Analog Devices Technology Licensing Office. Users
-# interested in such a license should contact jesd204-licensing@analog.com for
-# more information. This commercial license is sub-licensable (if you purchase
-# chips from Analog Devices, incorporate them into your PCB level product, and
-# purchase a JESD204 license, end users of your product will also have a
-# license to use this core in a commercial setting without releasing their
-# source code).
-#
-# In addition, we kindly ask you to acknowledge ADI in any program, application
-# or publication in which you use this JESD204 HDL core. (You are not required
-# to do so; it is up to your common sense to decide whether you want to comply
-# with this request or not.) For general publications, we suggest referencing :
-# “The design and implementation of the JESD204 HDL Core used in this project
-# is copyright © 2016-2017, Analog Devices, Inc.”
-#
+###############################################################################
+## Copyright (C) 2017-2019, 2021, 2022 Analog Devices, Inc. All rights reserved.
+### SPDX short identifier: ADIJESD204
+###############################################################################
 
 package require qsys 14.0
 

--- a/library/jesd204/jesd204_soft_pcs_tx/jesd204_8b10b_encoder.v
+++ b/library/jesd204/jesd204_soft_pcs_tx/jesd204_8b10b_encoder.v
@@ -1,46 +1,9 @@
-//
-// The ADI JESD204 Core is released under the following license, which is
-// different than all other HDL cores in this repository.
-//
-// Please read this, and understand the freedoms and responsibilities you have
-// by using this source code/core.
-//
-// The JESD204 HDL, is copyright © 2016-2017 Analog Devices Inc.
-//
-// This core is free software, you can use run, copy, study, change, ask
-// questions about and improve this core. Distribution of source, or resulting
-// binaries (including those inside an FPGA or ASIC) require you to release the
-// source of the entire project (excluding the system libraries provide by the
-// tools/compiler/FPGA vendor). These are the terms of the GNU General Public
-// License version 2 as published by the Free Software Foundation.
-//
-// This core  is distributed in the hope that it will be useful, but WITHOUT ANY
-// WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
-// A PARTICULAR PURPOSE. See the GNU General Public License for more details.
-//
-// You should have received a copy of the GNU General Public License version 2
-// along with this source code, and binary.  If not, see
-// <http://www.gnu.org/licenses/>.
-//
-// Commercial licenses (with commercial support) of this JESD204 core are also
-// available under terms different than the General Public License. (e.g. they
-// do not require you to accompany any image (FPGA or ASIC) using the JESD204
-// core with any corresponding source code.) For these alternate terms you must
-// purchase a license from Analog Devices Technology Licensing Office. Users
-// interested in such a license should contact jesd204-licensing@analog.com for
-// more information. This commercial license is sub-licensable (if you purchase
-// chips from Analog Devices, incorporate them into your PCB level product, and
-// purchase a JESD204 license, end users of your product will also have a
-// license to use this core in a commercial setting without releasing their
-// source code).
-//
-// In addition, we kindly ask you to acknowledge ADI in any program, application
-// or publication in which you use this JESD204 HDL core. (You are not required
-// to do so; it is up to your common sense to decide whether you want to comply
-// with this request or not.) For general publications, we suggest referencing :
-// “The design and implementation of the JESD204 HDL Core used in this project
-// is copyright © 2016-2017, Analog Devices, Inc.”
-//
+// ***************************************************************************
+// ***************************************************************************
+// Copyright (C) 2017, 2018, 2020, 2022 Analog Devices, Inc. All rights reserved.
+// SPDX short identifier: ADIJESD204
+// ***************************************************************************
+// ***************************************************************************
 
 `timescale 1ns/100ps
 

--- a/library/jesd204/jesd204_soft_pcs_tx/jesd204_soft_pcs_tx.v
+++ b/library/jesd204/jesd204_soft_pcs_tx/jesd204_soft_pcs_tx.v
@@ -1,46 +1,9 @@
-//
-// The ADI JESD204 Core is released under the following license, which is
-// different than all other HDL cores in this repository.
-//
-// Please read this, and understand the freedoms and responsibilities you have
-// by using this source code/core.
-//
-// The JESD204 HDL, is copyright © 2016-2017 Analog Devices Inc.
-//
-// This core is free software, you can use run, copy, study, change, ask
-// questions about and improve this core. Distribution of source, or resulting
-// binaries (including those inside an FPGA or ASIC) require you to release the
-// source of the entire project (excluding the system libraries provide by the
-// tools/compiler/FPGA vendor). These are the terms of the GNU General Public
-// License version 2 as published by the Free Software Foundation.
-//
-// This core  is distributed in the hope that it will be useful, but WITHOUT ANY
-// WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
-// A PARTICULAR PURPOSE. See the GNU General Public License for more details.
-//
-// You should have received a copy of the GNU General Public License version 2
-// along with this source code, and binary.  If not, see
-// <http://www.gnu.org/licenses/>.
-//
-// Commercial licenses (with commercial support) of this JESD204 core are also
-// available under terms different than the General Public License. (e.g. they
-// do not require you to accompany any image (FPGA or ASIC) using the JESD204
-// core with any corresponding source code.) For these alternate terms you must
-// purchase a license from Analog Devices Technology Licensing Office. Users
-// interested in such a license should contact jesd204-licensing@analog.com for
-// more information. This commercial license is sub-licensable (if you purchase
-// chips from Analog Devices, incorporate them into your PCB level product, and
-// purchase a JESD204 license, end users of your product will also have a
-// license to use this core in a commercial setting without releasing their
-// source code).
-//
-// In addition, we kindly ask you to acknowledge ADI in any program, application
-// or publication in which you use this JESD204 HDL core. (You are not required
-// to do so; it is up to your common sense to decide whether you want to comply
-// with this request or not.) For general publications, we suggest referencing :
-// “The design and implementation of the JESD204 HDL Core used in this project
-// is copyright © 2016-2017, Analog Devices, Inc.”
-//
+// ***************************************************************************
+// ***************************************************************************
+// Copyright (C) 2017, 2018, 2022 Analog Devices, Inc. All rights reserved.
+// SPDX short identifier: ADIJESD204
+// ***************************************************************************
+// ***************************************************************************
 
 `timescale 1ns/100ps
 

--- a/library/jesd204/jesd204_soft_pcs_tx/jesd204_soft_pcs_tx_hw.tcl
+++ b/library/jesd204/jesd204_soft_pcs_tx/jesd204_soft_pcs_tx_hw.tcl
@@ -1,46 +1,7 @@
-#
-# The ADI JESD204 Core is released under the following license, which is
-# different than all other HDL cores in this repository.
-#
-# Please read this, and understand the freedoms and responsibilities you have
-# by using this source code/core.
-#
-# The JESD204 HDL, is copyright © 2016-2017 Analog Devices Inc.
-#
-# This core is free software, you can use run, copy, study, change, ask
-# questions about and improve this core. Distribution of source, or resulting
-# binaries (including those inside an FPGA or ASIC) require you to release the
-# source of the entire project (excluding the system libraries provide by the
-# tools/compiler/FPGA vendor). These are the terms of the GNU General Public
-# License version 2 as published by the Free Software Foundation.
-#
-# This core  is distributed in the hope that it will be useful, but WITHOUT ANY
-# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
-# A PARTICULAR PURPOSE. See the GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License version 2
-# along with this source code, and binary.  If not, see
-# <http://www.gnu.org/licenses/>.
-#
-# Commercial licenses (with commercial support) of this JESD204 core are also
-# available under terms different than the General Public License. (e.g. they
-# do not require you to accompany any image (FPGA or ASIC) using the JESD204
-# core with any corresponding source code.) For these alternate terms you must
-# purchase a license from Analog Devices Technology Licensing Office. Users
-# interested in such a license should contact jesd204-licensing@analog.com for
-# more information. This commercial license is sub-licensable (if you purchase
-# chips from Analog Devices, incorporate them into your PCB level product, and
-# purchase a JESD204 license, end users of your product will also have a
-# license to use this core in a commercial setting without releasing their
-# source code).
-#
-# In addition, we kindly ask you to acknowledge ADI in any program, application
-# or publication in which you use this JESD204 HDL core. (You are not required
-# to do so; it is up to your common sense to decide whether you want to comply
-# with this request or not.) For general publications, we suggest referencing :
-# “The design and implementation of the JESD204 HDL Core used in this project
-# is copyright © 2016-2017, Analog Devices, Inc.”
-#
+###############################################################################
+## Copyright (C) 2017-2019, 2021, 2022 Analog Devices, Inc. All rights reserved.
+### SPDX short identifier: ADIJESD204
+###############################################################################
 
 package require qsys 14.0
 

--- a/library/jesd204/jesd204_tx/bd/bd.tcl
+++ b/library/jesd204/jesd204_tx/bd/bd.tcl
@@ -1,3 +1,8 @@
+###############################################################################
+## Copyright (C) 2021 Analog Devices, Inc. All rights reserved.
+### SPDX short identifier: ADIJESD204
+###############################################################################
+
 proc init {cellpath otherInfo} {
   set ip [get_bd_cells $cellpath]
 

--- a/library/jesd204/jesd204_tx/jesd204_tx.v
+++ b/library/jesd204/jesd204_tx/jesd204_tx.v
@@ -1,46 +1,9 @@
-//
-// The ADI JESD204 Core is released under the following license, which is
-// different than all other HDL cores in this repository.
-//
-// Please read this, and understand the freedoms and responsibilities you have
-// by using this source code/core.
-//
-// The JESD204 HDL, is copyright © 2016-2017 Analog Devices Inc.
-//
-// This core is free software, you can use run, copy, study, change, ask
-// questions about and improve this core. Distribution of source, or resulting
-// binaries (including those inside an FPGA or ASIC) require you to release the
-// source of the entire project (excluding the system libraries provide by the
-// tools/compiler/FPGA vendor). These are the terms of the GNU General Public
-// License version 2 as published by the Free Software Foundation.
-//
-// This core  is distributed in the hope that it will be useful, but WITHOUT ANY
-// WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
-// A PARTICULAR PURPOSE. See the GNU General Public License for more details.
-//
-// You should have received a copy of the GNU General Public License version 2
-// along with this source code, and binary.  If not, see
-// <http://www.gnu.org/licenses/>.
-//
-// Commercial licenses (with commercial support) of this JESD204 core are also
-// available under terms different than the General Public License. (e.g. they
-// do not require you to accompany any image (FPGA or ASIC) using the JESD204
-// core with any corresponding source code.) For these alternate terms you must
-// purchase a license from Analog Devices Technology Licensing Office. Users
-// interested in such a license should contact jesd204-licensing@analog.com for
-// more information. This commercial license is sub-licensable (if you purchase
-// chips from Analog Devices, incorporate them into your PCB level product, and
-// purchase a JESD204 license, end users of your product will also have a
-// license to use this core in a commercial setting without releasing their
-// source code).
-//
-// In addition, we kindly ask you to acknowledge ADI in any program, application
-// or publication in which you use this JESD204 HDL core. (You are not required
-// to do so; it is up to your common sense to decide whether you want to comply
-// with this request or not.) For general publications, we suggest referencing :
-// “The design and implementation of the JESD204 HDL Core used in this project
-// is copyright © 2016-2017, Analog Devices, Inc.”
-//
+// ***************************************************************************
+// ***************************************************************************
+// Copyright (C) 2017, 2018, 2020-2022 Analog Devices, Inc. All rights reserved.
+// SPDX short identifier: ADIJESD204
+// ***************************************************************************
+// ***************************************************************************
 
 `timescale 1ns/100ps
 

--- a/library/jesd204/jesd204_tx/jesd204_tx_constr.sdc
+++ b/library/jesd204/jesd204_tx/jesd204_tx_constr.sdc
@@ -1,46 +1,7 @@
-#
-# The ADI JESD204 Core is released under the following license, which is
-# different than all other HDL cores in this repository.
-#
-# Please read this, and understand the freedoms and responsibilities you have
-# by using this source code/core.
-#
-# The JESD204 HDL, is copyright © 2016-2017 Analog Devices Inc.
-#
-# This core is free software, you can use run, copy, study, change, ask
-# questions about and improve this core. Distribution of source, or resulting
-# binaries (including those inside an FPGA or ASIC) require you to release the
-# source of the entire project (excluding the system libraries provide by the
-# tools/compiler/FPGA vendor). These are the terms of the GNU General Public
-# License version 2 as published by the Free Software Foundation.
-#
-# This core  is distributed in the hope that it will be useful, but WITHOUT ANY
-# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
-# A PARTICULAR PURPOSE. See the GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License version 2
-# along with this source code, and binary.  If not, see
-# <http://www.gnu.org/licenses/>.
-#
-# Commercial licenses (with commercial support) of this JESD204 core are also
-# available under terms different than the General Public License. (e.g. they
-# do not require you to accompany any image (FPGA or ASIC) using the JESD204
-# core with any corresponding source code.) For these alternate terms you must
-# purchase a license from Analog Devices Technology Licensing Office. Users
-# interested in such a license should contact jesd204-licensing@analog.com for
-# more information. This commercial license is sub-licensable (if you purchase
-# chips from Analog Devices, incorporate them into your PCB level product, and
-# purchase a JESD204 license, end users of your product will also have a
-# license to use this core in a commercial setting without releasing their
-# source code).
-#
-# In addition, we kindly ask you to acknowledge ADI in any program, application
-# or publication in which you use this JESD204 HDL core. (You are not required
-# to do so; it is up to your common sense to decide whether you want to comply
-# with this request or not.) For general publications, we suggest referencing :
-# “The design and implementation of the JESD204 HDL Core used in this project
-# is copyright © 2016-2017, Analog Devices, Inc.”
-#
+###############################################################################
+## Copyright (C) 2017, 2021 Analog Devices, Inc. All rights reserved.
+### SPDX short identifier: ADIJESD204
+###############################################################################
 
 set script_dir [file dirname [info script]]
 

--- a/library/jesd204/jesd204_tx/jesd204_tx_constr.ttcl
+++ b/library/jesd204/jesd204_tx/jesd204_tx_constr.ttcl
@@ -1,46 +1,8 @@
-#
-# The ADI JESD204 Core is released under the following license, which is
-# different than all other HDL cores in this repository.
-#
-# Please read this, and understand the freedoms and responsibilities you have
-# by using this source code/core.
-#
-# The JESD204 HDL, is copyright © 2016-2017 Analog Devices Inc.
-#
-# This core is free software, you can use run, copy, study, change, ask
-# questions about and improve this core. Distribution of source, or resulting
-# binaries (including those inside an FPGA or ASIC) require you to release the
-# source of the entire project (excluding the system libraries provide by the
-# tools/compiler/FPGA vendor). These are the terms of the GNU General Public
-# License version 2 as published by the Free Software Foundation.
-#
-# This core  is distributed in the hope that it will be useful, but WITHOUT ANY
-# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
-# A PARTICULAR PURPOSE. See the GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License version 2
-# along with this source code, and binary.  If not, see
-# <http://www.gnu.org/licenses/>.
-#
-# Commercial licenses (with commercial support) of this JESD204 core are also
-# available under terms different than the General Public License. (e.g. they
-# do not require you to accompany any image (FPGA or ASIC) using the JESD204
-# core with any corresponding source code.) For these alternate terms you must
-# purchase a license from Analog Devices Technology Licensing Office. Users
-# interested in such a license should contact jesd204-licensing@analog.com for
-# more information. This commercial license is sub-licensable (if you purchase
-# chips from Analog Devices, incorporate them into your PCB level product, and
-# purchase a JESD204 license, end users of your product will also have a
-# license to use this core in a commercial setting without releasing their
-# source code).
-#
-# In addition, we kindly ask you to acknowledge ADI in any program, application
-# or publication in which you use this JESD204 HDL core. (You are not required
-# to do so; it is up to your common sense to decide whether you want to comply
-# with this request or not.) For general publications, we suggest referencing :
-# “The design and implementation of the JESD204 HDL Core used in this project
-# is copyright © 2016-2017, Analog Devices, Inc.”
-#
+###############################################################################
+## Copyright (C) 2017, 2018, 2021 Analog Devices, Inc. All rights reserved.
+### SPDX short identifier: ADIJESD204
+###############################################################################
+
 <: set ComponentName [getComponentNameString] :>
 <: setOutputDirectory "./" :>
 <: setFileName [ttcl_add $ComponentName "_constr"] :>

--- a/library/jesd204/jesd204_tx/jesd204_tx_ctrl.v
+++ b/library/jesd204/jesd204_tx/jesd204_tx_ctrl.v
@@ -1,46 +1,9 @@
-//
-// The ADI JESD204 Core is released under the following license, which is
-// different than all other HDL cores in this repository.
-//
-// Please read this, and understand the freedoms and responsibilities you have
-// by using this source code/core.
-//
-// The JESD204 HDL, is copyright © 2016-2017 Analog Devices Inc.
-//
-// This core is free software, you can use run, copy, study, change, ask
-// questions about and improve this core. Distribution of source, or resulting
-// binaries (including those inside an FPGA or ASIC) require you to release the
-// source of the entire project (excluding the system libraries provide by the
-// tools/compiler/FPGA vendor). These are the terms of the GNU General Public
-// License version 2 as published by the Free Software Foundation.
-//
-// This core  is distributed in the hope that it will be useful, but WITHOUT ANY
-// WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
-// A PARTICULAR PURPOSE. See the GNU General Public License for more details.
-//
-// You should have received a copy of the GNU General Public License version 2
-// along with this source code, and binary.  If not, see
-// <http://www.gnu.org/licenses/>.
-//
-// Commercial licenses (with commercial support) of this JESD204 core are also
-// available under terms different than the General Public License. (e.g. they
-// do not require you to accompany any image (FPGA or ASIC) using the JESD204
-// core with any corresponding source code.) For these alternate terms you must
-// purchase a license from Analog Devices Technology Licensing Office. Users
-// interested in such a license should contact jesd204-licensing@analog.com for
-// more information. This commercial license is sub-licensable (if you purchase
-// chips from Analog Devices, incorporate them into your PCB level product, and
-// purchase a JESD204 license, end users of your product will also have a
-// license to use this core in a commercial setting without releasing their
-// source code).
-//
-// In addition, we kindly ask you to acknowledge ADI in any program, application
-// or publication in which you use this JESD204 HDL core. (You are not required
-// to do so; it is up to your common sense to decide whether you want to comply
-// with this request or not.) For general publications, we suggest referencing :
-// “The design and implementation of the JESD204 HDL Core used in this project
-// is copyright © 2016-2017, Analog Devices, Inc.”
-//
+// ***************************************************************************
+// ***************************************************************************
+// Copyright (C) 2017-2019, 2021, 2022 Analog Devices, Inc. All rights reserved.
+// SPDX short identifier: ADIJESD204
+// ***************************************************************************
+// ***************************************************************************
 
 `timescale 1ns/100ps
 

--- a/library/jesd204/jesd204_tx/jesd204_tx_gearbox.v
+++ b/library/jesd204/jesd204_tx/jesd204_tx_gearbox.v
@@ -1,46 +1,9 @@
-//
-// The ADI JESD204 Core is released under the following license, which is
-// different than all other HDL cores in this repository.
-//
-// Please read this, and understand the freedoms and responsibilities you have
-// by using this source code/core.
-//
-// The JESD204 HDL, is copyright © 2016-2017 Analog Devices Inc.
-//
-// This core is free software, you can use run, copy, study, change, ask
-// questions about and improve this core. Distribution of source, or resulting
-// binaries (including those inside an FPGA or ASIC) require you to release the
-// source of the entire project (excluding the system libraries provide by the
-// tools/compiler/FPGA vendor). These are the terms of the GNU General Public
-// License version 2 as published by the Free Software Foundation.
-//
-// This core  is distributed in the hope that it will be useful, but WITHOUT ANY
-// WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
-// A PARTICULAR PURPOSE. See the GNU General Public License for more details.
-//
-// You should have received a copy of the GNU General Public License version 2
-// along with this source code, and binary.  If not, see
-// <http://www.gnu.org/licenses/>.
-//
-// Commercial licenses (with commercial support) of this JESD204 core are also
-// available under terms different than the General Public License. (e.g. they
-// do not require you to accompany any image (FPGA or ASIC) using the JESD204
-// core with any corresponding source code.) For these alternate terms you must
-// purchase a license from Analog Devices Technology Licensing Office. Users
-// interested in such a license should contact jesd204-licensing@analog.com for
-// more information. This commercial license is sub-licensable (if you purchase
-// chips from Analog Devices, incorporate them into your PCB level product, and
-// purchase a JESD204 license, end users of your product will also have a
-// license to use this core in a commercial setting without releasing their
-// source code).
-//
-// In addition, we kindly ask you to acknowledge ADI in any program, application
-// or publication in which you use this JESD204 HDL core. (You are not required
-// to do so; it is up to your common sense to decide whether you want to comply
-// with this request or not.) For general publications, we suggest referencing :
-// “The design and implementation of the JESD204 HDL Core used in this project
-// is copyright © 2016-2017, Analog Devices, Inc.”
-//
+// ***************************************************************************
+// ***************************************************************************
+// Copyright (C) 2017, 2018, 2021, 2022 Analog Devices, Inc. All rights reserved.
+// SPDX short identifier: ADIJESD204
+// ***************************************************************************
+// ***************************************************************************
 
 `timescale 1ns/100ps
 

--- a/library/jesd204/jesd204_tx/jesd204_tx_header.v
+++ b/library/jesd204/jesd204_tx/jesd204_tx_header.v
@@ -1,46 +1,9 @@
-//
-// The ADI JESD204 Core is released under the following license, which is
-// different than all other HDL cores in this repository.
-//
-// Please read this, and understand the freedoms and responsibilities you have
-// by using this source code/core.
-//
-// The JESD204 HDL, is copyright © 2016-2017 Analog Devices Inc.
-//
-// This core is free software, you can use run, copy, study, change, ask
-// questions about and improve this core. Distribution of source, or resulting
-// binaries (including those inside an FPGA or ASIC) require you to release the
-// source of the entire project (excluding the system libraries provide by the
-// tools/compiler/FPGA vendor). These are the terms of the GNU General Public
-// License version 2 as published by the Free Software Foundation.
-//
-// This core  is distributed in the hope that it will be useful, but WITHOUT ANY
-// WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
-// A PARTICULAR PURPOSE. See the GNU General Public License for more details.
-//
-// You should have received a copy of the GNU General Public License version 2
-// along with this source code, and binary.  If not, see
-// <http://www.gnu.org/licenses/>.
-//
-// Commercial licenses (with commercial support) of this JESD204 core are also
-// available under terms different than the General Public License. (e.g. they
-// do not require you to accompany any image (FPGA or ASIC) using the JESD204
-// core with any corresponding source code.) For these alternate terms you must
-// purchase a license from Analog Devices Technology Licensing Office. Users
-// interested in such a license should contact jesd204-licensing@analog.com for
-// more information. This commercial license is sub-licensable (if you purchase
-// chips from Analog Devices, incorporate them into your PCB level product, and
-// purchase a JESD204 license, end users of your product will also have a
-// license to use this core in a commercial setting without releasing their
-// source code).
-//
-// In addition, we kindly ask you to acknowledge ADI in any program, application
-// or publication in which you use this JESD204 HDL core. (You are not required
-// to do so; it is up to your common sense to decide whether you want to comply
-// with this request or not.) For general publications, we suggest referencing :
-// “The design and implementation of the JESD204 HDL Core used in this project
-// is copyright © 2016-2017, Analog Devices, Inc.”
-//
+// ***************************************************************************
+// ***************************************************************************
+// Copyright (C) 2017, 2018, 2020, 2022 Analog Devices, Inc. All rights reserved.
+// SPDX short identifier: ADIJESD204
+// ***************************************************************************
+// ***************************************************************************
 
 `timescale 1ns/100ps
 

--- a/library/jesd204/jesd204_tx/jesd204_tx_hw.tcl
+++ b/library/jesd204/jesd204_tx/jesd204_tx_hw.tcl
@@ -1,46 +1,7 @@
-#
-# The ADI JESD204 Core is released under the following license, which is
-# different than all other HDL cores in this repository.
-#
-# Please read this, and understand the freedoms and responsibilities you have
-# by using this source code/core.
-#
-# The JESD204 HDL, is copyright © 2016-2017 Analog Devices Inc.
-#
-# This core is free software, you can use run, copy, study, change, ask
-# questions about and improve this core. Distribution of source, or resulting
-# binaries (including those inside an FPGA or ASIC) require you to release the
-# source of the entire project (excluding the system libraries provide by the
-# tools/compiler/FPGA vendor). These are the terms of the GNU General Public
-# License version 2 as published by the Free Software Foundation.
-#
-# This core  is distributed in the hope that it will be useful, but WITHOUT ANY
-# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
-# A PARTICULAR PURPOSE. See the GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License version 2
-# along with this source code, and binary.  If not, see
-# <http://www.gnu.org/licenses/>.
-#
-# Commercial licenses (with commercial support) of this JESD204 core are also
-# available under terms different than the General Public License. (e.g. they
-# do not require you to accompany any image (FPGA or ASIC) using the JESD204
-# core with any corresponding source code.) For these alternate terms you must
-# purchase a license from Analog Devices Technology Licensing Office. Users
-# interested in such a license should contact jesd204-licensing@analog.com for
-# more information. This commercial license is sub-licensable (if you purchase
-# chips from Analog Devices, incorporate them into your PCB level product, and
-# purchase a JESD204 license, end users of your product will also have a
-# license to use this core in a commercial setting without releasing their
-# source code).
-#
-# In addition, we kindly ask you to acknowledge ADI in any program, application
-# or publication in which you use this JESD204 HDL core. (You are not required
-# to do so; it is up to your common sense to decide whether you want to comply
-# with this request or not.) For general publications, we suggest referencing :
-# “The design and implementation of the JESD204 HDL Core used in this project
-# is copyright © 2016-2017, Analog Devices, Inc.”
-#
+###############################################################################
+## Copyright (C) 2017-2022 Analog Devices, Inc. All rights reserved.
+### SPDX short identifier: ADIJESD204
+###############################################################################
 
 package require qsys 14.0
 

--- a/library/jesd204/jesd204_tx/jesd204_tx_ip.tcl
+++ b/library/jesd204/jesd204_tx/jesd204_tx_ip.tcl
@@ -1,46 +1,7 @@
-#
-# The ADI JESD204 Core is released under the following license, which is
-# different than all other HDL cores in this repository.
-#
-# Please read this, and understand the freedoms and responsibilities you have
-# by using this source code/core.
-#
-# The JESD204 HDL, is copyright © 2016-2017 Analog Devices Inc.
-#
-# This core is free software, you can use run, copy, study, change, ask
-# questions about and improve this core. Distribution of source, or resulting
-# binaries (including those inside an FPGA or ASIC) require you to release the
-# source of the entire project (excluding the system libraries provide by the
-# tools/compiler/FPGA vendor). These are the terms of the GNU General Public
-# License version 2 as published by the Free Software Foundation.
-#
-# This core  is distributed in the hope that it will be useful, but WITHOUT ANY
-# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
-# A PARTICULAR PURPOSE. See the GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License version 2
-# along with this source code, and binary.  If not, see
-# <http://www.gnu.org/licenses/>.
-#
-# Commercial licenses (with commercial support) of this JESD204 core are also
-# available under terms different than the General Public License. (e.g. they
-# do not require you to accompany any image (FPGA or ASIC) using the JESD204
-# core with any corresponding source code.) For these alternate terms you must
-# purchase a license from Analog Devices Technology Licensing Office. Users
-# interested in such a license should contact jesd204-licensing@analog.com for
-# more information. This commercial license is sub-licensable (if you purchase
-# chips from Analog Devices, incorporate them into your PCB level product, and
-# purchase a JESD204 license, end users of your product will also have a
-# license to use this core in a commercial setting without releasing their
-# source code).
-#
-# In addition, we kindly ask you to acknowledge ADI in any program, application
-# or publication in which you use this JESD204 HDL core. (You are not required
-# to do so; it is up to your common sense to decide whether you want to comply
-# with this request or not.) For general publications, we suggest referencing :
-# “The design and implementation of the JESD204 HDL Core used in this project
-# is copyright © 2016-2017, Analog Devices, Inc.”
-#
+###############################################################################
+## Copyright (C) 2017-2023 Analog Devices, Inc. All rights reserved.
+### SPDX short identifier: ADIJESD204
+###############################################################################
 
 source ../../../scripts/adi_env.tcl
 source $ad_hdl_dir/library/scripts/adi_ip_xilinx.tcl

--- a/library/jesd204/jesd204_tx/jesd204_tx_lane.v
+++ b/library/jesd204/jesd204_tx/jesd204_tx_lane.v
@@ -1,46 +1,9 @@
-//
-// The ADI JESD204 Core is released under the following license, which is
-// different than all other HDL cores in this repository.
-//
-// Please read this, and understand the freedoms and responsibilities you have
-// by using this source code/core.
-//
-// The JESD204 HDL, is copyright © 2016-2017 Analog Devices Inc.
-//
-// This core is free software, you can use run, copy, study, change, ask
-// questions about and improve this core. Distribution of source, or resulting
-// binaries (including those inside an FPGA or ASIC) require you to release the
-// source of the entire project (excluding the system libraries provide by the
-// tools/compiler/FPGA vendor). These are the terms of the GNU General Public
-// License version 2 as published by the Free Software Foundation.
-//
-// This core  is distributed in the hope that it will be useful, but WITHOUT ANY
-// WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
-// A PARTICULAR PURPOSE. See the GNU General Public License for more details.
-//
-// You should have received a copy of the GNU General Public License version 2
-// along with this source code, and binary.  If not, see
-// <http://www.gnu.org/licenses/>.
-//
-// Commercial licenses (with commercial support) of this JESD204 core are also
-// available under terms different than the General Public License. (e.g. they
-// do not require you to accompany any image (FPGA or ASIC) using the JESD204
-// core with any corresponding source code.) For these alternate terms you must
-// purchase a license from Analog Devices Technology Licensing Office. Users
-// interested in such a license should contact jesd204-licensing@analog.com for
-// more information. This commercial license is sub-licensable (if you purchase
-// chips from Analog Devices, incorporate them into your PCB level product, and
-// purchase a JESD204 license, end users of your product will also have a
-// license to use this core in a commercial setting without releasing their
-// source code).
-//
-// In addition, we kindly ask you to acknowledge ADI in any program, application
-// or publication in which you use this JESD204 HDL core. (You are not required
-// to do so; it is up to your common sense to decide whether you want to comply
-// with this request or not.) For general publications, we suggest referencing :
-// “The design and implementation of the JESD204 HDL Core used in this project
-// is copyright © 2016-2017, Analog Devices, Inc.”
-//
+// ***************************************************************************
+// ***************************************************************************
+// Copyright (C) 2017, 2018, 2020-2022 Analog Devices, Inc. All rights reserved.
+// SPDX short identifier: ADIJESD204
+// ***************************************************************************
+// ***************************************************************************
 
 `timescale 1ns/100ps
 

--- a/library/jesd204/jesd204_tx/jesd204_tx_lane_64b.v
+++ b/library/jesd204/jesd204_tx/jesd204_tx_lane_64b.v
@@ -1,46 +1,9 @@
-//
-// The ADI JESD204 Core is released under the following license, which is
-// different than all other HDL cores in this repository.
-//
-// Please read this, and understand the freedoms and responsibilities you have
-// by using this source code/core.
-//
-// The JESD204 HDL, is copyright © 2016-2017 Analog Devices Inc.
-//
-// This core is free software, you can use run, copy, study, change, ask
-// questions about and improve this core. Distribution of source, or resulting
-// binaries (including those inside an FPGA or ASIC) require you to release the
-// source of the entire project (excluding the system libraries provide by the
-// tools/compiler/FPGA vendor). These are the terms of the GNU General Public
-// License version 2 as published by the Free Software Foundation.
-//
-// This core  is distributed in the hope that it will be useful, but WITHOUT ANY
-// WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
-// A PARTICULAR PURPOSE. See the GNU General Public License for more details.
-//
-// You should have received a copy of the GNU General Public License version 2
-// along with this source code, and binary.  If not, see
-// <http://www.gnu.org/licenses/>.
-//
-// Commercial licenses (with commercial support) of this JESD204 core are also
-// available under terms different than the General Public License. (e.g. they
-// do not require you to accompany any image (FPGA or ASIC) using the JESD204
-// core with any corresponding source code.) For these alternate terms you must
-// purchase a license from Analog Devices Technology Licensing Office. Users
-// interested in such a license should contact jesd204-licensing@analog.com for
-// more information. This commercial license is sub-licensable (if you purchase
-// chips from Analog Devices, incorporate them into your PCB level product, and
-// purchase a JESD204 license, end users of your product will also have a
-// license to use this core in a commercial setting without releasing their
-// source code).
-//
-// In addition, we kindly ask you to acknowledge ADI in any program, application
-// or publication in which you use this JESD204 HDL core. (You are not required
-// to do so; it is up to your common sense to decide whether you want to comply
-// with this request or not.) For general publications, we suggest referencing :
-// “The design and implementation of the JESD204 HDL Core used in this project
-// is copyright © 2016-2017, Analog Devices, Inc.”
-//
+// ***************************************************************************
+// ***************************************************************************
+// Copyright (C) 2017, 2018, 2020-2022 Analog Devices, Inc. All rights reserved.
+// SPDX short identifier: ADIJESD204
+// ***************************************************************************
+// ***************************************************************************
 
 `timescale 1ns/100ps
 

--- a/library/jesd204/jesd204_tx/jesd204_tx_ooc.ttcl
+++ b/library/jesd204/jesd204_tx/jesd204_tx_ooc.ttcl
@@ -1,25 +1,7 @@
-# along with this source code, and binary.  If not, see
-# <http://www.gnu.org/licenses/>.
-#
-# Commercial licenses (with commercial support) of this JESD204 core are also
-# available under terms different than the General Public License. (e.g. they
-# do not require you to accompany any image (FPGA or ASIC) using the JESD204
-# core with any corresponding source code.) For these alternate terms you must
-# purchase a license from Analog Devices Technology Licensing Office. Users
-# interested in such a license should contact jesd204-licensing@analog.com for
-# more information. This commercial license is sub-licensable (if you purchase
-# chips from Analog Devices, incorporate them into your PCB level product, and
-# purchase a JESD204 license, end users of your product will also have a
-# license to use this core in a commercial setting without releasing their
-# source code).
-#
-# In addition, we kindly ask you to acknowledge ADI in any program, application
-# or publication in which you use this JESD204 HDL core. (You are not required
-# to do so; it is up to your common sense to decide whether you want to comply
-# with this request or not.) For general publications, we suggest referencing :
-# “The design and implementation of the JESD204 HDL Core used in this project
-# is copyright © 2016-2017, Analog Devices, Inc.”
-#
+###############################################################################
+## Copyright (C) 2017-2019, 2021 Analog Devices, Inc. All rights reserved.
+### SPDX short identifier: ADIJESD204
+###############################################################################
 
 <: setFileUsedIn { out_of_context synthesis implementation } :>
 <: ;#Component and file information :>

--- a/library/jesd204/jesd204_tx_static_config/jesd204_ilas_cfg_static.v
+++ b/library/jesd204/jesd204_tx_static_config/jesd204_ilas_cfg_static.v
@@ -1,46 +1,9 @@
-//
-// The ADI JESD204 Core is released under the following license, which is
-// different than all other HDL cores in this repository.
-//
-// Please read this, and understand the freedoms and responsibilities you have
-// by using this source code/core.
-//
-// The JESD204 HDL, is copyright © 2016-2017 Analog Devices Inc.
-//
-// This core is free software, you can use run, copy, study, change, ask
-// questions about and improve this core. Distribution of source, or resulting
-// binaries (including those inside an FPGA or ASIC) require you to release the
-// source of the entire project (excluding the system libraries provide by the
-// tools/compiler/FPGA vendor). These are the terms of the GNU General Public
-// License version 2 as published by the Free Software Foundation.
-//
-// This core  is distributed in the hope that it will be useful, but WITHOUT ANY
-// WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
-// A PARTICULAR PURPOSE. See the GNU General Public License for more details.
-//
-// You should have received a copy of the GNU General Public License version 2
-// along with this source code, and binary.  If not, see
-// <http://www.gnu.org/licenses/>.
-//
-// Commercial licenses (with commercial support) of this JESD204 core are also
-// available under terms different than the General Public License. (e.g. they
-// do not require you to accompany any image (FPGA or ASIC) using the JESD204
-// core with any corresponding source code.) For these alternate terms you must
-// purchase a license from Analog Devices Technology Licensing Office. Users
-// interested in such a license should contact jesd204-licensing@analog.com for
-// more information. This commercial license is sub-licensable (if you purchase
-// chips from Analog Devices, incorporate them into your PCB level product, and
-// purchase a JESD204 license, end users of your product will also have a
-// license to use this core in a commercial setting without releasing their
-// source code).
-//
-// In addition, we kindly ask you to acknowledge ADI in any program, application
-// or publication in which you use this JESD204 HDL core. (You are not required
-// to do so; it is up to your common sense to decide whether you want to comply
-// with this request or not.) For general publications, we suggest referencing :
-// “The design and implementation of the JESD204 HDL Core used in this project
-// is copyright © 2016-2017, Analog Devices, Inc.”
-//
+// ***************************************************************************
+// ***************************************************************************
+// Copyright (C) 2017, 2018, 2021, 2022 Analog Devices, Inc. All rights reserved.
+// SPDX short identifier: ADIJESD204
+// ***************************************************************************
+// ***************************************************************************
 
 `timescale 1ns/100ps
 

--- a/library/jesd204/jesd204_tx_static_config/jesd204_tx_static_config.v
+++ b/library/jesd204/jesd204_tx_static_config/jesd204_tx_static_config.v
@@ -1,46 +1,9 @@
-//
-// The ADI JESD204 Core is released under the following license, which is
-// different than all other HDL cores in this repository.
-//
-// Please read this, and understand the freedoms and responsibilities you have
-// by using this source code/core.
-//
-// The JESD204 HDL, is copyright © 2016-2017 Analog Devices Inc.
-//
-// This core is free software, you can use run, copy, study, change, ask
-// questions about and improve this core. Distribution of source, or resulting
-// binaries (including those inside an FPGA or ASIC) require you to release the
-// source of the entire project (excluding the system libraries provide by the
-// tools/compiler/FPGA vendor). These are the terms of the GNU General Public
-// License version 2 as published by the Free Software Foundation.
-//
-// This core  is distributed in the hope that it will be useful, but WITHOUT ANY
-// WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
-// A PARTICULAR PURPOSE. See the GNU General Public License for more details.
-//
-// You should have received a copy of the GNU General Public License version 2
-// along with this source code, and binary.  If not, see
-// <http://www.gnu.org/licenses/>.
-//
-// Commercial licenses (with commercial support) of this JESD204 core are also
-// available under terms different than the General Public License. (e.g. they
-// do not require you to accompany any image (FPGA or ASIC) using the JESD204
-// core with any corresponding source code.) For these alternate terms you must
-// purchase a license from Analog Devices Technology Licensing Office. Users
-// interested in such a license should contact jesd204-licensing@analog.com for
-// more information. This commercial license is sub-licensable (if you purchase
-// chips from Analog Devices, incorporate them into your PCB level product, and
-// purchase a JESD204 license, end users of your product will also have a
-// license to use this core in a commercial setting without releasing their
-// source code).
-//
-// In addition, we kindly ask you to acknowledge ADI in any program, application
-// or publication in which you use this JESD204 HDL core. (You are not required
-// to do so; it is up to your common sense to decide whether you want to comply
-// with this request or not.) For general publications, we suggest referencing :
-// “The design and implementation of the JESD204 HDL Core used in this project
-// is copyright © 2016-2017, Analog Devices, Inc.”
-//
+// ***************************************************************************
+// ***************************************************************************
+// Copyright (C) 2017, 2018, 2020-2022 Analog Devices, Inc. All rights reserved.
+// SPDX short identifier: ADIJESD204
+// ***************************************************************************
+// ***************************************************************************
 
 `timescale 1ns/100ps
 

--- a/library/jesd204/jesd204_tx_static_config/jesd204_tx_static_config_ip.tcl
+++ b/library/jesd204/jesd204_tx_static_config/jesd204_tx_static_config_ip.tcl
@@ -1,46 +1,7 @@
-#
-# The ADI JESD204 Core is released under the following license, which is
-# different than all other HDL cores in this repository.
-#
-# Please read this, and understand the freedoms and responsibilities you have
-# by using this source code/core.
-#
-# The JESD204 HDL, is copyright © 2016-2017 Analog Devices Inc.
-#
-# This core is free software, you can use run, copy, study, change, ask
-# questions about and improve this core. Distribution of source, or resulting
-# binaries (including those inside an FPGA or ASIC) require you to release the
-# source of the entire project (excluding the system libraries provide by the
-# tools/compiler/FPGA vendor). These are the terms of the GNU General Public
-# License version 2 as published by the Free Software Foundation.
-#
-# This core  is distributed in the hope that it will be useful, but WITHOUT ANY
-# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
-# A PARTICULAR PURPOSE. See the GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License version 2
-# along with this source code, and binary.  If not, see
-# <http://www.gnu.org/licenses/>.
-#
-# Commercial licenses (with commercial support) of this JESD204 core are also
-# available under terms different than the General Public License. (e.g. they
-# do not require you to accompany any image (FPGA or ASIC) using the JESD204
-# core with any corresponding source code.) For these alternate terms you must
-# purchase a license from Analog Devices Technology Licensing Office. Users
-# interested in such a license should contact jesd204-licensing@analog.com for
-# more information. This commercial license is sub-licensable (if you purchase
-# chips from Analog Devices, incorporate them into your PCB level product, and
-# purchase a JESD204 license, end users of your product will also have a
-# license to use this core in a commercial setting without releasing their
-# source code).
-#
-# In addition, we kindly ask you to acknowledge ADI in any program, application
-# or publication in which you use this JESD204 HDL core. (You are not required
-# to do so; it is up to your common sense to decide whether you want to comply
-# with this request or not.) For general publications, we suggest referencing :
-# “The design and implementation of the JESD204 HDL Core used in this project
-# is copyright © 2016-2017, Analog Devices, Inc.”
-#
+###############################################################################
+## Copyright (C) 2017-2019, 2021, 2022 Analog Devices, Inc. All rights reserved.
+### SPDX short identifier: ADIJESD204
+###############################################################################
 
 source ../../../scripts/adi_env.tcl
 source $ad_hdl_dir/library/scripts/adi_ip_xilinx.tcl

--- a/library/jesd204/jesd204_versal_gt_adapter_rx/jesd204_versal_gt_adapter_rx.v
+++ b/library/jesd204/jesd204_versal_gt_adapter_rx/jesd204_versal_gt_adapter_rx.v
@@ -1,46 +1,9 @@
-//
-// The ADI JESD204 Core is released under the following license, which is
-// different than all other HDL cores in this repository.
-//
-// Please read this, and understand the freedoms and responsibilities you have
-// by using this source code/core.
-//
-// The JESD204 HDL, is copyright © 2016-2017 Analog Devices Inc.
-//
-// This core is free software, you can use run, copy, study, change, ask
-// questions about and improve this core. Distribution of source, or resulting
-// binaries (including those inside an FPGA or ASIC) require you to release the
-// source of the entire project (excluding the system libraries provide by the
-// tools/compiler/FPGA vendor). These are the terms of the GNU General Public
-// License version 2 as published by the Free Software Foundation.
-//
-// This core  is distributed in the hope that it will be useful, but WITHOUT ANY
-// WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
-// A PARTICULAR PURPOSE. See the GNU General Public License for more details.
-//
-// You should have received a copy of the GNU General Public License version 2
-// along with this source code, and binary.  If not, see
-// <http://www.gnu.org/licenses/>.
-//
-// Commercial licenses (with commercial support) of this JESD204 core are also
-// available under terms different than the General Public License. (e.g. they
-// do not require you to accompany any image (FPGA or ASIC) using the JESD204
-// core with any corresponding source code.) For these alternate terms you must
-// purchase a license from Analog Devices Technology Licensing Office. Users
-// interested in such a license should contact jesd204-licensing@analog.com for
-// more information. This commercial license is sub-licensable (if you purchase
-// chips from Analog Devices, incorporate them into your PCB level product, and
-// purchase a JESD204 license, end users of your product will also have a
-// license to use this core in a commercial setting without releasing their
-// source code).
-//
-// In addition, we kindly ask you to acknowledge ADI in any program, application
-// or publication in which you use this JESD204 HDL core. (You are not required
-// to do so; it is up to your common sense to decide whether you want to comply
-// with this request or not.) For general publications, we suggest referencing :
-// “The design and implementation of the JESD204 HDL Core used in this project
-// is copyright © 2016-2017, Analog Devices, Inc.”
-//
+// ***************************************************************************
+// ***************************************************************************
+// Copyright (C) 2017, 2018, 2020-2022 Analog Devices, Inc. All rights reserved.
+// SPDX short identifier: ADIJESD204
+// ***************************************************************************
+// ***************************************************************************
 
 `timescale 1ns/100ps
 

--- a/library/jesd204/jesd204_versal_gt_adapter_rx/jesd204_versal_gt_adapter_rx_ip.tcl
+++ b/library/jesd204/jesd204_versal_gt_adapter_rx/jesd204_versal_gt_adapter_rx_ip.tcl
@@ -1,46 +1,7 @@
-#
-# The ADI JESD204 Core is released under the following license, which is
-# different than all other HDL cores in this repository.
-#
-# Please read this, and understand the freedoms and responsibilities you have
-# by using this source code/core.
-#
-# The JESD204 HDL, is copyright © 2016-2017 Analog Devices Inc.
-#
-# This core is free software, you can use run, copy, study, change, ask
-# questions about and improve this core. Distribution of source, or resulting
-# binaries (including those inside an FPGA or ASIC) require you to release the
-# source of the entire project (excluding the system libraries provide by the
-# tools/compiler/FPGA vendor). These are the terms of the GNU General Public
-# License version 2 as published by the Free Software Foundation.
-#
-# This core  is distributed in the hope that it will be useful, but WITHOUT ANY
-# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
-# A PARTICULAR PURPOSE. See the GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License version 2
-# along with this source code, and binary.  If not, see
-# <http://www.gnu.org/licenses/>.
-#
-# Commercial licenses (with commercial support) of this JESD204 core are also
-# available under terms different than the General Public License. (e.g. they
-# do not require you to accompany any image (FPGA or ASIC) using the JESD204
-# core with any corresponding source code.) For these alternate terms you must
-# purchase a license from Analog Devices Technology Licensing Office. Users
-# interested in such a license should contact jesd204-licensing@analog.com for
-# more information. This commercial license is sub-licensable (if you purchase
-# chips from Analog Devices, incorporate them into your PCB level product, and
-# purchase a JESD204 license, end users of your product will also have a
-# license to use this core in a commercial setting without releasing their
-# source code).
-#
-# In addition, we kindly ask you to acknowledge ADI in any program, application
-# or publication in which you use this JESD204 HDL core. (You are not required
-# to do so; it is up to your common sense to decide whether you want to comply
-# with this request or not.) For general publications, we suggest referencing :
-# “The design and implementation of the JESD204 HDL Core used in this project
-# is copyright © 2016-2017, Analog Devices, Inc.”
-#
+###############################################################################
+## Copyright (C) 2017-2022 Analog Devices, Inc. All rights reserved.
+### SPDX short identifier: ADIJESD204
+###############################################################################
 
 source ../../../scripts/adi_env.tcl
 source $ad_hdl_dir/library/scripts/adi_ip_xilinx.tcl

--- a/library/jesd204/jesd204_versal_gt_adapter_tx/jesd204_versal_gt_adapter_tx.v
+++ b/library/jesd204/jesd204_versal_gt_adapter_tx/jesd204_versal_gt_adapter_tx.v
@@ -1,46 +1,9 @@
-//
-// The ADI JESD204 Core is released under the following license, which is
-// different than all other HDL cores in this repository.
-//
-// Please read this, and understand the freedoms and responsibilities you have
-// by using this source code/core.
-//
-// The JESD204 HDL, is copyright © 2016-2017 Analog Devices Inc.
-//
-// This core is free software, you can use run, copy, study, change, ask
-// questions about and improve this core. Distribution of source, or resulting
-// binaries (including those inside an FPGA or ASIC) require you to release the
-// source of the entire project (excluding the system libraries provide by the
-// tools/compiler/FPGA vendor). These are the terms of the GNU General Public
-// License version 2 as published by the Free Software Foundation.
-//
-// This core  is distributed in the hope that it will be useful, but WITHOUT ANY
-// WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
-// A PARTICULAR PURPOSE. See the GNU General Public License for more details.
-//
-// You should have received a copy of the GNU General Public License version 2
-// along with this source code, and binary.  If not, see
-// <http://www.gnu.org/licenses/>.
-//
-// Commercial licenses (with commercial support) of this JESD204 core are also
-// available under terms different than the General Public License. (e.g. they
-// do not require you to accompany any image (FPGA or ASIC) using the JESD204
-// core with any corresponding source code.) For these alternate terms you must
-// purchase a license from Analog Devices Technology Licensing Office. Users
-// interested in such a license should contact jesd204-licensing@analog.com for
-// more information. This commercial license is sub-licensable (if you purchase
-// chips from Analog Devices, incorporate them into your PCB level product, and
-// purchase a JESD204 license, end users of your product will also have a
-// license to use this core in a commercial setting without releasing their
-// source code).
-//
-// In addition, we kindly ask you to acknowledge ADI in any program, application
-// or publication in which you use this JESD204 HDL core. (You are not required
-// to do so; it is up to your common sense to decide whether you want to comply
-// with this request or not.) For general publications, we suggest referencing :
-// “The design and implementation of the JESD204 HDL Core used in this project
-// is copyright © 2016-2017, Analog Devices, Inc.”
-//
+// ***************************************************************************
+// ***************************************************************************
+// Copyright (C) 2017-2019, 2021 Analog Devices, Inc. All rights reserved.
+// SPDX short identifier: ADIJESD204
+// ***************************************************************************
+// ***************************************************************************
 
 `timescale 1ns/100ps
 

--- a/library/jesd204/jesd204_versal_gt_adapter_tx/jesd204_versal_gt_adapter_tx_ip.tcl
+++ b/library/jesd204/jesd204_versal_gt_adapter_tx/jesd204_versal_gt_adapter_tx_ip.tcl
@@ -1,46 +1,7 @@
-#
-# The ADI JESD204 Core is released under the following license, which is
-# different than all other HDL cores in this repository.
-#
-# Please read this, and understand the freedoms and responsibilities you have
-# by using this source code/core.
-#
-# The JESD204 HDL, is copyright © 2016-2017 Analog Devices Inc.
-#
-# This core is free software, you can use run, copy, study, change, ask
-# questions about and improve this core. Distribution of source, or resulting
-# binaries (including those inside an FPGA or ASIC) require you to release the
-# source of the entire project (excluding the system libraries provide by the
-# tools/compiler/FPGA vendor). These are the terms of the GNU General Public
-# License version 2 as published by the Free Software Foundation.
-#
-# This core  is distributed in the hope that it will be useful, but WITHOUT ANY
-# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
-# A PARTICULAR PURPOSE. See the GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License version 2
-# along with this source code, and binary.  If not, see
-# <http://www.gnu.org/licenses/>.
-#
-# Commercial licenses (with commercial support) of this JESD204 core are also
-# available under terms different than the General Public License. (e.g. they
-# do not require you to accompany any image (FPGA or ASIC) using the JESD204
-# core with any corresponding source code.) For these alternate terms you must
-# purchase a license from Analog Devices Technology Licensing Office. Users
-# interested in such a license should contact jesd204-licensing@analog.com for
-# more information. This commercial license is sub-licensable (if you purchase
-# chips from Analog Devices, incorporate them into your PCB level product, and
-# purchase a JESD204 license, end users of your product will also have a
-# license to use this core in a commercial setting without releasing their
-# source code).
-#
-# In addition, we kindly ask you to acknowledge ADI in any program, application
-# or publication in which you use this JESD204 HDL core. (You are not required
-# to do so; it is up to your common sense to decide whether you want to comply
-# with this request or not.) For general publications, we suggest referencing :
-# “The design and implementation of the JESD204 HDL Core used in this project
-# is copyright © 2016-2017, Analog Devices, Inc.”
-#
+###############################################################################
+## Copyright (C) 2017-2022 Analog Devices, Inc. All rights reserved.
+### SPDX short identifier: ADIJESD204
+###############################################################################
 
 source ../../../scripts/adi_env.tcl
 source $ad_hdl_dir/library/scripts/adi_ip_xilinx.tcl

--- a/library/jesd204/scripts/jesd204.tcl
+++ b/library/jesd204/scripts/jesd204.tcl
@@ -1,46 +1,7 @@
-#
-# The ADI JESD204 Core is released under the following license, which is
-# different than all other HDL cores in this repository.
-#
-# Please read this, and understand the freedoms and responsibilities you have
-# by using this source code/core.
-#
-# The JESD204 HDL, is copyright © 2016-2017 Analog Devices Inc.
-#
-# This core is free software, you can use run, copy, study, change, ask
-# questions about and improve this core. Distribution of source, or resulting
-# binaries (including those inside an FPGA or ASIC) require you to release the
-# source of the entire project (excluding the system libraries provide by the
-# tools/compiler/FPGA vendor). These are the terms of the GNU General Public
-# License version 2 as published by the Free Software Foundation.
-#
-# This core  is distributed in the hope that it will be useful, but WITHOUT ANY
-# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
-# A PARTICULAR PURPOSE. See the GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License version 2
-# along with this source code, and binary.  If not, see
-# <http://www.gnu.org/licenses/>.
-#
-# Commercial licenses (with commercial support) of this JESD204 core are also
-# available under terms different than the General Public License. (e.g. they
-# do not require you to accompany any image (FPGA or ASIC) using the JESD204
-# core with any corresponding source code.) For these alternate terms you must
-# purchase a license from Analog Devices Technology Licensing Office. Users
-# interested in such a license should contact jesd204-licensing@analog.com for
-# more information. This commercial license is sub-licensable (if you purchase
-# chips from Analog Devices, incorporate them into your PCB level product, and
-# purchase a JESD204 license, end users of your product will also have a
-# license to use this core in a commercial setting without releasing their
-# source code).
-#
-# In addition, we kindly ask you to acknowledge ADI in any program, application
-# or publication in which you use this JESD204 HDL core. (You are not required
-# to do so; it is up to your common sense to decide whether you want to comply
-# with this request or not.) For general publications, we suggest referencing :
-# “The design and implementation of the JESD204 HDL Core used in this project
-# is copyright © 2016-2017, Analog Devices, Inc.”
-#
+###############################################################################
+## Copyright (C) 2017-2022 Analog Devices, Inc. All rights reserved.
+### SPDX short identifier: ADIJESD204
+###############################################################################
 
 proc adi_axi_jesd204_tx_create {ip_name num_lanes {num_links 1} {link_mode 1}} {
 

--- a/library/jesd204/tb/axi_jesd204_rx_regmap_tb.v
+++ b/library/jesd204/tb/axi_jesd204_rx_regmap_tb.v
@@ -1,46 +1,9 @@
-//
-// The ADI JESD204 Core is released under the following license, which is
-// different than all other HDL cores in this repository.
-//
-// Please read this, and understand the freedoms and responsibilities you have
-// by using this source code/core.
-//
-// The JESD204 HDL, is copyright © 2016-2017 Analog Devices Inc.
-//
-// This core is free software, you can use run, copy, study, change, ask
-// questions about and improve this core. Distribution of source, or resulting
-// binaries (including those inside an FPGA or ASIC) require you to release the
-// source of the entire project (excluding the system libraries provide by the
-// tools/compiler/FPGA vendor). These are the terms of the GNU General Public
-// License version 2 as published by the Free Software Foundation.
-//
-// This core  is distributed in the hope that it will be useful, but WITHOUT ANY
-// WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
-// A PARTICULAR PURPOSE. See the GNU General Public License for more details.
-//
-// You should have received a copy of the GNU General Public License version 2
-// along with this source code, and binary.  If not, see
-// <http://www.gnu.org/licenses/>.
-//
-// Commercial licenses (with commercial support) of this JESD204 core are also
-// available under terms different than the General Public License. (e.g. they
-// do not require you to accompany any image (FPGA or ASIC) using the JESD204
-// core with any corresponding source code.) For these alternate terms you must
-// purchase a license from Analog Devices Technology Licensing Office. Users
-// interested in such a license should contact jesd204-licensing@analog.com for
-// more information. This commercial license is sub-licensable (if you purchase
-// chips from Analog Devices, incorporate them into your PCB level product, and
-// purchase a JESD204 license, end users of your product will also have a
-// license to use this core in a commercial setting without releasing their
-// source code).
-//
-// In addition, we kindly ask you to acknowledge ADI in any program, application
-// or publication in which you use this JESD204 HDL core. (You are not required
-// to do so; it is up to your common sense to decide whether you want to comply
-// with this request or not.) For general publications, we suggest referencing :
-// “The design and implementation of the JESD204 HDL Core used in this project
-// is copyright © 2016-2017, Analog Devices, Inc.”
-//
+// ***************************************************************************
+// ***************************************************************************
+// Copyright (C) 2017-2019, 2021, 2022 Analog Devices, Inc. All rights reserved.
+// SPDX short identifier: ADIJESD204
+// ***************************************************************************
+// ***************************************************************************
 
 `timescale 1ns/100ps
 

--- a/library/jesd204/tb/axi_jesd204_tx_regmap_tb.v
+++ b/library/jesd204/tb/axi_jesd204_tx_regmap_tb.v
@@ -1,46 +1,9 @@
-//
-// The ADI JESD204 Core is released under the following license, which is
-// different than all other HDL cores in this repository.
-//
-// Please read this, and understand the freedoms and responsibilities you have
-// by using this source code/core.
-//
-// The JESD204 HDL, is copyright © 2016-2017 Analog Devices Inc.
-//
-// This core is free software, you can use run, copy, study, change, ask
-// questions about and improve this core. Distribution of source, or resulting
-// binaries (including those inside an FPGA or ASIC) require you to release the
-// source of the entire project (excluding the system libraries provide by the
-// tools/compiler/FPGA vendor). These are the terms of the GNU General Public
-// License version 2 as published by the Free Software Foundation.
-//
-// This core  is distributed in the hope that it will be useful, but WITHOUT ANY
-// WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
-// A PARTICULAR PURPOSE. See the GNU General Public License for more details.
-//
-// You should have received a copy of the GNU General Public License version 2
-// along with this source code, and binary.  If not, see
-// <http://www.gnu.org/licenses/>.
-//
-// Commercial licenses (with commercial support) of this JESD204 core are also
-// available under terms different than the General Public License. (e.g. they
-// do not require you to accompany any image (FPGA or ASIC) using the JESD204
-// core with any corresponding source code.) For these alternate terms you must
-// purchase a license from Analog Devices Technology Licensing Office. Users
-// interested in such a license should contact jesd204-licensing@analog.com for
-// more information. This commercial license is sub-licensable (if you purchase
-// chips from Analog Devices, incorporate them into your PCB level product, and
-// purchase a JESD204 license, end users of your product will also have a
-// license to use this core in a commercial setting without releasing their
-// source code).
-//
-// In addition, we kindly ask you to acknowledge ADI in any program, application
-// or publication in which you use this JESD204 HDL core. (You are not required
-// to do so; it is up to your common sense to decide whether you want to comply
-// with this request or not.) For general publications, we suggest referencing :
-// “The design and implementation of the JESD204 HDL Core used in this project
-// is copyright © 2016-2017, Analog Devices, Inc.”
-//
+// ***************************************************************************
+// ***************************************************************************
+// Copyright (C) 2017-2019, 2021, 2022 Analog Devices, Inc. All rights reserved.
+// SPDX short identifier: ADIJESD204
+// ***************************************************************************
+// ***************************************************************************
 
 `timescale 1ns/100ps
 

--- a/library/jesd204/tb/crc12_tb.v
+++ b/library/jesd204/tb/crc12_tb.v
@@ -1,46 +1,9 @@
-//
-// The ADI JESD204 Core is released under the following license, which is
-// different than all other HDL cores in this repository.
-//
-// Please read this, and understand the freedoms and responsibilities you have
-// by using this source code/core.
-//
-// The JESD204 HDL, is copyright © 2016-2017 Analog Devices Inc.
-//
-// This core is free software, you can use run, copy, study, change, ask
-// questions about and improve this core. Distribution of source, or resulting
-// binaries (including those inside an FPGA or ASIC) require you to release the
-// source of the entire project (excluding the system libraries provide by the
-// tools/compiler/FPGA vendor). These are the terms of the GNU General Public
-// License version 2 as published by the Free Software Foundation.
-//
-// This core  is distributed in the hope that it will be useful, but WITHOUT ANY
-// WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
-// A PARTICULAR PURPOSE. See the GNU General Public License for more details.
-//
-// You should have received a copy of the GNU General Public License version 2
-// along with this source code, and binary.  If not, see
-// <http://www.gnu.org/licenses/>.
-//
-// Commercial licenses (with commercial support) of this JESD204 core are also
-// available under terms different than the General Public License. (e.g. they
-// do not require you to accompany any image (FPGA or ASIC) using the JESD204
-// core with any corresponding source code.) For these alternate terms you must
-// purchase a license from Analog Devices Technology Licensing Office. Users
-// interested in such a license should contact jesd204-licensing@analog.com for
-// more information. This commercial license is sub-licensable (if you purchase
-// chips from Analog Devices, incorporate them into your PCB level product, and
-// purchase a JESD204 license, end users of your product will also have a
-// license to use this core in a commercial setting without releasing their
-// source code).
-//
-// In addition, we kindly ask you to acknowledge ADI in any program, application
-// or publication in which you use this JESD204 HDL core. (You are not required
-// to do so; it is up to your common sense to decide whether you want to comply
-// with this request or not.) For general publications, we suggest referencing :
-// “The design and implementation of the JESD204 HDL Core used in this project
-// is copyright © 2016-2017, Analog Devices, Inc.”
-//
+// ***************************************************************************
+// ***************************************************************************
+// Copyright (C) 2017, 2018, 2020, 2022 Analog Devices, Inc. All rights reserved.
+// SPDX short identifier: ADIJESD204
+// ***************************************************************************
+// ***************************************************************************
 
 `timescale 1ns/100ps
 

--- a/library/jesd204/tb/frame_align_tb.v
+++ b/library/jesd204/tb/frame_align_tb.v
@@ -1,46 +1,9 @@
-//
-// The ADI JESD204 Core is released under the following license, which is
-// different than all other HDL cores in this repository.
-//
-// Please read this, and understand the freedoms and responsibilities you have
-// by using this source code/core.
-//
-// The JESD204 HDL, is copyright Â© 2016-2017 Analog Devices Inc.
-//
-// This core is free software, you can use run, copy, study, change, ask
-// questions about and improve this core. Distribution of source, or resulting
-// binaries (including those inside an FPGA or ASIC) require you to release the
-// source of the entire project (excluding the system libraries provide by the
-// tools/compiler/FPGA vendor). These are the terms of the GNU General Public
-// License version 2 as published by the Free Software Foundation.
-//
-// This core  is distributed in the hope that it will be useful, but WITHOUT ANY
-// WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
-// A PARTICULAR PURPOSE. See the GNU General Public License for more details.
-//
-// You should have received a copy of the GNU General Public License version 2
-// along with this source code, and binary.  If not, see
-// <http://www.gnu.org/licenses/>.
-//
-// Commercial licenses (with commercial support) of this JESD204 core are also
-// available under terms different than the General Public License. (e.g. they
-// do not require you to accompany any image (FPGA or ASIC) using the JESD204
-// core with any corresponding source code.) For these alternate terms you must
-// purchase a license from Analog Devices Technology Licensing Office. Users
-// interested in such a license should contact jesd204-licensing@analog.com for
-// more information. This commercial license is sub-licensable (if you purchase
-// chips from Analog Devices, incorporate them into your PCB level product, and
-// purchase a JESD204 license, end users of your product will also have a
-// license to use this core in a commercial setting without releasing their
-// source code).
-//
-// In addition, we kindly ask you to acknowledge ADI in any program, application
-// or publication in which you use this JESD204 HDL core. (You are not required
-// to do so; it is up to your common sense to decide whether you want to comply
-// with this request or not.) For general publications, we suggest referencing :
-// “The design and implementation of the JESD204 HDL Core used in this project
-// is copyright © 2016-2017, Analog Devices, Inc.”
-//
+// ***************************************************************************
+// ***************************************************************************
+// Copyright (C) 2017-2022 Analog Devices, Inc. All rights reserved.
+// SPDX short identifier: ADIJESD204
+// ***************************************************************************
+// ***************************************************************************
 
 `timescale 1ns/100ps
 

--- a/library/jesd204/tb/jesd204_frame_align_replace_tb.v
+++ b/library/jesd204/tb/jesd204_frame_align_replace_tb.v
@@ -1,46 +1,9 @@
-//
-// The ADI JESD204 Core is released under the following license, which is
-// different than all other HDL cores in this repository.
-//
-// Please read this, and understand the freedoms and responsibilities you have
-// by using this source code/core.
-//
-// The JESD204 HDL, is copyright © 2016-2017 Analog Devices Inc.
-//
-// This core is free software, you can use run, copy, study, change, ask
-// questions about and improve this core. Distribution of source, or resulting
-// binaries (including those inside an FPGA or ASIC) require you to release the
-// source of the entire project (excluding the system libraries provide by the
-// tools/compiler/FPGA vendor). These are the terms of the GNU General Public
-// License version 2 as published by the Free Software Foundation.
-//
-// This core  is distributed in the hope that it will be useful, but WITHOUT ANY
-// WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
-// A PARTICULAR PURPOSE. See the GNU General Public License for more details.
-//
-// You should have received a copy of the GNU General Public License version 2
-// along with this source code, and binary.  If not, see
-// <http://www.gnu.org/licenses/>.
-//
-// Commercial licenses (with commercial support) of this JESD204 core are also
-// available under terms different than the General Public License. (e.g. they
-// do not require you to accompany any image (FPGA or ASIC) using the JESD204
-// core with any corresponding source code.) For these alternate terms you must
-// purchase a license from Analog Devices Technology Licensing Office. Users
-// interested in such a license should contact jesd204-licensing@analog.com for
-// more information. This commercial license is sub-licensable (if you purchase
-// chips from Analog Devices, incorporate them into your PCB level product, and
-// purchase a JESD204 license, end users of your product will also have a
-// license to use this core in a commercial setting without releasing their
-// source code).
-//
-// In addition, we kindly ask you to acknowledge ADI in any program, application
-// or publication in which you use this JESD204 HDL core. (You are not required
-// to do so; it is up to your common sense to decide whether you want to comply
-// with this request or not.) For general publications, we suggest referencing :
-// “The design and implementation of the JESD204 HDL Core used in this project
-// is copyright © 2016-2017, Analog Devices, Inc.”
-//
+// ***************************************************************************
+// ***************************************************************************
+// Copyright (C) 2017-2019, 2021, 2022 Analog Devices, Inc. All rights reserved.
+// SPDX short identifier: ADIJESD204
+// ***************************************************************************
+// ***************************************************************************
 
 `timescale 1ns/100ps
 

--- a/library/jesd204/tb/jesd204_frame_mark_tb.v
+++ b/library/jesd204/tb/jesd204_frame_mark_tb.v
@@ -1,46 +1,9 @@
-//
-// The ADI JESD204 Core is released under the following license, which is
-// different than all other HDL cores in this repository.
-//
-// Please read this, and understand the freedoms and responsibilities you have
-// by using this source code/core.
-//
-// The JESD204 HDL, is copyright © 2016-2017 Analog Devices Inc.
-//
-// This core is free software, you can use run, copy, study, change, ask
-// questions about and improve this core. Distribution of source, or resulting
-// binaries (including those inside an FPGA or ASIC) require you to release the
-// source of the entire project (excluding the system libraries provide by the
-// tools/compiler/FPGA vendor). These are the terms of the GNU General Public
-// License version 2 as published by the Free Software Foundation.
-//
-// This core  is distributed in the hope that it will be useful, but WITHOUT ANY
-// WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
-// A PARTICULAR PURPOSE. See the GNU General Public License for more details.
-//
-// You should have received a copy of the GNU General Public License version 2
-// along with this source code, and binary.  If not, see
-// <http://www.gnu.org/licenses/>.
-//
-// Commercial licenses (with commercial support) of this JESD204 core are also
-// available under terms different than the General Public License. (e.g. they
-// do not require you to accompany any image (FPGA or ASIC) using the JESD204
-// core with any corresponding source code.) For these alternate terms you must
-// purchase a license from Analog Devices Technology Licensing Office. Users
-// interested in such a license should contact jesd204-licensing@analog.com for
-// more information. This commercial license is sub-licensable (if you purchase
-// chips from Analog Devices, incorporate them into your PCB level product, and
-// purchase a JESD204 license, end users of your product will also have a
-// license to use this core in a commercial setting without releasing their
-// source code).
-//
-// In addition, we kindly ask you to acknowledge ADI in any program, application
-// or publication in which you use this JESD204 HDL core. (You are not required
-// to do so; it is up to your common sense to decide whether you want to comply
-// with this request or not.) For general publications, we suggest referencing :
-// “The design and implementation of the JESD204 HDL Core used in this project
-// is copyright © 2016-2017, Analog Devices, Inc.”
-//
+// ***************************************************************************
+// ***************************************************************************
+// Copyright (C) 2017, 2018, 2020-2022 Analog Devices, Inc. All rights reserved.
+// SPDX short identifier: ADIJESD204
+// ***************************************************************************
+// ***************************************************************************
 
 `timescale 1ns/100ps
 

--- a/library/jesd204/tb/loopback_64b_tb.v
+++ b/library/jesd204/tb/loopback_64b_tb.v
@@ -1,46 +1,9 @@
-//
-// The ADI JESD204 Core is released under the following license, which is
-// different than all other HDL cores in this repository.
-//
-// Please read this, and understand the freedoms and responsibilities you have
-// by using this source code/core.
-//
-// The JESD204 HDL, is copyright © 2016-2017 Analog Devices Inc.
-//
-// This core is free software, you can use run, copy, study, change, ask
-// questions about and improve this core. Distribution of source, or resulting
-// binaries (including those inside an FPGA or ASIC) require you to release the
-// source of the entire project (excluding the system libraries provide by the
-// tools/compiler/FPGA vendor). These are the terms of the GNU General Public
-// License version 2 as published by the Free Software Foundation.
-//
-// This core  is distributed in the hope that it will be useful, but WITHOUT ANY
-// WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
-// A PARTICULAR PURPOSE. See the GNU General Public License for more details.
-//
-// You should have received a copy of the GNU General Public License version 2
-// along with this source code, and binary.  If not, see
-// <http://www.gnu.org/licenses/>.
-//
-// Commercial licenses (with commercial support) of this JESD204 core are also
-// available under terms different than the General Public License. (e.g. they
-// do not require you to accompany any image (FPGA or ASIC) using the JESD204
-// core with any corresponding source code.) For these alternate terms you must
-// purchase a license from Analog Devices Technology Licensing Office. Users
-// interested in such a license should contact jesd204-licensing@analog.com for
-// more information. This commercial license is sub-licensable (if you purchase
-// chips from Analog Devices, incorporate them into your PCB level product, and
-// purchase a JESD204 license, end users of your product will also have a
-// license to use this core in a commercial setting without releasing their
-// source code).
-//
-// In addition, we kindly ask you to acknowledge ADI in any program, application
-// or publication in which you use this JESD204 HDL core. (You are not required
-// to do so; it is up to your common sense to decide whether you want to comply
-// with this request or not.) For general publications, we suggest referencing :
-// “The design and implementation of the JESD204 HDL Core used in this project
-// is copyright © 2016-2017, Analog Devices, Inc.”
-//
+// ***************************************************************************
+// ***************************************************************************
+// Copyright (C) 2017-2022 Analog Devices, Inc. All rights reserved.
+// SPDX short identifier: ADIJESD204
+// ***************************************************************************
+// ***************************************************************************
 
 `timescale 1ns/100ps
 

--- a/library/jesd204/tb/loopback_tb.v
+++ b/library/jesd204/tb/loopback_tb.v
@@ -1,46 +1,9 @@
-//
-// The ADI JESD204 Core is released under the following license, which is
-// different than all other HDL cores in this repository.
-//
-// Please read this, and understand the freedoms and responsibilities you have
-// by using this source code/core.
-//
-// The JESD204 HDL, is copyright © 2016-2017 Analog Devices Inc.
-//
-// This core is free software, you can use run, copy, study, change, ask
-// questions about and improve this core. Distribution of source, or resulting
-// binaries (including those inside an FPGA or ASIC) require you to release the
-// source of the entire project (excluding the system libraries provide by the
-// tools/compiler/FPGA vendor). These are the terms of the GNU General Public
-// License version 2 as published by the Free Software Foundation.
-//
-// This core  is distributed in the hope that it will be useful, but WITHOUT ANY
-// WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
-// A PARTICULAR PURPOSE. See the GNU General Public License for more details.
-//
-// You should have received a copy of the GNU General Public License version 2
-// along with this source code, and binary.  If not, see
-// <http://www.gnu.org/licenses/>.
-//
-// Commercial licenses (with commercial support) of this JESD204 core are also
-// available under terms different than the General Public License. (e.g. they
-// do not require you to accompany any image (FPGA or ASIC) using the JESD204
-// core with any corresponding source code.) For these alternate terms you must
-// purchase a license from Analog Devices Technology Licensing Office. Users
-// interested in such a license should contact jesd204-licensing@analog.com for
-// more information. This commercial license is sub-licensable (if you purchase
-// chips from Analog Devices, incorporate them into your PCB level product, and
-// purchase a JESD204 license, end users of your product will also have a
-// license to use this core in a commercial setting without releasing their
-// source code).
-//
-// In addition, we kindly ask you to acknowledge ADI in any program, application
-// or publication in which you use this JESD204 HDL core. (You are not required
-// to do so; it is up to your common sense to decide whether you want to comply
-// with this request or not.) For general publications, we suggest referencing :
-// “The design and implementation of the JESD204 HDL Core used in this project
-// is copyright © 2016-2017, Analog Devices, Inc.”
-//
+// ***************************************************************************
+// ***************************************************************************
+// Copyright (C) 2017-2022 Analog Devices, Inc. All rights reserved.
+// SPDX short identifier: ADIJESD204
+// ***************************************************************************
+// ***************************************************************************
 
 `timescale 1ns/100ps
 

--- a/library/jesd204/tb/rx_cgs_tb.v
+++ b/library/jesd204/tb/rx_cgs_tb.v
@@ -1,46 +1,9 @@
-//
-// The ADI JESD204 Core is released under the following license, which is
-// different than all other HDL cores in this repository.
-//
-// Please read this, and understand the freedoms and responsibilities you have
-// by using this source code/core.
-//
-// The JESD204 HDL, is copyright © 2016-2017 Analog Devices Inc.
-//
-// This core is free software, you can use run, copy, study, change, ask
-// questions about and improve this core. Distribution of source, or resulting
-// binaries (including those inside an FPGA or ASIC) require you to release the
-// source of the entire project (excluding the system libraries provide by the
-// tools/compiler/FPGA vendor). These are the terms of the GNU General Public
-// License version 2 as published by the Free Software Foundation.
-//
-// This core  is distributed in the hope that it will be useful, but WITHOUT ANY
-// WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
-// A PARTICULAR PURPOSE. See the GNU General Public License for more details.
-//
-// You should have received a copy of the GNU General Public License version 2
-// along with this source code, and binary.  If not, see
-// <http://www.gnu.org/licenses/>.
-//
-// Commercial licenses (with commercial support) of this JESD204 core are also
-// available under terms different than the General Public License. (e.g. they
-// do not require you to accompany any image (FPGA or ASIC) using the JESD204
-// core with any corresponding source code.) For these alternate terms you must
-// purchase a license from Analog Devices Technology Licensing Office. Users
-// interested in such a license should contact jesd204-licensing@analog.com for
-// more information. This commercial license is sub-licensable (if you purchase
-// chips from Analog Devices, incorporate them into your PCB level product, and
-// purchase a JESD204 license, end users of your product will also have a
-// license to use this core in a commercial setting without releasing their
-// source code).
-//
-// In addition, we kindly ask you to acknowledge ADI in any program, application
-// or publication in which you use this JESD204 HDL core. (You are not required
-// to do so; it is up to your common sense to decide whether you want to comply
-// with this request or not.) For general publications, we suggest referencing :
-// “The design and implementation of the JESD204 HDL Core used in this project
-// is copyright © 2016-2017, Analog Devices, Inc.”
-//
+// ***************************************************************************
+// ***************************************************************************
+// Copyright (C) 2017, 2018, 2022 Analog Devices, Inc. All rights reserved.
+// SPDX short identifier: ADIJESD204
+// ***************************************************************************
+// ***************************************************************************
 
 `timescale 1ns/100ps
 

--- a/library/jesd204/tb/rx_ctrl_tb.v
+++ b/library/jesd204/tb/rx_ctrl_tb.v
@@ -1,46 +1,9 @@
-//
-// The ADI JESD204 Core is released under the following license, which is
-// different than all other HDL cores in this repository.
-//
-// Please read this, and understand the freedoms and responsibilities you have
-// by using this source code/core.
-//
-// The JESD204 HDL, is copyright © 2016-2017 Analog Devices Inc.
-//
-// This core is free software, you can use run, copy, study, change, ask
-// questions about and improve this core. Distribution of source, or resulting
-// binaries (including those inside an FPGA or ASIC) require you to release the
-// source of the entire project (excluding the system libraries provide by the
-// tools/compiler/FPGA vendor). These are the terms of the GNU General Public
-// License version 2 as published by the Free Software Foundation.
-//
-// This core  is distributed in the hope that it will be useful, but WITHOUT ANY
-// WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
-// A PARTICULAR PURPOSE. See the GNU General Public License for more details.
-//
-// You should have received a copy of the GNU General Public License version 2
-// along with this source code, and binary.  If not, see
-// <http://www.gnu.org/licenses/>.
-//
-// Commercial licenses (with commercial support) of this JESD204 core are also
-// available under terms different than the General Public License. (e.g. they
-// do not require you to accompany any image (FPGA or ASIC) using the JESD204
-// core with any corresponding source code.) For these alternate terms you must
-// purchase a license from Analog Devices Technology Licensing Office. Users
-// interested in such a license should contact jesd204-licensing@analog.com for
-// more information. This commercial license is sub-licensable (if you purchase
-// chips from Analog Devices, incorporate them into your PCB level product, and
-// purchase a JESD204 license, end users of your product will also have a
-// license to use this core in a commercial setting without releasing their
-// source code).
-//
-// In addition, we kindly ask you to acknowledge ADI in any program, application
-// or publication in which you use this JESD204 HDL core. (You are not required
-// to do so; it is up to your common sense to decide whether you want to comply
-// with this request or not.) For general publications, we suggest referencing :
-// “The design and implementation of the JESD204 HDL Core used in this project
-// is copyright © 2016-2017, Analog Devices, Inc.”
-//
+// ***************************************************************************
+// ***************************************************************************
+// Copyright (C) 2017, 2018, 2022 Analog Devices, Inc. All rights reserved.
+// SPDX short identifier: ADIJESD204
+// ***************************************************************************
+// ***************************************************************************
 
 `timescale 1ns/100ps
 

--- a/library/jesd204/tb/rx_lane_tb.v
+++ b/library/jesd204/tb/rx_lane_tb.v
@@ -1,46 +1,9 @@
-//
-// The ADI JESD204 Core is released under the following license, which is
-// different than all other HDL cores in this repository.
-//
-// Please read this, and understand the freedoms and responsibilities you have
-// by using this source code/core.
-//
-// The JESD204 HDL, is copyright © 2016-2017 Analog Devices Inc.
-//
-// This core is free software, you can use run, copy, study, change, ask
-// questions about and improve this core. Distribution of source, or resulting
-// binaries (including those inside an FPGA or ASIC) require you to release the
-// source of the entire project (excluding the system libraries provide by the
-// tools/compiler/FPGA vendor). These are the terms of the GNU General Public
-// License version 2 as published by the Free Software Foundation.
-//
-// This core  is distributed in the hope that it will be useful, but WITHOUT ANY
-// WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
-// A PARTICULAR PURPOSE. See the GNU General Public License for more details.
-//
-// You should have received a copy of the GNU General Public License version 2
-// along with this source code, and binary.  If not, see
-// <http://www.gnu.org/licenses/>.
-//
-// Commercial licenses (with commercial support) of this JESD204 core are also
-// available under terms different than the General Public License. (e.g. they
-// do not require you to accompany any image (FPGA or ASIC) using the JESD204
-// core with any corresponding source code.) For these alternate terms you must
-// purchase a license from Analog Devices Technology Licensing Office. Users
-// interested in such a license should contact jesd204-licensing@analog.com for
-// more information. This commercial license is sub-licensable (if you purchase
-// chips from Analog Devices, incorporate them into your PCB level product, and
-// purchase a JESD204 license, end users of your product will also have a
-// license to use this core in a commercial setting without releasing their
-// source code).
-//
-// In addition, we kindly ask you to acknowledge ADI in any program, application
-// or publication in which you use this JESD204 HDL core. (You are not required
-// to do so; it is up to your common sense to decide whether you want to comply
-// with this request or not.) For general publications, we suggest referencing :
-// “The design and implementation of the JESD204 HDL Core used in this project
-// is copyright © 2016-2017, Analog Devices, Inc.”
-//
+// ***************************************************************************
+// ***************************************************************************
+// Copyright (C) 2017, 2018, 2021, 2022 Analog Devices, Inc. All rights reserved.
+// SPDX short identifier: ADIJESD204
+// ***************************************************************************
+// ***************************************************************************
 
 `timescale 1ns/100ps
 

--- a/library/jesd204/tb/rx_tb.v
+++ b/library/jesd204/tb/rx_tb.v
@@ -1,46 +1,9 @@
-//
-// The ADI JESD204 Core is released under the following license, which is
-// different than all other HDL cores in this repository.
-//
-// Please read this, and understand the freedoms and responsibilities you have
-// by using this source code/core.
-//
-// The JESD204 HDL, is copyright © 2016-2017 Analog Devices Inc.
-//
-// This core is free software, you can use run, copy, study, change, ask
-// questions about and improve this core. Distribution of source, or resulting
-// binaries (including those inside an FPGA or ASIC) require you to release the
-// source of the entire project (excluding the system libraries provide by the
-// tools/compiler/FPGA vendor). These are the terms of the GNU General Public
-// License version 2 as published by the Free Software Foundation.
-//
-// This core  is distributed in the hope that it will be useful, but WITHOUT ANY
-// WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
-// A PARTICULAR PURPOSE. See the GNU General Public License for more details.
-//
-// You should have received a copy of the GNU General Public License version 2
-// along with this source code, and binary.  If not, see
-// <http://www.gnu.org/licenses/>.
-//
-// Commercial licenses (with commercial support) of this JESD204 core are also
-// available under terms different than the General Public License. (e.g. they
-// do not require you to accompany any image (FPGA or ASIC) using the JESD204
-// core with any corresponding source code.) For these alternate terms you must
-// purchase a license from Analog Devices Technology Licensing Office. Users
-// interested in such a license should contact jesd204-licensing@analog.com for
-// more information. This commercial license is sub-licensable (if you purchase
-// chips from Analog Devices, incorporate them into your PCB level product, and
-// purchase a JESD204 license, end users of your product will also have a
-// license to use this core in a commercial setting without releasing their
-// source code).
-//
-// In addition, we kindly ask you to acknowledge ADI in any program, application
-// or publication in which you use this JESD204 HDL core. (You are not required
-// to do so; it is up to your common sense to decide whether you want to comply
-// with this request or not.) For general publications, we suggest referencing :
-// “The design and implementation of the JESD204 HDL Core used in this project
-// is copyright © 2016-2017, Analog Devices, Inc.”
-//
+// ***************************************************************************
+// ***************************************************************************
+// Copyright (C) 2017, 2018, 2021, 2022 Analog Devices, Inc. All rights reserved.
+// SPDX short identifier: ADIJESD204
+// ***************************************************************************
+// ***************************************************************************
 
 `timescale 1ns/100ps
 

--- a/library/jesd204/tb/scrambler_64b_tb.v
+++ b/library/jesd204/tb/scrambler_64b_tb.v
@@ -1,46 +1,9 @@
-//
-// The ADI JESD204 Core is released under the following license, which is
-// different than all other HDL cores in this repository.
-//
-// Please read this, and understand the freedoms and responsibilities you have
-// by using this source code/core.
-//
-// The JESD204 HDL, is copyright © 2016-2017 Analog Devices Inc.
-//
-// This core is free software, you can use run, copy, study, change, ask
-// questions about and improve this core. Distribution of source, or resulting
-// binaries (including those inside an FPGA or ASIC) require you to release the
-// source of the entire project (excluding the system libraries provide by the
-// tools/compiler/FPGA vendor). These are the terms of the GNU General Public
-// License version 2 as published by the Free Software Foundation.
-//
-// This core  is distributed in the hope that it will be useful, but WITHOUT ANY
-// WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
-// A PARTICULAR PURPOSE. See the GNU General Public License for more details.
-//
-// You should have received a copy of the GNU General Public License version 2
-// along with this source code, and binary.  If not, see
-// <http://www.gnu.org/licenses/>.
-//
-// Commercial licenses (with commercial support) of this JESD204 core are also
-// available under terms different than the General Public License. (e.g. they
-// do not require you to accompany any image (FPGA or ASIC) using the JESD204
-// core with any corresponding source code.) For these alternate terms you must
-// purchase a license from Analog Devices Technology Licensing Office. Users
-// interested in such a license should contact jesd204-licensing@analog.com for
-// more information. This commercial license is sub-licensable (if you purchase
-// chips from Analog Devices, incorporate them into your PCB level product, and
-// purchase a JESD204 license, end users of your product will also have a
-// license to use this core in a commercial setting without releasing their
-// source code).
-//
-// In addition, we kindly ask you to acknowledge ADI in any program, application
-// or publication in which you use this JESD204 HDL core. (You are not required
-// to do so; it is up to your common sense to decide whether you want to comply
-// with this request or not.) For general publications, we suggest referencing :
-// “The design and implementation of the JESD204 HDL Core used in this project
-// is copyright © 2016-2017, Analog Devices, Inc.”
-//
+// ***************************************************************************
+// ***************************************************************************
+// Copyright (C) 2017, 2018, 2020, 2022 Analog Devices, Inc. All rights reserved.
+// SPDX short identifier: ADIJESD204
+// ***************************************************************************
+// ***************************************************************************
 
 `timescale 1ns/100ps
 

--- a/library/jesd204/tb/scrambler_tb.v
+++ b/library/jesd204/tb/scrambler_tb.v
@@ -1,46 +1,9 @@
-//
-// The ADI JESD204 Core is released under the following license, which is
-// different than all other HDL cores in this repository.
-//
-// Please read this, and understand the freedoms and responsibilities you have
-// by using this source code/core.
-//
-// The JESD204 HDL, is copyright © 2016-2017 Analog Devices Inc.
-//
-// This core is free software, you can use run, copy, study, change, ask
-// questions about and improve this core. Distribution of source, or resulting
-// binaries (including those inside an FPGA or ASIC) require you to release the
-// source of the entire project (excluding the system libraries provide by the
-// tools/compiler/FPGA vendor). These are the terms of the GNU General Public
-// License version 2 as published by the Free Software Foundation.
-//
-// This core  is distributed in the hope that it will be useful, but WITHOUT ANY
-// WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
-// A PARTICULAR PURPOSE. See the GNU General Public License for more details.
-//
-// You should have received a copy of the GNU General Public License version 2
-// along with this source code, and binary.  If not, see
-// <http://www.gnu.org/licenses/>.
-//
-// Commercial licenses (with commercial support) of this JESD204 core are also
-// available under terms different than the General Public License. (e.g. they
-// do not require you to accompany any image (FPGA or ASIC) using the JESD204
-// core with any corresponding source code.) For these alternate terms you must
-// purchase a license from Analog Devices Technology Licensing Office. Users
-// interested in such a license should contact jesd204-licensing@analog.com for
-// more information. This commercial license is sub-licensable (if you purchase
-// chips from Analog Devices, incorporate them into your PCB level product, and
-// purchase a JESD204 license, end users of your product will also have a
-// license to use this core in a commercial setting without releasing their
-// source code).
-//
-// In addition, we kindly ask you to acknowledge ADI in any program, application
-// or publication in which you use this JESD204 HDL core. (You are not required
-// to do so; it is up to your common sense to decide whether you want to comply
-// with this request or not.) For general publications, we suggest referencing :
-// “The design and implementation of the JESD204 HDL Core used in this project
-// is copyright © 2016-2017, Analog Devices, Inc.”
-//
+// ***************************************************************************
+// ***************************************************************************
+// Copyright (C) 2017, 2018, 2022 Analog Devices, Inc. All rights reserved.
+// SPDX short identifier: ADIJESD204
+// ***************************************************************************
+// ***************************************************************************
 
 `timescale 1ns/100ps
 

--- a/library/jesd204/tb/soft_pcs_8b10b_sequence_tb.v
+++ b/library/jesd204/tb/soft_pcs_8b10b_sequence_tb.v
@@ -1,46 +1,9 @@
-//
-// The ADI JESD204 Core is released under the following license, which is
-// different than all other HDL cores in this repository.
-//
-// Please read this, and understand the freedoms and responsibilities you have
-// by using this source code/core.
-//
-// The JESD204 HDL, is copyright © 2016-2017 Analog Devices Inc.
-//
-// This core is free software, you can use run, copy, study, change, ask
-// questions about and improve this core. Distribution of source, or resulting
-// binaries (including those inside an FPGA or ASIC) require you to release the
-// source of the entire project (excluding the system libraries provide by the
-// tools/compiler/FPGA vendor). These are the terms of the GNU General Public
-// License version 2 as published by the Free Software Foundation.
-//
-// This core  is distributed in the hope that it will be useful, but WITHOUT ANY
-// WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
-// A PARTICULAR PURPOSE. See the GNU General Public License for more details.
-//
-// You should have received a copy of the GNU General Public License version 2
-// along with this source code, and binary.  If not, see
-// <http://www.gnu.org/licenses/>.
-//
-// Commercial licenses (with commercial support) of this JESD204 core are also
-// available under terms different than the General Public License. (e.g. they
-// do not require you to accompany any image (FPGA or ASIC) using the JESD204
-// core with any corresponding source code.) For these alternate terms you must
-// purchase a license from Analog Devices Technology Licensing Office. Users
-// interested in such a license should contact jesd204-licensing@analog.com for
-// more information. This commercial license is sub-licensable (if you purchase
-// chips from Analog Devices, incorporate them into your PCB level product, and
-// purchase a JESD204 license, end users of your product will also have a
-// license to use this core in a commercial setting without releasing their
-// source code).
-//
-// In addition, we kindly ask you to acknowledge ADI in any program, application
-// or publication in which you use this JESD204 HDL core. (You are not required
-// to do so; it is up to your common sense to decide whether you want to comply
-// with this request or not.) For general publications, we suggest referencing :
-// “The design and implementation of the JESD204 HDL Core used in this project
-// is copyright © 2016-2017, Analog Devices, Inc.”
-//
+// ***************************************************************************
+// ***************************************************************************
+// Copyright (C) 2017, 2018, 2022 Analog Devices, Inc. All rights reserved.
+// SPDX short identifier: ADIJESD204
+// ***************************************************************************
+// ***************************************************************************
 
 `timescale 1ns/100ps
 

--- a/library/jesd204/tb/soft_pcs_8b10b_table_tb.v
+++ b/library/jesd204/tb/soft_pcs_8b10b_table_tb.v
@@ -1,46 +1,9 @@
-//
-// The ADI JESD204 Core is released under the following license, which is
-// different than all other HDL cores in this repository.
-//
-// Please read this, and understand the freedoms and responsibilities you have
-// by using this source code/core.
-//
-// The JESD204 HDL, is copyright © 2016-2017 Analog Devices Inc.
-//
-// This core is free software, you can use run, copy, study, change, ask
-// questions about and improve this core. Distribution of source, or resulting
-// binaries (including those inside an FPGA or ASIC) require you to release the
-// source of the entire project (excluding the system libraries provide by the
-// tools/compiler/FPGA vendor). These are the terms of the GNU General Public
-// License version 2 as published by the Free Software Foundation.
-//
-// This core  is distributed in the hope that it will be useful, but WITHOUT ANY
-// WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
-// A PARTICULAR PURPOSE. See the GNU General Public License for more details.
-//
-// You should have received a copy of the GNU General Public License version 2
-// along with this source code, and binary.  If not, see
-// <http://www.gnu.org/licenses/>.
-//
-// Commercial licenses (with commercial support) of this JESD204 core are also
-// available under terms different than the General Public License. (e.g. they
-// do not require you to accompany any image (FPGA or ASIC) using the JESD204
-// core with any corresponding source code.) For these alternate terms you must
-// purchase a license from Analog Devices Technology Licensing Office. Users
-// interested in such a license should contact jesd204-licensing@analog.com for
-// more information. This commercial license is sub-licensable (if you purchase
-// chips from Analog Devices, incorporate them into your PCB level product, and
-// purchase a JESD204 license, end users of your product will also have a
-// license to use this core in a commercial setting without releasing their
-// source code).
-//
-// In addition, we kindly ask you to acknowledge ADI in any program, application
-// or publication in which you use this JESD204 HDL core. (You are not required
-// to do so; it is up to your common sense to decide whether you want to comply
-// with this request or not.) For general publications, we suggest referencing :
-// “The design and implementation of the JESD204 HDL Core used in this project
-// is copyright © 2016-2017, Analog Devices, Inc.”
-//
+// ***************************************************************************
+// ***************************************************************************
+// Copyright (C) 2017-2019, 2021, 2022 Analog Devices, Inc. All rights reserved.
+// SPDX short identifier: ADIJESD204
+// ***************************************************************************
+// ***************************************************************************
 
 `timescale 1ns/100ps
 

--- a/library/jesd204/tb/soft_pcs_loopback_tb.v
+++ b/library/jesd204/tb/soft_pcs_loopback_tb.v
@@ -1,46 +1,9 @@
-//
-// The ADI JESD204 Core is released under the following license, which is
-// different than all other HDL cores in this repository.
-//
-// Please read this, and understand the freedoms and responsibilities you have
-// by using this source code/core.
-//
-// The JESD204 HDL, is copyright © 2016-2017 Analog Devices Inc.
-//
-// This core is free software, you can use run, copy, study, change, ask
-// questions about and improve this core. Distribution of source, or resulting
-// binaries (including those inside an FPGA or ASIC) require you to release the
-// source of the entire project (excluding the system libraries provide by the
-// tools/compiler/FPGA vendor). These are the terms of the GNU General Public
-// License version 2 as published by the Free Software Foundation.
-//
-// This core  is distributed in the hope that it will be useful, but WITHOUT ANY
-// WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
-// A pcsTICULAR PURPOSE. See the GNU General Public License for more details.
-//
-// You should have received a copy of the GNU General Public License version 2
-// along with this source code, and binary.  If not, see
-// <http://www.gnu.org/licenses/>.
-//
-// Commercial licenses (with commercial support) of this JESD204 core are also
-// available under terms different than the General Public License. (e.g. they
-// do not require you to accompany any image (FPGA or ASIC) using the JESD204
-// core with any corresponding source code.) For these alternate terms you must
-// purchase a license from Analog Devices Technology Licensing Office. Users
-// interested in such a license should contact jesd204-licensing@analog.com for
-// more information. This commercial license is sub-licensable (if you purchase
-// chips from Analog Devices, incorporate them into your PCB level product, and
-// purchase a JESD204 license, end users of your product will also have a
-// license to use this core in a commercial setting without releasing their
-// source code).
-//
-// In addition, we kindly ask you to acknowledge ADI in any program, application
-// or publication in which you use this JESD204 HDL core. (You are not required
-// to do so; it is up to your common sense to decide whether you want to comply
-// with this request or not.) For general publications, we suggest referencing :
-// “The design and implementation of the JESD204 HDL Core used in this project
-// is copyright © 2016-2017, Analog Devices, Inc.”
-//
+// ***************************************************************************
+// ***************************************************************************
+// Copyright (C) 2017, 2018, 2022 Analog Devices, Inc. All rights reserved.
+// SPDX short identifier: ADIJESD204
+// ***************************************************************************
+// ***************************************************************************
 
 `timescale 1ns/100ps
 

--- a/library/jesd204/tb/soft_pcs_pattern_align_tb.v
+++ b/library/jesd204/tb/soft_pcs_pattern_align_tb.v
@@ -1,46 +1,9 @@
-//
-// The ADI JESD204 Core is released under the following license, which is
-// different than all other HDL cores in this repository.
-//
-// Please read this, and understand the freedoms and responsibilities you have
-// by using this source code/core.
-//
-// The JESD204 HDL, is copyright © 2016-2017 Analog Devices Inc.
-//
-// This core is free software, you can use run, copy, study, change, ask
-// questions about and improve this core. Distribution of source, or resulting
-// binaries (including those inside an FPGA or ASIC) require you to release the
-// source of the entire project (excluding the system libraries provide by the
-// tools/compiler/FPGA vendor). These are the terms of the GNU General Public
-// License version 2 as published by the Free Software Foundation.
-//
-// This core  is distributed in the hope that it will be useful, but WITHOUT ANY
-// WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
-// A PARTICULAR PURPOSE. See the GNU General Public License for more details.
-//
-// You should have received a copy of the GNU General Public License version 2
-// along with this source code, and binary.  If not, see
-// <http://www.gnu.org/licenses/>.
-//
-// Commercial licenses (with commercial support) of this JESD204 core are also
-// available under terms different than the General Public License. (e.g. they
-// do not require you to accompany any image (FPGA or ASIC) using the JESD204
-// core with any corresponding source code.) For these alternate terms you must
-// purchase a license from Analog Devices Technology Licensing Office. Users
-// interested in such a license should contact jesd204-licensing@analog.com for
-// more information. This commercial license is sub-licensable (if you purchase
-// chips from Analog Devices, incorporate them into your PCB level product, and
-// purchase a JESD204 license, end users of your product will also have a
-// license to use this core in a commercial setting without releasing their
-// source code).
-//
-// In addition, we kindly ask you to acknowledge ADI in any program, application
-// or publication in which you use this JESD204 HDL core. (You are not required
-// to do so; it is up to your common sense to decide whether you want to comply
-// with this request or not.) For general publications, we suggest referencing :
-// “The design and implementation of the JESD204 HDL Core used in this project
-// is copyright © 2016-2017, Analog Devices, Inc.”
-//
+// ***************************************************************************
+// ***************************************************************************
+// Copyright (C) 2017, 2018, 2022 Analog Devices, Inc. All rights reserved.
+// SPDX short identifier: ADIJESD204
+// ***************************************************************************
+// ***************************************************************************
 
 `timescale 1ns/100ps
 

--- a/library/jesd204/tb/tb_base.v
+++ b/library/jesd204/tb/tb_base.v
@@ -1,46 +1,9 @@
-//
-// The ADI JESD204 Core is released under the following license, which is
-// different than all other HDL cores in this repository.
-//
-// Please read this, and understand the freedoms and responsibilities you have
-// by using this source code/core.
-//
-// The JESD204 HDL, is copyright © 2016-2017 Analog Devices Inc.
-//
-// This core is free software, you can use run, copy, study, change, ask
-// questions about and improve this core. Distribution of source, or resulting
-// binaries (including those inside an FPGA or ASIC) require you to release the
-// source of the entire project (excluding the system libraries provide by the
-// tools/compiler/FPGA vendor). These are the terms of the GNU General Public
-// License version 2 as published by the Free Software Foundation.
-//
-// This core  is distributed in the hope that it will be useful, but WITHOUT ANY
-// WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
-// A PARTICULAR PURPOSE. See the GNU General Public License for more details.
-//
-// You should have received a copy of the GNU General Public License version 2
-// along with this source code, and binary.  If not, see
-// <http://www.gnu.org/licenses/>.
-//
-// Commercial licenses (with commercial support) of this JESD204 core are also
-// available under terms different than the General Public License. (e.g. they
-// do not require you to accompany any image (FPGA or ASIC) using the JESD204
-// core with any corresponding source code.) For these alternate terms you must
-// purchase a license from Analog Devices Technology Licensing Office. Users
-// interested in such a license should contact jesd204-licensing@analog.com for
-// more information. This commercial license is sub-licensable (if you purchase
-// chips from Analog Devices, incorporate them into your PCB level product, and
-// purchase a JESD204 license, end users of your product will also have a
-// license to use this core in a commercial setting without releasing their
-// source code).
-//
-// In addition, we kindly ask you to acknowledge ADI in any program, application
-// or publication in which you use this JESD204 HDL core. (You are not required
-// to do so; it is up to your common sense to decide whether you want to comply
-// with this request or not.) For general publications, we suggest referencing :
-// “The design and implementation of the JESD204 HDL Core used in this project
-// is copyright © 2016-2017, Analog Devices, Inc.”
-//
+// ***************************************************************************
+// ***************************************************************************
+// Copyright (C) 2017, 2019, 2020, 2022 Analog Devices, Inc. All rights reserved.
+// SPDX short identifier: ADIJESD204
+// ***************************************************************************
+// ***************************************************************************
 
   reg clk = 1'b0;
   reg [3:0] reset_shift = 4'b1111;

--- a/library/jesd204/tb/tx_64b_tb.v
+++ b/library/jesd204/tb/tx_64b_tb.v
@@ -1,46 +1,9 @@
-//
-// The ADI JESD204 Core is released under the following license, which is
-// different than all other HDL cores in this repository.
-//
-// Please read this, and understand the freedoms and responsibilities you have
-// by using this source code/core.
-//
-// The JESD204 HDL, is copyright © 2016-2017 Analog Devices Inc.
-//
-// This core is free software, you can use run, copy, study, change, ask
-// questions about and improve this core. Distribution of source, or resulting
-// binaries (including those inside an FPGA or ASIC) require you to release the
-// source of the entire project (excluding the system libraries provide by the
-// tools/compiler/FPGA vendor). These are the terms of the GNU General Public
-// License version 2 as published by the Free Software Foundation.
-//
-// This core  is distributed in the hope that it will be useful, but WITHOUT ANY
-// WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
-// A PARTICULAR PURPOSE. See the GNU General Public License for more details.
-//
-// You should have received a copy of the GNU General Public License version 2
-// along with this source code, and binary.  If not, see
-// <http://www.gnu.org/licenses/>.
-//
-// Commercial licenses (with commercial support) of this JESD204 core are also
-// available under terms different than the General Public License. (e.g. they
-// do not require you to accompany any image (FPGA or ASIC) using the JESD204
-// core with any corresponding source code.) For these alternate terms you must
-// purchase a license from Analog Devices Technology Licensing Office. Users
-// interested in such a license should contact jesd204-licensing@analog.com for
-// more information. This commercial license is sub-licensable (if you purchase
-// chips from Analog Devices, incorporate them into your PCB level product, and
-// purchase a JESD204 license, end users of your product will also have a
-// license to use this core in a commercial setting without releasing their
-// source code).
-//
-// In addition, we kindly ask you to acknowledge ADI in any program, application
-// or publication in which you use this JESD204 HDL core. (You are not required
-// to do so; it is up to your common sense to decide whether you want to comply
-// with this request or not.) For general publications, we suggest referencing :
-// “The design and implementation of the JESD204 HDL Core used in this project
-// is copyright © 2016-2017, Analog Devices, Inc.”
-//
+// ***************************************************************************
+// ***************************************************************************
+// Copyright (C) 2017, 2018, 2020-2022 Analog Devices, Inc. All rights reserved.
+// SPDX short identifier: ADIJESD204
+// ***************************************************************************
+// ***************************************************************************
 
 `timescale 1ns/100ps
 

--- a/library/jesd204/tb/tx_ctrl_phase_tb.v
+++ b/library/jesd204/tb/tx_ctrl_phase_tb.v
@@ -1,46 +1,9 @@
-//
-// The ADI JESD204 Core is released under the following license, which is
-// different than all other HDL cores in this repository.
-//
-// Please read this, and understand the freedoms and responsibilities you have
-// by using this source code/core.
-//
-// The JESD204 HDL, is copyright © 2016-2017 Analog Devices Inc.
-//
-// This core is free software, you can use run, copy, study, change, ask
-// questions about and improve this core. Distribution of source, or resulting
-// binaries (including those inside an FPGA or ASIC) require you to release the
-// source of the entire project (excluding the system libraries provide by the
-// tools/compiler/FPGA vendor). These are the terms of the GNU General Public
-// License version 2 as published by the Free Software Foundation.
-//
-// This core  is distributed in the hope that it will be useful, but WITHOUT ANY
-// WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
-// A PARTICULAR PURPOSE. See the GNU General Public License for more details.
-//
-// You should have received a copy of the GNU General Public License version 2
-// along with this source code, and binary.  If not, see
-// <http://www.gnu.org/licenses/>.
-//
-// Commercial licenses (with commercial support) of this JESD204 core are also
-// available under terms different than the General Public License. (e.g. they
-// do not require you to accompany any image (FPGA or ASIC) using the JESD204
-// core with any corresponding source code.) For these alternate terms you must
-// purchase a license from Analog Devices Technology Licensing Office. Users
-// interested in such a license should contact jesd204-licensing@analog.com for
-// more information. This commercial license is sub-licensable (if you purchase
-// chips from Analog Devices, incorporate them into your PCB level product, and
-// purchase a JESD204 license, end users of your product will also have a
-// license to use this core in a commercial setting without releasing their
-// source code).
-//
-// In addition, we kindly ask you to acknowledge ADI in any program, application
-// or publication in which you use this JESD204 HDL core. (You are not required
-// to do so; it is up to your common sense to decide whether you want to comply
-// with this request or not.) For general publications, we suggest referencing :
-// “The design and implementation of the JESD204 HDL Core used in this project
-// is copyright © 2016-2017, Analog Devices, Inc.”
-//
+// ***************************************************************************
+// ***************************************************************************
+// Copyright (C) 2017, 2018, 2021, 2022 Analog Devices, Inc. All rights reserved.
+// SPDX short identifier: ADIJESD204
+// ***************************************************************************
+// ***************************************************************************
 
 /*
  * Regardless of the phase relationship between LMFC and sync the output of the

--- a/library/jesd204/tb/tx_tb.v
+++ b/library/jesd204/tb/tx_tb.v
@@ -1,46 +1,9 @@
-//
-// The ADI JESD204 Core is released under the following license, which is
-// different than all other HDL cores in this repository.
-//
-// Please read this, and understand the freedoms and responsibilities you have
-// by using this source code/core.
-//
-// The JESD204 HDL, is copyright © 2016-2017 Analog Devices Inc.
-//
-// This core is free software, you can use run, copy, study, change, ask
-// questions about and improve this core. Distribution of source, or resulting
-// binaries (including those inside an FPGA or ASIC) require you to release the
-// source of the entire project (excluding the system libraries provide by the
-// tools/compiler/FPGA vendor). These are the terms of the GNU General Public
-// License version 2 as published by the Free Software Foundation.
-//
-// This core  is distributed in the hope that it will be useful, but WITHOUT ANY
-// WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
-// A PARTICULAR PURPOSE. See the GNU General Public License for more details.
-//
-// You should have received a copy of the GNU General Public License version 2
-// along with this source code, and binary.  If not, see
-// <http://www.gnu.org/licenses/>.
-//
-// Commercial licenses (with commercial support) of this JESD204 core are also
-// available under terms different than the General Public License. (e.g. they
-// do not require you to accompany any image (FPGA or ASIC) using the JESD204
-// core with any corresponding source code.) For these alternate terms you must
-// purchase a license from Analog Devices Technology Licensing Office. Users
-// interested in such a license should contact jesd204-licensing@analog.com for
-// more information. This commercial license is sub-licensable (if you purchase
-// chips from Analog Devices, incorporate them into your PCB level product, and
-// purchase a JESD204 license, end users of your product will also have a
-// license to use this core in a commercial setting without releasing their
-// source code).
-//
-// In addition, we kindly ask you to acknowledge ADI in any program, application
-// or publication in which you use this JESD204 HDL core. (You are not required
-// to do so; it is up to your common sense to decide whether you want to comply
-// with this request or not.) For general publications, we suggest referencing :
-// “The design and implementation of the JESD204 HDL Core used in this project
-// is copyright © 2016-2017, Analog Devices, Inc.”
-//
+// ***************************************************************************
+// ***************************************************************************
+// Copyright (C) 2017, 2018, 2021, 2022 Analog Devices, Inc. All rights reserved.
+// SPDX short identifier: ADIJESD204
+// ***************************************************************************
+// ***************************************************************************
 
 `timescale 1ns/100ps
 


### PR DESCRIPTION
**Seventh PR** out of a series of PRs regarding updating the licenses and copyrights in all files. They should be merged in this order.

New format: `Copyright (C) year, year Analog Devices, Inc. All rights reserved.`

#### First commit:
- Adds/edits the copyright and license header for all files which need ADI JESD specific license
- The starting year was determined and changed based on `git log --follow --format=%ad --date=format:'%Y' $file | tail -1` which returns the first year it was added
- All the years when it was edited should be listed. If they're not continuous years then with comma, otherwise with hyphen
- To some files, the complete header was added, since it was missing

#### Second commit:
- Adds LICENSE_ADIJESD204 license file, where the whole JESD204 license is specified and the short identifier
- Removes library/jesd204/README.md

#### Third commit:
- Inserts the "Support" section from previously deleted file library/jesd204/README.md into hdl/README.md

#### Forth commit:
 - Inserts the short identifier for LICENSE_ADIBSD license file