### PR TITLE
HDL files for 2-24 GHz XMW TX/RX Platforms

### DIFF
--- a/projects/ad9082_fmca_ebz_xmw_rx/Makefile
+++ b/projects/ad9082_fmca_ebz_xmw_rx/Makefile
@@ -1,0 +1,7 @@
+####################################################################################
+## Copyright (c) 2018 - 2021 Analog Devices, Inc.
+### SPDX short identifier: BSD-1-Clause
+## Auto-generated, do not modify!
+####################################################################################
+
+include ../scripts/project-toplevel.mk

--- a/projects/ad9082_fmca_ebz_xmw_rx/Readme.md
+++ b/projects/ad9082_fmca_ebz_xmw_rx/Readme.md
@@ -1,0 +1,7 @@
+# AD9082-FMCA-EBZ-XMW-RX HDL Project
+
+Here are some pointers to help you:
+  * Parts : [MxFE Quad, 16-Bit, 12 GSPS RF DAC and Dual, 12-Bit, 6 GSPS RF ADC](https://www.analog.com/ad9082)
+  * Project Doc: https://wiki.analog.com/resources/eval/developer-kits/2to24ghz-mxfe-rf-front-end
+  * HDL Doc: https://wiki.analog.com/resources/eval/user-guides/ad9081_fmca_ebz/ad9081_fmca_ebz_hdl
+  * Linux Drivers: https://wiki.analog.com/resources/tools-software/linux-drivers/iio-mxfe/ad9081

--- a/projects/ad9082_fmca_ebz_xmw_rx/zcu102/Makefile
+++ b/projects/ad9082_fmca_ebz_xmw_rx/zcu102/Makefile
@@ -1,0 +1,49 @@
+####################################################################################
+## Copyright (c) 2018 - 2021 Analog Devices, Inc.
+### SPDX short identifier: BSD-1-Clause
+## Auto-generated, do not modify!
+####################################################################################
+
+PROJECT_NAME := ad9082_fmca_ebz_xmw_rx_zcu102
+
+M_DEPS += ../../scripts/adi_pd.tcl
+M_DEPS += ../../common/zcu102/zcu102_system_constr.xdc
+M_DEPS += ../../common/zcu102/zcu102_system_bd.tcl
+M_DEPS += ../../common/xilinx/data_offload_bd.tcl
+M_DEPS += ../../common/xilinx/dacfifo_bd.tcl
+M_DEPS += ../../common/xilinx/adcfifo_bd.tcl
+M_DEPS += ../../ad9081_fmca_ebz/zcu102/timing_constr.xdc
+M_DEPS += ../../ad9082_fmca_ebz_xmw_rx/zcu102/system_top.v
+M_DEPS += ../../ad9082_fmca_ebz_xmw_rx/zcu102/system_constr.xdc
+M_DEPS += ../../ad9081_fmca_ebz/zcu102/system_bd.tcl
+M_DEPS += ../../ad9081_fmca_ebz/common/versal_transceiver.tcl
+M_DEPS += ../../ad9081_fmca_ebz/common/ad9081_fmca_ebz_bd.tcl
+M_DEPS += ../../../library/util_hbm/scripts/adi_util_hbm.tcl
+M_DEPS += ../../../library/jesd204/scripts/jesd204.tcl
+M_DEPS += ../../../library/common/ad_iobuf.v
+M_DEPS += ../../../library/common/ad_3w_spi.v
+
+LIB_DEPS += axi_dmac
+LIB_DEPS += axi_sysid
+LIB_DEPS += axi_tdd
+LIB_DEPS += data_offload
+LIB_DEPS += jesd204/ad_ip_jesd204_tpl_adc
+LIB_DEPS += jesd204/ad_ip_jesd204_tpl_dac
+LIB_DEPS += jesd204/axi_jesd204_rx
+LIB_DEPS += jesd204/axi_jesd204_tx
+LIB_DEPS += jesd204/jesd204_rx
+LIB_DEPS += jesd204/jesd204_tx
+LIB_DEPS += jesd204/jesd204_versal_gt_adapter_rx
+LIB_DEPS += jesd204/jesd204_versal_gt_adapter_tx
+LIB_DEPS += sysid_rom
+LIB_DEPS += util_adcfifo
+LIB_DEPS += util_dacfifo
+LIB_DEPS += util_do_ram
+LIB_DEPS += util_hbm
+LIB_DEPS += util_pack/util_cpack2
+LIB_DEPS += util_pack/util_upack2
+LIB_DEPS += util_tdd_sync
+LIB_DEPS += xilinx/axi_adxcvr
+LIB_DEPS += xilinx/util_adxcvr
+
+include ../../scripts/project-xilinx.mk

--- a/projects/ad9082_fmca_ebz_xmw_rx/zcu102/system_bd.tcl
+++ b/projects/ad9082_fmca_ebz_xmw_rx/zcu102/system_bd.tcl
@@ -1,0 +1,3 @@
+
+source $ad_hdl_dir/projects/ad9081_fmca_ebz/zcu102/system_bd.tcl
+

--- a/projects/ad9082_fmca_ebz_xmw_rx/zcu102/system_constr.xdc
+++ b/projects/ad9082_fmca_ebz_xmw_rx/zcu102/system_constr.xdc
@@ -1,0 +1,99 @@
+#
+## mxfe
+#
+
+set_property         -dict {PACKAGE_PIN P11   IOSTANDARD LVCMOS18                                     } [get_ports agc0[0]              ]    ; ## FMC0_LA17_CC_P      IO_L13P_T2L_N0_GC_QBC_67
+set_property         -dict {PACKAGE_PIN N11   IOSTANDARD LVCMOS18                                     } [get_ports agc0[1]              ]    ; ## FMC0_LA17_CC_N      IO_L13N_T2L_N1_GC_QBC_67
+set_property         -dict {PACKAGE_PIN N9    IOSTANDARD LVCMOS18                                     } [get_ports agc1[0]              ]    ; ## FMC0_LA18_CC_P      IO_L16P_T2U_N6_QBC_AD3P_67
+set_property         -dict {PACKAGE_PIN N8    IOSTANDARD LVCMOS18                                     } [get_ports agc1[1]              ]    ; ## FMC0_LA18_CC_N      IO_L16N_T2U_N7_QBC_AD3N_67
+set_property         -dict {PACKAGE_PIN N13   IOSTANDARD LVCMOS18                                     } [get_ports agc2[0]              ]    ; ## FMC0_LA20_P         IO_L22P_T3U_N6_DBC_AD0P_67
+set_property         -dict {PACKAGE_PIN M13   IOSTANDARD LVCMOS18                                     } [get_ports agc2[1]              ]    ; ## FMC0_LA20_N         IO_L22N_T3U_N7_DBC_AD0N_67
+set_property         -dict {PACKAGE_PIN P12   IOSTANDARD LVCMOS18                                     } [get_ports agc3[0]              ]    ; ## FMC0_LA21_P         IO_L21P_T3L_N4_AD8P_67
+set_property         -dict {PACKAGE_PIN N12   IOSTANDARD LVCMOS18                                     } [get_ports agc3[1]              ]    ; ## FMC0_LA21_N         IO_L21N_T3L_N5_AD8N_67
+set_property         -dict {PACKAGE_PIN Y3    IOSTANDARD LVDS     DIFF_TERM_ADV TERM_100 DQS_BIAS TRUE} [get_ports clkin10_n            ]    ; ## FMC0_CLK2_IO_N      IO_L13N_T2L_N1_GC_QBC_66
+set_property         -dict {PACKAGE_PIN Y4    IOSTANDARD LVDS     DIFF_TERM_ADV TERM_100 DQS_BIAS TRUE} [get_ports clkin10_p            ]    ; ## FMC0_CLK2_IO_P      IO_L13P_T2L_N0_GC_QBC_66
+set_property         -dict {PACKAGE_PIN R8    IOSTANDARD LVDS     DIFF_TERM_ADV TERM_100 DQS_BIAS TRUE} [get_ports clkin6_n             ]    ; ## FMC0_CLK1_M2C_N     IO_L12N_T1U_N11_GC_67
+set_property         -dict {PACKAGE_PIN T8    IOSTANDARD LVDS     DIFF_TERM_ADV TERM_100 DQS_BIAS TRUE} [get_ports clkin6_p             ]    ; ## FMC0_CLK1_M2C_P     IO_L12P_T1U_N10_GC_67
+set_property         -dict {PACKAGE_PIN G7                                                            } [get_ports fpga_refclk_in_n     ]    ; ## FMC0_GBTCLK0_M2C_N  MGTREFCLK0N_229
+set_property         -dict {PACKAGE_PIN G8                                                            } [get_ports fpga_refclk_in_p     ]    ; ## FMC0_GBTCLK0_M2C_P  MGTREFCLK0P_229
+set_property  -quiet -dict {PACKAGE_PIN F1                                                            } [get_ports rx_data_n[2]         ]    ; ## FMC0_DP2_M2C_N      MGTHRXN3_229    FPGA_SERDIN_0_N
+set_property  -quiet -dict {PACKAGE_PIN F2                                                            } [get_ports rx_data_p[2]         ]    ; ## FMC0_DP2_M2C_P      MGTHRXP3_229    FPGA_SERDIN_0_P
+set_property  -quiet -dict {PACKAGE_PIN H1                                                            } [get_ports rx_data_n[0]         ]    ; ## FMC0_DP0_M2C_N      MGTHRXN2_229    FPGA_SERDIN_1_N
+set_property  -quiet -dict {PACKAGE_PIN H2                                                            } [get_ports rx_data_p[0]         ]    ; ## FMC0_DP0_M2C_P      MGTHRXP2_229    FPGA_SERDIN_1_P
+set_property  -quiet -dict {PACKAGE_PIN M1                                                            } [get_ports rx_data_n[7]         ]    ; ## FMC0_DP7_M2C_N      MGTHRXN2_228    FPGA_SERDIN_2_N
+set_property  -quiet -dict {PACKAGE_PIN M2                                                            } [get_ports rx_data_p[7]         ]    ; ## FMC0_DP7_M2C_P      MGTHRXP2_228    FPGA_SERDIN_2_P
+set_property  -quiet -dict {PACKAGE_PIN T1                                                            } [get_ports rx_data_n[6]         ]    ; ## FMC0_DP6_M2C_N      MGTHRXN0_228    FPGA_SERDIN_3_N
+set_property  -quiet -dict {PACKAGE_PIN T2                                                            } [get_ports rx_data_p[6]         ]    ; ## FMC0_DP6_M2C_P      MGTHRXP0_228    FPGA_SERDIN_3_P
+set_property  -quiet -dict {PACKAGE_PIN P1                                                            } [get_ports rx_data_n[5]         ]    ; ## FMC0_DP5_M2C_N      MGTHRXN1_228    FPGA_SERDIN_4_N
+set_property  -quiet -dict {PACKAGE_PIN P2                                                            } [get_ports rx_data_p[5]         ]    ; ## FMC0_DP5_M2C_P      MGTHRXP1_228    FPGA_SERDIN_4_P
+set_property  -quiet -dict {PACKAGE_PIN L3                                                            } [get_ports rx_data_n[4]         ]    ; ## FMC0_DP4_M2C_N      MGTHRXN3_228    FPGA_SERDIN_5_N
+set_property  -quiet -dict {PACKAGE_PIN L4                                                            } [get_ports rx_data_p[4]         ]    ; ## FMC0_DP4_M2C_P      MGTHRXP3_228    FPGA_SERDIN_5_P
+set_property  -quiet -dict {PACKAGE_PIN K1                                                            } [get_ports rx_data_n[3]         ]    ; ## FMC0_DP3_M2C_N      MGTHRXN0_229    FPGA_SERDIN_6_N
+set_property  -quiet -dict {PACKAGE_PIN K2                                                            } [get_ports rx_data_p[3]         ]    ; ## FMC0_DP3_M2C_P      MGTHRXP0_229    FPGA_SERDIN_6_P
+set_property  -quiet -dict {PACKAGE_PIN J3                                                            } [get_ports rx_data_n[1]         ]    ; ## FMC0_DP1_M2C_N      MGTHRXN1_229    FPGA_SERDIN_7_N
+set_property  -quiet -dict {PACKAGE_PIN J4                                                            } [get_ports rx_data_p[1]         ]    ; ## FMC0_DP1_M2C_P      MGTHRXP1_229    FPGA_SERDIN_7_P
+set_property  -quiet -dict {PACKAGE_PIN G3                                                            } [get_ports tx_data_n[0]         ]    ; ## FMC0_DP0_C2M_N      MGTHTXN2_229    FPGA_SERDOUT_0_N
+set_property  -quiet -dict {PACKAGE_PIN G4                                                            } [get_ports tx_data_p[0]         ]    ; ## FMC0_DP0_C2M_P      MGTHTXP2_229    FPGA_SERDOUT_0_P
+set_property  -quiet -dict {PACKAGE_PIN F5                                                            } [get_ports tx_data_n[2]         ]    ; ## FMC0_DP2_C2M_N      MGTHTXN3_229    FPGA_SERDOUT_1_N
+set_property  -quiet -dict {PACKAGE_PIN F6                                                            } [get_ports tx_data_p[2]         ]    ; ## FMC0_DP2_C2M_P      MGTHTXP3_229    FPGA_SERDOUT_1_P
+set_property  -quiet -dict {PACKAGE_PIN N3                                                            } [get_ports tx_data_n[7]         ]    ; ## FMC0_DP7_C2M_N      MGTHTXN2_228    FPGA_SERDOUT_2_N
+set_property  -quiet -dict {PACKAGE_PIN N4                                                            } [get_ports tx_data_p[7]         ]    ; ## FMC0_DP7_C2M_P      MGTHTXP2_228    FPGA_SERDOUT_2_P
+set_property  -quiet -dict {PACKAGE_PIN R3                                                            } [get_ports tx_data_n[6]         ]    ; ## FMC0_DP6_C2M_N      MGTHTXN0_228    FPGA_SERDOUT_3_N
+set_property  -quiet -dict {PACKAGE_PIN R4                                                            } [get_ports tx_data_p[6]         ]    ; ## FMC0_DP6_C2M_P      MGTHTXP0_228    FPGA_SERDOUT_3_P
+set_property  -quiet -dict {PACKAGE_PIN H5                                                            } [get_ports tx_data_n[1]         ]    ; ## FMC0_DP1_C2M_N      MGTHTXN1_229    FPGA_SERDOUT_4_N
+set_property  -quiet -dict {PACKAGE_PIN H6                                                            } [get_ports tx_data_p[1]         ]    ; ## FMC0_DP1_C2M_P      MGTHTXP1_229    FPGA_SERDOUT_4_P
+set_property  -quiet -dict {PACKAGE_PIN P5                                                            } [get_ports tx_data_n[5]         ]    ; ## FMC0_DP5_C2M_N      MGTHTXN1_228    FPGA_SERDOUT_5_N
+set_property  -quiet -dict {PACKAGE_PIN P6                                                            } [get_ports tx_data_p[5]         ]    ; ## FMC0_DP5_C2M_P      MGTHTXP1_228    FPGA_SERDOUT_5_P
+set_property  -quiet -dict {PACKAGE_PIN M5                                                            } [get_ports tx_data_n[4]         ]    ; ## FMC0_DP4_C2M_N      MGTHTXN3_228    FPGA_SERDOUT_6_N
+set_property  -quiet -dict {PACKAGE_PIN M6                                                            } [get_ports tx_data_p[4]         ]    ; ## FMC0_DP4_C2M_P      MGTHTXP3_228    FPGA_SERDOUT_6_P
+set_property  -quiet -dict {PACKAGE_PIN K5                                                            } [get_ports tx_data_n[3]         ]    ; ## FMC0_DP3_C2M_N      MGTHTXN0_229    FPGA_SERDOUT_7_N
+set_property  -quiet -dict {PACKAGE_PIN K6                                                            } [get_ports tx_data_p[3]         ]    ; ## FMC0_DP3_C2M_P      MGTHTXP0_229    FPGA_SERDOUT_7_P
+set_property  -quiet -dict {PACKAGE_PIN V1    IOSTANDARD LVDS     DIFF_TERM_ADV TERM_100              } [get_ports fpga_syncin_0_n      ]    ; ## FMC0_LA02_N         IO_L23N_T3U_N9_66
+set_property  -quiet -dict {PACKAGE_PIN V2    IOSTANDARD LVDS     DIFF_TERM_ADV TERM_100              } [get_ports fpga_syncin_0_p      ]    ; ## FMC0_LA02_P         IO_L23P_T3U_N8_66
+set_property  -quiet -dict {PACKAGE_PIN Y1    IOSTANDARD LVCMOS18                                     } [get_ports fpga_syncin_1_n      ]    ; ## FMC0_LA03_N         IO_L22N_T3U_N7_DBC_AD0N_66
+set_property  -quiet -dict {PACKAGE_PIN Y2    IOSTANDARD LVCMOS18                                     } [get_ports fpga_syncin_1_p      ]    ; ## FMC0_LA03_P         IO_L22P_T3U_N6_DBC_AD0P_66
+set_property  -quiet -dict {PACKAGE_PIN AC4   IOSTANDARD LVDS                                         } [get_ports fpga_syncout_0_n     ]    ; ## FMC0_LA01_CC_N      IO_L16N_T2U_N7_QBC_AD3N_66
+set_property  -quiet -dict {PACKAGE_PIN AB4   IOSTANDARD LVDS                                         } [get_ports fpga_syncout_0_p     ]    ; ## FMC0_LA01_CC_P      IO_L16P_T2U_N6_QBC_AD3P_66
+set_property  -quiet -dict {PACKAGE_PIN AC1   IOSTANDARD LVCMOS18                                     } [get_ports fpga_syncout_1_n     ]    ; ## FMC0_LA06_N         IO_L19N_T3L_N1_DBC_AD9N_66
+set_property  -quiet -dict {PACKAGE_PIN AC2   IOSTANDARD LVCMOS18                                     } [get_ports fpga_syncout_1_p     ]    ; ## FMC0_LA06_P         IO_L19P_T3L_N0_DBC_AD9P_66
+set_property         -dict {PACKAGE_PIN AH4   IOSTANDARD LVCMOS18                                     } [get_ports gpio[0]              ]    ; ## FMC1_LA10_P
+set_property         -dict {PACKAGE_PIN AJ4   IOSTANDARD LVCMOS18                                     } [get_ports gpio[1]              ]    ; ## FMC1_LA10_N
+set_property         -dict {PACKAGE_PIN AG8   IOSTANDARD LVCMOS18                                     } [get_ports gpio[2]              ]    ; ## FMC1_LA13_P
+set_property         -dict {PACKAGE_PIN AH8   IOSTANDARD LVCMOS18                                     } [get_ports gpio[3]              ]    ; ## FMC1_LA13_N
+set_property         -dict {PACKAGE_PIN AH3   IOSTANDARD LVCMOS18                                     } [get_ports gpio[4]              ]    ; ## FMC1_LA05_N
+set_property         -dict {PACKAGE_PIN AG3   IOSTANDARD LVCMOS18                                     } [get_ports gpio[5]              ]    ; ## FMC1_LA05_P
+set_property         -dict {PACKAGE_PIN AJ2   IOSTANDARD LVCMOS18                                     } [get_ports gpio[6]              ]    ; ## FMC1_LA06_N
+set_property         -dict {PACKAGE_PIN AH2   IOSTANDARD LVCMOS18                                     } [get_ports gpio[7]              ]    ; ## FMC1_LA06_P
+set_property         -dict {PACKAGE_PIN AA11  IOSTANDARD LVCMOS18                                     } [get_ports gpio[8]              ]    ; ## FMC1_LA19_P
+set_property         -dict {PACKAGE_PIN AC11  IOSTANDARD LVCMOS18                                     } [get_ports gpio[9]              ]    ; ## FMC1_LA21_N
+set_property         -dict {PACKAGE_PIN AC12  IOSTANDARD LVCMOS18                                     } [get_ports gpio[10]             ]    ; ## FMC1_LA21_P
+set_property         -dict {PACKAGE_PIN AA10  IOSTANDARD LVCMOS18                                     } [get_ports gpio[11]             ]    ; ## FMC1_LA19_N
+set_property         -dict {PACKAGE_PIN D22   IOSTANDARD LVCMOS18                                     } [get_ports gpio[12]             ]    ; ## PMOD1_2
+set_property         -dict {PACKAGE_PIN AB5   IOSTANDARD LVCMOS18                                     } [get_ports hmc_gpio1            ]    ; ## FMC0_LA11_N         IO_L10N_T1U_N7_QBC_AD4N_66
+set_property         -dict {PACKAGE_PIN U4    IOSTANDARD LVCMOS18                                     } [get_ports hmc_sync             ]    ; ## FMC0_LA07_N         IO_L18N_T2U_N11_AD2N_66
+set_property         -dict {PACKAGE_PIN V4    IOSTANDARD LVCMOS18                                     } [get_ports irqb[0]              ]    ; ## FMC0_LA08_P         IO_L17P_T2U_N8_AD10P_66
+set_property         -dict {PACKAGE_PIN V3    IOSTANDARD LVCMOS18                                     } [get_ports irqb[1]              ]    ; ## FMC0_LA08_N         IO_L17N_T2U_N9_AD10N_66
+set_property         -dict {PACKAGE_PIN U5    IOSTANDARD LVCMOS18                                     } [get_ports rstb                 ]    ; ## FMC0_LA07_P         IO_L18P_T2U_N10_AD2P_66
+set_property         -dict {PACKAGE_PIN W5    IOSTANDARD LVCMOS18                                     } [get_ports rxen[0]              ]    ; ## FMC0_LA10_P         IO_L15P_T2L_N4_AD11P_66
+set_property         -dict {PACKAGE_PIN W4    IOSTANDARD LVCMOS18                                     } [get_ports rxen[1]              ]    ; ## FMC0_LA10_N         IO_L15N_T2L_N5_AD11N_66
+set_property         -dict {PACKAGE_PIN AB3   IOSTANDARD LVCMOS18                                     } [get_ports spi0_csb_ad9082      ]    ; ## FMC0_LA05_P         IO_L20P_T3L_N2_AD1P_66
+set_property         -dict {PACKAGE_PIN AC3   IOSTANDARD LVCMOS18                                     } [get_ports spi0_miso_ad9082     ]    ; ## FMC0_LA05_N         IO_L20N_T3L_N3_AD1N_66
+set_property         -dict {PACKAGE_PIN AA2   IOSTANDARD LVCMOS18                                     } [get_ports spi0_mosi_ad9082     ]    ; ## FMC0_LA04_P         IO_L21P_T3L_N4_AD8P_66
+set_property         -dict {PACKAGE_PIN AA1   IOSTANDARD LVCMOS18                                     } [get_ports spi0_sclk_ad9082     ]    ; ## FMC0_LA04_N         IO_L21N_T3L_N5_AD8N_66
+set_property         -dict {PACKAGE_PIN AF10  IOSTANDARD LVCMOS18                                     } [get_ports spi0_csb_admv8818[0] ]    ; ## FMC1_LA25_N
+set_property         -dict {PACKAGE_PIN AE10  IOSTANDARD LVCMOS18                                     } [get_ports spi0_csb_admv8818[1] ]    ; ## FMC1_LA25_P
+set_property         -dict {PACKAGE_PIN AB10  IOSTANDARD LVCMOS18                                     } [get_ports spi0_miso_admv8818   ]    ; ## FMC1_LA20_N
+set_property         -dict {PACKAGE_PIN AB11  IOSTANDARD LVCMOS18                                     } [get_ports spi0_mosi_admv8818   ]    ; ## FMC1_LA20_P
+set_property         -dict {PACKAGE_PIN AG9   IOSTANDARD LVCMOS18                                     } [get_ports spi0_sclk_admv8818   ]    ; ## FMC1_LA16_N
+set_property         -dict {PACKAGE_PIN W7    IOSTANDARD LVCMOS18                                     } [get_ports spi1_csb_hmc7044     ]    ; ## FMC0_LA12_P         IO_L9P_T1L_N4_AD12P_66
+set_property         -dict {PACKAGE_PIN AB6   IOSTANDARD LVCMOS18                                     } [get_ports spi1_sclk_hmc7044    ]    ; ## FMC0_LA11_P         IO_L10P_T1U_N6_QBC_AD4P_66
+set_property         -dict {PACKAGE_PIN W6    IOSTANDARD LVCMOS18                                     } [get_ports spi1_sdio_hmc7044    ]    ; ## FMC0_LA12_N         IO_L9N_T1L_N5_AD12N_66
+set_property         -dict {PACKAGE_PIN D20   IOSTANDARD LVCMOS18                                     } [get_ports spi1_csb_adf4371[0]  ]    ; ## PMOD1_0
+set_property         -dict {PACKAGE_PIN E20   IOSTANDARD LVCMOS18                                     } [get_ports spi1_csb_adf4371[1]  ]    ; ## PMOD1_1
+set_property         -dict {PACKAGE_PIN AH11  IOSTANDARD LVCMOS18                                     } [get_ports spi1_sclk_adf4371    ]    ; ## FMC1_LA24_N
+set_property         -dict {PACKAGE_PIN T13   IOSTANDARD LVCMOS18                                     } [get_ports spi1_sdio_adf4371    ]    ; ## FMC1_LA28_P
+set_property         -dict {PACKAGE_PIN AF8   IOSTANDARD LVCMOS18                                     } [get_ports spi1_dir_adf4371     ]    ; ## FMC1_LA11_N
+set_property         -dict {PACKAGE_PIN AA6   IOSTANDARD LVDS     DIFF_TERM_ADV TERM_100 DQS_BIAS TRUE} [get_ports sysref2_n            ]    ; ## FMC0_CLK0_M2C_N     IO_L12N_T1U_N11_GC_66
+set_property         -dict {PACKAGE_PIN AA7   IOSTANDARD LVDS     DIFF_TERM_ADV TERM_100 DQS_BIAS TRUE} [get_ports sysref2_p            ]    ; ## FMC0_CLK0_M2C_P     IO_L12P_T1U_N10_GC_66
+set_property         -dict {PACKAGE_PIN W2    IOSTANDARD LVCMOS18                                     } [get_ports txen[0]              ]    ; ## FMC0_LA09_P         IO_L24P_T3U_N10_66
+set_property         -dict {PACKAGE_PIN W1    IOSTANDARD LVCMOS18                                     } [get_ports txen[1]              ]    ; ## FMC0_LA09_N         IO_L24N_T3U_N11_66

--- a/projects/ad9082_fmca_ebz_xmw_rx/zcu102/system_project.tcl
+++ b/projects/ad9082_fmca_ebz_xmw_rx/zcu102/system_project.tcl
@@ -1,0 +1,58 @@
+
+source ../../scripts/adi_env.tcl
+source $ad_hdl_dir/projects/scripts/adi_project_xilinx.tcl
+source $ad_hdl_dir/projects/scripts/adi_board.tcl
+
+# get_env_param retrieves parameter value from the environment if exists,
+# other case use the default value
+#
+#   Use over-writable parameters from the environment.
+#
+#    e.g.
+#      make RX_JESD_L=4 RX_JESD_M=8 RX_JESD_S=1 TX_JESD_L=4 TX_JESD_M=8 TX_JESD_S=1
+#      make RX_JESD_L=8 RX_JESD_M=4 RX_JESD_S=1 TX_JESD_L=8 TX_JESD_M=4 TX_JESD_S=1
+
+#
+# Parameter description:
+#   JESD_MODE : Used link layer encoder mode
+#      64B66B - 64b66b link layer defined in JESD 204C
+#      8B10B  - 8b10b link layer defined in JESD 204B
+#
+#   RX_RATE :  Line rate of the Rx link ( MxFE to FPGA )
+#   TX_RATE :  Line rate of the Tx link ( FPGA to MxFE )
+#   [RX/TX]_JESD_M : Number of converters per link
+#   [RX/TX]_JESD_L : Number of lanes per link
+#   [RX/TX]_JESD_NP : Number of bits per sample, only 16 is supported
+#   [RX/TX]_NUM_LINKS : Number of links, matches numer of MxFE devices
+#
+#
+#  !!! For this carrier only 8B10B mode is supported !!!
+#
+
+adi_project ad9082_fmca_ebz_xmw_rx_zcu102 0 [list \
+  JESD_MODE    [get_env_param JESD_MODE    8B10B ]\
+  RX_LANE_RATE [get_env_param RX_RATE      15 ] \
+  TX_LANE_RATE [get_env_param TX_RATE      15 ] \
+  RX_JESD_M    [get_env_param RX_JESD_M    4 ] \
+  RX_JESD_L    [get_env_param RX_JESD_L    8 ] \
+  RX_JESD_S    [get_env_param RX_JESD_S    1 ] \
+  RX_JESD_NP   [get_env_param RX_JESD_NP   16] \
+  RX_NUM_LINKS [get_env_param RX_NUM_LINKS 1 ] \
+  TX_JESD_M    [get_env_param TX_JESD_M    4 ] \
+  TX_JESD_L    [get_env_param TX_JESD_L    8 ] \
+  TX_JESD_S    [get_env_param TX_JESD_S    1 ] \
+  TX_JESD_NP   [get_env_param TX_JESD_NP   16] \
+  TX_NUM_LINKS [get_env_param TX_NUM_LINKS 1 ] \
+]
+
+adi_project_files ad9082_fmca_ebz_xmw_rx_zcu102 [list \
+  "../../ad9082_fmca_ebz_xmw_rx/zcu102/system_top.v" \
+  "../../ad9082_fmca_ebz_xmw_rx/zcu102/system_constr.xdc" \
+  "../../ad9081_fmca_ebz/zcu102/timing_constr.xdc" \
+  "../../../library/common/ad_3w_spi.v" \
+  "$ad_hdl_dir/library/common/ad_iobuf.v" \
+  "$ad_hdl_dir/projects/common/zcu102/zcu102_system_constr.xdc" ]
+
+
+adi_project_run ad9082_fmca_ebz_xmw_rx_zcu102
+

--- a/projects/ad9082_fmca_ebz_xmw_rx/zcu102/system_top.v
+++ b/projects/ad9082_fmca_ebz_xmw_rx/zcu102/system_top.v
@@ -1,0 +1,361 @@
+// ***************************************************************************
+// ***************************************************************************
+// Copyright 2014 - 2023 (c) Analog Devices, Inc. All rights reserved.
+//
+// In this HDL repository, there are many different and unique modules, consisting
+// of various HDL (Verilog or VHDL) components. The individual modules are
+// developed independently, and may be accompanied by separate and unique license
+// terms.
+//
+// The user should read each of these license terms, and understand the
+// freedoms and responsibilities that he or she has by using this source/core.
+//
+// This core is distributed in the hope that it will be useful, but WITHOUT ANY
+// WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+// A PARTICULAR PURPOSE.
+//
+// Redistribution and use of source or resulting binaries, with or without modification
+// of this file, are permitted under one of the following two license terms:
+//
+//   1. The GNU General Public License version 2 as published by the
+//      Free Software Foundation, which can be found in the top level directory
+//      of this repository (LICENSE_GPL2), and also online at:
+//      <https://www.gnu.org/licenses/old-licenses/gpl-2.0.html>
+//
+// OR
+//
+//   2. An ADI specific BSD license, which can be found in the top level directory
+//      of this repository (LICENSE_ADIBSD), and also on-line at:
+//      https://github.com/analogdevicesinc/hdl/blob/master/LICENSE_ADIBSD
+//      This will allow to generate bit files and not release the source code,
+//      as long as it attaches to an ADI device.
+//
+// ***************************************************************************
+// ***************************************************************************
+
+`timescale 1ns/100ps
+
+module system_top  #(
+	parameter TX_JESD_L = 8,
+	parameter TX_NUM_LINKS = 1,
+	parameter RX_JESD_L = 8,
+	parameter RX_NUM_LINKS = 1,
+	parameter SHARED_DEVCLK = 0,
+	parameter JESD_MODE = "8B10B"
+) (
+	input  [12:0] gpio_bd_i,
+	output [ 7:0] gpio_bd_o,
+
+	// FMC HPC IOs
+	input  [1:0]  agc0,
+	input  [1:0]  agc1,
+	input  [1:0]  agc2,
+	input  [1:0]  agc3,
+	input         clkin6_n,
+	input         clkin6_p,
+	input         clkin10_n,
+	input         clkin10_p,
+	input         fpga_refclk_in_n,
+	input         fpga_refclk_in_p,
+	input  [RX_JESD_L*RX_NUM_LINKS-1:0]  rx_data_n,
+	input  [RX_JESD_L*RX_NUM_LINKS-1:0]  rx_data_p,
+	output [TX_JESD_L*TX_NUM_LINKS-1:0]  tx_data_n,
+	output [TX_JESD_L*TX_NUM_LINKS-1:0]  tx_data_p,
+	input    fpga_syncin_0_n,
+	input    fpga_syncin_0_p,
+	inout    fpga_syncin_1_n,
+	inout    fpga_syncin_1_p,
+	output   fpga_syncout_0_n,
+	output   fpga_syncout_0_p,
+	inout    fpga_syncout_1_n,
+	inout    fpga_syncout_1_p,
+	inout  [12:0] gpio,
+	inout         hmc_gpio1,
+	output        hmc_sync,
+	input  [1:0]  irqb,
+	output        rstb,
+	output [1:0]  rxen,
+	input         sysref2_n,
+	input         sysref2_p,
+	output [1:0]  txen,
+	// AD9082 SPI Signals
+	output        spi0_csb_ad9082,
+	input         spi0_miso_ad9082,
+	output        spi0_mosi_ad9082,
+	output        spi0_sclk_ad9082,
+	// ADMV8818 SPI Signals
+	output  [1:0] spi0_csb_admv8818,
+	input         spi0_miso_admv8818,
+	output        spi0_mosi_admv8818,
+	output        spi0_sclk_admv8818,
+	// HMC7044 SPI Signals
+	output        spi1_csb_hmc7044,
+	output        spi1_sclk_hmc7044,
+	inout         spi1_sdio_hmc7044,
+	// ADF4371 SPI Signals
+	output  [1:0] spi1_csb_adf4371,
+	output        spi1_sclk_adf4371,
+	inout         spi1_sdio_adf4371,
+	output        spi1_dir_adf4371
+);
+
+	// internal signals
+
+	wire    [94:0]  gpio_i;
+	wire    [94:0]  gpio_o;
+	wire    [94:0]  gpio_t;
+
+	// spi0 signals
+	wire    [ 2:0]  spi0_csn;
+	wire            spi0_sclk;
+	wire            spi0_miso;
+	wire            spi0_mosi;
+
+	// spi1 signals
+	wire    [ 2:0]  spi1_csn;
+	wire            spi1_sclk;
+	wire            spi1_mosi;
+	wire            spi1_miso;
+
+	// 3-wire spi miso signals
+	wire            spi1_miso_adf4371;
+	wire            spi1_miso_hmc7044;
+
+	wire            ref_clk;
+	wire            sysref;
+	wire    [TX_NUM_LINKS-1:0]   tx_syncin;
+	wire    [RX_NUM_LINKS-1:0]   rx_syncout;
+
+	wire    [7:0]   rx_data_p_loc;
+	wire    [7:0]   rx_data_n_loc;
+	wire    [7:0]   tx_data_p_loc;
+	wire    [7:0]   tx_data_n_loc;
+
+	wire            clkin6;
+	wire            clkin10;
+	wire            tx_device_clk;
+	wire            rx_device_clk_internal;
+	wire            rx_device_clk;
+
+	assign iic_rstn = 1'b1;
+
+	// instantiations
+
+	IBUFDS_GTE4 i_ibufds_ref_clk (
+		.CEB (1'd0),
+		.I (fpga_refclk_in_p),
+		.IB (fpga_refclk_in_n),
+		.O (ref_clk),
+		.ODIV2 ());
+
+	IBUFDS i_ibufds_sysref (
+		.I (sysref2_p),
+		.IB (sysref2_n),
+		.O (sysref));
+
+	IBUFDS i_ibufds_tx_device_clk (
+		.I (clkin6_p),
+		.IB (clkin6_n),
+		.O (clkin6));
+
+	IBUFDS i_ibufds_rx_device_clk (
+		.I (clkin10_p),
+		.IB (clkin10_n),
+		.O (clkin10));
+
+	IBUFDS i_ibufds_syncin_0 (
+		.I (fpga_syncin_0_p),
+		.IB (fpga_syncin_0_n),
+		.O (tx_syncin[0]));
+
+	OBUFDS i_obufds_syncout_0 (
+		.I (rx_syncout[0]),
+		.O (fpga_syncout_0_p),
+		.OB (fpga_syncout_0_n));
+
+	BUFG i_tx_device_clk (
+		.I (clkin6),
+		.O (tx_device_clk));
+
+	BUFG i_rx_device_clk (
+		.I (clkin10),
+		.O (rx_device_clk_internal));
+
+	assign rx_device_clk = SHARED_DEVCLK ? tx_device_clk : rx_device_clk_internal;
+
+	// spi
+
+	// spi0 output signals
+	assign spi0_csb_ad9082 = spi0_csn[0];
+	assign spi0_mosi_ad9082 = spi0_mosi;
+	assign spi0_sclk_ad9082 = spi0_sclk;
+
+	assign spi0_csb_admv8818[0] = spi0_csn[1];
+	assign spi0_csb_admv8818[1] = spi0_csn[2];
+	assign spi0_mosi_admv8818 = spi0_mosi;
+	assign spi0_sclk_admv8818 = spi0_sclk;
+
+	// spi0 input signals
+	assign spi0_miso = ~spi0_csn[0] ? spi0_miso_ad9082   :
+										 |(~spi0_csn[2:1]) ? spi0_miso_admv8818 :
+										 1'b0;
+
+	// spi1 output signals
+	assign spi1_csb_hmc7044 = spi1_csn[0];
+	assign spi1_sclk_hmc7044 = spi1_sclk;
+
+	assign spi1_csb_adf4371 = spi1_csn[2:1];
+	assign spi1_sclk_adf4371 = spi1_sclk;
+
+	// spi1 input signals
+	assign spi1_miso = |(~spi1_csn[2:1]) ? spi1_miso_adf4371 :
+											 ~spi1_csn[0]    ? spi1_miso_hmc7044 :
+											 1'b0;
+
+	// 3-wire spi configuration for HMC7044 and ADF4371a on spi1
+	ad_3w_spi #(
+		.NUM_OF_SLAVES(1)
+	) i_spi_hmc7044 (
+		.spi_csn (spi1_csn[0]),
+		.spi_clk (spi1_sclk),
+		.spi_mosi (spi1_mosi),
+		.spi_miso (spi1_miso_hmc7044),
+		.spi_sdio (spi1_sdio_hmc7044),
+		.spi_dir ());
+
+		ad_3w_spi #(
+		.NUM_OF_SLAVES(1)
+		) i_spi_adf4371 (
+		.spi_csn (&spi1_csn[2:1]),
+		.spi_clk (spi1_sclk),
+		.spi_mosi (spi1_mosi),
+		.spi_miso (spi1_miso_adf4371),
+		.spi_sdio (spi1_sdio_adf4371),
+		.spi_dir (spi1_dir_adf4371));
+
+	ad_iobuf #(
+		.DATA_WIDTH(14)
+	) i_iobuf (
+		.dio_t (gpio_t[43:30]),
+		.dio_i (gpio_o[43:30]),
+		.dio_o (gpio_i[43:30]),
+		.dio_p ({hmc_gpio1,       // 43
+						 gpio[12:0]}));   // 42-30
+
+	assign gpio_i[44] = agc0[0];
+	assign gpio_i[45] = agc0[1];
+	assign gpio_i[46] = agc1[0];
+	assign gpio_i[47] = agc1[1];
+	assign gpio_i[48] = agc2[0];
+	assign gpio_i[49] = agc2[1];
+	assign gpio_i[50] = agc3[0];
+	assign gpio_i[51] = agc3[1];
+	assign gpio_i[52] = irqb[0];
+	assign gpio_i[53] = irqb[1];
+
+	assign hmc_sync = gpio_o[54];
+	assign rstb     = gpio_o[55];
+	assign rxen[0]  = gpio_o[56];
+	assign rxen[1]  = gpio_o[57];
+	assign txen[0]  = gpio_o[58];
+	assign txen[1]  = gpio_o[59];
+
+	generate
+	if (TX_NUM_LINKS > 1 & JESD_MODE == "8B10B") begin
+		assign tx_syncin[1] = fpga_syncin_1_p;
+	end else begin
+		ad_iobuf #(
+			.DATA_WIDTH(2)
+		) i_syncin_iobuf (
+			.dio_t (gpio_t[61:60]),
+			.dio_i (gpio_o[61:60]),
+			.dio_o (gpio_i[61:60]),
+			.dio_p ({fpga_syncin_1_n,      // 61
+							 fpga_syncin_1_p}));   // 60
+	end
+
+	if (RX_NUM_LINKS > 1 & JESD_MODE == "8B10B") begin
+		assign fpga_syncout_1_p = rx_syncout[1];
+		assign fpga_syncout_1_n = 0;
+	end else begin
+		ad_iobuf #(
+			.DATA_WIDTH(2)
+		) i_syncout_iobuf (
+			.dio_t (gpio_t[63:62]),
+			.dio_i (gpio_o[63:62]),
+			.dio_o (gpio_i[63:62]),
+			.dio_p ({fpga_syncout_1_n,      // 63
+							 fpga_syncout_1_p}));   // 62
+	end
+	endgenerate
+	/* Board GPIOS. Buttons, LEDs, etc... */
+	assign gpio_i[20: 8] = gpio_bd_i;
+	assign gpio_bd_o = gpio_o[7:0];
+
+	// Unused GPIOs
+	assign gpio_i[59:54] = gpio_o[59:54];
+	assign gpio_i[94:64] = gpio_o[94:64];
+	assign gpio_i[29:21] = gpio_o[29:21];
+	assign gpio_i[7:0] = gpio_o[7:0];
+
+	system_wrapper i_system_wrapper (
+		.gpio_i (gpio_i),
+		.gpio_o (gpio_o),
+		.gpio_t (gpio_t),
+		.spi0_csn (spi0_csn),
+		.spi0_miso (spi0_miso),
+		.spi0_mosi (spi0_mosi),
+		.spi0_sclk (spi0_sclk),
+		.spi1_csn (spi1_csn),
+		.spi1_miso (spi1_miso),
+		.spi1_mosi (spi1_mosi),
+		.spi1_sclk (spi1_sclk),
+		// FMC HPC
+		.rx_data_0_n (rx_data_n_loc[0]),
+		.rx_data_0_p (rx_data_p_loc[0]),
+		.rx_data_1_n (rx_data_n_loc[1]),
+		.rx_data_1_p (rx_data_p_loc[1]),
+		.rx_data_2_n (rx_data_n_loc[2]),
+		.rx_data_2_p (rx_data_p_loc[2]),
+		.rx_data_3_n (rx_data_n_loc[3]),
+		.rx_data_3_p (rx_data_p_loc[3]),
+		.rx_data_4_n (rx_data_n_loc[4]),
+		.rx_data_4_p (rx_data_p_loc[4]),
+		.rx_data_5_n (rx_data_n_loc[5]),
+		.rx_data_5_p (rx_data_p_loc[5]),
+		.rx_data_6_n (rx_data_n_loc[6]),
+		.rx_data_6_p (rx_data_p_loc[6]),
+		.rx_data_7_n (rx_data_n_loc[7]),
+		.rx_data_7_p (rx_data_p_loc[7]),
+		.tx_data_0_n (tx_data_n_loc[0]),
+		.tx_data_0_p (tx_data_p_loc[0]),
+		.tx_data_1_n (tx_data_n_loc[1]),
+		.tx_data_1_p (tx_data_p_loc[1]),
+		.tx_data_2_n (tx_data_n_loc[2]),
+		.tx_data_2_p (tx_data_p_loc[2]),
+		.tx_data_3_n (tx_data_n_loc[3]),
+		.tx_data_3_p (tx_data_p_loc[3]),
+		.tx_data_4_n (tx_data_n_loc[4]),
+		.tx_data_4_p (tx_data_p_loc[4]),
+		.tx_data_5_n (tx_data_n_loc[5]),
+		.tx_data_5_p (tx_data_p_loc[5]),
+		.tx_data_6_n (tx_data_n_loc[6]),
+		.tx_data_6_p (tx_data_p_loc[6]),
+		.tx_data_7_n (tx_data_n_loc[7]),
+		.tx_data_7_p (tx_data_p_loc[7]),
+		.ref_clk_q0 (ref_clk),
+		.ref_clk_q1 (ref_clk),
+		.rx_device_clk (rx_device_clk),
+		.tx_device_clk (tx_device_clk),
+		.rx_sync_0 (rx_syncout),
+		.tx_sync_0 (tx_syncin),
+		.rx_sysref_0 (sysref),
+		.tx_sysref_0 (sysref));
+
+	assign rx_data_p_loc[RX_JESD_L*RX_NUM_LINKS-1:0] = rx_data_p[RX_JESD_L*RX_NUM_LINKS-1:0];
+	assign rx_data_n_loc[RX_JESD_L*RX_NUM_LINKS-1:0] = rx_data_n[RX_JESD_L*RX_NUM_LINKS-1:0];
+
+	assign tx_data_p[TX_JESD_L*TX_NUM_LINKS-1:0] = tx_data_p_loc[TX_JESD_L*TX_NUM_LINKS-1:0];
+	assign tx_data_n[TX_JESD_L*TX_NUM_LINKS-1:0] = tx_data_n_loc[TX_JESD_L*TX_NUM_LINKS-1:0];
+
+endmodule

--- a/projects/ad9082_fmca_ebz_xmw_tx/Makefile
+++ b/projects/ad9082_fmca_ebz_xmw_tx/Makefile
@@ -1,0 +1,7 @@
+####################################################################################
+## Copyright (c) 2018 - 2021 Analog Devices, Inc.
+### SPDX short identifier: BSD-1-Clause
+## Auto-generated, do not modify!
+####################################################################################
+
+include ../scripts/project-toplevel.mk

--- a/projects/ad9082_fmca_ebz_xmw_tx/Readme.md
+++ b/projects/ad9082_fmca_ebz_xmw_tx/Readme.md
@@ -1,0 +1,7 @@
+# AD9082-FMCA-EBZ-XMW-TX HDL Project
+
+Here are some pointers to help you:
+  * Parts : [MxFE Quad, 16-Bit, 12 GSPS RF DAC and Dual, 12-Bit, 6 GSPS RF ADC](https://www.analog.com/ad9082)
+  * Project Doc: https://wiki.analog.com/resources/eval/developer-kits/2to24ghz-mxfe-rf-front-end
+  * HDL Doc: https://wiki.analog.com/resources/eval/user-guides/ad9081_fmca_ebz/ad9081_fmca_ebz_hdl
+  * Linux Drivers: https://wiki.analog.com/resources/tools-software/linux-drivers/iio-mxfe/ad9081

--- a/projects/ad9082_fmca_ebz_xmw_tx/zcu102/Makefile
+++ b/projects/ad9082_fmca_ebz_xmw_tx/zcu102/Makefile
@@ -1,0 +1,49 @@
+####################################################################################
+## Copyright (c) 2018 - 2021 Analog Devices, Inc.
+### SPDX short identifier: BSD-1-Clause
+## Auto-generated, do not modify!
+####################################################################################
+
+PROJECT_NAME := ad9082_fmca_ebz_xmw_tx_zcu102
+
+M_DEPS += ../../scripts/adi_pd.tcl
+M_DEPS += ../../common/zcu102/zcu102_system_constr.xdc
+M_DEPS += ../../common/zcu102/zcu102_system_bd.tcl
+M_DEPS += ../../common/xilinx/data_offload_bd.tcl
+M_DEPS += ../../common/xilinx/dacfifo_bd.tcl
+M_DEPS += ../../common/xilinx/adcfifo_bd.tcl
+M_DEPS += ../../ad9081_fmca_ebz/zcu102/timing_constr.xdc
+M_DEPS += ../../ad9082_fmca_ebz_xmw_tx/zcu102/system_top.v
+M_DEPS += ../../ad9082_fmca_ebz_xmw_tx/zcu102/system_constr.xdc
+M_DEPS += ../../ad9081_fmca_ebz/zcu102/system_bd.tcl
+M_DEPS += ../../ad9081_fmca_ebz/common/versal_transceiver.tcl
+M_DEPS += ../../ad9081_fmca_ebz/common/ad9081_fmca_ebz_bd.tcl
+M_DEPS += ../../../library/util_hbm/scripts/adi_util_hbm.tcl
+M_DEPS += ../../../library/jesd204/scripts/jesd204.tcl
+M_DEPS += ../../../library/common/ad_iobuf.v
+M_DEPS += ../../../library/common/ad_3w_spi.v
+
+LIB_DEPS += axi_dmac
+LIB_DEPS += axi_sysid
+LIB_DEPS += axi_tdd
+LIB_DEPS += data_offload
+LIB_DEPS += jesd204/ad_ip_jesd204_tpl_adc
+LIB_DEPS += jesd204/ad_ip_jesd204_tpl_dac
+LIB_DEPS += jesd204/axi_jesd204_rx
+LIB_DEPS += jesd204/axi_jesd204_tx
+LIB_DEPS += jesd204/jesd204_rx
+LIB_DEPS += jesd204/jesd204_tx
+LIB_DEPS += jesd204/jesd204_versal_gt_adapter_rx
+LIB_DEPS += jesd204/jesd204_versal_gt_adapter_tx
+LIB_DEPS += sysid_rom
+LIB_DEPS += util_adcfifo
+LIB_DEPS += util_dacfifo
+LIB_DEPS += util_do_ram
+LIB_DEPS += util_hbm
+LIB_DEPS += util_pack/util_cpack2
+LIB_DEPS += util_pack/util_upack2
+LIB_DEPS += util_tdd_sync
+LIB_DEPS += xilinx/axi_adxcvr
+LIB_DEPS += xilinx/util_adxcvr
+
+include ../../scripts/project-xilinx.mk

--- a/projects/ad9082_fmca_ebz_xmw_tx/zcu102/system_bd.tcl
+++ b/projects/ad9082_fmca_ebz_xmw_tx/zcu102/system_bd.tcl
@@ -1,0 +1,3 @@
+
+source $ad_hdl_dir/projects/ad9081_fmca_ebz/zcu102/system_bd.tcl
+

--- a/projects/ad9082_fmca_ebz_xmw_tx/zcu102/system_constr.xdc
+++ b/projects/ad9082_fmca_ebz_xmw_tx/zcu102/system_constr.xdc
@@ -1,0 +1,96 @@
+#
+## mxfe
+#
+
+set_property         -dict {PACKAGE_PIN P11   IOSTANDARD LVCMOS18                                     } [get_ports agc0[0]            ]    ; ## FMC0_LA17_CC_P      IO_L13P_T2L_N0_GC_QBC_67
+set_property         -dict {PACKAGE_PIN N11   IOSTANDARD LVCMOS18                                     } [get_ports agc0[1]            ]    ; ## FMC0_LA17_CC_N      IO_L13N_T2L_N1_GC_QBC_67
+set_property         -dict {PACKAGE_PIN N9    IOSTANDARD LVCMOS18                                     } [get_ports agc1[0]            ]    ; ## FMC0_LA18_CC_P      IO_L16P_T2U_N6_QBC_AD3P_67
+set_property         -dict {PACKAGE_PIN N8    IOSTANDARD LVCMOS18                                     } [get_ports agc1[1]            ]    ; ## FMC0_LA18_CC_N      IO_L16N_T2U_N7_QBC_AD3N_67
+set_property         -dict {PACKAGE_PIN N13   IOSTANDARD LVCMOS18                                     } [get_ports agc2[0]            ]    ; ## FMC0_LA20_P         IO_L22P_T3U_N6_DBC_AD0P_67
+set_property         -dict {PACKAGE_PIN M13   IOSTANDARD LVCMOS18                                     } [get_ports agc2[1]            ]    ; ## FMC0_LA20_N         IO_L22N_T3U_N7_DBC_AD0N_67
+set_property         -dict {PACKAGE_PIN P12   IOSTANDARD LVCMOS18                                     } [get_ports agc3[0]            ]    ; ## FMC0_LA21_P         IO_L21P_T3L_N4_AD8P_67
+set_property         -dict {PACKAGE_PIN N12   IOSTANDARD LVCMOS18                                     } [get_ports agc3[1]            ]    ; ## FMC0_LA21_N         IO_L21N_T3L_N5_AD8N_67
+set_property         -dict {PACKAGE_PIN Y3    IOSTANDARD LVDS     DIFF_TERM_ADV TERM_100 DQS_BIAS TRUE} [get_ports clkin10_n          ]    ; ## FMC0_CLK2_IO_N      IO_L13N_T2L_N1_GC_QBC_66
+set_property         -dict {PACKAGE_PIN Y4    IOSTANDARD LVDS     DIFF_TERM_ADV TERM_100 DQS_BIAS TRUE} [get_ports clkin10_p          ]    ; ## FMC0_CLK2_IO_P      IO_L13P_T2L_N0_GC_QBC_66
+set_property         -dict {PACKAGE_PIN R8    IOSTANDARD LVDS     DIFF_TERM_ADV TERM_100 DQS_BIAS TRUE} [get_ports clkin6_n           ]    ; ## FMC0_CLK1_M2C_N     IO_L12N_T1U_N11_GC_67
+set_property         -dict {PACKAGE_PIN T8    IOSTANDARD LVDS     DIFF_TERM_ADV TERM_100 DQS_BIAS TRUE} [get_ports clkin6_p           ]    ; ## FMC0_CLK1_M2C_P     IO_L12P_T1U_N10_GC_67
+set_property         -dict {PACKAGE_PIN G7                                                            } [get_ports fpga_refclk_in_n   ]    ; ## FMC0_GBTCLK0_M2C_N  MGTREFCLK0N_229
+set_property         -dict {PACKAGE_PIN G8                                                            } [get_ports fpga_refclk_in_p   ]    ; ## FMC0_GBTCLK0_M2C_P  MGTREFCLK0P_229
+set_property  -quiet -dict {PACKAGE_PIN F1                                                            } [get_ports rx_data_n[2]       ]    ; ## FMC0_DP2_M2C_N      MGTHRXN3_229    FPGA_SERDIN_0_N
+set_property  -quiet -dict {PACKAGE_PIN F2                                                            } [get_ports rx_data_p[2]       ]    ; ## FMC0_DP2_M2C_P      MGTHRXP3_229    FPGA_SERDIN_0_P
+set_property  -quiet -dict {PACKAGE_PIN H1                                                            } [get_ports rx_data_n[0]       ]    ; ## FMC0_DP0_M2C_N      MGTHRXN2_229    FPGA_SERDIN_1_N
+set_property  -quiet -dict {PACKAGE_PIN H2                                                            } [get_ports rx_data_p[0]       ]    ; ## FMC0_DP0_M2C_P      MGTHRXP2_229    FPGA_SERDIN_1_P
+set_property  -quiet -dict {PACKAGE_PIN M1                                                            } [get_ports rx_data_n[7]       ]    ; ## FMC0_DP7_M2C_N      MGTHRXN2_228    FPGA_SERDIN_2_N
+set_property  -quiet -dict {PACKAGE_PIN M2                                                            } [get_ports rx_data_p[7]       ]    ; ## FMC0_DP7_M2C_P      MGTHRXP2_228    FPGA_SERDIN_2_P
+set_property  -quiet -dict {PACKAGE_PIN T1                                                            } [get_ports rx_data_n[6]       ]    ; ## FMC0_DP6_M2C_N      MGTHRXN0_228    FPGA_SERDIN_3_N
+set_property  -quiet -dict {PACKAGE_PIN T2                                                            } [get_ports rx_data_p[6]       ]    ; ## FMC0_DP6_M2C_P      MGTHRXP0_228    FPGA_SERDIN_3_P
+set_property  -quiet -dict {PACKAGE_PIN P1                                                            } [get_ports rx_data_n[5]       ]    ; ## FMC0_DP5_M2C_N      MGTHRXN1_228    FPGA_SERDIN_4_N
+set_property  -quiet -dict {PACKAGE_PIN P2                                                            } [get_ports rx_data_p[5]       ]    ; ## FMC0_DP5_M2C_P      MGTHRXP1_228    FPGA_SERDIN_4_P
+set_property  -quiet -dict {PACKAGE_PIN L3                                                            } [get_ports rx_data_n[4]       ]    ; ## FMC0_DP4_M2C_N      MGTHRXN3_228    FPGA_SERDIN_5_N
+set_property  -quiet -dict {PACKAGE_PIN L4                                                            } [get_ports rx_data_p[4]       ]    ; ## FMC0_DP4_M2C_P      MGTHRXP3_228    FPGA_SERDIN_5_P
+set_property  -quiet -dict {PACKAGE_PIN K1                                                            } [get_ports rx_data_n[3]       ]    ; ## FMC0_DP3_M2C_N      MGTHRXN0_229    FPGA_SERDIN_6_N
+set_property  -quiet -dict {PACKAGE_PIN K2                                                            } [get_ports rx_data_p[3]       ]    ; ## FMC0_DP3_M2C_P      MGTHRXP0_229    FPGA_SERDIN_6_P
+set_property  -quiet -dict {PACKAGE_PIN J3                                                            } [get_ports rx_data_n[1]       ]    ; ## FMC0_DP1_M2C_N      MGTHRXN1_229    FPGA_SERDIN_7_N
+set_property  -quiet -dict {PACKAGE_PIN J4                                                            } [get_ports rx_data_p[1]       ]    ; ## FMC0_DP1_M2C_P      MGTHRXP1_229    FPGA_SERDIN_7_P
+set_property  -quiet -dict {PACKAGE_PIN G3                                                            } [get_ports tx_data_n[0]       ]    ; ## FMC0_DP0_C2M_N      MGTHTXN2_229    FPGA_SERDOUT_0_N
+set_property  -quiet -dict {PACKAGE_PIN G4                                                            } [get_ports tx_data_p[0]       ]    ; ## FMC0_DP0_C2M_P      MGTHTXP2_229    FPGA_SERDOUT_0_P
+set_property  -quiet -dict {PACKAGE_PIN F5                                                            } [get_ports tx_data_n[2]       ]    ; ## FMC0_DP2_C2M_N      MGTHTXN3_229    FPGA_SERDOUT_1_N
+set_property  -quiet -dict {PACKAGE_PIN F6                                                            } [get_ports tx_data_p[2]       ]    ; ## FMC0_DP2_C2M_P      MGTHTXP3_229    FPGA_SERDOUT_1_P
+set_property  -quiet -dict {PACKAGE_PIN N3                                                            } [get_ports tx_data_n[7]       ]    ; ## FMC0_DP7_C2M_N      MGTHTXN2_228    FPGA_SERDOUT_2_N
+set_property  -quiet -dict {PACKAGE_PIN N4                                                            } [get_ports tx_data_p[7]       ]    ; ## FMC0_DP7_C2M_P      MGTHTXP2_228    FPGA_SERDOUT_2_P
+set_property  -quiet -dict {PACKAGE_PIN R3                                                            } [get_ports tx_data_n[6]       ]    ; ## FMC0_DP6_C2M_N      MGTHTXN0_228    FPGA_SERDOUT_3_N
+set_property  -quiet -dict {PACKAGE_PIN R4                                                            } [get_ports tx_data_p[6]       ]    ; ## FMC0_DP6_C2M_P      MGTHTXP0_228    FPGA_SERDOUT_3_P
+set_property  -quiet -dict {PACKAGE_PIN H5                                                            } [get_ports tx_data_n[1]       ]    ; ## FMC0_DP1_C2M_N      MGTHTXN1_229    FPGA_SERDOUT_4_N
+set_property  -quiet -dict {PACKAGE_PIN H6                                                            } [get_ports tx_data_p[1]       ]    ; ## FMC0_DP1_C2M_P      MGTHTXP1_229    FPGA_SERDOUT_4_P
+set_property  -quiet -dict {PACKAGE_PIN P5                                                            } [get_ports tx_data_n[5]       ]    ; ## FMC0_DP5_C2M_N      MGTHTXN1_228    FPGA_SERDOUT_5_N
+set_property  -quiet -dict {PACKAGE_PIN P6                                                            } [get_ports tx_data_p[5]       ]    ; ## FMC0_DP5_C2M_P      MGTHTXP1_228    FPGA_SERDOUT_5_P
+set_property  -quiet -dict {PACKAGE_PIN M5                                                            } [get_ports tx_data_n[4]       ]    ; ## FMC0_DP4_C2M_N      MGTHTXN3_228    FPGA_SERDOUT_6_N
+set_property  -quiet -dict {PACKAGE_PIN M6                                                            } [get_ports tx_data_p[4]       ]    ; ## FMC0_DP4_C2M_P      MGTHTXP3_228    FPGA_SERDOUT_6_P
+set_property  -quiet -dict {PACKAGE_PIN K5                                                            } [get_ports tx_data_n[3]       ]    ; ## FMC0_DP3_C2M_N      MGTHTXN0_229    FPGA_SERDOUT_7_N
+set_property  -quiet -dict {PACKAGE_PIN K6                                                            } [get_ports tx_data_p[3]       ]    ; ## FMC0_DP3_C2M_P      MGTHTXP0_229    FPGA_SERDOUT_7_P
+set_property  -quiet -dict {PACKAGE_PIN V1    IOSTANDARD LVDS     DIFF_TERM_ADV TERM_100              } [get_ports fpga_syncin_0_n    ]    ; ## FMC0_LA02_N         IO_L23N_T3U_N9_66
+set_property  -quiet -dict {PACKAGE_PIN V2    IOSTANDARD LVDS     DIFF_TERM_ADV TERM_100              } [get_ports fpga_syncin_0_p    ]    ; ## FMC0_LA02_P         IO_L23P_T3U_N8_66
+set_property  -quiet -dict {PACKAGE_PIN Y1    IOSTANDARD LVCMOS18                                     } [get_ports fpga_syncin_1_n    ]    ; ## FMC0_LA03_N         IO_L22N_T3U_N7_DBC_AD0N_66
+set_property  -quiet -dict {PACKAGE_PIN Y2    IOSTANDARD LVCMOS18                                     } [get_ports fpga_syncin_1_p    ]    ; ## FMC0_LA03_P         IO_L22P_T3U_N6_DBC_AD0P_66
+set_property  -quiet -dict {PACKAGE_PIN AC4   IOSTANDARD LVDS                                         } [get_ports fpga_syncout_0_n   ]    ; ## FMC0_LA01_CC_N      IO_L16N_T2U_N7_QBC_AD3N_66
+set_property  -quiet -dict {PACKAGE_PIN AB4   IOSTANDARD LVDS                                         } [get_ports fpga_syncout_0_p   ]    ; ## FMC0_LA01_CC_P      IO_L16P_T2U_N6_QBC_AD3P_66
+set_property  -quiet -dict {PACKAGE_PIN AC1   IOSTANDARD LVCMOS18                                     } [get_ports fpga_syncout_1_n   ]    ; ## FMC0_LA06_N         IO_L19N_T3L_N1_DBC_AD9N_66
+set_property  -quiet -dict {PACKAGE_PIN AC2   IOSTANDARD LVCMOS18                                     } [get_ports fpga_syncout_1_p   ]    ; ## FMC0_LA06_P         IO_L19P_T3L_N0_DBC_AD9P_66
+set_property         -dict {PACKAGE_PIN AH4   IOSTANDARD LVCMOS18                                     } [get_ports gpio[0]            ]    ; ## FMC1_LA10_P
+set_property         -dict {PACKAGE_PIN AJ4   IOSTANDARD LVCMOS18                                     } [get_ports gpio[1]            ]    ; ## FMC1_LA10_N
+set_property         -dict {PACKAGE_PIN AG8   IOSTANDARD LVCMOS18                                     } [get_ports gpio[2]            ]    ; ## FMC1_LA13_P
+set_property         -dict {PACKAGE_PIN AH8   IOSTANDARD LVCMOS18                                     } [get_ports gpio[3]            ]    ; ## FMC1_LA13_N
+set_property         -dict {PACKAGE_PIN AH3   IOSTANDARD LVCMOS18                                     } [get_ports gpio[4]            ]    ; ## FMC1_LA05_N
+set_property         -dict {PACKAGE_PIN AG3   IOSTANDARD LVCMOS18                                     } [get_ports gpio[5]            ]    ; ## FMC1_LA05_P
+set_property         -dict {PACKAGE_PIN AJ2   IOSTANDARD LVCMOS18                                     } [get_ports gpio[6]            ]    ; ## FMC1_LA06_N
+set_property         -dict {PACKAGE_PIN AH2   IOSTANDARD LVCMOS18                                     } [get_ports gpio[7]            ]    ; ## FMC1_LA06_P
+set_property         -dict {PACKAGE_PIN Y12   IOSTANDARD LVCMOS18                                     } [get_ports gpio[8]            ]    ; ## FMC0_LA16_P         IO_L5P_T0U_N8_AD14P_66
+set_property         -dict {PACKAGE_PIN AA12  IOSTANDARD LVCMOS18                                     } [get_ports gpio[9]            ]    ; ## FMC0_LA16_N         IO_L5N_T0U_N9_AD14N_66
+set_property         -dict {PACKAGE_PIN M14   IOSTANDARD LVCMOS18                                     } [get_ports gpio[10]           ]    ; ## FMC0_LA22_N         IO_L20N_T3L_N3_AD1N_67
+set_property         -dict {PACKAGE_PIN AB5   IOSTANDARD LVCMOS18                                     } [get_ports hmc_gpio1          ]    ; ## FMC0_LA11_N         IO_L10N_T1U_N7_QBC_AD4N_66
+set_property         -dict {PACKAGE_PIN U4    IOSTANDARD LVCMOS18                                     } [get_ports hmc_sync           ]    ; ## FMC0_LA07_N         IO_L18N_T2U_N11_AD2N_66
+set_property         -dict {PACKAGE_PIN V4    IOSTANDARD LVCMOS18                                     } [get_ports irqb[0]            ]    ; ## FMC0_LA08_P         IO_L17P_T2U_N8_AD10P_66
+set_property         -dict {PACKAGE_PIN V3    IOSTANDARD LVCMOS18                                     } [get_ports irqb[1]            ]    ; ## FMC0_LA08_N         IO_L17N_T2U_N9_AD10N_66
+set_property         -dict {PACKAGE_PIN U5    IOSTANDARD LVCMOS18                                     } [get_ports rstb               ]    ; ## FMC0_LA07_P         IO_L18P_T2U_N10_AD2P_66
+set_property         -dict {PACKAGE_PIN W5    IOSTANDARD LVCMOS18                                     } [get_ports rxen[0]            ]    ; ## FMC0_LA10_P         IO_L15P_T2L_N4_AD11P_66
+set_property         -dict {PACKAGE_PIN W4    IOSTANDARD LVCMOS18                                     } [get_ports rxen[1]            ]    ; ## FMC0_LA10_N         IO_L15N_T2L_N5_AD11N_66
+set_property         -dict {PACKAGE_PIN AB3   IOSTANDARD LVCMOS18                                     } [get_ports spi0_csb_ad9082    ]    ; ## FMC0_LA05_P         IO_L20P_T3L_N2_AD1P_66
+set_property         -dict {PACKAGE_PIN AC3   IOSTANDARD LVCMOS18                                     } [get_ports spi0_miso_ad9082   ]    ; ## FMC0_LA05_N         IO_L20N_T3L_N3_AD1N_66
+set_property         -dict {PACKAGE_PIN AA2   IOSTANDARD LVCMOS18                                     } [get_ports spi0_mosi_ad9082   ]    ; ## FMC0_LA04_P         IO_L21P_T3L_N4_AD8P_66
+set_property         -dict {PACKAGE_PIN AA1   IOSTANDARD LVCMOS18                                     } [get_ports spi0_sclk_ad9082   ]    ; ## FMC0_LA04_N         IO_L21N_T3L_N5_AD8N_66
+set_property         -dict {PACKAGE_PIN AF10  IOSTANDARD LVCMOS18                                     } [get_ports spi0_csb_admv8818  ]    ; ## FMC1_LA25_N
+set_property         -dict {PACKAGE_PIN AB10  IOSTANDARD LVCMOS18                                     } [get_ports spi0_miso_admv8818 ]    ; ## FMC1_LA20_N
+set_property         -dict {PACKAGE_PIN AB11  IOSTANDARD LVCMOS18                                     } [get_ports spi0_mosi_admv8818 ]    ; ## FMC1_LA20_P
+set_property         -dict {PACKAGE_PIN AG9   IOSTANDARD LVCMOS18                                     } [get_ports spi0_sclk_admv8818 ]    ; ## FMC1_LA16_N
+set_property         -dict {PACKAGE_PIN W7    IOSTANDARD LVCMOS18                                     } [get_ports spi1_csb_hmc7044   ]    ; ## FMC0_LA12_P         IO_L9P_T1L_N4_AD12P_66
+set_property         -dict {PACKAGE_PIN AB6   IOSTANDARD LVCMOS18                                     } [get_ports spi1_sclk_hmc7044  ]    ; ## FMC0_LA11_P         IO_L10P_T1U_N6_QBC_AD4P_66
+set_property         -dict {PACKAGE_PIN W6    IOSTANDARD LVCMOS18                                     } [get_ports spi1_sdio_hmc7044  ]    ; ## FMC0_LA12_N         IO_L9N_T1L_N5_AD12N_66
+set_property         -dict {PACKAGE_PIN D20   IOSTANDARD LVCMOS33                                     } [get_ports spi1_csb_adf4371[0]]    ; ## PMOD1_0
+set_property         -dict {PACKAGE_PIN E20   IOSTANDARD LVCMOS33                                     } [get_ports spi1_csb_adf4371[1]]    ; ## PMOD1_1
+set_property         -dict {PACKAGE_PIN AH11  IOSTANDARD LVCMOS18                                     } [get_ports spi1_sclk_adf4371  ]    ; ## FMC1_LA24_N
+set_property         -dict {PACKAGE_PIN T13   IOSTANDARD LVCMOS18                                     } [get_ports spi1_sdio_adf4371  ]    ; ## FMC1_LA28_P
+set_property         -dict {PACKAGE_PIN AF8   IOSTANDARD LVCMOS18                                     } [get_ports spi1_dir_adf4371   ]    ; ## FMC1_LA11_N
+set_property         -dict {PACKAGE_PIN AA6   IOSTANDARD LVDS     DIFF_TERM_ADV TERM_100 DQS_BIAS TRUE} [get_ports sysref2_n          ]    ; ## FMC0_CLK0_M2C_N     IO_L12N_T1U_N11_GC_66
+set_property         -dict {PACKAGE_PIN AA7   IOSTANDARD LVDS     DIFF_TERM_ADV TERM_100 DQS_BIAS TRUE} [get_ports sysref2_p          ]    ; ## FMC0_CLK0_M2C_P     IO_L12P_T1U_N10_GC_66
+set_property         -dict {PACKAGE_PIN W2    IOSTANDARD LVCMOS18                                     } [get_ports txen[0]            ]    ; ## FMC0_LA09_P         IO_L24P_T3U_N10_66
+set_property         -dict {PACKAGE_PIN W1    IOSTANDARD LVCMOS18                                     } [get_ports txen[1]            ]    ; ## FMC0_LA09_N         IO_L24N_T3U_N11_66

--- a/projects/ad9082_fmca_ebz_xmw_tx/zcu102/system_project.tcl
+++ b/projects/ad9082_fmca_ebz_xmw_tx/zcu102/system_project.tcl
@@ -1,0 +1,58 @@
+
+source ../../scripts/adi_env.tcl
+source $ad_hdl_dir/projects/scripts/adi_project_xilinx.tcl
+source $ad_hdl_dir/projects/scripts/adi_board.tcl
+
+# get_env_param retrieves parameter value from the environment if exists,
+# other case use the default value
+#
+#   Use over-writable parameters from the environment.
+#
+#    e.g.
+#      make RX_JESD_L=4 RX_JESD_M=8 RX_JESD_S=1 TX_JESD_L=4 TX_JESD_M=8 TX_JESD_S=1
+#      make RX_JESD_L=8 RX_JESD_M=4 RX_JESD_S=1 TX_JESD_L=8 TX_JESD_M=4 TX_JESD_S=1
+
+#
+# Parameter description:
+#   JESD_MODE : Used link layer encoder mode
+#      64B66B - 64b66b link layer defined in JESD 204C
+#      8B10B  - 8b10b link layer defined in JESD 204B
+#
+#   RX_RATE :  Line rate of the Rx link ( MxFE to FPGA )
+#   TX_RATE :  Line rate of the Tx link ( FPGA to MxFE )
+#   [RX/TX]_JESD_M : Number of converters per link
+#   [RX/TX]_JESD_L : Number of lanes per link
+#   [RX/TX]_JESD_NP : Number of bits per sample, only 16 is supported
+#   [RX/TX]_NUM_LINKS : Number of links, matches numer of MxFE devices
+#
+#
+#  !!! For this carrier only 8B10B mode is supported !!!
+#
+
+adi_project ad9082_fmca_ebz_xmw_tx_zcu102 0 [list \
+  JESD_MODE    [get_env_param JESD_MODE    8B10B ]\
+  RX_LANE_RATE [get_env_param RX_RATE      15 ] \
+  TX_LANE_RATE [get_env_param TX_RATE      15 ] \
+  RX_JESD_M    [get_env_param RX_JESD_M    4 ] \
+  RX_JESD_L    [get_env_param RX_JESD_L    8 ] \
+  RX_JESD_S    [get_env_param RX_JESD_S    1 ] \
+  RX_JESD_NP   [get_env_param RX_JESD_NP   16] \
+  RX_NUM_LINKS [get_env_param RX_NUM_LINKS 1 ] \
+  TX_JESD_M    [get_env_param TX_JESD_M    4 ] \
+  TX_JESD_L    [get_env_param TX_JESD_L    8 ] \
+  TX_JESD_S    [get_env_param TX_JESD_S    1 ] \
+  TX_JESD_NP   [get_env_param TX_JESD_NP   16] \
+  TX_NUM_LINKS [get_env_param TX_NUM_LINKS 1 ] \
+]
+
+adi_project_files ad9082_fmca_ebz_xmw_tx_zcu102 [list \
+  "../../ad9082_fmca_ebz_xmw_tx/zcu102/system_top.v" \
+  "../../ad9082_fmca_ebz_xmw_tx/zcu102/system_constr.xdc" \
+  "../../ad9081_fmca_ebz/zcu102/timing_constr.xdc" \
+  "../../../library/common/ad_3w_spi.v" \
+  "$ad_hdl_dir/library/common/ad_iobuf.v" \
+  "$ad_hdl_dir/projects/common/zcu102/zcu102_system_constr.xdc" ]
+
+
+adi_project_run ad9082_fmca_ebz_xmw_tx_zcu102
+

--- a/projects/ad9082_fmca_ebz_xmw_tx/zcu102/system_top.v
+++ b/projects/ad9082_fmca_ebz_xmw_tx/zcu102/system_top.v
@@ -1,0 +1,362 @@
+// ***************************************************************************
+// ***************************************************************************
+// Copyright 2014 -2023 (c) Analog Devices, Inc. All rights reserved.
+//
+// In this HDL repository, there are many different and unique modules, consisting
+// of various HDL (Verilog or VHDL) components. The individual modules are
+// developed independently, and may be accompanied by separate and unique license
+// terms.
+//
+// The user should read each of these license terms, and understand the
+// freedoms and responsibilities that he or she has by using this source/core.
+//
+// This core is distributed in the hope that it will be useful, but WITHOUT ANY
+// WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+// A PARTICULAR PURPOSE.
+//
+// Redistribution and use of source or resulting binaries, with or without modification
+// of this file, are permitted under one of the following two license terms:
+//
+//   1. The GNU General Public License version 2 as published by the
+//      Free Software Foundation, which can be found in the top level directory
+//      of this repository (LICENSE_GPL2), and also online at:
+//      <https://www.gnu.org/licenses/old-licenses/gpl-2.0.html>
+//
+// OR
+//
+//   2. An ADI specific BSD license, which can be found in the top level directory
+//      of this repository (LICENSE_ADIBSD), and also on-line at:
+//      https://github.com/analogdevicesinc/hdl/blob/master/LICENSE_ADIBSD
+//      This will allow to generate bit files and not release the source code,
+//      as long as it attaches to an ADI device.
+//
+// ***************************************************************************
+// ***************************************************************************
+
+`timescale 1ns/100ps
+
+module system_top  #(
+	parameter TX_JESD_L = 8,
+	parameter TX_NUM_LINKS = 1,
+	parameter RX_JESD_L = 8,
+	parameter RX_NUM_LINKS = 1,
+	parameter SHARED_DEVCLK = 0,
+	parameter JESD_MODE = "8B10B"
+) (
+	input  [12:0] gpio_bd_i,
+	output [ 7:0] gpio_bd_o,
+
+	// FMC HPC IOs
+	input  [1:0]  agc0,
+	input  [1:0]  agc1,
+	input  [1:0]  agc2,
+	input  [1:0]  agc3,
+	input         clkin6_n,
+	input         clkin6_p,
+	input         clkin10_n,
+	input         clkin10_p,
+	input         fpga_refclk_in_n,
+	input         fpga_refclk_in_p,
+	input  [RX_JESD_L*RX_NUM_LINKS-1:0]  rx_data_n,
+	input  [RX_JESD_L*RX_NUM_LINKS-1:0]  rx_data_p,
+	output [TX_JESD_L*TX_NUM_LINKS-1:0]  tx_data_n,
+	output [TX_JESD_L*TX_NUM_LINKS-1:0]  tx_data_p,
+	input    fpga_syncin_0_n,
+	input    fpga_syncin_0_p,
+	inout    fpga_syncin_1_n,
+	inout    fpga_syncin_1_p,
+	output   fpga_syncout_0_n,
+	output   fpga_syncout_0_p,
+	inout    fpga_syncout_1_n,
+	inout    fpga_syncout_1_p,
+	inout  [10:0] gpio,
+	inout         hmc_gpio1,
+	output        hmc_sync,
+	input  [1:0]  irqb,
+	output        rstb,
+	output [1:0]  rxen,
+	input         sysref2_n,
+	input         sysref2_p,
+	output [1:0]  txen,
+	// AD9082 SPI Signals
+	output        spi0_csb_ad9082,
+	input         spi0_miso_ad9082,
+	output        spi0_mosi_ad9082,
+	output        spi0_sclk_ad9082,
+	// ADMV8818 SPI Signals
+	output        spi0_csb_admv8818,
+	input         spi0_miso_admv8818,
+	output        spi0_mosi_admv8818,
+	output        spi0_sclk_admv8818,
+	// HMC7044 SPI Signals
+	output        spi1_csb_hmc7044,
+	output        spi1_sclk_hmc7044,
+	inout         spi1_sdio_hmc7044,
+	// ADF4371 SPI Signals
+	output  [1:0] spi1_csb_adf4371,
+	output        spi1_sclk_adf4371,
+	inout         spi1_sdio_adf4371,
+	output        spi1_dir_adf4371
+);
+
+	// internal signals
+
+	wire    [94:0]  gpio_i;
+	wire    [94:0]  gpio_o;
+	wire    [94:0]  gpio_t;
+
+	// spi0 signals
+	wire    [ 2:0]  spi0_csn;
+	wire            spi0_sclk;
+	wire            spi0_miso;
+	wire            spi0_mosi;
+
+	// spi1 signals
+	wire    [ 2:0]  spi1_csn;
+	wire            spi1_sclk;
+	wire            spi1_mosi;
+	wire            spi1_miso;
+
+	// 3-wire spi miso signals
+	wire            spi1_miso_adf4371;
+	wire            spi1_miso_hmc7044;
+
+	wire            ref_clk;
+	wire            sysref;
+	wire    [TX_NUM_LINKS-1:0]   tx_syncin;
+	wire    [RX_NUM_LINKS-1:0]   rx_syncout;
+
+	wire    [7:0]   rx_data_p_loc;
+	wire    [7:0]   rx_data_n_loc;
+	wire    [7:0]   tx_data_p_loc;
+	wire    [7:0]   tx_data_n_loc;
+
+	wire            clkin6;
+	wire            clkin10;
+	wire            tx_device_clk;
+	wire            rx_device_clk_internal;
+	wire            rx_device_clk;
+
+	assign iic_rstn = 1'b1;
+
+	// instantiations
+
+	IBUFDS_GTE4 i_ibufds_ref_clk (
+		.CEB (1'd0),
+		.I (fpga_refclk_in_p),
+		.IB (fpga_refclk_in_n),
+		.O (ref_clk),
+		.ODIV2 ());
+
+	IBUFDS i_ibufds_sysref (
+		.I (sysref2_p),
+		.IB (sysref2_n),
+		.O (sysref));
+
+	IBUFDS i_ibufds_tx_device_clk (
+		.I (clkin6_p),
+		.IB (clkin6_n),
+		.O (clkin6));
+
+	IBUFDS i_ibufds_rx_device_clk (
+		.I (clkin10_p),
+		.IB (clkin10_n),
+		.O (clkin10));
+
+	IBUFDS i_ibufds_syncin_0 (
+		.I (fpga_syncin_0_p),
+		.IB (fpga_syncin_0_n),
+		.O (tx_syncin[0]));
+
+	OBUFDS i_obufds_syncout_0 (
+		.I (rx_syncout[0]),
+		.O (fpga_syncout_0_p),
+		.OB (fpga_syncout_0_n));
+
+	BUFG i_tx_device_clk (
+		.I (clkin6),
+		.O (tx_device_clk));
+
+	BUFG i_rx_device_clk (
+		.I (clkin10),
+		.O (rx_device_clk_internal));
+
+	assign rx_device_clk = SHARED_DEVCLK ? tx_device_clk : rx_device_clk_internal;
+
+	// spi
+
+	// spi0 output signals
+	assign spi0_csb_ad9082 = spi0_csn[0];
+	assign spi0_mosi_ad9082 = spi0_mosi;
+	assign spi0_sclk_ad9082 = spi0_sclk;
+
+	assign spi0_csb_admv8818 = spi0_csn[1];
+	assign spi0_mosi_admv8818 = spi0_mosi;
+	assign spi0_sclk_admv8818 = spi0_sclk;
+
+	// spi0 input signals
+	assign spi0_miso = ~spi0_csn[0] ? spi0_miso_ad9082   :
+										 ~spi0_csn[1] ? spi0_miso_admv8818 :
+										 1'b0;
+
+	// spi1 output signals
+	assign spi1_csb_hmc7044 = spi1_csn[0];
+	assign spi1_sclk_hmc7044 = spi1_sclk;
+
+	assign spi1_csb_adf4371 = spi1_csn[2:1];
+	assign spi1_sclk_adf4371 = spi1_sclk;
+
+	// spi1 input signals
+	assign spi1_miso = |(~spi1_csn[2:1]) ? spi1_miso_adf4371 :
+											 ~spi1_csn[0]    ? spi1_miso_hmc7044 :
+											 1'b0;
+
+	// 3-wire spi configuration for HMC7044 and ADF4371a on spi1
+	ad_3w_spi #(
+		.NUM_OF_SLAVES(1)
+	) i_spi_hmc7044 (
+		.spi_csn (spi1_csn[0]),
+		.spi_clk (spi1_sclk),
+		.spi_mosi (spi1_mosi),
+		.spi_miso (spi1_miso_hmc7044),
+		.spi_sdio (spi1_sdio_hmc7044),
+		.spi_dir ());
+
+		ad_3w_spi #(
+		.NUM_OF_SLAVES(1)
+		) i_spi_adf4371 (
+		.spi_csn (&spi1_csn[2:1]),
+		.spi_clk (spi1_sclk),
+		.spi_mosi (spi1_mosi),
+		.spi_miso (spi1_miso_adf4371),
+		.spi_sdio (spi1_sdio_adf4371),
+		.spi_dir (spi1_dir_adf4371));
+
+	// gpios
+
+	ad_iobuf #(
+		.DATA_WIDTH(12)
+	) i_iobuf (
+		.dio_t (gpio_t[43:32]),
+		.dio_i (gpio_o[43:32]),
+		.dio_o (gpio_i[43:32]),
+		.dio_p ({hmc_gpio1,       // 43
+						 gpio[10:0]}));   // 42-32
+
+	assign gpio_i[44] = agc0[0];
+	assign gpio_i[45] = agc0[1];
+	assign gpio_i[46] = agc1[0];
+	assign gpio_i[47] = agc1[1];
+	assign gpio_i[48] = agc2[0];
+	assign gpio_i[49] = agc2[1];
+	assign gpio_i[50] = agc3[0];
+	assign gpio_i[51] = agc3[1];
+	assign gpio_i[52] = irqb[0];
+	assign gpio_i[53] = irqb[1];
+
+	assign hmc_sync = gpio_o[54];
+	assign rstb     = gpio_o[55];
+	assign rxen[0]  = gpio_o[56];
+	assign rxen[1]  = gpio_o[57];
+	assign txen[0]  = gpio_o[58];
+	assign txen[1]  = gpio_o[59];
+
+	generate
+	if (TX_NUM_LINKS > 1 & JESD_MODE == "8B10B") begin
+		assign tx_syncin[1] = fpga_syncin_1_p;
+	end else begin
+		ad_iobuf #(
+			.DATA_WIDTH(2)
+		) i_syncin_iobuf (
+			.dio_t (gpio_t[61:60]),
+			.dio_i (gpio_o[61:60]),
+			.dio_o (gpio_i[61:60]),
+			.dio_p ({fpga_syncin_1_n,      // 61
+							 fpga_syncin_1_p}));   // 60
+	end
+
+	if (RX_NUM_LINKS > 1 & JESD_MODE == "8B10B") begin
+		assign fpga_syncout_1_p = rx_syncout[1];
+		assign fpga_syncout_1_n = 0;
+	end else begin
+		ad_iobuf #(
+			.DATA_WIDTH(2)
+		) i_syncout_iobuf (
+			.dio_t (gpio_t[63:62]),
+			.dio_i (gpio_o[63:62]),
+			.dio_o (gpio_i[63:62]),
+			.dio_p ({fpga_syncout_1_n,      // 63
+							 fpga_syncout_1_p}));   // 62
+	end
+	endgenerate
+	/* Board GPIOS. Buttons, LEDs, etc... */
+	assign gpio_i[20: 8] = gpio_bd_i;
+	assign gpio_bd_o = gpio_o[7:0];
+
+	// Unused GPIOs
+	assign gpio_i[59:54] = gpio_o[59:54];
+	assign gpio_i[94:64] = gpio_o[94:64];
+	assign gpio_i[31:21] = gpio_o[31:21];
+	assign gpio_i[7:0] = gpio_o[7:0];
+
+	system_wrapper i_system_wrapper (
+		.gpio_i (gpio_i),
+		.gpio_o (gpio_o),
+		.gpio_t (gpio_t),
+		.spi0_csn (spi0_csn),
+		.spi0_miso (spi0_miso),
+		.spi0_mosi (spi0_mosi),
+		.spi0_sclk (spi0_sclk),
+		.spi1_csn (spi1_csn),
+		.spi1_miso (spi1_miso),
+		.spi1_mosi (spi1_mosi),
+		.spi1_sclk (spi1_sclk),
+		// FMC HPC
+		.rx_data_0_n (rx_data_n_loc[0]),
+		.rx_data_0_p (rx_data_p_loc[0]),
+		.rx_data_1_n (rx_data_n_loc[1]),
+		.rx_data_1_p (rx_data_p_loc[1]),
+		.rx_data_2_n (rx_data_n_loc[2]),
+		.rx_data_2_p (rx_data_p_loc[2]),
+		.rx_data_3_n (rx_data_n_loc[3]),
+		.rx_data_3_p (rx_data_p_loc[3]),
+		.rx_data_4_n (rx_data_n_loc[4]),
+		.rx_data_4_p (rx_data_p_loc[4]),
+		.rx_data_5_n (rx_data_n_loc[5]),
+		.rx_data_5_p (rx_data_p_loc[5]),
+		.rx_data_6_n (rx_data_n_loc[6]),
+		.rx_data_6_p (rx_data_p_loc[6]),
+		.rx_data_7_n (rx_data_n_loc[7]),
+		.rx_data_7_p (rx_data_p_loc[7]),
+		.tx_data_0_n (tx_data_n_loc[0]),
+		.tx_data_0_p (tx_data_p_loc[0]),
+		.tx_data_1_n (tx_data_n_loc[1]),
+		.tx_data_1_p (tx_data_p_loc[1]),
+		.tx_data_2_n (tx_data_n_loc[2]),
+		.tx_data_2_p (tx_data_p_loc[2]),
+		.tx_data_3_n (tx_data_n_loc[3]),
+		.tx_data_3_p (tx_data_p_loc[3]),
+		.tx_data_4_n (tx_data_n_loc[4]),
+		.tx_data_4_p (tx_data_p_loc[4]),
+		.tx_data_5_n (tx_data_n_loc[5]),
+		.tx_data_5_p (tx_data_p_loc[5]),
+		.tx_data_6_n (tx_data_n_loc[6]),
+		.tx_data_6_p (tx_data_p_loc[6]),
+		.tx_data_7_n (tx_data_n_loc[7]),
+		.tx_data_7_p (tx_data_p_loc[7]),
+		.ref_clk_q0 (ref_clk),
+		.ref_clk_q1 (ref_clk),
+		.rx_device_clk (rx_device_clk),
+		.tx_device_clk (tx_device_clk),
+		.rx_sync_0 (rx_syncout),
+		.tx_sync_0 (tx_syncin),
+		.rx_sysref_0 (sysref),
+		.tx_sysref_0 (sysref));
+
+	assign rx_data_p_loc[RX_JESD_L*RX_NUM_LINKS-1:0] = rx_data_p[RX_JESD_L*RX_NUM_LINKS-1:0];
+	assign rx_data_n_loc[RX_JESD_L*RX_NUM_LINKS-1:0] = rx_data_n[RX_JESD_L*RX_NUM_LINKS-1:0];
+
+	assign tx_data_p[TX_JESD_L*TX_NUM_LINKS-1:0] = tx_data_p_loc[TX_JESD_L*TX_NUM_LINKS-1:0];
+	assign tx_data_n[TX_JESD_L*TX_NUM_LINKS-1:0] = tx_data_n_loc[TX_JESD_L*TX_NUM_LINKS-1:0];
+
+endmodule


### PR DESCRIPTION
## PR Description

Modifying ad9082_fmca_ebz project to control 2-24GHz XMW TX and RX platforms targeting ZCU102 eval board with an AD9082 in the form of 2 new projects (ad9082_fmca_ebz_xmw_tx and ad9082_fmca_ebz_xmw_rx).
Source code includes peripheral control for ADF4371 (3-wire SPI controlled), ADMV8818 (4-wire SPI controlled) and ADRF5020, ADRF5730, ADRF5740 (GPIO controlled), along with original AD9082 and HMC7044 control.


## PR Type
- [ ] Bug fix (change that fixes an issue)
- [x] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the code style guidelines
- [x] I have performed a self-review of changes
- [x] I have compiled all hdl projects and libraries affected by this PR
- [x] I have tested in hardware affected projects, at least on relevant boards
- [x] I have commented my code, at least hard-to-understand parts
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe files, Copyright etc)
- [x] I have not introduced new Warnings/Critical Warnings on compilation
- [ ] I have added new hdl testbenches or updated existing ones
