### PR TITLE
adrv9009_zc706: Upgrade DMA

### DIFF
--- a/projects/adrv9009/zc706/system_bd.tcl
+++ b/projects/adrv9009/zc706/system_bd.tcl
@@ -19,6 +19,26 @@ sysid_gen_sys_init_file
 
 ad_ip_parameter sys_ps7 CONFIG.PCW_FPGA2_PERIPHERAL_FREQMHZ 250
 
+ad_ip_instance proc_sys_reset sys_250m_rstgen
+ad_ip_parameter sys_250m_rstgen CONFIG.C_EXT_RST_WIDTH 1
+
+ad_connect  sys_250m_clk sys_ps7/FCLK_CLK2
+ad_connect  sys_250m_reset sys_250m_rstgen/peripheral_reset
+ad_connect  sys_250m_resetn sys_250m_rstgen/peripheral_aresetn
+ad_connect  sys_250m_clk sys_250m_rstgen/slowest_sync_clk
+ad_connect  sys_250m_rstgen/ext_reset_in sys_ps7/FCLK_RESET2_N
+
+set sys_dma_clk           [get_bd_nets sys_250m_clk]
+set sys_dma_reset         [get_bd_nets sys_250m_reset]
+set sys_dma_resetn        [get_bd_nets sys_250m_resetn]
+
 source ../common/adrv9009_bd.tcl
+
+ad_ip_parameter axi_adrv9009_rx_dma CONFIG.FIFO_SIZE 32
+ad_ip_parameter axi_adrv9009_rx_os_dma CONFIG.FIFO_SIZE 32
+ad_ip_parameter axi_adrv9009_tx_dma CONFIG.FIFO_SIZE 32
+ad_ip_parameter axi_adrv9009_rx_dma CONFIG.MAX_BYTES_PER_BURST 4096
+ad_ip_parameter axi_adrv9009_rx_os_dma CONFIG.MAX_BYTES_PER_BURST 4096
+ad_ip_parameter axi_adrv9009_tx_dma CONFIG.MAX_BYTES_PER_BURST 4096
 
 ad_ip_parameter axi_adrv9009_rx_clkgen CONFIG.CLK1_DIV 6


### PR DESCRIPTION
## PR Description

The signal integrity for this project was very bad on No-OS.
Upgraded the DMA buffers and clock.

## PR Type
- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the code style guidelines
- [x] I have performed a self-review of changes
- [x] I have compiled all hdl projects and libraries affected by this PR
- [x] I have tested in hardware affected projects, at least on relevant boards
- [ ] I have commented my code, at least hard-to-understand parts
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe files, Copyright etc)
- [x] I have not introduced new Warnings/Critical Warnings on compilation
- [ ] I have added new hdl testbenches or updated existing ones
