### PR TITLE
Update to Vivado 2023.2 and fixes to util_hbm IP

### DIFF
--- a/library/util_hbm/scripts/adi_util_hbm.tcl
+++ b/library/util_hbm/scripts/adi_util_hbm.tcl
@@ -1,5 +1,5 @@
 ###############################################################################
-## Copyright (C) 2022-2023 Analog Devices, Inc. All rights reserved.
+## Copyright (C) 2022-2024 Analog Devices, Inc. All rights reserved.
 ### SPDX short identifier: ADIBSD
 ###############################################################################
 
@@ -33,12 +33,12 @@ proc ad_create_hbm {ip_name {density "4GB"}} {
   }
 }
 
-proc ad_create_util_hbm {name rx_tx_n src_width dst_width mem_size {axi_data_width 256} {mem_type 2}} {
+proc ad_create_util_hbm {name tx_rx_n src_width dst_width mem_size {axi_data_width 256} {mem_type 2}} {
 
   if {$mem_type == 2} {
     # HBM
     # split converter side bus into multiple AXI masters
-    set number_of_masters [expr int(ceil((${rx_tx_n} == 1 ? ${dst_width}.0 : ${src_width}.0) / ${axi_data_width}.0))]
+    set number_of_masters [expr int(ceil((${tx_rx_n} == 1 ? ${dst_width}.0 : ${src_width}.0) / ${axi_data_width}.0))]
   } else {
     # DDR we have always one master
     set number_of_masters 1
@@ -49,7 +49,7 @@ proc ad_create_util_hbm {name rx_tx_n src_width dst_width mem_size {axi_data_wid
     SRC_DATA_WIDTH $src_width \
     DST_DATA_WIDTH $dst_width \
     AXI_DATA_WIDTH $axi_data_width \
-    TX_RX_N $rx_tx_n \
+    TX_RX_N $tx_rx_n \
     NUM_M $number_of_masters \
     MEM_TYPE $mem_type \
   ]

--- a/library/util_hbm/util_hbm_ip.tcl
+++ b/library/util_hbm/util_hbm_ip.tcl
@@ -1,5 +1,5 @@
 ###############################################################################
-## Copyright (C) 2022-2023 Analog Devices, Inc. All rights reserved.
+## Copyright (C) 2022-2024 Analog Devices, Inc. All rights reserved.
 ### SPDX short identifier: ADIBSD
 ###############################################################################
 
@@ -153,7 +153,7 @@ foreach dir {"SRC" "DST"} {
 
 set_property -dict [list \
     "value_validation_type" "pairs" \
-    "value" "24" \
+    "value" "28" \
     "value_validation_pairs" {\
       "256MB" "28" \
       "512MB" "29" \
@@ -209,7 +209,7 @@ set_property -dict [list \
 # HBM_SEGMENTS_PER_MASTER = Storage size (MB) / 256 (MB) / number of masters
 set_property -dict [list \
     "enablement_value" "false" \
-    "value_tcl_expr" {expr  int(ceil(2**($LENGTH_WIDTH-28) / ${NUM_M}.0)) } \
+    "value_tcl_expr" { ceil(2**($LENGTH_WIDTH-28) / ${NUM_M}) } \
   ] \
   [ipx::get_user_parameters HBM_SEGMENTS_PER_MASTER -of_objects $cc]
 

--- a/scripts/adi_env.tcl
+++ b/scripts/adi_env.tcl
@@ -15,7 +15,7 @@ if [info exists ::env(ADI_GHDL_DIR)] {
 }
 
 # Define the supported tool version
-set required_vivado_version "2023.1"
+set required_vivado_version "2023.2"
 if {[info exists ::env(REQUIRED_VIVADO_VERSION)]} {
   set required_vivado_version $::env(REQUIRED_VIVADO_VERSION)
 } elseif {[info exists REQUIRED_VIVADO_VERSION]} {


### PR DESCRIPTION
## PR Description

- Updated the Vivado version to 2023.2
- Corrected the naming of a parameter in _ad_create_util_hbm_ procedure
- Gave valid default value to LENGTH_WIDTH in util_hbm IP
- Rewrote the value Tcl expression for HBM_SEGMENTS_PER_MASTER in util_hbm IP

A more detailed explanation:

The util_hbm IP fix came from the GithHub issue #1237 (AD9081_FMCA_EBZ/VCU128 project) where there were errors regarding `HBM_SEGMENTS_PER_MASTER` and `LENGTH_WIDTH` parameters from util_hbm IP, instantiated by data_offload IP.

`HBM_SEGMENTS_PER_MASTER` parameter was given no value because `LENGTH_WIDTH` didn't have a value from among the list of valid values. So the default value given to LENGTH_WIDTH (was 24) now is 28, from the list of accepted values.
Also, the way the Tcl expression for `HBM_SEGMENTS_PER_MASTER` was not accepted anymore by Vivado, so it had to be changed (even after giving a valid value for `LENGTH_WIDTH`).

Thus, the formula for `HBM_SEGMENTS_PER_MASTER` was changed from 
`{expr  int(ceil(2**($LENGTH_WIDTH-28) / ${NUM_M}.0)) }`
to
`{ ceil(2**($LENGTH_WIDTH-28) / ${NUM_M}) }`

After changing all these, still some projects were failing with timing constraints not met. I tried building these projects with Vivado 2023.2, and it appears that the timing issues are gone now, for _**the majority**_ of them.

## PR Type
- [x] Bug fix (change that fixes an issue)
- [x] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the code style guidelines
- [x] I have performed a self-review of changes
- [x] I have compiled all hdl projects and libraries affected by this PR
- [x] I have tested in hardware affected projects, at least on relevant boards
- [ ] I have commented my code, at least hard-to-understand parts
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe files, Copyright etc)
- [ ] I have not introduced new Warnings/Critical Warnings on compilation
- [ ] I have added new hdl testbenches or updated existing ones
