### PR TITLE
Fix axi ad9963 tx2 1 smp delay

### DIFF
--- a/library/axi_ad9963/axi_ad9963_if.v
+++ b/library/axi_ad9963/axi_ad9963_if.v
@@ -1,6 +1,6 @@
 // ***************************************************************************
 // ***************************************************************************
-// Copyright (C) 2014-2023 Analog Devices, Inc. All rights reserved.
+// Copyright (C) 2014-2024 Analog Devices, Inc. All rights reserved.
 //
 // In this HDL repository, there are many different and unique modules, consisting
 // of various HDL (Verilog or VHDL) components. The individual modules are
@@ -228,8 +228,8 @@ module axi_ad9963_if #(
     .R (dac_rst),
     .S (1'b0),
     .C (dac_clk),
-    .D1 (tx_data_p[l_inst]),
-    .D2 (tx_data_n[l_inst]),
+    .D1 (tx_data_n[l_inst]),
+    .D2 (tx_data_p[l_inst]),
     .Q (tx_data[l_inst]));
     end
   endgenerate
@@ -243,8 +243,8 @@ module axi_ad9963_if #(
     .R (dac_rst),
     .S (1'b0),
     .C (dac_clk),
-    .D1 (1'b1),
-    .D2 (1'b0),
+    .D1 (1'b0),
+    .D2 (1'b1),
     .Q (tx_iq));
 
 endmodule


### PR DESCRIPTION
This change fixes the Tx2 one sample delay compared to Tx1, due to bad data wiring at the ODDR ports.

## PR Type
- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the code style guidelines
- [x] I have performed a self-review of changes
- [x] I have compiled all hdl projects and libraries affected by this PR
- [x] I have tested in hardware affected projects, at least on relevant boards
- [ ] I have commented my code, at least hard-to-understand parts
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe files, Copyright etc)
- [x] I have not introduced new Warnings/Critical Warnings on compilation
- [ ] I have added new hdl testbenches or updated existing ones
