### PR TITLE
Update adaq7980 spi engine

### DIFF
--- a/projects/adaq7980_sdz/Readme.md
+++ b/projects/adaq7980_sdz/Readme.md
@@ -2,8 +2,8 @@
 
 Here are some pointers to help you:
   * [Board Product Page](https://www.analog.com/eval-adaq7980)
-  * Parts : [16-bit, 1 MSPS, μModule Data Acquisition System](https://www.analog.com/adaq7980)
-  * Parts : [16-bit, 500 kSPS, μModule Data Acquisition System](https://www.analog.com/adaq7988)
+  * Parts : [ADAQ7980, 16-bit, 1 MSPS, μModule Data Acquisition System](https://www.analog.com/adaq7980)
+  * Parts : [ADAQ7988, 16-bit, 500 kSPS, μModule Data Acquisition System](https://www.analog.com/adaq7988)
   * Project Doc: https://wiki.analog.com/resources/eval/user-guides/adaq7980-sdz
   * HDL Doc: https://wiki.analog.com/resources/eval/user-guides/adaq7980-sdz
   * Linux Drivers: https://wiki.analog.com/resources/tools-software/linux-drivers-all

--- a/projects/adaq7980_sdz/common/adaq7980_bd.tcl
+++ b/projects/adaq7980_sdz/common/adaq7980_bd.tcl
@@ -3,71 +3,25 @@
 ### SPDX short identifier: ADIBSD
 ###############################################################################
 
-create_bd_intf_port -mode Master -vlnv analog.com:interface:spi_master_rtl:1.0 spi
+create_bd_intf_port -mode Master -vlnv analog.com:interface:spi_master_rtl:1.0 adaq7980_spi
+source $ad_hdl_dir/library/spi_engine/scripts/spi_engine.tcl
 
-# create a SPI Engine architecture
+set data_width    16
+set async_spi_clk 1 
+set num_cs        1
+set num_sdi       1 
+set num_sdo       1 
+set sdi_delay     1 
+set echo_sclk     0 
 
-create_bd_cell -type hier spi
-current_bd_instance /spi
+set hier_spi_engine spi_adaq7980_adc
 
-  create_bd_pin -dir I -type clk clk
-  create_bd_pin -dir I -type rst resetn
-  create_bd_pin -dir O irq
-  create_bd_intf_pin -mode Master -vlnv analog.com:interface:spi_master_rtl:1.0 m_spi
-  create_bd_intf_pin -mode Master -vlnv xilinx.com:interface:axis_rtl:1.0 M_AXIS_SAMPLE
+spi_engine_create $hier_spi_engine $data_width $async_spi_clk $num_cs $num_sdi $num_sdo $sdi_delay $echo_sclk
 
-  ad_ip_instance spi_engine_execution execution
-  ad_ip_parameter execution CONFIG.DATA_WIDTH 16
-  ad_ip_parameter execution CONFIG.NUM_OF_CS 1
-
-  ad_ip_instance axi_spi_engine axi
-  ad_ip_parameter axi CONFIG.DATA_WIDTH 16
-  ad_ip_parameter axi CONFIG.NUM_OFFLOAD 1
-
-  ad_ip_instance spi_engine_offload offload
-  ad_ip_parameter offload CONFIG.DATA_WIDTH 16
-
-  ad_ip_instance spi_engine_interconnect interconnect
-  ad_ip_parameter interconnect CONFIG.DATA_WIDTH 16
-
-  ## to setup the sample rate of the system change the PULSE_PERIOD value
-  ## the actual sample rate will be PULSE_PERIOD * (1/sys_cpu_clk)
-  set cycle_per_sec_100mhz 100000000
-  set sampling_cycle [expr int(ceil(double($cycle_per_sec_100mhz) / $adc_sampling_rate))]
-  ad_ip_instance axi_pulse_gen trigger_gen
-  ad_ip_parameter trigger_gen CONFIG.ASYNC_CLK_EN 0
-  ad_ip_parameter trigger_gen CONFIG.PULSE_PERIOD $sampling_cycle
-  ad_ip_parameter trigger_gen CONFIG.PULSE_WIDTH 1
-
-  # clocks
-  ad_connect clk offload/spi_clk
-  ad_connect clk offload/ctrl_clk
-  ad_connect clk execution/clk
-  ad_connect clk axi/s_axi_aclk
-  ad_connect clk axi/spi_clk
-  ad_connect clk interconnect/clk
-  ad_connect clk trigger_gen/s_axi_aclk
-
-  # resets
-  ad_connect resetn axi/s_axi_aresetn
-  ad_connect resetn trigger_gen/s_axi_aresetn
-  ad_connect axi/spi_resetn offload/spi_resetn
-  ad_connect axi/spi_resetn execution/resetn
-  ad_connect axi/spi_resetn interconnect/resetn
-
-  # interfaces
-  ad_connect axi/spi_engine_offload_ctrl0 offload/spi_engine_offload_ctrl
-  ad_connect offload/spi_engine_ctrl interconnect/s0_ctrl
-  ad_connect axi/spi_engine_ctrl interconnect/s1_ctrl
-  ad_connect interconnect/m_ctrl execution/ctrl
-  ad_connect offload/offload_sdi M_AXIS_SAMPLE
-  ad_connect execution/spi m_spi
-
-  ad_connect trigger_gen/pulse offload/trigger
-
-  ad_connect irq axi/irq
-
-current_bd_instance /
+# axi_pwm_gen
+ad_ip_instance axi_pwm_gen spi_trigger_gen
+ad_ip_parameter spi_trigger_gen CONFIG.PULSE_0_PERIOD 160
+ad_ip_parameter spi_trigger_gen CONFIG.PULSE_0_WIDTH 1
 
 ad_ip_instance axi_dmac axi_adaq7980_dma
 ad_ip_parameter axi_adaq7980_dma CONFIG.DMA_TYPE_SRC 1
@@ -80,21 +34,36 @@ ad_ip_parameter axi_adaq7980_dma CONFIG.DMA_2D_TRANSFER 0
 ad_ip_parameter axi_adaq7980_dma CONFIG.DMA_DATA_WIDTH_SRC 16
 ad_ip_parameter axi_adaq7980_dma CONFIG.DMA_DATA_WIDTH_DEST 64
 
-ad_connect  sys_cpu_clk spi/clk
-ad_connect  sys_cpu_resetn spi/resetn
-ad_connect  sys_cpu_resetn axi_adaq7980_dma/m_dest_axi_aresetn
+ # axi_clkgen
+ad_ip_instance axi_clkgen spi_clkgen
+ad_ip_parameter spi_clkgen CONFIG.CLK0_DIV 5 
+ad_ip_parameter spi_clkgen CONFIG.VCO_DIV 1 
+ad_ip_parameter spi_clkgen CONFIG.VCO_MUL 8 
 
-ad_connect  spi/m_spi spi
-ad_connect  axi_adaq7980_dma/s_axis spi/M_AXIS_SAMPLE
+ad_connect $sys_cpu_clk spi_clkgen/clk
+ad_connect spi_clk spi_clkgen/clk_0
 
-ad_cpu_interconnect 0x44a00000 spi/axi
-ad_cpu_interconnect 0x44a10000 spi/trigger_gen
+ad_connect spi_clk spi_trigger_gen/ext_clk
+ad_connect $sys_cpu_clk spi_trigger_gen/s_axi_aclk
+ad_connect sys_cpu_resetn spi_trigger_gen/s_axi_aresetn
+ad_connect spi_trigger_gen/pwm_0 $hier_spi_engine/trigger
+
+ad_connect axi_adaq7980_dma/s_axis $hier_spi_engine/M_AXIS_SAMPLE
+ad_connect $hier_spi_engine/m_spi adaq7980_spi
+
+ad_connect $sys_cpu_clk $hier_spi_engine/clk
+ad_connect spi_clk $hier_spi_engine/spi_clk
+ad_connect spi_clk axi_adaq7980_dma/s_axis_aclk
+ad_connect sys_cpu_resetn $hier_spi_engine/resetn
+ad_connect sys_cpu_resetn axi_adaq7980_dma/m_dest_axi_aresetn
+
+ad_cpu_interconnect 0x44a00000 $hier_spi_engine/${hier_spi_engine}_axi_regmap
 ad_cpu_interconnect 0x44a30000 axi_adaq7980_dma
-
-ad_connect sys_cpu_clk axi_adaq7980_dma/s_axis_aclk
+ad_cpu_interconnect 0x44a70000 spi_clkgen
+ad_cpu_interconnect 0x44b00000 spi_trigger_gen
 
 ad_cpu_interrupt "ps-13" "mb-13" axi_adaq7980_dma/irq
-ad_cpu_interrupt "ps-12" "mb-12" spi/irq
+ad_cpu_interrupt "ps-12" "mb-12" $hier_spi_engine/irq
 
 ad_mem_hp2_interconnect sys_cpu_clk sys_ps7/S_AXI_HP2
 ad_mem_hp2_interconnect sys_cpu_clk axi_adaq7980_dma/m_dest_axi

--- a/projects/adaq7980_sdz/common/adaq7980_fmc.txt
+++ b/projects/adaq7980_sdz/common/adaq7980_fmc.txt
@@ -1,0 +1,17 @@
+FMC_pin   FMC_port         Schematic_name     System_top_name     IOSTANDARD          Termination
+
+# adaq7980
+               
+H20        FMC_LA15_N      SPORT_TSCLK        spi_sclk            LVCMOS25             #N/A
+H17        FMC_LA11_N      SDO                spi_sdi             LVCMOS25             #N/A
+H19        FMC_LA15_P      CNV                spi_cs              LVCMOS25             #N/A
+H25        FMC_LA21_P      GPIO0              adaq7980_gpio[0]    LVCMOS25             #N/A
+D26        FMC_LA26_P      GPIO1              adaq7980_gpio[1]    LVCMOS25             #N/A
+G25        FMC_LA22_N      GPIO2              adaq7980_gpio[2]    LVCMOS25             #N/A
+C26        FMC_LA27_P      GPIO3              adaq7980_gpio[3]    LVCMOS25             #N/A
+H26        FMC_LA21_N      GPIO4              adaq7980_gpio[4]    LVCMOS25             #N/A
+D27        FMC_LA26_N      GPIO5              adaq7980_gpio[5]    LVCMOS25             #N/A
+G27        FMC_LA25_P      GPIO6              adaq7980_gpio[6]    LVCMOS25             #N/A
+C27        FMC_LA27_N      GPIO7              adaq7980_gpio[7]    LVCMOS25             #N/A
+H31        FMC_LA28_P      REF_PD             adaq7980_ref_pd     LVCMOS25             #N/A
+G30        FMC_LA29_P      RBUF_PD            adaq7980_rbuf_pd    LVCMOS25             #N/A

--- a/projects/adaq7980_sdz/zed/Makefile
+++ b/projects/adaq7980_sdz/zed/Makefile
@@ -10,6 +10,7 @@ M_DEPS += ../common/adaq7980_bd.tcl
 M_DEPS += ../../scripts/adi_pd.tcl
 M_DEPS += ../../common/zed/zed_system_constr.xdc
 M_DEPS += ../../common/zed/zed_system_bd.tcl
+M_DEPS += ../../../library/spi_engine/scripts/spi_engine.tcl
 M_DEPS += ../../../library/common/ad_iobuf.v
 
 LIB_DEPS += axi_clkgen
@@ -17,6 +18,7 @@ LIB_DEPS += axi_dmac
 LIB_DEPS += axi_hdmi_tx
 LIB_DEPS += axi_i2s_adi
 LIB_DEPS += axi_pulse_gen
+LIB_DEPS += axi_pwm_gen
 LIB_DEPS += axi_spdif_tx
 LIB_DEPS += axi_sysid
 LIB_DEPS += spi_engine/axi_spi_engine

--- a/projects/adaq7980_sdz/zed/Makefile
+++ b/projects/adaq7980_sdz/zed/Makefile
@@ -17,7 +17,6 @@ LIB_DEPS += axi_clkgen
 LIB_DEPS += axi_dmac
 LIB_DEPS += axi_hdmi_tx
 LIB_DEPS += axi_i2s_adi
-LIB_DEPS += axi_pulse_gen
 LIB_DEPS += axi_pwm_gen
 LIB_DEPS += axi_spdif_tx
 LIB_DEPS += axi_sysid

--- a/projects/adaq7980_sdz/zed/system_bd.tcl
+++ b/projects/adaq7980_sdz/zed/system_bd.tcl
@@ -15,8 +15,5 @@ ad_ip_parameter rom_sys_0 CONFIG.ROM_ADDR_BITS 9
 
 sysid_gen_sys_init_file
 
-# specify ADC sampling rate in samples/seconds -- default is 1 MSPS
-set adc_sampling_rate 1000000
-
 source ../common/adaq7980_bd.tcl
 

--- a/projects/adaq7980_sdz/zed/system_constr.xdc
+++ b/projects/adaq7980_sdz/zed/system_constr.xdc
@@ -5,22 +5,22 @@
 
 # SPI interface
 
-set_property -dict {PACKAGE_PIN J17  IOSTANDARD LVCMOS25} [get_ports spi_sclk]            ; ## FMC_LPC_LA15_N
-set_property -dict {PACKAGE_PIN N18  IOSTANDARD LVCMOS25} [get_ports spi_sdi]             ; ## FMC_LPC_LA11_N
-set_property -dict {PACKAGE_PIN J16  IOSTANDARD LVCMOS25} [get_ports spi_cs]              ; ## FMC_LPC_LA15_P
+set_property -dict {PACKAGE_PIN J17  IOSTANDARD LVCMOS25} [get_ports spi_sclk]            ; ## H20  FMC_LA15_N  IO_L2N_T0_34
+set_property -dict {PACKAGE_PIN N18  IOSTANDARD LVCMOS25} [get_ports spi_sdi]             ; ## H17  FMC_LA11_N  IO_L5N_T0_34
+set_property -dict {PACKAGE_PIN J16  IOSTANDARD LVCMOS25} [get_ports spi_cs]              ; ## H19  FMC_LA15_P  IO_L2P_T0_34
 
 # GPIO signals
 
-set_property -dict {PACKAGE_PIN E19  IOSTANDARD LVCMOS25} [get_ports adaq7980_gpio[0]]    ; ## FMC_LPC_LA21_P
-set_property -dict {PACKAGE_PIN F18  IOSTANDARD LVCMOS25} [get_ports adaq7980_gpio[1]]    ; ## FMC_LPC_LA26_P
-set_property -dict {PACKAGE_PIN F19  IOSTANDARD LVCMOS25} [get_ports adaq7980_gpio[2]]    ; ## FMC_LPC_LA22_N
-set_property -dict {PACKAGE_PIN E21  IOSTANDARD LVCMOS25} [get_ports adaq7980_gpio[3]]    ; ## FMC_LPC_LA27_P
-set_property -dict {PACKAGE_PIN E20  IOSTANDARD LVCMOS25} [get_ports adaq7980_gpio[4]]    ; ## FMC_LPC_LA21_N
-set_property -dict {PACKAGE_PIN E18  IOSTANDARD LVCMOS25} [get_ports adaq7980_gpio[5]]    ; ## FMC_LPC_LA26_N
-set_property -dict {PACKAGE_PIN D22  IOSTANDARD LVCMOS25} [get_ports adaq7980_gpio[6]]    ; ## FMC_LPC_LA25_P
-set_property -dict {PACKAGE_PIN D21  IOSTANDARD LVCMOS25} [get_ports adaq7980_gpio[7]]    ; ## FMC_LPC_LA27_N
+set_property -dict {PACKAGE_PIN E19  IOSTANDARD LVCMOS25} [get_ports adaq7980_gpio[0]]    ; ## H25  FMC_LA21_P  IO_L21P_T3_DQS_AD14P_35
+set_property -dict {PACKAGE_PIN F18  IOSTANDARD LVCMOS25} [get_ports adaq7980_gpio[1]]    ; ## D26  FMC_LA26_P  IO_L5P_T0_AD9P_35
+set_property -dict {PACKAGE_PIN F19  IOSTANDARD LVCMOS25} [get_ports adaq7980_gpio[2]]    ; ## G25  FMC_LA22_N  IO_L20N_T3_AD6N_35
+set_property -dict {PACKAGE_PIN E21  IOSTANDARD LVCMOS25} [get_ports adaq7980_gpio[3]]    ; ## C26  FMC_LA27_P  IO_L17P_T2_AD5P_35
+set_property -dict {PACKAGE_PIN E20  IOSTANDARD LVCMOS25} [get_ports adaq7980_gpio[4]]    ; ## H26  FMC_LA21_N  IO_L21N_T3_DQS_AD14N_35
+set_property -dict {PACKAGE_PIN E18  IOSTANDARD LVCMOS25} [get_ports adaq7980_gpio[5]]    ; ## D27  FMC_LA26_N  IO_L5N_T0_AD9N_35
+set_property -dict {PACKAGE_PIN D22  IOSTANDARD LVCMOS25} [get_ports adaq7980_gpio[6]]    ; ## G27  FMC_LA25_P  IO_L16P_T2_35
+set_property -dict {PACKAGE_PIN D21  IOSTANDARD LVCMOS25} [get_ports adaq7980_gpio[7]]    ; ## C27  FMC_LA27_N  IO_L17N_T2_AD5N_35
 
 # REF_PD and RBUF_PD
 
-set_property -dict {PACKAGE_PIN A16  IOSTANDARD LVCMOS25} [get_ports adaq7980_ref_pd]     ; ## FMC_LPC_LA28_P
-set_property -dict {PACKAGE_PIN C17  IOSTANDARD LVCMOS25} [get_ports adaq7980_rbuf_pd]    ; ## FMC_LPC_LA29_P
+set_property -dict {PACKAGE_PIN A16  IOSTANDARD LVCMOS25} [get_ports adaq7980_ref_pd]     ; ## H31  FMC_LA28_P  IO_L9P_T1_DQS_AD3P_35
+set_property -dict {PACKAGE_PIN C17  IOSTANDARD LVCMOS25} [get_ports adaq7980_rbuf_pd]    ; ## G30  FMC_LA29_P  IO_L11P_T1_SRCC_35

--- a/projects/adaq7980_sdz/zed/system_top.v
+++ b/projects/adaq7980_sdz/zed/system_top.v
@@ -189,11 +189,11 @@ module system_top (
     .iic_mux_sda_i (iic_mux_sda_i_s),
     .iic_mux_sda_o (iic_mux_sda_o_s),
     .iic_mux_sda_t (iic_mux_sda_t_s),
-    .spi_sdo (),
-    .spi_sdo_t (),
-    .spi_sdi (spi_sdi),
-    .spi_cs (spi_cs),
-    .spi_sclk (spi_sclk),
+    .adaq7980_spi_sdo (),
+    .adaq7980_spi_sdo_t (),
+    .adaq7980_spi_sdi (spi_sdi),
+    .adaq7980_spi_cs (spi_cs),
+    .adaq7980_spi_sclk (spi_sclk),
     .otg_vbusoc (otg_vbusoc),
     .spdif (spdif));
 


### PR DESCRIPTION
## PR Description

I replaced the SPI Engine connections in the adaq7980_bd.tcl with the spi_engine_create procedure found in the spi_engine.tcl script. Through these changes, a more generic instantiation for the spi_engine can be achieved. I configured the parameters for axi_pwm_gen and axi_clkgen according to the results in the SPI_Engine_Timing_Computations Excel where I created a file for adaq7980.
I created the adaq7980_fmc.txt file for generating the system_constr.xdc file. I modified the system_bd.tcl, system_top.v, system_constr.xdc and Readme.md files. Also I regenerated the Makefile. It was tested in NO-OS. I created a new branch: update_adaq7980_noos_spi_engine in the NO-OS repository where I made some changes. The project works on this branch.

## PR Type
- [ ] Bug fix (change that fixes an issue)
- [x] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the code style guidelines
- [x] I have performed a self-review of changes
- [x] I have compiled all hdl projects and libraries affected by this PR
- [x] I have tested in hardware affected projects, at least on relevant boards
- [ ] I have commented my code, at least hard-to-understand parts
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe files, Copyright etc)
- [x] I have not introduced new Warnings/Critical Warnings on compilation
- [ ] I have added new hdl testbenches or updated existing ones
