### PR TITLE
ad9213_vcu118: Missing generated clock for hmc7044_spi

### DIFF
--- a/projects/ad9213_evb/vcu118/system_constr.xdc
+++ b/projects/ad9213_evb/vcu118/system_constr.xdc
@@ -86,3 +86,8 @@ create_clock -name global_clk_0   -period  3.2 [get_ports glbl_clk_0_p]
 set_input_delay -clock [get_clocks global_clk_0] \
   [expr [get_property PERIOD [get_clocks global_clk_0]] / 2] \
   [get_ports {rx_sysref_*}]
+
+# Create SPI clock
+create_generated_clock -name hmc7044_spi_clk  \
+  -source [get_pins i_system_wrapper/system_i/hmc7044_spi/ext_spi_clk] \
+  -divide_by 2 [get_pins i_system_wrapper/system_i/hmc7044_spi/sck_o]


### PR DESCRIPTION
## PR Description

The build log reported the following Critical Warning:

There are 8 register/latch pins with no clock driven by root clock pin: i_system_wrapper/system_i/hmc7044_spi/U0/NO_DUAL_QUAD_MODE.QSPI_NORMAL/QSPI_LEGACY_MD_GEN.QSPI_CORE_INTERFACE_I/LOGIC_FOR_MD_0_GEN.SPI_MODULE_I/RATIO_NOT_EQUAL_4_GENERATE.SCK_O_NQ_4_NO_STARTUP_USED.SCK_O_NE_4_FDRE_INST/Q (HIGH)

i_hmc7044_spi/spi_count_reg[0]/C
i_hmc7044_spi/spi_count_reg[1]/C
i_hmc7044_spi/spi_count_reg[2]/C
i_hmc7044_spi/spi_count_reg[3]/C
i_hmc7044_spi/spi_count_reg[4]/C
i_hmc7044_spi/spi_count_reg[5]/C
i_hmc7044_spi/spi_enable_reg/C
i_hmc7044_spi/spi_rd_wr_n_reg/C

## PR Type
- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the code style guidelines
- [x] I have performed a self-review of changes
- [x] I have compiled all hdl projects and libraries affected by this PR
- [ ] I have tested in hardware affected projects, at least on relevant boards
- [x] I have commented my code, at least hard-to-understand parts
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe files, Copyright etc)
- [x] I have not introduced new Warnings/Critical Warnings on compilation
- [ ] I have added new hdl testbenches or updated existing ones
