### PR TITLE
axi_pwm_gen: Fix 100% duty cycle width

### DIFF
--- a/docs/regmap/adi_regmap_pwm_gen.txt
+++ b/docs/regmap/adi_regmap_pwm_gen.txt
@@ -13,7 +13,7 @@ Version and Scratch Registers
 ENDREG
 
 FIELD
-[31:0] 0x00020100
+[31:0] 0x00020101
 VERSION[31:0]
 RO
 Version number. Unique to all cores.

--- a/library/axi_pwm_gen/axi_pwm_gen.sv
+++ b/library/axi_pwm_gen/axi_pwm_gen.sv
@@ -144,7 +144,7 @@ module axi_pwm_gen #(
   localparam        PWMS = N_PWMS-1;
   localparam [31:0] CORE_VERSION = {16'h0002,     /* MAJOR */
                                      8'h01,       /* MINOR */
-                                     8'h00};      /* PATCH */
+                                     8'h01};      /* PATCH */
   localparam [31:0] CORE_MAGIC = 32'h601a3471;    // PLSG
   localparam reg [31:0] PULSE_WIDTH_G[15:0] = '{PULSE_0_WIDTH,
                                                 PULSE_1_WIDTH,


### PR DESCRIPTION
This changes fix the 100 duty cycle setting of the pwm.
Before the axi_pwm_gen's behavior resampled a 99% duty cycle at the 100% setting.


## PR Type
- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the code style guidelines
- [x] I have performed a self-review of changes
- [x] I have compiled all hdl projects and libraries affected by this PR
- [x] I have tested in hardware affected projects, at least on relevant boards
- [ ] I have commented my code, at least hard-to-understand parts
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe files, Copyright etc)
- [x] I have not introduced new Warnings/Critical Warnings on compilation
- [ ] I have added new hdl testbenches or updated existing ones
