### PR TITLE
SPI Engine: add offload looping

### DIFF
--- a/docs/library/spi_engine/instruction-format.rst
+++ b/docs/library/spi_engine/instruction-format.rst
@@ -98,7 +98,7 @@ Configuration Write Instruction
 == == == == == == = = = = = = = = = =
 
 The configuration writes instruction updates a
-:ref:`spi_engine configutarion-registers`
+:ref:`spi_engine configuration-registers`
 of the SPI Engine execution module with a new value.
 
 .. list-table::
@@ -174,7 +174,66 @@ is the minimum, needed by the internal logic.
      - Time
      - The amount of time to wait.
 
-.. _spi_engine configutarion-registers:
+Loop Start Instruction
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+== == == == == == = = = = = = = = = =
+15 14 13 12 11 10 9 8 7 6 5 4 3 2 1 0
+== == == == == == = = = = = = = = = =
+1  0  0  1  r  r  r r n n n n n n n n
+== == == == == == = = = = = = = = = =
+
+The Loop Start instruction indicates the start of a loop region, that will be 
+executed a specified number of times. Together with the Loop End Instruction,
+this implements hardware instruction looping. All instructions between the loop
+start and loop end will be executed the specified number of times automatically
+by the SPI Engine. **Looping is only supported with instruction offloading, 
+The Loop Start and Loop End instructions will be treated as NOPs otherwise.**
+
+
+.. list-table::
+   :widths: 10 15 75
+   :header-rows: 1
+
+   * - Bits
+     - Name
+     - Description
+   * - r
+     - Reserved 
+     - Must always be 0.
+   * - n
+     - Loop count
+     - The number of times the loop will be repeated.
+
+Loop End Instruction
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+== == == == == == = = = = = = = = = =
+15 14 13 12 11 10 9 8 7 6 5 4 3 2 1 0
+== == == == == == = = = = = = = = = =
+1  0  0  0  r  r  r r r r r r r r r r
+== == == == == == = = = = = = = = = =
+
+The Loop End instruction indicates the end of a loop region. Together with the 
+Loop Start Instruction, this implements hardware instruction looping. All 
+instructions between the loop start and loop end will be executed automatically 
+by the SPI Engine, for the number of repeats specified on the Loop Start 
+instruction. **Looping is only supported with instruction offloading, The Loop 
+Start and Loop End instructions will be treated as NOPs otherwise.**
+
+
+.. list-table::
+   :widths: 10 15 75
+   :header-rows: 1
+
+   * - Bits
+     - Name
+     - Description
+   * - r
+     - Reserved 
+     - Must always be 0.
+
+.. _spi_engine configuration-registers:
 
 Configuration Registers
 --------------------------------------------------------------------------------

--- a/library/spi_engine/spi_engine_execution/spi_engine_execution.v
+++ b/library/spi_engine/spi_engine_execution/spi_engine_execution.v
@@ -76,10 +76,10 @@ module spi_engine_execution #(
   output reg three_wire
 );
 
-  localparam CMD_TRANSFER = 2'b00;
-  localparam CMD_CHIPSELECT = 2'b01;
-  localparam CMD_WRITE = 2'b10;
-  localparam CMD_MISC = 2'b11;
+  localparam CMD_TRANSFER = 4'b0000;
+  localparam CMD_CHIPSELECT = 4'b0001;
+  localparam CMD_WRITE = 4'b0010;
+  localparam CMD_MISC = 4'b0011;
 
   localparam MISC_SYNC = 1'b0;
   localparam MISC_SLEEP = 1'b1;
@@ -141,8 +141,8 @@ module spi_engine_execution #(
 
   reg [SDI_DELAY+1:0] trigger_rx_d = {(SDI_DELAY+2){1'b0}};
 
-  wire [1:0] inst = cmd[13:12];
-  wire [1:0] inst_d1 = cmd_d1[13:12];
+  wire [3:0] inst = cmd[15:12];
+  wire [3:0] inst_d1 = cmd_d1[15:12];
 
   wire exec_cmd = cmd_ready && cmd_valid;
   wire exec_transfer_cmd = exec_cmd && inst == CMD_TRANSFER;


### PR DESCRIPTION
## PR Description

Add two instructions for hardware looping: Loop Start and Loop End. This implementations makes it so both instructions only work on Offload mode, being ignored for direct SPI.

This is one of two similar draft PRs introducing this feature (compare and contrast #1293).

## PR Type
- [ ] Bug fix (change that fixes an issue)
- [x] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the code style guidelines
- [x] I have performed a self-review of changes
- [x] I have compiled all hdl projects and libraries affected by this PR
- [ ] I have tested in hardware affected projects, at least on relevant boards
- [x] I have commented my code, at least hard-to-understand parts
- [x] I have signed off all commits from this PR
- [x] I have updated the documentation (wiki pages, ReadMe files, Copyright etc)
- [x] I have not introduced new Warnings/Critical Warnings on compilation
- [x] I have added new hdl testbenches or updated existing ones
