### PR TITLE
Update ad738x spi engine

### DIFF
--- a/projects/ad738x_fmc/Readme.md
+++ b/projects/ad738x_fmc/Readme.md
@@ -2,11 +2,11 @@
 
 Here are some pointers to help you:
   * [Board Product Page](https://www.analog.com/eval-ad738xfmcz)
-  * Parts : [4MSPS Dual Simultaneous Sampling, 16-BIT SAR ADC, Differential Input](https://www.analog.com/ad7380)
-  * Parts : [4MSPS Dual Simultaneous Sampling, 14-BIT SAR ADC, Differential Input](https://www.analog.com/ad7381)
-  * Parts : [4-Channel, 4 MSPS, 16-Bit Dual Simultaneous Sampling SAR ADC](https://www.analog.com/ad7386)
-  * Parts : [4-Channel, 4 MSPS, 14-Bit, Dual, Simultaneous Sampling SAR ADC](https://www.analog.com/ad7387)
-  * Parts : [4-Channel, 4 MSPS, 12-Bit, Dual, Simultaneous Sampling SAR ADCs](https://www.analog.com/ad7388)
+  * Parts : [AD7380, 4MSPS Dual Simultaneous Sampling, 16-BIT SAR ADC, Differential Input](https://www.analog.com/ad7380)
+  * Parts : [AD7381, 4MSPS Dual Simultaneous Sampling, 14-BIT SAR ADC, Differential Input](https://www.analog.com/ad7381)
+  * Parts : [AD7386, 4-Channel, 4 MSPS, 16-Bit Dual Simultaneous Sampling SAR ADC](https://www.analog.com/ad7386)
+  * Parts : [AD7387, 4-Channel, 4 MSPS, 14-Bit, Dual, Simultaneous Sampling SAR ADC](https://www.analog.com/ad7387)
+  * Parts : [AD7388, 4-Channel, 4 MSPS, 12-Bit, Dual, Simultaneous Sampling SAR ADCs](https://www.analog.com/ad7388)
   * Project Doc: https://wiki.analog.com/resources/eval/user-guides/ad738x
   * HDL Doc: https://wiki.analog.com/resources/eval/user-guides/ad738x
   * Linux Drivers: https://wiki.analog.com/resources/tools-software/linux-drivers/iio-adc/ad738x

--- a/projects/ad738x_fmc/common/ad738x_bd.tcl
+++ b/projects/ad738x_fmc/common/ad738x_bd.tcl
@@ -3,92 +3,26 @@
 ### SPDX short identifier: ADIBSD
 ###############################################################################
 
-create_bd_intf_port -mode Master -vlnv analog.com:interface:spi_master_rtl:1.0 spi
+create_bd_intf_port -mode Master -vlnv analog.com:interface:spi_master_rtl:1.0 ad738x_spi
 
-# create a SPI Engine architecture
+source $ad_hdl_dir/library/spi_engine/scripts/spi_engine.tcl
 
-create_bd_cell -type hier spi
-current_bd_instance /spi
+set data_width    16
+set async_spi_clk 1
+set num_cs        1
+set num_sdi       2
+set num_sdo       1
+set sdi_delay     1
+set echo_sclk     0
 
-  create_bd_pin -dir I -type clk clk
-  create_bd_pin -dir I -type rst resetn
-  create_bd_pin -dir O irq
-  create_bd_intf_pin -mode Master -vlnv analog.com:interface:spi_master_rtl:1.0 m_spi
-  create_bd_intf_pin -mode Master -vlnv xilinx.com:interface:axis_rtl:1.0 M_AXIS_SAMPLE
+set hier_spi_engine spi_ad738x_adc
 
-  ad_ip_instance spi_engine_execution execution
-  ad_ip_parameter execution CONFIG.DATA_WIDTH $adc_resolution
-  ad_ip_parameter execution CONFIG.NUM_OF_CS 1
-  ad_ip_parameter execution CONFIG.NUM_OF_SDI $adc_num_of_channels
+spi_engine_create $hier_spi_engine $data_width $async_spi_clk $num_cs $num_sdi $num_sdo $sdi_delay $echo_sclk
 
-  ad_ip_instance axi_spi_engine axi
-  ad_ip_parameter axi CONFIG.DATA_WIDTH $adc_resolution
-  ad_ip_parameter axi CONFIG.NUM_OF_SDI $adc_num_of_channels
-  ad_ip_parameter axi CONFIG.NUM_OFFLOAD 1
-
-  ad_ip_instance spi_engine_offload offload
-  ad_ip_parameter offload CONFIG.DATA_WIDTH $adc_resolution
-  ad_ip_parameter offload CONFIG.NUM_OF_SDI $adc_num_of_channels
-
-  ad_ip_instance spi_engine_interconnect interconnect
-  ad_ip_parameter interconnect CONFIG.DATA_WIDTH $adc_resolution
-  ad_ip_parameter interconnect CONFIG.NUM_OF_SDI $adc_num_of_channels
-
-  ad_ip_instance util_pulse_gen trigger_gen
-
-  ## to setup the sample rate of the system change the PULSE_PERIOD value
-  ## the acutal sample rate will be PULSE_PERIOD * (1/sys_cpu_clk)
-  ## fsys_cpu_clk is defined to 100 MHZ
-  set cycle_per_sec_100mhz 100000000
-  set sampling_cycle [expr int(ceil(double($cycle_per_sec_100mhz) / $adc_sampling_rate))]
-  ad_ip_parameter trigger_gen CONFIG.PULSE_PERIOD $sampling_cycle
-  ad_ip_parameter trigger_gen CONFIG.PULSE_WIDTH 1
-
-  if {$adc_resolution < 16} {
-    ad_ip_instance util_axis_upscale axis_upscaler
-    ad_ip_parameter axis_upscaler CONFIG.NUM_OF_CHANNELS $adc_num_of_channels
-    ad_ip_parameter axis_upscaler CONFIG.DATA_WIDTH $adc_resolution
-    ad_ip_parameter axis_upscaler CONFIG.UDATA_WIDTH 16
-    ad_connect clk axis_upscaler/clk
-    ad_connect axi/spi_resetn axis_upscaler/resetn
-    ad_connect offload/offload_sdi axis_upscaler/s_axis
-    ad_connect axis_upscaler/m_axis M_AXIS_SAMPLE
-    ad_connect axis_upscaler/dfmt_enable GND
-    ad_connect axis_upscaler/dfmt_type GND
-    ad_connect axis_upscaler/dfmt_se GND
-  } else {
-    ad_connect offload/offload_sdi M_AXIS_SAMPLE
-  }
-
-  ad_connect axi/spi_engine_offload_ctrl0 offload/spi_engine_offload_ctrl
-  ad_connect offload/spi_engine_ctrl interconnect/s0_ctrl
-  ad_connect axi/spi_engine_ctrl interconnect/s1_ctrl
-  ad_connect interconnect/m_ctrl execution/ctrl
-
-  ad_connect execution/spi m_spi
-
-  ad_connect clk offload/spi_clk
-  ad_connect clk offload/ctrl_clk
-  ad_connect clk execution/clk
-  ad_connect clk axi/s_axi_aclk
-  ad_connect clk axi/spi_clk
-  ad_connect clk interconnect/clk
-  ad_connect clk trigger_gen/clk
-
-  ad_connect axi/spi_resetn offload/spi_resetn
-  ad_connect axi/spi_resetn execution/resetn
-  ad_connect axi/spi_resetn interconnect/resetn
-  ad_connect axi/spi_resetn trigger_gen/rstn
-  ad_connect trigger_gen/load_config GND
-  ad_connect trigger_gen/pulse_width GND
-  ad_connect trigger_gen/pulse_period GND
-
-  ad_connect trigger_gen/pulse offload/trigger
-
-  ad_connect resetn axi/s_axi_aresetn
-  ad_connect irq axi/irq
-
-current_bd_instance /
+ad_ip_instance axi_pwm_gen spi_trigger_gen
+# 300ns pwm period
+ad_ip_parameter spi_trigger_gen CONFIG.PULSE_0_PERIOD 48
+ad_ip_parameter spi_trigger_gen CONFIG.PULSE_0_WIDTH 1
 
 ad_ip_instance axi_dmac axi_ad738x_dma
 ad_ip_parameter axi_ad738x_dma CONFIG.DMA_TYPE_SRC 1
@@ -98,24 +32,38 @@ ad_ip_parameter axi_ad738x_dma CONFIG.SYNC_TRANSFER_START 0
 ad_ip_parameter axi_ad738x_dma CONFIG.AXI_SLICE_SRC 0
 ad_ip_parameter axi_ad738x_dma CONFIG.AXI_SLICE_DEST 1
 ad_ip_parameter axi_ad738x_dma CONFIG.DMA_2D_TRANSFER 0
-ad_ip_parameter axi_ad738x_dma CONFIG.DMA_DATA_WIDTH_SRC [expr $adc_num_of_channels * 16]
+ad_ip_parameter axi_ad738x_dma CONFIG.DMA_DATA_WIDTH_SRC 32
 ad_ip_parameter axi_ad738x_dma CONFIG.DMA_DATA_WIDTH_DEST 64
 
-ad_connect  sys_cpu_clk spi/clk
-ad_connect  sys_cpu_resetn spi/resetn
-ad_connect  sys_cpu_resetn axi_ad738x_dma/m_dest_axi_aresetn
+ad_ip_instance axi_clkgen spi_clkgen
+ad_ip_parameter spi_clkgen CONFIG.CLK0_DIV 5
+ad_ip_parameter spi_clkgen CONFIG.VCO_DIV 1
+ad_ip_parameter spi_clkgen CONFIG.VCO_MUL 8
 
-ad_connect  spi/m_spi spi
-ad_connect  axi_ad738x_dma/s_axis spi/M_AXIS_SAMPLE
+ad_connect $sys_cpu_clk spi_clkgen/clk
+ad_connect spi_clk spi_clkgen/clk_0
 
-ad_cpu_interconnect 0x44a00000 spi/axi
+ad_connect spi_clk spi_trigger_gen/ext_clk
+ad_connect $sys_cpu_clk spi_trigger_gen/s_axi_aclk
+ad_connect sys_cpu_resetn spi_trigger_gen/s_axi_aresetn
+ad_connect spi_trigger_gen/pwm_0 $hier_spi_engine/trigger
+
+ad_connect axi_ad738x_dma/s_axis $hier_spi_engine/M_AXIS_SAMPLE
+ad_connect $hier_spi_engine/m_spi ad738x_spi
+
+ad_connect $sys_cpu_clk $hier_spi_engine/clk
+ad_connect spi_clk $hier_spi_engine/spi_clk
+ad_connect spi_clk axi_ad738x_dma/s_axis_aclk
+ad_connect sys_cpu_resetn $hier_spi_engine/resetn
+ad_connect sys_cpu_resetn axi_ad738x_dma/m_dest_axi_aresetn
+
+ad_cpu_interconnect 0x44a00000 $hier_spi_engine/${hier_spi_engine}_axi_regmap
 ad_cpu_interconnect 0x44a30000 axi_ad738x_dma
-
-ad_connect sys_cpu_clk axi_ad738x_dma/s_axis_aclk
+ad_cpu_interconnect 0x44a70000 spi_clkgen
+ad_cpu_interconnect 0x44b00000 spi_trigger_gen
 
 ad_cpu_interrupt "ps-13" "mb-13" axi_ad738x_dma/irq
-ad_cpu_interrupt "ps-12" "mb-12" spi/irq
+ad_cpu_interrupt "ps-12" "mb-12" $hier_spi_engine/irq
 
 ad_mem_hp2_interconnect sys_cpu_clk sys_ps7/S_AXI_HP2
 ad_mem_hp2_interconnect sys_cpu_clk axi_ad738x_dma/m_dest_axi
-

--- a/projects/ad738x_fmc/common/ad738x_fmc.txt
+++ b/projects/ad738x_fmc/common/ad738x_fmc.txt
@@ -1,0 +1,9 @@
+# ad738x
+
+FMC_pin   FMC_port               Schematic_name     System_top_name     IOSTANDARD  Termination
+					             
+D8        FMC_LA01_CC_P          SDOA               spi_sdia            LVCMOS25    #N/A
+D9        FMC_LA01_CC_N          SDOB               spi_sdib            LVCMOS25    #N/A
+G6        FMC_LA00_CC_P          SCLK               spi_sclk            LVCMOS25    #N/A
+G7        FMC_LA00_CC_N          CS                 spi_cs              LVCMOS25    #N/A
+H7        FMC_LA02_P             SDI                spi_sdo             LVCMOS25    #N/A

--- a/projects/ad738x_fmc/common/ad738x_fmc.txt
+++ b/projects/ad738x_fmc/common/ad738x_fmc.txt
@@ -1,6 +1,6 @@
-# ad738x
-
 FMC_pin   FMC_port               Schematic_name     System_top_name     IOSTANDARD  Termination
+
+# ad738x
 					             
 D8        FMC_LA01_CC_P          SDOA               spi_sdia            LVCMOS25    #N/A
 D9        FMC_LA01_CC_N          SDOB               spi_sdib            LVCMOS25    #N/A

--- a/projects/ad738x_fmc/zed/Makefile
+++ b/projects/ad738x_fmc/zed/Makefile
@@ -10,12 +10,14 @@ M_DEPS += ../common/ad738x_bd.tcl
 M_DEPS += ../../scripts/adi_pd.tcl
 M_DEPS += ../../common/zed/zed_system_constr.xdc
 M_DEPS += ../../common/zed/zed_system_bd.tcl
+M_DEPS += ../../../library/spi_engine/scripts/spi_engine.tcl
 M_DEPS += ../../../library/common/ad_iobuf.v
 
 LIB_DEPS += axi_clkgen
 LIB_DEPS += axi_dmac
 LIB_DEPS += axi_hdmi_tx
 LIB_DEPS += axi_i2s_adi
+LIB_DEPS += axi_pwm_gen
 LIB_DEPS += axi_spdif_tx
 LIB_DEPS += axi_sysid
 LIB_DEPS += spi_engine/axi_spi_engine
@@ -23,8 +25,8 @@ LIB_DEPS += spi_engine/spi_engine_execution
 LIB_DEPS += spi_engine/spi_engine_interconnect
 LIB_DEPS += spi_engine/spi_engine_offload
 LIB_DEPS += sysid_rom
-LIB_DEPS += util_axis_upscale
 LIB_DEPS += util_i2c_mixer
+LIB_DEPS += util_axis_upscale
 LIB_DEPS += util_pulse_gen
 
 include ../../scripts/project-xilinx.mk

--- a/projects/ad738x_fmc/zed/system_bd.tcl
+++ b/projects/ad738x_fmc/zed/system_bd.tcl
@@ -15,17 +15,4 @@ ad_ip_parameter rom_sys_0 CONFIG.ROM_ADDR_BITS 9
 
 sysid_gen_sys_init_file
 
-# specify ADC resolution -- the design supports 16/14/12 bit resolutions
-
-set adc_resolution 16
-
-# specify the number of active channel -- 1 or 2 or 4
-
-set adc_num_of_channels 2
-
-# specify ADC sampling rate in sample/seconds -- default is 3 MSPS
-
-set adc_sampling_rate 3000000
-
 source ../common/ad738x_bd.tcl
-

--- a/projects/ad738x_fmc/zed/system_constr.xdc
+++ b/projects/ad738x_fmc/zed/system_constr.xdc
@@ -5,8 +5,8 @@
 
 # SPI interface
 
-set_property -dict {PACKAGE_PIN M19  IOSTANDARD LVCMOS25} [get_ports spi_sclk]            ; ## FMC_LPC_LA00_CC_P
-set_property -dict {PACKAGE_PIN N19  IOSTANDARD LVCMOS25} [get_ports spi_sdia]            ; ## FMC_LPC_LA01_CC_P
-set_property -dict {PACKAGE_PIN N20  IOSTANDARD LVCMOS25} [get_ports spi_sdib]            ; ## FMC_LPC_LA01_CC_N
-set_property -dict {PACKAGE_PIN P17  IOSTANDARD LVCMOS25} [get_ports spi_sdo]             ; ## FMC_LPC_LA02_P
-set_property -dict {PACKAGE_PIN M20  IOSTANDARD LVCMOS25} [get_ports spi_cs]              ; ## FMC_LPC_LA00_CC_N
+set_property -dict {PACKAGE_PIN M19  IOSTANDARD LVCMOS25} [get_ports spi_sclk]            ; ## G6 FMC_LA00_CC_P   IO_L13P_T2_MRCC_34
+set_property -dict {PACKAGE_PIN N19  IOSTANDARD LVCMOS25} [get_ports spi_sdia]            ; ## D8  FMC_LA01_CC_P  IO_L14P_T2_SRCC_34
+set_property -dict {PACKAGE_PIN N20  IOSTANDARD LVCMOS25} [get_ports spi_sdib]            ; ## D9  FMC_LA01_CC_N  IO_L14N_T2_SRCC_34
+set_property -dict {PACKAGE_PIN P17  IOSTANDARD LVCMOS25} [get_ports spi_sdo]             ; ## H7  FMC_LA02_P     IO_L20P_T3_34
+set_property -dict {PACKAGE_PIN M20  IOSTANDARD LVCMOS25} [get_ports spi_cs]              ; ## G7  FMC_LA00_CC_N  IO_L13N_T2_MRCC_34

--- a/projects/ad738x_fmc/zed/system_project.tcl
+++ b/projects/ad738x_fmc/zed/system_project.tcl
@@ -16,4 +16,3 @@ adi_project_files ad738x_fmc_zed [list \
     "$ad_hdl_dir/projects/common/zed/zed_system_constr.xdc"]
 
 adi_project_run ad738x_fmc_zed
-

--- a/projects/ad738x_fmc/zed/system_top.v
+++ b/projects/ad738x_fmc/zed/system_top.v
@@ -172,11 +172,11 @@ module system_top (
     .iic_mux_sda_i (iic_mux_sda_i_s),
     .iic_mux_sda_o (iic_mux_sda_o_s),
     .iic_mux_sda_t (iic_mux_sda_t_s),
-    .spi_sdo (spi_sdo),
-    .spi_sdo_t (),
-    .spi_sdi ({spi_sdib, spi_sdia}),
-    .spi_cs (spi_cs),
-    .spi_sclk (spi_sclk),
+    .ad738x_spi_sdo (spi_sdo),
+    .ad738x_spi_sdo_t (),
+    .ad738x_spi_sdi ({spi_sdib, spi_sdia}),
+    .ad738x_spi_cs (spi_cs),
+    .ad738x_spi_sclk (spi_sclk),
     .otg_vbusoc (otg_vbusoc),
     .spdif (spdif));
 


### PR DESCRIPTION
## PR Description
I replaced the SPI Engine connections in the ad738x_bd.tcl with the
spi_engine_create procedure found in the spi_engine.tcl script. Through
these changes, a more generic instantiation for the spi_engine can be
achieved. I also added ad738x_fmc.txt file for generating the system_constr.xdc file.
Tested with NO-OS. Only one channel works, partially.

## PR Type
- [ ] Bug fix (change that fixes an issue)
- [x] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the code style guidelines
- [x] I have performed a self-review of changes
- [x] I have compiled all hdl projects and libraries affected by this PR
- [x] I have tested in hardware affected projects, at least on relevant boards
- [ ] I have commented my code, at least hard-to-understand parts
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe files, Copyright etc)
- [x] I have not introduced new Warnings/Critical Warnings on compilation
- [ ] I have added new hdl testbenches or updated existing ones
