### PR TITLE
axi_dmac: Add support for DMA Scatter-Gather

### DIFF
--- a/docs/library/axi_dmac/block_diagram.svg
+++ b/docs/library/axi_dmac/block_diagram.svg
@@ -1,4 +1,5 @@
-<svg width="585" height="245" preserveAspectRatio="xMidYMid slice" version="1.1" viewBox="0 0 585 245" xmlns="http://www.w3.org/2000/svg">
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="585" height="250" preserveAspectRatio="xMidYMid slice" version="1.1" viewBox="0 0 585 250" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
  <defs>
   <marker id="h" overflow="visible" orient="auto">
    <path transform="scale(.4)" d="m5.77 0-8.65 5v-10z" fill-rule="evenodd" stroke="#000" stroke-width="1pt"/>
@@ -58,9 +59,22 @@
    <stop stop-color="#fce94f" offset="0"/>
    <stop stop-color="#729fcf" offset="1"/>
   </linearGradient>
+  <marker id="i-9" overflow="visible" orient="auto">
+   <path transform="scale(.4)" d="m5.77 0-8.65 5v-10z" fill-rule="evenodd" stroke="#000" stroke-width="1pt"/>
+  </marker>
+  <marker id="e-2" overflow="visible" orient="auto">
+   <path transform="scale(.4)" d="m5.77 0-8.65 5v-10z" fill-rule="evenodd" stroke="#000" stroke-width="1pt"/>
+  </marker>
+  <linearGradient id="linearGradient59824" x1="58.883" x2="77.454" y1="89.272" y2="89.272" gradientUnits="userSpaceOnUse">
+   <stop stop-color="#008080" offset="0"/>
+   <stop stop-color="#008080" stop-opacity="0" offset="1"/>
+  </linearGradient>
+  <marker id="a-0" overflow="visible" orient="auto">
+   <path transform="scale(-.2)" d="m5.77 0-8.65 5v-10z" fill-rule="evenodd" stroke="#000" stroke-width="1pt"/>
+  </marker>
  </defs>
- <g transform="matrix(4 0 0 4 -117.17 -304.15)">
-  <rect x="54.052" y="76.302" width="97.349" height="53.988" fill="#d3d7cf" fill-rule="evenodd" stroke="#000" stroke-width=".52917"/>
+ <g transform="matrix(4,0,0,4,-117.17,-304.15)">
+  <rect x="54.052" y="76.302" width="97.349" height="56.488" fill="#d3d7cf" fill-rule="evenodd" stroke="#000" stroke-width=".52917"/>
   <rect x="120.14" y="118.32" width="28.324" height="8.6862" fill="#fcaf3e" fill-rule="evenodd" stroke="#000" stroke-width=".52917"/>
   <g transform="translate(-.53474 -.4009)">
    <rect x="88.624" y="82.623" width="28.999" height="12.428" fill="url(#o)" fill-rule="evenodd" stroke="#000" stroke-width=".52917"/>
@@ -68,9 +82,9 @@
   </g>
   <g font-family="'Liberation Sans'" font-size="2.6458px" letter-spacing="0px" stroke-width=".26458px" word-spacing="0px">
    <text x="126.37469" y="123.3473" style="line-height:125%" xml:space="preserve"><tspan x="126.37469" y="123.3473" stroke-width=".26458px">Register Map</tspan></text>
-   <text x="119.46967" y="135.42929" style="line-height:125%" xml:space="preserve"><tspan x="119.46967" y="135.42929" stroke-width=".26458px">S_AXI</tspan></text>
-   <text x="129.22504" y="135.49905" style="line-height:125%" xml:space="preserve"><tspan x="129.22504" y="135.49905" stroke-width=".26458px">s_axi_aclk</tspan></text>
-   <text x="144.32582" y="135.49905" style="line-height:125%" xml:space="preserve"><tspan x="144.32582" y="135.49905" stroke-width=".26458px">irq</tspan></text>
+   <text x="119.46967" y="138.00647" style="line-height:125%" xml:space="preserve"><tspan x="119.46967" y="138.00647" stroke-width=".26458px">S_AXI</tspan></text>
+   <text x="129.22504" y="137.99905" style="line-height:125%" xml:space="preserve"><tspan x="129.22504" y="137.99905" stroke-width=".26458px">s_axi_aclk</tspan></text>
+   <text x="144.32582" y="137.99905" style="line-height:125%" xml:space="preserve"><tspan x="144.32582" y="137.99905" stroke-width=".26458px">irq</tspan></text>
   </g>
   <g transform="translate(-2.3947 -.19646)">
    <rect x="92.956" y="118.52" width="22.985" height="8.6862" fill="#ad7fa8" fill-rule="evenodd" stroke="#000" stroke-width=".52917"/>
@@ -90,12 +104,14 @@
     <path d="m117.73 88.436h7.0159" marker-end="url(#g)"/>
     <path d="m146.6 91.838h7.0159" marker-end="url(#f)"/>
     <path d="m49.178 92.405h7.0159" marker-end="url(#e)"/>
+    <path d="m49.178 126.67h7.0159" marker-end="url(#e-2)"/>
    </g>
-   <path d="m122.86 128.82v3.1851" marker-end="url(#p)" marker-start="url(#r)" stroke-width=".79375"/>
+   <path d="m122.86 128.82v5.6851" marker-end="url(#p)" marker-start="url(#r)" stroke-width=".79375"/>
    <g stroke-width=".79375">
-    <path d="m135.05 132.81v-4.154" marker-end="url(#c)" stroke-linecap="square"/>
-    <path d="m145.92 128.22v4.2876" marker-end="url(#b)" stroke-linecap="square"/>
+    <path d="m135.05 134.81v-6.154" marker-end="url(#c)" stroke-linecap="square"/>
+    <path d="m145.92 128.22v6.2876" marker-end="url(#b)" stroke-linecap="square"/>
     <path d="m115.81 122.66h3.0711" marker-start="url(#a)"/>
+    <path d="m87.961 122.87h-9.0342" marker-start="url(#a-0)"/>
    </g>
   </g>
   <text x="156.62027" y="89.125519" fill="#000000" font-family="'Liberation Sans'" font-size="2.6458px" letter-spacing="0px" stroke-width=".26458px" word-spacing="0px" style="line-height:125%" xml:space="preserve"><tspan x="156.62027" y="89.125519">AXI-MM /</tspan><tspan x="156.62027" y="92.432816">AXI-Streaming /</tspan><tspan x="156.62027" y="95.74012">FIFO</tspan></text>
@@ -121,5 +137,12 @@
   <text x="41.117294" y="85.428101" fill="#000000" font-family="'Liberation Sans'" font-size="2.6458px" letter-spacing="0px" stroke-width=".26458px" word-spacing="0px" style="line-height:125%" xml:space="preserve"><tspan x="41.117294" y="85.428101" stroke-width=".26458px">src_clk</tspan></text>
   <path d="m155.32 84.042h-7.0159" fill="none" marker-end="url(#h)" stroke="#000" stroke-width=".52917"/>
   <text x="155.82919" y="84.861137" fill="#000000" font-family="'Liberation Sans'" font-size="2.6458px" letter-spacing="0px" stroke-width=".26458px" word-spacing="0px" style="line-height:125%" xml:space="preserve"><tspan x="155.82919" y="84.861137" stroke-width=".26458px">dest_clk</tspan></text>
+  <g transform="translate(-.00024899 33.433)">
+   <rect x="59.148" y="80.92" width="18.041" height="16.704" fill="url(#linearGradient59824)" fill-rule="evenodd" stroke="#000" stroke-width=".52917"/>
+   <text transform="translate(.00024899 -33.433)" x="68.10511" y="120.30859" fill="#000000" font-family="'Liberation Sans'" font-size="2.6458px" letter-spacing="0px" stroke-width=".26458px" text-anchor="middle" word-spacing="0px" style="font-variant-caps:normal;font-variant-east-asian:normal;font-variant-ligatures:normal;font-variant-numeric:normal;line-height:125%" xml:space="preserve"><tspan x="68.10511" y="120.30859">Scatter-</tspan><tspan x="68.10511" y="123.61584">Gather</tspan><tspan x="68.10511" y="126.9231">Interface</tspan></text>
+  </g>
+  <path d="m49.947 118.89h7.0159" fill="none" marker-end="url(#i-9)" stroke="#000" stroke-width=".52917"/>
+  <text x="41.867359" y="119.68142" fill="#000000" font-family="'Liberation Sans'" font-size="2.6458px" letter-spacing="0px" stroke-width=".26458px" word-spacing="0px" style="line-height:125%" xml:space="preserve"><tspan x="41.867359" y="119.68142" stroke-width=".26458px">sg_clk</tspan></text>
+  <text x="38.796375" y="127.43142" fill="#000000" font-family="'Liberation Sans'" font-size="2.6458px" letter-spacing="0px" stroke-width=".26458px" word-spacing="0px" style="line-height:125%" xml:space="preserve"><tspan x="38.796375" y="127.43142">AXI-MM</tspan></text>
  </g>
 </svg>

--- a/docs/regmap/adi_regmap_dmac.txt
+++ b/docs/regmap/adi_regmap_dmac.txt
@@ -9,7 +9,7 @@ ENDTITLE
 REG
 0x000
 VERSION
-Version of the peripheral. Follows semantic versioning. Current version 4.04.61.
+Version of the peripheral. Follows semantic versioning. Current version 4.05.61.
 ENDREG
 
 FIELD
@@ -19,7 +19,7 @@ RO
 ENDFIELD
 
 FIELD
-[15:8] 0x03
+[15:8] 0x05
 VERSION_MINOR
 RO
 ENDFIELD
@@ -201,6 +201,15 @@ CONTROL
 ENDREG
 
 FIELD
+[2] 0x0
+HWDESC
+RW
+When set to 1 the scatter-gather transfers are enabled.
+
+Note, this field is only valid if the DMA channel has been configured with SG transfer support.
+ENDFIELD
+
+FIELD
 [1] 0x0
 PAUSE
 RW
@@ -242,7 +251,7 @@ TRANSFER_SUBMIT
 ENDREG
 
 FIELD
-[0] 0x00
+[0] 0x0
 TRANSFER_SUBMIT
 RW
 Writing a 1 to this register queues a new transfer. The bit transitions back to 0 once
@@ -464,7 +473,7 @@ STATUS
 ENDREG
 
 FIELD
-[31:0] 0x00
+[31:0] 0x00000000
 RESERVED
 RO
 This register is reserved for future usage. Reading it will always return 0.
@@ -479,7 +488,7 @@ CURRENT_DEST_ADDRESS
 ENDREG
 
 FIELD
-[31:0] 0x00
+[31:0] 0x00000000
 CURRENT_DEST_ADDRESS
 RO
 Address to which the next data sample is written to.
@@ -496,7 +505,7 @@ CURRENT_SRC_ADDRESS
 ENDREG
 
 FIELD
-[31:0] 0x00
+[31:0] 0x00000000
 CURRENT_SRC_ADDRESS
 RO
 Address form which the next data sample is read.
@@ -530,7 +539,7 @@ PARTIAL_TRANSFER_LENGTH
 ENDREG
 
 FIELD
-[31:0] 0x000000
+[31:0] 0x00000000
 PARTIAL_LENGTH
 RO
 Length of the partial transfer in bytes. Represents the number of bytes received
@@ -559,6 +568,41 @@ ENDFIELD
 ############################################################################################
 
 REG
+0x115
+DESCRIPTOR_ID
+ENDREG
+
+FIELD
+[31:0] 0x00000000
+DESCRIPTOR_ID
+RO
+ID of the descriptor that points to the current memory segment being transferred.
+If HWDESC is set to 0, then this register returns 0.
+
+ENDFIELD
+
+############################################################################################
+############################################################################################
+
+REG
+0x11f
+SG_ADDRESS
+ENDREG
+
+FIELD
+[31:0] 0x00000000
+SG_ADDRESS
+RW
+This register contains the starting address of the scatter-gather transfer. The address needs
+to be aligned to the bus width.
+
+This register is only valid if the DMA channel has been configured with SG transfer support.
+ENDFIELD
+
+############################################################################################
+############################################################################################
+
+REG
 0x124
 DEST_ADDRESS_HIGH
 ENDREG
@@ -569,7 +613,8 @@ DEST_ADDRESS_HIGH
 RW
 This register contains the HIGH segment of the destination address of the transfer.
 
-This register is only valid if the DMA_AXI_ADDR_WIDTH is bigger than 32 and if DMA channel has been configured for write to memory support.
+This register is only valid if the DMA_AXI_ADDR_WIDTH is bigger than 32 and if DMA channel
+has been configured for write to memory support.
 ENDFIELD
 
 ############################################################################################
@@ -586,7 +631,8 @@ SRC_ADDRESS_HIGH
 RW
 This register contains the HIGH segment of the source address of the transfer.
 
-This register is only valid if the DMA_AXI_ADDR_WIDTH is bigger than 32 and if the DMA channel has been configured for read from memory support.
+This register is only valid if the DMA_AXI_ADDR_WIDTH is bigger than 32 and if the DMA channel
+has been configured for read from memory support.
 ENDFIELD
 
 ############################################################################################
@@ -598,12 +644,13 @@ CURRENT_DEST_ADDRESS_HIGH
 ENDREG
 
 FIELD
-[31:0] 0x00
+[31:0] 0x00000000
 CURRENT_DEST_ADDRESS_HIGH
 RO
 HIGH segment of the address to which the next data sample is written to.
 
-This register is only valid if the DMA_AXI_ADDR_WIDTH is bigger than 32 and if the DMA channel has been configured for write to memory support.
+This register is only valid if the DMA_AXI_ADDR_WIDTH is bigger than 32 and if the DMA channel
+has been configured for write to memory support.
 ENDFIELD
 
 ############################################################################################
@@ -615,12 +662,31 @@ CURRENT_SRC_ADDRESS_HIGH
 ENDREG
 
 FIELD
-[31:0] 0x00
+[31:0] 0x00000000
 CURRENT_SRC_ADDRESS_HIGH
 RO
 HIGH segment of the address from which the next data sample is read.
 
-This register is only valid if the DMA_AXI_ADDR_WIDTH is bigger than 32 and if the DMA channel has been configured for read from memory support.
+This register is only valid if the DMA_AXI_ADDR_WIDTH is bigger than 32 and if the DMA channel
+has been configured for read from memory support.
+ENDFIELD
+
+############################################################################################
+############################################################################################
+
+REG
+0x12f
+SG_ADDRESS_HIGH
+ENDREG
+
+FIELD
+[31:0] 0x00000000
+SG_ADDRESS_HIGH
+RW
+HIGH segment of the starting address of the scatter-gather transfer.
+
+This register is only valid if the DMA_AXI_ADDR_WIDTH is bigger than 32 and if the DMA channel
+has been configured with SG transfer support.
 ENDFIELD
 
 ############################################################################################

--- a/library/axi_dmac/Makefile
+++ b/library/axi_dmac/Makefile
@@ -24,6 +24,7 @@ GENERIC_DEPS += dest_axi_mm.v
 GENERIC_DEPS += dest_axi_stream.v
 GENERIC_DEPS += dest_fifo_inf.v
 GENERIC_DEPS += dmac_2d_transfer.v
+GENERIC_DEPS += dmac_sg.v
 GENERIC_DEPS += inc_id.vh
 GENERIC_DEPS += request_arb.v
 GENERIC_DEPS += request_generator.v
@@ -52,6 +53,7 @@ INTEL_DEPS += ../util_axis_fifo/util_axis_fifo.v
 INTEL_DEPS += ../util_axis_fifo/util_axis_fifo_address_generator.v
 INTEL_DEPS += ../util_cdc/sync_bits.v
 INTEL_DEPS += ../util_cdc/sync_event.v
+INTEL_DEPS += ../util_cdc/sync_gray.v
 INTEL_DEPS += axi_dmac_constr.sdc
 INTEL_DEPS += axi_dmac_hw.tcl
 

--- a/library/axi_dmac/axi_dmac_constr.ttcl
+++ b/library/axi_dmac/axi_dmac_constr.ttcl
@@ -11,6 +11,10 @@
 <: set async_dest_req [getBooleanValue "ASYNC_CLK_DEST_REQ"] :>
 <: set async_req_src [getBooleanValue "ASYNC_CLK_REQ_SRC"] :>
 <: set async_src_dest [getBooleanValue "ASYNC_CLK_SRC_DEST"] :>
+<: set async_req_sg [getBooleanValue "ASYNC_CLK_REQ_SG"] :>
+<: set async_src_sg [getBooleanValue "ASYNC_CLK_SRC_SG"] :>
+<: set async_dest_sg [getBooleanValue "ASYNC_CLK_DEST_SG"] :>
+<: set sg_enabled [getBooleanValue "DMA_SG_TRANSFER"] :>
 <: set disable_debug_registers [getBooleanValue "DISABLE_DEBUG_REGISTERS"] :>
 
 set req_clk_ports_base {s_axi_aclk}
@@ -31,11 +35,28 @@ set dest_clk_ports "$dest_clk_ports $src_clk_ports_base"
 set req_clk_ports "$req_clk_ports $dest_clk_ports_base"
 set dest_clk_ports "$dest_clk_ports $req_clk_ports_base"
 <: } :>
+<: if {$sg_enabled} { :>
+set sg_clk_ports_base {m_sg_axi_aclk}
+set sg_clk_ports $sg_clk_ports_base
+<: if {[expr {!$async_req_sg}]} { :>
+set req_clk_ports "$req_clk_ports $sg_clk_ports_base"
+set sg_clk_ports "$sg_clk_ports $req_clk_ports_base"
+<: } :>
+<: if {[expr {!$async_src_sg}]} { :>
+set src_clk_ports "$src_clk_ports $sg_clk_ports_base"
+set sg_clk_ports "$sg_clk_ports $src_clk_ports_base"
+<: } :>
+<: if {[expr {!$async_dest_sg}]} { :>
+set dest_clk_ports "$dest_clk_ports $sg_clk_ports_base"
+set sg_clk_ports "$sg_clk_ports $dest_clk_ports_base"
+<: } :>
+set sg_clk [get_clocks -of_objects [get_ports -quiet $sg_clk_ports]]
+<: } :>
 set req_clk [get_clocks -of_objects [get_ports -quiet $req_clk_ports]]
 set src_clk [get_clocks -of_objects [get_ports -quiet $src_clk_ports]]
 set dest_clk [get_clocks -of_objects [get_ports -quiet $dest_clk_ports]]
 
-<: if {$async_req_src || $async_src_dest || $async_dest_req} { :>
+<: if {$async_req_src || $async_src_dest || $async_dest_req || ($async_req_sg && $sg_enabled)} { :>
 set_property ASYNC_REG TRUE \
 	[get_cells -quiet -hier *cdc_sync_stage1_reg*] \
 	[get_cells -quiet -hier *cdc_sync_stage2_reg*]
@@ -140,6 +161,7 @@ set_max_delay -quiet -datapath_only \
 	-to [get_cells -quiet -hier *cdc_sync_stage1_reg* \
 		-filter {NAME =~ *i_dest_response_fifo/zerodeep.i_raddr_sync* && IS_SEQUENTIAL}] \
 	[get_property -min PERIOD $req_clk]
+
 set_max_delay -quiet -datapath_only \
 	-from [get_cells -quiet -hier *cdc_sync_fifo_ram_reg* \
 		-filter {NAME =~ *i_dest_response_fifo* && IS_SEQUENTIAL}] \
@@ -209,12 +231,61 @@ set_max_delay -quiet -datapath_only \
 	-to $dest_clk \
 	[get_property -min PERIOD $dest_clk]
 
-  set_max_delay -quiet -datapath_only \
+set_max_delay -quiet -datapath_only \
   -from $src_clk \
   -through [get_cells -quiet -hier DP \
     -filter {NAME =~ *i_request_arb/eot_mem_dest_reg*}] \
 	-to $dest_clk \
 	[get_property -min PERIOD $dest_clk]
+
+<: } :>
+<: if {$async_req_sg && $sg_enabled} { :>
+set_false_path -quiet \
+	-from $req_clk \
+	-to [get_cells -quiet -hier *cdc_sync_stage1_reg* \
+		-filter {NAME =~ *i_sync_sg_enable* && IS_SEQUENTIAL}]
+
+set_max_delay -quiet -datapath_only \
+	-from $req_clk \
+	-to [get_cells -quiet -hier *cdc_sync_stage1_reg* \
+		-filter {NAME =~ *i_sg_addr_fifo/zerodeep.i_waddr_sync* && IS_SEQUENTIAL}] \
+	[get_property -min PERIOD $req_clk]
+
+set_max_delay -quiet -datapath_only \
+	-from $sg_clk \
+	-to [get_cells -quiet -hier *cdc_sync_stage1_reg* \
+		-filter {NAME =~ *i_sg_addr_fifo/zerodeep.i_raddr_sync* && IS_SEQUENTIAL}] \
+	[get_property -min PERIOD $sg_clk]
+
+set_max_delay -quiet -datapath_only \
+	-from [get_cells -quiet -hier *cdc_sync_fifo_ram_reg* \
+		-filter {NAME =~ *i_sg_addr_fifo* && IS_SEQUENTIAL}] \
+	-to $sg_clk \
+	[get_property -min PERIOD $sg_clk]
+
+set_max_delay -quiet -datapath_only \
+	-from $sg_clk \
+	-to [get_cells -quiet -hier *cdc_sync_stage1_reg* \
+		-filter {NAME =~ *i_sg_desc_fifo/zerodeep.i_waddr_sync* && IS_SEQUENTIAL}] \
+	[get_property -min PERIOD $sg_clk]
+
+set_max_delay -quiet -datapath_only \
+	-from $req_clk \
+	-to [get_cells -quiet -hier *cdc_sync_stage1_reg* \
+		-filter {NAME =~ *i_sg_desc_fifo/zerodeep.i_raddr_sync* && IS_SEQUENTIAL}] \
+	[get_property -min PERIOD $req_clk]
+
+set_max_delay -quiet -datapath_only \
+	-from [get_cells -quiet -hier *cdc_sync_fifo_ram_reg* \
+		-filter {NAME =~ *i_sg_desc_fifo* && IS_SEQUENTIAL}] \
+	-to $req_clk \
+	[get_property -min PERIOD $req_clk]
+
+set_false_path \
+  -to [get_pins -hierarchical * -filter {NAME=~*i_waddr_sync_gray/cdc_sync_stage1_reg[*]/D}]
+
+set_false_path \
+  -to [get_pins -hierarchical * -filter {NAME=~*i_raddr_sync_gray/cdc_sync_stage1_reg[*]/D}]
 
 <: } :>
 # Reset signals

--- a/library/axi_dmac/axi_dmac_hw.tcl
+++ b/library/axi_dmac/axi_dmac_hw.tcl
@@ -20,6 +20,7 @@ set_module_property VALIDATION_CALLBACK axi_dmac_validate
 ad_ip_files axi_dmac [list \
   $ad_hdl_dir/library/util_cdc/sync_bits.v \
   $ad_hdl_dir/library/util_cdc/sync_event.v \
+  $ad_hdl_dir/library/util_cdc/sync_gray.v \
   $ad_hdl_dir/library/common/up_axi.v \
   $ad_hdl_dir/library/util_axis_fifo/util_axis_fifo.v \
   $ad_hdl_dir/library/util_axis_fifo/util_axis_fifo_address_generator.v \
@@ -41,6 +42,7 @@ ad_ip_files axi_dmac [list \
   response_handler.v \
   axi_register_slice.v \
   dmac_2d_transfer.v \
+  dmac_sg.v \
   dest_axi_mm.v \
   dest_axi_stream.v \
   dest_fifo_inf.v \
@@ -127,6 +129,22 @@ foreach {suffix group} { \
 # FIFO interface
 set_parameter_property DMA_TYPE_SRC DEFAULT_VALUE 2
 
+# Scatter-Gather interface
+add_parameter DMA_AXI_PROTOCOL_SG INTEGER 1
+set_parameter_property DMA_AXI_PROTOCOL_SG DISPLAY_NAME "AXI Protocol"
+set_parameter_property DMA_AXI_PROTOCOL_SG HDL_PARAMETER true
+set_parameter_property DMA_AXI_PROTOCOL_SG ALLOWED_RANGES { "0:AXI4" "1:AXI3" }
+set_parameter_property DMA_AXI_PROTOCOL_SG VISIBLE true
+set_parameter_property DMA_AXI_PROTOCOL_SG GROUP $group
+
+add_parameter DMA_DATA_WIDTH_SG INTEGER 64
+set_parameter_property DMA_DATA_WIDTH_SG DISPLAY_NAME "Bus Width"
+set_parameter_property DMA_DATA_WIDTH_SG UNITS Bits
+set_parameter_property DMA_DATA_WIDTH_SG HDL_PARAMETER true
+set_parameter_property DMA_DATA_WIDTH_SG ALLOWED_RANGES {64}
+set_parameter_property DMA_DATA_WIDTH_SG VISIBLE true
+set_parameter_property DMA_DATA_WIDTH_SG GROUP $group
+
 set group "Features"
 
 add_parameter CYCLIC INTEGER 1
@@ -140,6 +158,12 @@ set_parameter_property DMA_2D_TRANSFER DISPLAY_NAME "2D Transfer Support"
 set_parameter_property DMA_2D_TRANSFER DISPLAY_HINT boolean
 set_parameter_property DMA_2D_TRANSFER HDL_PARAMETER true
 set_parameter_property DMA_2D_TRANSFER GROUP $group
+
+add_parameter DMA_SG_TRANSFER INTEGER 0
+set_parameter_property DMA_SG_TRANSFER DISPLAY_NAME "SG Transfer Support"
+set_parameter_property DMA_SG_TRANSFER DISPLAY_HINT boolean
+set_parameter_property DMA_SG_TRANSFER HDL_PARAMETER true
+set_parameter_property DMA_SG_TRANSFER GROUP $group
 
 add_parameter SYNC_TRANSFER_START INTEGER 0
 set_parameter_property SYNC_TRANSFER_START DISPLAY_NAME "Transfer Start Synchronization Support"
@@ -158,6 +182,9 @@ foreach {p name} { \
     ASYNC_CLK_REQ_SRC "Request and Source" \
     ASYNC_CLK_SRC_DEST "Source and Destination" \
     ASYNC_CLK_DEST_REQ "Destination and Request" \
+    ASYNC_CLK_REQ_SG "Request and Scatter-Gather" \
+    ASYNC_CLK_SRC_SG "Source and Scatter-Gather" \
+    ASYNC_CLK_DEST_SG "Destination and Scatter-Gather" \
   } {
 
   add_parameter ${p}_MANUAL INTEGER 1
@@ -202,6 +229,12 @@ foreach domain [list {*}$src_clks {*}$dest_clks] {
   set_parameter_property $p GROUP $group
 }
 
+add_parameter CLK_DOMAIN_SG INTEGER
+set_parameter_property CLK_DOMAIN_SG HDL_PARAMETER false
+set_parameter_property CLK_DOMAIN_SG SYSTEM_INFO {CLOCK_DOMAIN m_sg_axi_clock}
+set_parameter_property CLK_DOMAIN_SG VISIBLE false
+set_parameter_property CLK_DOMAIN_SG GROUP $group
+
 # axi4 slave
 
 ad_ip_intf_s_axi s_axi_aclk s_axi_aresetn 11
@@ -231,6 +264,7 @@ proc axi_dmac_validate {} {
     set req_domain [get_parameter_value CLK_DOMAIN_REQ]
     set src_domain [get_parameter_value [lindex $src_clks $type_src 0]]
     set dest_domain [get_parameter_value [lindex $dest_clks $type_dest 0]]
+    set sg_domain [get_parameter_value CLK_DOMAIN_SG]
 
     if {$req_domain != 0 && $req_domain == $src_domain} {
       set_parameter_value ASYNC_CLK_REQ_SRC 0
@@ -249,13 +283,31 @@ proc axi_dmac_validate {} {
     } else {
       set_parameter_value ASYNC_CLK_DEST_REQ 1
     }
+
+    if {$sg_domain != 0 && $sg_domain == $req_domain} {
+      set_parameter_value ASYNC_CLK_REQ_SG 0
+    } else {
+      set_parameter_value ASYNC_CLK_REQ_SG 1
+    }
+
+    if {$sg_domain != 0 && $sg_domain == $src_domain} {
+      set_parameter_value ASYNC_CLK_SRC_SG 0
+    } else {
+      set_parameter_value ASYNC_CLK_SRC_SG 1
+    }
+
+    if {$sg_domain != 0 && $sg_domain == $dest_domain} {
+      set_parameter_value ASYNC_CLK_DEST_SG 0
+    } else {
+      set_parameter_value ASYNC_CLK_DEST_SG 1
+    }
   } else {
-    foreach p {ASYNC_CLK_REQ_SRC ASYNC_CLK_SRC_DEST ASYNC_CLK_DEST_REQ} {
+    foreach p {ASYNC_CLK_REQ_SRC ASYNC_CLK_SRC_DEST ASYNC_CLK_DEST_REQ ASYNC_CLK_REQ_SG ASYNC_CLK_SRC_SG ASYNC_CLK_DEST_SG} {
       set_parameter_value $p [get_parameter_value ${p}_MANUAL]
     }
   }
 
-  foreach p {ASYNC_CLK_REQ_SRC ASYNC_CLK_SRC_DEST ASYNC_CLK_DEST_REQ} {
+  foreach p {ASYNC_CLK_REQ_SRC ASYNC_CLK_SRC_DEST ASYNC_CLK_DEST_REQ ASYNC_CLK_REQ_SG ASYNC_CLK_SRC_SG ASYNC_CLK_DEST_SG} {
     set_parameter_property ${p}_MANUAL VISIBLE [expr $auto_clk ? false : true]
     set_parameter_property $p VISIBLE $auto_clk
   }
@@ -296,6 +348,15 @@ add_interface_port m_src_axi_clock m_src_axi_aclk clk Input 1
 add_interface m_src_axi_reset reset end
 set_interface_property m_src_axi_reset associatedClock m_src_axi_clock
 add_interface_port m_src_axi_reset m_src_axi_aresetn reset_n Input 1
+
+# axi4 scatter-gather
+
+add_interface m_sg_axi_clock clock end
+add_interface_port m_sg_axi_clock m_sg_axi_aclk clk Input 1
+
+add_interface m_sg_axi_reset reset end
+set_interface_property m_sg_axi_reset associatedClock m_sg_axi_clock
+add_interface_port m_sg_axi_reset m_sg_axi_aresetn reset_n Input 1
 
 # axis destination/source
 
@@ -409,7 +470,7 @@ proc axi_dmac_elaborate {} {
   set disabled_intfs {}
 
   # add axi3 or axi4 interface depending on user selection
-  foreach {suffix port} {SRC m_src_axi DEST m_dest_axi} {
+  foreach {suffix port} {SRC m_src_axi DEST m_dest_axi SG m_sg_axi} {
     if {[get_parameter_value DMA_AXI_PROTOCOL_${suffix}] == 0} {
       set axi_type axi4
     } else {
@@ -432,6 +493,13 @@ proc axi_dmac_elaborate {} {
     set_interface_property m_src_axi combinedIssuingCapability $fifo_size
   } else {
     lappend disabled_intfs m_src_axi_clock m_src_axi_reset m_src_axi
+  }
+
+  if {[get_parameter_value DMA_SG_TRANSFER] == 1} {
+    set_interface_property m_sg_axi readIssuingCapability $fifo_size
+    set_interface_property m_sg_axi combinedIssuingCapability $fifo_size
+  } else {
+    lappend disabled_intfs m_sg_axi_clock m_sg_axi_reset m_sg_axi
   }
 
   # axis destination/source

--- a/library/axi_dmac/axi_dmac_ip.tcl
+++ b/library/axi_dmac/axi_dmac_ip.tcl
@@ -30,6 +30,7 @@ adi_ip_files axi_dmac [list \
   "response_handler.v" \
   "axi_register_slice.v" \
   "dmac_2d_transfer.v" \
+  "dmac_sg.v" \
   "dest_axi_mm.v" \
   "dest_axi_stream.v" \
   "dest_fifo_inf.v" \
@@ -91,6 +92,8 @@ adi_set_bus_dependency "m_src_axi" "m_src_axi" \
 	"(spirit:decode(id('MODELPARAM_VALUE.DMA_TYPE_SRC')) = 0)"
 adi_set_bus_dependency "m_dest_axi" "m_dest_axi" \
 	"(spirit:decode(id('MODELPARAM_VALUE.DMA_TYPE_DEST')) = 0)"
+adi_set_bus_dependency "m_sg_axi" "m_sg_axi" \
+	"(spirit:decode(id('MODELPARAM_VALUE.DMA_SG_TRANSFER')) = 1)"
 adi_set_bus_dependency "s_axis" "s_axis" \
 	"(spirit:decode(id('MODELPARAM_VALUE.DMA_TYPE_SRC')) = 1)"
 adi_set_bus_dependency "m_axis" "m_axis" \
@@ -118,7 +121,6 @@ set dummy_axi_ports [list \
 	"m_dest_axi_rdata" \
 	"m_src_axi_awvalid" \
 	"m_src_axi_awready" \
-	"m_src_axi_awvalid" \
 	"m_src_axi_awaddr" \
 	"m_src_axi_awlen" \
 	"m_src_axi_awsize" \
@@ -127,13 +129,28 @@ set dummy_axi_ports [list \
 	"m_src_axi_awprot" \
 	"m_src_axi_wvalid" \
 	"m_src_axi_wready" \
-	"m_src_axi_wvalid" \
 	"m_src_axi_wdata" \
 	"m_src_axi_wstrb" \
 	"m_src_axi_wlast" \
 	"m_src_axi_bready" \
 	"m_src_axi_bvalid" \
 	"m_src_axi_bresp" \
+	"m_sg_axi_awvalid" \
+	"m_sg_axi_awready" \
+	"m_sg_axi_awaddr" \
+	"m_sg_axi_awlen" \
+	"m_sg_axi_awsize" \
+	"m_sg_axi_awburst" \
+	"m_sg_axi_awcache" \
+	"m_sg_axi_awprot" \
+	"m_sg_axi_wvalid" \
+	"m_sg_axi_wready" \
+	"m_sg_axi_wdata" \
+	"m_sg_axi_wstrb" \
+	"m_sg_axi_wlast" \
+	"m_sg_axi_bready" \
+	"m_sg_axi_bvalid" \
+	"m_sg_axi_bresp" \
 ]
 
 # These are in the design to keep the Intel tools happy which require
@@ -153,7 +170,14 @@ lappend dummy_axi_ports \
 	"m_src_axi_awid" \
 	"m_src_axi_awlock" \
 	"m_src_axi_wid" \
-	"m_src_axi_bid"
+	"m_src_axi_bid" \
+	"m_sg_axi_arid" \
+	"m_sg_axi_arlock" \
+	"m_sg_axi_rid" \
+	"m_sg_axi_awid" \
+	"m_sg_axi_awlock" \
+	"m_sg_axi_wid" \
+	"m_sg_axi_bid"
 
 
 foreach p $dummy_axi_ports {
@@ -165,6 +189,9 @@ set_property master_address_space_ref m_dest_axi \
     -of_objects [ipx::current_core]]
 set_property master_address_space_ref m_src_axi \
     [ipx::get_bus_interfaces m_src_axi \
+    -of_objects [ipx::current_core]]
+set_property master_address_space_ref m_sg_axi \
+    [ipx::get_bus_interfaces m_sg_axi \
     -of_objects [ipx::current_core]]
 
 adi_add_bus "fifo_wr" "slave" \
@@ -198,7 +225,7 @@ adi_add_bus_clock "fifo_rd_clk" "fifo_rd"
 adi_set_bus_dependency "fifo_rd" "fifo_rd" \
 	"(spirit:decode(id('MODELPARAM_VALUE.DMA_TYPE_DEST')) = 2)"
 
-foreach port {"m_dest_axi_aresetn" "m_src_axi_aresetn" \
+foreach port {"m_dest_axi_aresetn" "m_src_axi_aresetn" "m_sg_axi_aresetn" \
   "s_axis_valid" "s_axis_data" "s_axis_last" "m_axis_ready" \
   "fifo_wr_en" "fifo_wr_din" "fifo_rd_en"} {
 	set_property DRIVER_VALUE "0" [ipx::get_ports $port]
@@ -240,17 +267,21 @@ set_property -dict [list \
 	[ipx::get_user_parameters DMA_AXI_ADDR_WIDTH -of_objects $cc]
 
 foreach {k v} { \
-		"ASYNC_CLK_REQ_SRC" "true" \
-		"ASYNC_CLK_SRC_DEST" "true" \
-		"ASYNC_CLK_DEST_REQ" "true" \
-		"CYCLIC" "false" \
-		"DMA_2D_TRANSFER" "false" \
-		"SYNC_TRANSFER_START" "false" \
-		"AXI_SLICE_SRC" "false" \
-		"AXI_SLICE_DEST" "false" \
-		"DISABLE_DEBUG_REGISTERS" "false" \
-    "ENABLE_DIAGNOSTICS_IF" "false" \
-    "CACHE_COHERENT_DEST" "false" \
+        "ASYNC_CLK_REQ_SRC" "true" \
+        "ASYNC_CLK_SRC_DEST" "true" \
+        "ASYNC_CLK_DEST_REQ" "true" \
+        "ASYNC_CLK_REQ_SG" "true" \
+        "ASYNC_CLK_SRC_SG" "true" \
+        "ASYNC_CLK_DEST_SG" "true" \
+        "CYCLIC" "false" \
+        "DMA_2D_TRANSFER" "false" \
+        "DMA_SG_TRANSFER" "false" \
+        "SYNC_TRANSFER_START" "false" \
+        "AXI_SLICE_SRC" "false" \
+        "AXI_SLICE_DEST" "false" \
+        "DISABLE_DEBUG_REGISTERS" "false" \
+        "ENABLE_DIAGNOSTICS_IF" "false" \
+        "CACHE_COHERENT_DEST" "false" \
 	} { \
 	set_property -dict [list \
 			"value_format" "bool" \
@@ -263,11 +294,6 @@ foreach {k v} { \
 		] \
 		[ipx::get_hdl_parameters $k -of_objects $cc]
 }
-
-set_property -dict [list \
-	"enablement_tcl_expr" "\$DMA_TYPE_SRC != 0" \
-] \
-[ipx::get_user_parameters SYNC_TRANSFER_START -of_objects $cc]
 
 foreach dir {"SRC" "DEST"} {
 	set_property -dict [list \
@@ -302,6 +328,8 @@ set src_group [ipgui::add_group -name {Source} -component $cc -parent $g \
 		-display_name {Source}]
 set dest_group [ipgui::add_group -name {Destination} -component $cc -parent $g \
 		-display_name {Destination}]
+set sg_group [ipgui::add_group -name {Scatter-Gather} -component $cc -parent $g \
+		-display_name {Scatter-Gather}]
 
 foreach {dir group} [list "SRC" $src_group "DEST" $dest_group] {
 	set p [ipgui::get_guiparamspec -name "DMA_TYPE_${dir}" -component $cc]
@@ -337,6 +365,9 @@ ipgui::move_param -component $cc -order 4 $p -parent $src_group
 set_property -dict [list \
 	"display_name" "Transfer Start Synchronization Support" \
 ] $p
+set_property -dict [list \
+	"enablement_tcl_expr" "\$DMA_TYPE_SRC != 0" \
+] [ipx::get_user_parameters SYNC_TRANSFER_START -of_objects $cc]
 
 set p [ipgui::get_guiparamspec -name "CACHE_COHERENT_DEST" -component $cc]
 ipgui::move_param -component $cc -order 4 $p -parent $dest_group
@@ -349,6 +380,32 @@ set_property -dict [list \
 	"value_tcl_expr" "\$DMA_TYPE_DEST == 0 && \$DMA_AXI_PROTOCOL_DEST == 0" \
 	"enablement_value" "false" \
 ] [ipx::get_user_parameters CACHE_COHERENT_DEST -of_objects $cc]
+
+set p [ipgui::get_guiparamspec -name "DMA_AXI_PROTOCOL_SG" -component $cc]
+ipgui::move_param -component $cc -order 0 $p -parent $sg_group
+set_property -dict [list \
+	"display_name" "AXI Protocol" \
+] $p
+set_property -dict [list \
+	"enablement_tcl_expr" "\$DMA_SG_TRANSFER == true" \
+] [ipx::get_user_parameters DMA_AXI_PROTOCOL_SG -of_objects $cc]
+set_property -dict [list \
+	"value_validation_type" "pairs" \
+	"value_validation_pairs" {"AXI3" "1" "AXI4" "0"} \
+] [ipx::get_user_parameters DMA_AXI_PROTOCOL_SG -of_objects $cc]
+
+set p [ipgui::get_guiparamspec -name "DMA_DATA_WIDTH_SG" -component $cc]
+ipgui::move_param -component $cc -order 1 $p -parent $sg_group
+set_property -dict [list \
+	"display_name" "Bus Width" \
+] $p
+set_property -dict [list \
+	"enablement_tcl_expr" "\$DMA_SG_TRANSFER == true" \
+] [ipx::get_user_parameters DMA_DATA_WIDTH_SG -of_objects $cc]
+set_property -dict [list \
+	"value_validation_type" "list" \
+	"value_validation_list" "64" \
+] [ipx::get_user_parameters DMA_DATA_WIDTH_SG -of_objects $cc]
 
 set general_group [ipgui::add_group -name "General Configuration" -component $cc \
 		-parent $page0 -display_name "General Configuration"]
@@ -399,6 +456,12 @@ set_property -dict [list \
 	"display_name" "2D Transfer Support" \
 ] $p
 
+set p [ipgui::get_guiparamspec -name "DMA_SG_TRANSFER" -component $cc]
+ipgui::move_param -component $cc -order 2 $p -parent $feature_group
+set_property -dict [list \
+	"display_name" "SG Transfer Support" \
+] $p
+
 set clk_group [ipgui::add_group -name {Clock Domain Configuration} -component $cc \
 		-parent $page0 -display_name {Clock Domain Configuration}]
 
@@ -420,6 +483,24 @@ set_property -dict [list \
 	"display_name" "Destination and Request Clock Asynchronous" \
 ] $p
 
+set p [ipgui::get_guiparamspec -name "ASYNC_CLK_REQ_SG" -component $cc]
+ipgui::move_param -component $cc -order 3 $p -parent $clk_group
+set_property -dict [list \
+	"display_name" "Request and Scatter-Gather Clock Asynchronous" \
+] $p
+
+set p [ipgui::get_guiparamspec -name "ASYNC_CLK_SRC_SG" -component $cc]
+ipgui::move_param -component $cc -order 4 $p -parent $clk_group
+set_property -dict [list \
+	"display_name" "Source and Scatter-Gather Clock Asynchronous" \
+] $p
+
+set p [ipgui::get_guiparamspec -name "ASYNC_CLK_DEST_SG" -component $cc]
+ipgui::move_param -component $cc -order 5 $p -parent $clk_group
+set_property -dict [list \
+	"display_name" "Destination and Scatter-Gather Clock Asynchronous" \
+] $p
+
 set dbg_group [ipgui::add_group -name {Debug} -component $cc \
 		-parent $page0 -display_name {Debug}]
 
@@ -437,6 +518,7 @@ set_property -dict [list \
 
 ipgui::remove_param -component $cc [ipgui::get_guiparamspec -name "AXI_ID_WIDTH_SRC" -component $cc]
 ipgui::remove_param -component $cc [ipgui::get_guiparamspec -name "AXI_ID_WIDTH_DEST" -component $cc]
+ipgui::remove_param -component $cc [ipgui::get_guiparamspec -name "AXI_ID_WIDTH_SG" -component $cc]
 ipgui::remove_param -component $cc [ipgui::get_guiparamspec -name "ALLOW_ASYM_MEM" -component $cc]
 ipgui::remove_param -component $cc [ipgui::get_guiparamspec -name "DMA_AXIS_ID_W" -component $cc]
 ipgui::remove_param -component $cc [ipgui::get_guiparamspec -name "DMA_AXIS_DEST_W" -component $cc]

--- a/library/axi_dmac/axi_dmac_pkg_sv.ttcl
+++ b/library/axi_dmac/axi_dmac_pkg_sv.ttcl
@@ -11,17 +11,23 @@
 <: set id                      [get_property MODELPARAM_VALUE.ID] :>
 <: set dma_data_width_src      [get_property MODELPARAM_VALUE.DMA_DATA_WIDTH_SRC] :>
 <: set dma_data_width_dest     [get_property MODELPARAM_VALUE.DMA_DATA_WIDTH_DEST] :>
+<: set dma_data_width_sg       [get_property MODELPARAM_VALUE.DMA_DATA_WIDTH_SG] :>
 <: set dma_length_width        [get_property MODELPARAM_VALUE.DMA_LENGTH_WIDTH] :>
 <: set dma_2d_transfer         [get_property MODELPARAM_VALUE.DMA_2D_TRANSFER] :>
+<: set dma_sg_transfer         [get_property MODELPARAM_VALUE.DMA_SG_TRANSFER] :>
 <: set async_clk_req_src       [get_property MODELPARAM_VALUE.ASYNC_CLK_REQ_SRC] :>
 <: set async_clk_src_dest      [get_property MODELPARAM_VALUE.ASYNC_CLK_SRC_DEST] :>
 <: set async_clk_dest_req      [get_property MODELPARAM_VALUE.ASYNC_CLK_DEST_REQ] :>
+<: set async_clk_req_sg        [get_property MODELPARAM_VALUE.ASYNC_CLK_REQ_SG] :>
+<: set async_clk_src_sg        [get_property MODELPARAM_VALUE.ASYNC_CLK_SRC_SG] :>
+<: set async_clk_dest_sg       [get_property MODELPARAM_VALUE.ASYNC_CLK_DEST_SG] :>
 <: set axi_slice_dest          [get_property MODELPARAM_VALUE.AXI_SLICE_DEST] :>
 <: set axi_slice_src           [get_property MODELPARAM_VALUE.AXI_SLICE_SRC] :>
 <: set sync_transfer_start     [get_property MODELPARAM_VALUE.SYNC_TRANSFER_START] :>
 <: set cyclic                  [get_property MODELPARAM_VALUE.CYCLIC] :>
 <: set dma_axi_protocol_dest   [get_property MODELPARAM_VALUE.DMA_AXI_PROTOCOL_DEST] :>
 <: set dma_axi_protocol_src    [get_property MODELPARAM_VALUE.DMA_AXI_PROTOCOL_SRC] :>
+<: set dma_axi_protocol_sg     [get_property MODELPARAM_VALUE.DMA_AXI_PROTOCOL_SG] :>
 <: set dma_type_dest           [get_property MODELPARAM_VALUE.DMA_TYPE_DEST] :>
 <: set dma_type_src            [get_property MODELPARAM_VALUE.DMA_TYPE_SRC] :>
 <: set dma_axi_addr_width      [get_property MODELPARAM_VALUE.DMA_AXI_ADDR_WIDTH] :>
@@ -29,6 +35,7 @@
 <: set fifo_size               [get_property MODELPARAM_VALUE.FIFO_SIZE] :>
 <: set axi_id_width_src        [get_property MODELPARAM_VALUE.AXI_ID_WIDTH_SRC] :>
 <: set axi_id_width_dest       [get_property MODELPARAM_VALUE.AXI_ID_WIDTH_DEST] :>
+<: set axi_id_width_sg         [get_property MODELPARAM_VALUE.AXI_ID_WIDTH_SG] :>
 <: set disable_debug_registers [get_property MODELPARAM_VALUE.DISABLE_DEBUG_REGISTERS] :>
 
 <: proc b2i {b} { if {$b==true} {return 1} else {return 0}} :>
@@ -45,17 +52,23 @@ package <=: ComponentName :>_pkg;
   parameter <=: ComponentName :>_ID                      = <=: $id :>;
   parameter <=: ComponentName :>_DMA_DATA_WIDTH_SRC      = <=: $dma_data_width_src :>;
   parameter <=: ComponentName :>_DMA_DATA_WIDTH_DEST     = <=: $dma_data_width_dest :>;
+  parameter <=: ComponentName :>_DMA_DATA_WIDTH_SG       = <=: $dma_data_width_sg :>;
   parameter <=: ComponentName :>_DMA_LENGTH_WIDTH        = <=: $dma_length_width :>;
   parameter <=: ComponentName :>_DMA_2D_TRANSFER         = <=: b2i $dma_2d_transfer :>;
+  parameter <=: ComponentName :>_DMA_SG_TRANSFER         = <=: b2i $dma_sg_transfer :>;
   parameter <=: ComponentName :>_ASYNC_CLK_REQ_SRC       = <=: b2i $async_clk_req_src :>;
   parameter <=: ComponentName :>_ASYNC_CLK_SRC_DEST      = <=: b2i $async_clk_src_dest :>;
   parameter <=: ComponentName :>_ASYNC_CLK_DEST_REQ      = <=: b2i $async_clk_dest_req :>;
+  parameter <=: ComponentName :>_ASYNC_CLK_REQ_SG        = <=: b2i $async_clk_req_sg :>;
+  parameter <=: ComponentName :>_ASYNC_CLK_SRC_SG        = <=: b2i $async_clk_src_sg :>;
+  parameter <=: ComponentName :>_ASYNC_CLK_DEST_SG       = <=: b2i $async_clk_dest_sg :>;
   parameter <=: ComponentName :>_AXI_SLICE_DEST          = <=: b2i $axi_slice_dest :>;
   parameter <=: ComponentName :>_AXI_SLICE_SRC           = <=: b2i $axi_slice_src :>;
   parameter <=: ComponentName :>_SYNC_TRANSFER_START     = <=: b2i $sync_transfer_start :>;
   parameter <=: ComponentName :>_CYCLIC                  = <=: b2i $cyclic :>;
   parameter <=: ComponentName :>_DMA_AXI_PROTOCOL_DEST   = <=: $dma_axi_protocol_dest :>;
   parameter <=: ComponentName :>_DMA_AXI_PROTOCOL_SRC    = <=: $dma_axi_protocol_src :>;
+  parameter <=: ComponentName :>_DMA_AXI_PROTOCOL_SG     = <=: $dma_axi_protocol_sg :>;
   parameter <=: ComponentName :>_DMA_TYPE_DEST           = <=: $dma_type_dest :>;
   parameter <=: ComponentName :>_DMA_TYPE_SRC            = <=: $dma_type_src :>;
   parameter <=: ComponentName :>_DMA_AXI_ADDR_WIDTH      = <=: $dma_axi_addr_width :>;
@@ -63,6 +76,7 @@ package <=: ComponentName :>_pkg;
   parameter <=: ComponentName :>_FIFO_SIZE               = <=: $fifo_size :>;
   parameter <=: ComponentName :>_AXI_ID_WIDTH_SRC        = <=: $axi_id_width_src :>;
   parameter <=: ComponentName :>_AXI_ID_WIDTH_DEST       = <=: $axi_id_width_dest :>;
+  parameter <=: ComponentName :>_AXI_ID_WIDTH_SG         = <=: $axi_id_width_sg :>;
   parameter <=: ComponentName :>_DISABLE_DEBUG_REGISTERS = <=: b2i $disable_debug_registers :>;
 //////////////////////////////////////////////////////////////////////////
 

--- a/library/axi_dmac/axi_dmac_regmap_request.v
+++ b/library/axi_dmac/axi_dmac_regmap_request.v
@@ -39,6 +39,7 @@ module axi_dmac_regmap_request #(
   parameter DISABLE_DEBUG_REGISTERS = 0,
   parameter BYTES_PER_BEAT_WIDTH_DEST = 1,
   parameter BYTES_PER_BEAT_WIDTH_SRC = 1,
+  parameter BYTES_PER_BEAT_WIDTH_SG = 1,
   parameter BYTES_PER_BURST_WIDTH = 7,
   parameter DMA_AXI_ADDR_WIDTH = 32,
   parameter DMA_LENGTH_WIDTH = 24,
@@ -47,6 +48,7 @@ module axi_dmac_regmap_request #(
   parameter HAS_DEST_ADDR = 1,
   parameter HAS_SRC_ADDR = 1,
   parameter DMA_2D_TRANSFER = 0,
+  parameter DMA_SG_TRANSFER = 0,
   parameter SYNC_TRANSFER_START = 0
 ) (
   input clk,
@@ -66,12 +68,14 @@ module axi_dmac_regmap_request #(
 
   // Control interface
   input ctrl_enable,
+  input ctrl_hwdesc,
 
   // DMA request interface
   output request_valid,
   input request_ready,
   output [DMA_AXI_ADDR_WIDTH-1:BYTES_PER_BEAT_WIDTH_DEST] request_dest_address,
   output [DMA_AXI_ADDR_WIDTH-1:BYTES_PER_BEAT_WIDTH_SRC] request_src_address,
+  output [DMA_AXI_ADDR_WIDTH-1:BYTES_PER_BEAT_WIDTH_SG] request_sg_address,
   output [DMA_LENGTH_WIDTH-1:0] request_x_length,
   output [DMA_LENGTH_WIDTH-1:0] request_y_length,
   output [DMA_LENGTH_WIDTH-1:0] request_dest_stride,
@@ -81,13 +85,14 @@ module axi_dmac_regmap_request #(
 
   // DMA response interface
   input response_eot,
+  input [31:0] response_sg_desc_id,
   input [BYTES_PER_BURST_WIDTH-1:0] response_measured_burst_length,
   input response_partial,
   input response_valid,
   output reg response_ready = 1'b1
 );
 
-  localparam MEASURED_LENGTH_WIDTH = (DMA_2D_TRANSFER == 1) ? 32 : DMA_LENGTH_WIDTH;
+  localparam MEASURED_LENGTH_WIDTH = DMA_2D_TRANSFER ? 32 : DMA_LENGTH_WIDTH;
   localparam HAS_ADDR_HIGH = DMA_AXI_ADDR_WIDTH > 32;
   localparam ADDR_LOW_MSB = HAS_ADDR_HIGH ? 31 : DMA_AXI_ADDR_WIDTH-1;
   localparam ADDR_HIGH_MSB = HAS_ADDR_HIGH ? DMA_AXI_ADDR_WIDTH-32-1 : 0;
@@ -128,8 +133,8 @@ module axi_dmac_regmap_request #(
 
   always @(posedge clk) begin
     if (reset == 1'b1) begin
-      up_dma_src_address <= 'h00;
       up_dma_dest_address <= 'h00;
+      up_dma_src_address <= 'h00;
       up_dma_x_length[DMA_LENGTH_WIDTH-1:DMA_LENGTH_ALIGN] <= 'h00;
       up_dma_req_valid <= 1'b0;
       up_dma_cyclic <= DMA_CYCLIC ? 1'b1 : 1'b0;
@@ -186,8 +191,11 @@ module axi_dmac_regmap_request #(
     9'h112: up_rdata <= up_measured_transfer_length;
     9'h113: up_rdata <= up_tlf_data[MEASURED_LENGTH_WIDTH-1 : 0];   // Length
     9'h114: up_rdata <= up_tlf_data[MEASURED_LENGTH_WIDTH+: 2];  // ID
+    9'h115: up_rdata <= response_sg_desc_id;
+    9'h11f: up_rdata <= {request_sg_address[ADDR_LOW_MSB:BYTES_PER_BEAT_WIDTH_SG],{BYTES_PER_BEAT_WIDTH_SG{1'b0}}};
     9'h124: up_rdata <= (HAS_ADDR_HIGH && HAS_DEST_ADDR) ? up_dma_dest_address[DMA_AXI_ADDR_WIDTH-1:32] : 32'h00;
     9'h125: up_rdata <= (HAS_ADDR_HIGH && HAS_SRC_ADDR) ? up_dma_src_address[DMA_AXI_ADDR_WIDTH-1:32] : 32'h00;
+    9'h12f: up_rdata <= HAS_ADDR_HIGH ? request_sg_address[DMA_AXI_ADDR_WIDTH-1:32] : 32'h00;
     default: up_rdata <= 32'h00;
     endcase
   end
@@ -221,9 +229,32 @@ module axi_dmac_regmap_request #(
   end
   endgenerate
 
+  generate
+  if (DMA_SG_TRANSFER == 1) begin
+    reg [DMA_AXI_ADDR_WIDTH-1:BYTES_PER_BEAT_WIDTH_SG]  up_dma_sg_address = 'h00;
+
+    always @(posedge clk) begin
+      if (reset == 1'b1) begin
+        up_dma_sg_address <= 'h00;
+      end else if (up_wreq == 1'b1) begin
+        case (up_waddr)
+        9'h11f: up_dma_sg_address[ADDR_LOW_MSB:BYTES_PER_BEAT_WIDTH_SG] <= up_wdata[ADDR_LOW_MSB:BYTES_PER_BEAT_WIDTH_SG];
+        9'h12f:
+          if (HAS_ADDR_HIGH) begin
+            up_dma_sg_address[DMA_AXI_ADDR_WIDTH-1:32] <= up_wdata[ADDR_HIGH_MSB:0];
+          end
+        endcase
+      end
+    end
+    assign request_sg_address = up_dma_sg_address;
+  end else begin
+    assign request_sg_address = 'h00;
+  end
+  endgenerate
+
   // In cyclic mode the same transfer is submitted over and over again
-  assign up_sot = up_dma_cyclic ? 1'b0 : up_dma_req_valid & up_dma_req_ready;
-  assign up_eot = up_dma_cyclic ? 1'b0 : response_eot & response_valid & response_ready;
+  assign up_sot = (up_dma_cyclic && !ctrl_hwdesc) ? 1'b0 : up_dma_req_valid & up_dma_req_ready;
+  assign up_eot = (up_dma_cyclic && !ctrl_hwdesc) ? 1'b0 : response_eot & response_valid & response_ready;
 
   assign request_valid = up_dma_req_valid;
   assign up_dma_req_ready = request_ready;

--- a/library/axi_dmac/axi_dmac_response_manager.v
+++ b/library/axi_dmac/axi_dmac_response_manager.v
@@ -155,7 +155,7 @@ module axi_dmac_response_manager #(
     end
   end
 
-  assign response_eot = (state == STATE_WRITE_RESPR) ? req_eot : 1'b1;
+  assign response_eot = (state == STATE_WRITE_RESPR) ? req_eot : 1'b0;
   assign response_partial = (state == STATE_WRITE_RESPR) ? req_response_partial : 1'b0;
 
   always @(posedge req_clk)

--- a/library/axi_dmac/axi_dmac_transfer.v
+++ b/library/axi_dmac/axi_dmac_transfer.v
@@ -38,17 +38,21 @@
 module axi_dmac_transfer #(
   parameter DMA_DATA_WIDTH_SRC = 64,
   parameter DMA_DATA_WIDTH_DEST = 64,
+  parameter DMA_DATA_WIDTH_SG = 64,
   parameter DMA_LENGTH_WIDTH = 24,
   parameter DMA_LENGTH_ALIGN = 3,
   parameter BYTES_PER_BEAT_WIDTH_DEST = $clog2(DMA_DATA_WIDTH_DEST/8),
   parameter BYTES_PER_BEAT_WIDTH_SRC = $clog2(DMA_DATA_WIDTH_SRC/8),
+  parameter BYTES_PER_BEAT_WIDTH_SG = $clog2(DMA_DATA_WIDTH_SG/8),
   parameter DMA_TYPE_DEST = 0,
   parameter DMA_TYPE_SRC = 2,
   parameter DMA_AXI_ADDR_WIDTH = 32,
-  parameter DMA_2D_TRANSFER = 1,
+  parameter DMA_2D_TRANSFER = 0,
+  parameter DMA_SG_TRANSFER = 0,
   parameter ASYNC_CLK_REQ_SRC = 1,
   parameter ASYNC_CLK_SRC_DEST = 1,
   parameter ASYNC_CLK_DEST_REQ = 1,
+  parameter ASYNC_CLK_REQ_SG = 1,
   parameter AXI_SLICE_DEST = 0,
   parameter AXI_SLICE_SRC = 0,
   parameter MAX_BYTES_PER_BURST = 128,
@@ -57,6 +61,7 @@ module axi_dmac_transfer #(
   parameter ID_WIDTH = $clog2(FIFO_SIZE*2),
   parameter AXI_LENGTH_WIDTH_SRC = 8,
   parameter AXI_LENGTH_WIDTH_DEST = 8,
+  parameter AXI_LENGTH_WIDTH_SG = 8,
   parameter ENABLE_DIAGNOSTICS_IF = 0,
   parameter ALLOW_ASYM_MEM = 0,
   parameter CACHE_COHERENT_DEST = 0
@@ -66,12 +71,14 @@ module axi_dmac_transfer #(
 
   input ctrl_enable,
   input ctrl_pause,
+  input ctrl_hwdesc,
 
   input req_valid,
   output req_ready,
 
   input [DMA_AXI_ADDR_WIDTH-1:BYTES_PER_BEAT_WIDTH_DEST] req_dest_address,
   input [DMA_AXI_ADDR_WIDTH-1:BYTES_PER_BEAT_WIDTH_SRC] req_src_address,
+  input [DMA_AXI_ADDR_WIDTH-1:BYTES_PER_BEAT_WIDTH_SG] req_sg_address,
   input [DMA_LENGTH_WIDTH-1:0] req_x_length,
   input [DMA_LENGTH_WIDTH-1:0] req_y_length,
   input [DMA_LENGTH_WIDTH-1:0] req_dest_stride,
@@ -80,6 +87,7 @@ module axi_dmac_transfer #(
   input req_last,
 
   output req_eot,
+  output [31:0] req_sg_desc_id,
   output [BYTES_PER_BURST_WIDTH-1:0] req_measured_burst_length,
   output req_response_partial,
   output req_response_valid,
@@ -90,6 +98,8 @@ module axi_dmac_transfer #(
   input m_dest_axi_aresetn,
   input m_src_axi_aclk,
   input m_src_axi_aresetn,
+  input m_sg_axi_aclk,
+  input m_sg_axi_aresetn,
 
   // Write address
   output [DMA_AXI_ADDR_WIDTH-1:0] m_axi_awaddr,
@@ -129,6 +139,23 @@ module axi_dmac_transfer #(
   output m_axi_rready,
   input m_axi_rvalid,
   input [1:0] m_axi_rresp,
+
+  // Read address
+  input m_sg_axi_arready,
+  output m_sg_axi_arvalid,
+  output [DMA_AXI_ADDR_WIDTH-1:0] m_sg_axi_araddr,
+  output [AXI_LENGTH_WIDTH_SG-1:0] m_sg_axi_arlen,
+  output [2:0] m_sg_axi_arsize,
+  output [1:0] m_sg_axi_arburst,
+  output [2:0] m_sg_axi_arprot,
+  output [3:0] m_sg_axi_arcache,
+
+  // Read data and response
+  input [DMA_DATA_WIDTH_SG-1:0] m_sg_axi_rdata,
+  input m_sg_axi_rlast,
+  output m_sg_axi_rready,
+  input m_sg_axi_rvalid,
+  input [1:0] m_sg_axi_rresp,
 
   // Slave streaming AXI interface
   input s_axis_aclk,
@@ -190,6 +217,19 @@ module axi_dmac_transfer #(
   wire dma_req_sync_transfer_start;
   wire dma_req_last;
 
+  wire [DMA_AXI_ADDR_WIDTH-1:BYTES_PER_BEAT_WIDTH_DEST] dma_sg_out_dest_address;
+  wire [DMA_AXI_ADDR_WIDTH-1:BYTES_PER_BEAT_WIDTH_SRC] dma_sg_out_src_address;
+  wire [DMA_LENGTH_WIDTH-1:0] dma_sg_x_length;
+  wire [DMA_LENGTH_WIDTH-1:0] dma_sg_y_length;
+  wire [DMA_LENGTH_WIDTH-1:0] dma_sg_src_stride;
+  wire [DMA_LENGTH_WIDTH-1:0] dma_sg_dst_stride;
+  wire [31:0] dma_sg_hwdesc_id;
+  wire dma_sg_hwdesc_eot;
+  wire dma_sg_in_req_valid;
+  wire dma_sg_in_req_ready;
+  wire dma_sg_out_req_valid;
+  wire dma_sg_out_req_ready;
+
   wire req_clk = ctrl_clk;
   wire req_resetn;
 
@@ -207,21 +247,31 @@ module axi_dmac_transfer #(
   wire src_enable;
   wire src_enabled;
 
+  wire sg_clk;
+  wire sg_ext_resetn;
+  wire sg_resetn;
+  wire sg_enable;
+  wire sg_enabled;
+
   wire req_valid_gated;
   wire req_ready_gated;
 
   wire abort_req;
+  wire dma_eot;
 
   axi_dmac_reset_manager #(
     .ASYNC_CLK_REQ_SRC (ASYNC_CLK_REQ_SRC),
     .ASYNC_CLK_SRC_DEST (ASYNC_CLK_SRC_DEST),
-    .ASYNC_CLK_DEST_REQ (ASYNC_CLK_DEST_REQ)
+    .ASYNC_CLK_DEST_REQ (ASYNC_CLK_DEST_REQ),
+    .ASYNC_CLK_REQ_SG (ASYNC_CLK_REQ_SG),
+    .DMA_SG_TRANSFER (DMA_SG_TRANSFER)
   ) i_reset_manager (
     .clk (ctrl_clk),
     .resetn (ctrl_resetn),
 
     .ctrl_enable (ctrl_enable),
     .ctrl_pause (ctrl_pause),
+    .ctrl_hwdesc (ctrl_hwdesc),
 
     .req_resetn (req_resetn),
     .req_enable (req_enable),
@@ -239,6 +289,12 @@ module axi_dmac_transfer #(
     .src_enable (src_enable),
     .src_enabled (src_enabled),
 
+    .sg_clk (sg_clk),
+    .sg_ext_resetn (sg_ext_resetn),
+    .sg_resetn (sg_resetn),
+    .sg_enable (sg_enable),
+    .sg_enabled (sg_enabled),
+
     .dbg_status (dbg_status));
 
   /*
@@ -250,7 +306,113 @@ module axi_dmac_transfer #(
   assign req_valid_gated = req_enable & req_valid;
   assign req_ready = req_enable & req_ready_gated;
 
+  assign req_eot = ctrl_hwdesc ? (dma_eot & dma_sg_hwdesc_eot) : dma_eot;
+  assign req_sg_desc_id = ctrl_hwdesc ? dma_sg_hwdesc_id : 'h00;
+  assign dma_sg_in_req_valid = ctrl_hwdesc ? req_valid_gated : 1'b0;
+
+  /* SG Interface */
+  generate if (DMA_SG_TRANSFER == 1) begin
+
+  dmac_sg #(
+    .DMA_AXI_ADDR_WIDTH(DMA_AXI_ADDR_WIDTH),
+    .DMA_DATA_WIDTH(DMA_DATA_WIDTH_SG),
+    .DMA_LENGTH_WIDTH(DMA_LENGTH_WIDTH),
+    .AXI_LENGTH_WIDTH(AXI_LENGTH_WIDTH_SG),
+    .BYTES_PER_BEAT_WIDTH_DEST(BYTES_PER_BEAT_WIDTH_DEST),
+    .BYTES_PER_BEAT_WIDTH_SRC(BYTES_PER_BEAT_WIDTH_SRC),
+    .BYTES_PER_BEAT_WIDTH_SG(BYTES_PER_BEAT_WIDTH_SG),
+    .ASYNC_CLK_REQ_SG(ASYNC_CLK_REQ_SG)
+  ) i_dmac_sg (
+    .req_clk(req_clk),
+    .req_resetn(req_resetn),
+    .req_enable(req_enable),
+
+    .sg_clk(sg_clk),
+    .sg_ext_resetn(sg_ext_resetn),
+    .sg_resetn(sg_resetn),
+    .sg_enable(sg_enable),
+    .sg_enabled(sg_enabled),
+
+    .req_in_valid(dma_sg_in_req_valid),
+    .req_in_ready(dma_sg_in_req_ready),
+
+    .req_out_valid(dma_sg_out_req_valid),
+    .req_out_ready(dma_sg_out_req_ready),
+
+    .req_desc_address(req_sg_address),
+
+    .out_dest_address(dma_sg_out_dest_address),
+    .out_src_address(dma_sg_out_src_address),
+
+    .out_x_length(dma_sg_x_length),
+    .out_y_length(dma_sg_y_length),
+    .out_dest_stride(dma_sg_dst_stride),
+    .out_src_stride(dma_sg_src_stride),
+    .resp_out_id(dma_sg_hwdesc_id),
+    .resp_out_eot(dma_sg_hwdesc_eot),
+    .resp_in_valid(dma_eot),
+
+    .m_axi_aclk(m_sg_axi_aclk),
+    .m_axi_aresetn(m_sg_axi_aresetn),
+
+    .m_axi_arready(m_sg_axi_arready),
+    .m_axi_arvalid(m_sg_axi_arvalid),
+    .m_axi_araddr(m_sg_axi_araddr),
+    .m_axi_arlen(m_sg_axi_arlen),
+    .m_axi_arsize(m_sg_axi_arsize),
+    .m_axi_arburst(m_sg_axi_arburst),
+    .m_axi_arprot(m_sg_axi_arprot),
+    .m_axi_arcache(m_sg_axi_arcache),
+
+    .m_axi_rdata(m_sg_axi_rdata),
+    .m_axi_rlast(m_sg_axi_rlast),
+    .m_axi_rready(m_sg_axi_rready),
+    .m_axi_rvalid(m_sg_axi_rvalid),
+    .m_axi_rresp(m_sg_axi_rresp));
+
+  end else begin
+
+  assign sg_clk = 1'b0;
+  assign sg_ext_resetn = 1'b0;
+  assign sg_enabled = 1'b0;
+  assign dma_sg_in_req_ready = 1'b0;
+  assign dma_sg_out_req_valid = 1'b0;
+  assign dma_sg_hwdesc_eot = 1'b0;
+  assign dma_sg_out_dest_address = 'h00;
+  assign dma_sg_out_src_address = 'h00;
+  assign dma_sg_x_length = 'h00;
+  assign dma_sg_y_length = 'h00;
+  assign dma_sg_dst_stride = 'h00;
+  assign dma_sg_src_stride = 'h00;
+  assign dma_sg_hwdesc_id = 'h00;
+
+  end endgenerate
+
+  /* 2D Interface */
   generate if (DMA_2D_TRANSFER == 1) begin
+
+  wire [DMA_AXI_ADDR_WIDTH-1:BYTES_PER_BEAT_WIDTH_DEST] dma_2d_dest_address;
+  wire [DMA_AXI_ADDR_WIDTH-1:BYTES_PER_BEAT_WIDTH_SRC] dma_2d_src_address;
+  wire [DMA_LENGTH_WIDTH-1:0] dma_2d_x_length;
+  wire [DMA_LENGTH_WIDTH-1:0] dma_2d_y_length;
+  wire [DMA_LENGTH_WIDTH-1:0] dma_2d_src_stride;
+  wire [DMA_LENGTH_WIDTH-1:0] dma_2d_dst_stride;
+  wire dma_2d_eot;
+
+  wire dma_2d_req_valid;
+  wire dma_2d_req_ready;
+
+  assign dma_2d_dest_address = ctrl_hwdesc ? dma_sg_out_dest_address : req_dest_address;
+  assign dma_2d_src_address = ctrl_hwdesc ? dma_sg_out_src_address : req_src_address;
+  assign dma_2d_x_length = ctrl_hwdesc ? dma_sg_x_length : req_x_length;
+  assign dma_2d_y_length = ctrl_hwdesc ? dma_sg_y_length : req_y_length;
+  assign dma_2d_src_stride = ctrl_hwdesc ? dma_sg_src_stride : req_src_stride;
+  assign dma_2d_dst_stride = ctrl_hwdesc ? dma_sg_dst_stride : req_dest_stride;
+
+  assign dma_2d_req_valid = ctrl_hwdesc ? dma_sg_out_req_valid : req_valid_gated;
+  assign req_ready_gated = ctrl_hwdesc ? dma_sg_in_req_ready : dma_2d_req_ready;
+  assign dma_eot = dma_2d_eot;
+  assign dma_sg_out_req_ready = dma_2d_req_ready;
 
   dmac_2d_transfer #(
     .DMA_AXI_ADDR_WIDTH(DMA_AXI_ADDR_WIDTH),
@@ -262,20 +424,20 @@ module axi_dmac_transfer #(
     .req_aclk (req_clk),
     .req_aresetn (req_resetn),
 
-    .req_eot (req_eot),
+    .req_eot (dma_2d_eot),
     .req_measured_burst_length (req_measured_burst_length),
     .req_response_partial (req_response_partial),
     .req_response_valid (req_response_valid),
     .req_response_ready (req_response_ready),
 
-    .req_valid (req_valid_gated),
-    .req_ready (req_ready_gated),
-    .req_dest_address (req_dest_address),
-    .req_src_address (req_src_address),
-    .req_x_length (req_x_length),
-    .req_y_length (req_y_length),
-    .req_dest_stride (req_dest_stride),
-    .req_src_stride (req_src_stride),
+    .req_valid (dma_2d_req_valid),
+    .req_ready (dma_2d_req_ready),
+    .req_dest_address (dma_2d_dest_address),
+    .req_src_address (dma_2d_src_address),
+    .req_x_length (dma_2d_x_length),
+    .req_y_length (dma_2d_y_length),
+    .req_dest_stride (dma_2d_dst_stride),
+    .req_src_stride (dma_2d_src_stride),
     .req_sync_transfer_start (req_sync_transfer_start),
     .req_last (req_last),
 
@@ -296,17 +458,18 @@ module axi_dmac_transfer #(
   end else begin
 
   /* Request */
-  assign dma_req_valid = req_valid_gated;
-  assign req_ready_gated = dma_req_ready;
+  assign dma_req_valid = ctrl_hwdesc ? dma_sg_out_req_valid : req_valid_gated;
+  assign req_ready_gated = ctrl_hwdesc ? dma_sg_in_req_ready : dma_req_ready;
+  assign dma_eot = dma_req_eot;
+  assign dma_sg_out_req_ready = dma_req_ready;
 
-  assign dma_req_dest_address = req_dest_address;
-  assign dma_req_src_address = req_src_address;
-  assign dma_req_length = req_x_length;
+  assign dma_req_dest_address = ctrl_hwdesc ? dma_sg_out_dest_address : req_dest_address;
+  assign dma_req_src_address = ctrl_hwdesc ? dma_sg_out_src_address : req_src_address;
+  assign dma_req_length = ctrl_hwdesc ? dma_sg_x_length : req_x_length;
   assign dma_req_sync_transfer_start = req_sync_transfer_start;
   assign dma_req_last = req_last;
 
   /* Response */
-  assign req_eot = dma_req_eot;
   assign req_measured_burst_length = dma_req_measured_burst_length;
   assign req_response_partial = dma_response_partial;
   assign req_response_valid = dma_response_valid;

--- a/library/axi_dmac/dmac_sg.v
+++ b/library/axi_dmac/dmac_sg.v
@@ -1,0 +1,336 @@
+// ***************************************************************************
+// ***************************************************************************
+// Copyright (C) 2023 Analog Devices, Inc. All rights reserved.
+//
+// In this HDL repository, there are many different and unique modules, consisting
+// of various HDL (Verilog or VHDL) components. The individual modules are
+// developed independently, and may be accompanied by separate and unique license
+// terms.
+//
+// The user should read each of these license terms, and understand the
+// freedoms and responsibilities that he or she has by using this source/core.
+//
+// This core is distributed in the hope that it will be useful, but WITHOUT ANY
+// WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+// A PARTICULAR PURPOSE.
+//
+// Redistribution and use of source or resulting binaries, with or without modification
+// of this file, are permitted under one of the following two license terms:
+//
+//   1. The GNU General Public License version 2 as published by the
+//      Free Software Foundation, which can be found in the top level directory
+//      of this repository (LICENSE_GPL2), and also online at:
+//      <https://www.gnu.org/licenses/old-licenses/gpl-2.0.html>
+//
+// OR
+//
+//   2. An ADI specific BSD license, which can be found in the top level directory
+//      of this repository (LICENSE_ADIBSD), and also on-line at:
+//      https://github.com/analogdevicesinc/hdl/blob/master/LICENSE_ADIBSD
+//      This will allow to generate bit files and not release the source code,
+//      as long as it attaches to an ADI device.
+//
+// ***************************************************************************
+// ***************************************************************************
+
+`timescale 1ns/100ps
+
+module dmac_sg #(
+  parameter DMA_AXI_ADDR_WIDTH = 32,
+  parameter DMA_DATA_WIDTH = 64,
+  parameter DMA_LENGTH_WIDTH = 24,
+  parameter AXI_LENGTH_WIDTH = 8,
+  parameter BYTES_PER_BEAT_WIDTH_DEST = 3,
+  parameter BYTES_PER_BEAT_WIDTH_SRC = 3,
+  parameter BYTES_PER_BEAT_WIDTH_SG = 3,
+  parameter ASYNC_CLK_REQ_SG = 1
+) (
+  input req_clk,
+  input req_resetn,
+  input req_enable,
+
+  output sg_clk,
+  input sg_resetn,
+  output sg_ext_resetn,
+  input sg_enable,
+  output sg_enabled,
+
+  input req_in_valid,
+  output req_in_ready,
+
+  output req_out_valid,
+  input req_out_ready,
+
+  output resp_out_eot,
+  input resp_in_valid,
+
+  input [DMA_AXI_ADDR_WIDTH-1:BYTES_PER_BEAT_WIDTH_SG] req_desc_address,
+
+  output [DMA_AXI_ADDR_WIDTH-1:BYTES_PER_BEAT_WIDTH_DEST] out_dest_address,
+  output [DMA_AXI_ADDR_WIDTH-1:BYTES_PER_BEAT_WIDTH_SRC] out_src_address,
+  output [DMA_LENGTH_WIDTH-1:0] out_x_length,
+  output [DMA_LENGTH_WIDTH-1:0] out_y_length,
+  output [DMA_LENGTH_WIDTH-1:0] out_dest_stride,
+  output [DMA_LENGTH_WIDTH-1:0] out_src_stride,
+  output [31:0] resp_out_id,
+
+  // Master AXI interface
+  input                            m_axi_aclk,
+  input                            m_axi_aresetn,
+
+  // Read address
+  input                            m_axi_arready,
+  output                           m_axi_arvalid,
+  output [DMA_AXI_ADDR_WIDTH-1:0]  m_axi_araddr,
+  output [AXI_LENGTH_WIDTH-1:0]    m_axi_arlen,
+  output [ 2:0]                    m_axi_arsize,
+  output [ 1:0]                    m_axi_arburst,
+  output [ 2:0]                    m_axi_arprot,
+  output [ 3:0]                    m_axi_arcache,
+
+  // Read data and response
+  input  [DMA_DATA_WIDTH-1:0]      m_axi_rdata,
+  input                            m_axi_rlast,
+  output                           m_axi_rready,
+  input                            m_axi_rvalid,
+  input  [ 1:0]                    m_axi_rresp
+);
+
+  localparam STATE_IDLE = 0;
+  localparam STATE_SEND_ADDR = 1;
+  localparam STATE_RECV_DESC = 2;
+  localparam STATE_DESC_READY = 3;
+
+  localparam MASK_LAST_HWDESC = 1 << 0;
+  localparam MASK_EOT_IRQ = 1 << 1;
+
+  localparam DMA_ADDRESS_WIDTH_DEST = DMA_AXI_ADDR_WIDTH - BYTES_PER_BEAT_WIDTH_DEST;
+  localparam DMA_ADDRESS_WIDTH_SRC = DMA_AXI_ADDR_WIDTH - BYTES_PER_BEAT_WIDTH_SRC;
+  localparam DMA_ADDRESS_WIDTH_SG = DMA_AXI_ADDR_WIDTH - BYTES_PER_BEAT_WIDTH_SG;
+  localparam DMA_DESCRIPTOR_WIDTH = DMA_ADDRESS_WIDTH_DEST + DMA_ADDRESS_WIDTH_SRC + 4*DMA_LENGTH_WIDTH;
+
+  wire [DMA_AXI_ADDR_WIDTH-1:BYTES_PER_BEAT_WIDTH_SG] first_desc_address;
+  reg [DMA_AXI_ADDR_WIDTH-1:BYTES_PER_BEAT_WIDTH_DEST] dest_addr;
+  reg [DMA_AXI_ADDR_WIDTH-1:BYTES_PER_BEAT_WIDTH_SRC] src_addr;
+  reg [DMA_AXI_ADDR_WIDTH-1:BYTES_PER_BEAT_WIDTH_SG] next_desc_addr;
+  reg [DMA_LENGTH_WIDTH-1:0] x_length;
+  reg [DMA_LENGTH_WIDTH-1:0] y_length;
+  reg [DMA_LENGTH_WIDTH-1:0] dest_stride;
+  reg [DMA_LENGTH_WIDTH-1:0] src_stride;
+
+  reg [1:0] hwdesc_state;
+  reg [2:0] hwdesc_counter;
+  reg [1:0] hwdesc_flags;
+  reg [31:0] hwdesc_id;
+
+  wire sg_in_valid;
+  wire sg_in_ready;
+  wire sg_out_valid;
+  wire sg_out_ready;
+  wire fetch_valid;
+  wire fetch_ready;
+  wire fifo_in_valid;
+  wire fifo_in_ready;
+  wire fifo_out_valid;
+  wire fifo_out_ready;
+  wire [32:0] fifo_in_data;
+  wire [32:0] fifo_out_data;
+
+  assign sg_clk = m_axi_aclk;
+  assign sg_ext_resetn = m_axi_aresetn;
+  assign sg_enabled = sg_enable | ~sg_in_ready;
+
+  assign sg_in_ready = hwdesc_state == STATE_IDLE;
+  assign fetch_valid = hwdesc_state == STATE_DESC_READY;
+  assign m_axi_arvalid = hwdesc_state == STATE_SEND_ADDR;
+  assign m_axi_rready = hwdesc_state == STATE_RECV_DESC;
+
+  assign m_axi_arsize  = 3'h3;
+  assign m_axi_arburst = 2'h1;
+  assign m_axi_arprot  = 3'h0;
+  assign m_axi_arcache = 4'h3;
+  assign m_axi_arlen   = 'h5;
+  assign m_axi_araddr  = {next_desc_addr, {BYTES_PER_BEAT_WIDTH_SG{1'b0}}};
+
+  util_axis_fifo #(
+    .DATA_WIDTH(DMA_ADDRESS_WIDTH_SG),
+    .ADDRESS_WIDTH(0),
+    .ASYNC_CLK(ASYNC_CLK_REQ_SG)
+  ) i_sg_addr_fifo (
+    .s_axis_aclk(req_clk),
+    .s_axis_aresetn(req_resetn),
+    .s_axis_valid(req_in_valid),
+    .s_axis_ready(req_in_ready),
+    .s_axis_full(),
+    .s_axis_data(req_desc_address),
+    .s_axis_room(),
+
+    .m_axis_aclk(sg_clk),
+    .m_axis_aresetn(sg_resetn),
+    .m_axis_valid(sg_in_valid),
+    .m_axis_ready(sg_in_ready),
+    .m_axis_data(first_desc_address),
+    .m_axis_level(),
+    .m_axis_empty());
+
+  always @(posedge sg_clk) begin
+    if (sg_resetn == 1'b0) begin
+      hwdesc_counter <= 'h0;
+    end else if (m_axi_rvalid) begin
+      hwdesc_counter <= hwdesc_counter + 1'b1;
+    end else if (hwdesc_state == STATE_DESC_READY) begin
+      hwdesc_counter <= 'h0;
+    end
+  end
+
+  // Read the descriptor data
+  always @(posedge sg_clk) begin
+    if (sg_resetn == 1'b0) begin
+      hwdesc_flags <= 'h00;
+      hwdesc_id <= 'h00;
+      dest_addr <= 'h00;
+      src_addr <= 'h00;
+      next_desc_addr <= 'h00;
+      y_length <= 'h00;
+      x_length <= 'h00;
+      src_stride <= 'h00;
+      dest_stride <= 'h00;
+    end else begin
+      if (sg_in_valid && sg_in_ready) begin
+        next_desc_addr <= first_desc_address;
+      end
+      if (m_axi_rvalid) begin
+        case (hwdesc_counter)
+        0: begin
+          hwdesc_id <= m_axi_rdata[63:32];
+          hwdesc_flags <= m_axi_rdata[1:0];
+          end
+        1: dest_addr <= m_axi_rdata[DMA_AXI_ADDR_WIDTH-1:BYTES_PER_BEAT_WIDTH_DEST];
+        2: src_addr <= m_axi_rdata[DMA_AXI_ADDR_WIDTH-1:BYTES_PER_BEAT_WIDTH_SRC];
+        3: next_desc_addr <= m_axi_rdata[DMA_AXI_ADDR_WIDTH-1:BYTES_PER_BEAT_WIDTH_SG];
+        4: begin
+          x_length <= m_axi_rdata[63:32];
+          y_length <= m_axi_rdata[31:0];
+          end
+        5: begin
+          dest_stride <= m_axi_rdata[63:32];
+          src_stride <= m_axi_rdata[31:0];
+          end
+        endcase
+      end
+    end
+  end
+
+  // Descriptor FSM
+  always @(posedge sg_clk) begin
+    if (sg_resetn == 1'b0) begin
+      hwdesc_state <= STATE_IDLE;
+    end else begin
+      case (hwdesc_state)
+        STATE_IDLE: begin
+          if (sg_in_valid == 1'b1 && sg_enable == 1'b1) begin
+            hwdesc_state <= STATE_SEND_ADDR;
+          end
+          end
+
+        STATE_SEND_ADDR: begin
+          if (m_axi_arready) begin
+            hwdesc_state <= STATE_RECV_DESC;
+          end
+          end
+
+        STATE_RECV_DESC: begin
+          if (m_axi_rvalid == 1'b1 && m_axi_rlast == 1'b1) begin
+            hwdesc_state <= STATE_DESC_READY;
+          end
+          end
+
+        STATE_DESC_READY: begin
+          if (sg_enable == 1'b0) begin
+              hwdesc_state <= STATE_IDLE;
+          end else if (fetch_ready == 1'b1) begin
+            if (hwdesc_flags & MASK_LAST_HWDESC) begin
+              hwdesc_state <= STATE_IDLE;
+            end else begin
+              hwdesc_state <= STATE_SEND_ADDR;
+            end
+          end
+          end
+      endcase
+    end
+  end
+
+  util_axis_fifo #(
+    .DATA_WIDTH(DMA_DESCRIPTOR_WIDTH),
+    .ADDRESS_WIDTH(0),
+    .ASYNC_CLK(ASYNC_CLK_REQ_SG)
+  ) i_sg_desc_fifo (
+    .s_axis_aclk(sg_clk),
+    .s_axis_aresetn(sg_resetn),
+    .s_axis_valid(sg_out_valid),
+    .s_axis_ready(sg_out_ready),
+    .s_axis_full(),
+    .s_axis_data({
+      dest_addr,
+      src_addr,
+      x_length,
+      y_length,
+      dest_stride,
+      src_stride}),
+    .s_axis_room(),
+
+    .m_axis_aclk(req_clk),
+    .m_axis_aresetn(req_resetn),
+    .m_axis_valid(req_out_valid),
+    .m_axis_ready(req_out_ready),
+    .m_axis_data({
+      out_dest_address,
+      out_src_address,
+      out_x_length,
+      out_y_length,
+      out_dest_stride,
+      out_src_stride}),
+    .m_axis_level(),
+    .m_axis_empty());
+
+  splitter #(
+    .NUM_M(2)
+  ) i_req_splitter (
+    .clk(sg_clk),
+    .resetn(sg_resetn),
+    .s_valid(fetch_valid),
+    .s_ready(fetch_ready),
+    .m_valid({
+      sg_out_valid,
+      fifo_in_valid}),
+    .m_ready({
+      sg_out_ready,
+      fifo_in_ready}));
+
+  assign fifo_in_data = {hwdesc_flags & MASK_EOT_IRQ ? 1'b1 : 1'b0, hwdesc_id};
+  assign fifo_out_ready = resp_in_valid;
+  assign resp_out_eot = fifo_out_data[32];
+  assign resp_out_id = fifo_out_data[31:0];
+
+  // Save the descriptor IDs and the eot descriptor flag in an async fifo
+  // Extract them one by one when the destination responds with an eot
+  util_axis_fifo #(
+    .DATA_WIDTH(33),
+    .ADDRESS_WIDTH(2),
+    .ASYNC_CLK(ASYNC_CLK_REQ_SG)
+  ) i_fifo (
+    .s_axis_aclk(sg_clk),
+    .s_axis_aresetn(sg_resetn),
+
+    .s_axis_valid(fifo_in_valid),
+    .s_axis_ready(fifo_in_ready),
+    .s_axis_data(fifo_in_data),
+
+    .m_axis_aclk(req_clk),
+    .m_axis_aresetn(req_resetn),
+
+    .m_axis_valid(fifo_out_valid),
+    .m_axis_ready(fifo_out_ready),
+    .m_axis_data(fifo_out_data));
+
+endmodule

--- a/library/axi_dmac/request_arb.v
+++ b/library/axi_dmac/request_arb.v
@@ -208,9 +208,6 @@ module request_arb #(
   wire [ID_WIDTH-1:0] source_id;
   wire [ID_WIDTH-1:0] response_id;
 
-  wire enabled_src;
-  wire enabled_dest;
-
   wire req_gen_valid;
   wire req_gen_ready;
   wire src_dest_valid;

--- a/library/util_hbm/util_hbm.v
+++ b/library/util_hbm/util_hbm.v
@@ -308,11 +308,13 @@ module util_hbm #(
        // Control interface
       .ctrl_enable(wr_request_enable),
       .ctrl_pause(1'b0),
+      .ctrl_hwdesc(1'b0),
 
       .req_valid(wr_request_valid),
       .req_ready(wr_request_ready_loc[i]),
       .req_dest_address(ADDR_OFFSET[AXI_ADDR_WIDTH-1:AXI_BYTES_PER_BEAT_WIDTH]),
       .req_src_address('h0),
+      .req_sg_address('h0),
       .req_x_length(wr_request_length >> NUM_M_LOG2),
       .req_y_length(0),
       .req_dest_stride(0),
@@ -321,6 +323,7 @@ module util_hbm #(
       .req_last(1'b1),
 
       .req_eot(wr_request_eot_loc[i]),
+      .req_sg_desc_id(),
       .req_measured_burst_length(wr_measured_burst_length[BYTES_PER_BURST_WIDTH*i+:BYTES_PER_BURST_WIDTH]),
       .req_response_partial(),
       .req_response_valid(wr_response_valid_loc[i]),
@@ -330,6 +333,8 @@ module util_hbm #(
       .m_dest_axi_aresetn(m_axi_aresetn),
       .m_src_axi_aclk(1'b0),
       .m_src_axi_aresetn(1'b0),
+      .m_sg_axi_aclk(1'b0),
+      .m_sg_axi_aresetn(1'b0),
 
       .m_axi_awaddr(m_axi_awaddr[AXI_ADDR_WIDTH*i+:AXI_ADDR_WIDTH]),
       .m_axi_awlen(m_axi_awlen[AXI_ALEN*i+:AXI_ALEN]),
@@ -350,7 +355,7 @@ module util_hbm #(
       .m_axi_bresp(m_axi_bresp[2*i+:2]),
       .m_axi_bready(m_axi_bready[i]),
 
-      .m_axi_arready(),
+      .m_axi_arready(1'b0),
       .m_axi_arvalid(),
       .m_axi_araddr(),
       .m_axi_arlen(),
@@ -359,11 +364,26 @@ module util_hbm #(
       .m_axi_arprot(),
       .m_axi_arcache(),
 
-      .m_axi_rdata(),
+      .m_axi_rdata('h0),
+      .m_axi_rlast(1'b0),
       .m_axi_rready(),
-      .m_axi_rvalid(),
-      .m_axi_rlast(),
-      .m_axi_rresp(),
+      .m_axi_rvalid(1'b0),
+      .m_axi_rresp(2'b00),
+
+      .m_sg_axi_arready(1'b0),
+      .m_sg_axi_arvalid(),
+      .m_sg_axi_araddr(),
+      .m_sg_axi_arlen(),
+      .m_sg_axi_arsize(),
+      .m_sg_axi_arburst(),
+      .m_sg_axi_arprot(),
+      .m_sg_axi_arcache(),
+
+      .m_sg_axi_rdata('h0),
+      .m_sg_axi_rlast(1'b0),
+      .m_sg_axi_rready(),
+      .m_sg_axi_rvalid(1'b0),
+      .m_sg_axi_rresp(2'b00),
 
       .s_axis_aclk(s_axis_aclk),
       .s_axis_ready(s_axis_ready_loc[i]),
@@ -458,11 +478,13 @@ module util_hbm #(
        // Control interface
       .ctrl_enable(rd_request_enable),
       .ctrl_pause(1'b0),
+      .ctrl_hwdesc(1'b0),
 
       .req_valid(rd_request_valid),
       .req_ready(rd_request_ready_loc[i]),
       .req_dest_address(0),
       .req_src_address(ADDR_OFFSET[AXI_ADDR_WIDTH-1:AXI_BYTES_PER_BEAT_WIDTH]),
+      .req_sg_address('h0),
       .req_x_length(rd_request_length >> NUM_M_LOG2),
       .req_y_length(0),
       .req_dest_stride(0),
@@ -471,6 +493,7 @@ module util_hbm #(
       .req_last(1'b1),
 
       .req_eot(rd_request_eot_loc[i]),
+      .req_sg_desc_id(),
       .req_measured_burst_length(),
       .req_response_partial(),
       .req_response_valid(rd_response_valid_loc[i]),
@@ -480,6 +503,8 @@ module util_hbm #(
       .m_dest_axi_aresetn(1'b0),
       .m_src_axi_aclk(m_axi_aclk),
       .m_src_axi_aresetn(m_axi_aresetn),
+      .m_sg_axi_aclk(1'b0),
+      .m_sg_axi_aresetn(1'b0),
 
       .m_axi_awaddr(),
       .m_axi_awlen(),
@@ -510,10 +535,25 @@ module util_hbm #(
       .m_axi_arcache(),
 
       .m_axi_rdata(m_axi_rdata[AXI_DATA_WIDTH*i+:AXI_DATA_WIDTH]),
+      .m_axi_rlast(m_axi_rlast[i]),
       .m_axi_rready(m_axi_rready[i]),
       .m_axi_rvalid(m_axi_rvalid[i]),
-      .m_axi_rlast(m_axi_rlast[i]),
       .m_axi_rresp(m_axi_rresp[2*i+:2]),
+
+      .m_sg_axi_arready (1'b0),
+      .m_sg_axi_arvalid (),
+      .m_sg_axi_araddr (),
+      .m_sg_axi_arlen (),
+      .m_sg_axi_arsize (),
+      .m_sg_axi_arburst (),
+      .m_sg_axi_arprot (),
+      .m_sg_axi_arcache (),
+
+      .m_sg_axi_rdata ('h0),
+      .m_sg_axi_rlast (1'b0),
+      .m_sg_axi_rready (),
+      .m_sg_axi_rvalid (1'b0),
+      .m_sg_axi_rresp (2'b00),
 
       .s_axis_aclk(1'b0),
       .s_axis_ready(),

--- a/projects/arradio/common/arradio_qsys.tcl
+++ b/projects/arradio/common/arradio_qsys.tcl
@@ -89,8 +89,10 @@ add_instance axi_adc_dma axi_dmac
 set_instance_parameter_value axi_adc_dma {ID} {0}
 set_instance_parameter_value axi_adc_dma {DMA_DATA_WIDTH_SRC} {64}
 set_instance_parameter_value axi_adc_dma {DMA_DATA_WIDTH_DEST} {128}
+set_instance_parameter_value axi_adc_dma {DMA_DATA_WIDTH_SG} {64}
 set_instance_parameter_value axi_adc_dma {DMA_LENGTH_WIDTH} {24}
 set_instance_parameter_value axi_adc_dma {DMA_2D_TRANSFER} {0}
+set_instance_parameter_value axi_adc_dma {DMA_SG_TRANSFER} {1}
 set_instance_parameter_value axi_adc_dma {AXI_SLICE_DEST} {0}
 set_instance_parameter_value axi_adc_dma {AXI_SLICE_SRC} {0}
 set_instance_parameter_value axi_adc_dma {SYNC_TRANSFER_START} {1}
@@ -102,6 +104,8 @@ add_connection sys_clk.clk axi_adc_dma.s_axi_clock
 add_connection sys_clk.clk_reset axi_adc_dma.s_axi_reset
 add_connection sys_dma_clk.clk axi_adc_dma.m_dest_axi_clock
 add_connection sys_dma_clk.clk_reset axi_adc_dma.m_dest_axi_reset
+add_connection sys_dma_clk.clk axi_adc_dma.m_sg_axi_clock
+add_connection sys_dma_clk.clk_reset axi_adc_dma.m_sg_axi_reset
 add_connection sys_dma_clk.clk axi_adc_dma.if_fifo_wr_clk
 add_connection util_adc_pack.if_packed_fifo_wr_en axi_adc_dma.if_fifo_wr_en
 add_connection util_adc_pack.if_packed_fifo_wr_sync axi_adc_dma.if_fifo_wr_sync
@@ -114,8 +118,10 @@ add_instance axi_dac_dma axi_dmac
 set_instance_parameter_value axi_dac_dma {ID} {0}
 set_instance_parameter_value axi_dac_dma {DMA_DATA_WIDTH_SRC} {64}
 set_instance_parameter_value axi_dac_dma {DMA_DATA_WIDTH_DEST} {64}
+set_instance_parameter_value axi_dac_dma {DMA_DATA_WIDTH_SG} {64}
 set_instance_parameter_value axi_dac_dma {DMA_LENGTH_WIDTH} {24}
 set_instance_parameter_value axi_dac_dma {DMA_2D_TRANSFER} {0}
+set_instance_parameter_value axi_dac_dma {DMA_SG_TRANSFER} {1}
 set_instance_parameter_value axi_dac_dma {AXI_SLICE_DEST} {0}
 set_instance_parameter_value axi_dac_dma {AXI_SLICE_SRC} {0}
 set_instance_parameter_value axi_dac_dma {SYNC_TRANSFER_START} {0}
@@ -127,6 +133,8 @@ add_connection sys_clk.clk axi_dac_dma.s_axi_clock
 add_connection sys_clk.clk_reset axi_dac_dma.s_axi_reset
 add_connection sys_dma_clk.clk axi_dac_dma.m_src_axi_clock
 add_connection sys_dma_clk.clk_reset axi_dac_dma.m_src_axi_reset
+add_connection sys_dma_clk.clk axi_dac_dma.m_sg_axi_clock
+add_connection sys_dma_clk.clk_reset axi_dac_dma.m_sg_axi_reset
 add_connection sys_dma_clk.clk axi_dac_dma.if_m_axis_aclk
 
 add_connection axi_dac_dma.m_axis util_dac_upack.s_axis
@@ -147,4 +155,6 @@ set_instance_parameter_value sys_hps {F2SDRAM_Width} {64 128 64}
 
 ad_dma_interconnect axi_adc_dma.m_dest_axi 1
 ad_dma_interconnect axi_dac_dma.m_src_axi 2
+ad_dma_interconnect axi_adc_dma.m_sg_axi 3
+ad_dma_interconnect axi_dac_dma.m_sg_axi 4
 

--- a/projects/fmcomms2/common/fmcomms2_bd.tcl
+++ b/projects/fmcomms2/common/fmcomms2_bd.tcl
@@ -142,11 +142,14 @@ ad_ip_parameter axi_ad9361_adc_dma CONFIG.SYNC_TRANSFER_START 1
 ad_ip_parameter axi_ad9361_adc_dma CONFIG.AXI_SLICE_SRC 0
 ad_ip_parameter axi_ad9361_adc_dma CONFIG.AXI_SLICE_DEST 0
 ad_ip_parameter axi_ad9361_adc_dma CONFIG.DMA_2D_TRANSFER 0
+ad_ip_parameter axi_ad9361_adc_dma CONFIG.DMA_SG_TRANSFER 1
 ad_ip_parameter axi_ad9361_adc_dma CONFIG.DMA_DATA_WIDTH_SRC 64
+ad_ip_parameter axi_ad9361_adc_dma CONFIG.DMA_DATA_WIDTH_SG 64
 
 ad_connect util_ad9361_divclk/clk_out axi_ad9361_adc_dma/fifo_wr_clk
 ad_connect util_ad9361_adc_pack/packed_fifo_wr axi_ad9361_adc_dma/fifo_wr
 ad_connect $sys_cpu_resetn axi_ad9361_adc_dma/m_dest_axi_aresetn
+ad_connect $sys_cpu_resetn axi_ad9361_adc_dma/m_sg_axi_aresetn
 
 # dac-path rfifo
 
@@ -200,12 +203,15 @@ ad_ip_parameter axi_ad9361_dac_dma CONFIG.CYCLIC 1
 ad_ip_parameter axi_ad9361_dac_dma CONFIG.AXI_SLICE_SRC 0
 ad_ip_parameter axi_ad9361_dac_dma CONFIG.AXI_SLICE_DEST 0
 ad_ip_parameter axi_ad9361_dac_dma CONFIG.DMA_2D_TRANSFER 0
+ad_ip_parameter axi_ad9361_dac_dma CONFIG.DMA_SG_TRANSFER 1
 ad_ip_parameter axi_ad9361_dac_dma CONFIG.DMA_DATA_WIDTH_DEST 64
+ad_ip_parameter axi_ad9361_dac_dma CONFIG.DMA_DATA_WIDTH_SG 64
 
 ad_connect util_ad9361_divclk/clk_out axi_ad9361_dac_dma/m_axis_aclk
 ad_connect axi_ad9361_dac_dma/m_axis util_ad9361_dac_upack/s_axis
 
 ad_connect $sys_cpu_resetn axi_ad9361_dac_dma/m_src_axi_aresetn
+ad_connect $sys_cpu_resetn axi_ad9361_dac_dma/m_sg_axi_aresetn
 
 # interconnects
 
@@ -216,6 +222,9 @@ ad_mem_hp1_interconnect $sys_cpu_clk sys_ps7/S_AXI_HP1
 ad_mem_hp1_interconnect $sys_cpu_clk axi_ad9361_adc_dma/m_dest_axi
 ad_mem_hp2_interconnect $sys_cpu_clk sys_ps7/S_AXI_HP2
 ad_mem_hp2_interconnect $sys_cpu_clk axi_ad9361_dac_dma/m_src_axi
+
+ad_mem_hp2_interconnect $sys_cpu_clk axi_ad9361_dac_dma/m_sg_axi
+ad_mem_hp1_interconnect $sys_cpu_clk axi_ad9361_adc_dma/m_sg_axi
 
 # interrupts
 


### PR DESCRIPTION
This commit introduces a different interface to submit transfers, using DMA descriptors.

The structure of the DMA descriptor is as follows:

struct dma_desc {
    u32 flags,
    u32 id,
    u64 dest_addr,
    u64 src_addr,
    u64 next_sg_addr,
    u32 y_len,
    u32 x_len,
    u32 src_stride,
    u32 dst_stride,
};

The 'flags' field currently offers two control bits:
- bit 0: if set, the transfer will complete after this last descriptor is processed, and the DMA core will go back to idle state; if cleared, the next DMA descriptor pointed to by 'next_sg_addr' will be loaded.
- bit 1: if set, an end-of-transfer interrupt will be raised after the memory segment pointed to by this descriptor has been transferred.

The 'id' field corresponds to an identifier of the descriptor.

The 'dest_addr' and 'src_addr' contain the destination and source addresses to use for the transfer, respectively.

The 'x_len' field contains the number of bytes to transfer, minus one.

The 'y_len', 'src_stride' and 'dst_stride' fields are only useful for 2D transfers, and should be set to zero if 2D transfers are not required.

To start a transfer, the address of the first DMA descriptor must be written to register 0x47c and the HWDESC bit of CONTROL register must be set. The Scatter-Gather transfer is queued similarly to the simple transfers, by writing 1 in TRANSFER_SUBMIT.

The Scatter-Gather interface has a dedicated AXI-MM bus configured for read transfers, with its own dedicated clock, which can be asynchronous.

The SG reset is generated by the reset manager to reset the logic after completing any pending transactions on the bus.

When the Scatter-Gather is enabled during runtime, the legacy cyclic functionality of the DMA is disabled.

The Scatter-Gather DMA currently uses a custom DMABUF interface for software control, since the ADI-specific interface only uses contiguous buffers. The software needs to be updated.

## PR Type
- [ ] Bug fix (change that fixes an issue)
- [x] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the code style guidelines
- [x] I have performed a self-review of changes
- [ ] I have compiled all hdl projects and libraries affected by this PR
- [x] I have tested in hardware affected projects, at least on relevant boards
- [x] I have commented my code, at least hard-to-understand parts
- [x] I have signed off all commits from this PR
- [x] I have updated the documentation (wiki pages, ReadMe files, Copyright etc)
- [ ] I have not introduced new Warnings/Critical Warnings on compilation
- [x] I have added new hdl testbenches or updated existing ones
