### PR TITLE
Update SPI Engine PULSAR ADC PMDZ

### DIFF
--- a/projects/pulsar_adc_pmdz/common/pulsar_adc_pmdz_fmc.txt
+++ b/projects/pulsar_adc_pmdz/common/pulsar_adc_pmdz_fmc.txt
@@ -1,0 +1,9 @@
+# pulsar_adc_pmdz
+
+Pin            Port               Schematic_name     System_top_name        IOSTANDARD  Termination
+
+PMOD J5 [8]    PMOD JA [4]        SCK                pulsar_adc_spi_sclk    LVCMOS33    #N/A
+PMOD J5 [6]    PMOD JA [2]        SDO                pulsar_adc_spi_sdi     LVCMOS33    #N/A
+PMOD J5 [4]    PMOD JA [3]        SDI                pulsar_adc_spi_sdo     LVCMOS33    #N/A
+PMOD J5 [2]    PMOD JA [1]        CS                 pulsar_adc_spi_cs      LVCMOS33    #N/A
+PMOD J5 [1]    PMOD JA [7]        INT                pulsar_adc_spi_pd      LVCMOS33    #N/A

--- a/projects/pulsar_adc_pmdz/common/pulsar_adc_pmdz_fmc.txt
+++ b/projects/pulsar_adc_pmdz/common/pulsar_adc_pmdz_fmc.txt
@@ -1,9 +1,0 @@
-# pulsar_adc_pmdz
-
-Pin            Port               Schematic_name     System_top_name        IOSTANDARD  Termination
-
-PMOD J5 [8]    PMOD JA [4]        SCK                pulsar_adc_spi_sclk    LVCMOS33    #N/A
-PMOD J5 [6]    PMOD JA [2]        SDO                pulsar_adc_spi_sdi     LVCMOS33    #N/A
-PMOD J5 [4]    PMOD JA [3]        SDI                pulsar_adc_spi_sdo     LVCMOS33    #N/A
-PMOD J5 [2]    PMOD JA [1]        CS                 pulsar_adc_spi_cs      LVCMOS33    #N/A
-PMOD J5 [1]    PMOD JA [7]        INT                pulsar_adc_spi_pd      LVCMOS33    #N/A

--- a/projects/pulsar_adc_pmdz/common/pulsar_adc_pmdz_pmod.txt
+++ b/projects/pulsar_adc_pmdz/common/pulsar_adc_pmdz_pmod.txt
@@ -1,6 +1,6 @@
-# pulsar_adc_pmdz
-
 Pin            Port               Schematic_name     System_top_name        IOSTANDARD  Termination
+
+# pulsar_adc_pmdz
 
 PMOD J5 [8]    PMOD JA [4]        SCK                pulsar_adc_spi_sclk    LVCMOS33    #N/A
 PMOD J5 [6]    PMOD JA [3]        SDO                pulsar_adc_spi_sdi     LVCMOS33    #N/A

--- a/projects/pulsar_adc_pmdz/common/pulsar_adc_pmdz_pmod.txt
+++ b/projects/pulsar_adc_pmdz/common/pulsar_adc_pmdz_pmod.txt
@@ -1,0 +1,9 @@
+# pulsar_adc_pmdz
+
+Pin            Port               Schematic_name     System_top_name        IOSTANDARD  Termination
+
+PMOD J5 [8]    PMOD JA [4]        SCK                pulsar_adc_spi_sclk    LVCMOS33    #N/A
+PMOD J5 [6]    PMOD JA [3]        SDO                pulsar_adc_spi_sdi     LVCMOS33    #N/A
+PMOD J5 [4]    PMOD JA [2]        SDI                pulsar_adc_spi_sdo     LVCMOS33    #N/A
+PMOD J5 [2]    PMOD JA [1]        CS                 pulsar_adc_spi_cs      LVCMOS33    #N/A
+PMOD J5 [1]    PMOD JA [7]        INT                pulsar_adc_spi_pd      LVCMOS33    #N/A

--- a/projects/pulsar_adc_pmdz/common/pulsar_adc_pmdz_pmod.txt
+++ b/projects/pulsar_adc_pmdz/common/pulsar_adc_pmdz_pmod.txt
@@ -2,8 +2,8 @@ Pin            Port               Schematic_name     System_top_name        IOST
 
 # pulsar_adc_pmdz
 
-PMOD J5 [8]    PMOD JA [4]        SCK                pulsar_adc_spi_sclk    LVCMOS33    #N/A
-PMOD J5 [6]    PMOD JA [3]        SDO                pulsar_adc_spi_sdi     LVCMOS33    #N/A
-PMOD J5 [4]    PMOD JA [2]        SDI                pulsar_adc_spi_sdo     LVCMOS33    #N/A
-PMOD J5 [2]    PMOD JA [1]        CS                 pulsar_adc_spi_cs      LVCMOS33    #N/A
-PMOD J5 [1]    PMOD JA [7]        INT                pulsar_adc_spi_pd      LVCMOS33    #N/A
+4              PMOD_4             SCK                pulsar_adc_spi_sclk    LVCMOS33    #N/A
+3              PMOD_3             SDO                pulsar_adc_spi_sdi     LVCMOS33    #N/A
+2              PMOD_2             SDI                pulsar_adc_spi_sdo     LVCMOS33    #N/A
+1              PMOD_1             CS                 pulsar_adc_spi_cs      LVCMOS33    #N/A
+7              PMOD_7             INT                pulsar_adc_spi_pd      LVCMOS33    #N/A

--- a/projects/pulsar_adc_pmdz/coraz7s/system_constr.xdc
+++ b/projects/pulsar_adc_pmdz/coraz7s/system_constr.xdc
@@ -5,11 +5,11 @@
 
 # ad40xx_fmc SPI interface
 set_property -dict {PACKAGE_PIN Y19 IOSTANDARD LVCMOS33 IOB TRUE} [get_ports pulsar_adc_spi_sdo]       ; ##  PMOD JA [2]
-set_property -dict {PACKAGE_PIN Y16 IOSTANDARD LVCMOS33 IOB TRUE} [get_ports pulsar_adc_spi_sdi]       ; ##  PMOD JA [1]
-set_property -dict {PACKAGE_PIN Y17 IOSTANDARD LVCMOS33 IOB TRUE} [get_ports pulsar_adc_spi_sclk]      ; ##  PMOD JA [3]
-set_property -dict {PACKAGE_PIN Y18 IOSTANDARD LVCMOS33 IOB TRUE} [get_ports pulsar_adc_spi_cs]        ; ##  PMOD JA [0]
+set_property -dict {PACKAGE_PIN Y16 IOSTANDARD LVCMOS33 IOB TRUE} [get_ports pulsar_adc_spi_sdi]       ; ##  PMOD JA [3]
+set_property -dict {PACKAGE_PIN Y17 IOSTANDARD LVCMOS33 IOB TRUE} [get_ports pulsar_adc_spi_sclk]      ; ##  PMOD JA [4]
+set_property -dict {PACKAGE_PIN Y18 IOSTANDARD LVCMOS33 IOB TRUE} [get_ports pulsar_adc_spi_cs]        ; ##  PMOD JA [1]
 
-set_property -dict {PACKAGE_PIN U18 IOSTANDARD LVCMOS33} [get_ports pulsar_adc_spi_pd]                 ; ##  PMOD JA [4]
+set_property -dict {PACKAGE_PIN U18 IOSTANDARD LVCMOS33} [get_ports pulsar_adc_spi_pd]                 ; ##  PMOD JA [7]
 
 # rename auto-generated clock for SPIEngine to spi_clk - 160MHz
 # NOTE: clk_fpga_0 is the first PL fabric clock, also called $sys_cpu_clk

--- a/projects/pulsar_adc_pmdz/coraz7s/system_constr.xdc
+++ b/projects/pulsar_adc_pmdz/coraz7s/system_constr.xdc
@@ -4,12 +4,12 @@
 ###############################################################################
 
 # ad40xx_fmc SPI interface
-set_property -dict {PACKAGE_PIN Y19 IOSTANDARD LVCMOS33 IOB TRUE} [get_ports pulsar_adc_spi_sdo]       ; ##  PMOD JA_2
-set_property -dict {PACKAGE_PIN Y16 IOSTANDARD LVCMOS33 IOB TRUE} [get_ports pulsar_adc_spi_sdi]       ; ##  PMOD JA_3
-set_property -dict {PACKAGE_PIN Y17 IOSTANDARD LVCMOS33 IOB TRUE} [get_ports pulsar_adc_spi_sclk]      ; ##  PMOD JA_4
-set_property -dict {PACKAGE_PIN Y18 IOSTANDARD LVCMOS33 IOB TRUE} [get_ports pulsar_adc_spi_cs]        ; ##  PMOD JA_1
+set_property -dict {PACKAGE_PIN Y19 IOSTANDARD LVCMOS33 IOB TRUE} [get_ports pulsar_adc_spi_sdo]       ; ##  PMOD JA1_N
+set_property -dict {PACKAGE_PIN Y16 IOSTANDARD LVCMOS33 IOB TRUE} [get_ports pulsar_adc_spi_sdi]       ; ##  PMOD JA2_P
+set_property -dict {PACKAGE_PIN Y17 IOSTANDARD LVCMOS33 IOB TRUE} [get_ports pulsar_adc_spi_sclk]      ; ##  PMOD JA2_N
+set_property -dict {PACKAGE_PIN Y18 IOSTANDARD LVCMOS33 IOB TRUE} [get_ports pulsar_adc_spi_cs]        ; ##  PMOD JA1_P
 
-set_property -dict {PACKAGE_PIN U18 IOSTANDARD LVCMOS33} [get_ports pulsar_adc_spi_pd]                 ; ##  PMOD JA_7
+set_property -dict {PACKAGE_PIN U18 IOSTANDARD LVCMOS33} [get_ports pulsar_adc_spi_pd]                 ; ##  PMOD JA3_P
 
 # rename auto-generated clock for SPIEngine to spi_clk - 160MHz
 # NOTE: clk_fpga_0 is the first PL fabric clock, also called $sys_cpu_clk

--- a/projects/pulsar_adc_pmdz/coraz7s/system_constr.xdc
+++ b/projects/pulsar_adc_pmdz/coraz7s/system_constr.xdc
@@ -4,12 +4,12 @@
 ###############################################################################
 
 # ad40xx_fmc SPI interface
-set_property -dict {PACKAGE_PIN Y19 IOSTANDARD LVCMOS33 IOB TRUE} [get_ports pulsar_adc_spi_sdo]       ; ##  PMOD JA [2]
-set_property -dict {PACKAGE_PIN Y16 IOSTANDARD LVCMOS33 IOB TRUE} [get_ports pulsar_adc_spi_sdi]       ; ##  PMOD JA [3]
-set_property -dict {PACKAGE_PIN Y17 IOSTANDARD LVCMOS33 IOB TRUE} [get_ports pulsar_adc_spi_sclk]      ; ##  PMOD JA [4]
-set_property -dict {PACKAGE_PIN Y18 IOSTANDARD LVCMOS33 IOB TRUE} [get_ports pulsar_adc_spi_cs]        ; ##  PMOD JA [1]
+set_property -dict {PACKAGE_PIN Y19 IOSTANDARD LVCMOS33 IOB TRUE} [get_ports pulsar_adc_spi_sdo]       ; ##  PMOD JA_2
+set_property -dict {PACKAGE_PIN Y16 IOSTANDARD LVCMOS33 IOB TRUE} [get_ports pulsar_adc_spi_sdi]       ; ##  PMOD JA_3
+set_property -dict {PACKAGE_PIN Y17 IOSTANDARD LVCMOS33 IOB TRUE} [get_ports pulsar_adc_spi_sclk]      ; ##  PMOD JA_4
+set_property -dict {PACKAGE_PIN Y18 IOSTANDARD LVCMOS33 IOB TRUE} [get_ports pulsar_adc_spi_cs]        ; ##  PMOD JA_1
 
-set_property -dict {PACKAGE_PIN U18 IOSTANDARD LVCMOS33} [get_ports pulsar_adc_spi_pd]                 ; ##  PMOD JA [7]
+set_property -dict {PACKAGE_PIN U18 IOSTANDARD LVCMOS33} [get_ports pulsar_adc_spi_pd]                 ; ##  PMOD JA_7
 
 # rename auto-generated clock for SPIEngine to spi_clk - 160MHz
 # NOTE: clk_fpga_0 is the first PL fabric clock, also called $sys_cpu_clk


### PR DESCRIPTION
## PR Description

I replaced the SPI Engine connections in the pulsar_adc_pmdz_bd.tcl with the
spi_engine_create procedure found in the spi_engine.tcl script. Through
these changes, a more generic instantiation for the spi_engine can be
achieved. I have update system_constr.xdc file and added pulsar_adc_pmdz_pmod.txt. Tests were done on the eval-ad7689-ebz and eval-ad7984-pmdz boards. Linux part works good on AD7689 if only one channel is selected and partially on AD7984.

## PR Type
- [ ] Bug fix (change that fixes an issue)
- [x] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the code style guidelines
- [x] I have performed a self-review of changes
- [x] I have compiled all hdl projects and libraries affected by this PR
- [x] I have tested in hardware affected projects, at least on relevant boards
- [ ] I have commented my code, at least hard-to-understand parts
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe files, Copyright etc)
- [x] I have not introduced new Warnings/Critical Warnings on compilation
- [ ] I have added new hdl testbenches or updated existing ones
