### PR TITLE
TCL: ad_hpmx_interconnect

### DIFF
--- a/projects/scripts/adi_board.tcl
+++ b/projects/scripts/adi_board.tcl
@@ -1173,6 +1173,7 @@ proc ad_hpmx_interconnect {p_sel p_address p_name {p_intf_name {}}} {
           set p_address [expr ($p_address + 0x20000000)]
         }
       }
+      puts "create_bd_addr_seg -range $p_seg_range -offset $p_address $sys_addr_cntrl_space $p_seg_name \"SEG_data_${p_name}\""
       create_bd_addr_seg -range $p_seg_range \
         -offset $p_address $sys_addr_cntrl_space \
         $p_seg_name "SEG_data_${p_name}"


### PR DESCRIPTION
## PR Description

Some custom projects might rely on other PS AXI master interfaces, rework `ad_cpu_interconnect` to allow users to specify other interfaces.

For now, I was only able to test this on a zynqmp project, and don't have the full list of interfaces for other platforms, but I'm happy to update the PR.

## PR Type
- [ ] Bug fix (change that fixes an issue)
- [x] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the code style guidelines
- [x] I have performed a self-review of changes
- [ ] I have compiled all hdl projects and libraries affected by this PR
- [ ] I have tested in hardware affected projects, at least on relevant boards
- [x] I have commented my code, at least hard-to-understand parts
- [x] I have signed off all commits from this PR
- [x] I have updated the documentation (wiki pages, ReadMe files, Copyright etc)
- [x] I have not introduced new Warnings/Critical Warnings on compilation
- [ ] I have added new hdl testbenches or updated existing ones
