### PR TITLE
adrv9009zu11eg/adrv2crr_fmcxmwbr1: Switch default build configuration

### DIFF
--- a/projects/adrv9009zu11eg/adrv2crr_fmcxmwbr1/system_project.tcl
+++ b/projects/adrv9009zu11eg/adrv2crr_fmcxmwbr1/system_project.tcl
@@ -17,12 +17,12 @@ source $ad_hdl_dir/projects/scripts/adi_board.tcl
 #   How to use over-writable parameters from the environment:
 #
 #    e.g.
-#      make ADI_PRODUCTION = 1
+#      make ADI_PRODUCTION = 0
 #
 #    ADI_PRODUCTION  - Defines the interface type (XMICROWAVE or FMCXMWBR1)
 #
-# LEGEND: 0 - XMICROWAVE - uses all the spi lines and gpios
-#         1 - FMCXMWBR1 - used for production testing
+# LEGEND: 0 - FMCXMWBR1 - used for production testing
+#         1 - XMICROWAVE - uses all the spi lines and gpios
 #
 ##-----------------------------------------------------------------------------
 
@@ -56,11 +56,11 @@ adi_project_files adrv9009zu11eg_fmcxmwbr1 [list \
 switch $intf {
   0 {
     adi_project_files adrv9009zu11eg_fmcxmwbr1 [list \
-      "system_top_xmicrowave.v" ]
+      "system_top_fmcxmwbr1.v" ]
   }
   1 {
     adi_project_files adrv9009zu11eg_fmcxmwbr1 [list \
-      "system_top_fmcxmwbr1.v" ]
+      "system_top_xmicrowave.v" ]
   }
 }
 


### PR DESCRIPTION
## PR Description

Set the default configuration to fmcxmwbr1, so that the project and folder name would be the same.

## PR Type
- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the code style guidelines
- [x] I have performed a self-review of changes
- [x] I have compiled all hdl projects and libraries affected by this PR
- [ ] I have tested in hardware affected projects, at least on relevant boards
- [ ] I have commented my code, at least hard-to-understand parts
- [ ] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe files, Copyright etc)
- [ ] I have not introduced new Warnings/Critical Warnings on compilation
- [ ] I have added new hdl testbenches or updated existing ones
