### PR TITLE
xilinx/ad_data_in.v: Add SDR support

### DIFF
--- a/library/xilinx/common/ad_data_in.v
+++ b/library/xilinx/common/ad_data_in.v
@@ -38,6 +38,7 @@
 module ad_data_in #(
   parameter   SINGLE_ENDED = 0,
   parameter   FPGA_TECHNOLOGY = 0,
+  parameter   DDR_SDR_N = 1,
   parameter   IDDR_CLK_EDGE ="SAME_EDGE",
   // for 7 series devices
   parameter   IDELAY_TYPE = "VAR_LOAD",
@@ -158,7 +159,7 @@ module ad_data_in #(
   end
   endgenerate
 
-  // receive data interface, ibuf -> idelay -> iddr
+  // receive data interface, ibuf -> idelay -> iddr(if enabled)
 
   // ibuf
 
@@ -244,35 +245,40 @@ module ad_data_in #(
   end
   endgenerate
 
-  // iddr
+  // DDR or SDR
 
   generate
-  if (FPGA_TECHNOLOGY == ULTRASCALE || FPGA_TECHNOLOGY == ULTRASCALE_PLUS) begin
-    IDDRE1 #(
-      .DDR_CLK_EDGE (IDDR_CLK_EDGE)
-    ) i_rx_data_iddr (
-      .R (1'b0),
-      .C (rx_clk),
-      .CB (~rx_clk),
-      .D (rx_data_idelay_s),
-      .Q1 (rx_data_p),
-      .Q2 (rx_data_n));
-  end
-  endgenerate
+    if (DDR_SDR_N == 1'b1) begin
+      // iddr
+      if (FPGA_TECHNOLOGY == ULTRASCALE || FPGA_TECHNOLOGY == ULTRASCALE_PLUS) begin
+        IDDRE1 #(
+          .DDR_CLK_EDGE (IDDR_CLK_EDGE)
+        ) i_rx_data_iddr (
+          .R (1'b0),
+          .C (rx_clk),
+          .CB (~rx_clk),
+          .D (rx_data_idelay_s),
+          .Q1 (rx_data_p),
+          .Q2 (rx_data_n));
+      end
 
-  generate
-  if (FPGA_TECHNOLOGY == SEVEN_SERIES) begin
-    IDDR #(
-      .DDR_CLK_EDGE (IDDR_CLK_EDGE)
-    ) i_rx_data_iddr (
-      .CE (1'b1),
-      .R (1'b0),
-      .S (1'b0),
-      .C (rx_clk),
-      .D (rx_data_idelay_s),
-      .Q1 (rx_data_p),
-      .Q2 (rx_data_n));
-  end
+      if (FPGA_TECHNOLOGY == SEVEN_SERIES) begin
+        IDDR #(
+          .DDR_CLK_EDGE (IDDR_CLK_EDGE)
+        ) i_rx_data_iddr (
+          .CE (1'b1),
+          .R (1'b0),
+          .S (1'b0),
+          .C (rx_clk),
+          .D (rx_data_idelay_s),
+          .Q1 (rx_data_p),
+          .Q2 (rx_data_n));
+      end
+    // sdr
+    end else begin
+      assign rx_data_p = rx_data_idelay_s;
+      assign rx_data_n = 1'b0;
+    end
   endgenerate
 
 endmodule


### PR DESCRIPTION
## PR Description

Add single data rate support to ad_data_in. This will help in adding IODELAYs to non designs that don't need dual data rate.

## PR Type
- [ ] Bug fix (change that fixes an issue)
- [x] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the code style guidelines
- [x] I have performed a self-review of changes
- [x] I have compiled all hdl projects and libraries affected by this PR
- [x] I have tested in hardware affected projects, at least on relevant boards
- [x] I have commented my code, at least hard-to-understand parts
- [ ] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe files, Copyright etc)
- [x] I have not introduced new Warnings/Critical Warnings on compilation
- [ ] I have added new hdl testbenches or updated existing ones
