### PR TITLE
spi_engine: Remove nonexistent interface, add dep

### DIFF
--- a/library/spi_engine/axi_spi_engine/axi_spi_engine_hw.tcl
+++ b/library/spi_engine/axi_spi_engine/axi_spi_engine_hw.tcl
@@ -109,12 +109,6 @@ proc p_elaboration {} {
 
   }
 
-  ad_interface signal  pulse_gen_period  output  32
-  ad_interface signal  pulse_gen_width   output  32
-  ad_interface signal  pulse_gen_load    output   1
-
-  lappend disabled_intfs if_pulse_gen_period if_pulse_gen_width if_pulse_gen_load
-
   foreach interface $disabled_intfs {
     set_interface_property $interface ENABLED false
   }

--- a/library/spi_engine/spi_engine_offload/Makefile
+++ b/library/spi_engine/spi_engine_offload/Makefile
@@ -21,6 +21,7 @@ XILINX_LIB_DEPS += util_cdc
 XILINX_INTERFACE_DEPS += spi_engine/interfaces
 
 INTEL_DEPS += ../../util_cdc/sync_bits.v
+INTEL_DEPS += ../../util_cdc/sync_event.v
 INTEL_DEPS += spi_engine_offload_hw.tcl
 
 include ../../scripts/library.mk

--- a/library/spi_engine/spi_engine_offload/spi_engine_offload_hw.tcl
+++ b/library/spi_engine/spi_engine_offload/spi_engine_offload_hw.tcl
@@ -10,6 +10,7 @@ source ../../scripts/adi_ip_intel.tcl
 ad_ip_create spi_engine_offload {SPI Engine Offload} p_elaboration
 ad_ip_files spi_engine_offload [list\
   $ad_hdl_dir/library/util_cdc/sync_bits.v \
+  $ad_hdl_dir/library/util_cdc/sync_event.v \
   spi_engine_offload.v]
 
 # parameters


### PR DESCRIPTION
## PR Description
Remove nonexistant pulse_gen_* interface on axi_spi_engine_hw.
Add sync_event.v to spi_engine_offload's intel_deps.
This commit:
* Fixes simulation on questa-intel.
* Resolves the following critical warning for spi-engine intel projects:
```
cn0540/de10nano$ grep -rn 'Critical Warning' .
cn0540_de10nano.map.rpt:; pulse_gen_period ; Unknown ; Critical Warning ; Named port was not declared by the instantiated entity ;
cn0540_de10nano.map.rpt:; pulse_gen_width  ; Unknown ; Critical Warning ; Named port was not declared by the instantiated entity ;
cn0540_de10nano.map.rpt:; pulse_gen_load   ; Unknown ; Critical Warning ; Named port was not declared by the instantiated entity ;
```

Note: We should also search for Critical warnings on *.map.rpt files for intel.

## PR Type
- [X] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [ ] I have followed the code style guidelines
- [x] I have performed a self-review of changes
- [ ] I have compiled all hdl projects and libraries affected by this PR
- [ ] I have tested in hardware affected projects, at least on relevant boards
- [ ] I have commented my code, at least hard-to-understand parts
- [ ] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe files, Copyright etc)
- [ ] I have not introduced new Warnings/Critical Warnings on compilation
- [ ] I have added new hdl testbenches or updated existing ones
