### PR TITLE
library: jesd204: Fixup Vivado exiting with error

### DIFF
--- a/library/jesd204/jesd204_common/jesd204_common_ip.tcl
+++ b/library/jesd204/jesd204_common/jesd204_common_ip.tcl
@@ -27,4 +27,5 @@ set_property display_name "ADI JESD204C Common Library" [ipx::current_core]
 set_property description "ADI JESD204C Common Library" [ipx::current_core]
 set_property hide_in_gui {1} [ipx::current_core]
 
+ipx::create_xgui_files [ipx::current_core]
 ipx::save_core [ipx::current_core]


### PR DESCRIPTION
## PR Description

The lack of the create_xgui_files causes Vivado to exit with an error when running
multiple Vivado instances (parallel make case).
`jesd204_common` was missing this tcl command.

To reproduce
```
(cd library ; make clean all -j8)
```
Fails on main, but not with the fix.
Important: the ip.log between branches are identical, the only difference is that 
Vivado exists with an error code at main.

Tested with Vivado 2022.2 and 2023.1.

## PR Type
- [X] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [X] I have followed the code style guidelines
- [X] I have performed a self-review of changes
- [X] I have compiled all hdl projects and libraries affected by this PR
- [ ] I have tested in hardware affected projects, at least on relevant boards
- [ ] I have commented my code, at least hard-to-understand parts
- [X] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe files, Copyright etc)
- [X] I have not introduced new Warnings/Critical Warnings on compilation
- [ ] I have added new hdl testbenches or updated existing ones
