### PR TITLE
ad9213_evb: Change DMA clock

### DIFF
--- a/projects/ad9213_evb/common/ad9213_evb_bd.tcl
+++ b/projects/ad9213_evb/common/ad9213_evb_bd.tcl
@@ -116,12 +116,12 @@ ad_connect  glbl_clk_0 rx_ad9213_tpl_core/link_clk
 ad_connect  glbl_clk_0 axi_ad9213_fifo/adc_clk
 
 # dma clock domain
-ad_connect  $sys_cpu_clk axi_ad9213_fifo/dma_clk
-ad_connect  $sys_cpu_clk axi_ad9213_dma/s_axis_aclk
+ad_connect  $sys_dma_clk axi_ad9213_fifo/dma_clk
+ad_connect  $sys_dma_clk axi_ad9213_dma/s_axis_aclk
 
 # connect resets
 ad_connect  glbl_clk_0_rstgen/peripheral_reset axi_ad9213_fifo/adc_rst
-ad_connect  $sys_cpu_resetn axi_ad9213_dma/m_dest_axi_aresetn
+ad_connect  $sys_dma_resetn axi_ad9213_dma/m_dest_axi_aresetn
 
 # connect dataflow
 ad_connect  axi_ad9213_jesd/rx_sof rx_ad9213_tpl_core/link_sof


### PR DESCRIPTION
## PR Description

The DMA in the ad9213_evb project was using sys_cpu_clk instead of sys_dma_clk.

## PR Type
- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the code style guidelines
- [x] I have performed a self-review of changes
- [x] I have compiled all hdl projects and libraries affected by this PR
- [x] I have tested in hardware affected projects, at least on relevant boards
- [ ] I have commented my code, at least hard-to-understand parts
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe files, Copyright etc)
- [x] I have not introduced new Warnings/Critical Warnings on compilation
- [ ] I have added new hdl testbenches or updated existing ones
