### PR TITLE
ad7606x: Reorder and fix mistake in name field from the parts' list

### DIFF
--- a/projects/ad7606x_fmc/Readme.md
+++ b/projects/ad7606x_fmc/Readme.md
@@ -4,8 +4,8 @@ Here are some pointers to help you:
   * [EVAL-AD7606B Product Page](https://www.analog.com/en/design-center/evaluation-hardware-and-software/evaluation-boards-kits/eval-ad7606b-fmcz.html)
   * [EVAL-AD7606C-16/18 Product Page](https://www.analog.com/en/design-center/evaluation-hardware-and-software/evaluation-boards-kits/eval-ad7606c-18.html)
   * Parts : [AD7606B, 8 Channels, 16-bit, 800 kSPS Bipolar Input, Simultaneous sampling ADC](https://www.analog.com/en/products/ad7606b.html)
-  * Parts : [AD7606B, 8 Channels, 18-bit, 1 MSPS Bipolar Input, Simultaneous sampling ADC](https://www.analog.com/en/products/ad7606c-18.html)
   * Parts : [AD7606C-16, 8 Channels, 16-bit, 1 MSPS Bipolar Input, Simultaneous sampling ADC](https://www.analog.com/en/products/ad7606c-16.html)
+  * Parts : [AD7606C-18, 8 Channels, 18-bit, 1 MSPS Bipolar Input, Simultaneous sampling ADC](https://www.analog.com/en/products/ad7606c-18.html)
   * Project Doc: https://wiki.analog.com/resources/eval/user-guides/ad7606x-fmcz
   * HDL Doc: https://wiki.analog.com/resources/eval/user-guides/ad7606x-fmc/hdl
   * NO-OS Drivers: [AD7606 - No-OS Driver](https://wiki.analog.com/resources/tools-software/uc-drivers/ad7606)


### PR DESCRIPTION
## PR Description

ad7606x: Reorder and fix mistake in name field from the parts' list

## PR Type
- [ ] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the code style guidelines
- [x] I have performed a self-review of changes
- [ ] I have compiled all hdl projects and libraries affected by this PR
- [ ] I have tested in hardware affected projects, at least on relevant boards
- [ ] I have commented my code, at least hard-to-understand parts
- [x] I have signed off all commits from this PR
- [x] I have updated the documentation (wiki pages, ReadMe files, Copyright etc)
- [x] I have not introduced new Warnings/Critical Warnings on compilation
- [ ] I have added new hdl testbenches or updated existing ones
