### PR TITLE
SPI Engine: add looping

### DIFF
--- a/docs/library/spi_engine/instruction-format.rst
+++ b/docs/library/spi_engine/instruction-format.rst
@@ -98,7 +98,7 @@ Configuration Write Instruction
 == == == == == == = = = = = = = = = =
 
 The configuration writes instruction updates a
-:ref:`spi_engine configutarion-registers`
+:ref:`spi_engine configuration-registers`
 of the SPI Engine execution module with a new value.
 
 .. list-table::
@@ -174,7 +174,63 @@ is the minimum, needed by the internal logic.
      - Time
      - The amount of time to wait.
 
-.. _spi_engine configutarion-registers:
+Loop Start Instruction
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+== == == == == == = = = = = = = = = =
+15 14 13 12 11 10 9 8 7 6 5 4 3 2 1 0
+== == == == == == = = = = = = = = = =
+1  0  0  1  r  r  r r n n n n n n n n
+== == == == == == = = = = = = = = = =
+
+The Loop Start instruction indicates the start of a loop region, that will be 
+executed a specified number of times. Together with the Loop End Instruction,
+this implements hardware instruction looping. All instructions between the loop
+start and loop end will be executed the specified number of times automatically
+by the SPI Engine. 
+
+.. list-table::
+   :widths: 10 15 75
+   :header-rows: 1
+
+   * - Bits
+     - Name
+     - Description
+   * - r
+     - Reserved 
+     - Must always be 0.
+   * - n
+     - Loop count
+     - The number of times the loop will be repeated.
+
+Loop End Instruction
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+== == == == == == = = = = = = = = = =
+15 14 13 12 11 10 9 8 7 6 5 4 3 2 1 0
+== == == == == == = = = = = = = = = =
+1  0  0  0  r  r  r r r r r r r r r r
+== == == == == == = = = = = = = = = =
+
+The Loop End instruction indicates the end of a loop region. Together with the 
+Loop Start Instruction, this implements hardware instruction looping. All 
+instructions between the loop start and loop end will be executed automatically 
+by the SPI Engine, for the number of repeats specified on the Loop Start 
+instruction.
+
+.. list-table::
+   :widths: 10 15 75
+   :header-rows: 1
+
+   * - Bits
+     - Name
+     - Description
+   * - r
+     - Reserved 
+     - Must always be 0.
+
+
+.. _spi_engine configuration-registers:
 
 Configuration Registers
 --------------------------------------------------------------------------------

--- a/library/spi_engine/scripts/spi_engine.tcl
+++ b/library/spi_engine/scripts/spi_engine.tcl
@@ -34,6 +34,7 @@ proc spi_engine_create {{name "spi_engine"} {data_width 32} {async_spi_clk 1} {n
   ad_ip_parameter $execution CONFIG.SDO_DEFAULT 1
   ad_ip_parameter $execution CONFIG.SDI_DELAY $sdi_delay
   ad_ip_parameter $execution CONFIG.ECHO_SCLK $echo_sclk
+  ad_ip_parameter $execution CONFIG.LOOP_CMD_MEM_ADDRESS_WIDTH $cmd_mem_addr_width
 
   ad_ip_instance axi_spi_engine $axi_regmap
   ad_ip_parameter $axi_regmap CONFIG.DATA_WIDTH $data_width

--- a/library/spi_engine/spi_engine_execution/spi_engine_execution_hw.tcl
+++ b/library/spi_engine/spi_engine_execution/spi_engine_execution_hw.tcl
@@ -21,6 +21,7 @@ ad_ip_parameter DATA_WIDTH INTEGER 8
 ad_ip_parameter NUM_OF_SDI INTEGER 1
 ad_ip_parameter SDI_DELAY INTEGER 0
 ad_ip_parameter SDO_DEFAULT INTEGER 0
+ad_ip_parameter LOOP_CMD_MEM_ADDRESS_WIDTH 4
 
 proc p_elaboration {} {
 

--- a/library/spi_engine/spi_engine_execution/spi_engine_execution_ip.tcl
+++ b/library/spi_engine/spi_engine_execution/spi_engine_execution_ip.tcl
@@ -128,6 +128,14 @@ set_property -dict [list \
  ] \
  [ipx::get_hdl_parameters ECHO_SCLK -of_objects $cc]
 
+## LOOP MEM ADR WIDTH
+set_property -dict [list \
+  "value_validation_type" "range_long" \
+  "value_validation_range_minimum" "1" \
+  "value_validation_range_maximum" "32" \
+ ] \
+ [ipx::get_user_parameters LOOP_CMD_MEM_ADDRESS_WIDTH -of_objects $cc]
+
 ## echo_sclk should be active only when ECHO_SCLK is set
 adi_set_ports_dependency echo_sclk ECHO_SCLK 0
 


### PR DESCRIPTION
## PR Description

Add two instructions for hardware looping: Loop Start and Loop End. This implementations uses a memory on the execution module to allow for looping for both offload and non-offload cases.

This is one of two similar draft PRs introducing this feature (compare and contrast to #1292).

## PR Type
- [ ] Bug fix (change that fixes an issue)
- [x] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the code style guidelines
- [x] I have performed a self-review of changes
- [x] I have compiled all hdl projects and libraries affected by this PR
- [ ] I have tested in hardware affected projects, at least on relevant boards
- [x] I have commented my code, at least hard-to-understand parts
- [x] I have signed off all commits from this PR
- [x] I have updated the documentation (wiki pages, ReadMe files, Copyright etc)
- [x] I have not introduced new Warnings/Critical Warnings on compilation
- [x] I have added new hdl testbenches or updated existing ones
