### PR TITLE
projects/cn0561: Update SPIE project. FMC pinout. Software test

### DIFF
--- a/projects/cn0561/common/cn0561_fmc.txt
+++ b/projects/cn0561/common/cn0561_fmc.txt
@@ -1,0 +1,30 @@
+# CN0561_FMC
+
+FMC_pin   FMC_port       Schematic_name     System_top_name     IOSTANDARD  Termination
+
+# cn0561 SPI configuration interface
+G9        LA03_P          DEC3/SDO           cn0561_spi_sdi      LVCMOS25    #N/A
+H11       LA04_N          DEC2/SDI           cn0561_spi_sdo      LVCMOS25    #N/A
+D8        LA01_P_CC       FORMAT1/SCLK       cn0561_spi_sclk     LVCMOS25    #N/A
+D11       LA05_P          FORMAT0/CSB        cn0561_spi_cs       LVCMOS25    #N/A
+
+# cn0561 data interface
+H4        CLK0_M2C_P      DCLK               cn0561_dclk         LVCMOS25    #N/A
+G7        LA00_N_CC       DOUT0              cn0561_din[0]       LVCMOS25    #N/A
+C11       LA06_N          DOUT1              cn0561_din[1]       LVCMOS25    #N/A
+H7        LA02_P          DOUT2              cn0561_din[2]       LVCMOS25    #N/A
+H8        LA02_N          DOUT3              cn0561_din[3]       LVCMOS25    #N/A
+G6        LA00_P_CC       ODR                cn0561_odr          LVCMOS25    #N/A
+
+# cn0561 GPIO lines
+G18       LA16_P          RESETB             cn0561_resetn       LVCMOS25    #N/A
+H13       LA07_P          PDNB               cn0561_pdn          LVCMOS25    #N/A
+H10       LA04_P          MODE               cn0561_mode         LVCMOS25    #N/A
+C14       LA10_P          DCLKRATE0/GPIO0    cn0561_gpio0        LVCMOS25    #N/A
+C15       LA10_N          DCLKRATE1/GPIO1    cn0561_gpio1        LVCMOS25    #N/A
+H16       LA11_P          DCLKRATE2/GPIO2    cn0561_gpio2        LVCMOS25    #N/A
+G15       LA12_P          FILTER0/GPIO4      cn0561_gpio4        LVCMOS25    #N/A
+G16       LA12_N          FILTER1/GPIO5      cn0561_gpio5        LVCMOS25    #N/A
+D17       LA13_P          FRAME0/GPIO6       cn0561_gpio6        LVCMOS25    #N/A
+D18       LA13_N          FRAME1/GPIO7       cn0561_gpio7        LVCMOS25    #N/A
+C10       LA06_P          PINB/SPI           cn0561_pinbspi      LVCMOS25    #N/A

--- a/projects/cn0561/coraz7s/system_constr.xdc
+++ b/projects/cn0561/coraz7s/system_constr.xdc
@@ -6,17 +6,16 @@
 set_property -dict {PACKAGE_PIN P16 IOSTANDARD LVCMOS33} [get_ports iic_scl]
 set_property -dict {PACKAGE_PIN P15 IOSTANDARD LVCMOS33} [get_ports iic_sda]
 
-set_property -dict {PACKAGE_PIN J18 IOSTANDARD LVCMOS33} [get_ports cn0561_spi_sdi]
-set_property -dict {PACKAGE_PIN K18 IOSTANDARD LVCMOS33} [get_ports cn0561_spi_sdo]
-set_property -dict {PACKAGE_PIN G15 IOSTANDARD LVCMOS33} [get_ports cn0561_spi_sclk]
-set_property -dict {PACKAGE_PIN U15 IOSTANDARD LVCMOS33} [get_ports cn0561_spi_cs]
+set_property -dict {PACKAGE_PIN J18 IOSTANDARD LVCMOS33} [get_ports cn0561_spi_sdi]     ; ## FMC_LPC_LA03_P
+set_property -dict {PACKAGE_PIN K18 IOSTANDARD LVCMOS33} [get_ports cn0561_spi_sdo]     ; ## FMC_LPC_LA04_N
+set_property -dict {PACKAGE_PIN G15 IOSTANDARD LVCMOS33} [get_ports cn0561_spi_sclk]    ; ## FMC_LPC_LA01_P_CC
+set_property -dict {PACKAGE_PIN U15 IOSTANDARD LVCMOS33} [get_ports cn0561_spi_cs]      ; ## FMC_LPC_LA05_P
 
-set_property -dict {PACKAGE_PIN T14 IOSTANDARD LVCMOS33} [get_ports cn0561_dclk]
-set_property -dict {PACKAGE_PIN V17 IOSTANDARD LVCMOS33} [get_ports cn0561_din[0]]
-set_property -dict {PACKAGE_PIN V18 IOSTANDARD LVCMOS33} [get_ports cn0561_din[1]]
-set_property -dict {PACKAGE_PIN R17 IOSTANDARD LVCMOS33} [get_ports cn0561_din[2]]
-set_property -dict {PACKAGE_PIN R14 IOSTANDARD LVCMOS33} [get_ports cn0561_din[3]]
-set_property -dict {PACKAGE_PIN T15 IOSTANDARD LVCMOS33} [get_ports cn0561_odr]
+set_property -dict {PACKAGE_PIN T14 IOSTANDARD LVCMOS33} [get_ports cn0561_dclk]        ; ## FMC_LPC_CLK0_M2C_P
+set_property -dict {PACKAGE_PIN V17 IOSTANDARD LVCMOS33} [get_ports cn0561_din[0]]      ; ## FMC_LPC_LA00_N_CC
+set_property -dict {PACKAGE_PIN V18 IOSTANDARD LVCMOS33} [get_ports cn0561_din[1]]      ; ## FMC_LPC_LA06_N
+set_property -dict {PACKAGE_PIN R17 IOSTANDARD LVCMOS33} [get_ports cn0561_din[2]]      ; ## FMC_LPC_LA02_P
+set_property -dict {PACKAGE_PIN R14 IOSTANDARD LVCMOS33} [get_ports cn0561_din[3]]      ; ## FMC_LPC_LA02_N
+set_property -dict {PACKAGE_PIN T15 IOSTANDARD LVCMOS33} [get_ports cn0561_odr]         ; ## FMC_LPC_LA00_P_CC
 
-set_property -dict {PACKAGE_PIN V13 IOSTANDARD LVCMOS33} [get_ports cn0561_pdn]
-
+set_property -dict {PACKAGE_PIN V13 IOSTANDARD LVCMOS33} [get_ports cn0561_pdn]         ; ## FMC_LPC_LA07_P

--- a/projects/cn0561/zed/system_constr.xdc
+++ b/projects/cn0561/zed/system_constr.xdc
@@ -6,17 +6,17 @@
 # cn0561 SPI configuration interface
 set_property -dict {PACKAGE_PIN N22 IOSTANDARD LVCMOS25} [get_ports cn0561_spi_sdi]       ; ## FMC_LPC_LA03_P
 set_property -dict {PACKAGE_PIN M22 IOSTANDARD LVCMOS25} [get_ports cn0561_spi_sdo]       ; ## FMC_LPC_LA04_N
-set_property -dict {PACKAGE_PIN N19 IOSTANDARD LVCMOS25} [get_ports cn0561_spi_sclk]      ; ## FMC_LPC_LA01_CC_P
+set_property -dict {PACKAGE_PIN N19 IOSTANDARD LVCMOS25} [get_ports cn0561_spi_sclk]      ; ## FMC_LPC_LA01_P_CC
 set_property -dict {PACKAGE_PIN J18 IOSTANDARD LVCMOS25} [get_ports cn0561_spi_cs]        ; ## FMC_LPC_LA05_P
 
 # cn0561 data interface
 
 set_property -dict {PACKAGE_PIN L18 IOSTANDARD LVCMOS25} [get_ports cn0561_dclk]          ; ## FMC_LPC_CLK0_M2C_P
-set_property -dict {PACKAGE_PIN M20 IOSTANDARD LVCMOS25} [get_ports cn0561_din[0]]        ; ## FMC_LPC_LA00_CC_N
+set_property -dict {PACKAGE_PIN M20 IOSTANDARD LVCMOS25} [get_ports cn0561_din[0]]        ; ## FMC_LPC_LA00_N_CC
 set_property -dict {PACKAGE_PIN J21 IOSTANDARD LVCMOS25} [get_ports cn0561_din[1]]        ; ## FMC_LPC_LA06_N
 set_property -dict {PACKAGE_PIN P17 IOSTANDARD LVCMOS25} [get_ports cn0561_din[2]]        ; ## FMC_LPC_LA02_P
 set_property -dict {PACKAGE_PIN P18 IOSTANDARD LVCMOS25} [get_ports cn0561_din[3]]        ; ## FMC_LPC_LA02_N
-set_property -dict {PACKAGE_PIN M19 IOSTANDARD LVCMOS25} [get_ports cn0561_odr]           ; ## FMC_LPC_LA00_CC_P
+set_property -dict {PACKAGE_PIN M19 IOSTANDARD LVCMOS25} [get_ports cn0561_odr]           ; ## FMC_LPC_LA00_P_CC
 
 # cn0561 GPIO lines
 


### PR DESCRIPTION
## PR Description

This PR covers the SPI Engine project checking and updates. Changes and additions include:
- Added txt description of all FMC pins used/unused
- Updated constraint files with FMC pinout location for Zed and Cora carrier boards

Hardware test with available software:
* CN0561 NO-OS updated for new HDL design (PWM trigger for SPIE offload)
   - CN0561-Zed **successful** test - ADC conversion 1MHz ODR
   - CN0561-Cora    **failed**    test - 0V on ADC output channel 

PR opened on NO-OS repo to introduce HDL design related changes. Merged into NO-OS master.

## PR Type
- [ ] Bug fix (change that fixes an issue)
- [x] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the code style guidelines
- [x] I have performed a self-review of changes
- [x] I have compiled all hdl projects and libraries affected by this PR
- [x] I have tested in hardware affected projects, at least on relevant boards
- [x] I have commented my code, at least hard-to-understand parts
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe files, Copyright etc)
- [x] I have not introduced new Warnings/Critical Warnings on compilation
- [ ] I have added new hdl testbenches or updated existing ones
