### PR TITLE
Add FIR filter for AD9081 on VCK190

### DIFF
--- a/projects/ad9081_fmca_ebz/vck190/Makefile
+++ b/projects/ad9081_fmca_ebz/vck190/Makefile
@@ -11,6 +11,7 @@ M_DEPS += ../../scripts/adi_pd.tcl
 M_DEPS += ../../common/xilinx/data_offload_bd.tcl
 M_DEPS += ../../common/xilinx/dacfifo_bd.tcl
 M_DEPS += ../../common/xilinx/adcfifo_bd.tcl
+M_DEPS += ../../common/xilinx/adi_fir_filter_bd.tcl
 M_DEPS += ../../common/vmk180/vmk180_system_bd.tcl
 M_DEPS += ../../common/vck190/vck190_system_constr.xdc
 M_DEPS += ../../common/vck190/vck190_system_bd.tcl

--- a/projects/ad9081_fmca_ebz/vck190/system_project.tcl
+++ b/projects/ad9081_fmca_ebz/vck190/system_project.tcl
@@ -31,26 +31,41 @@ source $ad_hdl_dir/projects/scripts/adi_board.tcl
 #   [RX/TX]_JESD_NP : Number of bits per sample, only 16 is supported
 #   [RX/TX]_NUM_LINKS : Number of links, matches numer of MxFE devices
 #   [RX/TX]_KS_PER_CHANNEL : Number of samples stored in internal buffers in kilosamples per converter (M)
+#   [ADC/DAC]_FIR_FILTER_INSERT : If 1 insert a FIR filter on the ADC/DAC path
+#   [ADC/DAC]_FIR_RATE : Filter rate
+#   [ADC/DAC]_FIR_PARALLEL_PATHS : Number of paralell paths. For scenarios where the sampling rate is x times the core clock
+#   [ADC/DAC]_FIR_CORE_CLK_RATE : Core clock in MHz
+#   [ADC/DAC]_FIR_SAMPLING_RATE : Sampling frequency in MHz
 
 #      make JESD_MODE=64B66B RX_LANE_RATE=24.75 TX_LANE_RATE=24.75 RX_JESD_M=8 RX_JESD_L=8 RX_JESD_S=2 RX_JESD_NP=12 TX_JESD_M=8 TX_JESD_L=8 TX_JESD_S=2 TX_JESD_NP=12
 
 adi_project ad9081_fmca_ebz_vck190 0 [list \
-  JESD_MODE         [get_env_param JESD_MODE     64B66B ]\
-  RX_LANE_RATE      [get_env_param RX_LANE_RATE   24.75 ] \
-  TX_LANE_RATE      [get_env_param TX_LANE_RATE   24.75 ] \
-  REF_CLK_RATE      [get_env_param REF_CLK_RATE     375 ] \
-  RX_JESD_M         [get_env_param RX_JESD_M          8 ] \
-  RX_JESD_L         [get_env_param RX_JESD_L          8 ] \
-  RX_JESD_S         [get_env_param RX_JESD_S          2 ] \
-  RX_JESD_NP        [get_env_param RX_JESD_NP        12 ] \
-  RX_NUM_LINKS      [get_env_param RX_NUM_LINKS       1 ] \
-  TX_JESD_M         [get_env_param TX_JESD_M          8 ] \
-  TX_JESD_L         [get_env_param TX_JESD_L          8 ] \
-  TX_JESD_S         [get_env_param TX_JESD_S          2 ] \
-  TX_JESD_NP        [get_env_param TX_JESD_NP        12 ] \
-  TX_NUM_LINKS      [get_env_param TX_NUM_LINKS       1 ] \
-  RX_KS_PER_CHANNEL [get_env_param RX_KS_PER_CHANNEL 64 ] \
-  TX_KS_PER_CHANNEL [get_env_param TX_KS_PER_CHANNEL 64 ] \
+  JESD_MODE              [get_env_param JESD_MODE              64B66B ]\
+  RX_LANE_RATE           [get_env_param RX_LANE_RATE            24.75 ] \
+  TX_LANE_RATE           [get_env_param TX_LANE_RATE            24.75 ] \
+  REF_CLK_RATE           [get_env_param REF_CLK_RATE              375 ] \
+  RX_JESD_M              [get_env_param RX_JESD_M                   8 ] \
+  RX_JESD_L              [get_env_param RX_JESD_L                   8 ] \
+  RX_JESD_S              [get_env_param RX_JESD_S                   2 ] \
+  RX_JESD_NP             [get_env_param RX_JESD_NP                 12 ] \
+  RX_NUM_LINKS           [get_env_param RX_NUM_LINKS                1 ] \
+  TX_JESD_M              [get_env_param TX_JESD_M                   8 ] \
+  TX_JESD_L              [get_env_param TX_JESD_L                   8 ] \
+  TX_JESD_S              [get_env_param TX_JESD_S                   2 ] \
+  TX_JESD_NP             [get_env_param TX_JESD_NP                 12 ] \
+  TX_NUM_LINKS           [get_env_param TX_NUM_LINKS                1 ] \
+  RX_KS_PER_CHANNEL      [get_env_param RX_KS_PER_CHANNEL          64 ] \
+  TX_KS_PER_CHANNEL      [get_env_param TX_KS_PER_CHANNEL          64 ] \
+  ADC_FIR_FILTER_INSERT  [get_env_param ADC_FIR_FILTER_INSERT       0 ] \
+  ADC_FIR_RATE           [get_env_param ADC_FIR_RATE                8 ] \
+  ADC_FIR_PARALLEL_PATHS [get_env_param ADC_FIR_PARALLEL_PATHS      1 ] \
+  ADC_FIR_CORE_CLK_RATE  [get_env_param ADC_FIR_CORE_CLK_RATE  122.88 ] \
+  ADC_FIR_SAMPLING_RATE  [get_env_param ADC_FIR_SAMPLING_RATE  122.88 ] \
+  DAC_FIR_FILTER_INSERT  [get_env_param DAC_FIR_FILTER_INSERT       0 ] \
+  DAC_FIR_RATE           [get_env_param DAC_FIR_RATE                8 ] \
+  DAC_FIR_PARALLEL_PATHS [get_env_param DAC_FIR_PARALLEL_PATHS      2 ] \
+  DAC_FIR_CORE_CLK_RATE  [get_env_param DAC_FIR_CORE_CLK_RATE  122.88 ] \
+  DAC_FIR_SAMPLING_RATE  [get_env_param DAC_FIR_SAMPLING_RATE   15.36 ] \
 ]
 
 adi_project_files ad9081_fmca_ebz_vck190 [list \

--- a/projects/ad9081_fmca_ebz/vck190/system_top.v
+++ b/projects/ad9081_fmca_ebz/vck190/system_top.v
@@ -125,6 +125,9 @@ module system_top  #(
   wire    [7:0]   tx_data_p_loc;
   wire    [7:0]   tx_data_n_loc;
 
+  wire            adc_fir_filter_active;
+  wire            dac_fir_filter_active;
+
   wire            clkin6;
   wire            clkin10;
   wire            tx_device_clk;
@@ -208,12 +211,14 @@ module system_top  #(
   assign gpio_i[52] = irqb[0];
   assign gpio_i[53] = irqb[1];
 
-  assign hmc_sync   = gpio_o[54];
-  assign rstb       = gpio_o[55];
-  assign rxen[0]    = gpio_o[56];
-  assign rxen[1]    = gpio_o[57];
-  assign txen[0]    = gpio_o[58];
-  assign txen[1]    = gpio_o[59];
+  assign adc_fir_filter_active = gpio_o[52];
+  assign dac_fir_filter_active = gpio_o[53];
+  assign hmc_sync              = gpio_o[54];
+  assign rstb                  = gpio_o[55];
+  assign rxen[0]               = gpio_o[56];
+  assign rxen[1]               = gpio_o[57];
+  assign txen[0]               = gpio_o[58];
+  assign txen[1]               = gpio_o[59];
 
   generate
   if (TX_NUM_LINKS > 1 & JESD_MODE == "8B10B") begin
@@ -298,6 +303,9 @@ module system_top  #(
     .GT_Serial_1_0_gtx_n (tx_data_n_loc[7:4]),
     .GT_Serial_1_0_grx_p (rx_data_p_loc[7:4]),
     .GT_Serial_1_0_grx_n (rx_data_n_loc[7:4]),
+
+    .adc_fir_filter_active (adc_fir_filter_active),
+    .dac_fir_filter_active (dac_fir_filter_active),
 
     .gt_reset (~rstb),
     .ref_clk_q0 (ref_clk),


### PR DESCRIPTION
## PR Description

This PR adds a configurable decimator/interpolator between the ADC and DAC paths.

## PR Type
- [ ] Bug fix (change that fixes an issue)
- [x] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the code style guidelines
- [x] I have performed a self-review of changes
- [x] I have compiled all hdl projects and libraries affected by this PR
- [ ] I have tested in hardware affected projects, at least on relevant boards
- [x] I have commented my code, at least hard-to-understand parts
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe files, Copyright etc)
- [x] I have not introduced new Warnings/Critical Warnings on compilation
- [ ] I have added new hdl testbenches or updated existing ones
