### PR TITLE
projects/max96724/kv260: Initial commit

### DIFF
--- a/projects/max96724/Makefile
+++ b/projects/max96724/Makefile
@@ -1,0 +1,7 @@
+####################################################################################
+## Copyright (c) 2023 Analog Devices, Inc.
+### SPDX short identifier: BSD-1-Clause
+## Auto-generated, do not modify!
+####################################################################################
+
+include ../scripts/project-toplevel.mk

--- a/projects/max96724/Readme.md
+++ b/projects/max96724/Readme.md
@@ -1,0 +1,9 @@
+# MAX96724-based Evaluation Kit's HDL Project
+
+Here are some pointers to help you:
+  * [Board Product Page](https://www.analog.com/en/design-center/evaluation-hardware-and-software/evaluation-boards-kits/max96724f-bak-evk.html)
+  * Parts : [MAX96724 Quad Tunneling GMSL2/1 to CSI-2 Deserializer](https://www.analog.com/products/MAX96724.html)
+            [Tier-IV C1 Camera with Integrated GMSL Serializer](sensor.tier4.jp/automotive-camera/#C1)
+  * Project Doc: https://wiki.analog.com/resources/eval/user-guides/ad-gmslcamrpi-adp/ug_amd_kria
+  * HDL Doc: https://wiki.analog.com/resources/eval/user-guides/ad-gmslcamrpi-adp/ug_amd_kria/hdl
+  * Linux Drivers: https://github.com/analogdevicesinc/linux/tree/gmsl/xilinx_v6.1_LTS

--- a/projects/max96724/kv260/Makefile
+++ b/projects/max96724/kv260/Makefile
@@ -1,0 +1,18 @@
+####################################################################################
+## Copyright (c) 2023 Analog Devices, Inc.
+### SPDX short identifier: BSD-1-Clause
+## Auto-generated, do not modify!
+####################################################################################
+
+PROJECT_NAME := max96724_kv260
+
+M_DEPS += system_bd.tcl
+M_DEPS += ../../scripts/adi_pd.tcl
+M_DEPS += ../../common/kv260/kv260_system_constr.xdc
+M_DEPS += ../../common/kv260/kv260_system_bd.tcl
+M_DEPS += ../../../library/common/ad_iobuf.v
+
+LIB_DEPS += axi_sysid
+LIB_DEPS += sysid_rom
+
+include ../../scripts/project-xilinx.mk

--- a/projects/max96724/kv260/system_bd.tcl
+++ b/projects/max96724/kv260/system_bd.tcl
@@ -1,0 +1,208 @@
+source $ad_hdl_dir/projects/common/kv260/kv260_system_bd.tcl
+source $ad_hdl_dir/projects/scripts/adi_pd.tcl
+
+create_bd_intf_port -mode Slave -vlnv xilinx.com:interface:mipi_phy_rtl:1.0 mipi_phy_if_0
+create_bd_port -dir I ap_rstn_frmbuf_0
+create_bd_port -dir I ap_rstn_frmbuf_1
+create_bd_port -dir I ap_rstn_frmbuf_2
+create_bd_port -dir I ap_rstn_frmbuf_3
+create_bd_port -dir I csirxss_rstn
+
+ad_ip_parameter sys_ps8 CONFIG.PSU__CRL_APB__PL0_REF_CTRL__FREQMHZ 300
+
+ad_ip_instance mipi_csi2_rx_subsystem mipi_csi2_rx_subsyst_0
+set_property -dict [ list \
+   CONFIG.CLK_LANE_IO_LOC {D7} \
+   CONFIG.CLK_LANE_IO_LOC_NAME {IO_L13P_T2L_N0_GC_QBC_66} \
+   CONFIG.DPHYRX_BOARD_INTERFACE {som240_1_connector_mipi_csi_raspi} \
+   CONFIG.CMN_NUM_LANES {2} \
+   CONFIG.CMN_PXL_FORMAT {YUV422_8bit} \
+   CONFIG.C_CLK_LANE_IO_POSITION {26} \
+   CONFIG.C_CSI_EN_ACTIVELANES {false} \
+   CONFIG.C_DATA_LANE0_IO_POSITION {28} \
+   CONFIG.C_DATA_LANE1_IO_POSITION {30} \
+   CONFIG.C_DPHY_LANES {2} \
+   CONFIG.C_EN_BG0_PIN0 {false} \
+   CONFIG.C_EN_BG1_PIN0 {false} \
+   CONFIG.C_EN_CSI_V2_0 {false} \
+   CONFIG.C_HS_SETTLE_NS {153} \
+   CONFIG.DATA_LANE0_IO_LOC {E5} \
+   CONFIG.DATA_LANE0_IO_LOC_NAME {IO_L14P_T2L_N2_GC_66} \
+   CONFIG.DATA_LANE1_IO_LOC {G6} \
+   CONFIG.DATA_LANE1_IO_LOC_NAME {IO_L15P_T2L_N4_AD11P_66} \
+   CONFIG.DPY_LINE_RATE {2500} \
+   CONFIG.C_EN_CSI_V2_0 {false} \
+   CONFIG.CMN_NUM_PIXELS {2} \
+   CONFIG.CMN_INC_VFB {true} \
+   CONFIG.DPY_EN_REG_IF {true} \
+   CONFIG.CSI_EMB_NON_IMG {false} \
+   CONFIG.VFB_TU_WIDTH {2} \
+   CONFIG.HP_IO_BANK_SELECTION {66} \
+   CONFIG.SupportLevel {1} \
+] [get_bd_cells mipi_csi2_rx_subsyst_0]
+
+ad_ip_instance axis_switch axis_switch_0
+set_property -dict [list \
+  CONFIG.HAS_TLAST {1} \
+  CONFIG.NUM_MI {4} \
+  CONFIG.NUM_SI {1} \
+  CONFIG.TDATA_NUM_BYTES {4} \
+  CONFIG.TDEST_WIDTH {4} \
+  CONFIG.TUSER_WIDTH {2} \
+] [get_bd_cells axis_switch_0]
+
+ad_ip_instance v_frmbuf_wr v_frmbuf_wr_0
+set_property -dict [list \
+  CONFIG.HAS_UYVY8 {1} \
+  CONFIG.HAS_YUYV8 {1} \
+  CONFIG.HAS_Y_UV8 {1} \
+  CONFIG.SAMPLES_PER_CLOCK {2} \
+] [get_bd_cells v_frmbuf_wr_0]
+
+ad_ip_instance v_frmbuf_wr v_frmbuf_wr_1
+set_property -dict [list \
+ CONFIG.HAS_UYVY8 {1} \
+ CONFIG.HAS_YUYV8 {1} \
+ CONFIG.HAS_Y_UV8 {1} \
+ CONFIG.SAMPLES_PER_CLOCK {2} \
+] [get_bd_cells v_frmbuf_wr_1]
+
+ad_ip_instance v_frmbuf_wr v_frmbuf_wr_2
+set_property -dict [list \
+  CONFIG.HAS_UYVY8 {1} \
+  CONFIG.HAS_YUYV8 {1} \
+  CONFIG.HAS_Y_UV8 {1} \
+  CONFIG.SAMPLES_PER_CLOCK {2} \
+] [get_bd_cells v_frmbuf_wr_2]
+
+ad_ip_instance v_frmbuf_wr v_frmbuf_wr_3
+set_property -dict [list \
+  CONFIG.HAS_UYVY8 {1} \
+  CONFIG.AXIMM_DATA_WIDTH {32} \
+  CONFIG.HAS_YUYV8 {1} \
+  CONFIG.HAS_Y_UV8 {1} \
+  CONFIG.SAMPLES_PER_CLOCK {2} \
+] [get_bd_cells v_frmbuf_wr_3]
+
+connect_bd_intf_net -intf_net mipi_phy_if_0_1 [get_bd_intf_ports mipi_phy_if_0] [get_bd_intf_pins mipi_csi2_rx_subsyst_0/mipi_phy_if]
+
+ad_ip_instance axis_subset_converter axis_subset_cnv_0
+ad_ip_parameter axis_subset_cnv_0 CONFIG.M_TDATA_NUM_BYTES {6}
+ad_ip_parameter axis_subset_cnv_0 CONFIG.S_TDATA_NUM_BYTES {4}
+ad_ip_parameter axis_subset_cnv_0 CONFIG.TDATA_REMAP {16'b0000000000000000,tdata[31:0]}
+ad_ip_parameter axis_subset_cnv_0 CONFIG.TKEEP_REMAP {1'b0}
+ad_ip_parameter axis_subset_cnv_0 CONFIG.TSTRB_REMAP {1'b0}
+
+ad_ip_instance axis_subset_converter axis_subset_cnv_1
+ad_ip_parameter axis_subset_cnv_1 CONFIG.M_TDATA_NUM_BYTES {6}
+ad_ip_parameter axis_subset_cnv_1 CONFIG.S_TDATA_NUM_BYTES {4}
+ad_ip_parameter axis_subset_cnv_1 CONFIG.TDATA_REMAP {16'b0000000000000000,tdata[31:0]}
+ad_ip_parameter axis_subset_cnv_1 CONFIG.TKEEP_REMAP {1'b0}
+ad_ip_parameter axis_subset_cnv_1 CONFIG.TSTRB_REMAP {1'b0}
+
+ad_ip_instance axis_subset_converter axis_subset_cnv_2
+ad_ip_parameter axis_subset_cnv_2 CONFIG.M_TDATA_NUM_BYTES {6}
+ad_ip_parameter axis_subset_cnv_2 CONFIG.S_TDATA_NUM_BYTES {4}
+ad_ip_parameter axis_subset_cnv_2 CONFIG.TDATA_REMAP {16'b0000000000000000,tdata[31:0]}
+ad_ip_parameter axis_subset_cnv_2 CONFIG.TKEEP_REMAP {1'b0}
+ad_ip_parameter axis_subset_cnv_2 CONFIG.TSTRB_REMAP {1'b0}
+
+ad_ip_instance axis_subset_converter axis_subset_cnv_3
+ad_ip_parameter axis_subset_cnv_3 CONFIG.M_TDATA_NUM_BYTES {6}
+ad_ip_parameter axis_subset_cnv_3 CONFIG.S_TDATA_NUM_BYTES {4}
+ad_ip_parameter axis_subset_cnv_3 CONFIG.TDATA_REMAP {16'b0000000000000000,tdata[31:0]}
+ad_ip_parameter axis_subset_cnv_3 CONFIG.TKEEP_REMAP {1'b0}
+ad_ip_parameter axis_subset_cnv_3 CONFIG.TSTRB_REMAP {1'b0}
+
+ad_ip_instance clk_wiz dphy_clk_generator
+ad_ip_parameter dphy_clk_generator CONFIG.PRIMITIVE PLL
+ad_ip_parameter dphy_clk_generator CONFIG.RESET_TYPE ACTIVE_LOW
+ad_ip_parameter dphy_clk_generator CONFIG.USE_LOCKED false
+ad_ip_parameter dphy_clk_generator CONFIG.CLKOUT1_REQUESTED_OUT_FREQ 200.000
+ad_ip_parameter dphy_clk_generator CONFIG.CLKOUT1_REQUESTED_PHASE 0.000
+ad_ip_parameter dphy_clk_generator CONFIG.CLKOUT1_REQUESTED_DUTY_CYCLE 50.000
+ad_ip_parameter dphy_clk_generator CONFIG.PRIM_SOURCE Global_buffer
+ad_ip_parameter dphy_clk_generator CONFIG.CLKIN1_UI_JITTER 0
+ad_ip_parameter dphy_clk_generator CONFIG.PRIM_IN_FREQ 250.000
+
+ad_ip_instance axi_iic axi_iic_mipi
+ad_ip_parameter axi_iic_mipi CONFIG.IIC_BOARD_INTERFACE {som240_1_connector_hda_iic_switch}
+ad_ip_parameter axi_iic_mipi CONFIG.IIC_FREQ_KHZ {95}
+
+make_bd_intf_pins_external [get_bd_intf_pins axi_iic_mipi/IIC]
+
+ad_connect dphy_clk_generator/clk_in1 $sys_dma_clk
+ad_connect dphy_clk_generator/resetn $sys_dma_resetn
+
+ad_connect mipi_csi2_rx_subsyst_0/video_aclk $sys_cpu_clk
+ad_connect mipi_csi2_rx_subsyst_0/video_aresetn csirxss_rstn
+ad_connect mipi_csi2_rx_subsyst_0/lite_aclk $sys_cpu_clk
+ad_connect mipi_csi2_rx_subsyst_0/lite_aresetn $sys_cpu_resetn
+ad_connect mipi_csi2_rx_subsyst_0/dphy_clk_200M dphy_clk_generator/clk_out1
+
+ad_connect mipi_csi2_rx_subsyst_0/video_out axis_switch_0/S00_AXIS
+ad_connect axis_switch_0/M00_AXIS axis_subset_cnv_0/S_AXIS
+ad_connect axis_switch_0/M01_AXIS axis_subset_cnv_1/S_AXIS
+ad_connect axis_switch_0/M02_AXIS axis_subset_cnv_2/S_AXIS
+ad_connect axis_switch_0/M03_AXIS axis_subset_cnv_3/S_AXIS
+
+ad_connect axis_switch_0/aclk $sys_cpu_clk
+ad_connect axis_switch_0/aresetn csirxss_rstn
+ad_connect axis_subset_cnv_0/aclk $sys_cpu_clk
+ad_connect axis_subset_cnv_0/aresetn ap_rstn_frmbuf_0
+ad_connect axis_subset_cnv_1/aclk $sys_cpu_clk
+ad_connect axis_subset_cnv_1/aresetn ap_rstn_frmbuf_1
+ad_connect axis_subset_cnv_2/aclk $sys_cpu_clk
+ad_connect axis_subset_cnv_2/aresetn ap_rstn_frmbuf_2
+ad_connect axis_subset_cnv_3/aclk $sys_cpu_clk
+ad_connect axis_subset_cnv_3/aresetn ap_rstn_frmbuf_3
+ad_connect axis_subset_cnv_0/M_AXIS v_frmbuf_wr_0/s_axis_video
+ad_connect axis_subset_cnv_1/M_AXIS v_frmbuf_wr_1/s_axis_video
+ad_connect axis_subset_cnv_2/M_AXIS v_frmbuf_wr_2/s_axis_video
+ad_connect axis_subset_cnv_3/M_AXIS v_frmbuf_wr_3/s_axis_video
+ad_connect v_frmbuf_wr_0/ap_clk $sys_cpu_clk
+ad_connect v_frmbuf_wr_0/ap_rst_n ap_rstn_frmbuf_0
+ad_connect v_frmbuf_wr_1/ap_clk $sys_cpu_clk
+ad_connect v_frmbuf_wr_1/ap_rst_n ap_rstn_frmbuf_1
+ad_connect v_frmbuf_wr_2/ap_clk $sys_cpu_clk
+ad_connect v_frmbuf_wr_2/ap_rst_n ap_rstn_frmbuf_2
+ad_connect v_frmbuf_wr_3/ap_clk $sys_cpu_clk
+ad_connect v_frmbuf_wr_3/ap_rst_n ap_rstn_frmbuf_3
+
+ad_connect axi_iic_mipi/s_axi_aclk $sys_cpu_clk
+ad_connect axi_iic_mipi/s_axi_aresetn $sys_cpu_resetn
+
+ad_cpu_interconnect 0x44A00000  mipi_csi2_rx_subsyst_0
+ad_cpu_interconnect 0x44A20000  axi_iic_mipi
+ad_cpu_interconnect 0x44A40000  v_frmbuf_wr_0
+ad_cpu_interconnect 0x44A60000  v_frmbuf_wr_1
+ad_cpu_interconnect 0x44A80000  v_frmbuf_wr_2
+ad_cpu_interconnect 0x44AA0000  v_frmbuf_wr_3
+
+ad_mem_hp0_interconnect $sys_cpu_clk sys_ps8/S_AXI_HP0
+ad_mem_hp0_interconnect $sys_cpu_clk v_frmbuf_wr_0/m_axi_mm_video
+ad_mem_hp1_interconnect $sys_cpu_clk sys_ps8/S_AXI_HP1
+ad_mem_hp1_interconnect $sys_cpu_clk v_frmbuf_wr_1/m_axi_mm_video
+ad_mem_hp2_interconnect $sys_cpu_clk sys_ps8/S_AXI_HP2
+ad_mem_hp2_interconnect $sys_cpu_clk v_frmbuf_wr_2/m_axi_mm_video
+ad_mem_hp3_interconnect $sys_cpu_clk sys_ps8/S_AXI_HP3
+ad_mem_hp3_interconnect $sys_cpu_clk v_frmbuf_wr_3/m_axi_mm_video
+
+ad_cpu_interrupt ps-13 mb-13 mipi_csi2_rx_subsyst_0/csirxss_csi_irq
+ad_cpu_interrupt ps-12 mb-12 axi_iic_mipi/iic2intc_irpt
+ad_cpu_interrupt ps-11 mb-11 v_frmbuf_wr_0/interrupt
+ad_cpu_interrupt ps-10 mb-10 v_frmbuf_wr_1/interrupt
+ad_cpu_interrupt ps-9 mb-9 v_frmbuf_wr_2/interrupt
+ad_cpu_interrupt ps-8 mb-8 v_frmbuf_wr_3/interrupt
+
+#system ID
+
+set mem_init_sys_path [get_env_param ADI_PROJECT_DIR ""]mem_init_sys.txt;
+
+#system ID
+ad_ip_parameter axi_sysid_0 CONFIG.ROM_ADDR_BITS 9
+ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "[pwd]/$mem_init_sys_path"
+ad_ip_parameter rom_sys_0 CONFIG.ROM_ADDR_BITS 9
+
+sysid_gen_sys_init_file
+

--- a/projects/max96724/kv260/system_constr.xdc
+++ b/projects/max96724/kv260/system_constr.xdc
@@ -1,0 +1,14 @@
+# constraints
+
+set_property  -dict {PACKAGE_PIN F11 IOSTANDARD LVCMOS33 SLEW SLOW DRIVE 4}  [get_ports rpi_en]; # Bank  45 VCCO - som240_1_b13 - IO_L11P_AD9P_45
+
+set_property -dict {PACKAGE_PIN G11 IOSTANDARD LVCMOS33 PULLUP true} [get_ports iic_scl_io]; # Bank  45 VCCO - som240_1_b13 - IO_L5P_HDGC_45
+set_property -dict {PACKAGE_PIN F10 IOSTANDARD LVCMOS33 PULLUP true} [get_ports iic_sda_io]; # Bank  45 VCCO - som240_1_b13 - IO_L5N_HDGC_45
+
+set_property -dict {PACKAGE_PIN F6 IOSTANDARD MIPI_DPHY_DCI DIFF_TERM_ADV TERM_100} [get_ports mipi_phy_if_0_data_n[1]]; # Bank  66 VCCO - som240_1_d1 - IO_L15N_T2L_N5_AD11N_66 (som240_1_a10)
+set_property -dict {PACKAGE_PIN G6 IOSTANDARD MIPI_DPHY_DCI DIFF_TERM_ADV TERM_100} [get_ports mipi_phy_if_0_data_p[1]]; # Bank  66 VCCO - som240_1_d1 - IO_L15P_T2L_N4_AD11P_66 (som240_1_a9)
+set_property -dict {PACKAGE_PIN D5 IOSTANDARD MIPI_DPHY_DCI DIFF_TERM_ADV TERM_100} [get_ports mipi_phy_if_0_data_n[0]]; # Bank  66 VCCO - som240_1_d1 - IO_L14N_T2L_N3_GC_66 (som240_1_b11)
+set_property -dict {PACKAGE_PIN E5 IOSTANDARD MIPI_DPHY_DCI DIFF_TERM_ADV TERM_100} [get_ports mipi_phy_if_0_data_p[0]]; # Bank  66 VCCO - som240_1_d1 - IO_L14P_T2L_N2_GC_66 (som240_1_b10)
+set_property -dict {PACKAGE_PIN D6 IOSTANDARD MIPI_DPHY_DCI DIFF_TERM_ADV TERM_100} [get_ports mipi_phy_if_0_clk_n]; # Bank  66 VCCO - som240_1_d1 - IO_L13N_T2L_N1_GC_QBC_66 (som240_1_c13)
+set_property -dict {PACKAGE_PIN D7 IOSTANDARD MIPI_DPHY_DCI DIFF_TERM_ADV TERM_100} [get_ports mipi_phy_if_0_clk_p]; # Bank  66 VCCO - som240_1_d1 - IO_L13P_T2L_N0_GC_QBC_66 (som240_1_c12)
+

--- a/projects/max96724/kv260/system_project.tcl
+++ b/projects/max96724/kv260/system_project.tcl
@@ -1,0 +1,13 @@
+source ../../../scripts/adi_env.tcl
+source $ad_hdl_dir/projects/scripts/adi_project_xilinx.tcl
+source $ad_hdl_dir/projects/scripts/adi_board.tcl
+
+adi_project max96724_kv260
+adi_project_files max96724_kv260 [list \
+  "system_top.v" \
+  "system_constr.xdc"\
+  "$ad_hdl_dir/library/common/ad_iobuf.v" \
+  "$ad_hdl_dir/projects/common/kv260/kv260_system_constr.xdc" ]
+
+adi_project_run max96724_kv260
+

--- a/projects/max96724/kv260/system_top.v
+++ b/projects/max96724/kv260/system_top.v
@@ -1,0 +1,91 @@
+// ***************************************************************************
+// ***************************************************************************
+// Copyright (C) 2023 Analog Devices, Inc. All rights reserved.
+//
+// In this HDL repository, there are many different and unique modules, consisting
+// of various HDL (Verilog or VHDL) components. The individual modules are
+// developed independently, and may be accompanied by separate and unique license
+// terms.
+//
+// The user should read each of these license terms, and understand the
+// freedoms and responsibilities that he or she has by using this source/core.
+//
+// This core is distributed in the hope that it will be useful, but WITHOUT ANY
+// WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+// A PARTICULAR PURPOSE.
+//
+// Redistribution and use of source or resulting binaries, with or without modification
+// of this file, are permitted under one of the following two license terms:
+//
+//   1. The GNU General Public License version 2 as published by the
+//      Free Software Foundation, which can be found in the top level directory
+//      of this repository (LICENSE_GPL2), and also online at:
+//      <https://www.gnu.org/licenses/old-licenses/gpl-2.0.html>
+//
+// OR
+//
+//   2. An ADI specific BSD license, which can be found in the top level directory
+//      of this repository (LICENSE_ADIBSD), and also on-line at:
+//      https://github.com/analogdevicesinc/hdl/blob/main/LICENSE_ADIBSD
+//      This will allow to generate bit files and not release the source code,
+//      as long as it attaches to an ADI device.
+//
+// ***************************************************************************
+// ***************************************************************************
+
+`timescale 1ns/100ps
+
+module system_top (
+
+  output          fan_en_b,
+  inout           iic_scl_io,
+  inout           iic_sda_io,
+  output          rpi_en,
+  input   [ 1:0]  mipi_phy_if_0_data_n,
+  input   [ 1:0]  mipi_phy_if_0_data_p,
+  input           mipi_phy_if_0_clk_n,
+  input           mipi_phy_if_0_clk_p
+);
+
+  wire    [94:0]  gpio_i;
+  wire    [94:0]  gpio_o;
+  wire            ap_rstn_frmbuf_0;
+  wire            ap_rstn_frmbuf_1;
+  wire            ap_rstn_frmbuf_2;
+  wire            ap_rstn_frmbuf_3;
+  wire            csirxss_rstn;
+
+  assign gpio_i[94:0] = gpio_o[94:0];
+
+  assign fan_en_b = gpio_o[0];
+  assign csirxss_rstn = gpio_o[1];
+  assign ap_rstn_frmbuf_0 = gpio_o[2];
+  assign ap_rstn_frmbuf_1 = gpio_o[3];
+  assign ap_rstn_frmbuf_2 = gpio_o[4];
+  assign ap_rstn_frmbuf_3 = gpio_o[5];
+  assign rpi_en = gpio_o[6];
+
+  // instantiations
+  system_wrapper i_system_wrapper (
+    .IIC_0_scl_io (iic_scl_io),
+    .IIC_0_sda_io (iic_sda_io),
+    .ap_rstn_frmbuf_0 (ap_rstn_frmbuf_0),
+    .ap_rstn_frmbuf_1 (ap_rstn_frmbuf_1),
+    .ap_rstn_frmbuf_2 (ap_rstn_frmbuf_2),
+    .ap_rstn_frmbuf_3 (ap_rstn_frmbuf_3),
+    .csirxss_rstn (csirxss_rstn),
+    .mipi_phy_if_0_data_n (mipi_phy_if_0_data_n),
+    .mipi_phy_if_0_data_p (mipi_phy_if_0_data_p),
+    .mipi_phy_if_0_clk_n (mipi_phy_if_0_clk_n),
+    .mipi_phy_if_0_clk_p (mipi_phy_if_0_clk_p),
+
+    .gpio_i (gpio_i),
+    .gpio_o (gpio_o),
+    .gpio_t (),
+
+    .spi0_csn (),
+    .spi0_miso (1'b0),
+    .spi0_mosi (),
+    .spi0_sclk ());
+
+endmodule


### PR DESCRIPTION
## PR Description
This commit adds the GMSL-based reference design for the Kria KV260 evauation kit (using TIER-IV's camera C1 with integrated GMSL serializer - YUV422 data format).

## PR Type
- [ ] Bug fix (change that fixes an issue)
- [x] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the code style guidelines
- [x] I have performed a self-review of changes
- [x] I have compiled all hdl projects and libraries affected by this PR
- [x] I have tested in hardware affected projects, at least on relevant boards
- [x] I have commented my code, at least hard-to-understand parts
- [x] I have signed off all commits from this PR
- [x] I have updated the documentation (wiki pages, ReadMe files, Copyright etc)
- [x] I have not introduced new Warnings/Critical Warnings on compilation
- [ ] I have added new hdl testbenches or updated existing ones
