### PR TITLE
project_xilinx.tcl: Fix the regex expression for Kria KV260 evaluation board

### DIFF
--- a/projects/scripts/adi_project_xilinx.tcl
+++ b/projects/scripts/adi_project_xilinx.tcl
@@ -167,7 +167,7 @@ proc adi_project_create {project_name mode parameter_list device {board "not-app
 
   if [regexp "^xc7z" $p_device] {
     set sys_zynq 1
-  } elseif [regexp "^xck" $p_device] {
+  } elseif [regexp "^xck26" $p_device] {
     set sys_zynq 2
   } elseif [regexp "^xczu" $p_device]  {
     set sys_zynq 2


### PR DESCRIPTION
- project_xilinx.tcl: Fix the regex expression for Kria KV260 evaluation board - [link](https://github.com/analogdevicesinc/hdl/commit/269e9fbe2ca6c17ec9489f355deea04c675843fc) (collapse the expression to xck26 in order to include only the kv260 board)