### PR TITLE
util_do_ram: Added keep signal to the FIFO

### DIFF
--- a/library/util_do_ram/util_do_ram.v
+++ b/library/util_do_ram/util_do_ram.v
@@ -92,7 +92,7 @@ module util_do_ram #(
   localparam DST_ADDRESS_WIDTH = LENGTH_WIDTH - DST_ADDR_ALIGN;
 
   wire  wr_enable;
-  wire  [DST_DATA_WIDTH-1:0] rd_data;
+  wire  [DST_DATA_WIDTH/8*9-1:0] rd_data;
   wire  [1:0] rd_fifo_room;
   wire        rd_enable;
   wire        rd_last_beat;
@@ -101,7 +101,7 @@ module util_do_ram #(
 
   reg [SRC_ADDRESS_WIDTH-1:0] wr_length = 'h0;
   reg [SRC_ADDRESS_WIDTH-1:0] wr_addr = 'h0;
-  reg [DST_DATA_WIDTH-1:0]    rd_data_l2 = 'h0;
+  reg [DST_DATA_WIDTH/8*9-1:0]    rd_data_l2 = 'h0;
   reg [DST_ADDRESS_WIDTH-1:0] rd_length = 'h0;
   reg [DST_ADDRESS_WIDTH-1:0] rd_addr = 'h0;
   reg rd_pending = 1'b0;
@@ -165,14 +165,14 @@ module util_do_ram #(
 
   ad_mem_asym #(
     .A_ADDRESS_WIDTH (SRC_ADDRESS_WIDTH),
-    .A_DATA_WIDTH (SRC_DATA_WIDTH),
+    .A_DATA_WIDTH (SRC_DATA_WIDTH/8*9),
     .B_ADDRESS_WIDTH (DST_ADDRESS_WIDTH),
-    .B_DATA_WIDTH (DST_DATA_WIDTH)
+    .B_DATA_WIDTH (DST_DATA_WIDTH/8*9)
   ) i_mem (
     .clka (s_axis_aclk),
     .wea (wr_enable),
     .addra (wr_addr),
-    .dina (s_axis_data),
+    .dina ({s_axis_data,s_axis_keep}),
 
     .clkb (m_axis_aclk),
     .reb (1'b1),
@@ -254,7 +254,7 @@ module util_do_ram #(
 
   // Read datapath to AXIS logic
   util_axis_fifo #(
-    .DATA_WIDTH(DST_DATA_WIDTH+1),
+    .DATA_WIDTH(DST_DATA_WIDTH/8*9+1),
     .ADDRESS_WIDTH(2),
     .ASYNC_CLK(0),
     .M_AXIS_REGISTERED(0)
@@ -274,7 +274,7 @@ module util_do_ram #(
     .m_axis_aresetn(m_axis_aresetn & rd_request_enable),
     .m_axis_valid(m_axis_valid),
     .m_axis_ready(m_axis_ready),
-    .m_axis_data({m_axis_last,m_axis_data}),
+    .m_axis_data({m_axis_last,m_axis_data,m_axis_keep}),
     .m_axis_level(),
     .m_axis_empty(),
     .m_axis_tkeep(),

--- a/library/util_do_ram/util_do_ram.v
+++ b/library/util_do_ram/util_do_ram.v
@@ -1,6 +1,6 @@
 // ***************************************************************************
 // ***************************************************************************
-// Copyright (C) 2022-2023 Analog Devices, Inc. All rights reserved.
+// Copyright (C) 2022-2024 Analog Devices, Inc. All rights reserved.
 //
 // In this HDL repository, there are many different and unique modules, consisting
 // of various HDL (Verilog or VHDL) components. The individual modules are

--- a/library/util_do_ram/util_do_ram.v
+++ b/library/util_do_ram/util_do_ram.v
@@ -174,7 +174,7 @@ module util_do_ram #(
     .clka (s_axis_aclk),
     .wea (wr_enable),
     .addra (wr_addr),
-    .dina ({s_axis_data}),
+    .dina (s_axis_data),
 
     .clkb (m_axis_aclk),
     .reb (1'b1),
@@ -190,7 +190,7 @@ module util_do_ram #(
     .clka (s_axis_aclk),
     .wea (wr_enable),
     .addra (wr_addr),
-    .dina ({s_axis_keep}),
+    .dina (s_axis_keep),
 
     .clkb (m_axis_aclk),
     .reb (1'b1),
@@ -277,7 +277,7 @@ module util_do_ram #(
 
   // Read datapath to AXIS logic
   util_axis_fifo #(
-    .DATA_WIDTH(DST_DATA_WIDTH/8*9+1),
+    .DATA_WIDTH(DST_DATA_WIDTH),
     .ADDRESS_WIDTH(2),
     .ASYNC_CLK(0),
     .M_AXIS_REGISTERED(0),
@@ -289,7 +289,7 @@ module util_do_ram #(
     .s_axis_valid(rd_fifo_s_valid),
     .s_axis_ready(rd_fifo_s_ready),
     .s_axis_full(),
-    .s_axis_data({rd_data_l2}),
+    .s_axis_data(rd_data_l2),
     .s_axis_room(rd_fifo_room),
     .s_axis_tkeep(rd_keep_l2),
     .s_axis_tlast(rd_last_l2),
@@ -299,7 +299,7 @@ module util_do_ram #(
     .m_axis_aresetn(m_axis_aresetn & rd_request_enable),
     .m_axis_valid(m_axis_valid),
     .m_axis_ready(m_axis_ready),
-    .m_axis_data({m_axis_data}),
+    .m_axis_data(m_axis_data),
     .m_axis_level(),
     .m_axis_empty(),
     .m_axis_tkeep(m_axis_keep),


### PR DESCRIPTION
## PR Description

Updated the util_do_ram to hold the keep value as well, not just the data. 
This part is required for the testbenches to pass if the keep is enabled for the verification IPs, which is on. 
Tested on data_offload and data_offload_2 testbenches with a branch: https://github.com/analogdevicesinc/testbenches/pull/82


## PR Type
- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the code style guidelines
- [x] I have performed a self-review of changes
- [ ] I have compiled all hdl projects and libraries affected by this PR
- [ ] I have tested in hardware affected projects, at least on relevant boards
- [ ] I have commented my code, at least hard-to-understand parts
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe files, Copyright etc)
- [x] I have not introduced new Warnings/Critical Warnings on compilation
- [x] I have added new hdl testbenches or updated existing ones
