### PR TITLE
ad9213_evb: vcu118: Fix synthesis (Vivado >= 2023.2)

### DIFF
--- a/projects/ad9213_evb/vcu118/system_constr.xdc
+++ b/projects/ad9213_evb/vcu118/system_constr.xdc
@@ -80,6 +80,9 @@ create_clock -name rx_ref_clk_replica   -period  1.6 [get_ports rx_ref_clk_repli
 # since GLBLCLK0 and GLBLCLK1 are not connected to global clock capable pins.
 create_clock -name global_clk_0   -period  3.2 [get_ports glbl_clk_0_p]
 
+# Create clock driving ad_3w_spi (worst case: sys_cpu/2)
+create_clock -name hmc7044_spi -period  20 [get_pins -hierarchical i_hmc7044_spi/hmc7044_clk_o]
+
 # Constraint SYSREFs
 # Assumption is that REFCLK and SYSREF have similar propagation delay,
 # and the SYSREF is a source synchronous Center-Aligned signal to REFCLK


### PR DESCRIPTION
## PR Description

Resolves critical warning:
```
CRITICAL WARNING: There are 8 registers with no clocks !!! See no_clock.log for details.
There are 8 register/latch pins with no clock driven by root clock pin: i_system_wrapper/system_i/hmc7044_spi/U0/NO_DUAL_QUAD_MODE.QSPI_NORMAL/QSPI_LEGACY_MD_GEN.QSPI_CORE_INTERFACE_I/LOGIC_FOR_MD_0_GEN.SPI_MODULE_I/RATIO_NOT_EQUAL_4_GENERATE.SCK_O_NQ_4_NO_STARTUP_USED.SCK_O_NE_4_FDRE_INST/Q (HIGH)

i_hmc7044_spi/spi_count_reg[0]/C
i_hmc7044_spi/spi_count_reg[1]/C
i_hmc7044_spi/spi_count_reg[2]/C
i_hmc7044_spi/spi_count_reg[3]/C
i_hmc7044_spi/spi_count_reg[4]/C
i_hmc7044_spi/spi_count_reg[5]/C
i_hmc7044_spi/spi_enable_reg/C
i_hmc7044_spi/spi_rd_wr_n_reg/C
```
This error occurs because the SPI adapter ad_spi_3w is being driven by hmc7044_spi/sck (axi_spi) which is not a clock, but a modulated net.
Possible solutions:

* rework ad_spi_3w to be driven by the same clock as axi_spi/ext_spi_clk and treat spi_clk as a register.
* create a clock for axi_spi with the worst case.

Decided to go with the second, since less rework is necessary.
The change creates the clock considering the worst scenario, that is, the clock driving axi_spi divided by 2, as described in the [AXI Quad SpI DS843 p62](https://docs.amd.com/v/u/en-US/ds843_axi_quad_spi).


@bia1708 please remove ad9213_evb.vcu118 from the denylist.

## PR Type
- [X] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [X] I have followed the code style guidelines
- [X] I have performed a self-review of changes
- [X] I have compiled all hdl projects and libraries affected by this PR
- [ ] I have tested in hardware affected projects, at least on relevant boards
- [ ] I have commented my code, at least hard-to-understand parts
- [ ] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe files, Copyright etc)
- [ ] I have not introduced new Warnings/Critical Warnings on compilation
- [ ] I have added new hdl testbenches or updated existing ones
