### PR TITLE
docs/ad7616: Remove duplicated info

### DIFF
--- a/docs/projects/ad7616_sdz/index.rst
+++ b/docs/projects/ad7616_sdz/index.rst
@@ -352,9 +352,6 @@ HDL related
    * - AXI_SYSID
      - :git-hdl:`library/axi_sysid`
      - :dokuwiki:`[Wiki] <resources/fpga/docs/axi_sysid>`
-   * - AXI_SPI_ENGINE
-     - :git-hdl:`library/spi_engine/axi_spi_engine`  **
-     - :ref:`here <spi_engine axi>`
    * - SPI_ENGINE_EXECUTION
      - :git-hdl:`library/spi_engine/spi_engine_execution` **
      - :ref:`here <spi_engine execution>`


### PR DESCRIPTION
## PR Description

The axi_spi_engine IP info was duplicated in the HDL related section.

## PR Type
- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the code style guidelines
- [x] I have performed a self-review of changes
- [ ] I have compiled all hdl projects and libraries affected by this PR
- [ ] I have tested in hardware affected projects, at least on relevant boards
- [ ] I have commented my code, at least hard-to-understand parts
- [ ] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe files, Copyright etc)
- [x] I have not introduced new Warnings/Critical Warnings on compilation
- [ ] I have added new hdl testbenches or updated existing ones
