### PR TITLE
pluto: Enable phaser integration

### DIFF
--- a/projects/pluto/Makefile
+++ b/projects/pluto/Makefile
@@ -12,10 +12,12 @@ M_DEPS += ../../library/util_cdc/sync_bits.v
 M_DEPS += ../../library/common/util_pulse_gen.v
 M_DEPS += ../../library/common/ad_iobuf.v
 M_DEPS += ../../library/common/ad_bus_mux.v
+M_DEPS += ../../library/axi_tdd/scripts/axi_tdd.tcl
 M_DEPS += ../../library/axi_ad9361/axi_ad9361_delay.tcl
 
 LIB_DEPS += axi_ad9361
 LIB_DEPS += axi_dmac
+LIB_DEPS += axi_tdd
 LIB_DEPS += util_pack/util_cpack2
 LIB_DEPS += util_pack/util_upack2
 

--- a/projects/pluto/Readme.md
+++ b/projects/pluto/Readme.md
@@ -2,7 +2,9 @@
 
 Here are some pointers to help you:
   * [Board Product Page](https://www.analog.com/adalm-pluto)
+  * [Board Product Page](https://www.analog.com/cn0566)
   * Parts : [RF Agile Transceiver](https://www.analog.com/ad9363)
   * Project Doc: https://wiki.analog.com/university/tools/pluto	
+  * Project Doc: https://wiki.analog.com/resources/eval/user-guides/circuits-from-the-lab/cn0566
   * HDL Doc: https://wiki.analog.com/resources/eval/user-guides/ad-fmcomms2-ebz/reference_hdl
   * Linux Drivers: https://wiki.analog.com/resources/tools-software/linux-drivers/iio-transceiver/ad9361

--- a/projects/pluto/system_constr.xdc
+++ b/projects/pluto/system_constr.xdc
@@ -56,17 +56,26 @@ set_property  -dict {PACKAGE_PIN  P9   IOSTANDARD LVCMOS18} [get_ports gpio_rese
 set_property  -dict {PACKAGE_PIN  K12  IOSTANDARD LVCMOS18} [get_ports enable]
 set_property  -dict {PACKAGE_PIN  K11  IOSTANDARD LVCMOS18} [get_ports txnrx]
 
-set_property  -dict {PACKAGE_PIN  M14  IOSTANDARD LVCMOS18 PULLTYPE PULLUP} [get_ports iic_scl]
-set_property  -dict {PACKAGE_PIN  N14  IOSTANDARD LVCMOS18 PULLTYPE PULLUP} [get_ports iic_sda]
-
 set_property  -dict {PACKAGE_PIN  E12  IOSTANDARD LVCMOS18  PULLTYPE PULLUP} [get_ports spi_csn]
 set_property  -dict {PACKAGE_PIN  E11  IOSTANDARD LVCMOS18} [get_ports spi_clk]
 set_property  -dict {PACKAGE_PIN  E13  IOSTANDARD LVCMOS18} [get_ports spi_mosi]
 set_property  -dict {PACKAGE_PIN  F12  IOSTANDARD LVCMOS18} [get_ports spi_miso]
 
-set_property  -dict {PACKAGE_PIN  R10  IOSTANDARD LVCMOS18} [get_ports pl_spi_clk_o]
-set_property  -dict {PACKAGE_PIN  M12  IOSTANDARD LVCMOS18} [get_ports pl_spi_miso]
-set_property  -dict {PACKAGE_PIN  K13  IOSTANDARD LVCMOS18} [get_ports pl_spi_mosi]
+# PL GPIOs
+#
+# Pin  | Package Pin | GPIO     | Pluto    | Phaser  |
+# -----|-------------|----------|----------|---------|
+# L10P | K13         | PL_GPIO0 | SPI MOSI | TXDATA  |
+# L12N | M12         | PL_GPIO1 | SPI MISO | BURST   |
+# L24N | R10         | PL_GPIO2 | SPI CLKO | MUXOUT  |
+# L7N  | N14         | PL_GPIO3 | IIC SDA  | IIC SDA |
+# L9N  | M14         | PL_GPIO4 | IIC SCL  | IIC SCL |
+
+set_property  -dict {PACKAGE_PIN  K13  IOSTANDARD LVCMOS18} [get_ports pl_gpio0]
+set_property  -dict {PACKAGE_PIN  M12  IOSTANDARD LVCMOS18} [get_ports pl_gpio1]
+set_property  -dict {PACKAGE_PIN  R10  IOSTANDARD LVCMOS18} [get_ports pl_gpio2]
+set_property  -dict {PACKAGE_PIN  N14  IOSTANDARD LVCMOS18 PULLTYPE PULLUP} [get_ports pl_gpio3]
+set_property  -dict {PACKAGE_PIN  M14  IOSTANDARD LVCMOS18 PULLTYPE PULLUP} [get_ports pl_gpio4]
 
 set_property  -dict {PACKAGE_PIN  P8   IOSTANDARD LVCMOS18} [get_ports clk_out]
 


### PR DESCRIPTION
## PR Description

This commit adds support for ADALM-PHASER, allowing the user to choose between the default PlutoSDR mode and Phaser mode through a software controlled GPIO pin: _phaser_enable_.

The Generic TDD Engine was integrated to output a logic signal on the L10P pin, which connects to the input of the ADF4159, when receiving an external synchronization signal on the L12N pin from the Raspberry Pi. Two additional TDD channels are used to synchronize the TX/RX DMA transfer start.

## PR Type
- [ ] Bug fix (change that fixes an issue)
- [x] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the code style guidelines
- [x] I have performed a self-review of changes
- [x] I have compiled all hdl projects and libraries affected by this PR
- [x] I have tested in hardware affected projects, at least on relevant boards
- [x] I have commented my code, at least hard-to-understand parts
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe files, Copyright etc)
- [ ] I have not introduced new Warnings/Critical Warnings on compilation
- [x] I have added new hdl testbenches or updated existing ones
