### PR TITLE
Tell flock to use sh

### DIFF
--- a/projects/scripts/project-xilinx.mk
+++ b/projects/scripts/project-xilinx.mk
@@ -118,7 +118,7 @@ $(PROJECT_NAME).sdk/system_top.xsa: $(M_DEPS)
 $(HDL_LIBRARY_PATH)%/component.xml: TARGET:=xilinx
 FORCE:
 $(HDL_LIBRARY_PATH)%/component.xml: FORCE
-	flock $(dir $@).lock -c " \
+	flock $(dir $@).lock sh -c " \
 	if [ -n \"${REQUIRED_VIVADO_VERSION}\" ]; then \
 		$(MAKE) -C $(dir $@) $(TARGET) REQUIRED_VIVADO_VERSION=${REQUIRED_VIVADO_VERSION}; \
 	else \


### PR DESCRIPTION
## PR Description

With the new `make -jX` support, flock is used but shells out sometimes. This assumes a bash like shell which isn't always the case. This fix forces flock to use sh.

PR to trigger the CI

## PR Type
- [X] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the code style guidelines
- [x] I have performed a self-review of changes
- [x] I have compiled all hdl projects and libraries affected by this PR
- [x] I have tested in hardware affected projects, at least on relevant boards
- [x] I have commented my code, at least hard-to-understand parts
- [x] I have signed off all commits from this PR
- [x] I have updated the documentation (wiki pages, ReadMe files, Copyright etc)
- [x] I have not introduced new Warnings/Critical Warnings on compilation
- [x] I have added new hdl testbenches or updated existing ones
