### PR TITLE
Add support for AD7606C-16 FMC Daughter Card on Xilinx ZCU102

### DIFF
--- a/projects/ad7606x_fmc/zcu102/Makefile
+++ b/projects/ad7606x_fmc/zcu102/Makefile
@@ -1,0 +1,27 @@
+####################################################################################
+## Copyright (c) 2018 - 2023 Analog Devices, Inc.
+### SPDX short identifier: BSD-1-Clause
+## Auto-generated, do not modify!
+####################################################################################
+
+PROJECT_NAME := ad7606x_fmc_zcu102
+
+M_DEPS += ../common/ad7606x_bd.tcl
+M_DEPS += ../../scripts/adi_pd.tcl
+M_DEPS += ../../common/zcu102/zcu102_system_constr.xdc
+M_DEPS += ../../common/zcu102/zcu102_system_bd.tcl
+M_DEPS += ../../../library/common/ad_iobuf.v
+
+LIB_DEPS += axi_ad7606x
+LIB_DEPS += axi_clkgen
+LIB_DEPS += axi_dmac
+LIB_DEPS += axi_hdmi_tx
+LIB_DEPS += axi_i2s_adi
+LIB_DEPS += axi_pwm_gen
+LIB_DEPS += axi_spdif_tx
+LIB_DEPS += axi_sysid
+LIB_DEPS += sysid_rom
+LIB_DEPS += util_i2c_mixer
+LIB_DEPS += util_pack/util_cpack2
+
+include ../../scripts/project-xilinx.mk

--- a/projects/ad7606x_fmc/zcu102/system_bd.tcl
+++ b/projects/ad7606x_fmc/zcu102/system_bd.tcl
@@ -1,0 +1,19 @@
+###############################################################################
+## Copyright (C) 2023 Analog Devices, Inc. All rights reserved.
+### SPDX short identifier: ADIBSD
+###############################################################################
+
+source $ad_hdl_dir/projects/common/zcu102/zcu102_system_bd.tcl
+source $ad_hdl_dir/projects/scripts/adi_pd.tcl
+
+source ../common/ad7606x_bd.tcl
+
+set mem_init_sys_path [get_env_param ADI_PROJECT_DIR ""]mem_init_sys.txt;
+
+#system ID
+ad_ip_parameter axi_sysid_0 CONFIG.ROM_ADDR_BITS 9
+ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "[pwd]/$mem_init_sys_path"
+ad_ip_parameter rom_sys_0 CONFIG.ROM_ADDR_BITS 9
+set sys_cstring "$DEV_CONFIG,$EXT_CLK"
+
+sysid_gen_sys_init_file $sys_cstring

--- a/projects/ad7606x_fmc/zcu102/system_constr.xdc
+++ b/projects/ad7606x_fmc/zcu102/system_constr.xdc
@@ -1,0 +1,40 @@
+###############################################################################
+## Copyright (C) 2023 Analog Devices, Inc. All rights reserved.
+### SPDX short identifier: ADIBSD
+###############################################################################
+
+# ad7606x
+
+set_property -dict {PACKAGE_PIN AB4     IOSTANDARD LVCMOS18} [get_ports adc_db[0] ]         ; ## D08 FMC_LPC_LA01_CC_P
+set_property -dict {PACKAGE_PIN AC4     IOSTANDARD LVCMOS18} [get_ports adc_db[1] ]         ; ## D09 FMC_LPC_LA01_CC_N
+set_property -dict {PACKAGE_PIN V1      IOSTANDARD LVCMOS18} [get_ports adc_db[2] ]         ; ## H08 FMC_LPC_LA02_N
+set_property -dict {PACKAGE_PIN Y1      IOSTANDARD LVCMOS18} [get_ports adc_db[3] ]         ; ## G10 FMC_LPC_LA03_N
+set_property -dict {PACKAGE_PIN AA1     IOSTANDARD LVCMOS18} [get_ports adc_db[4] ]         ; ## H11 FMC_LPC_LA04_N
+set_property -dict {PACKAGE_PIN U4      IOSTANDARD LVCMOS18} [get_ports adc_db[5] ]         ; ## H14 FMC_LPC_LA07_N
+set_property -dict {PACKAGE_PIN V3      IOSTANDARD LVCMOS18} [get_ports adc_db[6] ]         ; ## G13 FMC_LPC_LA08_N
+set_property -dict {PACKAGE_PIN Y3      IOSTANDARD LVCMOS18} [get_ports adc_db[7] ]         ; ## G07 FMC_LPC_LA00_CC_N
+set_property -dict {PACKAGE_PIN AC1     IOSTANDARD LVCMOS18} [get_ports adc_db[8] ]         ; ## C11 FMC_LPC_LA06_N
+set_property -dict {PACKAGE_PIN AB3     IOSTANDARD LVCMOS18} [get_ports adc_db[9] ]         ; ## D11 FMC_LPC_LA05_P
+set_property -dict {PACKAGE_PIN W2      IOSTANDARD LVCMOS18} [get_ports adc_db[10]]         ; ## D14 FMC_LPC_LA09_P
+set_property -dict {PACKAGE_PIN Y2      IOSTANDARD LVCMOS18} [get_ports adc_db[11]]         ; ## G09 FMC_LPC_LA03_P
+set_property -dict {PACKAGE_PIN AB5     IOSTANDARD LVCMOS18} [get_ports adc_db[12]]         ; ## H17 FMC_LPC_LA11_N
+set_property -dict {PACKAGE_PIN W6      IOSTANDARD LVCMOS18} [get_ports adc_db[13]]         ; ## G16 FMC_LPC_LA12_N
+set_property -dict {PACKAGE_PIN AB8     IOSTANDARD LVCMOS18} [get_ports adc_db[14]]         ; ## D17 FMC_LPC_LA13_P
+set_property -dict {PACKAGE_PIN AC8     IOSTANDARD LVCMOS18} [get_ports adc_db[15]]         ; ## D18 FMC_LPC_LA13_N
+
+set_property -dict {PACKAGE_PIN Y4      IOSTANDARD LVCMOS18} [get_ports adc_rd_n]           ; ## G06 FMC_LPC_LA00_CC_P
+set_property -dict {PACKAGE_PIN W5      IOSTANDARD LVCMOS18} [get_ports adc_wr_n]           ; ## C14 FMC_LPC_LA10_P
+
+# control lines
+set_property -dict {PACKAGE_PIN U5      IOSTANDARD LVCMOS18} [get_ports adc_busy]           ; ## H13 FMC_LPC_LA07_P
+set_property -dict {PACKAGE_PIN AC3     IOSTANDARD LVCMOS18} [get_ports adc_cnvst_n]        ; ## D12 FMC_LPC_LA05_N
+set_property -dict {PACKAGE_PIN AA2     IOSTANDARD LVCMOS18} [get_ports adc_cs_n]           ; ## H10 FMC_LPC_LA04_P
+set_property -dict {PACKAGE_PIN V4      IOSTANDARD LVCMOS18} [get_ports adc_first_data]     ; ## G12 FMC_LPC_LA08_P
+set_property -dict {PACKAGE_PIN AC2     IOSTANDARD LVCMOS18} [get_ports adc_reset]          ; ## C10 FMC_LPC_LA06_P
+set_property -dict {PACKAGE_PIN W7      IOSTANDARD LVCMOS18} [get_ports adc_os[0]]          ; ## G15 FMC_LPC_LA12_P
+set_property -dict {PACKAGE_PIN V2      IOSTANDARD LVCMOS18} [get_ports adc_os[1]]          ; ## H07 FMC_LPC_LA04_P
+set_property -dict {PACKAGE_PIN AB6     IOSTANDARD LVCMOS18} [get_ports adc_os[2]]          ; ## H16 FMC_LPC_LA11_P
+set_property -dict {PACKAGE_PIN W4      IOSTANDARD LVCMOS18} [get_ports adc_stby]           ; ## C15 FMC_LPC_LA10_N
+set_property -dict {PACKAGE_PIN W1      IOSTANDARD LVCMOS18} [get_ports adc_range]          ; ## D15 FMC_LPC_LA09_N
+set_property -dict {PACKAGE_PIN AC7     IOSTANDARD LVCMOS18} [get_ports adc_serpar]         ; ## C18 FMC_LPC_LA14_P
+set_property -dict {PACKAGE_PIN AC6     IOSTANDARD LVCMOS18} [get_ports adc_refsel]         ; ## C19 FMC_LPC_LA14_N

--- a/projects/ad7606x_fmc/zcu102/system_project.tcl
+++ b/projects/ad7606x_fmc/zcu102/system_project.tcl
@@ -1,0 +1,34 @@
+###############################################################################
+## Copyright (C) 2023 Analog Devices, Inc. All rights reserved.
+### SPDX short identifier: ADIBSD
+###############################################################################
+
+source ../../../scripts/adi_env.tcl
+source $ad_hdl_dir/projects/scripts/adi_project_xilinx.tcl
+source $ad_hdl_dir/projects/scripts/adi_board.tcl
+
+# Parameter description
+# DEV_CONFIG - The device which will be used
+#  - Options : AD7606B(0)/C-16(1)/C-18(2)
+# SIMPLE_STATUS_CRC - ADC read mode Options
+# - Options : SIMPLE(0), STATUS(1), CRC(2), CRC_STATUS(3)
+# EXT_CLK - Use external clock as ADC clock
+#  - Options : No(0), Yes(1)
+
+set DEV_CONFIG [get_env_param DEV_CONFIG 0]
+set SIMPLE_STATUS_CRC [get_env_param SIMPLE_STATUS_CRC 0]
+set EXT_CLK [get_env_param EXT_CLK 0]
+
+adi_project ad7606x_fmc_zcu102 0 [list \
+  DEV_CONFIG $DEV_CONFIG \
+  SIMPLE_STATUS_CRC $SIMPLE_STATUS_CRC \
+  EXT_CLK $EXT_CLK \
+]
+
+adi_project_files ad7606x_fmc_zcu102 [list \
+  "$ad_hdl_dir/library/common/ad_iobuf.v" \
+  "$ad_hdl_dir/projects/common/zcu102/zcu102_system_constr.xdc" \
+  "system_top.v" \
+  "system_constr.xdc"]
+
+adi_project_run ad7606x_fmc_zcu102

--- a/projects/ad7606x_fmc/zcu102/system_top.v
+++ b/projects/ad7606x_fmc/zcu102/system_top.v
@@ -1,0 +1,114 @@
+// ***************************************************************************
+// ***************************************************************************
+// Copyright (C) 2023 Analog Devices, Inc. All rights reserved.
+//
+// In this HDL repository, there are many different and unique modules, consisting
+// of various HDL (Verilog or VHDL) components. The individual modules are
+// developed independently, and may be accompanied by separate and unique license
+// terms.
+//
+// The user should read each of these license terms, and understand the
+// freedoms and responsibilities that he or she has by using this source/core.
+//
+// This core is distributed in the hope that it will be useful, but WITHOUT ANY
+// WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+// A PARTICULAR PURPOSE.
+//
+// Redistribution and use of source or resulting binaries, with or without modification
+// of this file, are permitted under one of the following two license terms:
+//
+//   1. The GNU General Public License version 2 as published by the
+//      Free Software Foundation, which can be found in the top level directory
+//      of this repository (LICENSE_GPL2), and also online at:
+//      <https://www.gnu.org/licenses/old-licenses/gpl-2.0.html>
+//
+// OR
+//
+//   2. An ADI specific BSD license, which can be found in the top level directory
+//      of this repository (LICENSE_ADIBSD), and also on-line at:
+//      https://github.com/analogdevicesinc/hdl/blob/main/LICENSE_ADIBSD
+//      This will allow to generate bit files and not release the source code,
+//      as long as it attaches to an ADI device.
+//
+// ***************************************************************************
+// ***************************************************************************
+
+`timescale 1ns/100ps
+
+module system_top (
+  adc_db,
+  adc_rd_n,
+  adc_wr_n,
+  adc_busy,
+  adc_cnvst_n,
+  adc_cs_n,
+  adc_first_data,
+  adc_reset,
+  adc_os,
+  adc_stby,
+  adc_range,
+  adc_refsel,
+  adc_serpar
+);
+
+  inout       [15:0]      adc_db;
+  output                  adc_rd_n;
+  output                  adc_wr_n;
+
+  input                   adc_busy;
+  output                  adc_cnvst_n;
+  output                  adc_cs_n;
+  input                   adc_first_data;
+  output                  adc_reset;
+  output      [2:0]       adc_os;
+  output                  adc_stby;
+  output                  adc_range;
+  output                  adc_refsel;
+  output                  adc_serpar;
+
+  // internal signals
+
+  wire    [94:0]  gpio_i;
+  wire    [94:0]  gpio_o;
+  wire    [94:0]  gpio_t;
+
+  wire            adc_db_t;
+  wire    [15:0]  adc_db_o;
+  wire    [15:0]  adc_db_i;
+
+  genvar i;
+
+  // instantiations
+
+  assign adc_serpar = gpio_o[39];
+  assign adc_refsel = gpio_o[38];
+  assign adc_reset = gpio_o[37];
+  assign adc_stby = gpio_o[36];
+  assign adc_range = gpio_o[35];
+  assign adc_os = gpio_o[34:32];
+
+  generate
+    for (i = 0; i < 16; i = i + 1) begin: adc_db_io
+      ad_iobuf i_iobuf_adc_db (
+        .dio_t(adc_db_t),
+        .dio_i(adc_db_o[i]),
+        .dio_o(adc_db_i[i]),
+        .dio_p(adc_db[i]));
+    end
+  endgenerate
+
+  system_wrapper i_system_wrapper (
+    .gpio_i (gpio_i),
+    .gpio_o (gpio_o),
+    .gpio_t (gpio_t),
+    .rx_busy (adc_busy),
+    .rx_cnvst_n (adc_cnvst_n),
+    .rx_cs_n (adc_cs_n),
+    .rx_db_i (adc_db_i),
+    .rx_db_o (adc_db_o),
+    .rx_db_t (adc_db_t),
+    .rx_first_data (adc_first_data),
+    .rx_rd_n (adc_rd_n),
+    .rx_wr_n (adc_wr_n));
+
+endmodule


### PR DESCRIPTION
## PR Description
This commit introduces comprehensive support for the AD7606C-16 FMC based daughter card when used with the Xilinx ZCU102 carrier board. Enhancements include the integration of a Verilog model for accurate simulation and interfacing, updates to the Makefile for streamlined compilation and deployment, and new TCL scripts for improved automation and configuration processes. These changes enable seamless integration and utilization of the AD7606C-16 FMC daughter card with the ZCU102, facilitating advanced data acquisition and processing capabilities for embedded projects.


## PR Type
- [ ] Bug fix (change that fixes an issue)
- [x] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the code style guidelines
- [x] I have performed a self-review of changes
- [x] I have compiled all hdl projects and libraries affected by this PR
- [x] I have tested in hardware affected projects, at least on relevant boards
- [x] I have commented my code, at least hard-to-understand parts
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe files, Copyright etc)
- [ ] I have not introduced new Warnings/Critical Warnings on compilation
- [ ] I have added new hdl testbenches or updated existing ones
