### PR TITLE
projects: Add missing sysid IP

### DIFF
--- a/projects/ad9213_dual_ebz/s10soc/Makefile
+++ b/projects/ad9213_dual_ebz/s10soc/Makefile
@@ -7,13 +7,16 @@
 PROJECT_NAME := ad9213_dual_ebz_s10soc
 
 M_DEPS += ../common/ad9213_dual_qsys.tcl
+M_DEPS += ../../scripts/adi_pd.tcl
 M_DEPS += ../../common/s10soc/s10soc_system_qsys.tcl
 M_DEPS += ../../common/s10soc/s10soc_system_assign.tcl
 M_DEPS += ../../common/intel/adcfifo_qsys.tcl
 M_DEPS += ../../../library/common/ad_3w_spi.v
 
 LIB_DEPS += axi_dmac
+LIB_DEPS += axi_sysid
 LIB_DEPS += intel/adi_jesd204
 LIB_DEPS += jesd204/ad_ip_jesd204_tpl_adc
+LIB_DEPS += sysid_rom
 
 include ../../scripts/project-intel.mk

--- a/projects/ad9213_dual_ebz/s10soc/system_qsys.tcl
+++ b/projects/ad9213_dual_ebz/s10soc/system_qsys.tcl
@@ -5,6 +5,7 @@
 
 set adc_fifo_address_width 15
 
+source $ad_hdl_dir/projects/scripts/adi_pd.tcl
 source $ad_hdl_dir/projects/common/s10soc/s10soc_system_qsys.tcl
 source $ad_hdl_dir/projects/common/intel/adcfifo_qsys.tcl
 
@@ -13,3 +14,11 @@ if [info exists ad_project_dir] {
 } else {
   source ../common/ad9213_dual_qsys.tcl
 }
+
+#system ID
+set_instance_parameter_value axi_sysid_0 {ROM_ADDR_BITS} {9}
+set_instance_parameter_value rom_sys_0 {ROM_ADDR_BITS} {9}
+
+set_instance_parameter_value rom_sys_0 {PATH_TO_FILE} "$mem_init_sys_file_path/mem_init_sys.txt"
+
+sysid_gen_sys_init_file

--- a/projects/adrv9009/s10soc/Makefile
+++ b/projects/adrv9009/s10soc/Makefile
@@ -7,14 +7,17 @@
 PROJECT_NAME := adrv9009_s10soc
 
 M_DEPS += ../common/adrv9009_qsys.tcl
+M_DEPS += ../../scripts/adi_pd.tcl
 M_DEPS += ../../common/s10soc/s10soc_system_qsys.tcl
 M_DEPS += ../../common/s10soc/s10soc_system_assign.tcl
 M_DEPS += ../../common/intel/dacfifo_qsys.tcl
 
 LIB_DEPS += axi_dmac
+LIB_DEPS += axi_sysid
 LIB_DEPS += intel/adi_jesd204
 LIB_DEPS += jesd204/ad_ip_jesd204_tpl_adc
 LIB_DEPS += jesd204/ad_ip_jesd204_tpl_dac
+LIB_DEPS += sysid_rom
 LIB_DEPS += util_pack/util_cpack2
 LIB_DEPS += util_pack/util_upack2
 

--- a/projects/adrv9009/s10soc/system_qsys.tcl
+++ b/projects/adrv9009/s10soc/system_qsys.tcl
@@ -6,6 +6,7 @@
 set dac_fifo_address_width 10
 set xcvr_reconfig_addr_width 11
 
+source $ad_hdl_dir/projects/scripts/adi_pd.tcl
 source $ad_hdl_dir/projects/common/s10soc/s10soc_system_qsys.tcl
 source $ad_hdl_dir/projects/common/intel/dacfifo_qsys.tcl
 
@@ -14,3 +15,11 @@ if [info exists ad_project_dir] {
 } else {
   source ../common/adrv9009_qsys.tcl
 }
+
+#system ID
+set_instance_parameter_value axi_sysid_0 {ROM_ADDR_BITS} {9}
+set_instance_parameter_value rom_sys_0 {ROM_ADDR_BITS} {9}
+
+set_instance_parameter_value rom_sys_0 {PATH_TO_FILE} "$mem_init_sys_file_path/mem_init_sys.txt"
+
+sysid_gen_sys_init_file

--- a/projects/adrv9009/s10soc/system_qsys.tcl
+++ b/projects/adrv9009/s10soc/system_qsys.tcl
@@ -23,3 +23,4 @@ set_instance_parameter_value rom_sys_0 {ROM_ADDR_BITS} {9}
 set_instance_parameter_value rom_sys_0 {PATH_TO_FILE} "$mem_init_sys_file_path/mem_init_sys.txt"
 
 sysid_gen_sys_init_file
+

--- a/projects/common/s10soc/Makefile
+++ b/projects/common/s10soc/Makefile
@@ -9,5 +9,7 @@ PROJECT_NAME := template_s10soc
 M_DEPS += ../../common/s10soc/s10soc_system_qsys.tcl
 M_DEPS += ../../common/s10soc/s10soc_system_assign.tcl
 
+LIB_DEPS += axi_sysid
+LIB_DEPS += sysid_rom
 
 include ../../scripts/project-intel.mk

--- a/projects/common/s10soc/s10soc_system_qsys.tcl
+++ b/projects/common/s10soc/s10soc_system_qsys.tcl
@@ -24,10 +24,16 @@ set_interface_property rst_ninit_done EXPORT_OF s10_reset.ninit_done
 
 # sysid
 
+add_instance axi_sysid_0 axi_sysid
+add_instance rom_sys_0 sysid_rom
+
 add_instance sys_id altera_avalon_sysid_qsys
 set_instance_parameter_value sys_id {ID} {0x00000100}
 add_connection sys_clk.clk sys_id.clk
 add_connection sys_clk.clk_reset sys_id.reset
+add_connection sys_clk.clk rom_sys_0.if_clk
+add_connection sys_clk.clk axi_sysid_0.s_axi_clock
+add_connection sys_clk.clk_reset axi_sysid_0.s_axi_reset
 
 # hps
 # round-about way - qsys-script doesn't support {*}?


### PR DESCRIPTION
## PR Description
The sysid IP was added in ad9209_fmca_ebz/vck190, ad9213_dual_ebz/s10soc and adrv9009/s10soc

## PR Type
- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the code style guidelines
- [x] I have performed a self-review of changes
- [x] I have compiled all hdl projects and libraries affected by this PR
- [ ] I have tested in hardware affected projects, at least on relevant boards
- [ ] I have commented my code, at least hard-to-understand parts
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe files, Copyright etc)
- [ ] I have not introduced new Warnings/Critical Warnings on compilation
- [ ] I have added new hdl testbenches or updated existing ones
