### PR TITLE
pluto: Enable phaser integration

### DIFF
--- a/projects/pluto/Makefile
+++ b/projects/pluto/Makefile
@@ -12,10 +12,12 @@ M_DEPS += ../../library/util_cdc/sync_bits.v
 M_DEPS += ../../library/common/util_pulse_gen.v
 M_DEPS += ../../library/common/ad_iobuf.v
 M_DEPS += ../../library/common/ad_bus_mux.v
+M_DEPS += ../../library/axi_tdd/scripts/axi_tdd.tcl
 M_DEPS += ../../library/axi_ad9361/axi_ad9361_delay.tcl
 
 LIB_DEPS += axi_ad9361
 LIB_DEPS += axi_dmac
+LIB_DEPS += axi_tdd
 LIB_DEPS += util_pack/util_cpack2
 LIB_DEPS += util_pack/util_upack2
 

--- a/projects/pluto/Readme.md
+++ b/projects/pluto/Readme.md
@@ -2,7 +2,9 @@
 
 Here are some pointers to help you:
   * [Board Product Page](https://www.analog.com/adalm-pluto)
+  * [Board Product Page](https://www.analog.com/cn0566)
   * Parts : [RF Agile Transceiver](https://www.analog.com/ad9363)
   * Project Doc: https://wiki.analog.com/university/tools/pluto	
+  * Project Doc: https://wiki.analog.com/resources/eval/user-guides/circuits-from-the-lab/cn0566
   * HDL Doc: https://wiki.analog.com/resources/eval/user-guides/ad-fmcomms2-ebz/reference_hdl
   * Linux Drivers: https://wiki.analog.com/resources/tools-software/linux-drivers/iio-transceiver/ad9361

--- a/projects/pluto/system_bd.tcl
+++ b/projects/pluto/system_bd.tcl
@@ -1,6 +1,7 @@
 # create board design
 
 source $ad_hdl_dir/projects/common/xilinx/adi_fir_filter_bd.tcl
+source $ad_hdl_dir/library/axi_tdd/scripts/axi_tdd.tcl
 
 # default ports
 
@@ -17,9 +18,9 @@ create_bd_port -dir I spi0_sdo_i
 create_bd_port -dir O spi0_sdo_o
 create_bd_port -dir I spi0_sdi_i
 
-create_bd_port -dir I -from 16 -to 0 gpio_i
-create_bd_port -dir O -from 16 -to 0 gpio_o
-create_bd_port -dir O -from 16 -to 0 gpio_t
+create_bd_port -dir I -from 17 -to 0 gpio_i
+create_bd_port -dir O -from 17 -to 0 gpio_o
+create_bd_port -dir O -from 17 -to 0 gpio_t
 
 create_bd_port -dir O spi_csn_o
 create_bd_port -dir I spi_csn_i
@@ -28,6 +29,9 @@ create_bd_port -dir O spi_clk_o
 create_bd_port -dir I spi_sdo_i
 create_bd_port -dir O spi_sdo_o
 create_bd_port -dir I spi_sdi_i
+
+create_bd_port -dir O txdata_o
+create_bd_port -dir I tdd_ext_sync
 
 # instance: sys_ps7
 
@@ -45,7 +49,7 @@ ad_ip_parameter sys_ps7 CONFIG.PCW_EN_RST1_PORT 1
 ad_ip_parameter sys_ps7 CONFIG.PCW_FPGA0_PERIPHERAL_FREQMHZ 100.0
 ad_ip_parameter sys_ps7 CONFIG.PCW_FPGA1_PERIPHERAL_FREQMHZ 200.0
 ad_ip_parameter sys_ps7 CONFIG.PCW_GPIO_EMIO_GPIO_ENABLE 1
-ad_ip_parameter sys_ps7 CONFIG.PCW_GPIO_EMIO_GPIO_IO 17
+ad_ip_parameter sys_ps7 CONFIG.PCW_GPIO_EMIO_GPIO_IO 18
 ad_ip_parameter sys_ps7 CONFIG.PCW_SPI1_PERIPHERAL_ENABLE 0
 ad_ip_parameter sys_ps7 CONFIG.PCW_I2C0_PERIPHERAL_ENABLE 0
 ad_ip_parameter sys_ps7 CONFIG.PCW_UART1_PERIPHERAL_ENABLE 1
@@ -215,6 +219,7 @@ ad_ip_parameter axi_ad9361_adc_dma CONFIG.AXI_SLICE_SRC 0
 ad_ip_parameter axi_ad9361_adc_dma CONFIG.AXI_SLICE_DEST 0
 ad_ip_parameter axi_ad9361_adc_dma CONFIG.DMA_2D_TRANSFER 0
 ad_ip_parameter axi_ad9361_adc_dma CONFIG.DMA_DATA_WIDTH_SRC 64
+ad_ip_parameter axi_ad9361_adc_dma CONFIG.SYNC_TRANSFER_START {true}
 
 ad_add_decimation_filter "rx_fir_decimator" 8 2 1 {61.44} {61.44} \
                          "$ad_hdl_dir/library/util_fir_int/coefile_int.coe"
@@ -275,7 +280,6 @@ ad_connect axi_ad9361/dac_valid_q0 tx_fir_interpolator/dac_valid_1
 ad_connect axi_ad9361/dac_data_q0 tx_fir_interpolator/data_out_1
 
 ad_connect  axi_ad9361/l_clk tx_upack/clk
-ad_connect  axi_ad9361/rst tx_upack/reset
 
 ad_connect  tx_upack/fifo_rd_data_0  tx_fir_interpolator/data_in_0
 ad_connect  tx_upack/enable_0  tx_fir_interpolator/enable_out_0
@@ -305,12 +309,50 @@ ad_connect  axi_ad9361/l_clk axi_ad9361_adc_dma/fifo_wr_clk
 ad_connect  axi_ad9361/l_clk axi_ad9361_dac_dma/m_axis_aclk
 ad_connect  cpack/fifo_wr_overflow axi_ad9361/adc_dovf
 
+# External TDD
+set TDD_CHANNEL_CNT 3
+set TDD_DEFAULT_POL 0b010
+set TDD_REG_WIDTH 32
+set TDD_BURST_WIDTH 32
+set TDD_SYNC_WIDTH 0
+set TDD_SYNC_INT 0
+set TDD_SYNC_EXT 1
+set TDD_SYNC_EXT_CDC 1
+ad_tdd_gen_create axi_tdd_0 $TDD_CHANNEL_CNT \
+                            $TDD_DEFAULT_POL \
+                            $TDD_REG_WIDTH \
+                            $TDD_BURST_WIDTH \
+                            $TDD_SYNC_WIDTH \
+                            $TDD_SYNC_INT \
+                            $TDD_SYNC_EXT \
+                            $TDD_SYNC_EXT_CDC
+
+ad_ip_instance util_vector_logic logic_inv [list \
+  C_OPERATION {not} \
+  C_SIZE 1]
+
+ad_ip_instance util_vector_logic logic_or_1 [list \
+  C_OPERATION {or} \
+  C_SIZE 1]
+
+ad_connect logic_inv/Op1  axi_ad9361/rst
+ad_connect logic_inv/Res  axi_tdd_0/resetn
+ad_connect axi_ad9361/l_clk axi_tdd_0/clk
+ad_connect axi_tdd_0/sync_in tdd_ext_sync
+ad_connect axi_tdd_0/tdd_channel_0 txdata_o
+ad_connect axi_tdd_0/tdd_channel_1 axi_ad9361_adc_dma/fifo_wr_sync
+
+ad_connect  logic_or_1/Op1  axi_ad9361/rst
+ad_connect  logic_or_1/Op2  axi_tdd_0/tdd_channel_2
+ad_connect  logic_or_1/Res  tx_upack/reset
+
 # interconnects
 
 ad_cpu_interconnect 0x79020000 axi_ad9361
 ad_cpu_interconnect 0x7C400000 axi_ad9361_adc_dma
 ad_cpu_interconnect 0x7C420000 axi_ad9361_dac_dma
 ad_cpu_interconnect 0x7C430000 axi_spi
+ad_cpu_interconnect 0x7C440000 axi_tdd_0
 
 ad_ip_parameter sys_ps7 CONFIG.PCW_USE_S_AXI_HP1 {1}
 ad_connect sys_cpu_clk sys_ps7/S_AXI_HP1_ACLK
@@ -340,5 +382,4 @@ ad_connect sys_cpu_resetn axi_ad9361_dac_dma/m_src_axi_aresetn
 ad_cpu_interrupt ps-13 mb-13 axi_ad9361_adc_dma/irq
 ad_cpu_interrupt ps-12 mb-12 axi_ad9361_dac_dma/irq
 ad_cpu_interrupt ps-11 mb-11 axi_spi/ip2intc_irpt
-
 

--- a/projects/pluto/system_constr.xdc
+++ b/projects/pluto/system_constr.xdc
@@ -51,17 +51,26 @@ set_property  -dict {PACKAGE_PIN  P9   IOSTANDARD LVCMOS18} [get_ports gpio_rese
 set_property  -dict {PACKAGE_PIN  K12  IOSTANDARD LVCMOS18} [get_ports enable]
 set_property  -dict {PACKAGE_PIN  K11  IOSTANDARD LVCMOS18} [get_ports txnrx]
 
-set_property  -dict {PACKAGE_PIN  M14  IOSTANDARD LVCMOS18 PULLTYPE PULLUP} [get_ports iic_scl]
-set_property  -dict {PACKAGE_PIN  N14  IOSTANDARD LVCMOS18 PULLTYPE PULLUP} [get_ports iic_sda]
-
 set_property  -dict {PACKAGE_PIN  E12  IOSTANDARD LVCMOS18  PULLTYPE PULLUP} [get_ports spi_csn]
 set_property  -dict {PACKAGE_PIN  E11  IOSTANDARD LVCMOS18} [get_ports spi_clk]
 set_property  -dict {PACKAGE_PIN  E13  IOSTANDARD LVCMOS18} [get_ports spi_mosi]
 set_property  -dict {PACKAGE_PIN  F12  IOSTANDARD LVCMOS18} [get_ports spi_miso]
 
-set_property  -dict {PACKAGE_PIN  R10  IOSTANDARD LVCMOS18} [get_ports pl_spi_clk_o]
-set_property  -dict {PACKAGE_PIN  M12  IOSTANDARD LVCMOS18} [get_ports pl_spi_miso]
-set_property  -dict {PACKAGE_PIN  K13  IOSTANDARD LVCMOS18} [get_ports pl_spi_mosi]
+# PL GPIOs
+#
+# Pin  | Package Pin | GPIO     | Pluto    | Phaser  |
+# -----|-------------|----------|----------|---------|
+# L10P | K13         | PL_GPIO0 | SPI MOSI | TXDATA  |
+# L12N | M12         | PL_GPIO1 | SPI MISO | BURST   |
+# L24N | R10         | PL_GPIO2 | SPI CLKO | MUXOUT  |
+# L7N  | N14         | PL_GPIO3 | IIC SDA  | IIC SDA |
+# L9N  | M14         | PL_GPIO4 | IIC SCL  | IIC SCL |
+
+set_property  -dict {PACKAGE_PIN  K13  IOSTANDARD LVCMOS18} [get_ports pl_gpio0]
+set_property  -dict {PACKAGE_PIN  M12  IOSTANDARD LVCMOS18} [get_ports pl_gpio1]
+set_property  -dict {PACKAGE_PIN  R10  IOSTANDARD LVCMOS18} [get_ports pl_gpio2]
+set_property  -dict {PACKAGE_PIN  N14  IOSTANDARD LVCMOS18 PULLTYPE PULLUP} [get_ports pl_gpio3]
+set_property  -dict {PACKAGE_PIN  M14  IOSTANDARD LVCMOS18 PULLTYPE PULLUP} [get_ports pl_gpio4]
 
 set_property  -dict {PACKAGE_PIN  P8   IOSTANDARD LVCMOS18} [get_ports clk_out]
 


### PR DESCRIPTION
Moving from **master** to **next_stable** the Pluto Phaser related changes.

This commit adds support for ADALM-PHASER, allowing the user to choose between the default PlutoSDR mode and Phaser mode through a software controlled GPIO pin: phaser_enable.

The Generic TDD Engine was integrated to output a logic signal on the L10P pin, which connects to the input of the ADF4159, when receiving an external synchronization signal on the L12N pin from the Raspberry Pi. Two additional TDD channels are used to synchronize the TX/RX DMA transfer start:
- TDD CH1 is connected to the RX DMA, triggering the synchronization flag;
- TDD CH2 is connected to the TX unpacker's reset, backpressuring the TX DMA until deasserted.

## PR Type
- [ ] Bug fix (change that fixes an issue)
- [x] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the code style guidelines
- [x] I have performed a self-review of changes
- [x] I have compiled all hdl projects and libraries affected by this PR
- [x] I have tested in hardware affected projects, at least on relevant boards
- [x] I have commented my code, at least hard-to-understand parts
- [x] I have signed off all commits from this PR
- [x] I have updated the documentation (wiki pages, ReadMe files, Copyright etc)
- [ ] I have not introduced new Warnings/Critical Warnings on compilation
- [x] I have added new hdl testbenches or updated existing ones
