### PR TITLE
AD469x: HDL build parameter

### DIFF
--- a/docs/projects/ad469x_fmc/index.rst
+++ b/docs/projects/ad469x_fmc/index.rst
@@ -51,6 +51,26 @@ The data path and clock domains are depicted in the below diagram:
    :align: center
    :alt: AD469X_FMC block diagram
 
+Configuration modes
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The SPI_4WIRE configuration parameter defines if CNV signal is linked to PWM or
+to SPI_CS to enable interfacing with a single 4-wire SPI port. By default it is
+set to 0. Depending on the required pin functionality, some hardware
+modifications need to be done on the board and/or ``make`` command:
+
+In case we link CNV signal to PWM:
+
+.. code-block::
+
+   make SPI_4WIRE=0
+
+In case we link CNV signal to SPI_CS:
+
+.. code-block::
+
+   make SPI_4WIRE=1
+
 CPU/Memory interconnects addresses
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -128,6 +148,14 @@ The Software GPIO number is calculated as follows:
      - INOUT
      - 32
      - 86
+   * - gpio[33]
+     - IN
+     - 33
+     - 87
+
+BSY_ALT_GP0 pin can be configured to function as a general-purpose input/output
+(GPIO), the threshold detection alert indicator, the busy indicator, or the
+second serial data output in dual-sdo MODE
 
 Interrupts
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -156,7 +184,18 @@ the HDL repository, and then build the project as follows:
    :linenos:
 
    user@analog:~$ cd hdl/projects/ad469x_fmc/zed
-   user@analog:~/hdl/projects/ad469x_fmc/zed$ make
+   user@analog:~/hdl/projects/ad469x_fmc/zed$ make SPI_4WIRE=0
+
+The result of the build, if parameters were used, will be in a folder named
+by the configuration used:
+
+if the following command was run
+
+``SPI_4WIRE=0``
+
+then the folder name will be:
+
+``SPI4WIRE0``
 
 A more comprehensive build guide can be found in the :ref:`build_hdl` user guide.
 

--- a/projects/ad469x_fmc/Readme.md
+++ b/projects/ad469x_fmc/Readme.md
@@ -9,3 +9,12 @@ Here are some pointers to help you:
   * Project Doc: https://wiki.analog.com/resources/eval/user-guides/ad469x
   * HDL Doc: https://wiki.analog.com/resources/eval/user-guides/ad469x
   * Linux Drivers: https://wiki.analog.com/resources/tools-software/linux-drivers-all
+# Building, Generating Bit Files
+
+How to use over-writable parameter from the environment:
+```
+hdl/projects/ad469x_fmc/zed> make SPI_4WIRE=0
+```
+SPI_4WIRE - Defines if CNV signal is linked to PWM or to SPI_CS
+* 0 - CNV signal is linked to PWM
+* 1 - CNV signal is linked to SPI_CS

--- a/projects/ad469x_fmc/common/ad469x_bd.tcl
+++ b/projects/ad469x_fmc/common/ad469x_bd.tcl
@@ -3,6 +3,11 @@
 ### SPDX short identifier: ADIBSD
 ###############################################################################
 
+# system level parameter
+
+set SPI_4WIRE $ad_project_params(SPI_4WIRE)
+puts "build parameter: SPI_4WIRE: $SPI_4WIRE"
+
 create_bd_intf_port -mode Master -vlnv analog.com:interface:spi_engine_rtl:1.0 ad469x_spi
 create_bd_port -dir O ad469x_spi_cnv
 create_bd_port -dir I ad469x_spi_busy

--- a/projects/ad469x_fmc/zed/system_constr.xdc
+++ b/projects/ad469x_fmc/zed/system_constr.xdc
@@ -4,14 +4,14 @@
 ###############################################################################
 
 # ad4696_fmc SPI interface
-set_property -dict {PACKAGE_PIN N19 IOSTANDARD LVCMOS25 IOB TRUE} [get_ports ad469x_spi_sdi]       ; ## D08  FMC_LA01_CC_P  IO_L14P_T2_SRCC_34
-set_property -dict {PACKAGE_PIN P17 IOSTANDARD LVCMOS25 IOB TRUE} [get_ports ad469x_spi_sdo]       ; ## H07  FMC_LA02_P     IO_L20P_T3_34
-set_property -dict {PACKAGE_PIN N20 IOSTANDARD LVCMOS25 IOB TRUE} [get_ports ad469x_spi_sclk]      ; ## D09  FMC_LA01_CC_N  IO_L14N_T2_SRCC_34
-set_property -dict {PACKAGE_PIN M19 IOSTANDARD LVCMOS25 IOB TRUE} [get_ports ad469x_spi_cs]        ; ## G06  FMC_LA00_CC_P  IO_L13P_T2_MRCC_34
-set_property -dict {PACKAGE_PIN M20 IOSTANDARD LVCMOS25} [get_ports ad469x_spi_cnv]       ; ## G07  FMC_LA00_CC_N  IO_L13N_T2_MRCC_34
+set_property -dict {PACKAGE_PIN N19 IOSTANDARD LVCMOS25 IOB TRUE} [get_ports ad469x_spi_sdi];  ## D08  FMC_LA01_CC_P  IO_L14P_T2_SRCC_34
+set_property -dict {PACKAGE_PIN P17 IOSTANDARD LVCMOS25 IOB TRUE} [get_ports ad469x_spi_sdo];  ## H07  FMC_LA02_P     IO_L20P_T3_34
+set_property -dict {PACKAGE_PIN N20 IOSTANDARD LVCMOS25 IOB TRUE} [get_ports ad469x_spi_sclk]; ## D09  FMC_LA01_CC_N  IO_L14N_T2_SRCC_34
+set_property -dict {PACKAGE_PIN M19 IOSTANDARD LVCMOS25 IOB TRUE} [get_ports ad469x_spi_cs];   ## G06  FMC_LA00_CC_P  IO_L13P_T2_MRCC_34
+set_property -dict {PACKAGE_PIN M20 IOSTANDARD LVCMOS25} [get_ports ad469x_spi_cnv];           ## G07  FMC_LA00_CC_N  IO_L13N_T2_MRCC_34
 
-set_property -dict {PACKAGE_PIN M21 IOSTANDARD LVCMOS25} [get_ports ad469x_resetn]        ; ## H10  FMC_LA04_P     IO_L15P_T2_DQS_34
-set_property -dict {PACKAGE_PIN P18 IOSTANDARD LVCMOS25} [get_ports ad469x_busy_alt_gp0]  ; ## H08  FMC_LA02_N     IO_L20N_T3_34
+set_property -dict {PACKAGE_PIN M21 IOSTANDARD LVCMOS25} [get_ports ad469x_resetn];            ## H10  FMC_LA04_P     IO_L15P_T2_DQS_34
+set_property -dict {PACKAGE_PIN P18 IOSTANDARD LVCMOS25} [get_ports ad469x_busy_alt_gp0];      ## H08  FMC_LA02_N     IO_L20N_T3_34
 
 # rename auto-generated clock for SPIEngine to spi_clk - 160MHz
 # NOTE: clk_fpga_0 is the first PL fabric clock, also called $sys_cpu_clk

--- a/projects/ad469x_fmc/zed/system_constr.xdc
+++ b/projects/ad469x_fmc/zed/system_constr.xdc
@@ -4,10 +4,10 @@
 ###############################################################################
 
 # ad4696_fmc SPI interface
-set_property -dict {PACKAGE_PIN N19 IOSTANDARD LVCMOS25} [get_ports ad469x_spi_sdi]       ; ## D08  FMC_LA01_CC_P  IO_L14P_T2_SRCC_34
-set_property -dict {PACKAGE_PIN P17 IOSTANDARD LVCMOS25} [get_ports ad469x_spi_sdo]       ; ## H07  FMC_LA02_P     IO_L20P_T3_34
-set_property -dict {PACKAGE_PIN N20 IOSTANDARD LVCMOS25} [get_ports ad469x_spi_sclk]      ; ## D09  FMC_LA01_CC_N  IO_L14N_T2_SRCC_34
-set_property -dict {PACKAGE_PIN M19 IOSTANDARD LVCMOS25} [get_ports ad469x_spi_cs]        ; ## G06  FMC_LA00_CC_P  IO_L13P_T2_MRCC_34
+set_property -dict {PACKAGE_PIN N19 IOSTANDARD LVCMOS25 IOB TRUE} [get_ports ad469x_spi_sdi]       ; ## D08  FMC_LA01_CC_P  IO_L14P_T2_SRCC_34
+set_property -dict {PACKAGE_PIN P17 IOSTANDARD LVCMOS25 IOB TRUE} [get_ports ad469x_spi_sdo]       ; ## H07  FMC_LA02_P     IO_L20P_T3_34
+set_property -dict {PACKAGE_PIN N20 IOSTANDARD LVCMOS25 IOB TRUE} [get_ports ad469x_spi_sclk]      ; ## D09  FMC_LA01_CC_N  IO_L14N_T2_SRCC_34
+set_property -dict {PACKAGE_PIN M19 IOSTANDARD LVCMOS25 IOB TRUE} [get_ports ad469x_spi_cs]        ; ## G06  FMC_LA00_CC_P  IO_L13P_T2_MRCC_34
 set_property -dict {PACKAGE_PIN M20 IOSTANDARD LVCMOS25} [get_ports ad469x_spi_cnv]       ; ## G07  FMC_LA00_CC_N  IO_L13N_T2_MRCC_34
 
 set_property -dict {PACKAGE_PIN M21 IOSTANDARD LVCMOS25} [get_ports ad469x_resetn]        ; ## H10  FMC_LA04_P     IO_L15P_T2_DQS_34

--- a/projects/ad469x_fmc/zed/system_project.tcl
+++ b/projects/ad469x_fmc/zed/system_project.tcl
@@ -7,7 +7,12 @@ source ../../../scripts/adi_env.tcl
 source ../../scripts/adi_project_xilinx.tcl
 source ../../scripts/adi_board.tcl
 
-adi_project ad469x_fmc_zed
+# Parameter description
+
+# SPI_4WIRE - For 0 CNV is linked to PWM. For 1 CNV is linked to SPI_CS
+
+adi_project ad469x_fmc_zed 0 [list \
+  SPI_4WIRE [get_env_param SPI_4WIRE 0]]
 
 adi_project_files ad469x_fmc_zed [list \
     "../../../library/common/ad_iobuf.v" \

--- a/projects/ad469x_fmc/zed/system_top.v
+++ b/projects/ad469x_fmc/zed/system_top.v
@@ -35,8 +35,9 @@
 
 `timescale 1ns/100ps
 
-module system_top (
-
+module system_top #(
+  parameter SPI_4WIRE = 0
+) (
   inout   [14:0]  ddr_addr,
   inout   [ 2:0]  ddr_ba,
   inout           ddr_cas_n,
@@ -107,9 +108,15 @@ module system_top (
   wire    [ 1:0]  iic_mux_sda_o_s;
   wire            iic_mux_sda_t_s;
 
-  // instantiations
+  wire            ad469x_spi_cnv_s;
+  wire            ad469x_spi_cs_s;
+
+  // instantiation
 
   assign gpio_i[63:33] = 31'b0;
+
+  assign ad469x_spi_cnv = (SPI_4WIRE == 0) ? ad469x_spi_cnv_s : ad469x_spi_cs_s;
+  assign ad469x_spi_cs = ad469x_spi_cs_s;
 
   ad_iobuf #(
     .DATA_WIDTH(1)
@@ -207,10 +214,10 @@ module system_top (
     .ad469x_spi_sdo (ad469x_spi_sdo),
     .ad469x_spi_sdo_t (),
     .ad469x_spi_sdi (ad469x_spi_sdi),
-    .ad469x_spi_cs (ad469x_spi_cs),
+    .ad469x_spi_cs (ad469x_spi_cs_s),
     .ad469x_spi_sclk (ad469x_spi_sclk),
     .ad469x_spi_busy(ad469x_busy_alt_gp0),
-    .ad469x_spi_cnv(ad469x_spi_cnv),
+    .ad469x_spi_cnv(ad469x_spi_cnv_s),
     .otg_vbusoc (otg_vbusoc),
     .spdif (spdif));
 

--- a/projects/ad469x_fmc/zed/system_top.v
+++ b/projects/ad469x_fmc/zed/system_top.v
@@ -113,10 +113,12 @@ module system_top #(
 
   // instantiation
 
-  assign gpio_i[63:33] = 31'b0;
+  assign gpio_i[63:34] = 30'b0;
 
   assign ad469x_spi_cnv = (SPI_4WIRE == 0) ? ad469x_spi_cnv_s : ad469x_spi_cs_s;
   assign ad469x_spi_cs = ad469x_spi_cs_s;
+
+  assign gpio_i[33] = ad469x_busy_alt_gp0;
 
   ad_iobuf #(
     .DATA_WIDTH(1)

--- a/projects/ad469x_fmc/zed/system_top.v
+++ b/projects/ad469x_fmc/zed/system_top.v
@@ -1,6 +1,6 @@
 // ***************************************************************************
 // ***************************************************************************
-// Copyright (C) 2020-2023 Analog Devices, Inc. All rights reserved.
+// Copyright (C) 2020-2024 Analog Devices, Inc. All rights reserved.
 //
 // In this HDL repository, there are many different and unique modules, consisting
 // of various HDL (Verilog or VHDL) components. The individual modules are


### PR DESCRIPTION
## PR Description

With the help of SPI_4WIRE parameter, for Conversion Mode, we can link the CNV to SPI_CS for 4-wire SPI interface
functionality. Also, BSY_ALT_GP0 is linked to trigger and GPIO.

## PR Type
- [ ] Bug fix (change that fixes an issue)
- [x] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the code style guidelines
- [x] I have performed a self-review of changes
- [x] I have compiled all hdl projects and libraries affected by this PR
- [ ] I have tested in hardware affected projects, at least on relevant boards
- [ ] I have commented my code, at least hard-to-understand parts
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe files, Copyright etc)
- [x] I have not introduced new Warnings/Critical Warnings on compilation
- [ ] I have added new hdl testbenches or updated existing ones
