### PR TITLE
adi_xilinx_device_info: Update speed_grade_list

### DIFF
--- a/library/scripts/adi_xilinx_device_info_enc.tcl
+++ b/library/scripts/adi_xilinx_device_info_enc.tcl
@@ -85,6 +85,8 @@ set speed_grade_list { \
         { -2L     21 } \
         { -2LV    22 } \
         { -2MP    23 } \
+        { -2LVC   24 } \
+        { -2LVI   25 } \
         { -3      30 }}
 
 set dev_package_list { \


### PR DESCRIPTION
- adi_xilinx_device_info: Update speed_grade_list;
- Add k26i's specific speed grade id (k26SOM-i);
- Add k26c's specific speed grade id (k26SOM-c, kv260, kr260);
- Started from [this EZ thread](https://ez.analog.com/fpga/f/q-a/571731/adrv9002-k26i---unsupported-speed-grade--2lvi)