### PR TITLE
Support for AD4080-EVB on ZedBoard

### DIFF
--- a/library/axi_ad408x/Makefile
+++ b/library/axi_ad408x/Makefile
@@ -1,0 +1,32 @@
+####################################################################################
+## Copyright (c) 2018 - 2024 Analog Devices, Inc.
+### SPDX short identifier: BSD-1-Clause
+## Auto-generated, do not modify!
+####################################################################################
+
+LIBRARY_NAME := axi_ad408x
+
+GENERIC_DEPS += ../common/ad_datafmt.v
+GENERIC_DEPS += ../common/ad_pack.v
+GENERIC_DEPS += ../common/ad_rst.v
+GENERIC_DEPS += ../common/up_adc_channel.v
+GENERIC_DEPS += ../common/up_adc_common.v
+GENERIC_DEPS += ../common/up_axi.v
+GENERIC_DEPS += ../common/up_clock_mon.v
+GENERIC_DEPS += ../common/up_delay_cntrl.v
+GENERIC_DEPS += ../common/up_xfer_cntrl.v
+GENERIC_DEPS += ../common/up_xfer_status.v
+GENERIC_DEPS += ad408x_phy.v
+GENERIC_DEPS += axi_ad408x.v
+
+XILINX_DEPS += ../xilinx/common/ad_data_clk.v
+XILINX_DEPS += ../xilinx/common/ad_data_in.v
+XILINX_DEPS += ../xilinx/common/ad_dcfilter.v
+XILINX_DEPS += ../xilinx/common/ad_rst_constr.xdc
+XILINX_DEPS += ../xilinx/common/ad_serdes_in.v
+XILINX_DEPS += ../xilinx/common/up_clock_mon_constr.xdc
+XILINX_DEPS += ../xilinx/common/up_xfer_cntrl_constr.xdc
+XILINX_DEPS += ../xilinx/common/up_xfer_status_constr.xdc
+XILINX_DEPS += axi_ad408x_ip.tcl
+
+include ../scripts/library.mk

--- a/library/axi_ad408x/ad408x_phy.v
+++ b/library/axi_ad408x/ad408x_phy.v
@@ -1,0 +1,513 @@
+// ***************************************************************************
+// ***************************************************************************
+// Copyright (C) 2022-2024 Analog Devices, Inc. All rights reserved.
+//
+// In this HDL repository, there are many different and unique modules, consisting
+// of various HDL(Verilog or VHDL) components. The individual modules are
+// developed independently, and may be accompanied by separate and unique license
+// terms.
+//
+// The user should read each of these license terms, and understand the
+// freedoms and responsibilities that he or she has by using this source/core.
+//
+// This core is distributed in the hope that it will be useful, but WITHOUT ANY
+// WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+// A PARTICULAR PURPOSE.
+//
+// Redistribution and use of source or resulting binaries, with or without modification
+// of this file, are permitted under one of the following two license terms:
+//
+//   1. The GNU General Public License version 2 as published by the
+//      Free Software Foundation, which can be found in the top level directory
+//      of this repository(LICENSE_GPL2), and also online at:
+//      <https://www.gnu.org/licenses/old-licenses/gpl-2.0.html>
+//
+// OR
+//
+//   2. An ADI specific BSD license, which can be found in the top level directory
+//      of this repository(LICENSE_ADIBSD), and also on-line at:
+//      https://github.com/analogdevicesinc/hdl/blob/master/LICENSE_ADIBSD
+//      This will allow to generate bit files and not release the source code,
+//      as long as it attaches to an ADI device.
+//
+// ***************************************************************************
+// ***************************************************************************
+
+`timescale 1ns/100ps
+
+module ad408x_phy #(
+  parameter FPGA_TECHNOLOGY = 0,
+  parameter DRP_WIDTH = 5,
+  parameter NUM_LANES = 2,  // Max number of lanes is 2
+  parameter DDR_SUPPORT = 1,
+  parameter IODELAY_CTRL = 1,
+  parameter IO_DELAY_GROUP = "dev_if_delay_group"
+) (
+
+  // device interface
+  input                             dclk_in_n,
+  input                             dclk_in_p,
+  input                             data_a_in_n,
+  input                             data_a_in_p,
+  input                             data_b_in_n,
+  input                             data_b_in_p,
+
+  // control interface
+
+  input                              sync_n,
+
+    // Assumption:
+    //  control bits are static after sync_n de-assertion
+
+  input                             sdr_ddr_n,
+  input        [4:0]                num_lanes,
+  input                             ddr_edge_sel,
+
+  // In uncorrected mode for each sample 80 bits are transferred
+  // the 20 LSBs are the corrected sample, the other bits are debug info
+
+  input                             uncorrected_mode,
+
+  // delay interface(for IDELAY macros)
+
+  input                             up_clk,
+  input   [NUM_LANES-1:0]           up_adc_dld,
+  input   [DRP_WIDTH*NUM_LANES-1:0] up_adc_dwdata,
+  output  [DRP_WIDTH*NUM_LANES-1:0] up_adc_drdata,
+  input                             delay_clk,
+  input                             delay_rst,
+  output                            delay_locked,
+
+  // internal reset and clocks
+
+  input                             adc_rst,
+  output                            adc_clk,
+  output                            adc_clk_div,
+
+  output      [31:0]                adc_data,
+  output                            adc_valid,
+
+  output      [127:0]               adc_uncor_data,
+  output                            adc_uncor_valid,
+
+  // Debug interface
+
+  output                            clk_in_s,
+  input                             bitslip_enable,
+  output                            sync_status
+);
+
+  // Use always DDR mode for SERDES, useful for SDR mode to adjust capture
+
+  localparam DDR_OR_SDR_N    = 1;
+  localparam CMOS_LVDS_N     = 0; // Use always LVDS mode
+  localparam SEVEN_SERIES    = 1;
+  localparam ULTRASCALE      = 2;
+  localparam ULTRASCALE_PLUS = 3;
+
+// Assumptions:
+//  A replica of sync_n on the external board serves as a reset signal
+//  for the clock received on the dclk_in_n/p pairs
+//  Clock will stay low if sync_n is low, once sync_n deasserts after an
+//  undefined amount of time the clock will start to toggle, glitch-less
+//  having a smooth start.
+//  Framing information will be reconstructed based on this assumption.
+//
+// Serdes reset
+//
+//  When deasserted synchronously with CLKDIV, internal logic re-times this
+//  deassertion to the first rising edge of CLK
+//  The reset signal should only be deasserted when it is known that CLK
+//  and CLKDIV are stable and present, and should be a minimum of two CLKDIV pulses
+//  wide. After deassertion of reset, the output is not valid until after two CLKDIV cycles.
+// Serdes factor
+//  A sample has 20 bits, this can be transferred either on one lane or two
+//  lanes, SDR or DDR.
+//
+//                                             clk_div per sample
+//   single_lane sdr_ddr_n  | dclk per sample | /5    | /4
+//   0           0          | 5               | 1     | 1.25
+//   0           1          | 10              | 2     | 2.5
+//   1           0          | 10              | 2     | 2.5
+//   1           1          | 20              | 4     | 5
+//
+//   To accommodate all cases a serdes factor of 10 could be used in DDR mode
+//   with a clock division of 5. This requires a cascaded serdes
+//   configuration. However this will work only in 7 series devices.
+//   Instead a serdes factor of 8 is used to support ultrascale devices too
+//  (which do not have the cascaded mode with a factor of 10). This requires
+//   additional packer circuitry from 4/8/16 bits to 20 bits depending on
+//   mode.
+//
+// Serdes output valid
+//   The latency of serdes in 7 series is two div_clk cycles. Output valid of
+//   the serdes will assert two cock cycles later its reset de-asserts.
+
+  // internal wire
+
+  wire [NUM_LANES-1:0] serdes_in_p;
+  wire [NUM_LANES-1:0] serdes_in_n;
+  wire [NUM_LANES-1:0] data_s0;
+  wire [NUM_LANES-1:0] data_s1;
+  wire [NUM_LANES-1:0] data_s2;
+  wire [NUM_LANES-1:0] data_s3;
+  wire [NUM_LANES-1:0] data_s4;
+  wire [NUM_LANES-1:0] data_s5;
+  wire [NUM_LANES-1:0] data_s6;
+  wire [NUM_LANES-1:0] data_s7;
+  wire                 adc_clk_in_fast;
+
+  assign single_lane = num_lanes[0];
+  assign sdr_ddr_loc_n = DDR_SUPPORT ? sdr_ddr_n : 1'b1;
+  assign sync_status = sync_status_int;
+
+  //
+  // data interface
+  //
+
+  IBUFGDS i_clk_in_ibuf(
+    .I(dclk_in_p),
+    .IB(dclk_in_n),
+    .O(clk_in_s));
+
+  generate
+  if(FPGA_TECHNOLOGY == SEVEN_SERIES) begin
+
+    BUFIO i_clk_buf(
+      .I(clk_in_s),
+      .O(adc_clk_in_fast));
+
+    BUFR #(
+      .BUFR_DIVIDE("4")
+    ) i_div_clk_buf (
+      .CLR(~sync_n),
+      .CE(1'b1),
+      .I(clk_in_s),
+      .O(adc_clk_div));
+
+  end else begin
+
+    BUFGCE #(
+      .CE_TYPE("SYNC"),
+      .IS_CE_INVERTED(1'b0),
+      .IS_I_INVERTED(1'b0)
+    ) i_clk_buf_fast(
+      .O(adc_clk_in_fast),
+      .CE(1'b1),
+      .I(clk_in_s));
+
+    BUFGCE_DIV #(
+      .BUFGCE_DIVIDE(4),
+      .IS_CE_INVERTED(1'b0),
+      .IS_CLR_INVERTED(1'b0),
+      .IS_I_INVERTED(1'b0)
+    ) i_div_clk_buf(
+      .O(adc_clk_div),
+      .CE(1'b1),
+      .CLR(~sync_n),
+      .I(clk_in_s));
+
+  end
+  endgenerate
+
+  assign serdes_in_p = {data_b_in_p, data_a_in_p};
+  assign serdes_in_n = {data_b_in_n, data_a_in_n};
+
+  // Min 2 div_clk cycles once div_clk is running after deassertion of sync
+  // Control externally the reset of serdes for precise timing
+
+  reg [5:0] serdes_reset = 6'b000110;
+
+  always @(posedge adc_clk_div or negedge sync_n) begin
+    if(~sync_n) begin
+      serdes_reset <= 6'b000110;
+    end else begin
+      serdes_reset <= {serdes_reset[4:0],1'b0};
+    end
+  end
+  assign serdes_reset_s = serdes_reset[5];
+
+  ad_serdes_in #(
+    .CMOS_LVDS_N(CMOS_LVDS_N),
+    .FPGA_TECHNOLOGY(FPGA_TECHNOLOGY),
+    .IODELAY_CTRL(IODELAY_CTRL),
+    .IODELAY_GROUP(IO_DELAY_GROUP),
+    .DDR_OR_SDR_N(DDR_OR_SDR_N),
+    .DATA_WIDTH(NUM_LANES),
+    .DRP_WIDTH(DRP_WIDTH),
+    .SERDES_FACTOR(8),
+    .EXT_SERDES_RESET(1)
+  ) i_serdes(
+    .rst(serdes_reset_s),
+    .ext_serdes_rst(serdes_reset_s),
+    .clk(adc_clk_in_fast),
+    .div_clk(adc_clk_div),
+    .data_s0(data_s0),
+    .data_s1(data_s1),
+    .data_s2(data_s2),
+    .data_s3(data_s3),
+    .data_s4(data_s4),
+    .data_s5(data_s5),
+    .data_s6(data_s6),
+    .data_s7(data_s7),
+    .data_in_p(serdes_in_p),
+    .data_in_n(serdes_in_n),
+    .up_clk(up_clk),
+    .up_dld(up_adc_dld),
+    .up_dwdata(up_adc_dwdata),
+    .up_drdata(up_adc_drdata),
+    .delay_clk(delay_clk),
+    .delay_rst(delay_rst),
+    .delay_locked(delay_locked));
+
+  wire      [7:0]       serdes_data_0;
+  wire      [7:0]       serdes_data_1;
+
+  assign {serdes_data_1[0],serdes_data_0[0]} = data_s0;  // f-e latest bit received
+  assign {serdes_data_1[1],serdes_data_0[1]} = data_s1;  // r-e
+  assign {serdes_data_1[2],serdes_data_0[2]} = data_s2;  // f-e
+  assign {serdes_data_1[3],serdes_data_0[3]} = data_s3;  // r-e
+  assign {serdes_data_1[4],serdes_data_0[4]} = data_s4;  // f-e
+  assign {serdes_data_1[5],serdes_data_0[5]} = data_s5;  // r-e
+  assign {serdes_data_1[6],serdes_data_0[6]} = data_s6;  // f-e
+  assign {serdes_data_1[7],serdes_data_0[7]} = data_s7;  // r-e oldest bit received
+
+  // Assert serdes valid after 2 clock cycles is pulled out of reset
+
+  reg [1:0] serdes_valid = 2'b00;
+
+  always @(posedge adc_clk_div) begin
+    if(serdes_reset_s) begin
+      serdes_valid <= 2'b00;
+    end else begin
+      serdes_valid <= {serdes_valid[0],1'b1};
+    end
+  end
+
+  wire [ 3:0] serdes_data_4_lane0;
+  wire [ 3:0] serdes_data_4_lane1;
+  wire [ 7:0] serdes_data_8;
+  wire [15:0] serdes_data_16;
+
+  // The serdes produces 8 bits at a div_clk cycle
+  // In SDR only half of those bits are valid,
+  //
+  //  mode           | number of valid bits per div_clk beat
+  //  sdr singe lane    4 bits
+  //  sdr dual lane     8 bits
+  //  ddr single lane   8 bits
+  //  ddr dual lane     16 bits
+  //
+  //  ddr_edge_sel - 0 posedge
+  //                 1 negedge
+
+  assign serdes_data_4_lane0 = ddr_edge_sel ? {serdes_data_0[6],
+                                               serdes_data_0[4],
+                                               serdes_data_0[2],
+                                               serdes_data_0[0]}
+                                            : {serdes_data_0[7],
+                                               serdes_data_0[5],
+                                               serdes_data_0[3],
+                                               serdes_data_0[1]};
+
+  assign serdes_data_4_lane1 = ddr_edge_sel ? {serdes_data_1[6],
+                                               serdes_data_1[4],
+                                               serdes_data_1[2],
+                                               serdes_data_1[0]}
+                                            : {serdes_data_1[7],
+                                               serdes_data_1[5],
+                                               serdes_data_1[3],
+                                               serdes_data_1[1]};
+
+  // For SDR(dual lane) take data from two lanes interleaved
+  // for DDR(single lane) take data from a single lane
+
+  assign serdes_data_8 = sdr_ddr_loc_n ? {serdes_data_4_lane0[3],
+                                      serdes_data_4_lane1[3],
+                                      serdes_data_4_lane0[2],
+                                      serdes_data_4_lane1[2],
+                                      serdes_data_4_lane0[1],
+                                      serdes_data_4_lane1[1],
+                                      serdes_data_4_lane0[0],
+                                      serdes_data_4_lane1[0]}
+                                   : serdes_data_0;
+
+  // For DDR dual lane interleave the two sedres outputs;
+
+  assign serdes_data_16 = {serdes_data_0[7],
+                           serdes_data_1[7],
+                           serdes_data_0[6],
+                           serdes_data_1[6],
+                           serdes_data_0[5],
+                           serdes_data_1[5],
+                           serdes_data_0[4],
+                           serdes_data_1[4],
+                           serdes_data_0[3],
+                           serdes_data_1[3],
+                           serdes_data_0[2],
+                           serdes_data_1[2],
+                           serdes_data_0[1],
+                           serdes_data_1[1],
+                           serdes_data_0[0],
+                           serdes_data_1[0]};
+
+  wire [19:0] packed_4_20;
+  wire [19:0] packed_8_20;
+  wire [19:0] packed_16_20;
+  wire [79:0] packed_20_80;
+  wire        pack80_valid;
+
+  ad_pack #(
+    .I_W(4),
+    .O_W(20),
+    .UNIT_W(1),
+    .ALIGN_TO_MSB(1)
+  ) i_ad_pack_4 (
+    .clk(adc_clk_div),
+    .reset(~serdes_valid[0]),
+    .idata(serdes_data_4_lane0),
+    .ivalid(serdes_valid[1]),
+    .odata(packed_4_20),
+    .ovalid(pack4_valid));
+
+  ad_pack #(
+    .I_W(8),
+    .O_W(20),
+    .UNIT_W(1),
+    .ALIGN_TO_MSB(1)
+  ) i_ad_pack_8 (
+    .clk(adc_clk_div),
+    .reset(~serdes_valid[0]),
+    .idata(serdes_data_8),
+    .ivalid(serdes_valid[1]),
+    .odata(packed_8_20),
+    .ovalid(pack8_valid));
+
+  ad_pack #(
+    .I_W(16),
+    .O_W(20),
+    .UNIT_W(1),
+    .ALIGN_TO_MSB(1)
+  ) i_ad_pack_16 (
+    .clk(adc_clk_div),
+    .reset(~serdes_valid[0]),
+    .idata(serdes_data_16),
+    .ivalid(serdes_valid[1]),
+    .odata(packed_16_20),
+    .ovalid(pack16_valid));
+
+  reg [19:0] packed_data;
+  reg        packed_data_valid;
+
+  always @(*) begin
+    case({single_lane,sdr_ddr_loc_n})
+      2'b00 : packed_data = packed_16_20;
+      2'b01 : packed_data = packed_8_20;
+      2'b10 : packed_data = packed_8_20;
+      2'b11 : packed_data = packed_4_20;
+    endcase
+  end
+
+  always @(*) begin
+    case({single_lane,sdr_ddr_loc_n})
+      2'b00 : packed_data_valid = pack16_valid;
+      2'b01 : packed_data_valid = pack8_valid;
+      2'b10 : packed_data_valid = pack8_valid;
+      2'b11 : packed_data_valid = pack4_valid;
+    endcase
+  end
+
+  // Align data
+  // Use different rotations based on selected mode
+  // Latency from first clock edge post sync_n deasertion to the first valid
+  // output of the packer should be constant allowing for a constant rotation every time.
+
+  reg [19:0] packed_data_d;
+
+  always @(posedge adc_clk_div) begin
+    if(packed_data_valid) begin
+      packed_data_d <= packed_data;
+    end
+  end
+
+  reg  [ 4:0]  shift_cnt = 5'd0;
+  reg          shift_cnt_en = 1'b0;
+  reg          sync_status_int = 1'b0;
+  reg          slip_d;
+  reg          slip_dd;
+
+  wire         shift_cnt_en_s;
+  wire [ 4:0]  shift_cnt_value;
+  wire [19:0]  pattern_value;
+
+  always @(posedge adc_clk_div) begin
+    slip_d <= bitslip_enable;
+    slip_dd <= slip_d;
+    if(serdes_reset_s || adc_data_shifted == pattern_value)
+      shift_cnt_en <= 1'b0;
+    else if(slip_d & ~slip_dd)
+      shift_cnt_en <= 1'b1;
+  end
+
+  assign shift_cnt_value = 'd19;
+  assign  pattern_value = 20'hac5d6;
+
+  always @(posedge adc_clk_div) begin
+    if(shift_cnt_en) begin
+      if(shift_cnt == shift_cnt_value || serdes_reset_s) begin
+        shift_cnt <= 0;
+        sync_status_int <= 1'b0;
+      end else if( adc_data_shifted != pattern_value &&(packed_data_valid_d & ~packed_data_valid) ) begin
+        shift_cnt <= shift_cnt + 1;
+      end
+      if(adc_data_shifted == pattern_value) begin
+        sync_status_int <= 1'b1;
+      end
+    end
+  end
+
+  reg [19:0]  adc_data_shifted;
+  reg packed_data_valid_d;
+
+  always @(posedge adc_clk_div) begin
+    // >> 1 for sdr,single lane
+    // >> 14 for sdr,dual lane
+    adc_data_shifted <= {packed_data_d,packed_data} >> shift_cnt;
+    packed_data_valid_d <= packed_data_valid;
+  end
+
+  // Sign extend to 32 bits
+
+  assign adc_data =  ~uncorrected_mode ? {{12{adc_data_shifted[19]}},adc_data_shifted} :
+                                         {{12{packed_20_80[19]}},packed_20_80[19:0]};
+  assign adc_valid = ~uncorrected_mode ? packed_data_valid_d : pack80_valid;
+
+  // Pack to 80 bit for the uncorrected mode
+  // Start packing after first three samples since first sample is not
+  // received fully
+
+  reg [2:0] pack_rst = 3'b111;
+
+  always @(posedge adc_clk_div) begin
+    packed_data_valid_d <= packed_data_valid;
+    if(packed_data_valid_d)
+      pack_rst <= {pack_rst,1'b0};
+  end
+
+  ad_pack #(
+    .I_W(20),
+    .O_W(80),
+    .UNIT_W(1),
+    .ALIGN_TO_MSB(1)
+  ) i_ad_pack_80 (
+    .clk(adc_clk_div),
+    .reset(pack_rst[2]),
+    .idata(adc_data_shifted),
+    .ivalid(packed_data_valid_d),
+    .odata(packed_20_80),
+    .ovalid(pack80_valid));
+
+  assign adc_uncor_valid = uncorrected_mode ? pack80_valid : 1'b0;
+  assign adc_uncor_data = {48'b0,packed_20_80};
+
+endmodule

--- a/library/axi_ad408x/axi_ad408x.v
+++ b/library/axi_ad408x/axi_ad408x.v
@@ -1,0 +1,363 @@
+// ***************************************************************************
+// ***************************************************************************
+// Copyright (C) 2022-2024 Analog Devices, Inc. All rights reserved.
+//
+// In this HDL repository, there are many different and unique modules, consisting
+// of various HDL(Verilog or VHDL) components. The individual modules are
+// developed independently, and may be accompanied by separate and unique license
+// terms.
+//
+// The user should read each of these license terms, and understand the
+// freedoms and responsibilities that he or she has by using this source/core.
+//
+// This core is distributed in the hope that it will be useful, but WITHOUT ANY
+// WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+// A PARTICULAR PURPOSE.
+//
+// Redistribution and use of source or resulting binaries, with or without modification
+// of this file, are permitted under one of the following two license terms:
+//
+//   1. The GNU General Public License version 2 as published by the
+//      Free Software Foundation, which can be found in the top level directory
+//      of this repository(LICENSE_GPL2), and also online at:
+//      <https://www.gnu.org/licenses/old-licenses/gpl-2.0.html>
+//
+// OR
+//
+//   2. An ADI specific BSD license, which can be found in the top level directory
+//      of this repository(LICENSE_ADIBSD), and also on-line at:
+//      https://github.com/analogdevicesinc/hdl/blob/master/LICENSE_ADIBSD
+//      This will allow to generate bit files and not release the source code,
+//      as long as it attaches to an ADI device.
+//
+// ***************************************************************************
+// ***************************************************************************
+
+`timescale 1ns/100ps
+
+module axi_ad408x #(
+  parameter   ID = 0,
+  parameter   FPGA_TECHNOLOGY = 0,
+  parameter   DRP_WIDTH = 5,
+  parameter   NUM_LANES = 2,   // Max number of lanes is 2
+  parameter   NUM_OF_CHANNELS = 2,
+  parameter   DDR_SUPPORT = 1,
+  parameter   HAS_DELAY_CTRL = 0,
+  parameter   DELAY_CTRL_NUM_LANES = 1,
+  parameter   DELAY_CTRL_DRP_WIDTH = 5,
+  parameter   IODELAY_CTRL = 1,
+  parameter   IO_DELAY_GROUP = "dev_if_delay_group"
+) (
+
+  // ADC interface
+
+  input                   dclk_in_n,
+  input                   dclk_in_p,
+  input                   data_a_in_n,
+  input                   data_a_in_p,
+  input                   data_b_in_n,
+  input                   data_b_in_p,
+  input                   sync_n,
+  input                   uncorrected_mode,
+
+  // output data interface
+
+  output                  adc_clk,
+  output      [ 31:0]     adc_data,
+  output                  adc_valid,
+  output      [127:0]     adc_uncor_data,
+  output                  adc_uncor_valid,
+  input                   adc_dovf,
+
+  // delay interface
+
+  input                   delay_clk,
+
+  // AXI interface
+
+  input                   s_axi_aclk,
+  input                   s_axi_aresetn,
+  input                   s_axi_awvalid,
+  input         [15:0]    s_axi_awaddr,
+  output                  s_axi_awready,
+  input                   s_axi_wvalid,
+  input         [31:0]    s_axi_wdata,
+  input         [ 3:0]    s_axi_wstrb,
+  output                  s_axi_wready,
+  output                  s_axi_bvalid,
+  output        [ 1:0]    s_axi_bresp,
+  input                   s_axi_bready,
+  input                   s_axi_arvalid,
+  input         [15:0]    s_axi_araddr,
+  output                  s_axi_arready,
+  output                  s_axi_rvalid,
+  output        [ 1:0]    s_axi_rresp,
+  output        [31:0]    s_axi_rdata,
+  input                   s_axi_rready,
+  input         [ 2:0]    s_axi_awprot,
+  input         [ 2:0]    s_axi_arprot
+);
+
+  localparam NUM_OF_UP_SPACES = 1 + NUM_OF_CHANNELS + HAS_DELAY_CTRL;
+
+  // internal signals
+
+  wire                    adc_clk_s;
+  wire                    adc_rst_s;
+  wire                    adc_enable;
+  wire                    delay_rst;
+  wire                    delay_locked;
+  wire                    bitslip_enable;
+  wire                    sync_status;
+  wire                    up_adc_ddr_edgesel;
+  wire          [ 4:0]    up_adc_num_lanes;
+  wire                    up_adc_sdr_ddr_n;
+  wire                    up_rstn;
+  wire                    up_clk;
+  wire          [13:0]    up_waddr_s;
+  wire          [13:0]    up_raddr_s;
+  wire                    up_sel_s;
+  wire                    up_wr_s;
+  wire          [13:0]    up_addr_s;
+  wire          [31:0]    up_wdata_s;
+  wire          [31:0]    up_rdata_s  [0:NUM_OF_UP_SPACES-1];
+  wire                    up_rack_s   [0:NUM_OF_UP_SPACES-1];
+  wire                    up_wack_s   [0:NUM_OF_UP_SPACES-1];
+  wire  [DELAY_CTRL_NUM_LANES-1:0]                       up_dld;
+  wire  [DELAY_CTRL_DRP_WIDTH*DELAY_CTRL_NUM_LANES-1:0]  up_dwdata;
+  wire  [DELAY_CTRL_DRP_WIDTH*DELAY_CTRL_NUM_LANES-1:0]  up_drdata;
+
+  reg [31:0]  up_rdata_r;
+  reg         up_rack_r;
+  reg         up_wack_r;
+  reg  [31:0] up_rdata = 'd0;
+  reg         up_rack  = 'd0;
+  reg         up_wack  = 'd0;
+
+  integer j;
+
+  assign adc_clk = adc_clk_s;
+  assign up_clk = s_axi_aclk;
+  assign up_rstn = s_axi_aresetn;
+
+  always @(*)
+  begin
+    up_rdata_r = 'h00;
+    up_rack_r = 'h00;
+    up_wack_r = 'h00;
+    for(j = 0; j < NUM_OF_UP_SPACES; j=j+1) begin
+      up_rack_r = up_rack_r | up_rack_s[j];
+      up_wack_r = up_wack_r | up_wack_s[j];
+      up_rdata_r = up_rdata_r | up_rdata_s[j];
+    end
+  end
+
+  always @(negedge up_rstn or posedge up_clk) begin
+    if(up_rstn == 0) begin
+      up_rdata <= 'd0;
+      up_rack <= 'd0;
+      up_wack <= 'd0;
+    end else begin
+      up_rdata <= up_rdata_r;
+      up_rack <= up_rack_r;
+      up_wack <= up_wack_r;
+    end
+  end
+
+  up_adc_channel #(
+    .CHANNEL_ID(0)
+  ) ad408x_channel_0 (
+    .adc_clk(adc_clk_s),
+    .adc_rst(adc_rst_s),
+    .adc_enable(adc_enable),
+    .adc_iqcor_enb(),
+    .adc_dcfilt_enb(),
+    .adc_dfmt_se(),
+    .adc_dfmt_type(),
+    .adc_dfmt_enable(),
+    .adc_dcfilt_offset(),
+    .adc_dcfilt_coeff(),
+    .adc_iqcor_coeff_1(),
+    .adc_iqcor_coeff_2(),
+    .adc_pnseq_sel(),
+    .adc_data_sel(),
+    .adc_pn_err(1'b0),
+    .adc_pn_oos(1'b0),
+    .adc_or(),
+    .adc_read_data(),
+    .adc_status_header('b0),
+    .adc_crc_err('b0),
+    .up_adc_crc_err(),
+    .up_adc_pn_err(),
+    .up_adc_pn_oos(),
+    .up_adc_or(),
+    .up_usr_datatype_be(),
+    .up_usr_datatype_signed(),
+    .up_usr_datatype_shift(),
+    .up_usr_datatype_total_bits(),
+    .up_usr_datatype_bits(),
+    .up_usr_decimation_m(),
+    .up_usr_decimation_n(),
+    .adc_usr_datatype_be(1'b0),
+    .adc_usr_datatype_signed(1'b1),
+    .adc_usr_datatype_shift(8'd0),
+    .adc_usr_datatype_total_bits(8'd32),
+    .adc_usr_datatype_bits(8'd32),
+    .adc_usr_decimation_m(16'd1),
+    .adc_usr_decimation_n(16'd1),
+    .up_rstn(up_rstn),
+    .up_clk(up_clk),
+    .up_wreq(up_wreq_s),
+    .up_waddr(up_waddr_s),
+    .up_wdata(up_wdata_s),
+    .up_wack(up_wack_s[0]),
+    .up_rreq(up_rreq_s),
+    .up_raddr(up_raddr_s),
+    .up_rdata(up_rdata_s[0]),
+    .up_rack(up_rack_s[0]));
+
+  up_adc_common #(
+    .ID(ID)
+  ) i_up_adc_common (
+    .mmcm_rst(),
+    .adc_clk(adc_clk),
+    .adc_rst(adc_rst_s),
+    .adc_r1_mode(),
+    .up_adc_ddr_edgesel(up_adc_ddr_edgesel),
+    .adc_pin_mode(),
+    .adc_status('h00),
+    .adc_sync_status(sync_status),
+    .adc_status_ovf(adc_dovf),
+    .adc_clk_ratio(32'd1),
+    .adc_start_code(),
+    .adc_sref_sync(),
+    .adc_sync(bitslip_enable),
+    .up_adc_num_lanes(up_adc_num_lanes),
+    .up_adc_sdr_ddr_n(up_adc_sdr_ddr_n),
+    .up_pps_rcounter(32'b0),
+    .up_pps_status(1'b0),
+    .up_pps_irq_mask(),
+    .up_adc_ce(),
+    .up_status_pn_err(1'b0),
+    .up_status_pn_oos(1'b0),
+    .up_status_or(1'b0),
+    .up_drp_sel(),
+    .up_drp_wr(),
+    .up_drp_addr(),
+    .up_drp_wdata(),
+    .up_drp_rdata(32'd0),
+    .up_drp_ready(1'd0),
+    .up_drp_locked(1'd1),
+    .adc_config_wr(),
+    .adc_config_ctrl(),
+    .adc_config_rd('d0),
+    .adc_ctrl_status('d0),
+    .up_usr_chanmax_out(),
+    .up_usr_chanmax_in(1),
+    .up_adc_gpio_in(32'b0),
+    .up_adc_gpio_out(),
+    .up_rstn(up_rstn),
+    .up_clk(up_clk),
+    .up_wreq(up_wreq_s),
+    .up_waddr(up_waddr_s),
+    .up_wdata(up_wdata_s),
+    .up_wack(up_wack_s[1]),
+    .up_rreq(up_rreq_s),
+    .up_raddr(up_raddr_s),
+    .up_rdata(up_rdata_s[1]),
+    .up_rack(up_rack_s[1]));
+
+ // ad4080 interface module
+
+  ad408x_phy #(
+    .FPGA_TECHNOLOGY(FPGA_TECHNOLOGY),
+    .DRP_WIDTH(DRP_WIDTH),
+    .NUM_LANES(NUM_LANES),
+    .DDR_SUPPORT(DDR_SUPPORT),
+    .IODELAY_CTRL(IODELAY_CTRL),
+    .IO_DELAY_GROUP(IO_DELAY_GROUP)
+  ) ad408x_interface (
+    .dclk_in_n(dclk_in_n),
+    .dclk_in_p(dclk_in_p),
+    .data_a_in_n(data_a_in_n),
+    .data_a_in_p(data_a_in_p),
+    .data_b_in_n(data_b_in_n),
+    .data_b_in_p(data_b_in_p),
+    .sync_n(sync_n),
+    .sdr_ddr_n(up_adc_sdr_ddr_n),
+    .num_lanes(up_adc_num_lanes),
+    .ddr_edge_sel(up_adc_ddr_edgesel),
+    .uncorrected_mode(uncorrected_mode),
+    .up_clk(up_clk),
+    .up_adc_dld(up_dld),
+    .up_adc_dwdata(up_dwdata),
+    .up_adc_drdata(up_drdata),
+    .delay_clk(delay_clk),
+    .delay_rst(delay_rst),
+    .delay_locked(delay_locked),
+    .adc_rst(adc_rst),
+    .adc_clk_div(adc_clk_s),
+    .adc_data(adc_data),
+    .adc_valid(adc_valid),
+    .adc_uncor_data(adc_uncor_data),
+    .adc_uncor_valid(adc_uncor_valid),
+    .bitslip_enable(bitslip_enable),
+    .sync_status(sync_status));
+
+  // adc delay control
+
+  up_delay_cntrl #(
+    .DISABLE(HAS_DELAY_CTRL==0),
+    .DATA_WIDTH(DELAY_CTRL_NUM_LANES),
+    .DRP_WIDTH(DELAY_CTRL_DRP_WIDTH),
+    .BASE_ADDRESS(6'h02)
+  ) i_delay_cntrl (
+    .delay_clk(delay_clk),
+    .delay_rst(delay_rst),
+    .delay_locked(delay_locked),
+    .up_dld(up_dld),
+    .up_dwdata(up_dwdata),
+    .up_drdata(up_drdata),
+    .up_rstn(up_rstn),
+    .up_clk(up_clk),
+    .up_wreq(up_wreq_s),
+    .up_waddr(up_waddr_s),
+    .up_wdata(up_wdata_s),
+    .up_wack(up_wack_s[1+HAS_DELAY_CTRL]),
+    .up_rreq(up_rreq_s),
+    .up_raddr(up_raddr_s),
+    .up_rdata(up_rdata_s[1+HAS_DELAY_CTRL]),
+    .up_rack(up_rack_s[1+HAS_DELAY_CTRL]));
+
+  // up bus interface
+
+  up_axi i_up_axi(
+    .up_rstn(up_rstn),
+    .up_clk(up_clk),
+    .up_axi_awvalid(s_axi_awvalid),
+    .up_axi_awaddr(s_axi_awaddr),
+    .up_axi_awready(s_axi_awready),
+    .up_axi_wvalid(s_axi_wvalid),
+    .up_axi_wdata(s_axi_wdata),
+    .up_axi_wstrb(s_axi_wstrb),
+    .up_axi_wready(s_axi_wready),
+    .up_axi_bvalid(s_axi_bvalid),
+    .up_axi_bresp(s_axi_bresp),
+    .up_axi_bready(s_axi_bready),
+    .up_axi_arvalid(s_axi_arvalid),
+    .up_axi_araddr(s_axi_araddr),
+    .up_axi_arready(s_axi_arready),
+    .up_axi_rvalid(s_axi_rvalid),
+    .up_axi_rresp(s_axi_rresp),
+    .up_axi_rdata(s_axi_rdata),
+    .up_axi_rready(s_axi_rready),
+    .up_wreq(up_wreq_s),
+    .up_waddr(up_waddr_s),
+    .up_wdata(up_wdata_s),
+    .up_wack(up_wack),
+    .up_rreq(up_rreq_s),
+    .up_raddr(up_raddr_s),
+    .up_rdata(up_rdata),
+    .up_rack(up_rack));
+
+endmodule

--- a/library/axi_ad408x/axi_ad408x.v
+++ b/library/axi_ad408x/axi_ad408x.v
@@ -58,15 +58,12 @@ module axi_ad408x #(
   input                   data_b_in_n,
   input                   data_b_in_p,
   input                   sync_n,
-  input                   uncorrected_mode,
 
   // output data interface
 
   output                  adc_clk,
   output      [ 31:0]     adc_data,
   output                  adc_valid,
-  output      [127:0]     adc_uncor_data,
-  output                  adc_uncor_valid,
   input                   adc_dovf,
 
   // delay interface
@@ -287,7 +284,6 @@ module axi_ad408x #(
     .sdr_ddr_n(up_adc_sdr_ddr_n),
     .num_lanes(up_adc_num_lanes),
     .ddr_edge_sel(up_adc_ddr_edgesel),
-    .uncorrected_mode(uncorrected_mode),
     .up_clk(up_clk),
     .up_adc_dld(up_dld),
     .up_adc_dwdata(up_dwdata),
@@ -299,8 +295,6 @@ module axi_ad408x #(
     .adc_clk_div(adc_clk_s),
     .adc_data(adc_data),
     .adc_valid(adc_valid),
-    .adc_uncor_data(adc_uncor_data),
-    .adc_uncor_valid(adc_uncor_valid),
     .bitslip_enable(bitslip_enable),
     .sync_status(sync_status));
 

--- a/library/axi_ad408x/axi_ad408x_ip.tcl
+++ b/library/axi_ad408x/axi_ad408x_ip.tcl
@@ -1,0 +1,47 @@
+###############################################################################
+## Copyright (C) 2022-2024 Analog Devices, Inc. All rights reserved.
+### SPDX short identifier: ADIBSD
+###############################################################################
+
+
+source ../../../hdl/scripts/adi_env.tcl
+source ../../../hdl/library/scripts/adi_ip_xilinx.tcl
+
+adi_ip_create axi_ad408x
+
+adi_ip_files axi_ad408x [list \
+  "$ad_hdl_dir/library/xilinx/common/ad_serdes_in.v" \
+  "$ad_hdl_dir/library/common/ad_pack.v" \
+  "$ad_hdl_dir/library/common/ad_rst.v" \
+  "$ad_hdl_dir/library/xilinx/common/ad_data_clk.v" \
+  "$ad_hdl_dir/library/xilinx/common/ad_data_in.v" \
+  "$ad_hdl_dir/library/xilinx/common/ad_dcfilter.v" \
+  "$ad_hdl_dir/library/common/ad_datafmt.v" \
+  "$ad_hdl_dir/library/common/up_xfer_status.v" \
+  "$ad_hdl_dir/library/common/up_xfer_cntrl.v" \
+  "$ad_hdl_dir/library/common/up_clock_mon.v" \
+  "$ad_hdl_dir/library/common/up_delay_cntrl.v" \
+  "$ad_hdl_dir/library/common/up_adc_common.v" \
+  "$ad_hdl_dir/library/common/up_adc_channel.v" \
+  "$ad_hdl_dir/library/common/up_axi.v" \
+  "$ad_hdl_dir/library/xilinx/common/up_xfer_cntrl_constr.xdc" \
+  "$ad_hdl_dir/library/xilinx/common/ad_rst_constr.xdc" \
+  "$ad_hdl_dir/library/xilinx/common/up_xfer_status_constr.xdc" \
+  "$ad_hdl_dir/library/xilinx/common/up_clock_mon_constr.xdc" \
+  "ad408x_phy.v" \
+  "axi_ad408x.v" ]
+
+adi_ip_properties axi_ad408x
+
+adi_init_bd_tcl
+adi_ip_bd axi_ad408x "bd/bd.tcl"
+
+set_property driver_value 0 [ipx::get_ports *dovf* -of_objects [ipx::current_core]]
+
+ipx::infer_bus_interface adc_clk xilinx.com:signal:clock_rtl:1.0 [ipx::current_core]
+ipx::infer_bus_interface delay_clk xilinx.com:signal:clock_rtl:1.0 [ipx::current_core]
+
+adi_add_auto_fpga_spec_params
+
+ipx::create_xgui_files [ipx::current_core]
+ipx::save_core [ipx::current_core]

--- a/library/common/ad_pack.v
+++ b/library/common/ad_pack.v
@@ -1,6 +1,6 @@
 // ***************************************************************************
 // ***************************************************************************
-// Copyright (C) 2014-2023 Analog Devices, Inc. All rights reserved.
+// Copyright (C) 2014-2024 Analog Devices, Inc. All rights reserved.
 //
 // In this HDL repository, there are many different and unique modules, consisting
 // of various HDL (Verilog or VHDL) components. The individual modules are
@@ -38,9 +38,10 @@
 // Packer:
 //   - pack I_W number of data units into O_W number of data units
 //   - data unit defined in bits by UNIT_W e.g 8 is a byte
+//   - align data to LSB or MSB
 //
 // Constraints:
-//   - O_W > I_W
+//   - O_W >= I_W
 //   - no backpressure
 //
 // Data format:
@@ -52,16 +53,26 @@
 //  O_W = 6
 //  UNIT_W = 8
 //
+//  Data aligned to LSB
+//
 //  idata : [B3,B2,B1,B0],[B7,B6,B5,B4],[B11,B10,B9,B8]
 //  odata:                             [B5,B4,B3,B2,B1,B0],[B11,B10,B9,B8,B7,B6]
 //
+//
+//  or
+//
+//  Data aligned to MSB
+//
+//  idata : [B0,B1,B2,B3],[B4,B5,B6,B7],[B8,B9,B10,B11]
+//  odata:                             [B0,B1,B2,B3,B4,B5],[B6,B7,B8,B9,B10,B11]
 
 module ad_pack #(
   parameter I_W = 4,
   parameter O_W = 6,
   parameter UNIT_W = 8,
   parameter I_REG = 0,
-  parameter O_REG = 1
+  parameter O_REG = 1,
+  parameter ALIGN_TO_MSB = 0
 ) (
   input                   clk,
   input                   reset,
@@ -89,18 +100,18 @@ module ad_pack #(
   wire pack_wr;
 
   function [31:0] gcd;
-    input [31:0]  a;
-    input [31:0]  b;
-    begin
-      while (a != b) begin
-        if (a > b) begin
-          a = a-b;
-        end else begin
-          b = b-a;
-        end
+  input [31:0]  a;
+  input [31:0]  b;
+  begin
+    while (a != b) begin
+      if (a > b) begin
+        a = a-b;
+      end else begin
+        b = b-a;
       end
-      gcd = a;
     end
+    gcd = a;
+  end
   endfunction
 
   generate
@@ -117,12 +128,23 @@ module ad_pack #(
         ivalid_d = ivalid;
         idata_d = idata;
       end
-
     end
   endgenerate
 
-  assign idata_dd_nx = {idata_d,idata_dd[SH_W*UNIT_W-1:I_W*UNIT_W]};
-  assign in_use_nx = {{I_W{ivalid_d}},in_use[SH_W-1:I_W]};
+  assign idata_dd_nx = ALIGN_TO_MSB ?
+                       {idata_dd,idata_d} :
+                       {idata_d,idata_dd[SH_W*UNIT_W-1:I_W*UNIT_W]};
+  assign in_use_nx = ALIGN_TO_MSB ?
+                       {in_use,{I_W{ivalid_d}}} :
+                       {{I_W{ivalid_d}},in_use[SH_W-1:I_W]};
+
+  // Keep track of accumulated elements,
+  // at every output valid, the number of elements that are left in the
+  // storage is changing if O_W is not integer multiple of I_W,
+  // these are packed together with future data.
+  // If the number of accumulated elements from previous operation together
+  // with the current input word form an output word a valid data can be
+  // generated.
 
   always @(posedge clk) begin
     if (reset) begin
@@ -139,18 +161,42 @@ module ad_pack #(
   end
 
   integer i;
+  generate
+
+  // Location of the output data in the storage differs from operation to
+  // operation and is tracked by the in_use register.
+  // Depending on the ALIGN_TO_MSB parameter either (1) the left most bits will be
+  // output or (0) the right most ones.
+  // out_mask represents the bits that are currently outputted, these get
+  // removed from the in_use register for the next operation
+
+  if (ALIGN_TO_MSB == 0) begin  // Data aligned to LSB
+    always @(*) begin
+      out_mask = 'b0;
+      idata_packed = 'b0;
+      for (i = SH_W-O_W; i >= 0; i=i-STEP) begin
+        if (in_use_nx[i]) begin
+          out_mask = {O_W{1'b1}} << i;
+          idata_packed = idata_dd_nx >> i*UNIT_W;
+        end
+      end
+    end
+
+    assign pack_wr = ivalid_d & |in_use_nx[SH_W-O_W:0];
+  end else begin  // Data aligned to MSB
   always @(*) begin
     out_mask = 'b0;
     idata_packed = 'b0;
-    for (i = SH_W-O_W; i >= 0; i=i-STEP) begin
-      if (in_use_nx[i]) begin
-        out_mask = {O_W{1'b1}} << i;
-        idata_packed = idata_dd_nx >> i*UNIT_W;
+      for (i = O_W-1 ; i <= SH_W-1; i=i+STEP) begin
+        if (in_use_nx[i]) begin
+          out_mask = {O_W{1'b1}} << (i-O_W+1);
+          idata_packed = idata_dd_nx >> (i-O_W+1)*UNIT_W;
+        end
       end
-    end
   end
-
-  assign pack_wr = ivalid_d & |in_use_nx[SH_W-O_W:0];
+  assign pack_wr = ivalid_d & |in_use_nx[SH_W-1:O_W-1];
+  end
+  endgenerate
 
   generate
     if (O_REG) begin : o_reg
@@ -168,12 +214,10 @@ module ad_pack #(
       end
 
     end else begin
-
       always @(*) begin
         ovalid = pack_wr;
         odata = idata_packed;
       end
-
     end
   endgenerate
 

--- a/library/common/tb/ad_pack_tb.v
+++ b/library/common/tb/ad_pack_tb.v
@@ -41,7 +41,8 @@ module ad_pack_tb;
   parameter I_W = 4;   // Width of input channel
   parameter O_W = 6;   // Width of output channel
   parameter UNIT_W = 8;
-  parameter VECT_W = 1024*8;  // Multiple of 8
+  parameter VECT_W = 256*UNIT_W*O_W;  // Multiple of output width
+  parameter ALIGN_TO_MSB = 0;
 
   `include "tb_base.v"
 
@@ -57,7 +58,8 @@ module ad_pack_tb;
   ad_pack #(
     .I_W(I_W),
     .O_W(O_W),
-    .UNIT_W(UNIT_W)
+    .UNIT_W(UNIT_W),
+    .ALIGN_TO_MSB(ALIGN_TO_MSB)
   ) DUT (
     .clk(clk),
     .reset(reset),
@@ -102,6 +104,37 @@ module ad_pack_tb;
   end
   endtask
 
+  task test_msb();
+  begin
+    @(posedge clk);
+    i = VECT_W/(I_W*UNIT_W)-1;
+    j = VECT_W/(O_W*UNIT_W)-1;
+    while (i >= 0) begin
+      @(posedge clk);
+      if ($urandom % 2 == 0) begin
+        idata <= input_vector[i*(I_W*UNIT_W) +: (I_W*UNIT_W)];
+        ivalid <= 1'b1;
+        i = i - 1;
+      end else begin
+        idata <= 'bx;
+        ivalid <= 1'b0;
+      end
+    end
+    @(posedge clk);
+    idata <= 'bx;
+    ivalid <= 1'b0;
+
+    // Check output vector
+    repeat (20) @(posedge clk);
+    for (i=0; i<(VECT_W/(O_W*UNIT_W))*(O_W*UNIT_W)/8; i=i+1) begin
+      if (input_vector[i*8+:8] !== output_vector[i*8+:8]) begin
+        failed <= 1'b1;
+        $display("i=%d Expected=%x Found=%x",i,input_vector[i*8+:8],output_vector[i*8+:8]);
+      end
+    end
+  end
+  endtask
+  
   initial begin
 
     @(negedge reset);
@@ -111,7 +144,10 @@ module ad_pack_tb;
       input_vector[i*8+:8] = i[7:0];
     end
 
-    test(1);
+    if (ALIGN_TO_MSB)
+      test_msb();
+    else
+      test(1);
 
     do_trigger_reset();
     @(negedge reset);
@@ -126,7 +162,10 @@ module ad_pack_tb;
       input_vector[i*8+:8] = $urandom;
     end
 
-    test(0);
+    if (ALIGN_TO_MSB)
+      test_msb();
+    else
+      test(0);
 
   end
 
@@ -134,7 +173,13 @@ module ad_pack_tb;
     if (ovalid) begin
       if (j < VECT_W/(O_W*UNIT_W)) begin
         output_vector[j*(O_W*UNIT_W) +: (O_W*UNIT_W)] = odata;
-        j = j + 1;
+        if (ALIGN_TO_MSB) begin
+          if (j > 0) begin
+            j = j - 1;
+          end
+        end else begin
+            j = j + 1;
+        end
       end
     end
   end

--- a/library/common/up_adc_common.v
+++ b/library/common/up_adc_common.v
@@ -1,6 +1,6 @@
 // ***************************************************************************
 // ***************************************************************************
-// Copyright (C) 2014-2023 Analog Devices, Inc. All rights reserved.
+// Copyright (C) 2014-2024 Analog Devices, Inc. All rights reserved.
 //
 // In this HDL repository, there are many different and unique modules, consisting
 // of various HDL (Verilog or VHDL) components. The individual modules are
@@ -84,6 +84,12 @@ module up_adc_common #(
   output  reg         up_pps_irq_mask,
   output  reg         up_adc_r1_mode = 'd0,
 
+  // controls in up clock domain
+
+  output  reg         up_adc_ddr_edgesel = 1'b0,
+  output  reg  [4:0]  up_adc_num_lanes = 5'b0,
+  output  reg         up_adc_sdr_ddr_n = 1'b0,
+
   // channel interface
 
   output              up_adc_ce,
@@ -148,11 +154,8 @@ module up_adc_common #(
   reg                 up_adc_ext_sync_disarm = 'd0;
   reg                 up_adc_ext_sync_manual_req = 'd0;
   reg                 up_adc_sref_sync = 'd0;
-  reg         [4:0]   up_adc_num_lanes = 'd0;
-  reg                 up_adc_sdr_ddr_n = 'd0;
   reg                 up_adc_symb_op = 'd0;
   reg                 up_adc_symb_8_16b = 'd0;
-  reg                 up_adc_ddr_edgesel = 'd0;
   reg                 up_adc_pin_mode = 'd0;
   reg                 up_status_ovf = 'd0;
   reg         [ 7:0]  up_usr_chanmax_int = 'd0;

--- a/library/xilinx/common/ad_serdes_in.v
+++ b/library/xilinx/common/ad_serdes_in.v
@@ -1,6 +1,6 @@
 // ***************************************************************************
 // ***************************************************************************
-// Copyright (C) 2014-2023 Analog Devices, Inc. All rights reserved.
+// Copyright (C) 2014-2024 Analog Devices, Inc. All rights reserved.
 //
 // In this HDL repository, there are many different and unique modules, consisting
 // of various HDL (Verilog or VHDL) components. The individual modules are
@@ -46,12 +46,14 @@ module ad_serdes_in #(
   parameter   IODELAY_ENABLE = 1,
   parameter   IODELAY_CTRL = 0,
   parameter   IODELAY_GROUP = "dev_if_delay_group",
-  parameter   REFCLK_FREQUENCY = 200
+  parameter   REFCLK_FREQUENCY = 200,
+  parameter   EXT_SERDES_RESET = 0
 ) (
 
   // reset and clocks
 
   input                           rst,
+  input                           ext_serdes_rst,
   input                           clk,
   input                           div_clk,
 
@@ -108,42 +110,43 @@ module ad_serdes_in #(
   wire  [(DATA_WIDTH-1):0]      data_in_idelay_s;
   wire  [(DATA_WIDTH-1):0]      data_shift1_s;
   wire  [(DATA_WIDTH-1):0]      data_shift2_s;
-  wire  serdes_rst = serdes_rst_seq[6];
+
+  wire  serdes_rst = (EXT_SERDES_RESET == 1) ? ext_serdes_rst :
+                                               serdes_rst_seq[6];
 
   // delay controller
 
   generate
-  if (IODELAY_CTRL_ENABLED == 1) begin
-    (* IODELAY_GROUP = IODELAY_GROUP *)
+    if (IODELAY_CTRL_ENABLED == 1) begin
+      (* IODELAY_GROUP = IODELAY_GROUP *)
     IDELAYCTRL #(
       .SIM_DEVICE(SIM_DEVICE_IDELAYCTRL)
     ) i_delay_ctrl (
       .RST (delay_rst),
       .REFCLK (delay_clk),
       .RDY (delay_locked));
-  end else begin
-    assign delay_locked = 1'b1;
-  end
+    end else begin
+      assign delay_locked = 1'b1;
+    end
   endgenerate
 
   // received data interface: ibuf -> idelay -> iserdes
-
   // ibuf
 
   genvar l_inst;
   generate
-  for (l_inst = 0; l_inst <= (DATA_WIDTH-1); l_inst = l_inst + 1) begin: g_io
-    if (CMOS_LVDS_N == 0) begin
-      IBUFDS i_ibuf (
-        .I (data_in_p[l_inst]),
-        .IB (data_in_n[l_inst]),
-        .O (data_in_ibuf_s[l_inst]));
-     end else begin
-       IBUF i_ibuf (
-        .I (data_in_p[l_inst]),
-        .O (data_in_ibuf_s[l_inst]));
-     end
-  end
+    for (l_inst = 0; l_inst <= (DATA_WIDTH-1); l_inst = l_inst + 1) begin: g_io
+      if (CMOS_LVDS_N == 0) begin
+        IBUFDS i_ibuf (
+          .I (data_in_p[l_inst]),
+          .IB (data_in_n[l_inst]),
+          .O (data_in_ibuf_s[l_inst]));
+      end else begin
+        IBUF i_ibuf (
+          .I (data_in_p[l_inst]),
+          .O (data_in_ibuf_s[l_inst]));
+      end
+    end
   endgenerate
 
   // bypass IDELAY
@@ -155,44 +158,44 @@ module ad_serdes_in #(
   endgenerate
 
   always @ (posedge div_clk) begin
-    if (rst) begin
-      serdes_rst_seq [6:0] <= 7'b0001110;
-    end else begin
-      serdes_rst_seq [6:0] <= {serdes_rst_seq [5:0], 1'b0};
+      if (rst) begin
+       serdes_rst_seq [6:0] <= 7'b0001110;
+      end else begin
+        serdes_rst_seq [6:0] <= {serdes_rst_seq [5:0], 1'b0};
+      end
     end
-  end
 
   // idelay + iserdes
 
   generate
-  if (FPGA_TECHNOLOGY == SEVEN_SERIES) begin
-    for (l_inst = 0; l_inst <= (DATA_WIDTH-1); l_inst = l_inst + 1) begin: g_data
+    if (FPGA_TECHNOLOGY == SEVEN_SERIES) begin
+      for (l_inst = 0; l_inst <= (DATA_WIDTH-1); l_inst = l_inst + 1) begin: g_data
 
-      if (IODELAY_ENABLE == 1) begin
-        (* IODELAY_GROUP = IODELAY_GROUP *)
-        IDELAYE2 #(
-          .CINVCTRL_SEL ("FALSE"),
-          .DELAY_SRC ("IDATAIN"),
-          .HIGH_PERFORMANCE_MODE ("FALSE"),
-          .IDELAY_TYPE ("VAR_LOAD"),
-          .IDELAY_VALUE (0),
-          .REFCLK_FREQUENCY (REFCLK_FREQUENCY),
-          .PIPE_SEL ("FALSE"),
-          .SIGNAL_PATTERN ("DATA")
-        ) i_idelay (
-          .CE (1'b0),
-          .INC (1'b0),
-          .DATAIN (1'b0),
-          .LDPIPEEN (1'b0),
-          .CINVCTRL (1'b0),
-          .REGRST (1'b0),
-          .C (up_clk),
-          .IDATAIN (data_in_ibuf_s[l_inst]),
-          .DATAOUT (data_in_idelay_s[l_inst]),
-          .LD (up_dld[l_inst]),
-          .CNTVALUEIN (up_dwdata[DRP_WIDTH*l_inst +: DRP_WIDTH]),
-          .CNTVALUEOUT (up_drdata[DRP_WIDTH*l_inst +: DRP_WIDTH]));
-      end
+        if (IODELAY_ENABLE == 1) begin
+          (* IODELAY_GROUP = IODELAY_GROUP *)
+          IDELAYE2 #(
+            .CINVCTRL_SEL ("FALSE"),
+            .DELAY_SRC ("IDATAIN"),
+            .HIGH_PERFORMANCE_MODE ("FALSE"),
+            .IDELAY_TYPE ("VAR_LOAD"),
+            .IDELAY_VALUE (0),
+            .REFCLK_FREQUENCY (REFCLK_FREQUENCY),
+            .PIPE_SEL ("FALSE"),
+            .SIGNAL_PATTERN ("DATA")
+          ) i_idelay (
+            .CE (1'b0),
+            .INC (1'b0),
+            .DATAIN (1'b0),
+            .LDPIPEEN (1'b0),
+            .CINVCTRL (1'b0),
+            .REGRST (1'b0),
+            .C (up_clk),
+            .IDATAIN (data_in_ibuf_s[l_inst]),
+            .DATAOUT (data_in_idelay_s[l_inst]),
+            .LD (up_dld[l_inst]),
+            .CNTVALUEIN (up_dwdata[DRP_WIDTH*l_inst +: DRP_WIDTH]),
+            .CNTVALUEOUT (up_drdata[DRP_WIDTH*l_inst +: DRP_WIDTH]));
+        end
 
       ISERDESE2  #(
         .DATA_RATE (DATA_RATE),
@@ -247,91 +250,91 @@ module ad_serdes_in #(
   endgenerate
 
   generate
-  if (FPGA_TECHNOLOGY == ULTRASCALE || FPGA_TECHNOLOGY == ULTRASCALE_PLUS) begin
-    for (l_inst = 0; l_inst <= (DATA_WIDTH-1); l_inst = l_inst + 1) begin: g_data
+    if (FPGA_TECHNOLOGY == ULTRASCALE || FPGA_TECHNOLOGY == ULTRASCALE_PLUS) begin
+      for (l_inst = 0; l_inst <= (DATA_WIDTH-1); l_inst = l_inst + 1) begin: g_data
 
-    wire   div_dld;
-    wire   en_vtc;
-    wire   ld_cnt;
-    reg [4:0] vtc_cnt = {5{1'b1}};
+        wire   div_dld;
+        wire   en_vtc;
+        wire   ld_cnt;
+        reg [4:0] vtc_cnt = {5{1'b1}};
 
-    sync_event sync_load (
-      .in_clk (up_clk),
-      .in_event (up_dld[l_inst]),
-      .out_clk (div_clk),
-      .out_event (div_dld));
+        sync_event sync_load (
+          .in_clk (up_clk),
+          .in_event (up_dld[l_inst]),
+          .out_clk (div_clk),
+          .out_event (div_dld));
 
-    if (IODELAY_ENABLE == 1) begin
-      (* IODELAY_GROUP = IODELAY_GROUP *)
-      IDELAYE3 #(
-        .CASCADE ("NONE"),          // Cascade setting (MASTER, NONE, SLAVE_END, SLAVE_MIDDLE)
-        .DELAY_FORMAT ("TIME"),     // Units of the DELAY_VALUE (COUNT, TIME)
-        .DELAY_SRC ("IDATAIN"),     // Delay input (DATAIN, IDATAIN)
-        .DELAY_TYPE ("VAR_LOAD"),   // Set the type of tap delay line (FIXED, VARIABLE, VAR_LOAD)
-        .DELAY_VALUE (0),           // Input delay value setting
-        .IS_CLK_INVERTED (1'b0),    // Optional inversion for CLK
-        .IS_RST_INVERTED (1'b0),    // Optional inversion for RST
-        .REFCLK_FREQUENCY (500.0),  // IDELAYCTRL clock input frequency in MHz (200.0-2667.0)
-        .SIM_DEVICE (SIM_DEVICE),   // Set the device version (ULTRASCALE, ULTRASCALE_PLUS, ULTRASCALE_PLUS_ES1,
-                                    // ULTRASCALE_PLUS_ES2)
-        .UPDATE_MODE ("ASYNC")      // Determines when updates to the delay will take effect (ASYNC, MANUAL, SYNC)
-      ) i_idelay (
-        .CASC_OUT (),                                       // 1-bit output: Cascade delay output to ODELAY input cascade
-        .CNTVALUEOUT (up_drdata[DRP_WIDTH*l_inst +: DRP_WIDTH]), // 9-bit output: Counter value output
-        .DATAOUT (data_in_idelay_s[l_inst]),                // 1-bit output: Delayed data output
-        .CASC_IN (1'b0),                                    // 1-bit input: Cascade delay input from slave ODELAY CASCADE_OUT
-        .CASC_RETURN (1'b0),                                // 1-bit input: Cascade delay returning from slave ODELAY DATAOUT
-        .CE (1'b0),                                         // 1-bit input: Active high enable increment/decrement input
-        .CLK (div_clk),                                     // 1-bit input: Clock input
-        .CNTVALUEIN (up_dwdata[DRP_WIDTH*l_inst +: DRP_WIDTH]),   // 9-bit input: Counter value input
-        .DATAIN (1'b0),                                     // 1-bit input: Data input from the logic
-        .EN_VTC (en_vtc),                                   // 1-bit input: Keep delay constant over VT
-        .IDATAIN (data_in_ibuf_s[l_inst]),                  // 1-bit input: Data input from the IOBUF
-        .INC (1'b0),                                        // 1-bit input: Increment / Decrement tap delay input
-        .LOAD (ld_cnt),                                     // 1-bit input: Load DELAY_VALUE input
-        .RST (rst));                                        // 1-bit input: Asynchronous Reset to the DELAY_VALUE
-    end
+        if (IODELAY_ENABLE == 1) begin
+          (* IODELAY_GROUP = IODELAY_GROUP *)
+          IDELAYE3 #(
+            .CASCADE ("NONE"),          // Cascade setting (MASTER, NONE, SLAVE_END, SLAVE_MIDDLE)
+            .DELAY_FORMAT ("TIME"),     // Units of the DELAY_VALUE (COUNT, TIME)
+            .DELAY_SRC ("IDATAIN"),     // Delay input (DATAIN, IDATAIN)
+            .DELAY_TYPE ("VAR_LOAD"),   // Set the type of tap delay line (FIXED, VARIABLE, VAR_LOAD)
+            .DELAY_VALUE (0),           // Input delay value setting
+            .IS_CLK_INVERTED (1'b0),    // Optional inversion for CLK
+            .IS_RST_INVERTED (1'b0),    // Optional inversion for RST
+            .REFCLK_FREQUENCY (500.0),  // IDELAYCTRL clock input frequency in MHz (200.0-2667.0)
+            .SIM_DEVICE (SIM_DEVICE),   // Set the device version (ULTRASCALE, ULTRASCALE_PLUS, ULTRASCALE_PLUS_ES1,
+                                         // ULTRASCALE_PLUS_ES2)
+             .UPDATE_MODE ("ASYNC")      // Determines when updates to the delay will take effect (ASYNC, MANUAL, SYNC)
+          ) i_idelay (
+            .CASC_OUT (),                                       // 1-bit output: Cascade delay output to ODELAY input cascade
+            .CNTVALUEOUT (up_drdata[DRP_WIDTH*l_inst +: DRP_WIDTH]), // 9-bit output: Counter value output
+            .DATAOUT (data_in_idelay_s[l_inst]),                // 1-bit output: Delayed data output
+            .CASC_IN (1'b0),                                    // 1-bit input: Cascade delay input from slave ODELAY CASCADE_OUT
+            .CASC_RETURN (1'b0),                                // 1-bit input: Cascade delay returning from slave ODELAY DATAOUT
+            .CE (1'b0),                                         // 1-bit input: Active high enable increment/decrement input
+            .CLK (div_clk),                                     // 1-bit input: Clock input
+            .CNTVALUEIN (up_dwdata[DRP_WIDTH*l_inst +: DRP_WIDTH]),   // 9-bit input: Counter value input
+            .DATAIN (1'b0),                                     // 1-bit input: Data input from the logic
+            .EN_VTC (en_vtc),                                   // 1-bit input: Keep delay constant over VT
+            .IDATAIN (data_in_ibuf_s[l_inst]),                  // 1-bit input: Data input from the IOBUF
+            .INC (1'b0),                                        // 1-bit input: Increment / Decrement tap delay input
+            .LOAD (ld_cnt),                                     // 1-bit input: Load DELAY_VALUE input
+            .RST (rst));                                        // 1-bit input: Asynchronous Reset to the DELAY_VALUE
+        end
 
-    always @(posedge div_clk) begin
-      if (div_dld) begin
-        vtc_cnt <= 'h0;
-      end else if (~(&vtc_cnt)) begin
-        vtc_cnt <= vtc_cnt + 1;
+        always @(posedge div_clk) begin
+          if (div_dld) begin
+            vtc_cnt <= 'h0;
+          end else if (~(&vtc_cnt)) begin
+            vtc_cnt <= vtc_cnt + 1;
+          end
+        end
+
+        assign en_vtc = &vtc_cnt;
+        assign ld_cnt = ~vtc_cnt[4] & (&vtc_cnt[3:0]);
+
+        ISERDESE3 #(
+           .DATA_WIDTH (8),            // Parallel data width (4,8)
+           .FIFO_ENABLE ("FALSE"),     // Enables the use of the FIFO
+           .FIFO_SYNC_MODE ("FALSE"),  // Enables the use of internal 2-stage synchronizers on the FIFO
+           .IS_CLK_B_INVERTED (1'b0),  // Optional inversion for CLK_B
+           .IS_CLK_INVERTED (1'b0),    // Optional inversion for CLK
+           .IS_RST_INVERTED (1'b0),    // Optional inversion for RST
+           .SIM_DEVICE (SIM_DEVICE)    // Set the device version (ULTRASCALE, ULTRASCALE_PLUS, ULTRASCALE_PLUS_ES1,
+                                       // ULTRASCALE_PLUS_ES2)
+        ) i_iserdes(
+           .FIFO_EMPTY (),                // 1-bit output: FIFO empty flag
+           .INTERNAL_DIVCLK (),           // 1-bit output: Internally divided down clock used when FIFO is
+                                          // disabled (do not connect)
+           .Q ({data_s0[l_inst],
+                data_s1[l_inst],
+                data_s2[l_inst],
+                data_s3[l_inst],
+                data_s4[l_inst],
+                data_s5[l_inst],
+                data_s6[l_inst],
+                data_s7[l_inst]}),        // 8-bit registered output
+           .CLK (clk),                    // 1-bit input: High-speed clock
+           .CLKDIV (div_clk),             // 1-bit input: Divided Clock
+           .CLK_B (~clk),                 // 1-bit input: Inversion of High-speed clock CLK
+           .D (data_in_idelay_s[l_inst]), // 1-bit input: Serial Data Input
+           .FIFO_RD_CLK (div_clk),        // 1-bit input: FIFO read clock
+           .FIFO_RD_EN (1'b1),            // 1-bit input: Enables reading the FIFO when asserted
+         .RST (serdes_rst));            // 1-bit input: Asynchronous Reset
       end
     end
-
-    assign en_vtc = &vtc_cnt;
-    assign ld_cnt = ~vtc_cnt[4] & (&vtc_cnt[3:0]);
-
-    ISERDESE3 #(
-      .DATA_WIDTH (8),            // Parallel data width (4,8)
-      .FIFO_ENABLE ("FALSE"),     // Enables the use of the FIFO
-      .FIFO_SYNC_MODE ("FALSE"),  // Enables the use of internal 2-stage synchronizers on the FIFO
-      .IS_CLK_B_INVERTED (1'b0),  // Optional inversion for CLK_B
-      .IS_CLK_INVERTED (1'b0),    // Optional inversion for CLK
-      .IS_RST_INVERTED (1'b0),    // Optional inversion for RST
-      .SIM_DEVICE (SIM_DEVICE)    // Set the device version (ULTRASCALE, ULTRASCALE_PLUS, ULTRASCALE_PLUS_ES1,
-                                  // ULTRASCALE_PLUS_ES2)
-    ) i_iserdes(
-      .FIFO_EMPTY (),                // 1-bit output: FIFO empty flag
-      .INTERNAL_DIVCLK (),           // 1-bit output: Internally divided down clock used when FIFO is
-                                     // disabled (do not connect)
-      .Q ({data_s0[l_inst],
-           data_s1[l_inst],
-           data_s2[l_inst],
-           data_s3[l_inst],
-           data_s4[l_inst],
-           data_s5[l_inst],
-           data_s6[l_inst],
-           data_s7[l_inst]}),        // 8-bit registered output
-      .CLK (clk),                    // 1-bit input: High-speed clock
-      .CLKDIV (div_clk),             // 1-bit input: Divided Clock
-      .CLK_B (~clk),                 // 1-bit input: Inversion of High-speed clock CLK
-      .D (data_in_idelay_s[l_inst]), // 1-bit input: Serial Data Input
-      .FIFO_RD_CLK (div_clk),        // 1-bit input: FIFO read clock
-      .FIFO_RD_EN (1'b1),            // 1-bit input: Enables reading the FIFO when asserted
-      .RST (serdes_rst));            // 1-bit input: Asynchronous Reset
-   end
-  end
   endgenerate
 endmodule

--- a/projects/ad408x_fmc_evb/Makefile
+++ b/projects/ad408x_fmc_evb/Makefile
@@ -1,0 +1,7 @@
+####################################################################################
+## Copyright (c) 2018 - 2024 Analog Devices, Inc.
+### SPDX short identifier: BSD-1-Clause
+## Auto-generated, do not modify!
+####################################################################################
+
+include ../scripts/project-toplevel.mk

--- a/projects/ad408x_fmc_evb/README.md
+++ b/projects/ad408x_fmc_evb/README.md
@@ -1,0 +1,10 @@
+# AD408X-FMC-EVB HDL Project
+
+Here are some pointers to help you:
+  * [Board Product Page](https://www.analog.com/AD408X-FMC-EVB)
+  * Parts : [AD4080, 20-Bit, 40MSPS, Differential SAR ADC](https://www.analog.com/ad4080)
+  * Parts : [ADF4350, Wideband Synthesizer with Integrated VCO](https://www.analog.com/adf4350)
+  * Parts : [AD9508, 1.65 GHz Clock Fanout Buffer with Output Dividers and Delay Adjust](https://www.analog.com/ad9508)
+  * Project Doc: https://wiki.analog.com/resources/eval/user-guides/ad408x_evb
+  * HDL Doc: https://wiki.analog.com/resources/eval/user-guides/ad408x_evb
+  * Linux Drivers: https://wiki.analog.com/resources/tools-software/linux-drivers-all

--- a/projects/ad408x_fmc_evb/common/ad408x_fmc.txt
+++ b/projects/ad408x_fmc_evb/common/ad408x_fmc.txt
@@ -1,0 +1,49 @@
+FMC_pin  FMC_port      Schematic_name    System_top_name  IOSTANDARD   Termination
+
+# ad408x
+
+H4       FMC_CLK0_M2C_P    DCO_P         dco_p         LVDS_25        DIFF_TERM 1
+H5       FMC_CLK0_M2C_N    DCO_N         dco_n         LVDS_25        DIFF_TERM 1
+G2       FMC_CLK1_M2C_P    FPGACLK_P     fpgaclk_p     LVDS_25        DIFF_TERM 1
+G3       FMC_CLK1_M2C_N    FPGACLK_N     fpgaclk_n     LVDS_25        DIFF_TERM 1
+D8       FMC_LA01_CC_P     CLK_P         clk_p         LVDS_25        DIFF_TERM 1
+D9       FMC_LA01_CC_N     CLK_N         clk_n         LVDS_25        DIFF_TERM 1
+H7       FMC_LA02_P        DA_P          da_p          LVDS_25        DIFF_TERM 1
+H8       FMC_LA02_N        DA_N          da_n          LVDS_25        DIFF_TERM 1
+G9       FMC_LA03_P        DB_P          db_p          LVDS_25        DIFF_TERM 1
+G10      FMC_LA03_N        DB_N          db_n          LVDS_25        DIFF_TERM 1
+H13      FMC_LA07_P        GPIO0_FMC     gpio0_fmc     LVCMOS25       #N/A
+C11      FMC_LA06_N        GPIO1_FMC     gpio1_fmc     LVCMOS25       #N/A
+D14      FMC_LA09_P        GPIO2_FMC     gpio2_fmc     LVCMOS25       #N/A
+D15      FMC_LA09_N        GPIO3_FMC     gpio3_fmc     LVCMOS25       #N/A
+H16      FMC_LA11_P        GP0_DIR       gp0_dir       LVCMOS25       #N/A
+C15      FMC_LA10_N        GP1_DIR       gp1_dir       LVCMOS25       #N/A
+G15      FMC_LA12_P        GP2_DIR       gp2_dir       LVCMOS25       #N/A
+H17      FMC_LA11_N        GP3_DIR       gp3_dir       LVCMOS25       #N/A
+H19      FMC_LA15_P        EN_PSU        en_psu        LVCMOS25       #N/A
+H20      FMC_LA15_N        PWRGD         pwrgd         LVCMOS25       #N/A
+H22      FMC_LA19_P        PD_V33B       pd_v33b       LVCMOS25       #N/A
+G16      FMC_LA12_N        OSC_EN        osc_en        LVCMOS25       #N/A
+G12      FMC_LA08_P        CS_N_SRC      cs_n_src      LVCMOS25       #N/A
+G13      FMC_LA08_N        SDIO_SRC      sdio_src      LVCMOS25       #N/A
+H14      FMC_LA07_N        SCLK_SRC      sclk_src      LVCMOS25       #N/A
+C19      FMC_LA14_N        CS1_0         cs1_0         LVCMOS25       #N/A
+C22      FMC_LA18_CC_P     CS1_1         cs1_1         LVCMOS25       #N/A
+D17      FMC_LA13_P        SDO_1         sdo_1         LVCMOS25       #N/A
+D18      FMC_LA13_N        SCLK1         sclk1         LVCMOS25       #N/A
+C18      FMC_LA14_P        SDIN1         sdin1         LVCMOS25       #N/A
+D20      FMC_LA17_CC_P     DOA_FMC       doa_fmc       LVCMOS25       #N/A
+D21      FMC_LA17_CC_N     DOB_FMC       dob_fmc       LVCMOS25       #N/A
+G18      FMC_LA16_P        DOC_FMC       doc_fmc       LVCMOS25       #N/A
+G19      FMC_LA16_N        DOD_FMC       dod_fmc       LVCMOS25       #N/A
+H23      FMC_LA19_N        PBIO<0>       pbio[0]       LVCMOS25       #N/A
+G21      FMC_LA20_P        PBIO<1>       pbio[1]       LVCMOS25       #N/A
+G22      FMC_LA20_N        PBIO<2>       pbio[2]       LVCMOS25       #N/A
+H25      FMC_LA21_P        PBIO<3>       pbio[3]       LVCMOS25       #N/A
+H26      FMC_LA21_N        PBIO<4>       pbio[4]       LVCMOS25       #N/A
+G24      FMC_LA22_P        PBIO<5>       pbio[5]       LVCMOS25       #N/A
+G25      FMC_LA22_N        PBIO<6>       pbio[6]       LVCMOS25       #N/A
+D23      FMC_LA23_P        PBIO<7>       pbio[7]       LVCMOS25       #N/A
+D24      FMC_LA23_N        PBIO<8>       pbio[8]       LVCMOS25       #N/A
+C10      FMC_LA06_P        AD9508_SYNC   ad9508_sync   LVCMOS25       #N/A
+C23      FMC_LA18_CC_N     ADF435X_LOCK  adf435x_lock  LVCMOS25       #N/A

--- a/projects/ad408x_fmc_evb/common/ad408x_fmc_evb_bd.tcl
+++ b/projects/ad408x_fmc_evb/common/ad408x_fmc_evb_bd.tcl
@@ -1,0 +1,91 @@
+###############################################################################
+## Copyright (C) 2022-2024 Analog Devices, Inc. All rights reserved.
+### SPDX short identifier: ADIBSD
+###############################################################################
+
+# ad4080 interface
+
+create_bd_port -dir I dco_p
+create_bd_port -dir I dco_n
+create_bd_port -dir I da_p
+create_bd_port -dir I da_n
+create_bd_port -dir I db_p
+create_bd_port -dir I db_n
+create_bd_port -dir I uncorrected_mode
+create_bd_port -dir I sync_n
+create_bd_port -dir O sys_cpu_out_clk
+
+# axi_ad408x
+
+ad_ip_instance axi_ad408x axi_ad4080_adc
+ad_ip_parameter axi_ad4080_adc CONFIG.NUM_OF_CHANNELS 1
+ad_ip_parameter axi_ad4080_adc CONFIG.HAS_DELAY_CTRL 1
+ad_ip_parameter axi_ad4080_adc CONFIG.DELAY_CTRL_NUM_LANES 2
+ad_ip_parameter axi_ad4080_adc CONFIG.DDR_SUPPORT 1
+
+# dma for rx1
+
+ad_ip_instance axi_dmac axi_ad4080_dma
+ad_ip_parameter axi_ad4080_dma CONFIG.DMA_TYPE_SRC 2
+ad_ip_parameter axi_ad4080_dma CONFIG.DMA_TYPE_DEST 0
+ad_ip_parameter axi_ad4080_dma CONFIG.CYCLIC 0
+ad_ip_parameter axi_ad4080_dma CONFIG.SYNC_TRANSFER_START 0
+ad_ip_parameter axi_ad4080_dma CONFIG.AXI_SLICE_SRC 0
+ad_ip_parameter axi_ad4080_dma CONFIG.AXI_SLICE_DEST 0
+ad_ip_parameter axi_ad4080_dma CONFIG.DMA_2D_TRANSFER 0
+ad_ip_parameter axi_ad4080_dma CONFIG.DMA_DATA_WIDTH_SRC 32
+
+# dma for uncorrected
+
+ad_ip_instance axi_dmac axi_ad4080_uc_dma
+ad_ip_parameter axi_ad4080_uc_dma CONFIG.DMA_TYPE_SRC 2
+ad_ip_parameter axi_ad4080_uc_dma CONFIG.DMA_TYPE_DEST 0
+ad_ip_parameter axi_ad4080_uc_dma CONFIG.CYCLIC 0
+ad_ip_parameter axi_ad4080_uc_dma CONFIG.SYNC_TRANSFER_START 0
+ad_ip_parameter axi_ad4080_uc_dma CONFIG.AXI_SLICE_SRC 0
+ad_ip_parameter axi_ad4080_uc_dma CONFIG.AXI_SLICE_DEST 0
+ad_ip_parameter axi_ad4080_uc_dma CONFIG.DMA_2D_TRANSFER 0
+ad_ip_parameter axi_ad4080_uc_dma CONFIG.DMA_DATA_WIDTH_SRC 128
+
+# connect interface to axi_ad4080_adc
+
+ad_connect dco_p            axi_ad4080_adc/dclk_in_p
+ad_connect dco_n            axi_ad4080_adc/dclk_in_n
+ad_connect da_p             axi_ad4080_adc/data_a_in_p
+ad_connect da_n             axi_ad4080_adc/data_a_in_n
+ad_connect db_p             axi_ad4080_adc/data_b_in_p
+ad_connect db_n             axi_ad4080_adc/data_b_in_n
+ad_connect sync_n           axi_ad4080_adc/sync_n
+ad_connect uncorrected_mode axi_ad4080_adc/uncorrected_mode
+
+ad_connect $sys_iodelay_clk axi_ad4080_adc/delay_clk
+
+# connect datapath
+
+ad_connect axi_ad4080_adc/adc_data  axi_ad4080_dma/fifo_wr_din
+ad_connect axi_ad4080_adc/adc_valid axi_ad4080_dma/fifo_wr_en
+
+ad_connect axi_ad4080_adc/adc_uncor_data  axi_ad4080_uc_dma/fifo_wr_din
+ad_connect axi_ad4080_adc/adc_uncor_valid axi_ad4080_uc_dma/fifo_wr_en
+
+# system runs on phy's received clock
+
+ad_connect axi_ad4080_adc/adc_clk axi_ad4080_dma/fifo_wr_clk
+ad_connect axi_ad4080_adc/adc_clk axi_ad4080_uc_dma/fifo_wr_clk
+ad_connect $sys_cpu_clk sys_cpu_out_clk
+
+ad_connect $sys_cpu_resetn axi_ad4080_dma/m_dest_axi_aresetn
+ad_connect $sys_cpu_resetn axi_ad4080_uc_dma/m_dest_axi_aresetn
+
+ad_cpu_interconnect 0x44A00000 axi_ad4080_adc
+ad_cpu_interconnect 0x44A30000 axi_ad4080_dma
+ad_cpu_interconnect 0x44A40000 axi_ad4080_uc_dma
+
+ad_mem_hp1_interconnect $sys_cpu_clk sys_ps7/S_AXI_HP1
+ad_mem_hp1_interconnect $sys_cpu_clk axi_ad4080_dma/m_dest_axi
+ad_mem_hp1_interconnect $sys_cpu_clk axi_ad4080_uc_dma/m_dest_axi
+
+ad_cpu_interrupt ps-13 mb-12 axi_ad4080_dma/irq
+ad_cpu_interrupt ps-12 mb-12 axi_ad4080_uc_dma/irq
+
+

--- a/projects/ad408x_fmc_evb/common/ad408x_fmc_evb_bd.tcl
+++ b/projects/ad408x_fmc_evb/common/ad408x_fmc_evb_bd.tcl
@@ -11,7 +11,6 @@ create_bd_port -dir I da_p
 create_bd_port -dir I da_n
 create_bd_port -dir I db_p
 create_bd_port -dir I db_n
-create_bd_port -dir I uncorrected_mode
 create_bd_port -dir I sync_n
 create_bd_port -dir O sys_cpu_out_clk
 
@@ -35,18 +34,6 @@ ad_ip_parameter axi_ad4080_dma CONFIG.AXI_SLICE_DEST 0
 ad_ip_parameter axi_ad4080_dma CONFIG.DMA_2D_TRANSFER 0
 ad_ip_parameter axi_ad4080_dma CONFIG.DMA_DATA_WIDTH_SRC 32
 
-# dma for uncorrected
-
-ad_ip_instance axi_dmac axi_ad4080_uc_dma
-ad_ip_parameter axi_ad4080_uc_dma CONFIG.DMA_TYPE_SRC 2
-ad_ip_parameter axi_ad4080_uc_dma CONFIG.DMA_TYPE_DEST 0
-ad_ip_parameter axi_ad4080_uc_dma CONFIG.CYCLIC 0
-ad_ip_parameter axi_ad4080_uc_dma CONFIG.SYNC_TRANSFER_START 0
-ad_ip_parameter axi_ad4080_uc_dma CONFIG.AXI_SLICE_SRC 0
-ad_ip_parameter axi_ad4080_uc_dma CONFIG.AXI_SLICE_DEST 0
-ad_ip_parameter axi_ad4080_uc_dma CONFIG.DMA_2D_TRANSFER 0
-ad_ip_parameter axi_ad4080_uc_dma CONFIG.DMA_DATA_WIDTH_SRC 128
-
 # connect interface to axi_ad4080_adc
 
 ad_connect dco_p            axi_ad4080_adc/dclk_in_p
@@ -56,7 +43,7 @@ ad_connect da_n             axi_ad4080_adc/data_a_in_n
 ad_connect db_p             axi_ad4080_adc/data_b_in_p
 ad_connect db_n             axi_ad4080_adc/data_b_in_n
 ad_connect sync_n           axi_ad4080_adc/sync_n
-ad_connect uncorrected_mode axi_ad4080_adc/uncorrected_mode
+
 
 ad_connect $sys_iodelay_clk axi_ad4080_adc/delay_clk
 
@@ -65,27 +52,17 @@ ad_connect $sys_iodelay_clk axi_ad4080_adc/delay_clk
 ad_connect axi_ad4080_adc/adc_data  axi_ad4080_dma/fifo_wr_din
 ad_connect axi_ad4080_adc/adc_valid axi_ad4080_dma/fifo_wr_en
 
-ad_connect axi_ad4080_adc/adc_uncor_data  axi_ad4080_uc_dma/fifo_wr_din
-ad_connect axi_ad4080_adc/adc_uncor_valid axi_ad4080_uc_dma/fifo_wr_en
-
 # system runs on phy's received clock
 
 ad_connect axi_ad4080_adc/adc_clk axi_ad4080_dma/fifo_wr_clk
-ad_connect axi_ad4080_adc/adc_clk axi_ad4080_uc_dma/fifo_wr_clk
 ad_connect $sys_cpu_clk sys_cpu_out_clk
 
 ad_connect $sys_cpu_resetn axi_ad4080_dma/m_dest_axi_aresetn
-ad_connect $sys_cpu_resetn axi_ad4080_uc_dma/m_dest_axi_aresetn
 
 ad_cpu_interconnect 0x44A00000 axi_ad4080_adc
 ad_cpu_interconnect 0x44A30000 axi_ad4080_dma
-ad_cpu_interconnect 0x44A40000 axi_ad4080_uc_dma
 
 ad_mem_hp1_interconnect $sys_cpu_clk sys_ps7/S_AXI_HP1
 ad_mem_hp1_interconnect $sys_cpu_clk axi_ad4080_dma/m_dest_axi
-ad_mem_hp1_interconnect $sys_cpu_clk axi_ad4080_uc_dma/m_dest_axi
 
 ad_cpu_interrupt ps-13 mb-12 axi_ad4080_dma/irq
-ad_cpu_interrupt ps-12 mb-12 axi_ad4080_uc_dma/irq
-
-

--- a/projects/ad408x_fmc_evb/zed/Makefile
+++ b/projects/ad408x_fmc_evb/zed/Makefile
@@ -1,0 +1,25 @@
+####################################################################################
+## Copyright (c) 2018 - 2024 Analog Devices, Inc.
+### SPDX short identifier: BSD-1-Clause
+## Auto-generated, do not modify!
+####################################################################################
+
+PROJECT_NAME := ad408x_fmc_evb_zed
+
+M_DEPS += ../common/ad408x_fmc_evb_bd.tcl
+M_DEPS += ../../scripts/adi_pd.tcl
+M_DEPS += ../../common/zed/zed_system_constr.xdc
+M_DEPS += ../../common/zed/zed_system_bd.tcl
+M_DEPS += ../../../library/common/ad_iobuf.v
+
+LIB_DEPS += axi_ad408x
+LIB_DEPS += axi_clkgen
+LIB_DEPS += axi_dmac
+LIB_DEPS += axi_hdmi_tx
+LIB_DEPS += axi_i2s_adi
+LIB_DEPS += axi_spdif_tx
+LIB_DEPS += axi_sysid
+LIB_DEPS += sysid_rom
+LIB_DEPS += util_i2c_mixer
+
+include ../../scripts/project-xilinx.mk

--- a/projects/ad408x_fmc_evb/zed/system_bd.tcl
+++ b/projects/ad408x_fmc_evb/zed/system_bd.tcl
@@ -1,0 +1,17 @@
+###############################################################################
+## Copyright (C) 2022-2024 Analog Devices, Inc. All rights reserved.
+### SPDX short identifier: ADIBSD
+###############################################################################
+
+source $ad_hdl_dir/projects/common/zed/zed_system_bd.tcl
+source ../common/ad408x_fmc_evb_bd.tcl
+source $ad_hdl_dir/projects/scripts/adi_pd.tcl
+
+#system ID
+
+set mem_init_sys_path [get_env_param ADI_PROJECT_DIR ""]mem_init_sys.txt;
+ad_ip_parameter axi_sysid_0 CONFIG.ROM_ADDR_BITS 9
+ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "[pwd]/$mem_init_sys_path"
+ad_ip_parameter rom_sys_0 CONFIG.ROM_ADDR_BITS 9
+
+sysid_gen_sys_init_file

--- a/projects/ad408x_fmc_evb/zed/system_constr.xdc
+++ b/projects/ad408x_fmc_evb/zed/system_constr.xdc
@@ -1,0 +1,66 @@
+###############################################################################
+## Copyright (C) 2022-2024 Analog Devices, Inc. All rights reserved.
+### SPDX short identifier: ADIBSD
+###############################################################################
+
+set_property -dict {PACKAGE_PIN L18 IOSTANDARD LVDS_25 DIFF_TERM 1} [get_ports dco_p]     ; ## H4  FMC_CLK0_M2C_P  IO_L12P_T1_MRCC_34
+set_property -dict {PACKAGE_PIN L19 IOSTANDARD LVDS_25 DIFF_TERM 1} [get_ports dco_n]     ; ## H5  FMC_CLK0_M2C_N  IO_L12N_T1_MRCC_34
+
+set_property -dict {PACKAGE_PIN D18 IOSTANDARD LVDS_25 DIFF_TERM 1} [get_ports fpgaclk_p] ; ## G2  FMC_CLK1_M2C_P  IO_L12P_T1_MRCC_35
+set_property -dict {PACKAGE_PIN C19 IOSTANDARD LVDS_25 DIFF_TERM 1} [get_ports fpgaclk_n] ; ## G3  FMC_CLK1_M2C_N  IO_L12N_T1_MRCC_35
+
+set_property -dict {PACKAGE_PIN N19 IOSTANDARD LVDS_25 DIFF_TERM 1} [get_ports clk_p]     ; ## D8  FMC_LA01_CC_P   IO_L14P_T2_SRCC_34
+set_property -dict {PACKAGE_PIN N20 IOSTANDARD LVDS_25 DIFF_TERM 1} [get_ports clk_n]     ; ## D9  FMC_LA01_CC_N   IO_L14N_T2_SRCC_34
+
+set_property -dict {PACKAGE_PIN P17 IOSTANDARD LVDS_25 DIFF_TERM 1} [get_ports da_p]      ; ## H7  FMC_LA02_P      IO_L20P_T3_34   
+set_property -dict {PACKAGE_PIN P18 IOSTANDARD LVDS_25 DIFF_TERM 1} [get_ports da_n]      ; ## H8  FMC_LA02_N      IO_L20N_T3_34  
+
+set_property -dict {PACKAGE_PIN N22 IOSTANDARD LVDS_25 DIFF_TERM 1} [get_ports db_p]      ; ## G9  FMC_LA03_P      IO_L16P_T2_34
+set_property -dict {PACKAGE_PIN P22 IOSTANDARD LVDS_25 DIFF_TERM 1} [get_ports db_n]      ; ## G10 FMC_LA03_N      IO_L16N_T2_34 
+
+set_property -dict {PACKAGE_PIN T16 IOSTANDARD LVCMOS25} [get_ports gpio0_fmc]            ; ## H13 FMC_LA07_P      IO_L21P_T3_DQS_34 
+set_property -dict {PACKAGE_PIN L22 IOSTANDARD LVCMOS25} [get_ports gpio1_fmc]            ; ## C11 FMC_LA06_N      IO_L10N_T1_34    
+set_property -dict {PACKAGE_PIN R20 IOSTANDARD LVCMOS25} [get_ports gpio2_fmc]            ; ## D14 FMC_LA09_P      IO_L17P_T2_34       
+set_property -dict {PACKAGE_PIN R21 IOSTANDARD LVCMOS25} [get_ports gpio3_fmc]            ; ## D15 FMC_LA09_N      IO_L17N_T2_34  
+            
+set_property -dict {PACKAGE_PIN N17 IOSTANDARD LVCMOS25} [get_ports gp0_dir]              ; ## H16 FMC_LA11_P       IO_L5P_T0_34   
+set_property -dict {PACKAGE_PIN T19 IOSTANDARD LVCMOS25} [get_ports gp1_dir]              ; ## C15 FMC_LA10_N       IO_L22N_T3_34   
+set_property -dict {PACKAGE_PIN P20 IOSTANDARD LVCMOS25} [get_ports gp2_dir]              ; ## G15 FMC_LA12_P       IO_L18P_T2_34 
+set_property -dict {PACKAGE_PIN N18 IOSTANDARD LVCMOS25} [get_ports gp3_dir]              ; ## H17 FMC_LA11_N       IO_L5N_T0_34 
+
+set_property -dict {PACKAGE_PIN J16 IOSTANDARD LVCMOS25} [get_ports en_psu]               ; ## H19 FMC_LA15_P       IO_L2P_T0_34 
+set_property -dict {PACKAGE_PIN J17 IOSTANDARD LVCMOS25} [get_ports pwrgd]                ; ## H20 FMC_LA15_N       IO_L2N_T0_34  
+set_property -dict {PACKAGE_PIN G15 IOSTANDARD LVCMOS25} [get_ports pd_v33b]              ; ## H22 FMC_LA19_P       IO_L4P_T0_35  
+set_property -dict {PACKAGE_PIN P21 IOSTANDARD LVCMOS25} [get_ports osc_en]               ; ## G16 FMC_LA12_N       IO_L18N_T2_34    
+
+set_property -dict {PACKAGE_PIN J21 IOSTANDARD LVCMOS25} [get_ports cs_n_src]             ; ## G12 FMC_LA08_P       IO_L8P_T1_34 
+set_property -dict {PACKAGE_PIN J22 IOSTANDARD LVCMOS25} [get_ports sdio_src]             ; ## G13 FMC_LA08_N       IO_L8N_T1_34   
+set_property -dict {PACKAGE_PIN T17 IOSTANDARD LVCMOS25} [get_ports sclk_src]             ; ## H14 FMC_LA07_N       IO_L21N_T3_DQS_34
+
+set_property -dict {PACKAGE_PIN K20 IOSTANDARD LVCMOS25} [get_ports cs1_0]                ; ## C19 FMC_LA14_N       IO_L11N_T1_SRCC_34 
+set_property -dict {PACKAGE_PIN D20 IOSTANDARD LVCMOS25} [get_ports cs1_1]                ; ## C22 FMC_LA18_CC_P    IO_L14P_T2_AD4P_SRCC_35  
+set_property -dict {PACKAGE_PIN L17 IOSTANDARD LVCMOS25} [get_ports sdo_1]                ; ## D17 FMC_LA13_P       IO_L4P_T0_34 
+set_property -dict {PACKAGE_PIN M17 IOSTANDARD LVCMOS25} [get_ports sclk1]                ; ## D18 FMC_LA13_N       IO_L4N_T0_34 
+set_property -dict {PACKAGE_PIN K19 IOSTANDARD LVCMOS25} [get_ports sdin1]                ; ## C18 FMC_LA14_P       IO_L11P_T1_SRCC_34  
+
+set_property -dict {PACKAGE_PIN B19 IOSTANDARD LVCMOS25} [get_ports doa_fmc]              ; ## D20 FMC_LA17_CC_P    IO_L13P_T2_MRCC_35 
+set_property -dict {PACKAGE_PIN B20 IOSTANDARD LVCMOS25} [get_ports dob_fmc]              ; ## D21 FMC_LA17_CC_N    IO_L13N_T2_MRCC_35 
+set_property -dict {PACKAGE_PIN J20 IOSTANDARD LVCMOS25} [get_ports doc_fmc]              ; ## G18 FMC_LA16_P       IO_L9P_T1_DQS_34
+set_property -dict {PACKAGE_PIN K21 IOSTANDARD LVCMOS25} [get_ports dod_fmc]              ; ## G19 FMC_LA16_N       IO_L9N_T1_DQS_34
+
+set_property -dict {PACKAGE_PIN G16 IOSTANDARD LVCMOS25} [get_ports pbio[0]]              ; ## H23 FMC_LA19_N       IO_L4N_T0_35 
+set_property -dict {PACKAGE_PIN G20 IOSTANDARD LVCMOS25} [get_ports pbio[1]]              ; ## G21 FMC_LA20_P       IO_L22P_T3_AD7P_35  
+set_property -dict {PACKAGE_PIN G21 IOSTANDARD LVCMOS25} [get_ports pbio[2]]              ; ## G22 FMC_LA20_N       IO_L22N_T3_AD7N_35  
+set_property -dict {PACKAGE_PIN E19 IOSTANDARD LVCMOS25} [get_ports pbio[3]]              ; ## H25 FMC_LA21_P       IO_L21P_T3_DQS_AD14P_35 
+set_property -dict {PACKAGE_PIN E20 IOSTANDARD LVCMOS25} [get_ports pbio[4]]              ; ## H26 FMC_LA21_N       IO_L21N_T3_DQS_AD14N_35
+set_property -dict {PACKAGE_PIN G19 IOSTANDARD LVCMOS25} [get_ports pbio[5]]              ; ## G24 FMC_LA22_P       IO_L20P_T3_AD6P_35 
+set_property -dict {PACKAGE_PIN F19 IOSTANDARD LVCMOS25} [get_ports pbio[6]]              ; ## G25 FMC_LA22_N       IO_L20N_T3_AD6N_35 
+set_property -dict {PACKAGE_PIN E15 IOSTANDARD LVCMOS25} [get_ports pbio[7]]              ; ## D23 FMC_LA23_P       IO_L3P_T0_DQS_AD1P_35 
+set_property -dict {PACKAGE_PIN D15 IOSTANDARD LVCMOS25} [get_ports pbio[8]]              ; ## D24 FMC_LA23_N       IO_L3N_T0_DQS_AD1N_35 
+
+set_property -dict {PACKAGE_PIN L21 IOSTANDARD LVCMOS25} [get_ports ad9508_sync]          ; ## C10 FMC_LA06_P       IO_L10P_T1_34 
+set_property -dict {PACKAGE_PIN C20 IOSTANDARD LVCMOS25} [get_ports adf435x_lock]         ; ## C23 FMC_LA18_CC_N    IO_L14N_T2_AD4N_SRCC_35    
+
+# clocks
+
+create_clock -period 2.500 -name dco_clk [get_ports dco_p]

--- a/projects/ad408x_fmc_evb/zed/system_project.tcl
+++ b/projects/ad408x_fmc_evb/zed/system_project.tcl
@@ -1,0 +1,18 @@
+###############################################################################
+## Copyright (C) 2022-2024 Analog Devices, Inc. All rights reserved.
+### SPDX short identifier: ADIBSD
+###############################################################################
+
+source ../../../scripts/adi_env.tcl
+source $ad_hdl_dir/projects/scripts/adi_project_xilinx.tcl
+source $ad_hdl_dir/projects/scripts/adi_board.tcl
+
+adi_project ad408x_fmc_evb_zed
+adi_project_files ad408x_fmc_evb_zed [list \
+  "$ad_hdl_dir/library/common/ad_iobuf.v" \
+  "$ad_hdl_dir/projects/common/zed/zed_system_constr.xdc" \
+  "system_constr.xdc" \
+  "system_top.v" ]
+
+adi_project_run ad408x_fmc_evb_zed
+

--- a/projects/ad408x_fmc_evb/zed/system_top.v
+++ b/projects/ad408x_fmc_evb/zed/system_top.v
@@ -187,7 +187,7 @@ module system_top (
 
   always @(posedge sys_cpu_out_clk) begin
     sync_req_d <= {sync_req_d[2:0],sync_req};
-    if (sync_req_d[1] & ~sync_req_d[3]) begin
+    if (sync_req_d[2] & ~sync_req_d[3]) begin
       ad9508_sync_s <= 1'b0;
     end else if (~sync_req_d[2] & sync_req_d[3]) begin
       ad9508_sync_s <= 1'b1;
@@ -340,7 +340,6 @@ module system_top (
     .db_p (db_p),
     .db_n (db_n),
     .sync_n (ad9508_sync),
-    .sys_cpu_out_clk (sys_cpu_out_clk),
-    .uncorrected_mode (1'b0));
+    .sys_cpu_out_clk (sys_cpu_out_clk));
 
 endmodule

--- a/projects/ad408x_fmc_evb/zed/system_top.v
+++ b/projects/ad408x_fmc_evb/zed/system_top.v
@@ -1,0 +1,346 @@
+// ***************************************************************************
+// ***************************************************************************
+// Copyright (C) 2022-2024 Analog Devices, Inc. All rights reserved.
+//
+// In this HDL repository, there are many different and unique modules, consisting
+// of various HDL (Verilog or VHDL) components. The individual modules are
+// developed independently, and may be accompanied by separate and unique license
+// terms.
+//
+// The user should read each of these license terms, and understand the
+// freedoms and responsibilities that he or she has by using this source/core.
+//
+// This core is distributed in the hope that it will be useful, but WITHOUT ANY
+// WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+// A PARTICULAR PURPOSE.
+//
+// Redistribution and use of source or resulting binaries, with or without modification
+// of this file, are permitted under one of the following two license terms:
+//
+//   1. The GNU General Public License version 2 as published by the
+//      Free Software Foundation, which can be found in the top level directory
+//      of this repository (LICENSE_GPL2), and also online at:
+//      <https://www.gnu.org/licenses/old-licenses/gpl-2.0.html>
+//
+// OR
+//
+//   2. An ADI specific BSD license, which can be found in the top level directory
+//      of this repository (LICENSE_ADIBSD), and also on-line at:
+//      https://github.com/analogdevicesinc/hdl/blob/master/LICENSE_ADIBSD
+//      This will allow to generate bit files and not release the source code,
+//      as long as it attaches to an ADI device.
+//
+// ***************************************************************************
+// ***************************************************************************
+
+`timescale 1ns/100ps
+
+`define ECHOED_CLK
+
+module system_top (
+
+  inout   [14:0]  ddr_addr,
+  inout   [ 2:0]  ddr_ba,
+  inout           ddr_cas_n,
+  inout           ddr_ck_n,
+  inout           ddr_ck_p,
+  inout           ddr_cke,
+  inout           ddr_cs_n,
+  inout   [ 3:0]  ddr_dm,
+  inout   [31:0]  ddr_dq,
+  inout   [ 3:0]  ddr_dqs_n,
+  inout   [ 3:0]  ddr_dqs_p,
+  inout           ddr_odt,
+  inout           ddr_ras_n,
+  inout           ddr_reset_n,
+  inout           ddr_we_n,
+
+  inout           fixed_io_ddr_vrn,
+  inout           fixed_io_ddr_vrp,
+  inout   [53:0]  fixed_io_mio,
+  inout           fixed_io_ps_clk,
+  inout           fixed_io_ps_porb,
+  inout           fixed_io_ps_srstb,
+
+  inout   [31:0]  gpio_bd,
+
+  output          hdmi_out_clk,
+  output          hdmi_vsync,
+  output          hdmi_hsync,
+  output          hdmi_data_e,
+  output  [15:0]  hdmi_data,
+
+  output          i2s_mclk,
+  output          i2s_bclk,
+  output          i2s_lrclk,
+  output          i2s_sdata_out,
+  input           i2s_sdata_in,
+
+  output          spdif,
+
+  inout           iic_scl,
+  inout           iic_sda,
+  inout   [ 1:0]  iic_mux_scl,
+  inout   [ 1:0]  iic_mux_sda,
+
+  input           otg_vbusoc,
+
+  // FMC connector
+
+  // Default 100 MHz clock
+
+  input           fpgaclk_p,
+  input           fpgaclk_n,
+
+  // LVDS data interace
+
+  input           dco_p,
+  input           dco_n,
+  input           da_p,
+  input           da_n,
+  input           db_p,
+  input           db_n,
+
+  // SPI data interface
+
+  input           doa_fmc,
+  input           dob_fmc,
+  input           doc_fmc,
+  input           dod_fmc,
+
+  output          gp0_dir,
+  output          gp1_dir,
+  output          gp2_dir,
+  output          gp3_dir,
+  inout           gpio1_fmc,
+  inout           gpio2_fmc,
+  inout           gpio3_fmc,
+
+  input           pwrgd,
+  input           adf435x_lock,
+  output          en_psu,
+  output          pd_v33b,
+  output          osc_en,
+  output          ad9508_sync,
+
+`ifdef ECHOED_CLK
+  // Input for Echoed clock mode
+  input           clk_p,
+  input           clk_n,
+`else
+  // Output for self clocked mode
+  output          clk_p,
+  output          clk_n,
+  output          fpga_cnvp,
+  output          fpga_cnvn,
+`endif
+
+  // ADC SPI
+
+  input           gpio0_fmc,
+  output          sclk_src,
+  output          cs_n_src,
+  output          sdio_src,
+
+  // Clock chips SPI
+
+  input           sdo_1, //ad9508
+  output          sclk1,
+  output          sdin1,
+  output          cs1_0, //ad9508
+  output          cs1_1  //adf4350
+);
+
+  // internal signals
+
+  wire    [63:0]  gpio_i;
+  wire    [63:0]  gpio_o;
+  wire    [63:0]  gpio_t;
+
+  wire    [ 1:0]  iic_mux_scl_i_s;
+  wire    [ 1:0]  iic_mux_scl_o_s;
+  wire            iic_mux_scl_t_s;
+  wire    [ 1:0]  iic_mux_sda_i_s;
+  wire    [ 1:0]  iic_mux_sda_o_s;
+  wire            iic_mux_sda_t_s;
+
+  reg             ad9508_sync_s = 1'b0;
+  reg     [ 3:0]  sync_req_d    = 4'b0;
+  reg     [26:0]  dbg_cnt       =  'b0;
+  reg     [26:0]  dbg_cnt_f     =  'b0;
+  reg     [26:0]  dbg_cnt_100_f =  'b0;
+
+  assign ad9508_sync   = ad9508_sync_s;
+  assign gpio_i[35]    = adf435x_lock;
+  assign gpio_i[36]    = pwrgd;
+  assign gpio_i[63:37] = gpio_o[63:37];
+
+  assign gp0_dir  = 1'b0;
+  assign gp1_dir  = 1'b0;
+  assign gp2_dir  = 1'b0;
+  assign gp3_dir  = 1'b0;
+  assign en_psu   = 1'b1;
+  assign osc_en   = pwrgd;
+
+  assign sync_req = gpio_o[42];
+  assign pd_v33b  = 1'b1;
+
+  always @(posedge sys_cpu_out_clk) begin
+    sync_req_d <= {sync_req_d[2:0],sync_req};
+    if (sync_req_d[1] & ~sync_req_d[3]) begin
+      ad9508_sync_s <= 1'b0;
+    end else if (~sync_req_d[2] & sync_req_d[3]) begin
+      ad9508_sync_s <= 1'b1;
+    end
+  end
+
+  // Dummy function to prevent sys_cpu_out_clk optimization
+  // Even if the clock is not used the diff termination should help signal
+  // integrity
+
+  always @(posedge sys_cpu_out_clk) begin
+    dbg_cnt <= dbg_cnt + 1;
+  end
+
+  // Dummy function to prevent fpga_clk optimization
+  // Even if the clock is not used the diff termination should help signal
+  // integrity
+
+  always @(posedge fpga_clk) begin
+    dbg_cnt_f <= dbg_cnt_f + 1;
+  end
+
+  // Dummy function to prevent fpga_100_clk optimization
+  // Even if the clock is not used the diff termination should help signal
+  // integrity
+
+  always @(posedge fpga_100_clk) begin
+    dbg_cnt_100_f <= dbg_cnt_100_f + 1;
+  end
+
+  // instantiations
+
+  IBUFDS i_fpga_clk (
+    .I (clk_p),
+    .IB (clk_n),
+    .O (fpga_clk));
+
+  IBUFDS i_fpga_100_clk (
+    .I (fpgaclk_p),
+    .IB (fpgaclk_n),
+    .O (fpga_100_clk));
+
+  ad_iobuf #(
+    .DATA_WIDTH(2)
+  ) i_gpio_4_3_mach1 (
+    .dio_t(gpio_t[34:33]),
+    .dio_i(gpio_o[34:33]),
+    .dio_o(gpio_i[34:33]),
+    .dio_p({gpio3_fmc,gpio2_fmc}));
+
+  ad_iobuf #(
+    .DATA_WIDTH(1)
+  ) i_gpio_2_mach1 (
+    .dio_t(gpio_t[32]),
+    .dio_i(gpio_o[32]),
+    .dio_o(gpio_i[32]),
+    .dio_p(gpio1_fmc));
+
+  ad_iobuf #(
+    .DATA_WIDTH(29)
+  ) i_gpio_bd (
+    .dio_t({gpio_t[31:22],gpio_t[18:0]}),
+    .dio_i({gpio_o[31:22],gpio_o[18:0]}),
+    .dio_o({gpio_i[31:22],gpio_i[18:0]}),
+    .dio_p({gpio_bd[31:22],gpio_bd[18:0]}));
+
+  ad_iobuf #(
+    .DATA_WIDTH(2)
+  ) i_iobuf_iic_scl (
+    .dio_t ({iic_mux_scl_t_s,iic_mux_scl_t_s}),
+    .dio_i (iic_mux_scl_o_s),
+    .dio_o (iic_mux_scl_i_s),
+    .dio_p (iic_mux_scl));
+
+  ad_iobuf #(
+    .DATA_WIDTH(2)
+  ) i_iobuf_iic_sda (
+    .dio_t ({iic_mux_sda_t_s,iic_mux_sda_t_s}),
+    .dio_i (iic_mux_sda_o_s),
+    .dio_o (iic_mux_sda_i_s),
+    .dio_p (iic_mux_sda));
+
+  system_wrapper i_system_wrapper (
+    .ddr_addr (ddr_addr),
+    .ddr_ba (ddr_ba),
+    .ddr_cas_n (ddr_cas_n),
+    .ddr_ck_n (ddr_ck_n),
+    .ddr_ck_p (ddr_ck_p),
+    .ddr_cke (ddr_cke),
+    .ddr_cs_n (ddr_cs_n),
+    .ddr_dm (ddr_dm),
+    .ddr_dq (ddr_dq),
+    .ddr_dqs_n (ddr_dqs_n),
+    .ddr_dqs_p (ddr_dqs_p),
+    .ddr_odt (ddr_odt),
+    .ddr_ras_n (ddr_ras_n),
+    .ddr_reset_n (ddr_reset_n),
+    .ddr_we_n (ddr_we_n),
+    .fixed_io_ddr_vrn (fixed_io_ddr_vrn),
+    .fixed_io_ddr_vrp (fixed_io_ddr_vrp),
+    .fixed_io_mio (fixed_io_mio),
+    .fixed_io_ps_clk (fixed_io_ps_clk),
+    .fixed_io_ps_porb (fixed_io_ps_porb),
+    .fixed_io_ps_srstb (fixed_io_ps_srstb),
+    .gpio_i (gpio_i),
+    .gpio_o (gpio_o),
+    .gpio_t (gpio_t),
+    .hdmi_data (hdmi_data),
+    .hdmi_data_e (hdmi_data_e),
+    .hdmi_hsync (hdmi_hsync),
+    .hdmi_out_clk (hdmi_out_clk),
+    .hdmi_vsync (hdmi_vsync),
+    .i2s_bclk (i2s_bclk),
+    .i2s_lrclk (i2s_lrclk),
+    .i2s_mclk (i2s_mclk),
+    .i2s_sdata_in (i2s_sdata_in),
+    .i2s_sdata_out (i2s_sdata_out),
+    .iic_fmc_scl_io (iic_scl),
+    .iic_fmc_sda_io (iic_sda),
+    .iic_mux_scl_i (iic_mux_scl_i_s),
+    .iic_mux_scl_o (iic_mux_scl_o_s),
+    .iic_mux_scl_t (iic_mux_scl_t_s),
+    .iic_mux_sda_i (iic_mux_sda_i_s),
+    .iic_mux_sda_o (iic_mux_sda_o_s),
+    .iic_mux_sda_t (iic_mux_sda_t_s),
+    .otg_vbusoc (otg_vbusoc),
+    .spdif (spdif),
+    .spi0_clk_i (1'b0),
+    .spi0_clk_o (sclk_src),
+    .spi0_csn_0_o (cs_n_src),
+    .spi0_csn_1_o (),
+    .spi0_csn_2_o (),
+    .spi0_csn_i (1'b1),
+    .spi0_sdi_i (gpio0_fmc),
+    .spi0_sdo_i (1'b0),
+    .spi0_sdo_o (sdio_src),
+    .spi1_clk_i (1'b0),
+    .spi1_clk_o (sclk1),
+    .spi1_csn_0_o (cs1_0),
+    .spi1_csn_1_o (cs1_1),
+    .spi1_csn_2_o (),
+    .spi1_csn_i (1'b1),
+    .spi1_sdi_i (sdo_1),
+    .spi1_sdo_i (1'b0),
+    .spi1_sdo_o (sdin1),
+    .dco_p (dco_p),
+    .dco_n (dco_n),
+    .da_p (da_p),
+    .da_n (da_n),
+    .db_p (db_p),
+    .db_n (db_n),
+    .sync_n (ad9508_sync),
+    .sys_cpu_out_clk (sys_cpu_out_clk),
+    .uncorrected_mode (1'b0));
+
+endmodule


### PR DESCRIPTION
## PR Description
Added support for AD4080-EVB on ZedBoard.
The project instantiates:
-the axi_ad408x interface IP
-a DMA for the 20bit conversion data stream

## PR Type
- [ ] Bug fix (change that fixes an issue)
- [x] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the code style guidelines
- [x] I have performed a self-review of changes
- [x] I have compiled all hdl projects and libraries affected by this PR
- [x] I have tested in hardware affected projects, at least on relevant boards
- [x] I have commented my code, at least hard-to-understand parts
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe files, Copyright etc)
- [x] I have not introduced new Warnings/Critical Warnings on compilation
- [ ] I have added new hdl testbenches or updated existing ones
