### PR TITLE
projects/ad9265_fmc/zc706: Fix adc_clk freq -- 125MHz

### DIFF
--- a/projects/ad9265_fmc/zc706/system_constr.xdc
+++ b/projects/ad9265_fmc/zc706/system_constr.xdc
@@ -35,4 +35,4 @@ set_property -dict {PACKAGE_PIN Y26     IOSTANDARD LVCMOS25} [get_ports spi_sdio
 
 # clocks
 
-create_clock -name adc_clk      -period 3.33 [get_ports adc_clk_in_p]
+create_clock -name adc_clk      -period 8.000 [get_ports adc_clk_in_p]


### PR DESCRIPTION
## PR Description

Changed the frequency of adc_clk to 125MHz as it was wrongly set to 300.3MHz. 

## PR Type
- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the code style guidelines
- [x] I have performed a self-review of changes
- [x] I have compiled all hdl projects and libraries affected by this PR
- [x] I have tested in hardware affected projects, at least on relevant boards
- [ ] I have commented my code, at least hard-to-understand parts
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe files, Copyright etc)
- [x] I have not introduced new Warnings/Critical Warnings on compilation
- [ ] I have added new hdl testbenches or updated existing ones
