### PR TITLE
Fix error regarding hierarchy that Vivado misses

### DIFF
--- a/library/jesd204/axi_jesd204_common/axi_jesd204_common_ip.tcl
+++ b/library/jesd204/axi_jesd204_common/axi_jesd204_common_ip.tcl
@@ -56,6 +56,8 @@ add_files -fileset [get_filesets sources_1] [list \
   "jesd204_up_sysref.v" \
 ]
 
+set_property source_mgmt_mode DisplayOnly [current_project]
+
 adi_ip_properties_lite axi_jesd204_common
 
 adi_ip_add_core_dependencies [list \

--- a/library/jesd204/axi_jesd204_rx/axi_jesd204_rx_ip.tcl
+++ b/library/jesd204/axi_jesd204_rx/axi_jesd204_rx_ip.tcl
@@ -58,6 +58,8 @@ adi_ip_files axi_jesd204_rx [list \
   "axi_jesd204_rx.v" \
 ]
 
+set_property source_mgmt_mode DisplayOnly [current_project]
+
 adi_ip_properties axi_jesd204_rx
 
 adi_ip_ttcl axi_jesd204_rx "axi_jesd204_rx_ooc.ttcl"

--- a/library/jesd204/axi_jesd204_tx/axi_jesd204_tx_ip.tcl
+++ b/library/jesd204/axi_jesd204_tx/axi_jesd204_tx_ip.tcl
@@ -56,6 +56,8 @@ adi_ip_files axi_jesd204_tx [list \
   "axi_jesd204_tx.v" \
 ]
 
+set_property source_mgmt_mode DisplayOnly [current_project]
+
 adi_ip_properties axi_jesd204_tx
 
 adi_ip_ttcl axi_jesd204_tx "axi_jesd204_tx_ooc.ttcl"

--- a/library/jesd204/jesd204_common/jesd204_common_ip.tcl
+++ b/library/jesd204/jesd204_common/jesd204_common_ip.tcl
@@ -58,6 +58,8 @@ add_files -fileset [get_filesets sources_1] [list \
   "pipeline_stage.v" \
 ]
 
+set_property source_mgmt_mode DisplayOnly [current_project]
+
 adi_ip_properties_lite jesd204_common
 
 set_property display_name "ADI JESD204C Common Library" [ipx::current_core]

--- a/library/jesd204/jesd204_rx/jesd204_rx_ip.tcl
+++ b/library/jesd204/jesd204_rx/jesd204_rx_ip.tcl
@@ -69,6 +69,8 @@ adi_ip_files jesd204_rx [list \
   "bd/bd.tcl"
 ]
 
+set_property source_mgmt_mode DisplayOnly [current_project]
+
 adi_ip_properties_lite jesd204_rx
 adi_ip_ttcl jesd204_rx "jesd204_rx_constr.ttcl"
 adi_ip_ttcl jesd204_rx "jesd204_rx_ooc.ttcl"

--- a/library/jesd204/jesd204_tx/jesd204_tx_ip.tcl
+++ b/library/jesd204/jesd204_tx/jesd204_tx_ip.tcl
@@ -62,6 +62,8 @@ adi_ip_files jesd204_tx [list \
   "bd/bd.tcl"
 ]
 
+set_property source_mgmt_mode DisplayOnly [current_project]
+
 adi_ip_properties_lite jesd204_tx
 adi_ip_ttcl jesd204_tx "jesd204_tx_constr.ttcl"
 adi_ip_ttcl jesd204_tx "jesd204_tx_ooc.ttcl"

--- a/library/util_cdc/util_cdc_ip.tcl
+++ b/library/util_cdc/util_cdc_ip.tcl
@@ -33,6 +33,8 @@ add_files -fileset [get_filesets sources_1] [list \
   "sync_event.v" \
 ]
 
+set_property source_mgmt_mode DisplayOnly [current_project]
+
 adi_ip_properties_lite util_cdc
 
 set_property name "util_cdc" [ipx::current_core]

--- a/library/util_cic/util_cic_ip.tcl
+++ b/library/util_cic/util_cic_ip.tcl
@@ -8,6 +8,8 @@ add_files -fileset [get_filesets sources_1] [list \
   "cic_comb.v" \
 ]
 
+set_property source_mgmt_mode DisplayOnly [current_project]
+
 adi_ip_properties_lite util_cic
 
 set_property name "util_cic" [ipx::current_core]

--- a/library/util_pack/util_upack2/util_upack2_ip.tcl
+++ b/library/util_pack/util_upack2/util_upack2_ip.tcl
@@ -34,6 +34,8 @@ adi_ip_files util_upack2 [list \
   "util_upack2_impl.v" \
   "util_upack2.v" ]
 
+set_property source_mgmt_mode DisplayOnly [current_project]
+
 adi_ip_properties_lite util_upack2
 
 adi_add_bus "s_axis" "slave" \


### PR DESCRIPTION
This issue was raised when building with Vivado 2023.1, and to ensure backwards compatibility, **these changes are being introduced while having Vivado 2022.2**. With this, many projects are still failing when using Vivado 2023.1.

Solution from here: https://support.xilinx.com/s/article/69320?language=en_US

Brought changes to the following IPs:
- util_cdc
- util_cic
- jesd204_rx/tx
- util_upack2
- axi_jesd204_common: used in axi_jesd204_rx/tx
- axi_jesd204_rx/tx
- jesd_common

Needs to be merged after #1136