### PR TITLE
Cache Coherency support for Jupiter SDR

### DIFF
--- a/docs/library/axi_dmac/index.rst
+++ b/docs/library/axi_dmac/index.rst
@@ -670,6 +670,25 @@ flag signal. For the AXI-Streaming interface the synchronization flag is carried
 in ``s_axis_user[0]``. In both cases the synchronization flag is qualified by
 the same control signal as the data.
 
+Cache Coherency
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+To enable Cache Coherency between the DMA and the CPU, the ``CACHE_COHERENT``
+HDL synthesis configuration parameter must be set.
+
+Two additional parameters are used to configure the Cache Coherent transactions:
+
+-  ``AXI_AXCACHE`` sets the ARCACHE/AWCACHE AXI cache support signals;
+-  ``AXI_AXPROT`` sets the ARPROT/AWPROT AXI access permission signals.
+
+They are initially set to the following default values through ``CACHE_COHERENT``:
+
+-  ``AXI_AXCACHE`` = ``CACHE_COHERENT`` ? ``4'b1111`` : ``4'b0011``
+-  ``AXI_AXPROT`` = ``CACHE_COHERENT`` ? ``3'b010``  : ``3'b000``
+
+If Cache Coherency is enabled, the ``AXI_AXCACHE`` and ``AXI_AXPROT`` values can
+be changed to support systems with different caching policies.
+
 Diagnostics interface
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/docs/regmap/adi_regmap_dmac.txt
+++ b/docs/regmap/adi_regmap_dmac.txt
@@ -9,7 +9,7 @@ ENDTITLE
 REG
 0x000
 VERSION
-Version of the peripheral. Follows semantic versioning. Current version 4.05.61.
+Version of the peripheral. Follows semantic versioning. Current version 4.05.62.
 ENDREG
 
 FIELD
@@ -25,7 +25,7 @@ RO
 ENDFIELD
 
 FIELD
-[7:0] 0x61
+[7:0] 0x62
 VERSION_PATCH
 RO
 ENDFIELD
@@ -80,7 +80,7 @@ ENDFIELD
 
 REG
 0x004
-INTERFACE_DESCRIPTION
+INTERFACE_DESCRIPTION_1
 ENDREG
 
 FIELD
@@ -118,6 +118,35 @@ R
 Value of ''BYTES_PER_BURST_WIDTH'' interface parameter. Log2 of the real ''MAX_BYTES_PER_BURST''.
 The starting address of the transfer must be aligned with ''MAX_BYTES_PER_BURST'' to avoid crossing
 the 4kB address boundary.
+ENDFIELD
+
+############################################################################################
+############################################################################################
+
+REG
+0x005
+INTERFACE_DESCRIPTION_2
+ENDREG
+
+FIELD
+[0] ''CACHE_COHERENT''
+CACHE_COHERENT
+R
+Value of ''CACHE_COHERENT'' parameter.(0 - Disabled, 1 -  Enabled )
+ENDFIELD
+
+FIELD
+[7:4] ''AXI_AXCACHE''
+AXI_AXCACHE
+R
+Value of ''AXI_AXCACHE'' parameter.
+ENDFIELD
+
+FIELD
+[10:8] ''AXI_AXPROT''
+AXI_AXPROT
+R
+Value of ''AXI_AXPROT'' parameter.
 ENDFIELD
 
 ############################################################################################

--- a/library/axi_dmac/address_generator.v
+++ b/library/axi_dmac/address_generator.v
@@ -1,6 +1,6 @@
 // ***************************************************************************
 // ***************************************************************************
-// Copyright (C) 2014-2023 Analog Devices, Inc. All rights reserved.
+// Copyright (C) 2014-2024 Analog Devices, Inc. All rights reserved.
 //
 // In this HDL repository, there are many different and unique modules, consisting
 // of various HDL (Verilog or VHDL) components. The individual modules are
@@ -43,7 +43,8 @@ module address_generator #(
   parameter BEATS_PER_BURST_WIDTH = 4,
   parameter BYTES_PER_BEAT_WIDTH = $clog2(DMA_DATA_WIDTH/8),
   parameter LENGTH_WIDTH = 8,
-  parameter CACHE_COHERENT = 0
+  parameter [3:0] AXI_AXCACHE = 4'b0011,
+  parameter [2:0] AXI_AXPROT = 3'b000
 ) (
   input                        clk,
   input                        resetn,
@@ -80,10 +81,8 @@ module address_generator #(
 `include "inc_id.vh"
 
   assign burst = 2'b01;
-  assign prot = 3'b000;
-  // If CACHE_COHERENT is set, signal downstream that this transaction must be
-  // looked up in cache. Otherwise default to "normal non-cachable bufferable".
-  assign cache = CACHE_COHERENT ? 4'b1110 : 4'b0011;
+  assign prot = AXI_AXPROT;
+  assign cache = AXI_AXCACHE;
   assign size = DMA_DATA_WIDTH == 1024 ? 3'b111 :
                 DMA_DATA_WIDTH ==  512 ? 3'b110 :
                 DMA_DATA_WIDTH ==  256 ? 3'b101 :

--- a/library/axi_dmac/axi_dmac.v
+++ b/library/axi_dmac/axi_dmac.v
@@ -1,6 +1,6 @@
 // ***************************************************************************
 // ***************************************************************************
-// Copyright (C) 2014-2023 Analog Devices, Inc. All rights reserved.
+// Copyright (C) 2014-2024 Analog Devices, Inc. All rights reserved.
 //
 // In this HDL repository, there are many different and unique modules, consisting
 // of various HDL (Verilog or VHDL) components. The individual modules are
@@ -70,7 +70,9 @@ module axi_dmac #(
   parameter DISABLE_DEBUG_REGISTERS = 0,
   parameter ENABLE_DIAGNOSTICS_IF = 0,
   parameter ALLOW_ASYM_MEM = 0,
-  parameter CACHE_COHERENT_DEST = 0
+  parameter CACHE_COHERENT = 0,
+  parameter [3:0] AXI_AXCACHE = 4'b0011,
+  parameter [2:0] AXI_AXPROT = 3'b000
 ) (
 
   // Slave AXI interface
@@ -447,7 +449,9 @@ module axi_dmac #(
     .DMA_2D_TRANSFER(DMA_2D_TRANSFER),
     .DMA_SG_TRANSFER(DMA_SG_TRANSFER),
     .SYNC_TRANSFER_START(SYNC_TRANSFER_START),
-    .CACHE_COHERENT_DEST(CACHE_COHERENT_DEST)
+    .CACHE_COHERENT(CACHE_COHERENT),
+    .AXI_AXCACHE(AXI_AXCACHE),
+    .AXI_AXPROT(AXI_AXPROT)
   ) i_regmap (
     .s_axi_aclk(s_axi_aclk),
     .s_axi_aresetn(s_axi_aresetn),
@@ -537,7 +541,8 @@ module axi_dmac #(
     .AXI_LENGTH_WIDTH_SG(8-(4*DMA_AXI_PROTOCOL_SG)),
     .ENABLE_DIAGNOSTICS_IF(ENABLE_DIAGNOSTICS_IF),
     .ALLOW_ASYM_MEM(ALLOW_ASYM_MEM),
-    .CACHE_COHERENT_DEST(CACHE_COHERENT_DEST)
+    .AXI_AXCACHE(AXI_AXCACHE),
+    .AXI_AXPROT(AXI_AXPROT)
   ) i_transfer (
     .ctrl_clk(s_axi_aclk),
     .ctrl_resetn(s_axi_aresetn),

--- a/library/axi_dmac/axi_dmac_ip.tcl
+++ b/library/axi_dmac/axi_dmac_ip.tcl
@@ -1,5 +1,5 @@
 ###############################################################################
-## Copyright (C) 2014-2023 Analog Devices, Inc. All rights reserved.
+## Copyright (C) 2014-2024 Analog Devices, Inc. All rights reserved.
 ### SPDX short identifier: ADIBSD
 ###############################################################################
 
@@ -274,14 +274,14 @@ foreach {k v} { \
         "ASYNC_CLK_SRC_SG" "true" \
         "ASYNC_CLK_DEST_SG" "true" \
         "CYCLIC" "false" \
-        "DMA_2D_TRANSFER" "false" \
         "DMA_SG_TRANSFER" "false" \
+        "DMA_2D_TRANSFER" "false" \
         "SYNC_TRANSFER_START" "false" \
         "AXI_SLICE_SRC" "false" \
         "AXI_SLICE_DEST" "false" \
         "DISABLE_DEBUG_REGISTERS" "false" \
         "ENABLE_DIAGNOSTICS_IF" "false" \
-        "CACHE_COHERENT_DEST" "false" \
+        "CACHE_COHERENT" "false" \
 	} { \
 	set_property -dict [list \
 			"value_format" "bool" \
@@ -369,18 +369,6 @@ set_property -dict [list \
 	"enablement_tcl_expr" "\$DMA_TYPE_SRC != 0" \
 ] [ipx::get_user_parameters SYNC_TRANSFER_START -of_objects $cc]
 
-set p [ipgui::get_guiparamspec -name "CACHE_COHERENT_DEST" -component $cc]
-ipgui::move_param -component $cc -order 4 $p -parent $dest_group
-set_property -dict [list \
-	"tooltip" "Assume destination port ensures cache coherency (e.g. Ultrascale HPC port)" \
-] $p
-set_property -dict [list \
-	"display_name" "Assume cache coherent" \
-	"enablement_tcl_expr" "\$DMA_TYPE_DEST == 0 && \$DMA_AXI_PROTOCOL_DEST == 0" \
-	"value_tcl_expr" "\$DMA_TYPE_DEST == 0 && \$DMA_AXI_PROTOCOL_DEST == 0" \
-	"enablement_value" "false" \
-] [ipx::get_user_parameters CACHE_COHERENT_DEST -of_objects $cc]
-
 set p [ipgui::get_guiparamspec -name "DMA_AXI_PROTOCOL_SG" -component $cc]
 ipgui::move_param -component $cc -order 0 $p -parent $sg_group
 set_property -dict [list \
@@ -441,6 +429,24 @@ set_property -dict [list \
 	"display_name" "DMA AXI Address Width" \
 ] $p
 
+set p [ipgui::get_guiparamspec -name "AXI_AXCACHE" -component $cc]
+ipgui::move_param -component $cc -order 5 $p -parent $general_group
+set_property -dict [list \
+        "display_name" "ARCACHE/AWCACHE" \
+] $p
+set_property -dict [list \
+        "enablement_tcl_expr" "\$CACHE_COHERENT == true" \
+] [ipx::get_user_parameters AXI_AXCACHE -of_objects $cc]
+
+set p [ipgui::get_guiparamspec -name "AXI_AXPROT" -component $cc]
+ipgui::move_param -component $cc -order 6 $p -parent $general_group
+set_property -dict [list \
+        "display_name" "ARPROT/AWPROT" \
+] $p
+set_property -dict [list \
+        "enablement_tcl_expr" "\$CACHE_COHERENT == true" \
+] [ipx::get_user_parameters AXI_AXPROT -of_objects $cc]
+
 set feature_group [ipgui::add_group -name "Features" -component $cc \
 		-parent $page0 -display_name "Features"]
 
@@ -450,17 +456,27 @@ set_property -dict [list \
 	"display_name" "Cyclic Transfer Support" \
 ] $p
 
-set p [ipgui::get_guiparamspec -name "DMA_2D_TRANSFER" -component $cc]
+set p [ipgui::get_guiparamspec -name "DMA_SG_TRANSFER" -component $cc]
 ipgui::move_param -component $cc -order 1 $p -parent $feature_group
+set_property -dict [list \
+	"display_name" "SG Transfer Support" \
+] $p
+
+set p [ipgui::get_guiparamspec -name "DMA_2D_TRANSFER" -component $cc]
+ipgui::move_param -component $cc -order 2 $p -parent $feature_group
 set_property -dict [list \
 	"display_name" "2D Transfer Support" \
 ] $p
 
-set p [ipgui::get_guiparamspec -name "DMA_SG_TRANSFER" -component $cc]
-ipgui::move_param -component $cc -order 2 $p -parent $feature_group
+set p [ipgui::get_guiparamspec -name "CACHE_COHERENT" -component $cc]
+ipgui::move_param -component $cc -order 3 $p -parent $feature_group
 set_property -dict [list \
-	"display_name" "SG Transfer Support" \
+	"tooltip" "Assume DMA ports ensure cache coherence (e.g. Ultrascale HPC port)" \
 ] $p
+set_property -dict [list \
+	"display_name" "Cache Coherent" \
+	"enablement_tcl_expr" "\$DMA_TYPE_SRC == 0 || \$DMA_TYPE_DEST == 0" \
+] [ipx::get_user_parameters CACHE_COHERENT -of_objects $cc]
 
 set clk_group [ipgui::add_group -name {Clock Domain Configuration} -component $cc \
 		-parent $page0 -display_name {Clock Domain Configuration}]

--- a/library/axi_dmac/axi_dmac_regmap.v
+++ b/library/axi_dmac/axi_dmac_regmap.v
@@ -1,6 +1,6 @@
 // ***************************************************************************
 // ***************************************************************************
-// Copyright (C) 2014-2023 Analog Devices, Inc. All rights reserved.
+// Copyright (C) 2014-2024 Analog Devices, Inc. All rights reserved.
 //
 // In this HDL repository, there are many different and unique modules, consisting
 // of various HDL (Verilog or VHDL) components. The individual modules are
@@ -53,7 +53,9 @@ module axi_dmac_regmap #(
   parameter DMA_2D_TRANSFER = 0,
   parameter DMA_SG_TRANSFER = 0,
   parameter SYNC_TRANSFER_START = 0,
-  parameter CACHE_COHERENT_DEST = 0
+  parameter CACHE_COHERENT = 0,
+  parameter [3:0] AXI_AXCACHE = 4'b0011,
+  parameter [2:0] AXI_AXPROT = 3'b000
 ) (
 
   // Slave AXI interface
@@ -121,7 +123,7 @@ module axi_dmac_regmap #(
   input [31:0] dbg_ids1
 );
 
-  localparam PCORE_VERSION = 'h00040561;
+  localparam PCORE_VERSION = 'h00040562;
   localparam HAS_ADDR_HIGH = DMA_AXI_ADDR_WIDTH > 32;
   localparam ADDR_LOW_MSB = HAS_ADDR_HIGH ? 31 : DMA_AXI_ADDR_WIDTH-1;
 
@@ -223,7 +225,10 @@ module axi_dmac_regmap #(
                            4'b0,BYTES_PER_BURST_WIDTH[3:0],
                            2'b0,DMA_TYPE_SRC[1:0],BYTES_PER_BEAT_WIDTH_SRC[3:0],
                            2'b0,DMA_TYPE_DEST[1:0],BYTES_PER_BEAT_WIDTH_DEST[3:0]};
-      9'h005: up_rdata <= {31'd0, CACHE_COHERENT_DEST};
+      9'h005: up_rdata <= {20'b0,
+                           1'b0,AXI_AXPROT,
+                           AXI_AXCACHE,
+                           3'b0,CACHE_COHERENT};
       9'h020: up_rdata <= up_irq_mask;
       9'h021: up_rdata <= up_irq_pending;
       9'h022: up_rdata <= up_irq_source;

--- a/library/axi_dmac/axi_dmac_transfer.v
+++ b/library/axi_dmac/axi_dmac_transfer.v
@@ -1,6 +1,6 @@
 // ***************************************************************************
 // ***************************************************************************
-// Copyright (C) 2014-2023 Analog Devices, Inc. All rights reserved.
+// Copyright (C) 2014-2024 Analog Devices, Inc. All rights reserved.
 //
 // In this HDL repository, there are many different and unique modules, consisting
 // of various HDL (Verilog or VHDL) components. The individual modules are
@@ -64,7 +64,8 @@ module axi_dmac_transfer #(
   parameter AXI_LENGTH_WIDTH_SG = 8,
   parameter ENABLE_DIAGNOSTICS_IF = 0,
   parameter ALLOW_ASYM_MEM = 0,
-  parameter CACHE_COHERENT_DEST = 0
+  parameter [3:0] AXI_AXCACHE = 4'b0011,
+  parameter [2:0] AXI_AXPROT = 3'b000
 ) (
   input ctrl_clk,
   input ctrl_resetn,
@@ -321,7 +322,9 @@ module axi_dmac_transfer #(
     .BYTES_PER_BEAT_WIDTH_DEST(BYTES_PER_BEAT_WIDTH_DEST),
     .BYTES_PER_BEAT_WIDTH_SRC(BYTES_PER_BEAT_WIDTH_SRC),
     .BYTES_PER_BEAT_WIDTH_SG(BYTES_PER_BEAT_WIDTH_SG),
-    .ASYNC_CLK_REQ_SG(ASYNC_CLK_REQ_SG)
+    .ASYNC_CLK_REQ_SG(ASYNC_CLK_REQ_SG),
+    .AXI_AXCACHE(AXI_AXCACHE),
+    .AXI_AXPROT(AXI_AXPROT)
   ) i_dmac_sg (
     .req_clk(req_clk),
     .req_resetn(req_resetn),
@@ -500,7 +503,8 @@ module axi_dmac_transfer #(
     .AXI_LENGTH_WIDTH_SRC (AXI_LENGTH_WIDTH_SRC),
     .ENABLE_DIAGNOSTICS_IF(ENABLE_DIAGNOSTICS_IF),
     .ALLOW_ASYM_MEM (ALLOW_ASYM_MEM),
-    .CACHE_COHERENT_DEST(CACHE_COHERENT_DEST)
+    .AXI_AXCACHE(AXI_AXCACHE),
+    .AXI_AXPROT(AXI_AXPROT)
   ) i_request_arb (
     .req_clk (req_clk),
     .req_resetn (req_resetn),

--- a/library/axi_dmac/bd/bd.tcl
+++ b/library/axi_dmac/bd/bd.tcl
@@ -1,5 +1,5 @@
 ###############################################################################
-## Copyright (C) 2015-2023 Analog Devices, Inc. All rights reserved.
+## Copyright (C) 2015-2024 Analog Devices, Inc. All rights reserved.
 ### SPDX short identifier: ADIBSD
 ###############################################################################
 
@@ -203,4 +203,11 @@ proc post_propagate {cellpath otherinfo} {
 	}
 
 	set_property "CONFIG.DMA_AXI_ADDR_WIDTH" $addr_width $ip
+
+	# AXCACHE/AXPROT configuration
+        set cache_coherent [get_property "CONFIG.CACHE_COHERENT" $ip]
+        set axcache [expr {$cache_coherent == true} ? 0b1111 : 0b0011]
+        set axprot [expr {$cache_coherent == true} ? 0b010 : 0b000]
+        set_property "CONFIG.AXI_AXCACHE" $axcache $ip
+        set_property "CONFIG.AXI_AXPROT" $axprot $ip
 }

--- a/library/axi_dmac/dest_axi_mm.v
+++ b/library/axi_dmac/dest_axi_mm.v
@@ -1,6 +1,6 @@
 // ***************************************************************************
 // ***************************************************************************
-// Copyright (C) 2014-2023 Analog Devices, Inc. All rights reserved.
+// Copyright (C) 2014-2024 Analog Devices, Inc. All rights reserved.
 //
 // In this HDL repository, there are many different and unique modules, consisting
 // of various HDL (Verilog or VHDL) components. The individual modules are
@@ -45,7 +45,8 @@ module dest_axi_mm #(
   parameter MAX_BYTES_PER_BURST = 128,
   parameter BYTES_PER_BURST_WIDTH = $clog2(MAX_BYTES_PER_BURST),
   parameter AXI_LENGTH_WIDTH = 8,
-  parameter CACHE_COHERENT = 0
+  parameter [3:0] AXI_AXCACHE = 4'b0011,
+  parameter [2:0] AXI_AXPROT = 3'b000
 ) (
   input                               m_axi_aclk,
   input                               m_axi_aresetn,
@@ -117,7 +118,8 @@ module dest_axi_mm #(
     .DMA_DATA_WIDTH(DMA_DATA_WIDTH),
     .LENGTH_WIDTH(AXI_LENGTH_WIDTH),
     .DMA_ADDR_WIDTH(DMA_ADDR_WIDTH),
-    .CACHE_COHERENT(CACHE_COHERENT)
+    .AXI_AXCACHE(AXI_AXCACHE),
+    .AXI_AXPROT(AXI_AXPROT)
   ) i_addr_gen (
     .clk(m_axi_aclk),
     .resetn(m_axi_aresetn),

--- a/library/axi_dmac/dmac_sg.v
+++ b/library/axi_dmac/dmac_sg.v
@@ -1,6 +1,6 @@
 // ***************************************************************************
 // ***************************************************************************
-// Copyright (C) 2023 Analog Devices, Inc. All rights reserved.
+// Copyright (C) 2023-2024 Analog Devices, Inc. All rights reserved.
 //
 // In this HDL repository, there are many different and unique modules, consisting
 // of various HDL (Verilog or VHDL) components. The individual modules are
@@ -43,7 +43,9 @@ module dmac_sg #(
   parameter BYTES_PER_BEAT_WIDTH_DEST = 3,
   parameter BYTES_PER_BEAT_WIDTH_SRC = 3,
   parameter BYTES_PER_BEAT_WIDTH_SG = 3,
-  parameter ASYNC_CLK_REQ_SG = 1
+  parameter ASYNC_CLK_REQ_SG = 1,
+  parameter [3:0] AXI_AXCACHE = 4'b0011,
+  parameter [2:0] AXI_AXPROT = 3'b000
 ) (
   input req_clk,
   input req_resetn,
@@ -147,8 +149,8 @@ module dmac_sg #(
 
   assign m_axi_arsize  = 3'h3;
   assign m_axi_arburst = 2'h1;
-  assign m_axi_arprot  = 3'h0;
-  assign m_axi_arcache = 4'h3;
+  assign m_axi_arprot  = AXI_AXPROT;
+  assign m_axi_arcache = AXI_AXCACHE;
   assign m_axi_arlen   = 'h5;
   assign m_axi_araddr  = {next_desc_addr, {BYTES_PER_BEAT_WIDTH_SG{1'b0}}};
 

--- a/library/axi_dmac/request_arb.v
+++ b/library/axi_dmac/request_arb.v
@@ -1,6 +1,6 @@
 // ***************************************************************************
 // ***************************************************************************
-// Copyright (C) 2014-2023 Analog Devices, Inc. All rights reserved.
+// Copyright (C) 2014-2024 Analog Devices, Inc. All rights reserved.
 //
 // In this HDL repository, there are many different and unique modules, consisting
 // of various HDL (Verilog or VHDL) components. The individual modules are
@@ -58,7 +58,8 @@ module request_arb #(
   parameter AXI_LENGTH_WIDTH_DEST = 8,
   parameter ENABLE_DIAGNOSTICS_IF = 0,
   parameter ALLOW_ASYM_MEM = 0,
-  parameter CACHE_COHERENT_DEST = 0
+  parameter [3:0] AXI_AXCACHE = 4'b0011,
+  parameter [2:0] AXI_AXPROT = 3'b000
 ) (
   input req_clk,
   input req_resetn,
@@ -357,7 +358,8 @@ module request_arb #(
     .MAX_BYTES_PER_BURST(MAX_BYTES_PER_BURST),
     .BYTES_PER_BURST_WIDTH(BYTES_PER_BURST_WIDTH),
     .AXI_LENGTH_WIDTH(AXI_LENGTH_WIDTH_DEST),
-    .CACHE_COHERENT(CACHE_COHERENT_DEST)
+    .AXI_AXCACHE(AXI_AXCACHE),
+    .AXI_AXPROT(AXI_AXPROT)
   ) i_dest_dma_mm (
     .m_axi_aclk(m_dest_axi_aclk),
     .m_axi_aresetn(dest_resetn),
@@ -619,7 +621,9 @@ module request_arb #(
     .DMA_ADDR_WIDTH(DMA_AXI_ADDR_WIDTH),
     .BEATS_PER_BURST_WIDTH(BEATS_PER_BURST_WIDTH_SRC),
     .BYTES_PER_BEAT_WIDTH(BYTES_PER_BEAT_WIDTH_SRC),
-    .AXI_LENGTH_WIDTH(AXI_LENGTH_WIDTH_SRC)
+    .AXI_LENGTH_WIDTH(AXI_LENGTH_WIDTH_SRC),
+    .AXI_AXCACHE(AXI_AXCACHE),
+    .AXI_AXPROT(AXI_AXPROT)
   ) i_src_dma_mm (
     .m_axi_aclk(m_src_axi_aclk),
     .m_axi_aresetn(src_resetn),

--- a/library/axi_dmac/src_axi_mm.v
+++ b/library/axi_dmac/src_axi_mm.v
@@ -1,6 +1,6 @@
 // ***************************************************************************
 // ***************************************************************************
-// Copyright (C) 2014-2023 Analog Devices, Inc. All rights reserved.
+// Copyright (C) 2014-2024 Analog Devices, Inc. All rights reserved.
 //
 // In this HDL repository, there are many different and unique modules, consisting
 // of various HDL (Verilog or VHDL) components. The individual modules are
@@ -42,7 +42,9 @@ module src_axi_mm #(
   parameter DMA_ADDR_WIDTH = 32,
   parameter BYTES_PER_BEAT_WIDTH = 3,
   parameter BEATS_PER_BURST_WIDTH = 4,
-  parameter AXI_LENGTH_WIDTH = 8
+  parameter AXI_LENGTH_WIDTH = 8,
+  parameter [3:0] AXI_AXCACHE = 4'b0011,
+  parameter [2:0] AXI_AXPROT = 3'b000
 ) (
   input                           m_axi_aclk,
   input                           m_axi_aresetn,
@@ -148,7 +150,9 @@ module src_axi_mm #(
     .BYTES_PER_BEAT_WIDTH(BYTES_PER_BEAT_WIDTH),
     .DMA_DATA_WIDTH(DMA_DATA_WIDTH),
     .LENGTH_WIDTH(AXI_LENGTH_WIDTH),
-    .DMA_ADDR_WIDTH(DMA_ADDR_WIDTH)
+    .DMA_ADDR_WIDTH(DMA_ADDR_WIDTH),
+    .AXI_AXCACHE(AXI_AXCACHE),
+    .AXI_AXPROT(AXI_AXPROT)
   ) i_addr_gen (
     .clk(m_axi_aclk),
     .resetn(m_axi_aresetn),

--- a/projects/jupiter_sdr/system_bd.tcl
+++ b/projects/jupiter_sdr/system_bd.tcl
@@ -1,5 +1,5 @@
 ###############################################################################
-## Copyright (C) 2021-2023 Analog Devices, Inc. All rights reserved.
+## Copyright (C) 2021-2024 Analog Devices, Inc. All rights reserved.
 ### SPDX short identifier: ADIBSD
 ################################################################################
 
@@ -322,6 +322,9 @@ ad_ip_parameter axi_adrv9001_rx1_dma CONFIG.AXI_SLICE_SRC 0
 ad_ip_parameter axi_adrv9001_rx1_dma CONFIG.AXI_SLICE_DEST 0
 ad_ip_parameter axi_adrv9001_rx1_dma CONFIG.DMA_2D_TRANSFER 0
 ad_ip_parameter axi_adrv9001_rx1_dma CONFIG.DMA_DATA_WIDTH_SRC 64
+ad_ip_parameter axi_adrv9001_rx1_dma CONFIG.CACHE_COHERENT 1
+ad_ip_parameter axi_adrv9001_rx1_dma CONFIG.AXI_AXCACHE 0b1111
+ad_ip_parameter axi_adrv9001_rx1_dma CONFIG.AXI_AXPROT 0b010
 
 ad_ip_instance util_cpack2 util_adc_1_pack { \
   NUM_OF_CHANNELS 4 \
@@ -339,6 +342,9 @@ ad_ip_parameter axi_adrv9001_rx2_dma CONFIG.AXI_SLICE_SRC 0
 ad_ip_parameter axi_adrv9001_rx2_dma CONFIG.AXI_SLICE_DEST 0
 ad_ip_parameter axi_adrv9001_rx2_dma CONFIG.DMA_2D_TRANSFER 0
 ad_ip_parameter axi_adrv9001_rx2_dma CONFIG.DMA_DATA_WIDTH_SRC 32
+ad_ip_parameter axi_adrv9001_rx2_dma CONFIG.CACHE_COHERENT 1
+ad_ip_parameter axi_adrv9001_rx2_dma CONFIG.AXI_AXCACHE 0b1111
+ad_ip_parameter axi_adrv9001_rx2_dma CONFIG.AXI_AXPROT 0b010
 
 ad_ip_instance util_cpack2 util_adc_2_pack { \
   NUM_OF_CHANNELS 2 \
@@ -356,6 +362,9 @@ ad_ip_parameter axi_adrv9001_tx1_dma CONFIG.AXI_SLICE_SRC 0
 ad_ip_parameter axi_adrv9001_tx1_dma CONFIG.AXI_SLICE_DEST 0
 ad_ip_parameter axi_adrv9001_tx1_dma CONFIG.DMA_2D_TRANSFER 0
 ad_ip_parameter axi_adrv9001_tx1_dma CONFIG.DMA_DATA_WIDTH_DEST 64
+ad_ip_parameter axi_adrv9001_tx1_dma CONFIG.CACHE_COHERENT 1
+ad_ip_parameter axi_adrv9001_tx1_dma CONFIG.AXI_AXCACHE 0b1111
+ad_ip_parameter axi_adrv9001_tx1_dma CONFIG.AXI_AXPROT 0b010
 
 ad_ip_instance util_upack2 util_dac_1_upack { \
   NUM_OF_CHANNELS 4 \
@@ -373,6 +382,9 @@ ad_ip_parameter axi_adrv9001_tx2_dma CONFIG.AXI_SLICE_SRC 0
 ad_ip_parameter axi_adrv9001_tx2_dma CONFIG.AXI_SLICE_DEST 0
 ad_ip_parameter axi_adrv9001_tx2_dma CONFIG.DMA_2D_TRANSFER 0
 ad_ip_parameter axi_adrv9001_tx2_dma CONFIG.DMA_DATA_WIDTH_DEST 32
+ad_ip_parameter axi_adrv9001_tx2_dma CONFIG.CACHE_COHERENT 1
+ad_ip_parameter axi_adrv9001_tx2_dma CONFIG.AXI_AXCACHE 0b1111
+ad_ip_parameter axi_adrv9001_tx2_dma CONFIG.AXI_AXPROT 0b010
 
 ad_ip_instance util_upack2 util_dac_2_upack { \
   NUM_OF_CHANNELS 2 \
@@ -600,11 +612,11 @@ ad_cpu_interconnect 0x44A60000  axi_adrv9001_tx2_dma
 ad_cpu_interconnect 0x45000000  axi_sysid_0
 ad_cpu_interconnect 0x44A70000  pl_sysmon
 
-ad_mem_hp1_interconnect $sys_dma_clk sys_ps7/S_AXI_HP1
-ad_mem_hp1_interconnect $sys_dma_clk axi_adrv9001_rx1_dma/m_dest_axi
-ad_mem_hp1_interconnect $sys_dma_clk axi_adrv9001_rx2_dma/m_dest_axi
-ad_mem_hp1_interconnect $sys_dma_clk axi_adrv9001_tx1_dma/m_src_axi
-ad_mem_hp1_interconnect $sys_dma_clk axi_adrv9001_tx2_dma/m_src_axi
+ad_mem_hpc0_interconnect $sys_dma_clk sys_ps7/S_AXI_HPC0
+ad_mem_hpc0_interconnect $sys_dma_clk axi_adrv9001_rx1_dma/m_dest_axi
+ad_mem_hpc0_interconnect $sys_dma_clk axi_adrv9001_rx2_dma/m_dest_axi
+ad_mem_hpc0_interconnect $sys_dma_clk axi_adrv9001_tx1_dma/m_src_axi
+ad_mem_hpc0_interconnect $sys_dma_clk axi_adrv9001_tx2_dma/m_src_axi
 
 ad_connect $sys_dma_resetn axi_adrv9001_rx1_dma/m_dest_axi_aresetn
 ad_connect $sys_dma_resetn axi_adrv9001_rx2_dma/m_dest_axi_aresetn


### PR DESCRIPTION
## PR Description

This PR adds Cache Coherency support for Jupiter SDR. The HPC (High Performance Coherent) interfaces are used in conjunction with the updated AXCACHE/AXPROT AXI signal values to enable cache coherency. 

The DMA was updated to support Cache Coherency for systems with different caching policies, by allowing the user to manually set the AXCACHE/AXPROT values to be different than the default (most commonly used) values when needed. Implemented to work for both Xilinx and Intel systems.

## PR Type
- [ ] Bug fix (change that fixes an issue)
- [x] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the code style guidelines
- [x] I have performed a self-review of changes
- [x] I have compiled all hdl projects and libraries affected by this PR
- [x] I have tested in hardware affected projects, at least on relevant boards
- [x] I have commented my code, at least hard-to-understand parts
- [x] I have signed off all commits from this PR
- [x] I have updated the documentation (wiki pages, ReadMe files, Copyright etc)
- [x] I have not introduced new Warnings/Critical Warnings on compilation
- [ ] I have added new hdl testbenches or updated existing ones
