### PR TITLE
spi_engine: Revert Offload AXI signals, ctrl fixup

### DIFF
--- a/library/spi_engine/interfaces/interfaces_ip.tcl
+++ b/library/spi_engine/interfaces/interfaces_ip.tcl
@@ -22,11 +22,11 @@ adi_if_define "spi_engine_ctrl"
 adi_if_ports input 1 cmd_ready
 adi_if_ports output 1 cmd_valid
 adi_if_ports output 16 cmd_data
-adi_if_ports input 1 sdo_data_ready
-adi_if_ports output 1 sdo_data_valid
+adi_if_ports input 1 sdo_ready
+adi_if_ports output 1 sdo_valid
 adi_if_ports output -1 sdo_data
-adi_if_ports output 1 sdi_data_ready
-adi_if_ports input 1 sdi_data_valid
+adi_if_ports output 1 sdi_ready
+adi_if_ports input 1 sdi_valid
 adi_if_ports input -1 sdi_data
 adi_if_ports output 1 sync_ready
 adi_if_ports input 1 sync_valid

--- a/library/spi_engine/spi_engine_offload/spi_engine_offload_ip.tcl
+++ b/library/spi_engine/spi_engine_offload/spi_engine_offload_ip.tcl
@@ -66,9 +66,9 @@ adi_add_bus "offload_sdi" "master" \
 	"xilinx.com:interface:axis_rtl:1.0" \
 	"xilinx.com:interface:axis:1.0" \
 	{ \
-		{"offload_sdi_valid" "tvalid"} \
-		{"offload_sdi_ready" "tready"} \
-		{"offload_sdi_data" "tdata"} \
+		{"offload_sdi_valid" "TVALID"} \
+		{"offload_sdi_ready" "TREADY"} \
+		{"offload_sdi_data" "TDATA"} \
 	}
 
 adi_add_bus_clock "spi_clk" "spi_engine_ctrl:offload_sdi" "spi_resetn"


### PR DESCRIPTION
Minor, non-breaking fixes.
Revert AXI bus signals back to upper case on SPI Engine Offload IP, changed on e2ca5a991aadff875d54c82e8174ba641dc2fb09. Fixup signals from sd*_data_* to sd*_* for spi_engine_ctrl interface. Non-breaking mistake, but added warnings to the IP.

Edit: also solves hanging testbenches due to case-sensitiveness during tb compilation not present during synthesis.

## PR Description

Please replace this comment with summary, motivation and context of the changes.
List any dependencies required for this change.

You can check the checkboxes below by inserting a 'x' between square brackets
(without any other characters or spaces) or just check them after publishing the PR.

If there is a breaking change, specify dependent PRs in description and
try to push all related PRs at the same time.


## PR Type
- [X] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [X] I have followed the code style guidelines
- [X] I have performed a self-review of changes
- [X] I have compiled all hdl projects and libraries affected by this PR
- [] I have tested in hardware affected projects, at least on relevant boards
- [ ] I have commented my code, at least hard-to-understand parts
- [X] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe files, Copyright etc)
- [ ] I have not introduced new Warnings/Critical Warnings on compilation
- [ ] I have added new hdl testbenches or updated existing ones
