### PR TITLE
library/scripts/library.mk: Fix .lock cleaning for IPs requiring other IPs

### DIFF
--- a/library/scripts/library.mk
+++ b/library/scripts/library.mk
@@ -61,6 +61,9 @@ clean-all:
 	$(call clean, \
 		$(CLEAN_TARGET) .lock, \
 		$(HL)$(LIBRARY_NAME)$(NC) library)
+	@for lib in $(XILINX_LIB_DEPS); do \
+		$(MAKE) -C $(HDL_LIBRARY_PATH)$${lib} clean; \
+	done
 
 ifneq ($(INTEL_DEPS),)
 


### PR DESCRIPTION
## PR Description

Added cleaning of the .lock files for XILINX_LIB_DEPS as well.

For example, the case with axi_dmac, which has util_cdc and util_axis_fifo as dependency libraries:
when running `make clean-all` in a project which uses axi_dmac, this cleaning procedure wouldn't remove the `.lock` from util_cdc and util_axis_fifo, because they are dependencies of a dependency and the cleaning would go only on libraries specified in the Makefile of the project and not further down in the hierarchy. Not removing this lock file would make the build get stuck at the libraries.

Built the AD9265/ZC706 & Zedboard and AD485x/Zedboard and it works.

## PR Type
- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the code style guidelines
- [x] I have performed a self-review of changes
- [x] I have compiled all hdl projects and libraries affected by this PR
- [ ] I have tested in hardware affected projects, at least on relevant boards
- [ ] I have commented my code, at least hard-to-understand parts
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe files, Copyright etc)
- [x] I have not introduced new Warnings/Critical Warnings on compilation
- [ ] I have added new hdl testbenches or updated existing ones
