### PR TITLE
Update to Vivado 2023.1

### DIFF
--- a/library/data_offload/data_offload.v
+++ b/library/data_offload/data_offload.v
@@ -37,7 +37,7 @@
 module data_offload #(
 
   parameter          ID = 0,
-  parameter   [ 0:0] MEM_TYPE = 1'b0,               // 1'b0 -FPGA RAM; 1'b1 - external memory
+  parameter          MEM_TYPE = 0,                  // 1'b0 -FPGA RAM; 1'b1 - external memory
   parameter          MEM_SIZE_LOG2 = 10,            // log2 of memory size in bytes
 
   parameter          TX_OR_RXN_PATH = 0,            // if set IP is used in TX path, other wise in RX path

--- a/scripts/adi_env.tcl
+++ b/scripts/adi_env.tcl
@@ -15,7 +15,7 @@ if [info exists ::env(ADI_GHDL_DIR)] {
 }
 
 # Define the supported tool version
-set required_vivado_version "2022.2"
+set required_vivado_version "2023.1"
 if {[info exists ::env(REQUIRED_VIVADO_VERSION)]} {
   set required_vivado_version $::env(REQUIRED_VIVADO_VERSION)
 } elseif {[info exists REQUIRED_VIVADO_VERSION]} {


### PR DESCRIPTION
- Updated the Vivado version to 2023.1
- Fixed an error in the data_offload IP regarding the MEM_TYPE parameter