### PR TITLE
util_axis_fifo: Update

### DIFF
--- a/library/util_axis_fifo/util_axis_fifo.v
+++ b/library/util_axis_fifo/util_axis_fifo.v
@@ -1,6 +1,6 @@
 // ***************************************************************************
 // ***************************************************************************
-// Copyright (C) 2014-2023 Analog Devices, Inc. All rights reserved.
+// Copyright (C) 2014-2024 Analog Devices, Inc. All rights reserved.
 //
 // In this HDL repository, there are many different and unique modules, consisting
 // of various HDL (Verilog or VHDL) components. The individual modules are

--- a/library/util_axis_fifo/util_axis_fifo.v
+++ b/library/util_axis_fifo/util_axis_fifo.v
@@ -148,8 +148,8 @@ module util_axis_fifo #(
               axis_tlast_d <= s_axis_tlast;
           end
           assign m_axis_tlast = axis_tlast_d;
-
-        end
+        end else
+          assign m_axis_tlast = 'b0;
 
         // TKEEP support
         if (TKEEP_EN) begin
@@ -161,8 +161,8 @@ module util_axis_fifo #(
               axis_tkeep_d <= s_axis_tkeep;
           end
           assign m_axis_tkeep = axis_tkeep_d;
-
-        end
+        end else
+          assign m_axis_tkeep = {DATA_WIDTH/8{1'b1}};
 
     end /* zerodeep */
     else
@@ -205,7 +205,8 @@ module util_axis_fifo #(
           end
         end
         assign m_axis_tlast = axis_tlast_d;
-      end
+      end else
+        assign m_axis_tlast = 'b0;
 
       // TKEEP support
       if (TKEEP_EN) begin
@@ -219,8 +220,8 @@ module util_axis_fifo #(
           end
         end
         assign m_axis_tkeep = axis_tkeep_d;
-
-      end
+      end else
+        assign m_axis_tkeep = {DATA_WIDTH/8{1'b1}};
 
      end /* !ASYNC_CLK */
 
@@ -288,13 +289,17 @@ module util_axis_fifo #(
     end else if (TKEEP_EN) begin
       assign s_axis_data_int_s = {s_axis_tkeep, s_axis_data};
       assign m_axis_tkeep = m_axis_data_int_s[MEM_WORD-1-:DATA_WIDTH/8];
+      assign m_axis_tlast = 'b0;
       assign m_axis_data = m_axis_data_int_s[DATA_WIDTH-1:0];
     end else if (TLAST_EN) begin
       assign s_axis_data_int_s = {s_axis_tlast, s_axis_data};
+      assign m_axis_tkeep = {DATA_WIDTH/8{1'b1}};
       assign m_axis_tlast = m_axis_data_int_s[DATA_WIDTH];
       assign m_axis_data = m_axis_data_int_s[DATA_WIDTH-1:0];
     end else begin
       assign s_axis_data_int_s = {s_axis_data};
+      assign m_axis_tkeep = {DATA_WIDTH/8{1'b1}};
+      assign m_axis_tlast = 'b0;
       assign m_axis_data = m_axis_data_int_s[DATA_WIDTH-1:0];
     end
 


### PR DESCRIPTION
## PR Description

Added missing signal drivers for tlast and tkeep that would otherwise produce a no driver warning, which can lead to unexpected behavior of the design. 

The new warning that now appears is that the respective signals are hard wire to 0 in case of tlast and to 1 in case of tkeep, but this is isn't a problem at all. 


## PR Type
- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the code style guidelines
- [x] I have performed a self-review of changes
- [ ] I have compiled all hdl projects and libraries affected by this PR
- [ ] I have tested in hardware affected projects, at least on relevant boards
- [ ] I have commented my code, at least hard-to-understand parts
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe files, Copyright etc)
- [ ] I have not introduced new Warnings/Critical Warnings on compilation
- [ ] I have added new hdl testbenches or updated existing ones
