### PR TITLE
doc: Fixed SPI documentation consistency

### DIFF
--- a/docs/library/spi_engine/instruction-format.rst
+++ b/docs/library/spi_engine/instruction-format.rst
@@ -210,9 +210,9 @@ bus behavior.
        high.
    * - [0]
      - CPHA
-     - Configures the phase of the SCLK signal. When 0, data is updated on the
-       leading edge and sampled on the trailing edge. When 1, data is is
-       sampled on the leading edge and updated on the trailing edge.
+     - Configures the phase of the SCLK signal. When 0, data is sampled on the
+       leading edge and updated on the trailing edge. When 1, data is 
+       sampled on the trailing edge and updated on the leading edge.
 
 .. _spi_engine prescaler-configuration-register:
 

--- a/library/spi_engine/spi_engine_execution/spi_engine_execution_ip.tcl
+++ b/library/spi_engine/spi_engine_execution/spi_engine_execution_ip.tcl
@@ -62,7 +62,7 @@ set cc [ipx::current_core]
 set_property -dict [list \
   "value_validation_type" "range_long" \
   "value_validation_range_minimum" "8" \
-  "value_validation_range_maximum" "256" \
+  "value_validation_range_maximum" "32" \
  ] \
  [ipx::get_user_parameters DATA_WIDTH -of_objects $cc]
 
@@ -70,7 +70,7 @@ set_property -dict [list \
 set_property -dict [list \
   "value_validation_type" "range_long" \
   "value_validation_range_minimum" "1" \
-  "value_validation_range_maximum" "32" \
+  "value_validation_range_maximum" "8" \
  ] \
  [ipx::get_user_parameters NUM_OF_CS -of_objects $cc]
 


### PR DESCRIPTION
## PR Description

I have updated the documentation for the SPI. I had to modify spi_engine_execution_ip.tcl because the scripts are using it for some strings.


## PR Type
- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the code style guidelines
- [x] I have performed a self-review of changes
- [ ] I have compiled all hdl projects and libraries affected by this PR
- [ ] I have tested in hardware affected projects, at least on relevant boards
- [ ] I have commented my code, at least hard-to-understand parts
- [ ] I have signed off all commits from this PR
- [x] I have updated the documentation (wiki pages, ReadMe files, Copyright etc)
- [x] I have not introduced new Warnings/Critical Warnings on compilation
- [ ] I have added new hdl testbenches or updated existing ones
