### PR TITLE
projects/ad9434_fmc/zed: Fix timing issue in IP and constraints 

### DIFF
--- a/docs/projects/ad9434_fmc/index.rst
+++ b/docs/projects/ad9434_fmc/index.rst
@@ -11,7 +11,7 @@ The :adi:`AD9434` is a 12-bit monolithic sampling analog-to-digital converter
 operates at up to a 500 MSPS conversion rate and is optimized for outstanding
 dynamic performance in wideband carrier and broadband systems. All necessary
 functions, including a sample-and-hold and voltage reference, are included on
-the chip to provide a complete signal conversion solution. This reference 
+the chip to provide a complete signal conversion solution. This reference
 design includes a data capture interface and the external DDR-DRAM interface
 for sample storage. It allows programming the device and monitoring its internal
 status registers. The board also provides other options to drive the clock and
@@ -76,6 +76,14 @@ For LVPECL and LVDS configurations, appropriate charge pump filter circuit
 values are necessary to have an optimized clock buffer performance from
 :adi:`AD9517-4`.
 
+.. warning::
+
+   On Zedboard, the frequency is set to 463.82MHz, because there is a limitation
+   for BUFG input clock frequency to 464MHz, which is below the maximum
+   sampling rate of the ADC (500MSPS).
+
+   Thus the adc_clk period is set to 2.156ns (463.82MHz) on Zedboard.
+
 CPU/Memory interconnects addresses
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -106,7 +114,7 @@ SPI connections
      - 1
    * - PS
      - SPI 0
-     - AD9434BCPZ
+     - AD9434
      - 0
 
 Interrupts
@@ -167,8 +175,9 @@ Here you can find the quick start guides available for these evaluation boards:
 Hardware related
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-- Product datasheets: :adi:`AD9434`
-- :dokuwiki:`EVAL-AD9434 user guide <resources/eval/ad9434fmc-500ebz>`
+-  Product datasheet: :adi:`AD9434`
+-  Schematic file: `ad9434_fmc_500ebz_sch.pdf <https://wiki.analog.com/_media/resources/eval/ad9434_fmc_500ebz_sch.pdf>`__
+-  :dokuwiki:`EVAL-AD9434 user guide <resources/eval/ad9434fmc-500ebz>`
 
 HDL related
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -190,19 +199,19 @@ HDL related
      - :ref:`here <axi_dmac>`
    * - AXI_CLKGEN
      - :git-hdl:`library/axi_clkgen <library/axi_clkgen>`
-     - :dokuwiki:`[Wiki] <resources/fpga/docs/axi_clkgen>`
+     - :ref:`here <axi_clkgen>`
    * - AXI_HDMI_TX
      - :git-hdl:`library/axi_hdmi_tx <library/axi_hdmi_tx>`
-     - :dokuwiki:`[Wiki] <resources/fpga/docs/axi_hdmi_tx>`
+     - :ref:`here <axi_hdmi_tx>`
    * - AXI_SPDIF_TX
      - :git-hdl:`library/axi_spdif_tx <library/axi_spdif_tx>`
      - ---
    * - AXI_SYSID
      - :git-hdl:`library/axi_sysid <library/axi_sysid>`
-     - :dokuwiki:`[Wiki] <resources/fpga/docs/axi_sysid>`
+     - :ref:`here <axi_sysid>`
    * - SYSID_ROM
      - :git-hdl:`library/sysid_rom <library/sysid_rom>`
-     - :dokuwiki:`[Wiki] <resources/fpga/docs/axi_sysid>`
+     - :ref:`here <axi_sysid>`
 
 Software related
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/library/axi_ad9434/axi_ad9434_if.v
+++ b/library/axi_ad9434/axi_ad9434_if.v
@@ -1,6 +1,6 @@
 // ***************************************************************************
 // ***************************************************************************
-// Copyright (C) 2014-2023 Analog Devices, Inc. All rights reserved.
+// Copyright (C) 2014-2024 Analog Devices, Inc. All rights reserved.
 //
 // In this HDL repository, there are many different and unique modules, consisting
 // of various HDL (Verilog or VHDL) components. The individual modules are
@@ -167,7 +167,7 @@ module axi_ad9434_if #(
     .FPGA_TECHNOLOGY (FPGA_TECHNOLOGY),
     .CLKIN_DS_OR_SE_N (1),
     .MMCM_OR_BUFR_N (1),
-    .MMCM_CLKIN_PERIOD (2),
+    .MMCM_CLKIN_PERIOD (2.156),
     .MMCM_VCO_DIV (6),
     .MMCM_VCO_MUL (12),
     .MMCM_CLK0_DIV (2),

--- a/projects/ad9434_fmc/zed/system_constr.xdc
+++ b/projects/ad9434_fmc/zed/system_constr.xdc
@@ -1,5 +1,5 @@
 ###############################################################################
-## Copyright (C) 2023 Analog Devices, Inc. All rights reserved.
+## Copyright (C) 2023-2024 Analog Devices, Inc. All rights reserved.
 ### SPDX short identifier: ADIBSD
 ###############################################################################
 
@@ -43,3 +43,10 @@ set_property -dict {PACKAGE_PIN B21 IOSTANDARD LVCMOS25} [get_ports spi_csn_clk]
 set_property -dict {PACKAGE_PIN B22 IOSTANDARD LVCMOS25} [get_ports spi_csn_adc]                  ; ## G37  FMC_LA33_N     IO_L18N_T2_AD13N_35
 set_property -dict {PACKAGE_PIN A21 IOSTANDARD LVCMOS25} [get_ports spi_dio]                      ; ## H37  FMC_LA32_P     IO_L15P_T2_DQS_AD12P_35
 set_property -dict {PACKAGE_PIN A22 IOSTANDARD LVCMOS25} [get_ports spi_sclk]                     ; ## H38  FMC_LA32_N     IO_L15N_T2_DQS_AD12N_35
+
+# 463.82MHz
+create_clock -name adc_clk          -period 2.156    [get_ports adc_clk_p]
+create_clock -name adc_core_clk     -period 8.624    [get_pins i_system_wrapper/system_i/axi_ad9434/adc_clk]
+
+set_clock_groups -asynchronous -group [get_clocks adc_clk]
+set_clock_groups -asynchronous -group [get_clocks adc_core_clk]


### PR DESCRIPTION
## PR Description

- Set the adc_clk period to 2.156ns
- Set the frequency to 463.82MHz because on Zedboard, there is a limitation for BUFG input clock frequency to 464MHz, which is below the maximum sampling rate of the ADC (500MSPS) (info based on [DS187, Table 67: Global Clock Switching Characteristics](https://docs.amd.com/v/u/en-US/ds187-XC7Z010-XC7Z020-Data-Sheet) (FMAX_BUFG))
- Updated the documentation
- Linux PR: https://github.com/analogdevicesinc/linux/pull/2532

## PR Type
- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the code style guidelines
- [x] I have performed a self-review of changes
- [x] I have compiled all hdl projects and libraries affected by this PR
- [x] I have tested in hardware affected projects, at least on relevant boards
- [x] I have commented my code, at least hard-to-understand parts
- [x] I have signed off all commits from this PR
- [x] I have updated the documentation (wiki pages, ReadMe files, Copyright etc)
- [x] I have not introduced new Warnings/Critical Warnings on compilation
- [ ] I have added new hdl testbenches or updated existing ones
