### PR TITLE
cn0561: Set DCLK frequency to 50 MHz

### DIFF
--- a/docs/projects/cn0561/cn0561_hdl.svg
+++ b/docs/projects/cn0561/cn0561_hdl.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   sodipodi:docname="cn0561_hdl_3.svg"
-   inkscape:version="1.2.2 (732a01da63, 2022-12-09)"
+   sodipodi:docname="cn0561_hdl.svg"
+   inkscape:version="1.3 (0e150ed6c4, 2023-07-21)"
    style="shape-rendering:crispEdges"
    id="svg6470"
    version="1.1"
@@ -1123,17 +1123,17 @@
      inkscape:snap-page="true"
      showguides="false"
      inkscape:window-maximized="1"
-     inkscape:window-y="-8"
-     inkscape:window-x="-8"
+     inkscape:window-y="1342"
+     inkscape:window-x="2392"
      inkscape:window-height="1122"
      inkscape:window-width="1920"
      units="px"
      showgrid="true"
      inkscape:current-layer="layer1"
      inkscape:document-units="px"
-     inkscape:cy="375.53571"
-     inkscape:cx="212.67857"
-     inkscape:zoom="2.8"
+     inkscape:cy="389.28571"
+     inkscape:cx="450"
+     inkscape:zoom="1.4"
      inkscape:pageshadow="2"
      inkscape:pageopacity="0.0"
      borderopacity="1.0"
@@ -1147,7 +1147,11 @@
        originy="153.20751"
        originx="190.78628"
        id="grid7015"
-       type="xygrid" />
+       type="xygrid"
+       spacingy="1"
+       spacingx="1"
+       units="px"
+       visible="true" />
   </sodipodi:namedview>
   <metadata
      id="metadata6467">
@@ -1157,7 +1161,6 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
@@ -1450,7 +1453,7 @@
          style="stroke-width:1.1434"
          y="885.40247"
          x="505.39069"
-         sodipodi:role="line">  48MHz</tspan></text>
+         sodipodi:role="line">  50MHz</tspan></text>
     <rect
        y="707.07867"
        x="20.524199"
@@ -1725,15 +1728,15 @@
        inkscape:export-xdpi="96"
        id="text6100-7-7"
        y="1031.8214"
-       x="116.02357"
+       x="110.8271"
        style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.1963px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1.1434;shape-rendering:crispEdges;enable-background:new"
        xml:space="preserve"
        transform="scale(1.0309198,0.97000757)"><tspan
          id="tspan5125-0-2"
          style="stroke-width:1.1434"
          y="1031.8214"
-         x="116.02357"
-         sodipodi:role="line"> spi_clk = 96MHz</tspan></text>
+         x="110.8271"
+         sodipodi:role="line"> spi_clk = 100MHz</tspan></text>
     <text
        inkscape:export-ydpi="96"
        inkscape:export-xdpi="96"

--- a/docs/projects/cn0561/index.rst
+++ b/docs/projects/cn0561/index.rst
@@ -32,7 +32,7 @@ are necessary to interact with the device using a Xilinx FPGA development
 board; to acquire data from the ADC device, supporting continuous data 
 capture at maximum 1.5 MSPS data rate. However, due to a hardware limitation, 
 the Cora-Z7s variant will only support a maximum data clock of 24MHz,
-in contrast with 48MHz supported on the Zedboard.
+in contrast with 50MHz supported on the Zedboard.
 
 Supported boards
 -------------------------------------------------------------------------------

--- a/projects/cn0561/common/cn0561_bd.tcl
+++ b/projects/cn0561/common/cn0561_bd.tcl
@@ -26,7 +26,7 @@ spi_engine_create $hier_spi_engine $data_width $async_spi_clk $num_cs $num_sdi $
 
 ad_ip_instance axi_clkgen axi_cn0561_clkgen
 ad_ip_parameter axi_cn0561_clkgen CONFIG.VCO_DIV 5
-ad_ip_parameter axi_cn0561_clkgen CONFIG.VCO_MUL 48
+ad_ip_parameter axi_cn0561_clkgen CONFIG.VCO_MUL 50
 ad_ip_parameter axi_cn0561_clkgen CONFIG.CLK0_DIV 10
 
 # dma to receive data stream

--- a/projects/cn0561/zed/system_constr.xdc
+++ b/projects/cn0561/zed/system_constr.xdc
@@ -4,30 +4,30 @@
 ###############################################################################
 
 # cn0561 SPI configuration interface
-set_property -dict {PACKAGE_PIN N22 IOSTANDARD LVCMOS25} [get_ports cn0561_spi_sdi]       ; ## FMC_LPC_LA03_P
-set_property -dict {PACKAGE_PIN M22 IOSTANDARD LVCMOS25} [get_ports cn0561_spi_sdo]       ; ## FMC_LPC_LA04_N
-set_property -dict {PACKAGE_PIN N19 IOSTANDARD LVCMOS25} [get_ports cn0561_spi_sclk]      ; ## FMC_LPC_LA01_P_CC
-set_property -dict {PACKAGE_PIN J18 IOSTANDARD LVCMOS25} [get_ports cn0561_spi_cs]        ; ## FMC_LPC_LA05_P
+set_property -dict {PACKAGE_PIN N22 IOSTANDARD LVCMOS25} [get_ports cn0561_spi_sdi];         ## FMC_LPC_LA03_P
+set_property -dict {PACKAGE_PIN M22 IOSTANDARD LVCMOS25} [get_ports cn0561_spi_sdo];         ## FMC_LPC_LA04_N
+set_property -dict {PACKAGE_PIN N19 IOSTANDARD LVCMOS25} [get_ports cn0561_spi_sclk];        ## FMC_LPC_LA01_P_CC
+set_property -dict {PACKAGE_PIN J18 IOSTANDARD LVCMOS25} [get_ports cn0561_spi_cs];          ## FMC_LPC_LA05_P
 
 # cn0561 data interface
 
-set_property -dict {PACKAGE_PIN L18 IOSTANDARD LVCMOS25} [get_ports cn0561_dclk]          ; ## FMC_LPC_CLK0_M2C_P
-set_property -dict {PACKAGE_PIN M20 IOSTANDARD LVCMOS25} [get_ports cn0561_din[0]]        ; ## FMC_LPC_LA00_N_CC
-set_property -dict {PACKAGE_PIN J21 IOSTANDARD LVCMOS25} [get_ports cn0561_din[1]]        ; ## FMC_LPC_LA06_N
-set_property -dict {PACKAGE_PIN P17 IOSTANDARD LVCMOS25} [get_ports cn0561_din[2]]        ; ## FMC_LPC_LA02_P
-set_property -dict {PACKAGE_PIN P18 IOSTANDARD LVCMOS25} [get_ports cn0561_din[3]]        ; ## FMC_LPC_LA02_N
-set_property -dict {PACKAGE_PIN M19 IOSTANDARD LVCMOS25} [get_ports cn0561_odr]           ; ## FMC_LPC_LA00_P_CC
+set_property -dict {PACKAGE_PIN L18 IOSTANDARD LVCMOS25 IOB TRUE} [get_ports cn0561_dclk];   ## FMC_LPC_CLK0_M2C_P
+set_property -dict {PACKAGE_PIN M20 IOSTANDARD LVCMOS25 IOB TRUE} [get_ports cn0561_din[0]]; ## FMC_LPC_LA00_N_CC
+set_property -dict {PACKAGE_PIN J21 IOSTANDARD LVCMOS25 IOB TRUE} [get_ports cn0561_din[1]]; ## FMC_LPC_LA06_N
+set_property -dict {PACKAGE_PIN P17 IOSTANDARD LVCMOS25 IOB TRUE} [get_ports cn0561_din[2]]; ## FMC_LPC_LA02_P
+set_property -dict {PACKAGE_PIN P18 IOSTANDARD LVCMOS25 IOB TRUE} [get_ports cn0561_din[3]]; ## FMC_LPC_LA02_N
+set_property -dict {PACKAGE_PIN M19 IOSTANDARD LVCMOS25} [get_ports cn0561_odr];             ## FMC_LPC_LA00_P_CC
 
 # cn0561 GPIO lines
 
-set_property -dict {PACKAGE_PIN J20 IOSTANDARD LVCMOS25} [get_ports cn0561_resetn]        ; ## FMC_LPC_LA16_P
-set_property -dict {PACKAGE_PIN T16 IOSTANDARD LVCMOS25} [get_ports cn0561_pdn]           ; ## FMC_LPC_LA07_P
-set_property -dict {PACKAGE_PIN M21 IOSTANDARD LVCMOS25} [get_ports cn0561_mode]          ; ## FMC_LPC_LA04_P
-set_property -dict {PACKAGE_PIN R19 IOSTANDARD LVCMOS25} [get_ports cn0561_gpio0]         ; ## FMC_LPC_LA10_P
-set_property -dict {PACKAGE_PIN T19 IOSTANDARD LVCMOS25} [get_ports cn0561_gpio1]         ; ## FMC_LPC_LA10_N
-set_property -dict {PACKAGE_PIN N17 IOSTANDARD LVCMOS25} [get_ports cn0561_gpio2]         ; ## FMC_LPC_LA11_P
-set_property -dict {PACKAGE_PIN P20 IOSTANDARD LVCMOS25} [get_ports cn0561_gpio4]         ; ## FMC_LPC_LA12_P
-set_property -dict {PACKAGE_PIN P21 IOSTANDARD LVCMOS25} [get_ports cn0561_gpio5]         ; ## FMC_LPC_LA12_N
-set_property -dict {PACKAGE_PIN L17 IOSTANDARD LVCMOS25} [get_ports cn0561_gpio6]         ; ## FMC_LPC_LA13_P
-set_property -dict {PACKAGE_PIN M17 IOSTANDARD LVCMOS25} [get_ports cn0561_gpio7]         ; ## FMC_LPC_LA13_N
-set_property -dict {PACKAGE_PIN L21 IOSTANDARD LVCMOS25} [get_ports cn0561_pinbspi]       ; ## FMC_LPC_LA06_P
+set_property -dict {PACKAGE_PIN J20 IOSTANDARD LVCMOS25} [get_ports cn0561_resetn];          ## FMC_LPC_LA16_P
+set_property -dict {PACKAGE_PIN T16 IOSTANDARD LVCMOS25} [get_ports cn0561_pdn];             ## FMC_LPC_LA07_P
+set_property -dict {PACKAGE_PIN M21 IOSTANDARD LVCMOS25} [get_ports cn0561_mode];            ## FMC_LPC_LA04_P
+set_property -dict {PACKAGE_PIN R19 IOSTANDARD LVCMOS25} [get_ports cn0561_gpio0];           ## FMC_LPC_LA10_P
+set_property -dict {PACKAGE_PIN T19 IOSTANDARD LVCMOS25} [get_ports cn0561_gpio1];           ## FMC_LPC_LA10_N
+set_property -dict {PACKAGE_PIN N17 IOSTANDARD LVCMOS25} [get_ports cn0561_gpio2];           ## FMC_LPC_LA11_P
+set_property -dict {PACKAGE_PIN P20 IOSTANDARD LVCMOS25} [get_ports cn0561_gpio4];           ## FMC_LPC_LA12_P
+set_property -dict {PACKAGE_PIN P21 IOSTANDARD LVCMOS25} [get_ports cn0561_gpio5];           ## FMC_LPC_LA12_N
+set_property -dict {PACKAGE_PIN L17 IOSTANDARD LVCMOS25} [get_ports cn0561_gpio6];           ## FMC_LPC_LA13_P
+set_property -dict {PACKAGE_PIN M17 IOSTANDARD LVCMOS25} [get_ports cn0561_gpio7];           ## FMC_LPC_LA13_N
+set_property -dict {PACKAGE_PIN L21 IOSTANDARD LVCMOS25} [get_ports cn0561_pinbspi];         ## FMC_LPC_LA06_P


### PR DESCRIPTION
## PR Description

Change axi_clk_gen output frequency to 100MHz for set DCLK frequency to 50 MHz.
This is a requirement if we set the DCLK pin as an input in slave mode.

## PR Type
- [ ] Bug fix (change that fixes an issue)
- [x] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the code style guidelines
- [x] I have performed a self-review of changes
- [x] I have compiled all hdl projects and libraries affected by this PR
- [x] I have tested in hardware affected projects, at least on relevant boards
- [ ] I have commented my code, at least hard-to-understand parts
- [x] I have signed off all commits from this PR
- [x] I have updated the documentation (wiki pages, ReadMe files, Copyright etc)
- [x] I have not introduced new Warnings/Critical Warnings on compilation
- [ ] I have added new hdl testbenches or updated existing ones
