### PR TITLE
docs: fix CNTRL_2 DATA_FORMAT field

### DIFF
--- a/docs/regmap/adi_regmap_dac.txt
+++ b/docs/regmap/adi_regmap_dac.txt
@@ -143,7 +143,7 @@ FIELD
 [4] 0x00000000
 DATA_FORMAT
 RW
-Select data format 2's complement (0x0) or offset binary (0x1).
+Select data format unsigned (0x0) or 2's complement (0x1).
 NOT-APPLICABLE if DAC_DP_DISABLE is set (0x1).
 ENDFIELD
 


### PR DESCRIPTION
Noted that in my application, ad3552r-axi, i need to set this bit (4) to 0 to have unsigned 16bit samples generated.

## PR Description

Fix DAC IP documentation.


## PR Type
- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [ ] I have followed the code style guidelines
- [x] I have performed a self-review of changes
- [ ] I have compiled all hdl projects and libraries affected by this PR
- [ ] I have tested in hardware affected projects, at least on relevant boards
- [ ] I have commented my code, at least hard-to-understand parts
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe files, Copyright etc)
- [ ] I have not introduced new Warnings/Critical Warnings on compilation
- [ ] I have added new hdl testbenches or updated existing ones
