### PR TITLE
i3c_controller: Naming convention, corner case fix

### DIFF
--- a/docs/library/i3c_controller/i3c_controller_core.rst
+++ b/docs/library/i3c_controller/i3c_controller_core.rst
@@ -22,6 +22,10 @@ Files
      - Verilog source for the peripheral.
    * - :git-hdl:`master:library/i3c_controller/i3c_controller_core/i3c_controller_core.tcl`
      - TCL script to generate the Vivado IP-integrator project for the peripheral.
+   * - :git-hdl:`master:library/i3c_controller/i3c_controller_core/i3c_controller_core_ip.tcl`
+     - TCL script to generate the Vivado IP-integrator project for the peripheral.
+   * - :git-hdl:`master:library/i3c_controller/i3c_controller_core/i3c_controller_core_hw.tcl`
+     - TCL script to generate the Quartus IP-integrator project for the peripheral.
 
 
 Configuration Parameters
@@ -38,7 +42,3 @@ Signal and Interface Pins
 --------------------------------------------------------------------------------
 
 .. hdl-interfaces::
-
-Theory of Operation
---------------------------------------------------------------------------------
-

--- a/docs/library/i3c_controller/i3c_controller_host_interface.rst
+++ b/docs/library/i3c_controller/i3c_controller_host_interface.rst
@@ -25,8 +25,10 @@ Files
      - Description
    * - :git-hdl:`master:library/i3c_controller/i3c_controller_host_interface/i3c_controller_host_interface.v`
      - Verilog source for the peripheral.
-   * - :git-hdl:`master:library/i3c_controller/i3c_controller_host_interface/i3c_controller_host_interface.tcl`
+   * - :git-hdl:`master:library/i3c_controller/i3c_controller_host_interface/i3c_controller_host_interface_ip.tcl`
      - TCL script to generate the Vivado IP-integrator project for the peripheral.
+   * - :git-hdl:`master:library/i3c_controller/i3c_controller_host_interface/i3c_controller_host_interface_hw.tcl`
+     - TCL script to generate the Quartus IP-integrator project for the peripheral.
 
 Configuration Parameters
 --------------------------------------------------------------------------------
@@ -64,6 +66,8 @@ Signal and Interface Pins
    * - rmap
      - Interface give the :ref:`i3c_controller core` access to some register map
        addresses.
+
+.. _i3c_controller regmap:
 
 Register Map
 --------------------------------------------------------------------------------

--- a/docs/library/i3c_controller/interface.rst
+++ b/docs/library/i3c_controller/interface.rst
@@ -66,7 +66,7 @@ the following subsections.
 
 .. note::
 
-  CCC always broadcast header after an idle bus, therefore "Bcast. header"
+  CCC always broadcast header after a bus available, therefore "Bcast. header"
   is ignored for CCC\s.
 
 .. _i3c_controller ccc:
@@ -231,8 +231,11 @@ On software, check bit:
 In-Band Interrupts
 ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
-IBI\s are accepted autonomously during bus idle if the feature is enabled.
-The accepted IBI\s fill the IBI FIFO and generate an interrupt to the
+IBI's are resolved autonomously during bus available per specification,
+if they are accepted or rejected depends if the feature itself is enabled;
+see I3C Controller's :ref:`i3c_controller regmap` register ``IBI_CONFIG`` for
+more info.
+The accepted IBI's fill the IBI FIFO and generate an interrupt to the
 PS.
 
 The structure of the received IBI is:

--- a/docs/regmap/adi_regmap_i3c_controller.txt
+++ b/docs/regmap/adi_regmap_i3c_controller.txt
@@ -466,7 +466,7 @@ OPS_STATUS_NOP
 RO
 This bit is set to 1 when the bus is not executing any procedure.
 It is not idle bus condition since it set right after the Stop.
-ENDIELD
+ENDFIELD
 
 FIELD
 [6:5] 0x0
@@ -505,12 +505,12 @@ ENDREG
 
 FIELD
 [1] 0x0
-IBI_CONFIG_AUTO
+IBI_CONFIG_LISTEN
 WO
-Set this bit to listen for IBI requests (when a peripheral pulls SDA Low during quiet times).
+Set this bit to listen for IBI requests (when a peripheral pulls SDA Low during bus available).
 After the IBI request is resolved, the controller returns to idle, since it is was not doing
 a cmd transfer.
-IBI_CONFIG_ENABLE must be set 1.
+This should be set to 1 during normal operation, even if IBI_CONFIG_ENABLE is disabled.
 ENDFIELD
 
 FIELD
@@ -521,8 +521,10 @@ Set this bit to accept (ACK) IBI requests.
 If disabled, the controller will NACK IBI requests.
 If enabled, the controller will ACK the IBI request and receive the MDB.
 In both cases, the controller will proceed with the cmd transfer after resolving the IBI
-request.
-Accepted IBIs fill the IBI_FIFO and generate an interruption in the PS.
+request, if any.
+Accepted IBIs fill the IBI_FIFO and generate an interrupt to the PS.
+IBI_CONFIG_LISTEN set to 1 and IBI_CONFIG_ENABLE set to 0 ensures that incoming IBIs are
+rejected as they come.
 ENDFIELD
 
 ############################################################################################
@@ -552,9 +554,9 @@ ENDFIELD
 
 FIELD
 [3] 0x0
-DEV_CHAR_HAS_IBI_MDB
+DEV_CHAR_HAS_IBI_PAYLOAD
 RW
-Indicates if the device sends an MDB during the IBI.
+Indicates if the device sends at least MDB during the IBI.
 0 does not, 1 does.
 ENDFIELD
 

--- a/library/i3c_controller/i3c_controller_core/i3c_controller_bit_mod.v
+++ b/library/i3c_controller/i3c_controller_core/i3c_controller_bit_mod.v
@@ -62,7 +62,7 @@ module i3c_controller_bit_mod #(
   // Mux to alternative logic to support I²C devices.
   input  i2c_mode,
   // Indicates that the bus is not transferring,
-  // is *not* bus idle condition because does not wait 200us after P.
+  // is *not* bus available condition because does not wait 1s after P.
   output nop,
   // 0:  1.56MHz
   // 1:  3.12MHz

--- a/library/i3c_controller/i3c_controller_core/i3c_controller_core.v
+++ b/library/i3c_controller/i3c_controller_core/i3c_controller_core.v
@@ -110,7 +110,8 @@ module i3c_controller_core #(
   wire i2c_mode;
 
   i3c_controller_framing #(
-    .MAX_DEVS(MAX_DEVS)
+    .MAX_DEVS(MAX_DEVS),
+    .CLK_MOD(CLK_MOD)
   ) i_i3c_controller_framing (
     .reset_n(reset_n),
     .clk(clk),

--- a/library/i3c_controller/i3c_controller_core/i3c_controller_word.v
+++ b/library/i3c_controller/i3c_controller_core/i3c_controller_word.v
@@ -376,7 +376,7 @@ module i3c_controller_word (
                 ibi_requested <= i < 6 & rx === 1'b0 ? 1'b1 : ibi_requested;
                 if (i[2:0] == 7) begin
                   arbitration_valid <= 1'b1;
-                  if (ibi_dev_is_attached & ibi_requested & ~ibi_bcr_2) begin
+                  if (ibi_enable & ibi_requested & ibi_dev_is_attached & ~ibi_bcr_2) begin
                     ibi_tick <= 1'b1;
                   end
                 end


### PR DESCRIPTION
Rename "idle bus" to "bus available" per specification:
* Tune it to require < 1us.

Rename "IBI auto" to "IBI listen":
* Clarify that the controller is listening for IBI's.
* Explain that this field should be set.
* Fix for known IBI's DA with IBI disabled.

## PR Description

Please replace this comment with summary, motivation and context of the changes.
List any dependencies required for this change.

You can check the checkboxes below by inserting a 'x' between square brackets
(without any other characters or spaces) or just check them after publishing the PR.

If there is a breaking change, specify dependent PRs in description and
try to push all related PRs at the same time.


## PR Type
- [X] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [X] I have followed the code style guidelines
- [X] I have performed a self-review of changes
- [X] I have compiled all hdl projects and libraries affected by this PR
- [X] I have tested in hardware affected projects, at least on relevant boards
- [X] I have commented my code, at least hard-to-understand parts
- [X] I have signed off all commits from this PR
- [X] I have updated the documentation (wiki pages, ReadMe files, Copyright etc)
- [X] I have not introduced new Warnings/Critical Warnings on compilation
- [X] I have added new hdl testbenches or updated existing ones
