### PR TITLE
Update ad5766 spi engine

### DIFF
--- a/projects/ad5766_sdz/Readme.md
+++ b/projects/ad5766_sdz/Readme.md
@@ -2,8 +2,8 @@
 
 Here are some pointers to help you:
   * [Board Product Page](https://www.analog.com/EVAL-AD5766)
-  * Parts : [16-Channel, 16-Bit Voltage Output denseDAC](https://www.analog.com/ad5766)
-            [16-Channel, 12-Bit Voltage Output denseDAC](https://www.analog.com/ad5767)
+  * Parts : [AD5766, 16-Channel, 16-Bit Voltage Output denseDAC](https://www.analog.com/ad5766)
+            [AD5767, 16-Channel, 12-Bit Voltage Output denseDAC](https://www.analog.com/ad5767)
   * Project Doc: 
   * HDL Doc: 
   * NO-OS Drivers: [AD5766 - No-OS Driver](https://wiki.analog.com/resources/tools-software/uc-drivers/ad5766)

--- a/projects/ad5766_sdz/common/ad5766_fmc.txt
+++ b/projects/ad5766_sdz/common/ad5766_fmc.txt
@@ -1,6 +1,6 @@
-# ad5766
-
 FMC_pin   FMC_port       Schematic_name     System_top_name     IOSTANDARD  Termination
+
+# ad5766
 
 H20       FMC_LA15_N     SCLK               spi_sclk            LVCMOS25    #N/A
 G19       FMC_LA16_N     SDI                spi_sdo             LVCMOS25    #N/A

--- a/projects/ad5766_sdz/common/ad5766_fmc.txt
+++ b/projects/ad5766_sdz/common/ad5766_fmc.txt
@@ -1,0 +1,9 @@
+# ad5766
+
+FMC_pin   FMC_port       Schematic_name     System_top_name     IOSTANDARD  Termination
+
+H20       FMC_LA15_N     SCLK               spi_sclk            LVCMOS25    #N/A
+G19       FMC_LA16_N     SDI                spi_sdo             LVCMOS25    #N/A
+H17       FMC_LA11_N     SDO                spi_sdi             LVCMOS25    #N/A
+H19       FMC_LA15_P     SYNCn              spi_cs              LVCMOS25    #N/A
+H25       FMC_LA21_P     RESETn             reset               LVCMOS25    #N/A

--- a/projects/ad5766_sdz/zed/system_constr.xdc
+++ b/projects/ad5766_sdz/zed/system_constr.xdc
@@ -5,11 +5,11 @@
 
 # SPI interface
 
-set_property -dict {PACKAGE_PIN J17  IOSTANDARD LVCMOS25} [get_ports spi_sclk]   ; ## FMC_LPC_LA15_N
-set_property -dict {PACKAGE_PIN K21  IOSTANDARD LVCMOS25} [get_ports spi_sdo]    ; ## FMC_LPC_LA16_N
-set_property -dict {PACKAGE_PIN N18  IOSTANDARD LVCMOS25} [get_ports spi_sdi]    ; ## FMC_LPC_LA11_N
-set_property -dict {PACKAGE_PIN J16  IOSTANDARD LVCMOS25} [get_ports spi_cs]     ; ## FMC_LPC_LA15_P
+set_property -dict {PACKAGE_PIN J17  IOSTANDARD LVCMOS25} [get_ports spi_sclk]   ; ## FMC_LA15_N IO_L2N_T0_34
+set_property -dict {PACKAGE_PIN K21  IOSTANDARD LVCMOS25} [get_ports spi_sdo]    ; ## FMC_LA16_N IO_L9N_T1_DQS_34
+set_property -dict {PACKAGE_PIN N18  IOSTANDARD LVCMOS25} [get_ports spi_sdi]    ; ## FMC_LA11_N IO_L5N_T0_34
+set_property -dict {PACKAGE_PIN J16  IOSTANDARD LVCMOS25} [get_ports spi_cs]     ; ## FMC_LA15_P IO_L2P_T0_34
 
 # reset signal
 
-set_property -dict {PACKAGE_PIN E19  IOSTANDARD LVCMOS25} [get_ports reset]      ; ## FMC_LPC_LA21_P
+set_property -dict {PACKAGE_PIN E19  IOSTANDARD LVCMOS25} [get_ports reset]      ; ## FMC_LA21_P IO_L21P_T3_DQS_AD14P_35


### PR DESCRIPTION
## PR Description

The functionality of the ad5766 project was verified with SPI Engine. Over the old version it was created the ad5766_fmc.txt file for generating the system_constr.xdc file. Also it was updated the system_constr.xdc and Readme.md files. Tested with NO-OS. No correct signals were obtained from the DAC output channels.

## PR Type
- [ ] Bug fix (change that fixes an issue)
- [x] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the code style guidelines
- [x] I have performed a self-review of changes
- [x] I have compiled all hdl projects and libraries affected by this PR
- [x] I have tested in hardware affected projects, at least on relevant boards
- [ ] I have commented my code, at least hard-to-understand parts
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe files, Copyright etc)
- [x] I have not introduced new Warnings/Critical Warnings on compilation
- [ ] I have added new hdl testbenches or updated existing ones
