### PR TITLE
lib/axi_pwm_gen: Update pause_cnt logic

### DIFF
--- a/library/axi_pwm_gen/axi_pwm_gen.sv
+++ b/library/axi_pwm_gen/axi_pwm_gen.sv
@@ -1,6 +1,6 @@
 // ***************************************************************************
 // ***************************************************************************
-// Copyright (C) 2021-2023 Analog Devices, Inc. All rights reserved.
+// Copyright (C) 2021-2024 Analog Devices, Inc. All rights reserved.
 //
 // In this HDL repository, there are many different and unique modules, consisting
 // of various HDL (Verilog or VHDL) components. The individual modules are
@@ -298,7 +298,8 @@ module axi_pwm_gen #(
     end
   end
 
-  assign pause_cnt = ((pwm_armed[1]  |
+  assign pause_cnt = ((pwm_armed[0]  |
+                       pwm_armed[1]  |
                        pwm_armed[2]  |
                        pwm_armed[3]  |
                        pwm_armed[4]  |


### PR DESCRIPTION
## PR Description
Updated the pause_cnt logic. Before this modification, no pwm signal was generated on pwm channel 0.
## PR Type
- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the code style guidelines
- [x] I have performed a self-review of changes
- [ ] I have compiled all hdl projects and libraries affected by this PR
- [x] I have tested in hardware affected projects, at least on relevant boards
- [ ] I have commented my code, at least hard-to-understand parts
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe files, Copyright etc)
- [x] I have not introduced new Warnings/Critical Warnings on compilation
- [ ] I have added new hdl testbenches or updated existing ones
