### PR TITLE
ad_gmsl2eth_sl: Add missing mfp_*_p2 pins to pwm_gen-based logic

### DIFF
--- a/projects/ad_gmsl2eth_sl/common/ad_gmsl2eth_sl_bd.tcl
+++ b/projects/ad_gmsl2eth_sl/common/ad_gmsl2eth_sl_bd.tcl
@@ -21,6 +21,10 @@ create_bd_port -dir O mfp_0_p1
 create_bd_port -dir O mfp_1_p1
 create_bd_port -dir O mfp_2_p1
 create_bd_port -dir O mfp_3_p1
+create_bd_port -dir O mfp_0_p2
+create_bd_port -dir O mfp_1_p2
+create_bd_port -dir O mfp_2_p2
+create_bd_port -dir O mfp_3_p2
 
 set mipi_phy_if_0 [ create_bd_intf_port -mode Slave -vlnv xilinx.com:interface:mipi_phy_rtl:1.0 mipi_phy_if_0 ]
 set mipi_phy_if_1 [ create_bd_intf_port -mode Slave -vlnv xilinx.com:interface:mipi_phy_rtl:1.0 mipi_phy_if_1 ]
@@ -230,7 +234,7 @@ ad_ip_parameter v_frmbuf_7 CONFIG.MAX_ROWS {1080}
 ad_ip_parameter v_frmbuf_7 CONFIG.SAMPLES_PER_CLOCK {2}
 
 ad_ip_instance axi_pwm_gen axi_pwm_gen_0
-ad_ip_parameter axi_pwm_gen_0 CONFIG.N_PWMS {4}
+ad_ip_parameter axi_pwm_gen_0 CONFIG.N_PWMS {8}
 
 ad_ip_instance axis_subset_converter axis_subset_cnv_0
 ad_ip_parameter axis_subset_cnv_0 CONFIG.M_TDATA_NUM_BYTES {6}
@@ -324,7 +328,6 @@ ad_connect axis_subset_cnv_6/aresetn ap_rstn_frmbuf_6
 ad_connect axis_subset_cnv_7/aclk sys_cpu_clk
 ad_connect axis_subset_cnv_7/aresetn ap_rstn_frmbuf_7
 
-
 ad_connect v_frmbuf_0/ap_rst_n ap_rstn_frmbuf_0
 ad_connect v_frmbuf_1/ap_rst_n ap_rstn_frmbuf_1
 ad_connect v_frmbuf_2/ap_rst_n ap_rstn_frmbuf_2
@@ -343,7 +346,6 @@ ad_connect v_frmbuf_4/m_axi_mm_video axi_hp1_interconnect/S00_AXI
 ad_connect v_frmbuf_5/m_axi_mm_video axi_hp1_interconnect/S01_AXI
 ad_connect v_frmbuf_6/m_axi_mm_video axi_hp1_interconnect/S02_AXI
 ad_connect v_frmbuf_7/m_axi_mm_video axi_hp1_interconnect/S03_AXI
-
 
 ad_connect axis_subset_cnv_0/M_AXIS v_frmbuf_0/s_axis_video
 ad_connect axis_subset_cnv_1/M_AXIS v_frmbuf_1/s_axis_video
@@ -391,6 +393,10 @@ ad_connect axi_pwm_gen_0/pwm_0 mfp_0_p1
 ad_connect axi_pwm_gen_0/pwm_1 mfp_1_p1
 ad_connect axi_pwm_gen_0/pwm_2 mfp_2_p1
 ad_connect axi_pwm_gen_0/pwm_3 mfp_3_p1
+ad_connect axi_pwm_gen_0/pwm_4 mfp_0_p2
+ad_connect axi_pwm_gen_0/pwm_5 mfp_1_p2
+ad_connect axi_pwm_gen_0/pwm_6 mfp_2_p2
+ad_connect axi_pwm_gen_0/pwm_7 mfp_3_p2
 ad_connect axi_pwm_gen_0/ext_clk sys_cpu_clk
 
 create_bd_intf_port -mode Master -vlnv xilinx.com:interface:iic_rtl:1.0 tca_iic

--- a/projects/ad_gmsl2eth_sl/k26/system_top.v
+++ b/projects/ad_gmsl2eth_sl/k26/system_top.v
@@ -119,11 +119,6 @@ module system_top (
   assign sfp_i2c_rstn = gpio_o[10];
   assign sfp_i2c_en = 1'b0;
 
-  assign mfp_3_p2 = 1'b0;
-  assign mfp_2_p2 = 1'b0;
-  assign mfp_1_p2 = 1'b0;
-  assign mfp_0_p2 = 1'b0;
-
   ad_iobuf #(
     .DATA_WIDTH(2)
   ) iobuf_0 (
@@ -166,6 +161,10 @@ module system_top (
     .mfp_2_p1 (mfp_2_p1),
     .mfp_1_p1 (mfp_1_p1),
     .mfp_0_p1 (mfp_0_p1),
+    .mfp_3_p2 (mfp_3_p2),
+    .mfp_2_p2 (mfp_2_p2),
+    .mfp_1_p2 (mfp_1_p2),
+    .mfp_0_p2 (mfp_0_p2),
     .mipi_phy_if_0_clk_n (mipi_ch0_clk_n),
     .mipi_phy_if_0_clk_p (mipi_ch0_clk_p),
     .mipi_phy_if_0_data_n (mipi_ch0_data_n),


### PR DESCRIPTION
## PR Description

- ad_gmsl2eth_sl: Add missing mfp_*_p2 pins to pwm_gen-based logic

## PR Type
- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the code style guidelines
- [x] I have performed a self-review of changes
- [ ] I have compiled all hdl projects and libraries affected by this PR
- [ ] I have tested in hardware affected projects, at least on relevant boards
- [ ] I have commented my code, at least hard-to-understand parts
- [ ] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe files, Copyright etc)
- [x] I have not introduced new Warnings/Critical Warnings on compilation
- [ ] I have added new hdl testbenches or updated existing ones
