### PR TITLE
SPI Engine: Fixed delay behaviour on Chip-Select and Sleep instructions

### DIFF
--- a/docs/library/spi_engine/instruction-format.rst
+++ b/docs/library/spi_engine/instruction-format.rst
@@ -69,7 +69,7 @@ instruction is twice the delay.
 
 .. math::
 
-   delay = t * \frac{div + 1}{f_{clk}}
+   delay = t * \frac{(div + 1)*2}{f_{clk}}
 
 .. list-table::
    :widths: 10 15 75

--- a/docs/library/spi_engine/instruction-format.rst
+++ b/docs/library/spi_engine/instruction-format.rst
@@ -65,7 +65,8 @@ specified delay. The length of the delay depends on the module clock frequency,
 the setting of the prescaler register and the t parameter of the instruction.
 This delay is inserted before and after the update of the chip-select signal,
 so the total execution time of the chip-select
-instruction is twice the delay.
+instruction is twice the delay, plus a fixed 2 clock cycles (fast clock, not prescaled)
+for the internal logic.
 
 .. math::
 
@@ -152,11 +153,12 @@ Sleep Instruction
 The sleep instruction stops the execution of the command stream for the
 specified amount of time. The time is based on the external clock frequency the
 configuration value of the prescaler register and the time parameter of the
-instruction.
+instruction. A fixed delay of two clock cycles (fast, not affected by the prescaler)
+is the minimum, needed by the internal logic.
 
 .. math::
 
-   sleep\_time = \frac{(t + 1) * ((div + 1) * 2)}{f_{clk}}
+   sleep\_time = \frac{2+(t) * ((div + 1) * 2)}{f_{clk}}
 
 .. list-table::
    :widths: 10 15 75

--- a/library/spi_engine/spi_engine_execution/spi_engine_execution.v
+++ b/library/spi_engine/spi_engine_execution/spi_engine_execution.v
@@ -157,6 +157,8 @@ module spi_engine_execution #(
 
   wire sleep_counter_compare;
   wire cs_sleep_counter_compare;
+  wire cs_sleep_early_exit;
+  reg cs_sleep_repeat;
 
   wire io_ready1;
   wire io_ready2;
@@ -167,7 +169,9 @@ module spi_engine_execution #(
 
   (* direct_enable = "yes" *) wire cs_gen;
 
-  assign cs_gen = inst_d1 == CMD_CHIPSELECT && cs_sleep_counter_compare == 1'b1;
+  assign cs_gen = inst_d1 == CMD_CHIPSELECT && (cs_sleep_counter_compare == 1'b1) 
+                  && (cs_sleep_repeat == 1'b0)
+                  && (idle == 1'b0);
   assign cmd_ready = idle;
 
   always @(posedge clk) begin
@@ -241,15 +245,29 @@ module spi_engine_execution #(
 
   assign sleep_counter_compare = sleep_counter == cmd_d1[7:0] && clk_div_last == 1'b1;
   assign cs_sleep_counter_compare = cs_sleep_counter == cmd_d1[9:8] && clk_div_last == 1'b1;
+  assign cs_sleep_early_exit = (cmd_d1[9:8] == 0);
 
   always @(posedge clk) begin
-    if (idle == 1'b1) begin
+    if (resetn == 1'b0) begin
+      cs_sleep_repeat <= 1'b0;
+    end else begin
+      if (idle) begin
+        cs_sleep_repeat <= 1'b0;
+      end else if (cs_sleep_counter_compare && (inst_d1 == CMD_CHIPSELECT)) begin
+        cs_sleep_repeat <= !cs_sleep_repeat;
+      end
+    end
+    
+  end
+
+  always @(posedge clk) begin
+    if (idle == 1'b1 || (cs_sleep_counter_compare && !cs_sleep_repeat && inst_d1 == CMD_CHIPSELECT)) begin
       counter <= 'h00;
     end else if (clk_div_last == 1'b1 && wait_for_io == 1'b0) begin
       if (bit_counter == word_length) begin
-          counter <= (counter & BIT_COUNTER_CLEAR) + (transfer_active ? 'h1 : 'h10) + BIT_COUNTER_CARRY;
+          counter <= (counter & BIT_COUNTER_CLEAR) + (transfer_active ? 'h1 : (2**BIT_COUNTER_WIDTH)) + BIT_COUNTER_CARRY;
       end else begin
-        counter <= counter + (transfer_active ? 'h1 : 'h10);
+        counter <= counter + (transfer_active ? 'h1 : (2**BIT_COUNTER_WIDTH));
       end
     end
   end
@@ -267,7 +285,7 @@ module spi_engine_execution #(
             idle <= 1'b1;
         end
         CMD_CHIPSELECT: begin
-          if (cs_sleep_counter_compare)
+          if ((cs_sleep_counter_compare && cs_sleep_repeat) || cs_sleep_early_exit)
             idle <= 1'b1;
         end
         CMD_MISC: begin

--- a/library/spi_engine/spi_engine_execution/spi_engine_execution.v
+++ b/library/spi_engine/spi_engine_execution/spi_engine_execution.v
@@ -169,7 +169,7 @@ module spi_engine_execution #(
 
   (* direct_enable = "yes" *) wire cs_gen;
 
-  assign cs_gen = inst_d1 == CMD_CHIPSELECT 
+  assign cs_gen = inst_d1 == CMD_CHIPSELECT
                   && ((cs_sleep_counter_compare == 1'b1) || cs_sleep_early_exit)
                   && (cs_sleep_repeat == 1'b0)
                   && (idle == 1'b0);


### PR DESCRIPTION
## PR Description

This PR fixes observed behavior of the Chip-Select and Sleep instructions not matching the documentation. A separate testbench was created for this behavior on [a fork](https://github.com/LBFFilho/testbenches/tree/spi_engine_instruction_fix). A corresponding PR will be created for the testbench. To run it, simply go to the testbenches/pulsar_adc_pmdz directory, and run

`make CFG=cfg1 TST=sleep_delay_test`

According to the [documentation on the wiki](https://wiki.analog.com/resources/fpga/peripherals/spi_engine/instruction_format), the Sleep instruction should sleep for

`sleep_time = (t + 1) * ((div + 1) * 2) / f_clk`

where "t" is the parameter given to the sleep instruction. However, the current SPI engine implementation (before this PR) actually sleeps for double the duration, due to the way the counter was implemented. The Chip-Select instruction was also affected by this.

The Chip-Select instruction documentation states that the instruction was supposed to create a delay before *and* after the CS change. The delay after a CS change is useful when implementing fast SPI converters, which sometimes have some timing requirements between CS activation and a SCLK edge. However, the behavior before this PR is that the full delay was happening only before the CS change.  Additionally, as stated above, the counter implementation made the delay double (but didn't make it happen after the CS change). 
The wiki documentation gives the following for the Chip-Select instruction, where t is the delay parameter:

`delay_per_edge = t * (div + 1) / f_clk`

This would imply that this instruction does not use the same prescaler as the rest of the SPI Engine, so I updated the formula on the .rst documentation to reflect this, to:

`delay_per_edge = t * (div + 1) *2/ f_clk`

The changes introduced do not affect the behavior for CS when t=0, which, as far as I know is the common case. So it shouldn't break any existing projects.

## PR Type
- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the code style guidelines
- [x] I have performed a self-review of changes
- [ ] I have compiled all hdl projects and libraries affected by this PR
- [ ] I have tested in hardware affected projects, at least on relevant boards
- [x] I have commented my code, at least hard-to-understand parts
- [x] I have signed off all commits from this PR
- [x] I have updated the documentation (wiki pages, ReadMe files, Copyright etc)
- [x] I have not introduced new Warnings/Critical Warnings on compilation
- [x] I have added new hdl testbenches or updated existing ones
