### PR TITLE
.github/workflows: Rename branch name for GitHub actions

### DIFF
--- a/.github/workflows/check_for_guideline_rules.yml
+++ b/.github/workflows/check_for_guideline_rules.yml
@@ -9,7 +9,7 @@ name: Guideline checker
 on:
   pull_request:
     branches:
-      - master
+      - main
     paths:
       - 'library/**'
       - 'projects/**'

--- a/.github/workflows/test_n_lint.yml
+++ b/.github/workflows/test_n_lint.yml
@@ -10,7 +10,7 @@ name: Lint
 on:
   pull_request:
     branches:
-      - master
+      - main
     paths:
       - 'library/**'
       - 'projects/**'


### PR DESCRIPTION
## PR Description

Renamed the branch on which the actions are run on, from ``master`` to ``main`` due to the renaming of the default branch.
Otherwise these actions are not triggered.

## PR Type
- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the code style guidelines
- [x] I have performed a self-review of changes
- [ ] I have compiled all hdl projects and libraries affected by this PR
- [ ] I have tested in hardware affected projects, at least on relevant boards
- [ ] I have commented my code, at least hard-to-understand parts
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe files, Copyright etc)
- [ ] I have not introduced new Warnings/Critical Warnings on compilation
- [ ] I have added new hdl testbenches or updated existing ones
