### PR TITLE
ADRV9001 Verilog typo / error

### DIFF
--- a/library/axi_adrv9001/adrv9001_rx_link.v
+++ b/library/axi_adrv9001/adrv9001_rx_link.v
@@ -297,7 +297,7 @@ module adrv9001_rx_link #(
     .idata (rx_data8_1_aligned),
     .sof (rx_data8_strobe_aligned[7]),
     .odata (rx_data16_1_packed),
-    .ovalid (rx_data16_1_paked_valid),
+    .ovalid (rx_data16_1_packed_valid),
     .osof (rx_data16_1_packed_osof));
 
   adrv9001_pack #(

--- a/library/axi_adrv9001/adrv9001_rx_link.v
+++ b/library/axi_adrv9001/adrv9001_rx_link.v
@@ -310,7 +310,7 @@ module adrv9001_rx_link #(
     .sof (rx_data16_0_packed_osof),
     .odata (rx_data32_0_packed),
     .ovalid (rx_data32_0_packed_valid),
-    .osof (rx_data32_0_packed_osof));
+    .osof ());
 
   generate if (CMOS_LVDS_N) begin
     assign rx_data_i = ~rx_single_lane ? {rx_data8_1_aligned,rx_data8_0_aligned} :


### PR DESCRIPTION
## PR Description

I found two verilog errors in this file, a signal was misspelled, and another doesn't exist. I'm not sure how to run the tests but I believe my changes are correct, looking for some feedback here.

## PR Type
- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the code style guidelines
- [x] I have performed a self-review of changes
- [ ] I have compiled all hdl projects and libraries affected by this PR
- [ ] I have tested in hardware affected projects, at least on relevant boards
- [ ] I have commented my code, at least hard-to-understand parts
- [ ] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe files, Copyright etc)
- [ ] I have not introduced new Warnings/Critical Warnings on compilation
- [ ] I have added new hdl testbenches or updated existing ones
