### PR TITLE
sysid: Fix mem init file path

### DIFF
--- a/projects/scripts/adi_pd.tcl
+++ b/projects/scripts/adi_pd.tcl
@@ -1,5 +1,5 @@
 ###############################################################################
-## Copyright (C) 2020-2023 Analog Devices, Inc. All rights reserved.
+## Copyright (C) 2020-2024 Analog Devices, Inc. All rights reserved.
 ### SPDX short identifier: ADIBSD
 ###############################################################################
 
@@ -7,7 +7,7 @@
 
 set mem_init_sys_file_path [pwd]
 if {[info exists ::env(ADI_PROJECT_DIR)]} {
-  set mem_init_sys_file_path $::env(ADI_PROJECT_DIR)
+  set mem_init_sys_file_path [string trimright [pwd]/$::env(ADI_PROJECT_DIR) "/"]
 }
 
 ## Converts a string input to hex and adds whitespace as padding to obtain the size defined by
@@ -212,7 +212,7 @@ proc sysid_gen_sys_init_file {{custom_string {}} {address_bits {9}}} {
   set sys_mem_hex [format %0-${memory_size}s [concat $comh_hex$verh_hex$projname_hex$boardname_hex$custom_hex]];
 
   if {[info exists ::env(ADI_PROJECT_DIR)]} {
-    set mem_init_sys_file_path $::env(ADI_PROJECT_DIR)mem_init_sys.txt
+    set mem_init_sys_file_path [pwd]/$::env(ADI_PROJECT_DIR)mem_init_sys.txt
   } else {
     set mem_init_sys_file_path "mem_init_sys.txt"
   }


### PR DESCRIPTION
This PR fixes the handling of the path to the sysid memory init file

## PR Type
- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [ ] I have followed the code style guidelines
- [x] I have performed a self-review of changes
- [ ] I have compiled all hdl projects and libraries affected by this PR
- [x] I have tested in hardware affected projects, at least on relevant boards
- [ ] I have commented my code, at least hard-to-understand parts
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe files, Copyright etc)
- [x] I have not introduced new Warnings/Critical Warnings on compilation
- [ ] I have added new hdl testbenches or updated existing ones
