### PR TITLE
axi_ad7606x: Fix DRP locked

### DIFF
--- a/library/axi_ad7606x/axi_ad7606x.v
+++ b/library/axi_ad7606x/axi_ad7606x.v
@@ -433,7 +433,7 @@ module axi_ad7606x #(
     .up_drp_wdata (),
     .up_drp_rdata (),
     .up_drp_ready (),
-    .up_drp_locked (),
+    .up_drp_locked (1'b1),
     .adc_config_wr (wr_data_s),
     .adc_config_ctrl (adc_config_ctrl_s),
     .adc_config_rd ({16'd0, rd_data_s}),


### PR DESCRIPTION
software expects DRP locked to be 1 and it should be set to 1 if not used

https://git.kernel.org/pub/scm/linux/kernel/git/jic23/iio.git/commit/?h=testing&id=70a0e10f8ab62ba82b080347ca0a119e14e964c9

## PR Description

Please replace this comment with summary, motivation and context of the changes.
List any dependencies required for this change.

You can check the checkboxes below by inserting a 'x' between square brackets
(without any other characters or spaces) or just check them after publishing the PR.

If there is a breaking change, specify dependent PRs in description and
try to push all related PRs at the same time.


## PR Type
- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the code style guidelines
- [x] I have performed a self-review of changes
- [x] I have compiled all hdl projects and libraries affected by this PR
- [x] I have tested in hardware affected projects, at least on relevant boards
- [ ] I have commented my code, at least hard-to-understand parts
- [ ] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe files, Copyright etc)
- [x] I have not introduced new Warnings/Critical Warnings on compilation
- [ ] I have added new hdl testbenches or updated existing ones
