### PR TITLE
axi_jesd204_rx: Fixup write to up_cfg_buffer_delay

### DIFF
--- a/docs/regmap/adi_regmap_jesd_rx.txt
+++ b/docs/regmap/adi_regmap_jesd_rx.txt
@@ -560,10 +560,16 @@ RO
 ENDFIELD
 
 FIELD
-[9:0] 0x00000000
-BUFFER_DEALY
+[9:2] 0x00000000
+BUFFER_DELAY
 RW
 Buffer release opportunity offset from LMFC.
+ENDFIELD
+
+FIELD
+[1:0] 0x00000000
+RESERVED
+RO
 ENDFIELD
 
 ############################################################################################

--- a/library/jesd204/axi_jesd204_rx/jesd204_up_rx.v
+++ b/library/jesd204/axi_jesd204_rx/jesd204_up_rx.v
@@ -1,6 +1,6 @@
 // ***************************************************************************
 // ***************************************************************************
-// Copyright (C) 2016-2018, 2020-2022 Analog Devices, Inc. All rights reserved.
+// Copyright (C) 2016-2018, 2020-2024 Analog Devices, Inc. All rights reserved.
 // SPDX short identifier: ADIJESD204
 // ***************************************************************************
 // ***************************************************************************
@@ -150,7 +150,7 @@ module jesd204_up_rx #(
       /* JESD RX configuraton */
       12'h090: begin
         up_cfg_buffer_early_release <= up_wdata[16];
-        up_cfg_buffer_delay <= up_wdata[7:0];
+        up_cfg_buffer_delay <= up_wdata[9:2];
       end
       endcase
     end else if (up_wreq == 1'b1) begin


### PR DESCRIPTION
Change up_cfg_buffer_delay assignment from up_wdata [7:0] to [9:2].

## PR Description

Test [axi_jesd204_rx_regmap_tb.v](../blob/6128dd1ab53c9414bce2432457e41919501a1816/library/jesd204/tb/axi_jesd204_rx_regmap_tb.v#L267) was failing at register x90 with output:
```
Address 00000240, Expected 000103fc, Found 000103f0
```
The issue is at fields _Buffer release delay_ [9:2] and _Data path width alignment_ [1:0], the latter is always 2'b00.
Investigating jesd204_up_rx.v, I noticed that up_cfg_buffer_delay is assigned up_wdata[7:0] instead of [9:2], incoherent with the read instruction.
I ran all tests at tb and now all succeeds (xsim, 2023.1).

## PR Type
- [X] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [X] I have followed the code style guidelines
- [X] I have performed a self-review of changes
- [ ] I have compiled all hdl projects and libraries affected by this PR
- [ ] I have tested in hardware affected projects, at least on relevant boards
- [X] I have commented my code, at least hard-to-understand parts
- [X] I have signed off all commits from this PR
- [X] I have updated the documentation (wiki pages, ReadMe files, Copyright etc)
- [ ] I have not introduced new Warnings/Critical Warnings on compilation
- [X] I have added new hdl testbenches or updated existing ones
