### PR TITLE
hdl: Zed-AD7768: Wideband fixed bug_2022_R2

### DIFF
--- a/projects/ad7768evb/Makefile
+++ b/projects/ad7768evb/Makefile
@@ -1,5 +1,5 @@
 ####################################################################################
-## Copyright (c) 2018 - 2023 Analog Devices, Inc.
+## Copyright (c) 2018 - 2024 Analog Devices, Inc.
 ### SPDX short identifier: BSD-1-Clause
 ## Auto-generated, do not modify!
 ####################################################################################

--- a/projects/ad7768evb/zed/Makefile
+++ b/projects/ad7768evb/zed/Makefile
@@ -1,5 +1,5 @@
 ####################################################################################
-## Copyright (c) 2018 - 2023 Analog Devices, Inc.
+## Copyright (c) 2018 - 2024 Analog Devices, Inc.
 ### SPDX short identifier: BSD-1-Clause
 ## Auto-generated, do not modify!
 ####################################################################################

--- a/projects/ad7768evb/zed/system_top.v
+++ b/projects/ad7768evb/zed/system_top.v
@@ -96,7 +96,7 @@ module system_top (
   inout                   gpio_1_mode_1,
   inout                   gpio_2_mode_2,
   inout                   gpio_3_mode_3,
-  inout                   gpio_4_filter,
+  output                  gpio_4_filter,
   output                  reset_n,
   output                  start_n,
   output                  mclk
@@ -133,19 +133,19 @@ module system_top (
   // use crystal
 
   assign mclk = 1'b0;
-  assign start_n = gpio_o[33];
+  assign start_n = 1'b1;
+  assign gpio_4_filter = 1'b1;
   assign reset_n = gpio_o[32];
 
   // instantiations
 
   ad_iobuf #(
-    .DATA_WIDTH(5)
+    .DATA_WIDTH(4)
   ) i_iobuf (
-    .dio_t (gpio_t[52:48]),
-    .dio_i (gpio_o[52:48]),
-    .dio_o (gpio_i[52:48]),
-    .dio_p ({ gpio_4_filter,        // 52
-              gpio_3_mode_3,        // 51
+    .dio_t (gpio_t[51:48]),
+    .dio_i (gpio_o[51:48]),
+    .dio_o (gpio_i[51:48]),
+    .dio_p ({ gpio_3_mode_3,        // 51
               gpio_2_mode_2,        // 50
               gpio_1_mode_1,        // 49
               gpio_0_mode_0         // 48

--- a/projects/ad7768evb/zed/system_top.v
+++ b/projects/ad7768evb/zed/system_top.v
@@ -1,6 +1,6 @@
 // ***************************************************************************
 // ***************************************************************************
-// Copyright (C) 2019-2023 Analog Devices, Inc. All rights reserved.
+// Copyright (C) 2019-2024 Analog Devices, Inc. All rights reserved.
 //
 // In this HDL repository, there are many different and unique modules, consisting
 // of various HDL (Verilog or VHDL) components. The individual modules are
@@ -159,9 +159,9 @@ module system_top (
     .dio_o (gpio_i[31:0]),
     .dio_p (gpio_bd));
 
-  assign gpio_i[33:32] = 2'b0;
-  assign gpio_i[47:34] = gpio_o[47:34];
-  assign gpio_i[63:53] = gpio_o[63:53];
+  assign gpio_i[32] = 2'b0;
+  assign gpio_i[47:33] = gpio_o[47:33];
+  assign gpio_i[63:52] = gpio_o[63:52];
 
   ad_iobuf #(
     .DATA_WIDTH(2)


### PR DESCRIPTION
## PR Description

In SPI control mode, when not used as GPIO the FILTER pin and when a crystal is used as the clock source, this pin must be set to 1. The START pin must be tied to a logic 1 through a pull-up resistor, when it is not used.

## PR Type
- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the code style guidelines
- [x] I have performed a self-review of changes
- [x] I have compiled all hdl projects and libraries affected by this PR
- [x] I have tested in hardware affected projects, at least on relevant boards
- [ ] I have commented my code, at least hard-to-understand parts
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe files, Copyright etc)
- [x] I have not introduced new Warnings/Critical Warnings on compilation
- [ ] I have added new hdl testbenches or updated existing ones
