### PR TITLE
Assignment fix in reset, in library/axi_pwm_gen/axi_pwm_gen_regmap.sv

### DIFF
--- a/library/axi_pwm_gen/axi_pwm_gen_regmap.sv
+++ b/library/axi_pwm_gen/axi_pwm_gen_regmap.sv
@@ -88,9 +88,9 @@ module axi_pwm_gen_regmap #(
     if (up_rstn == 0) begin
       up_wack <= 'd0;
       up_scratch <= 'd0;
-      up_pwm_width = PULSE_WIDTH_G[0:N_PWMS];
-      up_pwm_period = PULSE_PERIOD_G[0:N_PWMS];
-      up_pwm_offset = PULSE_OFFSET_G[0:N_PWMS];
+      up_pwm_width <= PULSE_WIDTH_G[0:N_PWMS];
+      up_pwm_period <= PULSE_PERIOD_G[0:N_PWMS];
+      up_pwm_offset <= PULSE_OFFSET_G[0:N_PWMS];
       up_load_config <= 1'b0;
       up_reset <= 1'b1;
     end else begin


### PR DESCRIPTION
## PR Description

Replaced blocking assignments with non blocking in reset, in the register map write side.
Lattice tools give error for using blocking assignments at one side and non blocking in the other.

## PR Type
- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the code style guidelines
- [x] I have performed a self-review of changes
- [ ] I have compiled all hdl projects and libraries affected by this PR
- [ ] I have tested in hardware affected projects, at least on relevant boards
- [ ] I have commented my code, at least hard-to-understand parts
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe files, Copyright etc)
- [ ] I have not introduced new Warnings/Critical Warnings on compilation
- [ ] I have added new hdl testbenches or updated existing ones
