### PR TITLE
projects/common: Removed absent system_constr.xdc file

### DIFF
--- a/projects/common/ac701/system_project.tcl
+++ b/projects/common/ac701/system_project.tcl
@@ -11,7 +11,6 @@ adi_project template_ac701
 adi_project_files template_ac701 [list \
   "$ad_hdl_dir/library/common/ad_iobuf.v" \
   "$ad_hdl_dir/projects/common/ac701/ac701_system_constr.xdc" \
-  "system_constr.xdc"\
   "system_top.v" ]
   
 adi_project_run template_ac701

--- a/projects/common/coraz7s/system_project.tcl
+++ b/projects/common/coraz7s/system_project.tcl
@@ -11,7 +11,6 @@ adi_project template_coraz7s
 adi_project_files template_coraz7s [list \
     "$ad_hdl_dir/library/common/ad_iobuf.v" \
     "$ad_hdl_dir/projects/common/coraz7s/coraz7s_system_constr.xdc" \
-    "system_constr.xdc" \
     "system_top.v" ]
 
 adi_project_run template_coraz7s

--- a/projects/common/kcu105/system_project.tcl
+++ b/projects/common/kcu105/system_project.tcl
@@ -11,7 +11,6 @@ adi_project template_kcu105
 adi_project_files template_kcu105 [list \
   "$ad_hdl_dir/library/common/ad_iobuf.v" \
   "$ad_hdl_dir/projects/common/kcu105/kcu105_system_constr.xdc" \
-  "system_constr.xdc"\
   "$ad_hdl_dir/projects/common/kcu105/kcu105_system_lutram_constr.xdc" \
   "system_top.v" ]
   

--- a/projects/common/vc707/system_project.tcl
+++ b/projects/common/vc707/system_project.tcl
@@ -11,7 +11,6 @@ adi_project template_vc707
 adi_project_files template_vc707 [list \
   "$ad_hdl_dir/library/common/ad_iobuf.v" \
   "$ad_hdl_dir/projects/common/vc707/vc707_system_constr.xdc" \
-  "system_constr.xdc"\
   "system_top.v" ]
 
 adi_project_run template_vc707

--- a/projects/common/vc709/system_project.tcl
+++ b/projects/common/vc709/system_project.tcl
@@ -11,7 +11,6 @@ adi_project template_vc709
 adi_project_files template_vc709 [list \
   "$ad_hdl_dir/library/common/ad_iobuf.v" \
   "$ad_hdl_dir/projects/common/vc709/vc709_system_constr.xdc" \
-  "system_constr.xdc"\
   "system_top.v" ]
 
 adi_project_run template_vc709

--- a/projects/common/vcu118/system_project.tcl
+++ b/projects/common/vcu118/system_project.tcl
@@ -11,7 +11,6 @@ adi_project template_vcu118
 adi_project_files template_vcu118 [list \
   "$ad_hdl_dir/library/common/ad_iobuf.v" \
   "$ad_hdl_dir/projects/common/vcu118/vcu118_system_constr.xdc" \
-  "system_constr.xdc"\
   "system_top.v" ]
 
 adi_project_run template_vcu118

--- a/projects/common/vcu128/system_project.tcl
+++ b/projects/common/vcu128/system_project.tcl
@@ -11,7 +11,6 @@ adi_project template_vcu128
 adi_project_files template_vcu118 [list \
   "$ad_hdl_dir/library/common/ad_iobuf.v" \
   "$ad_hdl_dir/projects/common/vcu128/vcu128_system_constr.xdc" \
-  "system_constr.xdc"\
   "system_top.v" ]
 
 adi_project_run template_vcu118

--- a/projects/common/vmk180/system_project.tcl
+++ b/projects/common/vmk180/system_project.tcl
@@ -11,7 +11,6 @@ adi_project template_vmk180
 adi_project_files template_vmk180 [list \
   "$ad_hdl_dir/library/common/ad_iobuf.v" \
   "$ad_hdl_dir/projects/common/vmk180/vmk180_system_constr.xdc" \
-  "system_constr.xdc"\
   "system_top.v" ]
 
 adi_project_run template_vmk180

--- a/projects/common/zc702/system_project.tcl
+++ b/projects/common/zc702/system_project.tcl
@@ -11,7 +11,6 @@ adi_project template_zc702
 adi_project_files template_zc702 [list \
   "$ad_hdl_dir/library/common/ad_iobuf.v" \
   "$ad_hdl_dir/projects/common/zc702/zc702_system_constr.xdc" \
-  "system_constr.xdc" \
   "system_top.v" ]
 
 adi_project_run template_zc702

--- a/projects/common/zcu102/system_project.tcl
+++ b/projects/common/zcu102/system_project.tcl
@@ -11,7 +11,6 @@ adi_project template_zcu102
 adi_project_files template_zcu102 [list \
   "$ad_hdl_dir/library/common/ad_iobuf.v" \
   "$ad_hdl_dir/projects/common/zcu102/zcu102_system_constr.xdc" \
-  "system_constr.xdc" \
   "system_top.v" ]
 
 adi_project_run template_zcu102


### PR DESCRIPTION
## PR Description

- Removed all absent system_constr.xdc file calls from Xilinx-related system_project.tcl


## PR Type
- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the code style guidelines
- [x] I have performed a self-review of changes
- [ ] I have compiled all hdl projects and libraries affected by this PR
- [ ] I have tested in hardware affected projects, at least on relevant boards
- [ ] I have commented my code, at least hard-to-understand parts
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe files, Copyright etc)
- [x] I have not introduced new Warnings/Critical Warnings on compilation
- [ ] I have added new hdl testbenches or updated existing ones
