### PR TITLE
projects/ad4134_fmc: Update SPIE project. Add FMC pinout. Test soft support on hardware

### DIFF
--- a/projects/ad4134_fmc/common/ad4134_fmc.txt
+++ b/projects/ad4134_fmc/common/ad4134_fmc.txt
@@ -1,0 +1,32 @@
+# AD4134_FMC
+
+FMC_pin   FMC_port       Schematic_name     System_top_name     IOSTANDARD  Termination
+
+# ad4134 SPI configuration interface
+G9        LA03_P          DEC3/SDO           ad4134_spi_sdi      LVCMOS25    #N/A
+H11       LA04_N          DEC2/SDI           ad4134_spi_sdo      LVCMOS25    #N/A
+D8        LA01_P_CC       FORMAT1/SCLK       ad4134_spi_sclk     LVCMOS25    #N/A
+D11       LA05_P          FORMAT0/CSB        ad4134_spi_cs       LVCMOS25    #N/A
+
+# ad4134 data interface
+H4        CLK0_M2C_P      DCLK               ad4134_dclk         LVCMOS25    #N/A
+G7        LA00_N_CC       DOUT0              ad4134_din[0]       LVCMOS25    #N/A
+C11       LA06_N          DOUT1              ad4134_din[1]       LVCMOS25    #N/A
+H7        LA02_P          DOUT2              ad4134_din[2]       LVCMOS25    #N/A
+H8        LA02_N          DOUT3              ad4134_din[3]       LVCMOS25    #N/A
+G6        LA00_P_CC       ODR                ad4134_odr          LVCMOS25    #N/A
+
+# ad4134 GPIO lines
+G18       LA16_P          RESETB             ad4134_resetn       LVCMOS25    #N/A
+H13       LA07_P          PDNB               ad4134_pdn          LVCMOS25    #N/A
+H10       LA04_P          MODE               ad4134_mode         LVCMOS25    #N/A
+C14       LA10_P          DCLKRATE0/GPIO0    ad4134_gpio0        LVCMOS25    #N/A
+C15       LA10_N          DCLKRATE1/GPIO1    ad4134_gpio1        LVCMOS25    #N/A
+H16       LA11_P          DCLKRATE2/GPIO2    ad4134_gpio2        LVCMOS25    #N/A
+G15       LA12_P          FILTER0/GPIO4      ad4134_gpio4        LVCMOS25    #N/A
+G16       LA12_N          FILTER1/GPIO5      ad4134_gpio5        LVCMOS25    #N/A
+D17       LA13_P          FRAME0/GPIO6       ad4134_gpio6        LVCMOS25    #N/A
+D18       LA13_N          FRAME1/GPIO7       ad4134_gpio7        LVCMOS25    #N/A
+C10       LA06_P          PINB/SPI           ad4134_pinbspi      LVCMOS25    #N/A
+C18       LA14_P          MODE               ad4134_dclkio       LVCMOS25    #N/A
+C19       LA14_N          DEC1/DCLKMODE      ad4134_dclk_mode    LVCMOS25    #N/A 

--- a/projects/ad4134_fmc/zed/system_constr.xdc
+++ b/projects/ad4134_fmc/zed/system_constr.xdc
@@ -6,17 +6,17 @@
 # ad4134 SPI configuration interface
 set_property -dict {PACKAGE_PIN N22 IOSTANDARD LVCMOS25} [get_ports ad4134_spi_sdi]       ; ## FMC_LPC_LA03_P
 set_property -dict {PACKAGE_PIN M22 IOSTANDARD LVCMOS25} [get_ports ad4134_spi_sdo]       ; ## FMC_LPC_LA04_N
-set_property -dict {PACKAGE_PIN N19 IOSTANDARD LVCMOS25} [get_ports ad4134_spi_sclk]      ; ## FMC_LPC_LA01_CC_P
+set_property -dict {PACKAGE_PIN N19 IOSTANDARD LVCMOS25} [get_ports ad4134_spi_sclk]      ; ## FMC_LPC_LA01_P_CC
 set_property -dict {PACKAGE_PIN J18 IOSTANDARD LVCMOS25} [get_ports ad4134_spi_cs]        ; ## FMC_LPC_LA05_P
 
 # ad4134 data interface
 
 set_property -dict {PACKAGE_PIN L18 IOSTANDARD LVCMOS25} [get_ports ad4134_dclk]          ; ## FMC_LPC_CLK0_M2C_P
-set_property -dict {PACKAGE_PIN M20 IOSTANDARD LVCMOS25} [get_ports ad4134_din[0]]        ; ## FMC_LPC_LA00_CC_N
+set_property -dict {PACKAGE_PIN M20 IOSTANDARD LVCMOS25} [get_ports ad4134_din[0]]        ; ## FMC_LPC_LA00_N_CC
 set_property -dict {PACKAGE_PIN L22 IOSTANDARD LVCMOS25} [get_ports ad4134_din[1]]        ; ## FMC_LPC_LA06_N
 set_property -dict {PACKAGE_PIN P17 IOSTANDARD LVCMOS25} [get_ports ad4134_din[2]]        ; ## FMC_LPC_LA02_P
 set_property -dict {PACKAGE_PIN P18 IOSTANDARD LVCMOS25} [get_ports ad4134_din[3]]        ; ## FMC_LPC_LA02_N
-set_property -dict {PACKAGE_PIN M19 IOSTANDARD LVCMOS25} [get_ports ad4134_odr]           ; ## FMC_LPC_LA00_CC_P
+set_property -dict {PACKAGE_PIN M19 IOSTANDARD LVCMOS25} [get_ports ad4134_odr]           ; ## FMC_LPC_LA00_P_CC
 
 # ad4134 GPIO lines
 


### PR DESCRIPTION
## PR Description

This PR covers the AD4134 SPI Engine project checking and updates. Changes and additions include:
* Added txt description of all FMC pins used/unused
* Updated constraint files with FMC pinout location

Hardware test with available software:
 * Linux: Test **partially successful**. A dc signal is obtained. [ad4134 Linux driver](https://github.com/analogdevicesinc/linux/blob/529d8ebd2ca325649c04c62416f675d5afd8f8a4/drivers/iio/adc/ad4134.c)

 * NO-OS: Tested **failed**. It cannot communicate with the chip on the evaluation board.
   [AD413X NO-OS project](https://github.com/analogdevicesinc/no-OS/tree/master/projects/ad413x) Debugger log: dev_init fails. dev_id should be 4, but it is always 0. Changes in NO-OS must be made in order to recognize the chip. 

## PR Type
- [ ] Bug fix (change that fixes an issue)
- [x] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the code style guidelines
- [x] I have performed a self-review of changes
- [x] I have compiled all hdl projects and libraries affected by this PR
- [x] I have tested in hardware affected projects, at least on relevant boards
- [x] I have commented my code, at least hard-to-understand parts
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe files, Copyright etc)
- [x] I have not introduced new Warnings/Critical Warnings on compilation
- [ ] I have added new hdl testbenches or updated existing ones
