### PR TITLE
SPI Engine: create inverted CS mode

### DIFF
--- a/docs/library/spi_engine/instruction-format.rst
+++ b/docs/library/spi_engine/instruction-format.rst
@@ -67,7 +67,8 @@ The physical outputs on each pin may be inverted relative to the command
 according to the mask set by :ref:`spi_engine cs-invert-mask-instruction`. The
 Invert Mask acts only on the output registers of the Chip-Select pins. Thus, if
 the last 8 bits of the Chip-Select instruction are 0xFE, only CS[0] will be
-active regardless of polarity, and transparently to the programmer.
+active regardless of polarity. The polarity inversion process (if needed) is
+transparent to the programmer.
 
 Before and after the update is performed the execution module is paused for the
 specified delay. The length of the delay depends on the module clock frequency,
@@ -197,12 +198,12 @@ CS Invert Mask Instruction
 The CS Invert Mask Instructions allows the user to select on a per-pin basis
 whether the Chip Select will be active-low (default) or active-high (inverted).
 Note that the Chip-Select instructions should remain the same because the value
-of CS is inverted at the output register, and additional logic (eg. reset
+of CS is inverted at the output register, and additional logic (e.g. reset
 counters) occurs when the CS active state is asserted. 
 
 Since the physical values on the pins are inverted at the output, the current
-Invert Mask should not affect the use of the :ref:`spi_engine cs-instruction`.
-As an example, a Chip-Select Instruction with the 's' field equal to 0xFE will
+Invert Mask does not affect the use of the :ref:`spi_engine cs-instruction`. As
+an example, a Chip-Select Instruction with the 's' field equal to 0xFE will
 always result in only CS[0] being active. For an Invert Mask of 0xFF, this would
 result on only CS[0] being high. For an Invert Mask of 0x00, this would result
 on only CS[0] being low. For an Invert Mask of 0x01, this would result on all CS

--- a/docs/library/spi_engine/instruction-format.rst
+++ b/docs/library/spi_engine/instruction-format.rst
@@ -61,10 +61,9 @@ The chip-select instruction updates the value chip-select output signal of the
 SPI Engine execution module.
 
 If the cs_active_high bit of the :ref:`spi_engine spi-configuration-register` 
-is set to 1, the actual values on the pins will be the opposite of the values 
-on each of the bits for the instruction. Thus, if the last 8 bits of this 
-instruction are 0xFE, CS[0] will be active regardless of polarity, and 
-transparently to the programmer.
+is set to 1, the actual values on each pin will be inverted relative to the 
+command. Thus, if the last 8 bits of this instruction are 0xFE, CS[0] will be 
+active regardless of polarity, and transparently to the programmer.
 
 Before and after the update is performed the execution module is paused for the
 specified delay. The length of the delay depends on the module clock frequency,
@@ -209,8 +208,8 @@ bus behavior.
    * - [3]
      - cs_active_high
      - Configures the polarity of CS. When 0 (default), CS is active-low as 
-       usual. If set to 1, CS will be active-high. Note that there's no need 
-       to change the command instructions because the value of CS is inverted 
+       usual. If set to 1, CS will be active-high. Note that the command 
+       instructions should remain the same because the value of CS is inverted 
        at the output register and additional logic (eg. reset counters) occurs 
        when the CS active state is asserted. 
        This was introduced in version 1.02.00 of the core, setting this bit on 

--- a/docs/library/spi_engine/instruction-format.rst
+++ b/docs/library/spi_engine/instruction-format.rst
@@ -4,7 +4,7 @@ SPI Engine Instruction Set Specification
 ================================================================================
 
 The SPI Engine instruction set is a simple 16-bit instruction set of which
-13-bit is currently allocated (bits 15,11,10 are always 0).
+13-bits are currently allocated (bits 15,11,10 are always 0).
 
 Instructions
 --------------------------------------------------------------------------------
@@ -48,6 +48,9 @@ accepted/becomes available.
      - Length
      - n + 1 number of words that will be transferred.
 
+
+.. _spi_engine cs-instruction:
+
 Chip-Select Instruction
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -60,11 +63,11 @@ Chip-Select Instruction
 The chip-select instruction updates the value chip-select output signal of the
 SPI Engine execution module.
 
-The actual values on each pin might be inverted relative to the command
+The physical outputs on each pin may be inverted relative to the command
 according to the mask set by :ref:`spi_engine cs-invert-mask-instruction`. The
 Invert Mask acts only on the output registers of the Chip-Select pins. Thus, if
-the last 8 bits of this instruction are 0xFE, CS[0] will be active regardless of
-polarity, and transparently to the programmer.
+the last 8 bits of the Chip-Select instruction are 0xFE, only CS[0] will be
+active regardless of polarity, and transparently to the programmer.
 
 Before and after the update is performed the execution module is paused for the
 specified delay. The length of the delay depends on the module clock frequency,
@@ -195,7 +198,18 @@ The CS Invert Mask Instructions allows the user to select on a per-pin basis
 whether the Chip Select will be active-low (default) or active-high (inverted).
 Note that the Chip-Select instructions should remain the same because the value
 of CS is inverted at the output register, and additional logic (eg. reset
-counters) occurs when the CS active state is asserted. This was introduced in
+counters) occurs when the CS active state is asserted. 
+
+Since the physical values on the pins are inverted at the output, the current
+Invert Mask should not affect the use of the :ref:`spi_engine cs-instruction`.
+As an example, a Chip-Select Instruction with the 's' field equal to 0xFE will
+always result in only CS[0] being active. For an Invert Mask of 0xFF, this would
+result on only CS[0] being high. For an Invert Mask of 0x00, this would result
+on only CS[0] being low. For an Invert Mask of 0x01, this would result on all CS
+pins being high, but only CS[0] is active in this case (since it's the only one
+currently treated as active-high).
+
+This was introduced in
 version 1.02.00 of the core.
 
 .. list-table::

--- a/docs/library/spi_engine/instruction-format.rst
+++ b/docs/library/spi_engine/instruction-format.rst
@@ -209,11 +209,12 @@ bus behavior.
    * - [3]
      - cs_active_high
      - Configures the polarity of CS. When 0 (default), CS is active-low as 
-     - usual. If set to 1, CS will be active-high. Note that there's no need 
-     - to change the commands: for cs_active_high=1, the value of CS will be 
-     - automatically inverted with respect to the command. This was introduced
-     - in version 1.02.71 of the core, setting this bit on earlier versions has
-     - no effect.
+       usual. If set to 1, CS will be active-high. Note that there's no need 
+       to change the command instructions because the value of CS is inverted 
+       at the output register and additional logic (eg. reset counters) occurs 
+       when the CS active state is asserted. 
+       This was introduced in version 1.02.00 of the core, setting this bit on 
+       earlier versions has no effect.
    * - [2]
      - three_wire
      - Configures the output of the three_wire pin.

--- a/docs/library/spi_engine/instruction-format.rst
+++ b/docs/library/spi_engine/instruction-format.rst
@@ -60,6 +60,12 @@ Chip-select Instruction
 The chip-select instruction updates the value chip-select output signal of the
 SPI Engine execution module.
 
+If the cs_active_high bit of the :ref:`spi_engine spi-configuration-register` 
+is set to 1, the actual values on the pins will be the opposite of the values 
+on each of the bits for the instruction. Thus, if the last 8 bits of this 
+instruction are 0xFE, CS[0] will be active regardless of polarity, and 
+transparently to the programmer.
+
 Before and after the update is performed the execution module is paused for the
 specified delay. The length of the delay depends on the module clock frequency,
 the setting of the prescaler register and the parameter :math:`t` of the
@@ -197,9 +203,15 @@ bus behavior.
    * - Bits
      - Name
      - Description
-   * - [7:3]
+   * - [7:4]
      - reserved
      - Must always be 0.
+   * - [3]
+     - cs_active_high
+     - Configures the polarity of CS. When 0 (default), CS is active-low as 
+     - usual. If set to 1, CS will be active-high. Note that there's no need 
+     - to change the commands: for cs_active_high=1, the value of CS will be 
+     - automatically inverted with respect to the command.
    * - [2]
      - three_wire
      - Configures the output of the three_wire pin.

--- a/docs/library/spi_engine/instruction-format.rst
+++ b/docs/library/spi_engine/instruction-format.rst
@@ -4,7 +4,7 @@ SPI Engine Instruction Set Specification
 ================================================================================
 
 The SPI Engine instruction set is a simple 16-bit instruction set of which
-12-bit is currently allocated (bits 15,14,11,10 are always 0).
+13-bit is currently allocated (bits 15,11,10 are always 0).
 
 Instructions
 --------------------------------------------------------------------------------
@@ -48,7 +48,7 @@ accepted/becomes available.
      - Length
      - n + 1 number of words that will be transferred.
 
-Chip-select Instruction
+Chip-Select Instruction
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 == == == == == == = = = = = = = = = =
@@ -60,10 +60,11 @@ Chip-select Instruction
 The chip-select instruction updates the value chip-select output signal of the
 SPI Engine execution module.
 
-If the cs_active_high bit of the :ref:`spi_engine spi-configuration-register` 
-is set to 1, the actual values on each pin will be inverted relative to the 
-command. Thus, if the last 8 bits of this instruction are 0xFE, CS[0] will be 
-active regardless of polarity, and transparently to the programmer.
+The actual values on each pin might be inverted relative to the command
+according to the mask set by :ref:`spi_engine cs-invert-mask-instruction`. The
+Invert Mask acts only on the output registers of the Chip-Select pins. Thus, if
+the last 8 bits of this instruction are 0xFE, CS[0] will be active regardless of
+polarity, and transparently to the programmer.
 
 Before and after the update is performed the execution module is paused for the
 specified delay. The length of the delay depends on the module clock frequency,
@@ -103,7 +104,7 @@ Configuration Write Instruction
 == == == == == == = = = = = = = = = =
 
 The configuration writes instruction updates a
-:ref:`spi_engine configutarion-registers`
+:ref:`spi_engine configuration-registers`
 of the SPI Engine execution module with a new value.
 
 .. list-table::
@@ -179,7 +180,40 @@ is the minimum, needed by the internal logic.
      - Time
      - The amount of time to wait.
 
-.. _spi_engine configutarion-registers:
+.. _spi_engine cs-invert-mask-instruction:
+
+CS Invert Mask Instruction
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+== == == == == == = = = = = = = = = =
+15 14 13 12 11 10 9 8 7 6 5 4 3 2 1 0
+== == == == == == = = = = = = = = = =
+0  1  0  0  r  r  r r m m m m m m m m
+== == == == == == = = = = = = = = = =
+
+The CS Invert Mask Instructions allows the user to select on a per-pin basis
+whether the Chip Select will be active-low (default) or active-high (inverted).
+Note that the Chip-Select instructions should remain the same because the value
+of CS is inverted at the output register, and additional logic (eg. reset
+counters) occurs when the CS active state is asserted. This was introduced in
+version 1.02.00 of the core.
+
+.. list-table::
+   :widths: 10 15 75
+   :header-rows: 1
+
+   * - Bits
+     - Name
+     - Description
+   * - r
+     - reserved
+     - Reserved for future use. Must always be set to 0.
+   * - m
+     - Mask 
+     - Mask for selecting inverted CS channels. For the bits set to 1, the
+       corresponding channel will be inverted at the output. 
+
+.. _spi_engine configuration-registers:
 
 Configuration Registers
 --------------------------------------------------------------------------------
@@ -202,18 +236,9 @@ bus behavior.
    * - Bits
      - Name
      - Description
-   * - [7:4]
+   * - [7:3]
      - reserved
      - Must always be 0.
-   * - [3]
-     - cs_active_high
-     - Configures the polarity of CS. When 0 (default), CS is active-low as 
-       usual. If set to 1, CS will be active-high. Note that the command 
-       instructions should remain the same because the value of CS is inverted 
-       at the output register and additional logic (eg. reset counters) occurs 
-       when the CS active state is asserted. 
-       This was introduced in version 1.02.00 of the core, setting this bit on 
-       earlier versions has no effect.
    * - [2]
      - three_wire
      - Configures the output of the three_wire pin.

--- a/docs/library/spi_engine/instruction-format.rst
+++ b/docs/library/spi_engine/instruction-format.rst
@@ -211,7 +211,9 @@ bus behavior.
      - Configures the polarity of CS. When 0 (default), CS is active-low as 
      - usual. If set to 1, CS will be active-high. Note that there's no need 
      - to change the commands: for cs_active_high=1, the value of CS will be 
-     - automatically inverted with respect to the command.
+     - automatically inverted with respect to the command. This was introduced
+     - in version 1.02.71 of the core, setting this bit on earlier versions has
+     - no effect.
    * - [2]
      - three_wire
      - Configures the output of the three_wire pin.

--- a/docs/regmap/adi_regmap_spi_engine.txt
+++ b/docs/regmap/adi_regmap_spi_engine.txt
@@ -13,19 +13,19 @@ Version of the peripheral. Follows semantic versioning. Current version 1.02.00.
 ENDREG
 
 FIELD
-[31:16] 0x01
+[31:16] 0x00000001
 VERSION_MAJOR
 RO
 ENDFIELD
 
 FIELD
-[15:8] 0x02
+[15:8] 0x00000002
 VERSION_MINOR
 RO
 ENDFIELD
 
 FIELD
-[7:0] 0x0
+[7:0] 0x00000000
 VERSION_PATCH
 RO
 ENDFIELD

--- a/docs/regmap/adi_regmap_spi_engine.txt
+++ b/docs/regmap/adi_regmap_spi_engine.txt
@@ -9,7 +9,7 @@ ENDTITLE
 REG
 0x00
 VERSION
-Version of the peripheral. Follows semantic versioning. Current version 1.00.71.
+Version of the peripheral. Follows semantic versioning. Current version 1.02.00.
 ENDREG
 
 FIELD
@@ -19,13 +19,13 @@ RO
 ENDFIELD
 
 FIELD
-[15:8] 0x01
+[15:8] 0x02
 VERSION_MINOR
 RO
 ENDFIELD
 
 FIELD
-[7:0] 0x71
+[7:0] 0x0
 VERSION_PATCH
 RO
 ENDFIELD

--- a/library/spi_engine/axi_spi_engine/axi_spi_engine.v
+++ b/library/spi_engine/axi_spi_engine/axi_spi_engine.v
@@ -133,7 +133,7 @@ module axi_spi_engine #(
   input [7:0] offload_sync_data
 );
 
-  localparam PCORE_VERSION = 'h010271;
+  localparam PCORE_VERSION = 'h010200;
   localparam S_AXI = 0;
   localparam UP_FIFO = 1;
 

--- a/library/spi_engine/axi_spi_engine/axi_spi_engine.v
+++ b/library/spi_engine/axi_spi_engine/axi_spi_engine.v
@@ -133,7 +133,7 @@ module axi_spi_engine #(
   input [7:0] offload_sync_data
 );
 
-  localparam PCORE_VERSION = 'h010171;
+  localparam PCORE_VERSION = 'h010271;
   localparam S_AXI = 0;
   localparam UP_FIFO = 1;
 

--- a/library/spi_engine/spi_engine_execution/spi_engine_execution.v
+++ b/library/spi_engine/spi_engine_execution/spi_engine_execution.v
@@ -207,7 +207,7 @@ module spi_engine_execution #(
       cpha <= DEFAULT_SPI_CFG[0];
       cpol <= DEFAULT_SPI_CFG[1];
       three_wire <= DEFAULT_SPI_CFG[2];
-      cs_active_high   <=  DEFAULT_SPI_CFG[3];
+      cs_active_high <=  DEFAULT_SPI_CFG[3];
       clk_div <= DEFAULT_CLK_DIV;
       word_length <= DATA_WIDTH;
       left_aligned <= 8'b0;

--- a/library/spi_engine/spi_engine_execution/spi_engine_execution.v
+++ b/library/spi_engine/spi_engine_execution/spi_engine_execution.v
@@ -133,6 +133,7 @@ module spi_engine_execution #(
   reg cpha = DEFAULT_SPI_CFG[0];
   reg cpol = DEFAULT_SPI_CFG[1];
   reg [7:0] clk_div = DEFAULT_CLK_DIV;
+  reg cs_active_high = DEFAULT_SPI_CFG[3];
 
   reg sdo_enabled = 1'b0;
   reg sdi_enabled = 1'b0;
@@ -206,6 +207,7 @@ module spi_engine_execution #(
       cpha <= DEFAULT_SPI_CFG[0];
       cpol <= DEFAULT_SPI_CFG[1];
       three_wire <= DEFAULT_SPI_CFG[2];
+      cs_active_high   <=  DEFAULT_SPI_CFG[3];
       clk_div <= DEFAULT_CLK_DIV;
       word_length <= DATA_WIDTH;
       left_aligned <= 8'b0;
@@ -214,6 +216,7 @@ module spi_engine_execution #(
         cpha <= cmd[0];
         cpol <= cmd[1];
         three_wire <= cmd[2];
+        cs_active_high <= cmd[3];
       end else if (cmd[9:8] == REG_CLK_DIV) begin
         clk_div <= cmd[7:0];
       end else if (cmd[9:8] == REG_WORD_LENGTH) begin
@@ -310,7 +313,7 @@ module spi_engine_execution #(
     if (resetn == 1'b0) begin
       cs <= 'hff;
     end else if (cs_gen) begin
-      cs <= cmd_d1[NUM_OF_CS-1:0];
+      cs <= (cs_active_high) ? ~cmd_d1[NUM_OF_CS-1:0] : cmd_d1[NUM_OF_CS-1:0];
     end
   end
 

--- a/library/spi_engine/spi_engine_execution/spi_engine_execution.v
+++ b/library/spi_engine/spi_engine_execution/spi_engine_execution.v
@@ -1,6 +1,6 @@
 // ***************************************************************************
 // ***************************************************************************
-// Copyright (C) 2015-2023 Analog Devices, Inc. All rights reserved.
+// Copyright (C) 2015-2024 Analog Devices, Inc. All rights reserved.
 //
 // In this HDL repository, there are many different and unique modules, consisting
 // of various HDL (Verilog or VHDL) components. The individual modules are


### PR DESCRIPTION
Add a cs_active_high bit to the Configuration Register, which corresponds to the SPI_CS_HIGH linux flag. This bit inverts any CS values at the pin, so the internal logic remains the same. 
Thus when this bit is set, all behaviour that would happen on a negative edge of the CS pin (internal buffer clears) ends up happening on the positive edge.
This way the CS polarity is transparent to software (eg. setting cs to 0xFE is always enabling CS[0], setting it high if cs_active_high is set, or low otherwise). 

A separate test configuration for this setup is found below:
https://github.com/analogdevicesinc/testbenches/pull/89

## PR Type
- [ ] Bug fix (change that fixes an issue)
- [x] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the code style guidelines
- [x] I have performed a self-review of changes
- [ ] I have compiled all hdl projects and libraries affected by this PR
- [ ] I have tested in hardware affected projects, at least on relevant boards
- [ ] I have commented my code, at least hard-to-understand parts
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe files, Copyright etc)
- [x] I have not introduced new Warnings/Critical Warnings on compilation
- [x] I have added new hdl testbenches or updated existing ones
