### PR TITLE
fmcomms2: Fix synthesis (Vivado >= 2023.2)

### DIFF
--- a/projects/common/kc705/system_project.tcl
+++ b/projects/common/kc705/system_project.tcl
@@ -11,7 +11,6 @@ adi_project template_kc705
 adi_project_files template_kc705 [list \
   "$ad_hdl_dir/library/common/ad_iobuf.v" \
   "$ad_hdl_dir/projects/common/kc705/kc705_system_constr.xdc" \
-  "system_constr.xdc"\
   "system_top.v" ]
 
 adi_project_run template_kc705

--- a/projects/fmcomms2/kc705/system_top.v
+++ b/projects/fmcomms2/kc705/system_top.v
@@ -209,7 +209,7 @@ module system_top (
     .sys_clk_n (sys_clk_n),
     .sys_clk_p (sys_clk_p),
     .sys_rst (sys_rst),
-    .spi_clk_i (spi_clk),
+    .spi_clk_i (),
     .spi_clk_o (spi_clk),
     .spi_csn_i (spi_csn),
     .spi_csn_o (spi_csn),

--- a/projects/fmcomms2/kcu105/system_top.v
+++ b/projects/fmcomms2/kcu105/system_top.v
@@ -169,7 +169,7 @@ module system_top (
     .sgmii_txn (phy_tx_n),
     .sgmii_txp (phy_tx_p),
 
-    .spi_clk_i (spi_clk),
+    .spi_clk_i (),
     .spi_clk_o (spi_clk),
     .spi_csn_i (spi_csn),
     .spi_csn_o (spi_csn),

--- a/projects/fmcomms2/vc707/system_top.v
+++ b/projects/fmcomms2/vc707/system_top.v
@@ -197,7 +197,7 @@ module system_top (
     .sys_clk_n (sys_clk_n),
     .sys_clk_p (sys_clk_p),
     .sys_rst (sys_rst),
-    .spi_clk_i (spi_clk),
+    .spi_clk_i (),
     .spi_clk_o (spi_clk),
     .spi_csn_i (spi_csn),
     .spi_csn_o (spi_csn),


### PR DESCRIPTION
## PR Description

Investigating the log, I noticed that
```
Instance ..SCK_O_NE_4_FDRE_INST cannot be placed in site OLOGIC_X1Y0 because the output signal of the cell requires general routing to fabric and cells placed in OLOGIC can only be routed to delay or I/O site.
```
Explained in [AMD article 66668](https://support.xilinx.com/s/article/66668?language=en_US).
Even though there is no additional cell in the path beyond the target register (FDRE), the dangling spi_clk_i net seem to trigger the error starting on Vivado 2023.2.

 ![Screenshot 2024-07-25 170324](https://github.com/user-attachments/assets/35e2cde5-54a0-48d2-9c30-aa0d6a4b5e37)

The solution was to remove the spi_clk_i/o loopback on the system_top to ensure only one net in this path, since the target register is instantiated at IP level.

Also, fixup nonexistent file in common/kc705 from system_project.tcl.

@bia1708 can you please remove the fmcomms2 projects from the denylist?

All 3 projects compilation succeeded.

## PR Type
- [X] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [X] I have followed the code style guidelines
- [X] I have performed a self-review of changes
- [X] I have compiled all hdl projects and libraries affected by this PR
- [ ] I have tested in hardware affected projects, at least on relevant boards
- [ ] I have commented my code, at least hard-to-understand parts
- [ ] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe files, Copyright etc)
- [ ] I have not introduced new Warnings/Critical Warnings on compilation
- [ ] I have added new hdl testbenches or updated existing ones
