### PR TITLE
Add feature for inverted LVDS data in ad_data_in and axi_ad9361

### DIFF
--- a/library/axi_ad9361/axi_ad9361.v
+++ b/library/axi_ad9361/axi_ad9361.v
@@ -1,6 +1,6 @@
 // ***************************************************************************
 // ***************************************************************************
-// Copyright (C) 2014-2023 Analog Devices, Inc. All rights reserved.
+// Copyright (C) 2014-2024 Analog Devices, Inc. All rights reserved.
 //
 // In this HDL repository, there are many different and unique modules, consisting
 // of various HDL (Verilog or VHDL) components. The individual modules are
@@ -37,8 +37,6 @@
 
 module axi_ad9361 #(
 
-  // parameters
-
   parameter   ID = 0,
   parameter   MODE_1R1T = 0,
   parameter   FPGA_TECHNOLOGY = 0,
@@ -70,7 +68,12 @@ module axi_ad9361 #(
   parameter   MIMO_ENABLE = 0,
   parameter   USE_SSI_CLK = 1,
   parameter   DELAY_REFCLK_FREQUENCY = 200,
-  parameter   RX_NODPA = 0
+  parameter   RX_NODPA = 0,
+  // for lvds mode only -- polarity inversion for each line and for frame
+  // bits 5:0 - per line inversion of data in ad_data_in, lines 5-0
+  // bit 6 - frame inversion
+  // i.e.: 64 means inversion on all 5 lines and frame as well
+  parameter   INV_POL = 0
 ) (
 
   // physical interface (receive-lvds)
@@ -408,7 +411,8 @@ module axi_ad9361 #(
     .CLK_DESKEW (MIMO_ENABLE),
     .USE_SSI_CLK (USE_SSI_CLK),
     .DELAY_REFCLK_FREQUENCY (DELAY_REFCLK_FREQUENCY),
-    .RX_NODPA (RX_NODPA)
+    .RX_NODPA (RX_NODPA),
+    .INV_POL (INV_POL)
   ) i_dev_if (
     .rx_clk_in_p (rx_clk_in_p),
     .rx_clk_in_n (rx_clk_in_n),

--- a/library/axi_ad9361/xilinx/axi_ad9361_lvds_if.v
+++ b/library/axi_ad9361/xilinx/axi_ad9361_lvds_if.v
@@ -45,10 +45,12 @@ module axi_ad9361_lvds_if #(
   parameter   USE_SSI_CLK = 1,
   parameter   DELAY_REFCLK_FREQUENCY = 200,
   parameter   RX_NODPA = 0,
-  // for lvds mode only -- polarity inversion for each line and for frame
+  // for lvds mode only -- polarity inversion for each line, for frame and
+  // clock
   // bits 5:0 - per line inversion of data in ad_data_in, lines 5-0
   // bit 6 - frame inversion
-  // i.e.: 64 means inversion on all 5 lines and frame as well
+  // bit 7 - clock inversion
+  // i.e.: 255 means inversion on all 6 lines, frame and clock as well
   parameter   INV_POL = 0
 ) (
 
@@ -177,7 +179,7 @@ module axi_ad9361_lvds_if #(
 
   // local parameters
 
-  localparam [6:0] INV_POL_PER_LINE = INV_POL;
+  localparam [7:0] INV_POL_PER_LINE = INV_POL;
 
   // drp interface signals
 
@@ -631,7 +633,9 @@ module axi_ad9361_lvds_if #(
 
   // device clock interface (receive clock)
   generate if (USE_SSI_CLK == 1) begin
-  ad_data_clk i_clk (
+  ad_data_clk #(
+    .INV_POL (INV_POL[7])
+  ) i_clk (
     .rst (1'd0),
     .locked (),
     .clk_in_p (rx_clk_in_p),

--- a/library/xilinx/common/ad_data_clk.v
+++ b/library/xilinx/common/ad_data_clk.v
@@ -37,7 +37,10 @@
 
 module ad_data_clk #(
 
-  parameter   SINGLE_ENDED = 0
+  parameter   SINGLE_ENDED = 0,
+  // for lvds mode only
+  // invert polarity of signals
+  parameter   INV_POL = 0
 ) (
   input               rst,
   output              locked,
@@ -50,6 +53,8 @@ module ad_data_clk #(
   // internal signals
 
   wire                clk_ibuf_s;
+  wire                clk_ibuf_inv_s;
+  wire                clk_ibuf_not_inv_s;
 
   // defaults
 
@@ -59,14 +64,17 @@ module ad_data_clk #(
 
   generate
   if (SINGLE_ENDED == 1) begin
-  IBUFG i_rx_clk_ibuf (
-    .I (clk_in_p),
-    .O (clk_ibuf_s));
+    IBUFG i_rx_clk_ibuf (
+      .I (clk_in_p),
+      .O (clk_ibuf_s));
   end else begin
-  IBUFGDS i_rx_clk_ibuf (
-    .I (clk_in_p),
-    .IB (clk_in_n),
-    .O (clk_ibuf_s));
+    IBUFDS_DIFF_OUT i_rx_clk_ibuf (
+      .I (clk_in_p),
+      .IB (clk_in_n),
+      .O (clk_ibuf_not_inv_s),
+      .OB (clk_ibuf_inv_s));
+
+    assign clk_ibuf_s = (INV_POL == 1) ? clk_ibuf_inv_s : clk_ibuf_not_inv_s;
   end
   endgenerate
 

--- a/library/xilinx/common/ad_data_in.v
+++ b/library/xilinx/common/ad_data_in.v
@@ -51,6 +51,7 @@ module ad_data_in #(
   parameter   IODELAY_GROUP = "dev_if_delay_group",
   parameter   REFCLK_FREQUENCY = 200,
   // for lvds mode only
+  // invert polarity of signals
   parameter   INV_POL = 0
 ) (
 

--- a/projects/fmcomms2/common/fmcomms2_bd.tcl
+++ b/projects/fmcomms2/common/fmcomms2_bd.tcl
@@ -1,5 +1,5 @@
 ###############################################################################
-## Copyright (C) 2014-2023 Analog Devices, Inc. All rights reserved.
+## Copyright (C) 2014-2024 Analog Devices, Inc. All rights reserved.
 ### SPDX short identifier: ADIBSD
 ###############################################################################
 
@@ -32,6 +32,7 @@ create_bd_port -dir O tdd_sync_t
 
 ad_ip_instance axi_ad9361 axi_ad9361
 ad_ip_parameter axi_ad9361 CONFIG.ID 0
+ad_ip_parameter axi_ad9361 CONFIG.INV_POL 0
 
 # set to 1 for CORDIC or 2 for POLYNOMIAL
 ad_ip_parameter axi_ad9361 CONFIG.DAC_DDS_TYPE 1


### PR DESCRIPTION
## PR Description

This started out from an EZ thread (https://ez.analog.com/fpga/f/q-a/577761/te0820-tef1002-fmcomms3-porting-fmcomms3-to-tef1002) and it seemed like a good feature to implement so it was decided to add it.

This applies only to LVDS mode!

In ad_data_in, the IBUFDS instance was replaced with an IBUFDS_DIFF_OUT such that the inverted output can be used. A parameter was added to select between inverted and normal mode. 
The `INV_POL` parameter is interpreted as follows:
- bits 5-0 are for data lines 5-0
- bit 6 is for frame inversion
- bit 7 is for clock inversion

Changes were made in the xilinx/axi_ad9361_lvds_if.v module for having the option to invert the data and the frame for Tx, before being sent to ad_data_out.

The FMCOMMS2 base design has an `INV_POL` parameter added, by default set to 0.
In hardware, the FMCOMMS2/ZCU102 project was tested.

So far, we don't have a use case when we want inversion for this, in our repository.

## PR Type
- [ ] Bug fix (change that fixes an issue)
- [x] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the code style guidelines
- [x] I have performed a self-review of changes
- [x] I have compiled all hdl projects and libraries affected by this PR
- [x] I have tested in hardware affected projects, at least on relevant boards
- [x] I have commented my code, at least hard-to-understand parts
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe files, Copyright etc)
- [x] I have not introduced new Warnings/Critical Warnings on compilation
- [ ] I have added new hdl testbenches or updated existing ones
