### PR TITLE
Replaced master from links with main

### DIFF
--- a/projects/adrv9009zu11eg/adrv2crr_fmcxmwbr1/system_top_xmicrowave.v
+++ b/projects/adrv9009zu11eg/adrv2crr_fmcxmwbr1/system_top_xmicrowave.v
@@ -26,7 +26,7 @@
 //
 //   2. An ADI specific BSD license, which can be found in the top level directory
 //      of this repository (LICENSE_ADIBSD), and also on-line at:
-//      https://github.com/analogdevicesinc/hdl/blob/master/LICENSE_ADIBSD
+//      https://github.com/analogdevicesinc/hdl/blob/main/LICENSE_ADIBSD
 //      This will allow to generate bit files and not release the source code,
 //      as long as it attaches to an ADI device.
 //

--- a/projects/adrv9026/zcu102/system_top.v
+++ b/projects/adrv9026/zcu102/system_top.v
@@ -26,7 +26,7 @@
 //
 //   2. An ADI specific BSD license, which can be found in the top level directory
 //      of this repository (LICENSE_ADIBSD), and also on-line at:
-//      https://github.com/analogdevicesinc/hdl/blob/master/LICENSE_ADIBSD
+//      https://github.com/analogdevicesinc/hdl/blob/main/LICENSE_ADIBSD
 //      This will allow to generate bit files and not release the source code,
 //      as long as it attaches to an ADI device.
 //

--- a/projects/adrv904x/zcu102/system_top.v
+++ b/projects/adrv904x/zcu102/system_top.v
@@ -26,7 +26,7 @@
 //
 //   2. An ADI specific BSD license, which can be found in the top level directory
 //      of this repository (LICENSE_ADIBSD), and also on-line at:
-//      https://github.com/analogdevicesinc/hdl/blob/master/LICENSE_ADIBSD
+//      https://github.com/analogdevicesinc/hdl/blob/main/LICENSE_ADIBSD
 //      This will allow to generate bit files and not release the source code,
 //      as long as it attaches to an ADI device.
 //

--- a/projects/cn0585/zed/system_top.v
+++ b/projects/cn0585/zed/system_top.v
@@ -26,7 +26,7 @@
 //
 //   2. An ADI specific BSD license, which can be found in the top level directory
 //      of this repository(LICENSE_ADIBSD), and also on-line at:
-//      https://github.com/analogdevicesinc/hdl/blob/master/LICENSE_ADIBSD
+//      https://github.com/analogdevicesinc/hdl/blob/main/LICENSE_ADIBSD
 //      This will allow to generate bit files and not release the source code,
 //      as long as it attaches to an ADI device.
 //

--- a/projects/common/vpk180/system_top.v
+++ b/projects/common/vpk180/system_top.v
@@ -26,7 +26,7 @@
 //
 //   2. An ADI specific BSD license, which can be found in the top level directory
 //      of this repository (LICENSE_ADIBSD), and also on-line at:
-//      https://github.com/analogdevicesinc/hdl/blob/master/LICENSE_ADIBSD
+//      https://github.com/analogdevicesinc/hdl/blob/main/LICENSE_ADIBSD
 //      This will allow to generate bit files and not release the source code,
 //      as long as it attaches to an ADI device.
 //

--- a/projects/pulsar_lvds_adc/zed/ad7626_system_top.v
+++ b/projects/pulsar_lvds_adc/zed/ad7626_system_top.v
@@ -26,7 +26,7 @@
 //
 //   2. An ADI specific BSD license, which can be found in the top level directory
 //      of this repository (LICENSE_ADIBSD), and also on-line at:
-//      https://github.com/analogdevicesinc/hdl/blob/master/LICENSE_ADIBSD
+//      https://github.com/analogdevicesinc/hdl/blob/main/LICENSE_ADIBSD
 //      This will allow to generate bit files and not release the source code,
 //      as long as it attaches to an ADI device.
 //

--- a/projects/pulsar_lvds_adc/zed/ad7960_system_top.v
+++ b/projects/pulsar_lvds_adc/zed/ad7960_system_top.v
@@ -26,7 +26,7 @@
 //
 //   2. An ADI specific BSD license, which can be found in the top level directory
 //      of this repository (LICENSE_ADIBSD), and also on-line at:
-//      https://github.com/analogdevicesinc/hdl/blob/master/LICENSE_ADIBSD
+//      https://github.com/analogdevicesinc/hdl/blob/main/LICENSE_ADIBSD
 //      This will allow to generate bit files and not release the source code,
 //      as long as it attaches to an ADI device.
 //

--- a/projects/wiki_summary.sh
+++ b/projects/wiki_summary.sh
@@ -39,7 +39,7 @@ do
 	README="./${PROJECT}/Readme.md"
 	if [ ! -f ${README} ] ; then
 		echo -n "  ${PROJECT} |"
-		echo -n "  [[repo>hdl/tree/master/projects/${PROJECT}|Source]] |"
+		echo -n "  [[repo>hdl/tree/main/projects/${PROJECT}|Source]] |"
 		echo -n " missing ${README} |||"
 	else
 		BOARD=$(grep -i "Board Product Page" ${README} | sed -e 's|^.*(||' -e 's|).*$||' -e 's|http.*\/\/www\.analog\.com\/|adi>|')
@@ -62,7 +62,7 @@ do
 			echo -n "  ${PROJECT} |"
 		fi
 
-		echo -n "  [[repo>hdl/tree/master/projects/${PROJECT}|Source]] |"
+		echo -n "  [[repo>hdl/tree/main/projects/${PROJECT}|Source]] |"
 
 		if [ ! -z "${PROJECT_DOC}" ] ; then
 			i=0


### PR DESCRIPTION
## PR Description

Made a script to check each link that contains the word "/master" and then replace it with "/main" in all the files from 
the /projects folder.

## PR Type
- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the code style guidelines
- [x] I have performed a self-review of changes
- [ ] I have compiled all hdl projects and libraries affected by this PR
- [ ] I have tested in hardware affected projects, at least on relevant boards
- [ ] I have commented my code, at least hard-to-understand parts
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe files, Copyright etc)
- [ ] I have not introduced new Warnings/Critical Warnings on compilation
- [ ] I have added new hdl testbenches or updated existing ones
