### PR TITLE
adi_env.tcl: Update Quartus Pro version to 23.2.0

### DIFF
--- a/scripts/adi_env.tcl
+++ b/scripts/adi_env.tcl
@@ -31,7 +31,7 @@ if {[info exists ::env(ADI_IGNORE_VERSION_CHECK)]} {
 
 # Define the supported tool version
 if {![info exists REQUIRED_QUARTUS_VERSION]} {
-  set REQUIRED_QUARTUS_VERSION "22.4.0"
+  set REQUIRED_QUARTUS_VERSION "23.2.0"
 }
 
 # This helper pocedure retrieves the value of varible from environment if exists,


### PR DESCRIPTION
## PR Description

 * The version is set to be `23.2.0` because this is what Quartus returns as value when running the --version command
 * Still, Quartus has as installation path `intelFPGA_pro/23.2` and not the version which contains an additional `.0`
 * Intel projects failing: adv7513/de10nano, but this one uses Quartus Standard and not Quartus Pro whose version is updated now

## PR Type
- [ ] Bug fix (change that fixes an issue)
- [x] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the code style guidelines
- [x] I have performed a self-review of changes
- [x] I have compiled all hdl projects and libraries affected by this PR
- [ ] I have tested in hardware affected projects, at least on relevant boards
- [ ] I have commented my code, at least hard-to-understand parts
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe files, Copyright etc)
- [x] I have not introduced new Warnings/Critical Warnings on compilation
- [ ] I have added new hdl testbenches or updated existing ones
