### PR TITLE
SPI Engine: Add registers for Offload memory and FIFO sizes

### DIFF
--- a/docs/regmap/adi_regmap_spi_engine.txt
+++ b/docs/regmap/adi_regmap_spi_engine.txt
@@ -81,6 +81,70 @@ ENDFIELD
 ############################################################################################
 
 REG
+0x04
+OFFLOAD_MEM_ADDR_WIDTH
+ENDREG
+
+FIELD
+[15:8] 0x04
+SDO_MEM_ADDRESS_WIDTH
+RO
+Address width for the data (SDO) memory on the Offload Module.
+The size of the memory is thus ``2**SDO_MEM_ADDRESS_WIDTH``.
+ENDFIELD
+
+FIELD
+[7:0] 0x04
+CMD_MEM_ADDRESS_WIDTH
+RO
+Address width for the command memory on the Offload Module.
+The size of the command memory is thus ``2**CMD_MEM_ADDRESS_WIDTH``.
+ENDFIELD
+
+############################################################################################
+############################################################################################
+
+REG
+0x05
+FIFO_ADDR_WIDTH
+ENDREG
+
+FIELD
+[31:24] 0x05
+SDI_FIFO_ADDRESS_WIDTH
+RO
+Address width for the SDI FIFO.
+The size of the SDI FIFO is thus ``2**SDI_FIFO_ADDRESS_WIDTH``.
+ENDFIELD
+
+FIELD
+[23:16] 0x05
+SDO_FIFO_ADDRESS_WIDTH
+RO
+Address width for the SDO FIFO.
+The size of the SDO FIFO is thus ``2**SDO_FIFO_ADDRESS_WIDTH``.
+ENDFIELD
+
+FIELD
+[15:8] 0x04
+SYNC_FIFO_ADDRESS_WIDTH
+RO
+Address width for the synchronization FIFO.
+The size of the synchronization FIFO is thus ``2**SYNC_FIFO_ADDRESS_WIDTH``.
+ENDFIELD
+
+FIELD
+[7:0] 0x04
+CMD_FIFO_ADDRESS_WIDTH
+RO
+Address width for the command FIFO.
+The size of the command FIFO is thus ``2**CMD_FIFO_ADDRESS_WIDTH``.
+ENDFIELD
+
+############################################################################################
+############################################################################################
+
+REG
 0x10
 ENABLE
 ENDREG

--- a/docs/regmap/adi_regmap_spi_engine.txt
+++ b/docs/regmap/adi_regmap_spi_engine.txt
@@ -19,7 +19,7 @@ RO
 ENDFIELD
 
 FIELD
-[15:8] 0x00
+[15:8] 0x01
 VERSION_MINOR
 RO
 ENDFIELD
@@ -90,7 +90,7 @@ FIELD
 SDO_MEM_ADDRESS_WIDTH
 RO
 Address width for the data (SDO) memory on the Offload Module.
-The size of the memory is thus ``2**SDO_MEM_ADDRESS_WIDTH``.
+The size of the memory is thus ``2**SDO_MEM_ADDRESS_WIDTH`` data words.
 ENDFIELD
 
 FIELD
@@ -98,7 +98,7 @@ FIELD
 CMD_MEM_ADDRESS_WIDTH
 RO
 Address width for the command memory on the Offload Module.
-The size of the command memory is thus ``2**CMD_MEM_ADDRESS_WIDTH``.
+The size of the command memory is thus ``2**CMD_MEM_ADDRESS_WIDTH`` instructions.
 ENDFIELD
 
 ############################################################################################

--- a/library/spi_engine/axi_spi_engine/axi_spi_engine.v
+++ b/library/spi_engine/axi_spi_engine/axi_spi_engine.v
@@ -334,12 +334,20 @@ module axi_spi_engine #(
   end
   endgenerate
 
+  reg [7:0] offload_sdo_mem_address_width = OFFLOAD0_SDO_MEM_ADDRESS_WIDTH;
+  reg [7:0] offload_cmd_mem_address_width = OFFLOAD0_CMD_MEM_ADDRESS_WIDTH;
+  reg [7:0] sdi_fifo_address_width = SDI_FIFO_ADDRESS_WIDTH;
+  reg [7:0] sdo_fifo_address_width = SDO_FIFO_ADDRESS_WIDTH;
+  reg [7:0] sync_fifo_address_width = SYNC_FIFO_ADDRESS_WIDTH;
+  reg [7:0] cmd_fifo_address_width = CMD_FIFO_ADDRESS_WIDTH;
   always @(posedge clk) begin
     case (up_raddr_s)
       8'h00: up_rdata_ff <= PCORE_VERSION;
       8'h01: up_rdata_ff <= ID;
       8'h02: up_rdata_ff <= up_scratch;
       8'h03: up_rdata_ff <= {8'b0, NUM_OF_SDI, DATA_WIDTH};
+      8'h04: up_rdata_ff <= {16'b0, offload_sdo_mem_address_width, offload_cmd_mem_address_width};
+      8'h05: up_rdata_ff <= {sdi_fifo_address_width, sdo_fifo_address_width, sync_fifo_address_width, cmd_fifo_address_width};
       8'h10: up_rdata_ff <= up_sw_reset;
       8'h20: up_rdata_ff <= up_irq_mask;
       8'h21: up_rdata_ff <= up_irq_pending;

--- a/library/spi_engine/axi_spi_engine/axi_spi_engine.v
+++ b/library/spi_engine/axi_spi_engine/axi_spi_engine.v
@@ -133,7 +133,7 @@ module axi_spi_engine #(
   input [7:0] offload_sync_data
 );
 
-  localparam PCORE_VERSION = 'h010071;
+  localparam PCORE_VERSION = 'h010171;
   localparam S_AXI = 0;
   localparam UP_FIFO = 1;
 

--- a/library/spi_engine/axi_spi_engine/axi_spi_engine.v
+++ b/library/spi_engine/axi_spi_engine/axi_spi_engine.v
@@ -1,6 +1,6 @@
 // ***************************************************************************
 // ***************************************************************************
-// Copyright (C) 2015-2023 Analog Devices, Inc. All rights reserved.
+// Copyright (C) 2015-2024 Analog Devices, Inc. All rights reserved.
 //
 // In this HDL repository, there are many different and unique modules, consisting
 // of various HDL (Verilog or VHDL) components. The individual modules are

--- a/library/spi_engine/scripts/spi_engine.tcl
+++ b/library/spi_engine/scripts/spi_engine.tcl
@@ -3,7 +3,7 @@
 ### SPDX short identifier: ADIBSD
 ###############################################################################
 
-proc spi_engine_create {{name "spi_engine"} {data_width 32} {async_spi_clk 1} {num_cs 1} {num_sdi 1} {num_sdo 1} {sdi_delay 0} {echo_sclk 0}} {
+proc spi_engine_create {{name "spi_engine"} {data_width 32} {async_spi_clk 1} {num_cs 1} {num_sdi 1} {num_sdo 1} {sdi_delay 0} {echo_sclk 0} {cmd_mem_addr_width 4} {data_mem_addr_width 4} {sdi_fifo_addr_width 5} {sdo_fifo_addr_width 5} {sync_fifo_addr_width 4} {cmd_fifo_addr_width 4}} {
   puts "echo_sclk: $echo_sclk"
 
   create_bd_cell -type hier $name
@@ -40,11 +40,19 @@ proc spi_engine_create {{name "spi_engine"} {data_width 32} {async_spi_clk 1} {n
   ad_ip_parameter $axi_regmap CONFIG.NUM_OFFLOAD 1
   ad_ip_parameter $axi_regmap CONFIG.NUM_OF_SDI $num_sdi
   ad_ip_parameter $axi_regmap CONFIG.ASYNC_SPI_CLK $async_spi_clk
+  ad_ip_parameter $axi_regmap CONFIG.OFFLOAD0_CMD_MEM_ADDRESS_WIDTH $cmd_mem_addr_width
+  ad_ip_parameter $axi_regmap CONFIG.OFFLOAD0_SDO_MEM_ADDRESS_WIDTH $data_mem_addr_width
+  ad_ip_parameter $axi_regmap CONFIG.SDI_FIFO_ADDRESS_WIDTH $sdi_fifo_addr_width
+  ad_ip_parameter $axi_regmap CONFIG.SDO_FIFO_ADDRESS_WIDTH $sdo_fifo_addr_width
+  ad_ip_parameter $axi_regmap CONFIG.SYNC_FIFO_ADDRESS_WIDTH $sync_fifo_addr_width
+  ad_ip_parameter $axi_regmap CONFIG.CMD_FIFO_ADDRESS_WIDTH $cmd_fifo_addr_width
 
   ad_ip_instance spi_engine_offload $offload
   ad_ip_parameter $offload CONFIG.DATA_WIDTH $data_width
   ad_ip_parameter $offload CONFIG.ASYNC_SPI_CLK $async_spi_clk
   ad_ip_parameter $offload CONFIG.NUM_OF_SDI $num_sdi
+  ad_ip_parameter $offload CONFIG.CMD_MEM_ADDRESS_WIDTH $cmd_mem_addr_width
+  ad_ip_parameter $offload CONFIG.SDO_MEM_ADDRESS_WIDTH $data_mem_addr_width
 
   ad_ip_instance spi_engine_interconnect $interconnect
   ad_ip_parameter $interconnect CONFIG.DATA_WIDTH $data_width

--- a/library/spi_engine/scripts/spi_engine.tcl
+++ b/library/spi_engine/scripts/spi_engine.tcl
@@ -1,5 +1,5 @@
 ###############################################################################
-## Copyright (C) 2020-2023 Analog Devices, Inc. All rights reserved.
+## Copyright (C) 2020-2024 Analog Devices, Inc. All rights reserved.
 ### SPDX short identifier: ADIBSD
 ###############################################################################
 


### PR DESCRIPTION
## PR Description


Adds registers at dword 0x04 and 0x05, respectively allowing software to get the sizes of the Offload Module memories (command and sdo) or the sizes of the FIFOs on the AXI regmap.

I'm not sure if this is the occasion for incrementing the SPI Engine patch version (or minor version).

## PR Type
- [ ] Bug fix (change that fixes an issue)
- [x] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the code style guidelines
- [x] I have performed a self-review of changes
- [ ] I have compiled all hdl projects and libraries affected by this PR
- [ ] I have tested in hardware affected projects, at least on relevant boards
- [ ] I have commented my code, at least hard-to-understand parts
- [x] I have signed off all commits from this PR
- [x] I have updated the documentation (wiki pages, ReadMe files, Copyright etc)
- [x] I have not introduced new Warnings/Critical Warnings on compilation
- [ ] I have added new hdl testbenches or updated existing ones
