### PR TITLE
s10soc: Fixed a minor issue preventing some projects to be built.

### DIFF
--- a/projects/ad9213_dual_ebz/s10soc/system_qsys.tcl
+++ b/projects/ad9213_dual_ebz/s10soc/system_qsys.tcl
@@ -16,9 +16,16 @@ if [info exists ad_project_dir] {
 }
 
 #system ID
+
+if {[info exists ::env(ADI_PROJECT_DIR)]} {
+  set mem_init_sys_file_path "$::env(ADI_PROJECT_DIR)mem_init_sys.txt";
+} else {
+  set mem_init_sys_file_path mem_init_sys.txt;
+}
+
 set_instance_parameter_value axi_sysid_0 {ROM_ADDR_BITS} {9}
 set_instance_parameter_value rom_sys_0 {ROM_ADDR_BITS} {9}
 
-set_instance_parameter_value rom_sys_0 {PATH_TO_FILE} "$mem_init_sys_file_path/mem_init_sys.txt"
+set_instance_parameter_value rom_sys_0 {PATH_TO_FILE} $mem_init_sys_file_path
 
 sysid_gen_sys_init_file

--- a/projects/adrv9009/s10soc/system_qsys.tcl
+++ b/projects/adrv9009/s10soc/system_qsys.tcl
@@ -17,10 +17,17 @@ if [info exists ad_project_dir] {
 }
 
 #system ID
+
+if {[info exists ::env(ADI_PROJECT_DIR)]} {
+  set mem_init_sys_file_path "$::env(ADI_PROJECT_DIR)mem_init_sys.txt";
+} else {
+  set mem_init_sys_file_path mem_init_sys.txt;
+}
+
 set_instance_parameter_value axi_sysid_0 {ROM_ADDR_BITS} {9}
 set_instance_parameter_value rom_sys_0 {ROM_ADDR_BITS} {9}
 
-set_instance_parameter_value rom_sys_0 {PATH_TO_FILE} "$mem_init_sys_file_path/mem_init_sys.txt"
+set_instance_parameter_value rom_sys_0 {PATH_TO_FILE} $mem_init_sys_file_path
 
 sysid_gen_sys_init_file
 


### PR DESCRIPTION
## PR Description

The introduction of sysid IPs on some Stratix 10 projects introduced a problem where they would fail to build, due to `mem_init_sys_file_path` not being defined. This PR fixes this.


## PR Type
- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the code style guidelines
- [x] I have performed a self-review of changes
- [x] I have compiled all hdl projects and libraries affected by this PR
- [ ] I have tested in hardware affected projects, at least on relevant boards
- [ ] I have commented my code, at least hard-to-understand parts
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe files, Copyright etc)
- [x] I have not introduced new Warnings/Critical Warnings on compilation
- [ ] I have added new hdl testbenches or updated existing ones
