### PR TITLE
Fix: ad9209_fmca_ebz: vck190: Implemented the Versal reset changes

### DIFF
--- a/projects/ad9081_fmca_ebz/common/ad9081_fmca_ebz_bd.tcl
+++ b/projects/ad9081_fmca_ebz/common/ad9081_fmca_ebz_bd.tcl
@@ -207,14 +207,18 @@ if {$ADI_PHY_SEL == 1} {
     }
   }
 
-  ad_connect gt_reset                     jesd204_phy/gtreset_in
-  ad_connect gt_reset_rx_datapath         jesd204_phy/gtreset_rx_datapath
-  ad_connect gt_reset_tx_datapath         jesd204_phy/gtreset_tx_datapath
-  ad_connect gt_reset_rx_pll_and_datapath jesd204_phy/gtreset_rx_pll_and_datapath
-  ad_connect gt_reset_tx_pll_and_datapath jesd204_phy/gtreset_tx_pll_and_datapath
-  ad_connect gt_powergood                 jesd204_phy/gtpowergood
-  ad_connect rx_resetdone                 jesd204_phy/rx_resetdone
-  ad_connect tx_resetdone                 jesd204_phy/tx_resetdone
+  ad_connect gt_reset                       jesd204_phy/gtreset_in
+  ad_connect gt_powergood                   jesd204_phy/gtpowergood
+  if {$INTF_CFG != "TX"} {
+    ad_connect gt_reset_rx_datapath         jesd204_phy/gtreset_rx_datapath
+    ad_connect gt_reset_rx_pll_and_datapath jesd204_phy/gtreset_rx_pll_and_datapath
+    ad_connect rx_resetdone                 jesd204_phy/rx_resetdone
+  }
+  if {$INTF_CFG != "RX"} {
+    ad_connect gt_reset_tx_datapath         jesd204_phy/gtreset_tx_datapath
+    ad_connect gt_reset_tx_pll_and_datapath jesd204_phy/gtreset_tx_pll_and_datapath
+    ad_connect tx_resetdone                 jesd204_phy/tx_resetdone
+  }
 }
 
 # Instantiate ADC (Rx) path


### PR DESCRIPTION
## PR Description

Implements the necessary changes to support the new Versal reset sequence triggered by the software.

## PR Type
- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the code style guidelines
- [x] I have performed a self-review of changes
- [x] I have compiled all hdl projects and libraries affected by this PR
- [x] I have tested in hardware affected projects, at least on relevant boards
- [ ] I have commented my code, at least hard-to-understand parts
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe files, Copyright etc)
- [ ] I have not introduced new Warnings/Critical Warnings on compilation
- [ ] I have added new hdl testbenches or updated existing ones
