### PR TITLE
Util axis fifo asym

### DIFF
--- a/library/common/ad_mem.v
+++ b/library/common/ad_mem.v
@@ -1,6 +1,6 @@
 // ***************************************************************************
 // ***************************************************************************
-// Copyright (C) 2014-2023 Analog Devices, Inc. All rights reserved.
+// Copyright (C) 2014-2024 Analog Devices, Inc. All rights reserved.
 //
 // In this HDL repository, there are many different and unique modules, consisting
 // of various HDL (Verilog or VHDL) components. The individual modules are

--- a/library/common/ad_mem.v
+++ b/library/common/ad_mem.v
@@ -54,6 +54,14 @@ module ad_mem #(
   (* ram_style = "block" *)
   reg         [(DATA_WIDTH-1):0]      m_ram[0:((2**ADDRESS_WIDTH)-1)];
 
+  integer i;
+  initial
+    for (i = 0; i < 2 ** ADDRESS_WIDTH; i = i+1)
+      m_ram[i] = {DATA_WIDTH{1'b0}};
+
+  initial
+    doutb <= {DATA_WIDTH{1'b0}};
+
   always @(posedge clka) begin
     if (wea == 1'b1) begin
       m_ram[addra] <= dina;

--- a/library/common/ad_mem.v
+++ b/library/common/ad_mem.v
@@ -1,6 +1,6 @@
 // ***************************************************************************
 // ***************************************************************************
-// Copyright (C) 2014-2024 Analog Devices, Inc. All rights reserved.
+// Copyright (C) 2014-2025 Analog Devices, Inc. All rights reserved.
 //
 // In this HDL repository, there are many different and unique modules, consisting
 // of various HDL (Verilog or VHDL) components. The individual modules are

--- a/library/data_offload/data_offload.v
+++ b/library/data_offload/data_offload.v
@@ -250,7 +250,7 @@ module data_offload #(
   // it's supported just with the FIFO interface
   util_axis_fifo_asym #(
     .S_DATA_WIDTH (SRC_DATA_WIDTH),
-    .S_ADDRESS_WIDTH (SRC_ADDR_WIDTH_BYPASS),
+    .ADDRESS_WIDTH (SRC_ADDR_WIDTH_BYPASS),
     .M_DATA_WIDTH (DST_DATA_WIDTH),
     .ASYNC_CLK (1)
   ) i_bypass_fifo (

--- a/library/data_offload/data_offload.v
+++ b/library/data_offload/data_offload.v
@@ -1,6 +1,6 @@
 // ***************************************************************************
 // ***************************************************************************
-// Copyright (C) 2021-2023 Analog Devices, Inc. All rights reserved.
+// Copyright (C) 2021-2024 Analog Devices, Inc. All rights reserved.
 //
 // In this HDL repository, there are many different and unique modules, consisting
 // of various HDL (Verilog or VHDL) components. The individual modules are

--- a/library/data_offload/data_offload.v
+++ b/library/data_offload/data_offload.v
@@ -1,6 +1,6 @@
 // ***************************************************************************
 // ***************************************************************************
-// Copyright (C) 2021-2024 Analog Devices, Inc. All rights reserved.
+// Copyright (C) 2021-2025 Analog Devices, Inc. All rights reserved.
 //
 // In this HDL repository, there are many different and unique modules, consisting
 // of various HDL (Verilog or VHDL) components. The individual modules are

--- a/library/util_axis_fifo/util_axis_fifo.v
+++ b/library/util_axis_fifo/util_axis_fifo.v
@@ -154,7 +154,7 @@ module util_axis_fifo #(
         // TKEEP support
         if (TKEEP_EN) begin
 
-          reg axis_tkeep_d;
+          reg [DATA_WIDTH/8-1:0] axis_tkeep_d;
 
           always @(posedge s_axis_aclk) begin
             if (s_axis_ready == 1'b1 && s_axis_valid == 1'b1)
@@ -210,7 +210,7 @@ module util_axis_fifo #(
 
       // TKEEP support
       if (TKEEP_EN) begin
-        reg  axis_tkeep_d;
+        reg [DATA_WIDTH/8-1:0] axis_tkeep_d;
 
         always @(posedge s_axis_aclk) begin
           if (!s_axis_aresetn) begin

--- a/library/util_axis_fifo/util_axis_fifo.v
+++ b/library/util_axis_fifo/util_axis_fifo.v
@@ -1,6 +1,6 @@
 // ***************************************************************************
 // ***************************************************************************
-// Copyright (C) 2014-2024 Analog Devices, Inc. All rights reserved.
+// Copyright (C) 2014-2025 Analog Devices, Inc. All rights reserved.
 //
 // In this HDL repository, there are many different and unique modules, consisting
 // of various HDL (Verilog or VHDL) components. The individual modules are

--- a/library/util_axis_fifo_asym/util_axis_fifo_asym.v
+++ b/library/util_axis_fifo_asym/util_axis_fifo_asym.v
@@ -37,14 +37,15 @@
 module util_axis_fifo_asym #(
   parameter ASYNC_CLK = 1,
   parameter S_DATA_WIDTH = 64,
-  parameter S_ADDRESS_WIDTH = 5,
+  parameter ADDRESS_WIDTH = 5,
   parameter M_DATA_WIDTH = 128,
   parameter M_AXIS_REGISTERED = 1,
   parameter ALMOST_EMPTY_THRESHOLD = 4,
   parameter ALMOST_FULL_THRESHOLD = 4,
   parameter TLAST_EN = 0,
   parameter TKEEP_EN = 0,
-  parameter S_FIFO_LIMITED = 0
+  parameter FIFO_LIMITED = 0,
+  parameter ADDRESS_WIDTH_PERSPECTIVE = 0
 ) (
   input m_axis_aclk,
   input m_axis_aresetn,
@@ -66,7 +67,7 @@ module util_axis_fifo_asym #(
   input s_axis_tlast,
   output s_axis_full,
   output s_axis_almost_full,
-  output [S_ADDRESS_WIDTH-1:0] s_axis_room
+  output [ADDRESS_WIDTH-1:0] s_axis_room
 );
 
   // define which interface has a wider bus
@@ -77,9 +78,11 @@ module util_axis_fifo_asym #(
 
   // atomic parameters - NOTE: depth is always defined by the slave attributes
   localparam A_WIDTH = (RATIO_TYPE) ? M_DATA_WIDTH : S_DATA_WIDTH;
-  localparam A_ADDRESS = (S_FIFO_LIMITED) ? ((RATIO_TYPE) ? S_ADDRESS_WIDTH : (S_ADDRESS_WIDTH-$clog2(RATIO))) : S_ADDRESS_WIDTH;
-  localparam A_ALMOST_FULL_THRESHOLD = (S_FIFO_LIMITED) ? ((RATIO_TYPE) ? ALMOST_FULL_THRESHOLD : (ALMOST_FULL_THRESHOLD/RATIO)) : ALMOST_FULL_THRESHOLD;
-  localparam A_ALMOST_EMPTY_THRESHOLD = (S_FIFO_LIMITED) ? ((RATIO_TYPE) ? (ALMOST_EMPTY_THRESHOLD/RATIO) : ALMOST_EMPTY_THRESHOLD) : ALMOST_EMPTY_THRESHOLD; 
+  localparam A_ADDRESS = (ADDRESS_WIDTH_PERSPECTIVE) ?
+    ((FIFO_LIMITED) ? ((RATIO_TYPE) ? (ADDRESS_WIDTH-$clog2(RATIO)) : ADDRESS_WIDTH) : ADDRESS_WIDTH) :
+    ((FIFO_LIMITED) ? ((RATIO_TYPE) ? ADDRESS_WIDTH : (ADDRESS_WIDTH-$clog2(RATIO))) : ADDRESS_WIDTH);
+  localparam A_ALMOST_FULL_THRESHOLD = (RATIO_TYPE) ? ALMOST_FULL_THRESHOLD : (ALMOST_FULL_THRESHOLD/RATIO);
+  localparam A_ALMOST_EMPTY_THRESHOLD = (RATIO_TYPE) ? (ALMOST_EMPTY_THRESHOLD/RATIO) : ALMOST_EMPTY_THRESHOLD;
 
   // slave and master sequencers
   reg [$clog2(RATIO)-1:0] s_axis_counter;

--- a/library/util_axis_fifo_asym/util_axis_fifo_asym.v
+++ b/library/util_axis_fifo_asym/util_axis_fifo_asym.v
@@ -1,6 +1,6 @@
 // ***************************************************************************
 // ***************************************************************************
-// Copyright (C) 2021-2023 Analog Devices, Inc. All rights reserved.
+// Copyright (C) 2021-2024 Analog Devices, Inc. All rights reserved.
 //
 // In this HDL repository, there are many different and unique modules, consisting
 // of various HDL (Verilog or VHDL) components. The individual modules are

--- a/library/util_axis_fifo_asym/util_axis_fifo_asym.v
+++ b/library/util_axis_fifo_asym/util_axis_fifo_asym.v
@@ -1,6 +1,6 @@
 // ***************************************************************************
 // ***************************************************************************
-// Copyright (C) 2021-2024 Analog Devices, Inc. All rights reserved.
+// Copyright (C) 2021-2025 Analog Devices, Inc. All rights reserved.
 //
 // In this HDL repository, there are many different and unique modules, consisting
 // of various HDL (Verilog or VHDL) components. The individual modules are

--- a/library/util_axis_fifo_asym/util_axis_fifo_asym.v
+++ b/library/util_axis_fifo_asym/util_axis_fifo_asym.v
@@ -252,7 +252,12 @@ module util_axis_fifo_asym #(
       assign m_axis_data = m_axis_data_int_s;
       // if every instance has a valid data, the interface has valid data,
       // otherwise valid is asserted only if TLAST is asserted
-      assign m_axis_valid_int = (|(m_axis_tlast_int_s & m_axis_valid_int_s)) ? |m_axis_valid_int_s : &m_axis_valid_int_s;
+      // assign m_axis_valid_int = (|(m_axis_tlast_int_s & m_axis_valid_int_s)) ? |m_axis_valid_int_s : &m_axis_valid_int_s;
+      if (TLAST_EN) begin
+        assign m_axis_valid_int = (|(m_axis_tlast_int_s & m_axis_valid_int_s)) ? |m_axis_valid_int_s : &m_axis_valid_int_s;
+      end else begin
+        assign m_axis_valid_int = &m_axis_valid_int_s;
+      end
       assign m_axis_valid = m_axis_valid_int;
       // if one of the atomic instance is empty, m_axis_empty should be asserted
       assign m_axis_empty = |m_axis_empty_int_s;

--- a/library/util_axis_fifo_asym/util_axis_fifo_asym.v
+++ b/library/util_axis_fifo_asym/util_axis_fifo_asym.v
@@ -152,7 +152,7 @@ module util_axis_fifo_asym #(
 
       for (i=0; i<RATIO; i=i+1) begin
         assign s_axis_valid_int_s[i] = s_axis_valid & s_axis_ready;
-                
+
         if (TKEEP_EN) begin
 
           assign s_axis_tlast_int_s[i] = (i==RATIO-1) ? ((|s_axis_tkeep[M_DATA_WIDTH/8*i+:M_DATA_WIDTH/8]) ? s_axis_tlast : 1'b0) :

--- a/library/util_axis_fifo_asym/util_axis_fifo_asym_ip.tcl
+++ b/library/util_axis_fifo_asym/util_axis_fifo_asym_ip.tcl
@@ -1,5 +1,5 @@
 ###############################################################################
-## Copyright (C) 2015-2023 Analog Devices, Inc. All rights reserved.
+## Copyright (C) 2015-2024 Analog Devices, Inc. All rights reserved.
 ### SPDX short identifier: ADIBSD
 ###############################################################################
 

--- a/library/util_axis_fifo_asym/util_axis_fifo_asym_ip.tcl
+++ b/library/util_axis_fifo_asym/util_axis_fifo_asym_ip.tcl
@@ -30,6 +30,7 @@ adi_add_bus "s_axis" "slave" \
 		{"s_axis_ready" "TREADY"} \
 		{"s_axis_data" "TDATA"} \
 		{"s_axis_tlast" "TLAST"} \
+		{"s_axis_tkeep" "TKEEP"} \
 	}
 
 adi_add_bus "m_axis" "master" \
@@ -40,11 +41,30 @@ adi_add_bus "m_axis" "master" \
 		{"m_axis_ready" "TREADY"} \
 		{"m_axis_data" "TDATA"} \
 		{"m_axis_tlast" "TLAST"} \
+		{"m_axis_tkeep" "TKEEP"} \
 	}
 
 adi_add_bus_clock "m_axis_aclk" "m_axis" "m_axis_aresetn"
 adi_add_bus_clock "s_axis_aclk" "s_axis" "s_axis_aresetn"
 
+set cc [ipx::current_core]
+
+set_property -dict [list \
+	"value_format" "bool" \
+	"value" "false" \
+] [ipx::get_user_parameters S_FIFO_LIMITED -of_objects $cc]
+
+set_property -dict [list \
+	"value_format" "bool" \
+	"value" "false" \
+] [ipx::get_hdl_parameters S_FIFO_LIMITED -of_objects $cc]
+
+set_property -dict [list \
+	"display_name" "S FIFO Limited" \
+	"tooltip" "Limit the amount of data the the Slave FIFO can accumulate. Enabling this bit may reduce the size of S Address, Almost Empty Threshold and Almost Full Threshold depending on the Slave and Master data width ratio." \
+] [ipgui::get_guiparamspec -name "S_FIFO_LIMITED" -component $cc]
+
 ## TODO: Validate RD_ADDRESS_WIDTH
 
-ipx::save_core [ipx::current_core]
+ipx::create_xgui_files $cc
+ipx::save_core $cc

--- a/library/util_axis_fifo_asym/util_axis_fifo_asym_ip.tcl
+++ b/library/util_axis_fifo_asym/util_axis_fifo_asym_ip.tcl
@@ -49,20 +49,37 @@ adi_add_bus_clock "s_axis_aclk" "s_axis" "s_axis_aresetn"
 
 set cc [ipx::current_core]
 
+# FIFO_LIMITED Property
 set_property -dict [list \
 	"value_format" "bool" \
 	"value" "false" \
-] [ipx::get_user_parameters S_FIFO_LIMITED -of_objects $cc]
+] [ipx::get_user_parameters FIFO_LIMITED -of_objects $cc]
 
 set_property -dict [list \
 	"value_format" "bool" \
 	"value" "false" \
-] [ipx::get_hdl_parameters S_FIFO_LIMITED -of_objects $cc]
+] [ipx::get_hdl_parameters FIFO_LIMITED -of_objects $cc]
 
 set_property -dict [list \
-	"display_name" "S FIFO Limited" \
-	"tooltip" "Limit the amount of data the the Slave FIFO can accumulate. Enabling this bit may reduce the size of S Address, Almost Empty Threshold and Almost Full Threshold depending on the Slave and Master data width ratio." \
-] [ipgui::get_guiparamspec -name "S_FIFO_LIMITED" -component $cc]
+	"display_name" "FIFO Sample Limited" \
+	"tooltip" "Limit the amount of samples the FIFO can accumulate. Enabling this bit may reduce the size of Address, Almost Empty Threshold and Almost Full Threshold depending on the Slave and Master data width ratio." \
+] [ipgui::get_guiparamspec -name "FIFO_LIMITED" -component $cc]
+
+
+set_property -dict [list \
+	"value_format" "bool" \
+	"value" "false" \
+] [ipx::get_user_parameters ADDRESS_WIDTH_PERSPECTIVE -of_objects $cc]
+
+set_property -dict [list \
+	"value_format" "bool" \
+	"value" "false" \
+] [ipx::get_hdl_parameters ADDRESS_WIDTH_PERSPECTIVE -of_objects $cc]
+
+set_property -dict [list \
+	"display_name" "Address Width Perspective" \
+	"tooltip" "Sets the address width from the perspective of Master if True, or Slave if false." \
+] [ipgui::get_guiparamspec -name "ADDRESS_WIDTH_PERSPECTIVE" -component $cc]
 
 ## TODO: Validate RD_ADDRESS_WIDTH
 


### PR DESCRIPTION
## PR Description

Added initialization for ad_mem, which helps the testbench by automatically clearing all the FIFOs at the beginning of the simulation. 
Fixed a bug that was related to different data width on the input and output of the FIFO, when it was using asymmetric clocks. 
Added parameter to be able to set the FIFO size from the perspective of Master or Slave.
Added parameter to toggle to result in a reduced size FIFO. 

Update the affected Data Offload IP. 

Tested all of the changes in the Testbenches repository, where these IPs were used, the tests pass. 

analogdevicesinc/testbenches#77
analogdevicesinc/testbenches#161

Updated information on the FIFO here:
[Wiki](https://wiki.analog.com/resources/fpga/docs/util_axis_fifo_asym)


## PR Type
- [x] Bug fix (change that fixes an issue)
- [x] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the code style guidelines
- [x] I have performed a self-review of changes
- [ ] I have compiled all hdl projects and libraries affected by this PR
- [ ] I have tested in hardware affected projects, at least on relevant boards
- [x] I have commented my code, at least hard-to-understand parts
- [x] I have signed off all commits from this PR
- [x] I have updated the documentation (wiki pages, ReadMe files, Copyright etc)
- [x] I have not introduced new Warnings/Critical Warnings on compilation
- [x] I have added new hdl testbenches or updated existing ones
