### PR TITLE
SPI Engine: fix word_length affecting sleep

### DIFF
--- a/docs/regmap/adi_regmap_spi_engine.txt
+++ b/docs/regmap/adi_regmap_spi_engine.txt
@@ -9,7 +9,7 @@ ENDTITLE
 REG
 0x00
 VERSION
-Version of the peripheral. Follows semantic versioning. Current version 1.02.00.
+Version of the peripheral. Follows semantic versioning. Current version 1.02.01.
 ENDREG
 
 FIELD
@@ -25,7 +25,7 @@ RO
 ENDFIELD
 
 FIELD
-[7:0] 0x00000000
+[7:0] 0x00000001
 VERSION_PATCH
 RO
 ENDFIELD

--- a/library/spi_engine/axi_spi_engine/axi_spi_engine.v
+++ b/library/spi_engine/axi_spi_engine/axi_spi_engine.v
@@ -133,7 +133,7 @@ module axi_spi_engine #(
   input [7:0] offload_sync_data
 );
 
-  localparam PCORE_VERSION = 'h010200;
+  localparam PCORE_VERSION = 'h010201;
   localparam S_AXI = 0;
   localparam UP_FIFO = 1;
 

--- a/library/spi_engine/spi_engine_execution/spi_engine_execution.v
+++ b/library/spi_engine/spi_engine_execution/spi_engine_execution.v
@@ -268,8 +268,8 @@ module spi_engine_execution #(
     if (idle == 1'b1 || (cs_sleep_counter_compare && !cs_sleep_repeat && inst_d1 == CMD_CHIPSELECT)) begin
       counter <= 'h00;
     end else if (clk_div_last == 1'b1 && wait_for_io == 1'b0) begin
-      if (bit_counter == word_length) begin
-        counter <= (counter & BIT_COUNTER_CLEAR) + (transfer_active ? 'h1 : (2**BIT_COUNTER_WIDTH)) + BIT_COUNTER_CARRY;
+      if (bit_counter == word_length && transfer_active) begin
+        counter <= (counter & BIT_COUNTER_CLEAR) + 'h1 + BIT_COUNTER_CARRY;
       end else begin
         counter <= counter + (transfer_active ? 'h1 : (2**BIT_COUNTER_WIDTH));
       end


### PR DESCRIPTION
Currently word_length can affect the sleep duration, this fixes it.
Tested with updated testbench (https://github.com/analogdevicesinc/testbenches/pull/110)

## PR Type
- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the code style guidelines
- [x] I have performed a self-review of changes
- [ ] I have compiled all hdl projects and libraries affected by this PR
- [ ] I have tested in hardware affected projects, at least on relevant boards
- [ ] I have commented my code, at least hard-to-understand parts
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe files, Copyright etc)
- [x] I have not introduced new Warnings/Critical Warnings on compilation
- [x] I have added new hdl testbenches or updated existing ones
