### PR TITLE
axi_ad7606x: Add the correct IP's name

### DIFF
--- a/library/axi_ad7606x/axi_ad7606x_ip.tcl
+++ b/library/axi_ad7606x/axi_ad7606x_ip.tcl
@@ -11,7 +11,7 @@ global VIVADO_IP_LIBRARY
 
 adi_ip_create axi_ad7606x
 
-adi_ip_files axi_ad7606 [list \
+adi_ip_files axi_ad7606x [list \
     "$ad_hdl_dir/library/common/ad_edge_detect.v" \
     "$ad_hdl_dir/library/xilinx/common/ad_rst_constr.xdc" \
     "$ad_hdl_dir/library/common/ad_rst.v" \


### PR DESCRIPTION
## PR Description

axi_ad7606x: Add the correct IP's name [Critical Warning generated by the incorrect name in the `adi_ip_files` function];

## PR Type
- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the code style guidelines
- [x] I have performed a self-review of changes
- [x] I have compiled all hdl projects and libraries affected by this PR
- [ ] I have tested in hardware affected projects, at least on relevant boards
- [x] I have commented my code, at least hard-to-understand parts
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe files, Copyright etc)
- [x] I have not introduced new Warnings/Critical Warnings on compilation
- [ ] I have added new hdl testbenches or updated existing ones
