### PR TITLE
axi_pwm_gen: New features based on parameters

### DIFF
--- a/docs/library/axi_pwm_gen/block_diagram.svg
+++ b/docs/library/axi_pwm_gen/block_diagram.svg
@@ -1,0 +1,1715 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:osb="http://www.openswatchbook.org/uri/2009/osb"
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   preserveAspectRatio="xMidYMid slice"
+   viewBox="0 0 774.80311 396.8504"
+   sodipodi:docname="axi_pwm_gen.svg"
+   inkscape:version="1.0 (4035a4fb49, 2020-05-01)"
+   version="1.1"
+   id="svg2"
+   height="105mm"
+   width="205mm">
+  <defs
+     id="defs4">
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker9600"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="DotM">
+      <path
+         transform="matrix(0.4,0,0,0.4,2.96,0.4)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="m -2.5,-1 c 0,2.76 -2.24,5 -5,5 -2.76,0 -5,-2.24 -5,-5 0,-2.76 2.24,-5 5,-5 2.76,0 5,2.24 5,5 z"
+         id="path9598" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:stockid="DotM"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker9116"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path9114"
+         d="m -2.5,-1 c 0,2.76 -2.24,5 -5,5 -2.76,0 -5,-2.24 -5,-5 0,-2.76 2.24,-5 5,-5 2.76,0 5,2.24 5,5 z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(0.4,0,0,0.4,2.96,0.4)" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="DotM"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="DotM">
+      <path
+         transform="matrix(0.4,0,0,0.4,2.96,0.4)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="m -2.5,-1 c 0,2.76 -2.24,5 -5,5 -2.76,0 -5,-2.24 -5,-5 0,-2.76 2.24,-5 5,-5 2.76,0 5,2.24 5,5 z"
+         id="path8116" />
+    </marker>
+    <marker
+       inkscape:stockid="TriangleOutM"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker3105"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path3103"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="scale(0.4)"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:stockid="TriangleOutM"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker2795"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path2793"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="scale(0.4)"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:stockid="TriangleOutM"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker1975"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path1973"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="scale(0.4)"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:stockid="TriangleInM"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker1653"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         inkscape:connector-curvature="0"
+         id="path1651"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="scale(-0.4)" />
+    </marker>
+    <marker
+       inkscape:stockid="TriangleOutM"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker1337"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path1335"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="scale(0.4)"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <inkscape:perspective
+       id="perspective191"
+       inkscape:persp3d-origin="0.56338024 : 0.3875969 : 1"
+       inkscape:vp_z="1.1267605 : 0.58139534 : 1"
+       inkscape:vp_y="0 : 2.3255814 : 0"
+       inkscape:vp_x="0 : 0.58139534 : 1"
+       sodipodi:type="inkscape:persp3d" />
+    <marker
+       inkscape:stockid="TriangleOutM"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker18751"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         inkscape:connector-curvature="0"
+         id="path18753"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="scale(0.4)" />
+    </marker>
+    <marker
+       inkscape:stockid="TriangleOutM"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker5817"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path5819"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="scale(0.4)"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker11520"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="TriangleOutM">
+      <path
+         inkscape:connector-curvature="0"
+         transform="scale(0.4)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         id="path11522" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker9429"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="TriangleOutM">
+      <path
+         inkscape:connector-curvature="0"
+         transform="scale(0.4)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         id="path9431" />
+    </marker>
+    <marker
+       inkscape:stockid="TriangleOutM"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker8525"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         inkscape:connector-curvature="0"
+         id="path8527"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="scale(0.4)" />
+    </marker>
+    <marker
+       inkscape:stockid="TriangleOutM"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker14694"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path14696"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="scale(0.4)"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:stockid="TriangleOutM"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker13964"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path13966"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="scale(0.4)"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:stockid="TriangleOutM"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker13210"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path13212"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="scale(0.4)"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker12618"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="TriangleOutM">
+      <path
+         transform="scale(0.4)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         id="path12620"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker12206"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="TriangleOutM">
+      <path
+         inkscape:connector-curvature="0"
+         transform="scale(0.4)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         id="path12208" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker11392"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="TriangleOutM">
+      <path
+         inkscape:connector-curvature="0"
+         transform="scale(0.4)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         id="path11394" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker9085"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="TriangleOutM">
+      <path
+         transform="scale(0.4)"
+         style="fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         id="path9087"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <linearGradient
+       osb:paint="solid"
+       id="linearGradient9055">
+      <stop
+         id="stop9057"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1;" />
+    </linearGradient>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker8895"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="TriangleOutM">
+      <path
+         transform="scale(0.4)"
+         style="fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         id="path8897"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:stockid="TriangleInM"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker10933-1"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         inkscape:connector-curvature="0"
+         id="path10935-1"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="scale(-0.4)" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="TriangleInM-7-1"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="TriangleInM">
+      <path
+         transform="scale(-0.4)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         id="path4660-1-6"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:stockid="TriangleInM"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker10933"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         inkscape:connector-curvature="0"
+         id="path10935"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="scale(-0.4)" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker6005"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="TriangleInM">
+      <path
+         transform="scale(-0.4)"
+         style="fill:#0000ff;fill-opacity:1;fill-rule:evenodd;stroke:#0000ff;stroke-width:1pt;stroke-opacity:1"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         id="path6007"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker15643-48"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="TriangleInM">
+      <path
+         transform="scale(-0.4)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         id="path15645-1"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker7250"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="TriangleInM">
+      <path
+         transform="scale(-0.4)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         id="path7252"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:stockid="TriangleInM"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker24668"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         inkscape:connector-curvature="0"
+         id="path24670"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="scale(-0.4)" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker7256"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="TriangleInM">
+      <path
+         transform="scale(-0.4)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         id="path7258"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:stockid="TriangleInM"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker24284"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         inkscape:connector-curvature="0"
+         id="path24286"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="scale(-0.4)" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker7268"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="TriangleInM">
+      <path
+         transform="scale(-0.4)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         id="path7270"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker7276"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="TriangleInM">
+      <path
+         transform="scale(-0.4)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         id="path7278"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker15643-42"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="TriangleInM">
+      <path
+         transform="scale(-0.4)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         id="path15645-20"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:stockid="TriangleInM"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker12344-7"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         inkscape:connector-curvature="0"
+         id="path12346-6"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="scale(-0.4)" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker12474-7"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="TriangleOutM">
+      <path
+         transform="scale(0.4)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         id="path12476-1"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:stockid="TriangleInM"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker10933-1-1"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         inkscape:connector-curvature="0"
+         id="path10935-1-0"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="scale(-0.4)" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker4705-2"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="TriangleOutM">
+      <path
+         inkscape:connector-curvature="0"
+         transform="scale(0.4)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         id="path4580-1" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker15643-48-7"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="TriangleInM">
+      <path
+         transform="scale(-0.4)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         id="path15645-1-3"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker9663"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="TriangleInM">
+      <path
+         transform="scale(-0.4)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         id="path9665"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:stockid="TriangleInM"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker24668-2"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         inkscape:connector-curvature="0"
+         id="path24670-4"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="scale(-0.4)" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker9669"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="TriangleInM">
+      <path
+         transform="scale(-0.4)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         id="path9671"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker15643-48-9-2"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="TriangleInM">
+      <path
+         transform="scale(-0.4)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         id="path15645-1-5-0"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:stockid="TriangleInM"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker24284-0"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         inkscape:connector-curvature="0"
+         id="path24286-2"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="scale(-0.4)" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker9681"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="TriangleInM">
+      <path
+         transform="scale(-0.4)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         id="path9683"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker9689"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="TriangleInM">
+      <path
+         transform="scale(-0.4)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         id="path9691"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker15643-42-6"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="TriangleInM">
+      <path
+         transform="scale(-0.4)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         id="path15645-20-64"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker15643-48-9-3"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="TriangleInM">
+      <path
+         transform="scale(-0.4)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         id="path15645-1-5-00"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker12206-7"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="TriangleOutM">
+      <path
+         inkscape:connector-curvature="0"
+         transform="scale(0.4)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         id="path12208-1" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker9429-8"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="TriangleOutM">
+      <path
+         inkscape:connector-curvature="0"
+         transform="scale(0.4)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         id="path9431-8" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker12206-0"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="TriangleOutM">
+      <path
+         inkscape:connector-curvature="0"
+         transform="scale(0.4)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         id="path12208-0" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker10888-6"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="TriangleOutM">
+      <path
+         inkscape:connector-curvature="0"
+         transform="scale(0.4)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         id="path10890-3" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker11392-1"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="TriangleOutM">
+      <path
+         inkscape:connector-curvature="0"
+         transform="scale(0.4)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         id="path11394-1" />
+    </marker>
+    <inkscape:perspective
+       sodipodi:type="inkscape:persp3d"
+       inkscape:vp_x="0 : 0.0011627907 : 1"
+       inkscape:vp_y="0 : 2.3255814 : 0"
+       inkscape:vp_z="0.0014084507 : 0.0011627907 : 1"
+       inkscape:persp3d-origin="0.00070422531 : 0.00077519378 : 1"
+       id="perspective3520" />
+    <inkscape:perspective
+       sodipodi:type="inkscape:persp3d"
+       inkscape:vp_x="0 : 0.0011627907 : 1"
+       inkscape:vp_y="0 : 2.3255814 : 0"
+       inkscape:vp_z="0.0014084507 : 0.0011627907 : 1"
+       inkscape:persp3d-origin="0.00070422531 : 0.00077519378 : 1"
+       id="perspective3553" />
+    <inkscape:perspective
+       sodipodi:type="inkscape:persp3d"
+       inkscape:vp_x="0 : 0.0011627907 : 1"
+       inkscape:vp_y="0 : 2.3255814 : 0"
+       inkscape:vp_z="0.0014084507 : 0.0011627907 : 1"
+       inkscape:persp3d-origin="0.00070422531 : 0.00077519378 : 1"
+       id="perspective3581" />
+    <inkscape:perspective
+       sodipodi:type="inkscape:persp3d"
+       inkscape:vp_x="0 : 0.0011627907 : 1"
+       inkscape:vp_y="0 : 2.3255814 : 0"
+       inkscape:vp_z="0.0014084507 : 0.0011627907 : 1"
+       inkscape:persp3d-origin="0.00070422531 : 0.00077519378 : 1"
+       id="perspective3609" />
+    <inkscape:perspective
+       sodipodi:type="inkscape:persp3d"
+       inkscape:vp_x="0 : 0.0011627907 : 1"
+       inkscape:vp_y="0 : 2.3255814 : 0"
+       inkscape:vp_z="0.0014084507 : 0.0011627907 : 1"
+       inkscape:persp3d-origin="0.00070422531 : 0.00077519378 : 1"
+       id="perspective3634" />
+    <inkscape:perspective
+       sodipodi:type="inkscape:persp3d"
+       inkscape:vp_x="0 : 0.0011627907 : 1"
+       inkscape:vp_y="0 : 2.3255814 : 0"
+       inkscape:vp_z="0.0014084507 : 0.0011627907 : 1"
+       inkscape:persp3d-origin="0.00070422531 : 0.00077519378 : 1"
+       id="perspective4728" />
+    <inkscape:perspective
+       sodipodi:type="inkscape:persp3d"
+       inkscape:vp_x="0 : 0.0011627907 : 1"
+       inkscape:vp_y="0 : 2.3255814 : 0"
+       inkscape:vp_z="0.0014084507 : 0.0011627907 : 1"
+       inkscape:persp3d-origin="0.00070422531 : 0.00077519378 : 1"
+       id="perspective4758" />
+    <inkscape:perspective
+       sodipodi:type="inkscape:persp3d"
+       inkscape:vp_x="0 : 0.0011627907 : 1"
+       inkscape:vp_y="0 : 2.3255814 : 0"
+       inkscape:vp_z="0.0014084507 : 0.0011627907 : 1"
+       inkscape:persp3d-origin="0.00070422531 : 0.00077519378 : 1"
+       id="perspective4758-5" />
+    <inkscape:perspective
+       sodipodi:type="inkscape:persp3d"
+       inkscape:vp_x="0 : 0.0011627907 : 1"
+       inkscape:vp_y="0 : 2.3255814 : 0"
+       inkscape:vp_z="0.0014084507 : 0.0011627907 : 1"
+       inkscape:persp3d-origin="0.00070422531 : 0.00077519378 : 1"
+       id="perspective4793" />
+    <inkscape:perspective
+       sodipodi:type="inkscape:persp3d"
+       inkscape:vp_x="0 : 0.0011627907 : 1"
+       inkscape:vp_y="0 : 2.3255814 : 0"
+       inkscape:vp_z="0.0014084507 : 0.0011627907 : 1"
+       inkscape:persp3d-origin="0.00070422531 : 0.00077519378 : 1"
+       id="perspective4824" />
+    <inkscape:perspective
+       sodipodi:type="inkscape:persp3d"
+       inkscape:vp_x="0 : 0.0011627907 : 1"
+       inkscape:vp_y="0 : 2.3255814 : 0"
+       inkscape:vp_z="0.0014084507 : 0.0011627907 : 1"
+       inkscape:persp3d-origin="0.00070422531 : 0.00077519378 : 1"
+       id="perspective4846" />
+    <inkscape:perspective
+       sodipodi:type="inkscape:persp3d"
+       inkscape:vp_x="0 : 0.0011627907 : 1"
+       inkscape:vp_y="0 : 2.3255814 : 0"
+       inkscape:vp_z="0.0014084507 : 0.0011627907 : 1"
+       inkscape:persp3d-origin="0.00070422531 : 0.00077519378 : 1"
+       id="perspective4892" />
+    <inkscape:perspective
+       sodipodi:type="inkscape:persp3d"
+       inkscape:vp_x="0 : 0.0011627907 : 1"
+       inkscape:vp_y="0 : 2.3255814 : 0"
+       inkscape:vp_z="0.0014084507 : 0.0011627907 : 1"
+       inkscape:persp3d-origin="0.00070422531 : 0.00077519378 : 1"
+       id="perspective4952" />
+    <inkscape:perspective
+       sodipodi:type="inkscape:persp3d"
+       inkscape:vp_x="0 : 0.0011627907 : 1"
+       inkscape:vp_y="0 : 2.3255814 : 0"
+       inkscape:vp_z="0.0014084507 : 0.0011627907 : 1"
+       inkscape:persp3d-origin="0.00070422531 : 0.00077519378 : 1"
+       id="perspective4985" />
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker12206-7-1"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="TriangleOutM">
+      <path
+         inkscape:connector-curvature="0"
+         transform="scale(0.4)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         id="path12208-1-8" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker12474-7-9-2"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="TriangleOutM">
+      <path
+         transform="scale(0.4)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         id="path12476-1-2-3"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker12474-7-9-5"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="TriangleOutM">
+      <path
+         transform="scale(0.4)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         id="path12476-1-2-9"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker12474-7-9-5-2"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="TriangleOutM">
+      <path
+         transform="scale(0.4)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         id="path12476-1-2-9-8"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker12474-7-9-5-7"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="TriangleOutM">
+      <path
+         transform="scale(0.4)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         id="path12476-1-2-9-3"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker12474-7-9-2-3"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="TriangleOutM">
+      <path
+         transform="scale(0.4)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         id="path12476-1-2-3-1"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker12474-7-9-5-0"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="TriangleOutM">
+      <path
+         transform="scale(0.4)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         id="path12476-1-2-9-36"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker12474-7-9-5-0-3"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="TriangleOutM">
+      <path
+         transform="scale(0.4)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         id="path12476-1-2-9-36-2"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker12474-7-9-5-0-3-5"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="TriangleOutM">
+      <path
+         transform="scale(0.4)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         id="path12476-1-2-9-36-2-5"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker12474-7-9-5-9"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="TriangleOutM">
+      <path
+         transform="scale(0.4)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         id="path12476-1-2-9-1"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker12474-7-9-2-6"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="TriangleOutM">
+      <path
+         transform="scale(0.4)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         id="path12476-1-2-3-2"
+         inkscape:connector-curvature="0" />
+    </marker>
+  </defs>
+  <sodipodi:namedview
+     inkscape:document-rotation="0"
+     inkscape:snap-to-guides="false"
+     inkscape:snap-bbox-edge-midpoints="true"
+     inkscape:snap-bbox="true"
+     inkscape:snap-nodes="false"
+     inkscape:snap-grids="false"
+     inkscape:snap-global="false"
+     inkscape:window-maximized="1"
+     inkscape:window-y="-9"
+     inkscape:window-x="-9"
+     inkscape:window-height="2093"
+     inkscape:window-width="3840"
+     units="mm"
+     width="180mm"
+     showgrid="false"
+     inkscape:current-layer="g12973-9"
+     inkscape:document-units="px"
+     inkscape:cy="184.73009"
+     inkscape:cx="647.40946"
+     inkscape:zoom="2.4781457"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     borderopacity="1.0"
+     bordercolor="#666666"
+     pagecolor="#ffffff"
+     id="base">
+    <inkscape:grid
+       snapvisiblegridlinesonly="true"
+       enabled="true"
+       visible="true"
+       empspacing="5"
+       id="grid4147"
+       type="xygrid" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     transform="translate(0,-655.51158)"
+     id="layer1"
+     inkscape:groupmode="layer"
+     inkscape:label="Layer 1">
+    <rect
+       y="667.9389"
+       x="112.56175"
+       height="373.51859"
+       width="579.34064"
+       id="rect4477"
+       style="display:inline;fill:#000000;fill-opacity:0;fill-rule:nonzero;stroke:#000000;stroke-width:1.74925;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:0;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;enable-background:new" />
+    <text
+       id="text10879"
+       y="899.47211"
+       x="273.66757"
+       style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none"
+       xml:space="preserve"><tspan
+         style="font-size:12.5px;line-height:1.25"
+         y="899.47211"
+         x="273.66757"
+         id="tspan10881"
+         sodipodi:role="line"> </tspan></text>
+    <text
+       transform="scale(0.9326486,1.0722152)"
+       id="text8759-9"
+       y="918.76776"
+       x="61.305099"
+       style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none"
+       xml:space="preserve"><tspan
+         style="font-size:15px;line-height:1.25;fill:#000000"
+         y="918.76776"
+         x="61.305099"
+         id="tspan8761-0"
+         sodipodi:role="line">s_axi</tspan></text>
+    <path
+       sodipodi:nodetypes="cc"
+       inkscape:connector-curvature="0"
+       id="path6277-8"
+       d="m 322.05906,942.76038 59.35201,0.125"
+       style="fill:none;stroke:#000000;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:0;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#marker12474-7)" />
+    <path
+       sodipodi:nodetypes="cc"
+       inkscape:connector-curvature="0"
+       id="path7718-1"
+       d="m 333.50999,844.29091 h 46.90866"
+       style="fill:none;stroke:#000000;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:0;stroke-dasharray:none;stroke-opacity:1;marker-start:url(#marker9600);marker-end:url(#marker12206-7)" />
+    <flowRoot
+       transform="translate(50,36)"
+       style="font-style:normal;font-weight:normal;line-height:0.01%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none"
+       id="flowRoot5658"
+       xml:space="preserve"><flowRegion
+         id="flowRegion5660"><rect
+           y="18.918919"
+           x="-59.459461"
+           height="577.47748"
+           width="960.36035"
+           id="rect5662" /></flowRegion><flowPara
+         style="font-size:15px;line-height:1.25"
+         id="flowPara5664"> </flowPara></flowRoot>
+    <path
+       sodipodi:nodetypes="cc"
+       inkscape:connector-curvature="0"
+       id="path9553-2"
+       d="m 91.86561,991.6879 35.34898,-0.2012"
+       style="fill:none;stroke:#000000;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:0;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#marker11392-1)" />
+    <rect
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.87;fill:#ffff99;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:2.18929;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:0;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:new"
+       id="rect4867-1-6"
+       width="536.38409"
+       height="22.728928"
+       x="133.77641"
+       y="979.7132" />
+    <text
+       transform="scale(0.98838577,1.0117507)"
+       id="text8784-5"
+       y="983.50702"
+       x="404.2442"
+       style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none"
+       xml:space="preserve"><tspan
+         style="font-size:15px;line-height:1.25;text-align:center;text-anchor:middle"
+         id="tspan10800"
+         y="983.50702"
+         x="404.2442"
+         sodipodi:role="line">Register Map</tspan></text>
+    <g
+       transform="translate(-138.4348,113.9069)"
+       id="g4930">
+      <g
+         transform="translate(203.29289,23.823223)"
+         id="g3910">
+        <rect
+           style="display:inline;opacity:0.87;fill:#fffeff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:2.064;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;enable-background:new"
+           id="rect4867-1-5-7"
+           width="131.37004"
+           height="50.056286"
+           x="443.17923"
+           y="546.75519" />
+        <text
+           id="text19531"
+           y="576.31213"
+           x="509.16476"
+           style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none"
+           xml:space="preserve"><tspan
+             style="font-size:15px;line-height:1.25;text-align:center;text-anchor:middle"
+             y="576.31213"
+             x="509.16476"
+             sodipodi:role="line"
+             id="tspan3829">axi_pwm_gen_1</tspan></text>
+      </g>
+      <g
+         transform="translate(120.85533,17.26549)"
+         id="g3869">
+        <rect
+           style="display:inline;opacity:0.87;fill:#fffeff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:2.064;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;enable-background:new"
+           id="rect4867-1-5-7-3"
+           width="131.37004"
+           height="50.056286"
+           x="525.69653"
+           y="623.42444" />
+        <text
+           id="text19531-6"
+           y="653.29779"
+           x="591.24609"
+           style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none"
+           xml:space="preserve"><tspan
+             style="font-size:15px;line-height:1.25;text-align:center;text-anchor:middle"
+             y="653.29779"
+             x="591.24609"
+             sodipodi:role="line"
+             id="tspan3829-7">axi_pwm_gen_1</tspan></text>
+      </g>
+      <g
+         id="g3869-5"
+         transform="translate(120.81383,86.944274)">
+        <rect
+           style="display:inline;opacity:0.87;fill:#fffeff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:2.064;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;enable-background:new"
+           id="rect4867-1-5-7-3-3"
+           width="131.37004"
+           height="50.056286"
+           x="525.69653"
+           y="623.42444" />
+        <text
+           id="text19531-6-5"
+           y="653.29779"
+           x="591.24609"
+           style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none"
+           xml:space="preserve"><tspan
+             style="font-size:15px;line-height:1.25;text-align:center;text-anchor:middle"
+             y="653.29779"
+             x="591.24609"
+             sodipodi:role="line"
+             id="tspan3829-7-6">axi_pwm_gen_1</tspan></text>
+      </g>
+      <g
+         id="g3869-2"
+         transform="translate(120.81384,176.42752)">
+        <rect
+           style="display:inline;opacity:0.87;fill:#fffeff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:2.064;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;enable-background:new"
+           id="rect4867-1-5-7-3-9"
+           width="131.37004"
+           height="50.056286"
+           x="525.69653"
+           y="623.42444" />
+        <text
+           id="text19531-6-1"
+           y="653.29779"
+           x="591.24609"
+           style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none"
+           xml:space="preserve"><tspan
+             style="font-size:15px;line-height:1.25;text-align:center;text-anchor:middle"
+             y="653.29779"
+             x="591.24609"
+             sodipodi:role="line"
+             id="tspan3829-7-2">axi_pwm_gen_1</tspan></text>
+      </g>
+      <g
+         transform="translate(-172.67946,209.17175)"
+         id="g3910-3">
+        <rect
+           style="display:inline;opacity:0.87;fill:#fffeff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;enable-background:new"
+           id="rect4867-1-5-7-6"
+           width="80.895638"
+           height="50.493565"
+           x="454.9606"
+           y="474.53656" />
+        <text
+           id="text19531-7"
+           y="496.31213"
+           x="497.16476"
+           style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none"
+           xml:space="preserve"><tspan
+             style="font-size:15px;line-height:1.25;text-align:center;text-anchor:middle"
+             y="496.31213"
+             x="497.16476"
+             sodipodi:role="line"
+             id="tspan3829-5">offset</tspan><tspan
+             id="tspan4445"
+             style="font-size:15px;line-height:1.25;text-align:center;text-anchor:middle"
+             y="515.06213"
+             x="497.16476"
+             sodipodi:role="line">counter</tspan></text>
+      </g>
+    </g>
+    <path
+       sodipodi:nodetypes="cc"
+       inkscape:connector-curvature="0"
+       id="path9553-6-7"
+       d="M 90.554177,823.46164 H 137.04564"
+       style="fill:none;stroke:#000000;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:0;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#marker11392)" />
+    <text
+       transform="scale(0.97456407,1.0260998)"
+       id="text8759-7"
+       y="794.07037"
+       x="4.1424942"
+       style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none"
+       xml:space="preserve"><tspan
+         style="font-size:15px;line-height:1.25"
+         y="794.07037"
+         x="4.1424942"
+         id="tspan8761-9"
+         sodipodi:role="line">external_sync</tspan></text>
+    <g
+       transform="translate(213.74922,165.17925)"
+       id="g5774-2">
+      <rect
+         y="598.41962"
+         x="173.07582"
+         height="35.114685"
+         width="54.726078"
+         id="rect4867-9"
+         style="display:inline;opacity:0.87;fill:#fffeff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;enable-background:new" />
+      <text
+         id="text4869-4"
+         y="598.34186"
+         x="188.48598"
+         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0%;font-family:sans-serif;-inkscape-font-specification:sans-serif;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;letter-spacing:0px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-anchor:start;display:inline;overflow:visible;visibility:visible;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;marker:none;enable-background:new"
+         xml:space="preserve"
+         transform="scale(0.96162093,1.0399108)"><tspan
+           y="598.34186"
+           x="188.48598"
+           sodipodi:role="line"
+           style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:15px;line-height:125%;font-family:sans-serif;-inkscape-font-specification:sans-serif;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;letter-spacing:0px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-anchor:start;display:inline;overflow:visible;visibility:visible;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;marker:none;enable-background:new"
+           id="tspan8763-6">equal</tspan></text>
+    </g>
+    <g
+       transform="translate(76.25,36)"
+       id="g4389">
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none"
+         x="644.84644"
+         y="645.67053"
+         id="text8784-4-4-1"
+         transform="scale(0.97456407,1.0260998)"><tspan
+           sodipodi:role="line"
+           x="644.84644"
+           y="645.67053"
+           id="tspan11726"
+           style="font-size:15px;line-height:1.25">pwm 0</tspan></text>
+      <path
+         sodipodi:nodetypes="cc"
+         inkscape:connector-curvature="0"
+         id="path4967"
+         d="m 566.38465,673.97739 77.68686,-0.12188"
+         style="fill:none;stroke:#000000;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#marker9429)" />
+      <text
+         id="text4791"
+         y="713.0813"
+         x="625.44867"
+         style="font-style:normal;font-weight:normal;font-size:6.66667px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none"
+         xml:space="preserve" />
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none"
+         x="650.65497"
+         y="714.09644"
+         id="text8784-4-4-1-0"
+         transform="scale(0.97456407,1.0260998)"><tspan
+           sodipodi:role="line"
+           x="650.65497"
+           y="714.09644"
+           id="tspan11726-6"
+           style="font-size:15px;line-height:1.25">pwp 1</tspan></text>
+    </g>
+    <g
+       transform="translate(214.00092,233.81623)"
+       id="g5774-2-7">
+      <rect
+         y="598.41962"
+         x="173.07582"
+         height="35.114685"
+         width="54.726078"
+         id="rect4867-9-0"
+         style="display:inline;opacity:0.87;fill:#fffeff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;enable-background:new" />
+      <text
+         id="text4869-4-9"
+         y="598.34186"
+         x="188.48598"
+         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0%;font-family:sans-serif;-inkscape-font-specification:sans-serif;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;letter-spacing:0px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-anchor:start;display:inline;overflow:visible;visibility:visible;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;marker:none;enable-background:new"
+         xml:space="preserve"
+         transform="scale(0.96162093,1.0399108)"><tspan
+           y="598.34186"
+           x="188.48598"
+           sodipodi:role="line"
+           style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:15px;line-height:125%;font-family:sans-serif;-inkscape-font-specification:sans-serif;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;letter-spacing:0px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-anchor:start;display:inline;overflow:visible;visibility:visible;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;marker:none;enable-background:new"
+           id="tspan8763-6-3">equal</tspan></text>
+    </g>
+    <g
+       transform="translate(215.07269,319.76246)"
+       id="g5774-2-6">
+      <rect
+         y="598.41962"
+         x="173.07582"
+         height="35.114685"
+         width="54.726078"
+         id="rect4867-9-06"
+         style="display:inline;opacity:0.87;fill:#fffeff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;enable-background:new" />
+      <text
+         id="text4869-4-2"
+         y="598.34186"
+         x="188.48598"
+         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0%;font-family:sans-serif;-inkscape-font-specification:sans-serif;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;letter-spacing:0px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-anchor:start;display:inline;overflow:visible;visibility:visible;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;marker:none;enable-background:new"
+         xml:space="preserve"
+         transform="scale(0.96162093,1.0399108)"><tspan
+           y="598.34186"
+           x="188.48598"
+           sodipodi:role="line"
+           style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:15px;line-height:125%;font-family:sans-serif;-inkscape-font-specification:sans-serif;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;letter-spacing:0px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-anchor:start;display:inline;overflow:visible;visibility:visible;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;marker:none;enable-background:new"
+           id="tspan8763-6-6">equal</tspan></text>
+    </g>
+    <path
+       sodipodi:nodetypes="cccc"
+       inkscape:connector-curvature="0"
+       id="path5237"
+       d="m 378.79483,719.55838 -45.19508,0.0536 v 210.6235 h 47.32669"
+       style="fill:none;stroke:#000000;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-start:url(#marker10933-1);marker-end:url(#marker2795)" />
+    <path
+       sodipodi:nodetypes="cc"
+       inkscape:connector-curvature="0"
+       id="path7718-1-7"
+       d="m 333.51096,775.13213 h 46.48816"
+       style="fill:none;stroke:#000000;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:0;stroke-dasharray:none;stroke-opacity:1;marker-start:url(#marker9116);marker-end:url(#marker12206-7-1)" />
+    <g
+       transform="translate(72,36)"
+       id="g12973">
+      <text
+         transform="translate(-105.57947,95.17239)"
+         xml:space="preserve"
+         style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none"
+         x="315.48645"
+         y="663.33356"
+         id="text19531-6-12"><tspan
+           id="tspan3829-7-9"
+           sodipodi:role="line"
+           x="315.48645"
+           y="663.33356"
+           style="font-size:15px;line-height:1.25;text-align:center;text-anchor:middle">offset_1</tspan></text>
+      <path
+         style="fill:none;stroke:#000000;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:0;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#marker12474-7-9-2)"
+         d="m 244.81698,754.39618 11.81953,0.0233 c 2.29651,-4.34215 6.67912,-4.96865 9.61475,0.019 l 41.91774,0.0827"
+         id="path6277-8-0-7"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cccc" />
+    </g>
+    <path
+       sodipodi:nodetypes="cc"
+       inkscape:connector-curvature="0"
+       id="path6277-8-0-2"
+       d="m 441.76951,780.02455 59.35202,0.125"
+       style="fill:none;stroke:#000000;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:0;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#marker12474-7-9-5)" />
+    <path
+       sodipodi:nodetypes="cc"
+       inkscape:connector-curvature="0"
+       id="path6277-8-0-2-9"
+       d="m 441.82679,850.28009 59.35202,0.125"
+       style="fill:none;stroke:#000000;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:0;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#marker12474-7-9-5-2)" />
+    <path
+       sodipodi:nodetypes="cc"
+       inkscape:connector-curvature="0"
+       id="path6277-8-0-2-6"
+       d="m 443.04905,938.2127 58.25996,0.125"
+       style="fill:none;stroke:#000000;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:0;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#marker12474-7-9-5-7)" />
+    <g
+       id="g12973-9"
+       transform="translate(72.155691,105.53797)">
+      <text
+         transform="translate(-105.57947,95.17239)"
+         xml:space="preserve"
+         style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none"
+         x="315.48645"
+         y="663.33356"
+         id="text19531-6-12-4"><tspan
+           id="tspan3829-7-9-7"
+           sodipodi:role="line"
+           x="315.48645"
+           y="663.33356"
+           style="font-size:15px;line-height:1.25;text-align:center;text-anchor:middle">offset_2</tspan></text>
+      <path
+         style="fill:none;stroke:#000000;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:0;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#marker12474-7-9-2-3)"
+         d="m 244.81698,754.39618 11.81953,0.0233 c 2.29651,-4.34215 6.67912,-4.96865 9.61475,0.019 l 41.91774,0.0827"
+         id="path6277-8-0-7-8"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cccc" />
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none"
+         x="213.25398"
+         y="841.96698"
+         id="text19531-6-12-4-4"><tspan
+           id="tspan1927"
+           sodipodi:role="line"
+           x="213.25398"
+           y="841.96698"
+           style="font-size:15px;line-height:1.25;text-align:center;text-anchor:middle">offset_15</tspan></text>
+      <path
+         id="path1838"
+         d="m 490.57969,790.45501 h 25.16342"
+         style="fill:none;stroke:#000000;stroke-width:1.41698;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:1.41698, 8.50189;stroke-dashoffset:0;stroke-opacity:1" />
+      <path
+         style="fill:none;stroke:#000000;stroke-width:1.37622;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:1.37622, 8.25736;stroke-dashoffset:0;stroke-opacity:1"
+         d="m 333.92603,790.94075 h 23.73673"
+         id="path1838-5" />
+      <path
+         id="path1838-5-0"
+         d="m 198.6023,790.94075 h 23.73673"
+         style="fill:none;stroke:#000000;stroke-width:1.37622;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:1.37622, 8.25736;stroke-dashoffset:0;stroke-opacity:1" />
+      <path
+         style="fill:none;stroke:#000000;stroke-width:1.41698;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:1.41698, 8.50189;stroke-dashoffset:0;stroke-opacity:1"
+         d="m 641.83607,790.98562 h 25.16342"
+         id="path1838-8" />
+    </g>
+    <path
+       sodipodi:nodetypes="cc"
+       inkscape:connector-curvature="0"
+       id="path6277-8-0-2-1"
+       d="m 640.42859,780.02372 73.35202,0.125"
+       style="fill:none;stroke:#000000;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:0;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#marker12474-7-9-5-0)" />
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none"
+       x="723.4624"
+       y="817.22333"
+       id="text8784-4-4-1-0-0"
+       transform="scale(0.97456407,1.0260998)"><tspan
+         sodipodi:role="line"
+         x="723.4624"
+         y="817.22333"
+         id="tspan11726-6-6"
+         style="font-size:15px;line-height:1.25">pwm 2</tspan></text>
+    <path
+       sodipodi:nodetypes="cc"
+       inkscape:connector-curvature="0"
+       id="path6277-8-0-2-1-1"
+       d="m 639.38459,849.84158 73.35202,0.125"
+       style="fill:none;stroke:#000000;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:0;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#marker12474-7-9-5-0-3)" />
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none"
+       x="723.79462"
+       y="903.86609"
+       id="text8784-4-4-1-0-0-4"
+       transform="scale(0.97456407,1.0260998)"><tspan
+         sodipodi:role="line"
+         x="723.79462"
+         y="903.86609"
+         id="tspan11726-6-6-7"
+         style="font-size:15px;line-height:1.25">pwm 15</tspan></text>
+    <path
+       sodipodi:nodetypes="cc"
+       inkscape:connector-curvature="0"
+       id="path6277-8-0-2-1-1-6"
+       d="m 639.70834,938.74547 73.35202,0.125"
+       style="fill:none;stroke:#000000;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:0;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#marker12474-7-9-5-0-3-5)" />
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none"
+       x="473.4437"
+       y="774.64136"
+       id="text19531-6-12-4-4-5-9"><tspan
+         id="tspan3829-7-9-7-5-6-3"
+         sodipodi:role="line"
+         x="473.4437"
+         y="774.64136"
+         style="font-size:15px;line-height:1.25;text-align:center;text-anchor:middle">sync</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none"
+       x="471.87842"
+       y="844.43988"
+       id="text19531-6-12-4-4-5-9-7"><tspan
+         id="tspan3829-7-9-7-5-6-3-4"
+         sodipodi:role="line"
+         x="471.87842"
+         y="844.43988"
+         style="font-size:15px;line-height:1.25;text-align:center;text-anchor:middle">sync</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none"
+       x="471.93478"
+       y="932.40247"
+       id="text19531-6-12-4-4-5-9-7-5"><tspan
+         id="tspan3829-7-9-7-5-6-3-4-2"
+         sodipodi:role="line"
+         x="471.93478"
+         y="932.40247"
+         style="font-size:15px;line-height:1.25;text-align:center;text-anchor:middle">sync</tspan></text>
+    <g
+       transform="translate(213.03009,94.75194)"
+       id="g5774-2-2">
+      <rect
+         y="598.41962"
+         x="173.07582"
+         height="35.114685"
+         width="54.726078"
+         id="rect4867-9-7"
+         style="display:inline;opacity:0.87;fill:#fffeff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;enable-background:new" />
+      <text
+         id="text4869-4-0"
+         y="598.34186"
+         x="188.48598"
+         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0%;font-family:sans-serif;-inkscape-font-specification:sans-serif;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;letter-spacing:0px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-anchor:start;display:inline;overflow:visible;visibility:visible;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;marker:none;enable-background:new"
+         xml:space="preserve"
+         transform="scale(0.96162093,1.0399108)"><tspan
+           y="598.34186"
+           x="188.48598"
+           sodipodi:role="line"
+           style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:15px;line-height:125%;font-family:sans-serif;-inkscape-font-specification:sans-serif;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;letter-spacing:0px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-anchor:start;display:inline;overflow:visible;visibility:visible;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;marker:none;enable-background:new"
+           id="tspan8763-6-9">equal</tspan></text>
+    </g>
+    <path
+       sodipodi:nodetypes="cc"
+       inkscape:connector-curvature="0"
+       id="path6277-8-0-2-3"
+       d="m 441.05038,709.59724 59.35202,0.125"
+       style="fill:none;stroke:#000000;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:0;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#marker12474-7-9-5-9)" />
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none"
+       x="472.72458"
+       y="704.21405"
+       id="text19531-6-12-4-4-5-9-6"><tspan
+         id="tspan3829-7-9-7-5-6-3-0"
+         sodipodi:role="line"
+         x="472.72458"
+         y="704.21405"
+         style="font-size:15px;line-height:1.25;text-align:center;text-anchor:middle">sync</tspan></text>
+    <g
+       transform="translate(70.582819,-52.714522)"
+       id="g12973-6">
+      <text
+         transform="translate(-105.57947,95.17239)"
+         xml:space="preserve"
+         style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none"
+         x="315.48645"
+         y="663.33356"
+         id="text19531-6-12-1"><tspan
+           id="tspan3829-7-9-8"
+           sodipodi:role="line"
+           x="315.48645"
+           y="663.33356"
+           style="font-size:15px;line-height:1.25;text-align:center;text-anchor:middle">offset_0</tspan></text>
+      <path
+         style="fill:none;stroke:#000000;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:0;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#marker12474-7-9-2-6)"
+         d="m 244.25126,754.43848 63.91774,0.0827"
+         id="path6277-8-0-7-7"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cc" />
+    </g>
+    <path
+       sodipodi:nodetypes="cc"
+       inkscape:connector-curvature="0"
+       id="path6277-8-0"
+       d="m 225.22462,823.86828 108.41267,0.125"
+       style="fill:none;stroke:#000000;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:0;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#DotM)" />
+  </g>
+</svg>

--- a/docs/library/axi_pwm_gen/index.rst
+++ b/docs/library/axi_pwm_gen/index.rst
@@ -1,0 +1,275 @@
+.. _axi_pwm_gen:
+
+AXI PWM Generator
+================================================================================
+
+.. hdl-component-diagram::
+
+The :git-hdl:`AXI PWM Generator <library/axi_pwm_gen>` core is used to generate
+a maximum of 16 configurable signals (Pulse-Width Modulations).
+The pulses are generated according to the state of a counter;
+there is one counter for each pulse.
+
+Features
+--------------------------------------------------------------------------------
+
+* Up to 16 configurable signals (period, width, offset)
+* External synchronization
+* External clock
+
+Files
+--------------------------------------------------------------------------------
+
+.. list-table::
+   :header-rows: 1
+
+   * - Name
+     - Description
+   * - :git-hdl:`library/axi_pwm_gen/axi_pwm_gen.sv`
+     - SystemVerilog source for the top module
+   * - :git-hdl:`library/axi_pwm_gen/axi_pwm_gen_1.v`
+     - Verilog source for a channel module
+   * - :git-hdl:`library/axi_pwm_gen/axi_pwm_gen_regmap.sv`
+     - SystemVerilog source for regmap
+   * - :git-hdl:`library/axi_pwm_gen/axi_pwm_gen_constr.ttcl`
+     - Dynamic constraint file (AMD tools)
+   * - :git-hdl:`library/axi_pwm_gen/axi_pwm_gen_constr.sdc`
+     - Constraint file (Intel tools)
+   * - :git-hdl:`library/axi_pwm_gen/axi_pwm_gen_ip.tcl`
+     - IP definition file (AMD tools)
+   * - :git-hdl:`library/axi_pwm_gen/axi_pwm_gen_hw.tcl`
+     - IP definition file (Intel tools)
+
+Block Diagram
+--------------------------------------------------------------------------------
+
+.. image:: block_diagram.svg
+   :alt: AXI PWM Generator block diagram
+
+Configuration Parameters
+--------------------------------------------------------------------------------
+
+.. note::
+
+   The pulse period, width and offset are set in number of clock cycles.
+   The clock is the axi clock or if activated, the external clock.
+
+.. hdl-parameters::
+
+   * - ID
+     - Core ID should be unique for each IP in the system.
+   * - ASYNC_CLK_EN
+     - Use external clock, asynchronous to s_axi_aclk.
+   * - N_PWMS
+     - Number of pulses/pwms.
+   * - PWM_EXT_SYNC
+     - PWM offset counter uses external sync.
+   * - EXT_ASYNC_SYNC
+     - The external sync for pulse 0 is asynchronous.
+   * - SOFTWARE_BRINGUP
+     - Require software, to bring the core out if reset
+   * - EXT_SYNC_PHASE_ALIGN
+     - Set default flag value for external sync phase align feature
+   * - FORCE_ALIGN
+     - Set default flag value for force align feature
+   * - START_AT_SYNC
+     - Set default flag value for start at sync feature
+
+.. _axi_pwm_gen interface:
+
+Interface
+--------------------------------------------------------------------------------
+
+.. hdl-interfaces::
+
+   * - ext_clk
+     - External clock.
+   * - ext_sync
+     - External sync signal, synchronizes pulses to an external signal.
+   * - pwm_*
+     - Output PWM, up to 16, indexed from 0 to 15.
+
+Detailed Description
+--------------------------------------------------------------------------------
+Let's start with some base notions:
+
+- The pulse generators are based on incrementing counters.
+
+- The pulse period starts on the high level interval and ends on the low level.
+
+- By default, all counters start at the same time. When a different phase (delay)
+  is needed between the pulses, we can set an offset.
+
+- The offset feature can synchronize channels 0 to 15 relative to an offset
+  counter.
+
+- The offset counter will wait for a HIGH -> LOW transition of the
+  synchronization pulse (''load_config'' or ''ext_sync'').
+  For more info see the below channel phase alignment feature.
+
+- To **disable a PWM channel**, write 0 to its ``period`` register.
+
+- The duty cycle is the ratio between pulse width over pulse period.
+
+The following features can be enabled by setting a flag in the
+register REG_UP_CONTROL(0x18):
+
+Channel phase alignment
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The AXI PWM Generator core can be synchronized by an external signal on the
+HIGH -> LOW transition of the ext_sync signal.
+
+The external sync can be used in two modes, based on the external sync align
+feature.
+
+- external_sync_align flag is set(1) the ext_sync will trigger a phase align
+  at each neg-edge.
+- otherwise the phase align must be armed by a load config toggle, while
+  the external sync must be held HIGH.
+
+Software bringup (software reset)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+If set, the software must bring the core out of reset, after a system reset,
+for the pwm signals to be generated.
+
+Force align
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+If set, the current active pulses are immediately stopped and realigned.
+Otherwise, the synchronized pulses will start only after all running pulse
+periods end. Software overwritable at runtime.
+
+Start at sync
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+If active, the pulses will start after the trigger event.
+Otherwise each pulse will start after a period equal to the one for which
+it is set. Software over writable at runtime.
+
+This flags are software overwritable at runtime. Default value is given at build time.
+
+-  software bringup = 1
+-  start at sync = 1
+-  force align = 0
+-  ext sync align = 0
+
+Timing Diagrams and examples
+--------------------------------------------------------------------------------
+
+The timing diagram below, shows the ``load_config`` functionality with
+force sync and force start disabled.
+
+.. wavedrom::
+
+  { "signal" : [
+    { "name": "clk", "wave": "P.............................."},
+    { "name": "pwm_1 period", "wave": "9.............9................","data":["8","10"]},
+    { "name": "pwm_1 pulse",  "wave": "9.............9................","data":["3","5"]},
+    { "name": "pwm_1 offset", "wave": "9.............9................","data":["1","0"]},
+    { "name": "pwm_2 period", "wave": "6.............6................","data":["8","10"]},
+    { "name": "pwm_2 pulse",  "wave": "6.............6................","data":["3","5"]},
+    { "name": "pwm_2 offset", "wave": "6.............6................","data":["5","4"]},
+    { "name": "load_config", "wave": "0............10................",phase: 0,},
+    { "name": "offset counter", "wave": "7777777777777777777777777777777","data":["55","56","57","58","59","60","61","62","63","64","65","66","67","68","0","1","2","3","4","5","6","7","8","9","10","11","12","13","14","15","16"]},
+    { "name": "counter 0", "wave": "45555555544444=6666666666333333","data":["8","1","2","3","4","5","6","7","8","1","2","3","4","5","1","1","2","3","4","5","6","7","8","9","10","1","2","3","4","5","6"]},
+    { "name": "pwm 0", "wave": "lh..l....h...l.h....l....h....l"},
+    { "name": "counter 1", "wave": "44444555555554=...6666666666333","data":["4","5","6","7","8","1","2","3","4","5","6","7","8","1","1","1","2","3","4","5","6","7","8","9","10","1","2","3","4","5"]},
+    { "name": "pwm 1", "wave": "l....h..l....hl...h....l....h.."},
+  ],
+  foot: {text: ['tspan', 'load_config force_sync and start at sync e.g.'],
+  }}
+
+The timing diagram below, shows the ``load_config`` functionality with
+force sync disabled and force start enabled.
+
+.. wavedrom::
+
+  { "signal" : [
+    { "name": "clk", "wave": "P.............................."},
+    { "name": "pwm_1 period", "wave": "9...........9..................","data":["8","10"]},
+    { "name": "pwm_1 pulse",  "wave": "9...........9..................","data":["3","5"]},
+    { "name": "pwm_1 offset", "wave": "9...........9..................","data":["1","0"]},
+    { "name": "pwm_2 period", "wave": "6...........6..................","data":["8","10"]},
+    { "name": "pwm_2 pulse",  "wave": "6...........6..................","data":["3","5"]},
+    { "name": "pwm_2 offset", "wave": "6...........6..................","data":["5","4"]},
+    { "name": "load_config", "wave": "0..........10..................",phase: 0,},
+    { "name": "offset counter", "wave": "7777777777777777777777777777777","data":["55","56","57","58","59","60","61","62","63","64","65","66","67","68","0","1","2","3","4","5","6","7","8","9","10","11","12","13","14","15","16"]},
+    { "name": "counter 0", "wave": "45555555544444444=6666666666333","data":["8","1","2","3","4","5","6","7","8","1","2","3","4","5","6","7","8","1","1","2","3","4","5","6","7","8","9","10","1","2","3"]},
+    { "name": "pwm 0", "wave": "lh..l....h...l....h....l....h.."},
+    { "name": "counter 1", "wave": "4444455555555=.......6666666666","data":["4","5","6","7","8","1","2","3","4","5","6","7","8","1","1","2","3","4","5","6","7","8","9","10"]},
+    { "name": "pwm 1", "wave": "l....h..l............h....l...."},
+  ],
+  foot: {text: ['tspan', 'load_config with start at sync(default)'],
+  }}
+
+The timing diagram below, shows the ``load_config`` functionality with
+force sync and force start enabled.
+
+.. wavedrom::
+
+  { "signal" : [
+    { "name": "clk", "wave": "P.............................."},
+    { "name": "pwm_1 period", "wave": "9.............9................","data":["8","10"]},
+    { "name": "pwm_1 pulse",  "wave": "9.............9................","data":["3","5"]},
+    { "name": "pwm_1 offset", "wave": "9.............9................","data":["1","0"]},
+    { "name": "pwm_2 period", "wave": "6.............6................","data":["8","10"]},
+    { "name": "pwm_2 pulse",  "wave": "6.............6................","data":["3","5"]},
+    { "name": "pwm_2 offset", "wave": "6.............6................","data":["5","4"]},
+    { "name": "load_config", "wave": "0............10................",phase: 0,},
+    { "name": "offset counter", "wave": "7777777777777777777777777777777","data":["55","56","57","58","59","60","61","62","63","64","65","66","67","68","0","1","2","3","4","5","6","7","8","9","10","11","12","13","14","15","16"]},
+    { "name": "counter 0", "wave": "45555555544444=6666666666333333","data":["8","1","2","3","4","5","6","7","8","1","2","3","4","5","1","1","2","3","4","5","6","7","8","9","10","1","2","3","4","5","6"]},
+    { "name": "pwm 0", "wave": "lh..l....h...l.h....l....h....l"},
+    { "name": "counter 1", "wave": "44444555555554=...6666666666333","data":["4","5","6","7","8","1","2","3","4","5","6","7","8","1","1","1","2","3","4","5","6","7","8","9","10","1","2","3","4","5"]},
+    { "name": "pwm 1", "wave": "l....h..l....hl...h....l....h.."},
+  ],
+  foot: {text: ['tspan', 'load_config force_sync and start at sync e.g.'],
+  }}
+
+The below timing diagrams, shows the ``external_sync`` functionality:
+
+.. wavedrom::
+
+  { "signal" : [
+    { "name": "clk", "wave": "P............................"},
+    { "name": "pwm_1 period", "wave": "9............................","data":["8"]},
+    { "name": "pwm_1 pulse", "wave": "9............................","data":["3"]},
+    { "name": "pwm_1 offset", "wave": "9............................","data":["1"]},
+    { "name": "pwm_2 period", "wave": "6............................","data":["8"]},
+    { "name": "pwm_2 pulse", "wave": "6............................","data":["3"]},
+    { "name": "pwm_2 offset", "wave": "6............................","data":["5"]},
+    { "name": "external_sync", "wave": "1....0.......................",phase: 0.5,},
+    { "name": "offset counter", "wave": "=.....7777777777777777777777=","data":["0","1","2","3","4","5","6","7","8","9","10","11","12","13","14","15","16","17","18","19","20","21","22"]},
+    { "name": "counter 0", "wave": "=......444444455555555444444=","data":["1","2","3","4","5","6","7","8","1","2","3","4","5","6","7","8","1","2","3","4","5","6"]},
+    { "name": "pwm 0", "wave": "l......h..l....h..l....h..l.."},
+    { "name": "counter 1", "wave": "=..........44444445555555544=","data":["1","2","3","4","5","6","7","8","1","2","3","4","5","6","7","8","1","2"]},
+    { "name": "pwm 1", "wave": "l..........h..l....h..l....h."},
+  ],
+  foot: {text: ['tspan', 'External sync, start at sync (default) e.g.'],
+  }}
+
+.. wavedrom::
+
+  { "signal" : [
+    { "name": "clk", "wave": "P............................"},
+    { "name": "pwm_1 period", "wave": "9............................","data":["8"]},
+    { "name": "pwm_1 pulse", "wave": "9............................","data":["3"]},
+    { "name": "pwm_1 offset", "wave": "9............................","data":["1"]},
+    { "name": "pwm_2 period", "wave": "6............................","data":["8"]},
+    { "name": "pwm_2 pulse", "wave": "6............................","data":["3"]},
+    { "name": "pwm_2 offset", "wave": "6............................","data":["5"]},
+    { "name": "external_sync", "wave": "1....0.......................",phase: 0.5,},
+    { "name": "offset counter", "wave": "=.....7777777777777777777777=","data":["0","1","2","3","4","5","6","7","8","9","10","11","12","13","14","15","16","17","18","19","20","21","22"]},
+    { "name": "counter 0", "wave": "=......444444455555555444444=","data":["1","2","3","4","5","6","7","8","1","2","3","4","5","6","7","8","1","2","3","4","5","6"]},
+    { "name": "pwm 0", "wave": "l.............h..l....h..l..."},
+    { "name": "counter 1", "wave": "=..........44444445555555544=","data":["1","2","3","4","5","6","7","8","1","2","3","4","5","6","7","8","1","2"]},
+    { "name": "pwm 1", "wave": "l.................h..l....h.."},
+  ],
+  foot: {text: ['tspan', 'External sync without start at sync e.g.'],
+  }}
+
+Register Map
+--------------------------------------------------------------------------------
+
+.. hdl-regmap::
+   :name: axi_pwm_gen

--- a/docs/library/index.rst
+++ b/docs/library/index.rst
@@ -14,9 +14,10 @@ Contents
 .. toctree::
    :maxdepth: 1
 
-   axi_dmac/index
    i3c_controller/index
-   spi_engine/index
-   jesd204/index
    axi_adxcvr/index
+   axi_dmac/index
+   axi_pwm_gen/index
+   jesd204/index
+   spi_engine/index
    xilinx/index

--- a/docs/regmap/adi_regmap_pwm_gen.txt
+++ b/docs/regmap/adi_regmap_pwm_gen.txt
@@ -13,7 +13,7 @@ Version and Scratch Registers
 ENDREG
 
 FIELD
-[31:0] 0x00010100
+[31:0] 0x00020100
 VERSION[31:0]
 RO
 Version number. Unique to all cores.
@@ -92,6 +92,41 @@ ENDFIELD
 
 ############################################################################################
 ############################################################################################
+
+REG
+0x0006
+REG_CONFIG
+Features enable register
+ENDREG
+
+FIELD
+[2] 0x0
+EXT_SYNC_ALIGN
+RW
+If active the ext_sync will trigger a phase align at each neg-edge.
+Otherwise the phase align will be armed by a load config toggle.
+ENDFIELD
+
+FIELD
+[1] 0x0
+FORCE_ALIGN
+RW
+If active the current active pulses are immediately stopped and realigned.
+Otherwise, the synchronized pulses will start only after all running pulse periods end.
+ENDFIELD
+
+FIELD
+[0] 0x1
+START_AT_SYNC
+RW
+If active, the pulses will start after the trigger event.
+Otherwise each pulse will start after a period equal to the one for which it is set.
+Default valew can be overwritten at build time through parameters.
+ENDFIELD
+
+############################################################################################
+############################################################################################
+
 
 REG
 0x0005

--- a/library/axi_pwm_gen/Makefile
+++ b/library/axi_pwm_gen/Makefile
@@ -1,5 +1,5 @@
 ####################################################################################
-## Copyright (c) 2018 - 2023 Analog Devices, Inc.
+## Copyright (c) 2018 - 2024 Analog Devices, Inc.
 ### SPDX short identifier: BSD-1-Clause
 ## Auto-generated, do not modify!
 ####################################################################################
@@ -21,6 +21,7 @@ XILINX_LIB_DEPS += util_cdc
 INTEL_DEPS += ../intel/common/up_rst_constr.sdc
 INTEL_DEPS += ../util_cdc/sync_bits.v
 INTEL_DEPS += ../util_cdc/sync_data.v
+INTEL_DEPS += ../util_cdc/sync_event.v
 INTEL_DEPS += axi_pwm_gen_constr.sdc
 INTEL_DEPS += axi_pwm_gen_hw.tcl
 

--- a/library/axi_pwm_gen/axi_pwm_gen_constr.sdc
+++ b/library/axi_pwm_gen/axi_pwm_gen_constr.sdc
@@ -1,5 +1,5 @@
 ###############################################################################
-## Copyright (C) 2021-2023 Analog Devices, Inc. All rights reserved.
+## Copyright (C) 2021-2024 Analog Devices, Inc. All rights reserved.
 ### SPDX short identifier: ADIBSD
 ###############################################################################
 

--- a/library/axi_pwm_gen/axi_pwm_gen_constr.ttcl
+++ b/library/axi_pwm_gen/axi_pwm_gen_constr.ttcl
@@ -34,4 +34,16 @@ set_property ASYNC_REG TRUE \
     -from [get_pins -hierarchical * -filter {NAME=~*i_load_config_sync/in_toggle_d1_reg/C}] \
     -to [get_pins -hierarchical * -filter {NAME=~*i_load_config_sync/i_sync_out/cdc_sync_stage1_reg[0]/D}]
 
+  set_false_path \
+    -from [get_cells -hierarchical * -filter {NAME=~*i_regmap/*i_pwm_controls/cdc_hold_reg*}] \
+    -to [get_cells -hierarchical * -filter {NAME=~*i_regmap/*i_pwm_controls/out_data_reg*}]
+
+  set_false_path \
+    -from [get_cells -hierarchical * -filter {NAME=~*i_regmap/*i_pwm_controls/in_toggle_d1_reg}] \
+    -to [get_cells -hierarchical * -filter {NAME=~*i_regmap/*i_pwm_controls/i_sync_out/cdc_sync_stage1_reg[*]}]
+
+  set_false_path \
+    -from [get_cells -hierarchical * -filter {NAME=~*i_regmap/*i_pwm_controls/out_toggle_d1_reg}] \
+    -to [get_cells -hierarchical * -filter {NAME=~*i_regmap/*i_pwm_controls/i_sync_in/cdc_sync_stage1_reg[*]}]
+
 <: } :>

--- a/library/axi_pwm_gen/axi_pwm_gen_constr.ttcl
+++ b/library/axi_pwm_gen/axi_pwm_gen_constr.ttcl
@@ -1,5 +1,5 @@
 ###############################################################################
-## Copyright (C) 2021-2023 Analog Devices, Inc. All rights reserved.
+## Copyright (C) 2021-2024 Analog Devices, Inc. All rights reserved.
 # SPDX short identifier: ADIBSD
 ###############################################################################
 

--- a/library/axi_pwm_gen/axi_pwm_gen_hw.tcl
+++ b/library/axi_pwm_gen/axi_pwm_gen_hw.tcl
@@ -1,5 +1,5 @@
 ###############################################################################
-## Copyright (C) 2023 Analog Devices, Inc. All rights reserved.
+## Copyright (C) 2023-2024 Analog Devices, Inc. All rights reserved.
 ### SPDX short identifier: ADIBSD
 ###############################################################################
 
@@ -30,6 +30,10 @@ ad_ip_parameter ASYNC_CLK_EN INTEGER 1
 ad_ip_parameter N_PWMS INTEGER 1
 ad_ip_parameter PWM_EXT_SYNC INTEGER 0
 ad_ip_parameter EXT_ASYNC_SYNC INTEGER 0
+ad_ip_parameter EXT_SYNC_PHASE_ALIGN INTEGER 0
+ad_ip_parameter SOFTWARE_BRINGUP INTEGER 1
+ad_ip_parameter FORCE_ALIGN INTEGER 0
+ad_ip_parameter START_AT_SYNC INTEGER 1
 ad_ip_parameter PULSE_0_WIDTH INTEGER 7
 ad_ip_parameter PULSE_1_WIDTH INTEGER 7
 ad_ip_parameter PULSE_2_WIDTH INTEGER 7

--- a/library/axi_pwm_gen/axi_pwm_gen_ip.tcl
+++ b/library/axi_pwm_gen/axi_pwm_gen_ip.tcl
@@ -1,5 +1,5 @@
 ###############################################################################
-## Copyright (C) 2021-2023 Analog Devices, Inc. All rights reserved.
+## Copyright (C) 2021-2024 Analog Devices, Inc. All rights reserved.
 ### SPDX short identifier: ADIBSD
 ###############################################################################
 
@@ -67,45 +67,76 @@ ipx::save_core $cc
 ipgui::add_page -name {AXI PWM Generator} -component $cc -display_name {AXI PWM Generator}
 set page0 [ipgui::get_pagespec -name "AXI PWM Generator" -component $cc]
 
-ipgui::add_param -name "ASYNC_CLK_EN" -component $cc -parent $page0
-set_property -dict [list \
-  "display_name" "ASYNC_CLK_EN" \
-  "tooltip" "External clock for the counter" \
-  "widget" "checkBox" \
-] [ipgui::get_guiparamspec -name "ASYNC_CLK_EN" -component $cc]
-
-ipgui::add_param -name "EXT_ASYNC_SYNC" -component $cc -parent $page0
-set_property -dict [list \
-  "display_name" "External sync signal is asynchronous" \
-  "tooltip" "NOTE: If active the ext_sync will be delayed 2 clock cycles." \
-  "widget" "checkBox" \
-] [ipgui::get_guiparamspec -name "EXT_ASYNC_SYNC" -component $cc]
-
+# N_PWMs
 ipgui::add_param -name "N_PWMS" -component $cc -parent $page0
 set_property -dict [list \
   "display_name" "Number of pwms" \
 ] [ipgui::get_guiparamspec -name "N_PWMS" -component $cc]
 
+# ASYNC_CLK_EN
+ipgui::add_param -name "ASYNC_CLK_EN" -component $cc -parent $page0
+set_property -dict [list \
+  "display_name" "ASYNC_CLK_EN" \
+  "tooltip" "The logic and PWMs will be driven by ext_clk. Otherwise the axi clock will be used" \
+  "widget" "checkBox" \
+] [ipgui::get_guiparamspec -name "ASYNC_CLK_EN" -component $cc]
+
+# PWM_EXT_SYNC
 ipgui::add_param -name "PWM_EXT_SYNC" -component $cc -parent $page0
 set_property -dict [list \
   "display_name" "External sync" \
-  "tooltip" "NOTE: If active the whole pwm gen module will be waiting for the ext_sync to be set low. A load config or reset must be used before deaserting the ext_sync" \
+  "tooltip" "If active the whole pwm gen module will be waiting for the ext_sync to be set low. A load config or reset must be used before de-asserting the ext_sync to retrigger the sync process" \
   "widget" "checkBox" \
 ] [ipgui::get_guiparamspec -name "PWM_EXT_SYNC" -component $cc]
 
+# EXT_ASYNC_SYNC
 ipgui::add_param -name "EXT_ASYNC_SYNC" -component $cc -parent $page0
 set_property -dict [list \
   "display_name" "External sync signal is asynchronous" \
   "tooltip" "NOTE: If active the ext_sync will be delayed 2 clock cycles." \
   "widget" "checkBox" \
 ] [ipgui::get_guiparamspec -name "EXT_ASYNC_SYNC" -component $cc]
+  set_property enablement_tcl_expr {expr $PWM_EXT_SYNC == 1} [ipx::get_user_parameters EXT_ASYNC_SYNC -of_objects $cc]
+
+# SOFTWARE_BRINGUP
+ipgui::add_param -name "SOFTWARE_BRINGUP" -component $cc -parent $page0
+set_property -dict [list \
+  "display_name" "Require software bringup" \
+  "tooltip" "If active the software must bring the core out of soft reset, after a system reset, in order for the pwm signals to be generated" \
+  "widget" "checkBox" \
+] [ipgui::get_guiparamspec -name "SOFTWARE_BRINGUP" -component $cc]
+
+# EXT_SYNC_PHASE_ALIGN
+ipgui::add_param -name "EXT_SYNC_PHASE_ALIGN" -component $cc -parent $page0
+set_property -dict [list \
+  "display_name" "External sync enable phase align" \
+  "tooltip" "If active the ext_sync will trigger a phase align at each neg-edge. Otherwise the phase align will be armed by a load config toggle. Software over writable at runtime." \
+  "widget" "checkBox" \
+] [ipgui::get_guiparamspec -name "EXT_SYNC_PHASE_ALIGN" -component $cc]
+  set_property enablement_tcl_expr {expr $PWM_EXT_SYNC == 1} [ipx::get_user_parameters EXT_SYNC_PHASE_ALIGN -of_objects $cc]
+
+# FORCE_ALIGN
+ipgui::add_param -name "FORCE_ALIGN" -component $cc -parent $page0
+set_property -dict [list \
+  "display_name" "Force align" \
+  "tooltip" "If active the current active pulses are immediately stopped and realigned. Otherwise, the synchronized pulses will start only after all running pulse periods end. Software over writable at runtime." \
+  "widget" "checkBox" \
+] [ipgui::get_guiparamspec -name "FORCE_ALIGN" -component $cc]
+
+# START_AT_SYNC
+ipgui::add_param -name "START_AT_SYNC" -component $cc -parent $page0
+set_property -dict [list \
+  "display_name" "Start at sync" \
+  "tooltip" "If active, the pulses will start after the trigger event. Otherwise each pulse will start after a period equal to the one for which it is set. Software over writable at runtime." \
+  "widget" "checkBox" \
+] [ipgui::get_guiparamspec -name "START_AT_SYNC" -component $cc]
 
 # Maximum 16 pwms
 for {set i 0} {$i < 16} {incr i} {
   ipgui::add_param -name "PULSE_${i}_WIDTH" -component $cc -parent $page0
   set_property -dict [list \
     "display_name" "PULSE $i width" \
-    "tooltip" "PULSE width of the generated signal. The unit interval is the system or external clock period." \
+    "tooltip" "PULSE width of the generated signal. The unit interval represents a period the system or external clock period." \
   ] [ipgui::get_guiparamspec -name "PULSE_${i}_WIDTH" -component $cc]
 
   set_property -dict [list \
@@ -114,11 +145,12 @@ for {set i 0} {$i < 16} {incr i} {
     "value_validation_range_maximum" "2147483647" \
    ] \
   [ipx::get_user_parameters PULSE_${i}_WIDTH -of_objects $cc]
+  set_property enablement_tcl_expr "expr \$N_PWMS >= $i" [ipx::get_user_parameters PULSE_${i}_WIDTH -of_objects $cc]
 
   ipgui::add_param -name "PULSE_${i}_PERIOD" -component $cc -parent $page0
   set_property -dict [list \
     "display_name" "PULSE ${i} period" \
-    "tooltip" "Period of the generated signal. The unit interval is the system or external clock period." \
+    "tooltip" "Period of the generated signal. The unit interval represents a period the system or external clock period." \
   ] [ipgui::get_guiparamspec -name "PULSE_${i}_PERIOD" -component $cc]
 
   set_property -dict [list \
@@ -127,11 +159,12 @@ for {set i 0} {$i < 16} {incr i} {
     "value_validation_range_maximum" "2147483647" \
    ] \
   [ipx::get_user_parameters PULSE_${i}_PERIOD -of_objects $cc]
+  set_property enablement_tcl_expr "expr \$N_PWMS >= $i" [ipx::get_user_parameters PULSE_${i}_PERIOD -of_objects $cc]
 
   ipgui::add_param -name "PULSE_${i}_OFFSET" -component $cc -parent $page0
   set_property -dict [list \
     "display_name" "PULSE ${i} offset" \
-    "tooltip" "Offset of the generated signal referenced to PULSE 1. The unit interval is the system or external clock period." \
+    "tooltip" "Offset of the generated signal referenced to PULSE 1. The unit interval represents a period the system or external clock period." \
   ] [ipgui::get_guiparamspec -name "PULSE_${i}_OFFSET" -component $cc]
 
   set_property -dict [list \
@@ -140,6 +173,7 @@ for {set i 0} {$i < 16} {incr i} {
     "value_validation_range_maximum" "2147483647" \
    ] \
   [ipx::get_user_parameters PULSE_${i}_OFFSET -of_objects $cc]
+  set_property enablement_tcl_expr "expr \$N_PWMS >= $i" [ipx::get_user_parameters PULSE_${i}_OFFSET -of_objects $cc]
 }
 
 for {set i 0} {$i < 16} {incr i} {


### PR DESCRIPTION
## PR Description

1. External sync sampled on a clock faster than the rest of the core.
   - dedicated input clock
   - event logic synchronization to core clock
2. External sync force the phase align. The external sync was used to align the phases of enabled pwms, but only after being armed by a load_config signal toggle. This feature lets the user decide between using load_config to arm and wait for a neg-edge of sync or automatic phase align trigger on the ext_sync neg-edge.
3. Force align. Lets the user chose between immediately stopping the active pulses and realigning them, or waiting for all running pulse periods end, before realigning.
4. Start at sync. when feture is activated, the pulses will start immediately after the trigger event. Otherwise, each pulse will start after a period equal to the one for which it is set.

## PR Type
- [x] Bug fix (change that fixes an issue)
- [x] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the code style guidelines
- [x] I have performed a self-review of changes
- [ ] I have compiled all hdl projects and libraries affected by this PR
- [ ] I have tested in hardware affected projects, at least on relevant boards
- [x] I have commented my code, at least hard-to-understand parts
- [x] I have signed off all commits from this PR
- [x] I have updated the documentation (wiki pages, ReadMe files, Copyright etc)
- [x]  I have not introduced new Warnings/Critical Warnings on compilation
- [ ] I have added new hdl testbenches or updated existing ones
