### PR TITLE
projects/ad7134_fmc: Update AD7134 SPIE project. Add FMC pinout. Test software support

### DIFF
--- a/projects/ad7134_fmc/common/ad7134_fmc.txt
+++ b/projects/ad7134_fmc/common/ad7134_fmc.txt
@@ -1,0 +1,45 @@
+# AD7134_FMC
+
+FMC_pin   FMC_port       Schematic_name     System_top_name     IOSTANDARD  Termination
+
+# ad713x SPI configuration interface
+G9        LA03_P          DEC3/SDO           ad713x_spi_sdi      LVCMOS25    #N/A
+H11       LA04_N          DEC2/SDI           ad713x_spi_sdo      LVCMOS25    #N/A
+D8        LA01_P_CC       FORMAT1/SCLK       ad713x_spi_sclk     LVCMOS25    #N/A
+D11       LA05_P          FORMAT0/CSB_1      ad713x_spi_cs[0]    LVCMOS25    #N/A
+D12       LA05_N          FORMAT0/CSB_2      ad713x_spi_cs[1]    LVCMOS25    #N/A
+
+# ad713x data interface
+H4        CLK0_M2C_P      DCLK               ad713x_dclk         LVCMOS25    #N/A
+G7        LA00_N_CC       DOUT0_1            ad713x_din[0]       LVCMOS25    #N/A
+C11       LA06_N          DOUT1_1            ad713x_din[1]       LVCMOS25    #N/A
+H7        LA02_P          DOUT2_1            ad713x_din[2]       LVCMOS25    #N/A
+H8        LA02_N          DOUT3_1            ad713x_din[3]       LVCMOS25    #N/A
+G12       LA08_P          DOUT0_2            ad713x_din[4]       LVCMOS25    #N/A
+G13       LA08_N          DOUT1_2            ad713x_din[5]       LVCMOS25    #N/A
+D14       LA09_P          DOUT2_2            ad713x_din[6]       LVCMOS25    #N/A
+D15       LA09_N          DOUT3_2            ad713x_din[7]       LVCMOS25    #N/A
+
+G6        LA00_P_CC       ODR                ad713x_odr          LVCMOS25    #N/A
+
+# ad713x GPIO lines
+G18       LA16_P          RESETB_1           ad713x_resetn[0]    LVCMOS25    #N/A
+G19       LA16_N          RESETB_2           ad713x_resetn[1]    LVCMOS25    #N/A
+H13       LA07_P          PDNB_1             ad713x_pdn[0]       LVCMOS25    #N/A
+H14       LA07_N          PDNB_2             ad713x_pdn[1]       LVCMOS25    #N/A
+H10       LA04_P          MODE_1             ad713x_mode[0]      LVCMOS25    #N/A
+G10       LA03_N          MODE_2             ad713x_mode[1]      LVCMOS25    #N/A
+C14       LA10_P          DCLKRATE0/GPIO0    ad713x_gpio[0]      LVCMOS25    #N/A
+C15       LA10_N          DCLKRATE1/GPIO1    ad713x_gpio[1]      LVCMOS25    #N/A
+H16       LA11_P          DCLKRATE2/GPIO2    ad713x_gpio[2]      LVCMOS25    #N/A
+G15       LA12_P          FILTER0/GPIO4      ad713x_gpio[4]      LVCMOS25    #N/A
+G16       LA12_N          FILTER1/GPIO5      ad713x_gpio[5]      LVCMOS25    #N/A
+D17       LA13_P          FRAME0/GPIO6       ad713x_gpio[6]      LVCMOS25    #N/A
+D18       LA13_N          FRAME1/GPIO7       ad713x_gpio[7]      LVCMOS25    #N/A
+C18       LA14_P          DEC0/DCLKIO_1      ad713x_dclkio[0]    LVCMOS25    #N/A
+H19       LA15_P          DEC0/DCLKIO_2      ad713x_dclkio[1]    LVCMOS25    #N/A
+C10       LA06_P          PINB/SPI           ad713x_pinbspi      LVCMOS25    #N/A
+C19       LA14_N          DEC1/DCLKMODE      ad713x_dclkmode     LVCMOS25    #N/A
+
+# ad713x reference clock (not used by default)
+D9        LA01_N_CC       SDPCLK             ad713x_sdpclk       LVCMOS25    #N/A

--- a/projects/ad7134_fmc/zed/system_constr.xdc
+++ b/projects/ad7134_fmc/zed/system_constr.xdc
@@ -7,22 +7,22 @@
 
 set_property -dict {PACKAGE_PIN N22 IOSTANDARD LVCMOS25} [get_ports ad713x_spi_sdi]       ; ## FMC_LPC_LA03_P
 set_property -dict {PACKAGE_PIN M22 IOSTANDARD LVCMOS25} [get_ports ad713x_spi_sdo]       ; ## FMC_LPC_LA04_N
-set_property -dict {PACKAGE_PIN N19 IOSTANDARD LVCMOS25} [get_ports ad713x_spi_sclk]      ; ## FMC_LPC_LA01_CC_P
+set_property -dict {PACKAGE_PIN N19 IOSTANDARD LVCMOS25} [get_ports ad713x_spi_sclk]      ; ## FMC_LPC_LA01_P_CC
 set_property -dict {PACKAGE_PIN J18 IOSTANDARD LVCMOS25} [get_ports ad713x_spi_cs[0]]     ; ## FMC_LPC_LA05_P
 set_property -dict {PACKAGE_PIN K18 IOSTANDARD LVCMOS25} [get_ports ad713x_spi_cs[1]]     ; ## FMC_LPC_LA05_N
 
 # ad713x data interface
 
 set_property -dict {PACKAGE_PIN L18 IOSTANDARD LVCMOS25} [get_ports ad713x_dclk]          ; ## FMC_LPC_CLK0_M2C_P
-set_property -dict {PACKAGE_PIN M20 IOSTANDARD LVCMOS25} [get_ports ad713x_din[0]]        ; ## FMC_LPC_LA00_CC_N
-set_property -dict {PACKAGE_PIN L22 IOSTANDARD LVCMOS25} [get_ports ad713x_din[1]]        ; ## FMC_LPC_LA08_P
+set_property -dict {PACKAGE_PIN M20 IOSTANDARD LVCMOS25} [get_ports ad713x_din[0]]        ; ## FMC_LPC_LA00_N_CC
+set_property -dict {PACKAGE_PIN L22 IOSTANDARD LVCMOS25} [get_ports ad713x_din[1]]        ; ## FMC_LPC_LA06_N
 set_property -dict {PACKAGE_PIN P17 IOSTANDARD LVCMOS25} [get_ports ad713x_din[2]]        ; ## FMC_LPC_LA02_P
 set_property -dict {PACKAGE_PIN P18 IOSTANDARD LVCMOS25} [get_ports ad713x_din[3]]        ; ## FMC_LPC_LA02_N
-set_property -dict {PACKAGE_PIN J21 IOSTANDARD LVCMOS25} [get_ports ad713x_din[4]]        ; ## FMC_LPC_LA06_N
+set_property -dict {PACKAGE_PIN J21 IOSTANDARD LVCMOS25} [get_ports ad713x_din[4]]        ; ## FMC_LPC_LA08_P
 set_property -dict {PACKAGE_PIN J22 IOSTANDARD LVCMOS25} [get_ports ad713x_din[5]]        ; ## FMC_LPC_LA08_N
 set_property -dict {PACKAGE_PIN R20 IOSTANDARD LVCMOS25} [get_ports ad713x_din[6]]        ; ## FMC_LPC_LA09_P
 set_property -dict {PACKAGE_PIN R21 IOSTANDARD LVCMOS25} [get_ports ad713x_din[7]]        ; ## FMC_LPC_LA09_N
-set_property -dict {PACKAGE_PIN M19 IOSTANDARD LVCMOS25} [get_ports ad713x_odr]           ; ## FMC_LPC_LA00_CC_P
+set_property -dict {PACKAGE_PIN M19 IOSTANDARD LVCMOS25} [get_ports ad713x_odr]           ; ## FMC_LPC_LA00_P_CC
 
 # ad713x GPIO lines
 
@@ -47,4 +47,4 @@ set_property -dict {PACKAGE_PIN K20 IOSTANDARD LVCMOS25} [get_ports ad713x_dclkm
 
 # ad713x reference clock (not used by default)
 
-set_property -dict {PACKAGE_PIN N20 IOSTANDARD LVCMOS25} [get_ports ad713x_sdpclk]        ; ## FMC_LPC_LA01_CC_N
+set_property -dict {PACKAGE_PIN N20 IOSTANDARD LVCMOS25} [get_ports ad713x_sdpclk]        ; ## FMC_LPC_LA01_N_CC


### PR DESCRIPTION
This PR covers the AD7134 SPI Engine project checking and updates. Changes and additions include:
* Added txt description of all FMC pins used/unused
* Updated constraint files with FMC pinout location

Hardware test with available software:
AD7134 NO-OS **needs updating** for new HDL design (PWM trigger for SPIE offload)
NO-OS PR not yet up, waiting for CN0561 PR to see what soft team expects.

Test **failed**. Initialization of ADC device fails. Debug log:
 * ad713x_init failed due to CHIP_TYPE == 0, it should be CHIP_TYPE == 7
 * first ad713x device (ADC chs 0-3) CHIP_TYPE not initialized 
 * second ad713x device (ADC chs 3-7) initialized successfully

Force initialization via the Vitis debugger ==> 0V on ADC channels, conversation fails

## PR Type
- [ ] Bug fix (change that fixes an issue)
- [x] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the code style guidelines
- [x] I have performed a self-review of changes
- [x] I have compiled all hdl projects and libraries affected by this PR
- [x] I have tested in hardware affected projects, at least on relevant boards
- [x] I have commented my code, at least hard-to-understand parts
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe files, Copyright etc)
- [x] I have not introduced new Warnings/Critical Warnings on compilation
- [ ] I have added new hdl testbenches or updated existing ones
