### PR TITLE
project-intel.mk: change 'system_top.v' to '$(wildcard system_top*.v)'

### DIFF
--- a/projects/scripts/project-intel.mk
+++ b/projects/scripts/project-intel.mk
@@ -94,7 +94,7 @@ endif
 
 CLEAN_DIRS := $(dir $(wildcard */*_quartus.log))
 
-M_DEPS += system_top.v
+M_DEPS += $(wildcard system_top*.v)
 M_DEPS += system_qsys.tcl
 M_DEPS += system_project.tcl
 M_DEPS += system_constr.sdc


### PR DESCRIPTION
## PR Description

Change necessary to build intel projects with different system_top verilog files.
This was patterned to https://github.com/analogdevicesinc/hdl/blob/ae09b8a1bb123a40d2b9c112e3049f79755f2a7b/projects/scripts/project-xilinx.mk#L70

## PR Type
- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the code style guidelines
- [x] I have performed a self-review of changes
- [x] I have compiled all hdl projects and libraries affected by this PR
- [x] I have tested in hardware affected projects, at least on relevant boards
- [x] I have commented my code, at least hard-to-understand parts
- [x] I have signed off all commits from this PR
- [x] I have updated the documentation (wiki pages, ReadMe files, Copyright etc)
- [x] I have not introduced new Warnings/Critical Warnings on compilation
- [ ] I have added new hdl testbenches or updated existing ones
