### PR TITLE
(CI for #1201) TCL: ad_hpmx_interconnect

### DIFF
--- a/projects/common/vcu118/vcu118_system_bd.tcl
+++ b/projects/common/vcu118/vcu118_system_bd.tcl
@@ -286,8 +286,8 @@ ad_cpu_interconnect 0x44A70000 axi_spi
 ad_cpu_interconnect 0x41400000 sys_mb_debug
 
 ## Peripheral Data Interface runs at the new sys_mb_clk frequency
-ad_ip_parameter axi_cpu_interconnect CONFIG.NUM_CLKS 2
-ad_connect sys_mb_clk axi_cpu_interconnect/aclk1
+ad_ip_parameter axi_dp_interconnect CONFIG.NUM_CLKS 2
+ad_connect sys_mb_clk axi_dp_interconnect/aclk1
 
 # interconnect - memory
 

--- a/projects/common/vcu128/vcu128_system_bd.tcl
+++ b/projects/common/vcu128/vcu128_system_bd.tcl
@@ -326,11 +326,11 @@ ad_cpu_interconnect 0x45100000 axi_ddr_cntrl C0_DDR4_S_AXI_CTRL
 
 ### Workaround for DDR controller with control interface
 ### DDR contoller control interface runs at UI clock not CPU clock
-set_property -dict [list CONFIG.NUM_CLKS {3}] [get_bd_cells axi_cpu_interconnect]
-ad_connect axi_ddr_cntrl/c0_ddr4_ui_clk  axi_cpu_interconnect/aclk1
+set_property -dict [list CONFIG.NUM_CLKS {3}] [get_bd_cells axi_dp_interconnect]
+ad_connect axi_ddr_cntrl/c0_ddr4_ui_clk  axi_dp_interconnect/aclk1
 
 ### Peripheral Data Interface runs at the sys_mb_clk frequency
-ad_connect sys_mb_clk axi_cpu_interconnect/aclk2
+ad_connect sys_mb_clk axi_dp_interconnect/aclk2
 
 # interconnect - memory
 

--- a/projects/scripts/adi_board.tcl
+++ b/projects/scripts/adi_board.tcl
@@ -7,7 +7,6 @@ package require math
 
 ## Global variables for interconnect interface indexing
 #
-set sys_cpu_interconnect_index 0
 set sys_hpc0_interconnect_index -1
 set sys_hpc1_interconnect_index -1
 set sys_hp0_interconnect_index -1
@@ -954,55 +953,65 @@ proc ad_mem_hpx_interconnect {p_sel p_clk p_name} {
 ## Create an AXI4 Lite memory mapped interface connection for register maps,
 #  instantiates an interconnect and reconfigure it at every process call.
 #
+#  \param[p_sel] - name of the high speed interface
+#                  valid values are HPM0_FPD, HPM1_FPD, HPM0_LPD
 #  \param[p_address] - address offset of the IP register map
 #  \param[p_name] - name of the IP
 #  \param[p_intf_name] - name of the AXI MM Slave interface (optional)
 #
-proc ad_cpu_interconnect {p_address p_name {p_intf_name {}}} {
+proc ad_hpmx_interconnect {p_sel p_address p_name {p_intf_name {}}} {
 
   global sys_zynq
-  global sys_cpu_interconnect_index
   global use_smartconnect
 
-  set i_str "M$sys_cpu_interconnect_index"
-  if {$sys_cpu_interconnect_index < 10} {
-    set i_str "M0$sys_cpu_interconnect_index"
-  }
+  set interconnect_name [format "axi_%s_interconnect" [string tolower $p_sel]]
 
-  if {$sys_cpu_interconnect_index == 0} {
+  if {[catch {
+    set interconnect_index [get_property CONFIG.NUM_MI [get_bd_cells $interconnect_name]]
+  } err]} {
+    set interconnect_index 0
+  }
+  set i_str [format "M%02d" $interconnect_index]
+
+  if {$i_str eq "M00"} {
 
     if {$use_smartconnect == 1} {
-      ad_ip_instance smartconnect axi_cpu_interconnect [ list \
+      ad_ip_instance smartconnect $interconnect_name [ list \
         NUM_MI 1 \
         NUM_SI 1 \
       ]
-      ad_connect sys_cpu_clk axi_cpu_interconnect/aclk
-      ad_connect sys_cpu_resetn axi_cpu_interconnect/aresetn
+      ad_connect sys_cpu_clk $interconnect_name/aclk
+      ad_connect sys_cpu_resetn $interconnect_name/aresetn
     } else {
-      ad_ip_instance axi_interconnect axi_cpu_interconnect
-      ad_connect sys_cpu_clk axi_cpu_interconnect/ACLK
-      ad_connect sys_cpu_clk axi_cpu_interconnect/S00_ACLK
-      ad_connect sys_cpu_resetn axi_cpu_interconnect/ARESETN
-      ad_connect sys_cpu_resetn axi_cpu_interconnect/S00_ARESETN
+      ad_ip_instance axi_interconnect $interconnect_name
+      ad_connect sys_cpu_clk $interconnect_name/ACLK
+      ad_connect sys_cpu_clk $interconnect_name/S00_ACLK
+      ad_connect sys_cpu_resetn $interconnect_name/ARESETN
+      ad_connect sys_cpu_resetn $interconnect_name/S00_ARESETN
     }
 
     if {$sys_zynq == 3} {
       ad_connect sys_cpu_clk sys_cips/m_axi_fpd_aclk
-      ad_connect axi_cpu_interconnect/S00_AXI sys_cips/M_AXI_FPD
-    }
-    if {$sys_zynq == 2} {
+      ad_connect $interconnect_name/S00_AXI sys_cips/M_AXI_FPD
+    } elseif {($p_sel eq "HPM0_FPD") && ($sys_zynq == 2)} {
+      ad_connect sys_cpu_clk sys_ps8/maxihpm0_fpd_aclk
+      ad_connect $interconnect_name/S00_AXI sys_ps8/M_AXI_HPM0_FPD
+    } elseif {($p_sel eq "HPM1_FPD") && ($sys_zynq == 2)} {
+      ad_connect sys_cpu_clk sys_ps8/maxihpm1_fpd_aclk
+      ad_connect $interconnect_name/S00_AXI sys_ps8/M_AXI_HPM1_FPD
+    } elseif {($p_sel eq "HPM0_LPD") && ($sys_zynq == 2)} {
       ad_connect sys_cpu_clk sys_ps8/maxihpm0_lpd_aclk
-      ad_connect axi_cpu_interconnect/S00_AXI sys_ps8/M_AXI_HPM0_LPD
-    }
-    if {$sys_zynq == 1} {
+      ad_connect $interconnect_name/S00_AXI sys_ps8/M_AXI_HPM0_LPD
+    } elseif {($p_sel eq "GP0") && ($sys_zynq == 1)} {
       ad_connect sys_cpu_clk sys_ps7/M_AXI_GP0_ACLK
-      ad_connect axi_cpu_interconnect/S00_AXI sys_ps7/M_AXI_GP0
-    }
-    if {$sys_zynq == 0} {
-      ad_connect axi_cpu_interconnect/S00_AXI sys_mb/M_AXI_DP
-    }
-    if {$sys_zynq == -1} {
-      ad_connect axi_cpu_interconnect/S00_AXI mng_axi_vip/M_AXI
+      ad_connect $interconnect_name/S00_AXI sys_ps7/M_AXI_GP0
+    } elseif {($p_sel eq "GP1") && ($sys_zynq == 1)} {
+      ad_connect sys_cpu_clk sys_ps7/M_AXI_GP1_ACLK
+      ad_connect $interconnect_name/S00_AXI sys_ps7/M_AXI_GP1
+    } elseif {$sys_zynq == 0} {
+      ad_connect $interconnect_name/S00_AXI sys_mb/M_AXI_DP
+    } elseif {$sys_zynq == -1} {
+      ad_connect $interconnect_name/S00_AXI mng_axi_vip/M_AXI
     }
   }
 
@@ -1022,8 +1031,7 @@ proc ad_cpu_interconnect {p_address p_name {p_intf_name {}}} {
     set sys_addr_cntrl_space [get_bd_addr_spaces mng_axi_vip/Master_AXI]
   }
 
-  set sys_cpu_interconnect_index [expr $sys_cpu_interconnect_index + 1]
-
+  set interconnect_index [expr $interconnect_index + 1]
 
   set p_cell [get_bd_cells $p_name]
   set p_intf [get_bd_intf_pins -filter \
@@ -1105,11 +1113,11 @@ proc ad_cpu_interconnect {p_address p_name {p_intf_name {}}} {
     }
   }
 
-  set_property CONFIG.NUM_MI $sys_cpu_interconnect_index [get_bd_cells axi_cpu_interconnect]
+  set_property CONFIG.NUM_MI $interconnect_index [get_bd_cells $interconnect_name]
 
   if {$use_smartconnect == 0} {
-    ad_connect sys_cpu_clk axi_cpu_interconnect/${i_str}_ACLK
-    ad_connect sys_cpu_resetn axi_cpu_interconnect/${i_str}_ARESETN
+    ad_connect sys_cpu_clk $interconnect_name/${i_str}_ACLK
+    ad_connect sys_cpu_resetn $interconnect_name/${i_str}_ARESETN
   }
   if {$p_intf_clock ne ""} {
     ad_connect sys_cpu_clk ${p_intf_clock}
@@ -1117,7 +1125,7 @@ proc ad_cpu_interconnect {p_address p_name {p_intf_name {}}} {
   if {$p_intf_reset ne ""} {
     ad_connect sys_cpu_resetn ${p_intf_reset}
   }
-  ad_connect axi_cpu_interconnect/${i_str}_AXI ${p_intf}
+  ad_connect $interconnect_name/${i_str}_AXI ${p_intf}
 
   set p_seg [get_bd_addr_segs -of [get_bd_addr_spaces -of [get_bd_intf_pins -filter "NAME=~ *${p_intf_name}*" -of $p_hier_cell]]]
   set p_index 0
@@ -1147,6 +1155,7 @@ proc ad_cpu_interconnect {p_address p_name {p_intf_name {}}} {
           set p_address [expr ($p_address + 0x20000000)]
         }
       }
+      puts "create_bd_addr_seg -range $p_seg_range -offset $p_address $sys_addr_cntrl_space $p_seg_name SEG_data_$p_name"
       create_bd_addr_seg -range $p_seg_range \
         -offset $p_address $sys_addr_cntrl_space \
         $p_seg_name "SEG_data_${p_name}"
@@ -1155,6 +1164,22 @@ proc ad_cpu_interconnect {p_address p_name {p_intf_name {}}} {
     }
     incr p_index
   }
+}
+
+## Create an AXI4 Lite memory mapped interface connection for register maps,
+#  instantiates an interconnect and reconfigure it at every process call.
+#
+#  \param[p_address] - address offset of the IP register map
+#  \param[p_name] - name of the IP
+#  \param[p_intf_name] - name of the AXI MM Slave interface (optional)
+#
+proc ad_cpu_interconnect {p_address p_name {p_intf_name {}}} {
+
+  if     {$sys_zynq == -1} {ad_hpmx_interconnect "AXI"      $p_address $p_name $p_intf_name}
+  elseif {$sys_zynq ==  0} {ad_hpmx_interconnect "DP"       $p_address $p_name $p_intf_name}
+  elseif {$sys_zynq ==  1} {ad_hpmx_interconnect "GP0"      $p_address $p_name $p_intf_name}
+  elseif {$sys_zynq ==  2} {ad_hpmx_interconnect "HPM0_LPD" $p_address $p_name $p_intf_name}
+  elseif {$sys_zynq ==  3} {ad_hpmx_interconnect "FPD"      $p_address $p_name $p_intf_name}
 }
 
 ## Connects an IP interrupt port to the system's interrupt controller interface.

--- a/projects/scripts/adi_board.tcl
+++ b/projects/scripts/adi_board.tcl
@@ -1175,11 +1175,19 @@ proc ad_hpmx_interconnect {p_sel p_address p_name {p_intf_name {}}} {
 #
 proc ad_cpu_interconnect {p_address p_name {p_intf_name {}}} {
 
-  if     {$sys_zynq == -1} {ad_hpmx_interconnect "AXI"      $p_address $p_name $p_intf_name}
-  elseif {$sys_zynq ==  0} {ad_hpmx_interconnect "DP"       $p_address $p_name $p_intf_name}
-  elseif {$sys_zynq ==  1} {ad_hpmx_interconnect "GP0"      $p_address $p_name $p_intf_name}
-  elseif {$sys_zynq ==  2} {ad_hpmx_interconnect "HPM0_LPD" $p_address $p_name $p_intf_name}
-  elseif {$sys_zynq ==  3} {ad_hpmx_interconnect "FPD"      $p_address $p_name $p_intf_name}
+  global sys_zynq
+
+  if {$sys_zynq == -1} {
+    ad_hpmx_interconnect "AXI"      $p_address $p_name $p_intf_name
+  } elseif {$sys_zynq ==  0} {
+    ad_hpmx_interconnect "DP"       $p_address $p_name $p_intf_name
+  } elseif {$sys_zynq ==  1} {
+    ad_hpmx_interconnect "GP0"      $p_address $p_name $p_intf_name
+  } elseif {$sys_zynq ==  2} {
+    ad_hpmx_interconnect "HPM0_LPD" $p_address $p_name $p_intf_name
+  } elseif {$sys_zynq ==  3} {
+    ad_hpmx_interconnect "FPD"      $p_address $p_name $p_intf_name
+  }
 }
 
 ## Connects an IP interrupt port to the system's interrupt controller interface.


### PR DESCRIPTION
## PR Description

Trigger CI for https://github.com/analogdevicesinc/hdl/pull/1201
Added fixes to the o.g. PR and updated affected projects (those touching "ad_cpu_interconnect" IP core directly)

Some custom projects might rely on other PS AXI master interfaces, rework ad_cpu_interconnect to allow users to specify other interfaces.

For now, I was only able to test this on a zynqmp project, and don't have the full list of interfaces for other platforms, but I'm happy to update the PR.

This PR should run on all projects. Already rebased on main.

## PR Type
- [ ] Bug fix (change that fixes an issue)
- [X] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [ ] I have followed the code style guidelines
- [ ] I have performed a self-review of changes
- [ ] I have compiled all hdl projects and libraries affected by this PR
- [ ] I have tested in hardware affected projects, at least on relevant boards
- [ ] I have commented my code, at least hard-to-understand parts
- [ ] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe files, Copyright etc)
- [ ] I have not introduced new Warnings/Critical Warnings on compilation
- [ ] I have added new hdl testbenches or updated existing ones
