### PR TITLE
ad4134: Set DCLK frequency to 50 MHz

### DIFF
--- a/projects/ad4134_fmc/common/ad4134_bd.tcl
+++ b/projects/ad4134_fmc/common/ad4134_bd.tcl
@@ -26,7 +26,7 @@ spi_engine_create $hier_spi_engine $data_width $async_spi_clk $num_cs $num_sdi $
 
 ad_ip_instance axi_clkgen axi_ad4134_clkgen
 ad_ip_parameter axi_ad4134_clkgen CONFIG.VCO_DIV 5
-ad_ip_parameter axi_ad4134_clkgen CONFIG.VCO_MUL 48
+ad_ip_parameter axi_ad4134_clkgen CONFIG.VCO_MUL 50
 ad_ip_parameter axi_ad4134_clkgen CONFIG.CLK0_DIV 10
 
 # dma to receive data stream


### PR DESCRIPTION
## PR Description

Change axi_clk_gen output frequency to 100MHz for set DCLK frequency to 50 MHz.
This is a requirement if we set the DCLK pin as an input in slave mode.

## PR Type
- [ ] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [ ] I have followed the code style guidelines
- [ ] I have performed a self-review of changes
- [ ] I have compiled all hdl projects and libraries affected by this PR
- [ ] I have tested in hardware affected projects, at least on relevant boards
- [ ] I have commented my code, at least hard-to-understand parts
- [ ] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe files, Copyright etc)
- [ ] I have not introduced new Warnings/Critical Warnings on compilation
- [ ] I have added new hdl testbenches or updated existing ones
