### PR TITLE
lib/axi_pwm_gen: Update ext_sync-related axi_pwm_gen's logic

### DIFF
--- a/library/axi_pwm_gen/Makefile
+++ b/library/axi_pwm_gen/Makefile
@@ -1,5 +1,5 @@
 ####################################################################################
-## Copyright (c) 2018 - 2023 Analog Devices, Inc.
+## Copyright (c) 2018 - 2024 Analog Devices, Inc.
 ### SPDX short identifier: BSD-1-Clause
 ## Auto-generated, do not modify!
 ####################################################################################
@@ -21,6 +21,7 @@ XILINX_LIB_DEPS += util_cdc
 INTEL_DEPS += ../intel/common/up_rst_constr.sdc
 INTEL_DEPS += ../util_cdc/sync_bits.v
 INTEL_DEPS += ../util_cdc/sync_data.v
+INTEL_DEPS += ../util_cdc/sync_event.v
 INTEL_DEPS += axi_pwm_gen_constr.sdc
 INTEL_DEPS += axi_pwm_gen_hw.tcl
 

--- a/library/axi_pwm_gen/axi_pwm_gen_1.v
+++ b/library/axi_pwm_gen/axi_pwm_gen_1.v
@@ -1,6 +1,6 @@
 // ***************************************************************************
 // ***************************************************************************
-// Copyright (C) 2021-2023 Analog Devices, Inc. All rights reserved.
+// Copyright (C) 2021-2024 Analog Devices, Inc. All rights reserved.
 //
 // In this HDL repository, there are many different and unique modules, consisting
 // of various HDL (Verilog or VHDL) components. The individual modules are
@@ -26,7 +26,7 @@
 //
 //   2. An ADI specific BSD license, which can be found in the top level directory
 //      of this repository (LICENSE_ADIBSD), and also on-line at:
-//      https://github.com/analogdevicesinc/hdl/blob/master/LICENSE_ADIBSD
+//      https://github.com/analogdevicesinc/hdl/blob/main/LICENSE_ADIBSD
 //      This will allow to generate bit files and not release the source code,
 //      as long as it attaches to an ADI device.
 //
@@ -35,6 +35,7 @@
 `timescale 1ns/1ps
 
 module axi_pwm_gen_1 #(
+  parameter   EXT_SYNC_NO_LOAD_CONFIG = 0,
   // the width and period are defined in number of clock cycles
   parameter   PULSE_WIDTH = 7,
   parameter   PULSE_PERIOD = 100000000
@@ -45,6 +46,7 @@ module axi_pwm_gen_1 #(
   input       [31:0]  pulse_width,
   input       [31:0]  pulse_period,
   input               load_config,
+  input               ext_sync_edge,
   input               sync,
 
   output              pulse,
@@ -64,6 +66,7 @@ module axi_pwm_gen_1 #(
 
   // internal wires
 
+  wire                         ext_sync_load_cfg;
   wire                         phase_align;
   wire                         end_of_period;
   wire                         end_of_pulse;
@@ -72,6 +75,8 @@ module axi_pwm_gen_1 #(
   // enable pwm
 
   assign pulse_enable = (pulse_period_d != 32'd0) ? 1'b1 : 1'b0;
+
+  assign ext_sync_load_config = (EXT_SYNC_NO_LOAD_CONFIG) ? ext_sync_edge : 1'b0;
 
   // flop the desired period
 
@@ -102,6 +107,8 @@ module axi_pwm_gen_1 #(
       phase_align_armed <= 1'b1;
     end else begin
       if (load_config == 1'b1) begin
+        phase_align_armed <= sync;
+      end else if (ext_sync_edge == 1'b1) begin
         phase_align_armed <= sync;
       end else begin
         phase_align_armed <= phase_align_armed & sync;

--- a/library/axi_pwm_gen/axi_pwm_gen_constr.sdc
+++ b/library/axi_pwm_gen/axi_pwm_gen_constr.sdc
@@ -1,5 +1,5 @@
 ###############################################################################
-## Copyright (C) 2021-2023 Analog Devices, Inc. All rights reserved.
+## Copyright (C) 2021-2024 Analog Devices, Inc. All rights reserved.
 ### SPDX short identifier: ADIBSD
 ###############################################################################
 

--- a/library/axi_pwm_gen/axi_pwm_gen_constr.ttcl
+++ b/library/axi_pwm_gen/axi_pwm_gen_constr.ttcl
@@ -1,5 +1,5 @@
 ###############################################################################
-## Copyright (C) 2021-2023 Analog Devices, Inc. All rights reserved.
+## Copyright (C) 2021-2024 Analog Devices, Inc. All rights reserved.
 # SPDX short identifier: ADIBSD
 ###############################################################################
 

--- a/library/axi_pwm_gen/axi_pwm_gen_hw.tcl
+++ b/library/axi_pwm_gen/axi_pwm_gen_hw.tcl
@@ -1,5 +1,5 @@
 ###############################################################################
-## Copyright (C) 2023 Analog Devices, Inc. All rights reserved.
+## Copyright (C) 2023-2024 Analog Devices, Inc. All rights reserved.
 ### SPDX short identifier: ADIBSD
 ###############################################################################
 
@@ -30,6 +30,8 @@ ad_ip_parameter ASYNC_CLK_EN INTEGER 1
 ad_ip_parameter N_PWMS INTEGER 1
 ad_ip_parameter PWM_EXT_SYNC INTEGER 0
 ad_ip_parameter EXT_ASYNC_SYNC INTEGER 0
+ad_ip_parameter EXT_SYNC_FASTER_CLK 0
+ad_ip_parameter EXT_SYNC_NO_LOAD_CONFIG 0
 ad_ip_parameter PULSE_0_WIDTH INTEGER 7
 ad_ip_parameter PULSE_1_WIDTH INTEGER 7
 ad_ip_parameter PULSE_2_WIDTH INTEGER 7
@@ -87,6 +89,8 @@ ad_ip_intf_s_axi s_axi_aclk s_axi_aresetn 16
 # external clock and external sync
 ad_interface clock ext_clk input 1
 ad_interface signal ext_sync input 1
+ad_interface clock clk_ext_sync input 1
+ad_interface signal ext_sync_faster_clk input 1
 
 # output signals
 for {set i 0} {$i < 16} {incr i} {

--- a/library/axi_pwm_gen/axi_pwm_gen_ip.tcl
+++ b/library/axi_pwm_gen/axi_pwm_gen_ip.tcl
@@ -1,5 +1,5 @@
 ###############################################################################
-## Copyright (C) 2021-2023 Analog Devices, Inc. All rights reserved.
+## Copyright (C) 2021-2024 Analog Devices, Inc. All rights reserved.
 ### SPDX short identifier: ADIBSD
 ###############################################################################
 
@@ -100,6 +100,20 @@ set_property -dict [list \
   "widget" "checkBox" \
 ] [ipgui::get_guiparamspec -name "EXT_ASYNC_SYNC" -component $cc]
 
+ipgui::add_param -name "EXT_SYNC_NO_LOAD_CONFIG" -component $cc -parent $page0
+set_property -dict [list \
+  "display_name" "External synchronization without load_config" \
+  "tooltip" "NOTE: If active the external synchronization would be made without load_config." \
+  "widget" "checkBox" \
+] [ipgui::get_guiparamspec -name "EXT_SYNC_NO_LOAD_CONFIG" -component $cc]
+
+ipgui::add_param -name "EXT_SYNC_FASTER_CLK" -component $cc -parent $page0
+set_property -dict [list \
+  "display_name" "External sync based on a faster clock" \
+  "tooltip" "NOTE: If active the external sync would be based on a faster clock than the pwm_gen logic." \
+  "widget" "checkBox" \
+] [ipgui::get_guiparamspec -name "EXT_SYNC_FASTER_CLK" -component $cc]
+
 # Maximum 16 pwms
 for {set i 0} {$i < 16} {incr i} {
   ipgui::add_param -name "PULSE_${i}_WIDTH" -component $cc -parent $page0
@@ -149,6 +163,12 @@ for {set i 0} {$i < 16} {incr i} {
 
 adi_set_ports_dependency "ext_sync" \
 	"(spirit:decode(id('MODELPARAM_VALUE.PWM_EXT_SYNC')) == 1)"
+
+adi_set_ports_dependency "ext_sync_faster_clk" \
+	"(spirit:decode(id('MODELPARAM_VALUE.EXT_SYNC_FASTER_CLK')) == 1)"
+
+adi_set_ports_dependency "clk_ext_sync" \
+	"(spirit:decode(id('MODELPARAM_VALUE.EXT_SYNC_FASTER_CLK')) == 1)"
 
 set_property driver_value 0 [ipx::get_ports -filter "direction==in" -of_objects $cc]
 

--- a/library/axi_pwm_gen/axi_pwm_gen_regmap.sv
+++ b/library/axi_pwm_gen/axi_pwm_gen_regmap.sv
@@ -1,6 +1,6 @@
 // ***************************************************************************
 // ***************************************************************************
-// Copyright (C) 2021-2023 Analog Devices, Inc. All rights reserved.
+// Copyright (C) 2021-2024 Analog Devices, Inc. All rights reserved.
 //
 // In this HDL repository, there are many different and unique modules, consisting
 // of various HDL (Verilog or VHDL) components. The individual modules are
@@ -26,7 +26,7 @@
 //
 //   2. An ADI specific BSD license, which can be found in the top level directory
 //      of this repository (LICENSE_ADIBSD), and also on-line at:
-//      https://github.com/analogdevicesinc/hdl/blob/master/LICENSE_ADIBSD
+//      https://github.com/analogdevicesinc/hdl/blob/main/LICENSE_ADIBSD
 //      This will allow to generate bit files and not release the source code,
 //      as long as it attaches to an ADI device.
 //


### PR DESCRIPTION
## PR Description

New operation mode for the external synchronization:
External synchronization using a signal that is based on a faster clock (also compatible with slower clock than the ext_clk or axi_clk of the axi_pwm_gen module) + without using the load_config register (continuous offset-related synchronization - e.g. synchronization at 1 s by using a 1 Hz sync signal).

## PR Type
- [ ] Bug fix (change that fixes an issue)
- [x] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the code style guidelines
- [x] I have performed a self-review of changes
- [ ] I have compiled all hdl projects and libraries affected by this PR
- [x] I have tested in hardware affected projects, at least on relevant boards
- [ ] I have commented my code, at least hard-to-understand parts
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe files, Copyright etc)
- [x] I have not introduced new Warnings/Critical Warnings on compilation
- [ ] I have added new hdl testbenches or updated existing ones
