### PR TITLE
pulsar_adc: Add build options to include AD7944

### DIFF
--- a/docs/projects/pulsar_adc/index.rst
+++ b/docs/projects/pulsar_adc/index.rst
@@ -5,7 +5,7 @@ PULSAR-ADC HDL project
 
 Overview
 ---------------------------------------------------------------------------------
-Depending on the type of connector it uses, the Pulsar family is divided into
+Depending on the type of connector it uses, the PulSAR family is divided into
 the products which have **PMOD** connectors and **FMC** connectors.
 
 PulSAR converters which have PMOD boards associated with them are low power ADCs
@@ -17,10 +17,16 @@ the differences being found in their performance.  A full description of these
 products are available in their respective data sheets and should be consulted
 when utilizing the boards.
 
-ADAQ40xx families is also part of the family of pulsar converters with PMOD
-connector. This type of boards come with the :adi:`EVAL-PMD-IB1Z` PMOD to
+With PMOD
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+ADAQ40xx families is also part of the family of PulSAR converters with PMOD
+connector.
+
+This type of boards come with the :adi:`EVAL-PMD-IB1Z` PMOD to
 field programmable gate array (FPGA) mezzanine card (FMC) interposer board that
 interfaces with the system demonstration controller board.
+
 The :adi:`ADAQ4003` is an 18-bit precision data acquisition sub-system SiP
 design on a laminate that includes the :adi:`AD4003` ADC with a fully
 differential driver the :adi:`ADA4945-1`, a reference buffer
@@ -30,7 +36,11 @@ challenges for a wide range of applications similar to AD400x, yet it still
 provides the flexibility. It offers over 75% area savings compared to discrete
 design and reduces TTM.
 
+With FMC
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
 PulSAR converters which have FMC boards associated with them are AD40xx family.
+
 The :adi:`AD4003` / :adi:`AD4007` / :adi:`AD4011` / :adi:`AD4020` are low noise,
 low power, high speed, 18-bit, precision successive approximation register (SAR)
 analog-to-digital converters (ADCs). The :adi:`AD4003`, :adi:`AD4007`, and
@@ -48,59 +58,60 @@ input/output power consumption, broadens processor options, and simplifies the
 task of sending data across digital isolation.
 
 Applications:
-  * Battery-powered equipment
-  * Data acquisition
-  * Instrumentation
-  * Medical instruments
-  * Process controls
-  * Machine automation
+
+* Battery-powered equipment
+* Data acquisition
+* Instrumentation
+* Medical instruments
+* Process controls
+* Machine automation
 
 Supported boards
 -------------------------------------------------------------------------------
 
 PulSAR with PMOD connector:
 
--  :adi:`EVAL-AD7942-PMDZ <EVAL-AD7942-PMDZ>`
--  :adi:`EVAL-AD7946-PMDZ <EVAL-AD7946-PMDZ>`
--  :adi:`EVAL-AD7988-1-PMDZ <EVAL-AD7988-1-PMDZ>`
--  :adi:`EVAL-AD7685-PMDZ <EVAL-AD7685-PMDZ>`
--  :adi:`EVAL-AD7687-PMDZ <EVAL-AD7687-PMDZ>`
--  :adi:`EVAL-AD7691-PMDZ <EVAL-AD7691-PMDZ>`
--  :adi:`EVAL-AD7686-PMDZ <EVAL-AD7686-PMDZ>`
--  :adi:`EVAL-AD7688-PMDZ <EVAL-AD7688-PMDZ>`
--  :adi:`EVAL-AD7693-PMDZ <EVAL-AD7693-PMDZ>`
--  :adi:`EVAL-AD7988-5-PMDZ <EVAL-AD7988-5-PMDZ>`
--  :adi:`EVAL-AD7980-PMDZ <EVAL-AD7980-PMDZ>`
--  :adi:`EVAL-AD7983-PMDZ <EVAL-AD7983-PMDZ>`
--  :adi:`EVAL-AD7690-PMDZ <EVAL-AD7690-PMDZ>`
--  :adi:`EVAL-AD7982-PMDZ <EVAL-AD7982-PMDZ>`
--  :adi:`EVAL-AD7984-PMDZ <EVAL-AD7984-PMDZ>`
--  :adi:`EVAL-ADAQ40xx <EVAL-ADAQ40xx>`
+-  :adi:`EVAL-AD7685-PMDZ`
+-  :adi:`EVAL-AD7686-PMDZ`
+-  :adi:`EVAL-AD7687-PMDZ`
+-  :adi:`EVAL-AD7688-PMDZ`
+-  :adi:`EVAL-AD7690-PMDZ`
+-  :adi:`EVAL-AD7691-PMDZ`
+-  :adi:`EVAL-AD7693-PMDZ`
+-  :adi:`EVAL-AD7942-PMDZ`
+-  :adi:`EVAL-AD7946-PMDZ`
+-  :adi:`EVAL-AD7980-PMDZ`
+-  :adi:`EVAL-AD7982-PMDZ`
+-  :adi:`EVAL-AD7983-PMDZ`
+-  :adi:`EVAL-AD7984-PMDZ`
+-  :adi:`EVAL-AD7988-1-PMDZ`
+-  :adi:`EVAL-AD7988-5-PMDZ`
+-  :adi:`EVAL-ADAQ40xx`
 
 PulSAR with FMC connector:
 
--  :adi:`EVAL-AD400x-FMCZ <EVAL-AD400x-FMCZ>`
+-  :adi:`EVAL-AD400x-FMCZ`
 
 Supported devices
 -------------------------------------------------------------------------------
 
 PulSAR with PMOD connector:
 
+-  :adi:`AD7685`
+-  :adi:`AD7686`
+-  :adi:`AD7687`
+-  :adi:`AD7688`
+-  :adi:`AD7690`
+-  :adi:`AD7691`
+-  :adi:`AD7693`
 -  :adi:`AD7942`
 -  :adi:`AD7946`
--  :adi:`AD7988-1`
--  :adi:`AD7685`
--  :adi:`AD7687`
--  :adi:`AD7691`
--  :adi:`AD7686`
--  :adi:`AD7688`
--  :adi:`AD7693`
--  :adi:`AD7988-5`
 -  :adi:`AD7980`
--  :adi:`AD7983`
--  :adi:`AD7690`
 -  :adi:`AD7982`
+-  :adi:`AD7983`
 -  :adi:`AD7984`
+-  :adi:`AD7988-1`
+-  :adi:`AD7988-5`
 -  :adi:`ADAQ4003`
 
 PulSAR with FMC connector:
@@ -119,7 +130,7 @@ Supported carriers
 Other required hardware
 -------------------------------------------------------------------------------
 
--   :adi:`EVAL-PMD-IB1Z <EVAL-PMD-IB1Z>`
+-  :adi:`EVAL-PMD-IB1Z`
 
 .. note::
 
@@ -133,7 +144,7 @@ Block diagram
 
 The data path and clock domains are depicted in the below diagrams:
 
-PulSAR_ADC_PMDZ 
+PulSAR_ADC_PMDZ
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. image:: pulsar_adc_pmod_hdl.svg
@@ -141,7 +152,7 @@ PulSAR_ADC_PMDZ
    :align: center
    :alt: PulSAR_ADC_PMOD block diagram
 
-PulSAR_ADC_FMC 
+PulSAR_ADC_FMC
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. image:: pulsar_adc_fmc_hdl.svg
@@ -152,21 +163,27 @@ PulSAR_ADC_FMC
 Configuration modes
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-For AD40xx/ADAQ40xx projects the AD40XX_ADAQ400X_N parameter defines the type
-of ADC (AD40xx or ADAQ40xx). By default is set to 1. Depending on the project,
-some hardware modifications need to be done on the board and/or make command:
+The Zedboard-based PulSAR ADC project can be built to use either the FMC
+connector or the Pmod JA connector.
 
-In case of the **ADAQ40xx** project:
+The ``FMC_N_PMOD`` parameter is used to select between the them:
 
-.. code-block::
+*  0 - for PMOD
+*  1 - for FMC (default)
 
-   make AD40XX_ADAQ400X_N=0
+The PulSAR project supports different configurations required for certain
+ADCs, like the AD7944.
 
-In case of the **AD40xx** project:
+These modes are selected using the ``SPI_OP_MODE`` parameter:
 
-.. code-block::
+*  0 - for normal SPI Engine connections (default)
+*  1 - for 3-wire "single" mode where CS drives the SDO line while the CS line
+   is driven by GPIO
+*  2 - SDO is driven by GPIO and the CS line is driven by CS.
 
-   make AD40XX_ADAQ400X_N=1
+.. caution::
+
+   The SPI_OP_MODE parameter must only be used for the FMC variant.
 
 CPU/Memory interconnects addresses
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -234,8 +251,8 @@ The Software GPIO number is calculated as follows:
 -  Zynq-7000: if PS7 is used, then offset is 54
 
 .. list-table::
-   :widths: 25 25 25 25
-   :header-rows: 2
+   :widths: 40 25 25 25
+   :header-rows: 3
 
    * - GPIO signal
      - Direction
@@ -245,20 +262,24 @@ The Software GPIO number is calculated as follows:
      - (from FPGA view)
      -
      - Zynq-7000
-   * - pulsar_adc_spi_pd *
-     - OUT
-     - 32
-     - 86
-   * - ad40xx_amp_pd **
+   * - pulsar_gpio[0] (PD)*
      - INOUT
      - 32
      - 86
+   * - pulsar_gpio[1] (TURBO)**
+     - INOUT
+     - 33
+     - 87
+   * - pulsar_gpio[2] (SDO - SPI_OP_MODE=2)**
+     - INOUT
+     - 34
+     - 88
 
 .. admonition:: Legend
    :class: note
 
-   -   ``*`` instantiated only for PulSAR_ADC_PMDZ projects
-   -   ``**`` instantiated only for AD40XX_ADAQ400X_N=1 (AD40xx)
+   -  ``*`` instantiated only for PulSAR_ADC_PMDZ projects
+   -  ``**`` instantiated only for FMC_N_PMOD=1 (AD40xx)
 
 Interrupts
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -289,20 +310,48 @@ the HDL repository, and then build the project as follows:.
    :linenos:
 
    user@analog:~$ cd hdl/projects/pulsar_adc/zed
-   user@analog:~/hdl/projects/pulsar_adc/zed$ make AD40XX_ADAQ400X_N=1
+   user@analog:~/hdl/projects/pulsar_adc/zed$ make FMC_N_PMOD=1 SPI_OP_MODE=0
+
+Build examples:
+
+Zedboard Pmod support
+
+.. code-block::
+
+   make FMC_N_PMOD=0
+
+Zedboard standard configuration FMC support (default)
+
+.. code-block::
+
+   make FMC_N_PMOD=1 SPI_OP_MODE=0 - builds standard FMC version
+
+Zedboard FMC support for AD7944 4-wire mode ("multi")
+
+.. code-block::
+
+   make FMC_N_PMOD=1 SPI_OP_MODE=1
+
+Zedboard FMC support for AD7944 chain mode or 3-wire "single"
+
+.. code-block::
+
+   make FMC_N_PMOD=1 SPI_OP_MODE=2
 
 The result of the build, if parameters were used, will be in a folder named
-by the configuration used:
+by the used configuration. If the following command was run
 
-if the following command was run
+.. code-block::
 
-``make AD40XX_ADAQ400X_N=0``
+   make FMC_N_PMOD=1 SPI_OP_MODE=0
 
 then the folder name will be:
 
-``AD40XX_ADAQ400X_N0``
+``FMC_N_PMOD1_SPI_OP_MODE0``
 
-For projects that have coraz7s as a carrier, the build is done without parameters.
+.. note::
+
+   For the CoraZ7S-based projects, the build is donw without parameters!
 
 A more comprehensive build guide can be found in the :ref:`build_hdl` user guide.
 
@@ -312,9 +361,7 @@ Resources
 Hardware related
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-PulSAR with PMOD connector:
-
--  Product datasheets:
+Datasheets for PulSAR with PMOD connector:
 
 -  :adi:`AD7942`
 -  :adi:`AD7946`
@@ -334,7 +381,7 @@ PulSAR with PMOD connector:
 -  :adi:`UG-682, Evaluation Board User Guide <media/en/technical-documentation/user-guides/6-Lead_SOT-23_ADC_Driver_UG-682.pdf>`
 -  :adi:`UG-340, Evaluation Board User Guide <media/en/technical-documentation/user-guides/UG-340.pdf>`
 
-PulSAR with FMC connector:
+Datasheets PulSAR with FMC connector:
 
 -  :adi:`AD4003`
 -  :adi:`AD4007`
@@ -353,7 +400,7 @@ HDL related
 -  :dokuwiki:`[Wiki] AD40xx/ADAQ40xx quick start guide <resources/eval/user-guides/circuits-from-the-lab/pulsar-adc-pmods>`
 
 .. list-table::
-   :widths: 30 35 35
+   :widths: 30 40 30
    :header-rows: 1
 
    * - IP name
@@ -373,7 +420,7 @@ HDL related
      - ---
    * - AXI_PWM_GEN
      - :git-hdl:`library/axi_pwm_gen`
-     - :ref:`here <axi_pwm_gen>` 
+     - :ref:`here <axi_pwm_gen>`
    * - AXI_SPDIF_TX
      - :git-hdl:`library/axi_spdif_tx <library/axi_spdif_tx>` *
      - ---
@@ -402,7 +449,7 @@ HDL related
 .. admonition:: Legend
    :class: note
 
-   -   ``*`` instantiated only for AD40xx/ADAQ40xx
+   ``*`` instantiated only for AD40xx/ADAQ40xx
 
 -  :ref:`SPI Engine Framework documentation <spi_engine>`
 

--- a/projects/pulsar_adc/Readme.md
+++ b/projects/pulsar_adc/Readme.md
@@ -68,8 +68,7 @@ Here are some pointers to help you:
   * AD4020
 
 build example:
-make FMC_N_PMOD=0
-make FMC_N_PMOD=1 SPI_OP_MODE=0
-make FMC_N_PMOD=1 SPI_OP_MODE=1
-make FMC_N_PMOD=1 SPI_OP_MODE=2
-
+make FMC_N_PMOD=0 - builds PMOD version
+make FMC_N_PMOD=1 SPI_OP_MODE=0 - builds standard FMC version
+make FMC_N_PMOD=1 SPI_OP_MODE=1 - builds FMC version with ADC SDO pin driven by SPI Engine CS and ADC CS pin driven by GPIO
+make FMC_N_PMOD=1 SPI_OP_MODE=2 - builds FMC version with ADC SDO pin driven by GPIO and ADC CS pin driven by SPI Engine CS

--- a/projects/pulsar_adc/Readme.md
+++ b/projects/pulsar_adc/Readme.md
@@ -66,3 +66,10 @@ Here are some pointers to help you:
   * AD4011
   * ADAQ4003
   * AD4020
+
+build example:
+make FMC_N_PMOD=0
+make FMC_N_PMOD=1 SPI_OP_MODE=0
+make FMC_N_PMOD=1 SPI_OP_MODE=1
+make FMC_N_PMOD=1 SPI_OP_MODE=2
+

--- a/projects/pulsar_adc/zed/Makefile
+++ b/projects/pulsar_adc/zed/Makefile
@@ -6,8 +6,11 @@
 
 PROJECT_NAME := pulsar_adc_pmdz_zed
 
-M_DEPS += system_constr_adaq400x.xdc
-M_DEPS += system_constr_ad40xx.xdc
+M_DEPS += system_constr_pmod.xdc
+M_DEPS += system_constr_fmc.xdc
+M_DEPS += system_constr_fmc_sm0.xdc
+M_DEPS += system_constr_fmc_sm1.xdc
+M_DEPS += system_constr_fmc_sm2.xdc
 M_DEPS += ../common/pulsar_adc_bd.tcl
 M_DEPS += ../../scripts/adi_pd.tcl
 M_DEPS += ../../common/zed/zed_system_constr.xdc

--- a/projects/pulsar_adc/zed/system_bd.tcl
+++ b/projects/pulsar_adc/zed/system_bd.tcl
@@ -6,16 +6,15 @@
 source $ad_hdl_dir/projects/common/zed/zed_system_bd.tcl
 source $ad_hdl_dir/projects/scripts/adi_pd.tcl
 
+# block design
 source ../common/pulsar_adc_bd.tcl
 
 #system ID
-
-set mem_init_sys_path [get_env_param ADI_PROJECT_DIR ""]mem_init_sys.txt;
-
 ad_ip_parameter axi_sysid_0 CONFIG.ROM_ADDR_BITS 9
-ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "[pwd]/$mem_init_sys_path"
+ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "$mem_init_sys_file_path/mem_init_sys.txt"
 ad_ip_parameter rom_sys_0 CONFIG.ROM_ADDR_BITS 9
 
-set AD40XX_ADAQ400X_N [get_env_param AD40XX_ADAQ400X_N 1]
-set sys_cstring "ad40xx: $AD40XX_ADAQ400X_N"
+set sys_cstring "FMC_N_PMOD=$ad_project_params(FMC_N_PMOD)\
+  SPI_OP_MODE=$ad_project_params(SPI_OP_MODE)"
+
 sysid_gen_sys_init_file $sys_cstring

--- a/projects/pulsar_adc/zed/system_constr_fmc.xdc
+++ b/projects/pulsar_adc/zed/system_constr_fmc.xdc
@@ -3,14 +3,11 @@
 ### SPDX short identifier: ADIBSD
 ###############################################################################
 
-# ad40xx_fmc SPI interface
+set_property -dict {PACKAGE_PIN N19 IOSTANDARD LVCMOS25 IOB TRUE} [get_ports pulsar_spi_sdi]       ; ## D8   FMC_LA01_CC_P  IO_L14P_T2_SRCC_34
+set_property -dict {PACKAGE_PIN M19 IOSTANDARD LVCMOS25 IOB TRUE} [get_ports pulsar_spi_sclk]      ; ## G6   FMC_LA00_CC_P  IO_L13P_T2_MRCC_34
 
-set_property -dict {PACKAGE_PIN P17 IOSTANDARD LVCMOS25 IOB TRUE} [get_ports ad40xx_spi_sdo]       ; ## H7   FMC_LA02_P     IO_L20P_T3_34
-set_property -dict {PACKAGE_PIN N19 IOSTANDARD LVCMOS25 IOB TRUE} [get_ports ad40xx_spi_sdi]       ; ## D8   FMC_LA01_CC_P  IO_L14P_T2_SRCC_34
-set_property -dict {PACKAGE_PIN M19 IOSTANDARD LVCMOS25 IOB TRUE} [get_ports ad40xx_spi_sclk]      ; ## G6   FMC_LA00_CC_P  IO_L13P_T2_MRCC_34
-set_property -dict {PACKAGE_PIN M20 IOSTANDARD LVCMOS25 IOB TRUE} [get_ports ad40xx_spi_cs]        ; ## G7   FMC_LA00_CC_N  IO_L13N_T2_MRCC_34
-
-set_property -dict {PACKAGE_PIN P22 IOSTANDARD LVCMOS25} [get_ports ad40xx_amp_pd]                 ; ## G10  FMC_LA03_N     IO_L16N_T2_34
+set_property -dict {PACKAGE_PIN P22 IOSTANDARD LVCMOS25} [get_ports pulsar_gpio[0]]                ; ## G10  FMC_LA03_N     IO_L16N_T2_34
+set_property -dict {PACKAGE_PIN N20 IOSTANDARD LVCMOS25} [get_ports pulsar_gpio[1]]                ; ## D09  FMC_LA01_CC_N
 
 # NOTE: clk_fpga_0 is the first PL fabric clock, also called $sys_cpu_clk
 

--- a/projects/pulsar_adc/zed/system_constr_fmc_sm0.xdc
+++ b/projects/pulsar_adc/zed/system_constr_fmc_sm0.xdc
@@ -1,0 +1,7 @@
+###############################################################################
+## Copyright (C) 2024 Analog Devices, Inc. All rights reserved.
+### SPDX short identifier: ADIBSD
+###############################################################################
+
+set_property -dict {PACKAGE_PIN M20 IOSTANDARD LVCMOS25 IOB TRUE} [get_ports pulsar_spi_cs];  ## G7   FMC_LA00_CC_N  IO_L13N_T2_MRCC_34
+set_property -dict {PACKAGE_PIN P17 IOSTANDARD LVCMOS25 IOB TRUE} [get_ports pulsar_spi_sdo]; ## H7   FMC_LA02_P     IO_L20P_T3_34

--- a/projects/pulsar_adc/zed/system_constr_fmc_sm1.xdc
+++ b/projects/pulsar_adc/zed/system_constr_fmc_sm1.xdc
@@ -1,0 +1,7 @@
+###############################################################################
+## Copyright (C) 2024 Analog Devices, Inc. All rights reserved.
+### SPDX short identifier: ADIBSD
+###############################################################################
+
+set_property -dict {PACKAGE_PIN M20 IOSTANDARD LVCMOS25}          [get_ports pulsar_spi_cs];  ## G7   FMC_LA00_CC_N  IO_L13N_T2_MRCC_34
+set_property -dict {PACKAGE_PIN P17 IOSTANDARD LVCMOS25 IOB TRUE} [get_ports pulsar_spi_sdo]; ## H7   FMC_LA02_P     IO_L20P_T3_34

--- a/projects/pulsar_adc/zed/system_constr_fmc_sm2.xdc
+++ b/projects/pulsar_adc/zed/system_constr_fmc_sm2.xdc
@@ -1,0 +1,7 @@
+###############################################################################
+## Copyright (C) 2024 Analog Devices, Inc. All rights reserved.
+### SPDX short identifier: ADIBSD
+###############################################################################
+
+set_property -dict {PACKAGE_PIN M20 IOSTANDARD LVCMOS25 IOB TRUE} [get_ports pulsar_spi_cs];  ## G7   FMC_LA00_CC_N  IO_L13N_T2_MRCC_34
+set_property -dict {PACKAGE_PIN P17 IOSTANDARD LVCMOS25}          [get_ports pulsar_spi_sdo]; ## H7   FMC_LA02_P     IO_L20P_T3_34

--- a/projects/pulsar_adc/zed/system_constr_pmod.xdc
+++ b/projects/pulsar_adc/zed/system_constr_pmod.xdc
@@ -3,12 +3,10 @@
 ### SPDX short identifier: ADIBSD
 ###############################################################################
 
-# adaq400x PMOD SPI interface - the PMOD JA1 is used
-
-set_property -dict {PACKAGE_PIN AA11 IOSTANDARD LVCMOS33} [get_ports adaq400x_spi_sdo]       ; ## JA2
-set_property -dict {PACKAGE_PIN Y10  IOSTANDARD LVCMOS33} [get_ports adaq400x_spi_sdi]       ; ## JA3
-set_property -dict {PACKAGE_PIN AA9  IOSTANDARD LVCMOS33} [get_ports adaq400x_spi_sclk]      ; ## JA4
-set_property -dict {PACKAGE_PIN Y11  IOSTANDARD LVCMOS33} [get_ports adaq400x_spi_cs]        ; ## JA1
+set_property -dict {PACKAGE_PIN AA11 IOSTANDARD LVCMOS33 IOB TRUE} [get_ports pulsar_spi_sdo];   ## JA2
+set_property -dict {PACKAGE_PIN Y10  IOSTANDARD LVCMOS33 IOB TRUE} [get_ports pulsar_spi_sdi];   ## JA3
+set_property -dict {PACKAGE_PIN AA9  IOSTANDARD LVCMOS33 IOB TRUE} [get_ports pulsar_spi_sclk];  ## JA4
+set_property -dict {PACKAGE_PIN Y11  IOSTANDARD LVCMOS33 IOB TRUE} [get_ports pulsar_spi_cs];    ## JA1
 
 # NOTE: clk_fpga_0 is the first PL fabric clock, also called $sys_cpu_clk
 

--- a/projects/pulsar_adc/zed/system_project.tcl
+++ b/projects/pulsar_adc/zed/system_project.tcl
@@ -16,31 +16,45 @@ source $ad_hdl_dir/projects/scripts/adi_board.tcl
 ##  ADAQ4003
 ##
 ## NOTE: Make sure that you set up your required ADC resolution in pulsar_adc_bd.tcl
-##  
+##
 
 ## Please select which eval board do you want to use
 ##
 ##    1 - EVAL-AD40XX-FMCZ
 ##    0 - EVAL-ADAQ400x
 ##
-set AD40XX_ADAQ400X_N [get_env_param AD40XX_ADAQ400X_N 1]
+set FMC_N_PMOD [get_env_param FMC_N_PMOD 1]
+set SPI_OP_MODE [get_env_param SPI_OP_MODE 0]
 
-adi_project pulsar_adc_pmdz_zed
+adi_project pulsar_adc_pmdz_zed 0 [list \
+  FMC_N_PMOD    [get_env_param FMC_N_PMOD  1] \
+  SPI_OP_MODE   [get_env_param SPI_OP_MODE 0] ]
 
-if {$AD40XX_ADAQ400X_N == 0} {
+adi_project_files pulsar_adc_pmdz_zed [list \
+  "$ad_hdl_dir/library/common/ad_iobuf.v" \
+  "$ad_hdl_dir/projects/common/zed/zed_system_constr.xdc" ]
+
+if {$FMC_N_PMOD == 0} {
   adi_project_files pulsar_adc_pmdz_zed [list \
-      "$ad_hdl_dir/library/common/ad_iobuf.v" \
-      "system_top_adaq400x.v" \
-      "system_constr_adaq400x.xdc" \
-      "$ad_hdl_dir/projects/common/zed/zed_system_constr.xdc"]
-} elseif {$AD40XX_ADAQ400X_N == 1} {
-   adi_project_files pulsar_adc_pmdz_zed [list \
-      "$ad_hdl_dir/library/common/ad_iobuf.v" \
-      "system_top_ad40xx.v" \
-      "system_constr_ad40xx.xdc" \
-      "$ad_hdl_dir/projects/common/zed/zed_system_constr.xdc"]
+    "system_top_pmod.v" \
+    "system_constr_pmod.xdc" ]
+} elseif {$FMC_N_PMOD == 1} {
+    adi_project_files pulsar_adc_pmdz_zed [list \
+      "system_top_fmc.v" \
+      "system_constr_fmc.xdc" ]
+    if {$SPI_OP_MODE == 0} {
+    adi_project_files pulsar_adc_pmdz_zed [list \
+      "system_constr_fmc_sm0.xdc" ]
+    } elseif {$SPI_OP_MODE == 1} {
+    adi_project_files pulsar_adc_pmdz_zed [list \
+      "system_constr_fmc_sm1.xdc" ]
+    } elseif {$SPI_OP_MODE == 2} {
+    adi_project_files pulsar_adc_pmdz_zed [list \
+      "system_constr_fmc_sm2.xdc" ]
+    }
 } else {
   return -code error [format "ERROR: Invalid eval board type! ..."]
 }
 
 adi_project_run pulsar_adc_pmdz_zed
+

--- a/projects/pulsar_adc/zed/system_top_pmod.v
+++ b/projects/pulsar_adc/zed/system_top_pmod.v
@@ -83,14 +83,10 @@ module system_top (
 
   input           otg_vbusoc,
 
-  // ad400x SPI configuration interface
-
-  input           ad40xx_spi_sdi,
-  output          ad40xx_spi_sdo,
-  output          ad40xx_spi_sclk,
-  output          ad40xx_spi_cs,
-
-  inout           ad40xx_amp_pd
+  input           pulsar_spi_sdi,
+  output          pulsar_spi_sdo,
+  output          pulsar_spi_sclk,
+  output          pulsar_spi_cs
 );
 
   // internal signals
@@ -107,15 +103,7 @@ module system_top (
 
   // instantiations
 
-  assign gpio_i[63:33] = gpio_o[63:33];
-
-  ad_iobuf #(
-    .DATA_WIDTH(1)
-  ) i_admp_pd_iobuf (
-    .dio_t(gpio_t[32]),
-    .dio_i(gpio_o[32]),
-    .dio_o(gpio_i[32]),
-    .dio_p(ad40xx_amp_pd));
+  assign gpio_i[63:32] = gpio_o[63:32];
 
   ad_iobuf #(
     .DATA_WIDTH(32)
@@ -202,12 +190,12 @@ module system_top (
     .spi1_sdi_i (1'b0),
     .spi1_sdo_i (1'b0),
     .spi1_sdo_o (),
-    .pulsar_adc_spi_cs(ad40xx_spi_cs),
-    .pulsar_adc_spi_sclk(ad40xx_spi_sclk),
-    .pulsar_adc_spi_sdi(ad40xx_spi_sdi),
-    .pulsar_adc_spi_sdo(ad40xx_spi_sdo),
-    .pulsar_adc_spi_sdo_t(),
-    .pulsar_adc_spi_three_wire(),
+    .pulsar_adc_spi_cs (pulsar_spi_cs),
+    .pulsar_adc_spi_sclk (pulsar_spi_sclk),
+    .pulsar_adc_spi_sdi (pulsar_spi_sdi),
+    .pulsar_adc_spi_sdo (pulsar_spi_sdo),
+    .pulsar_adc_spi_sdo_t (),
+    .pulsar_adc_spi_three_wire (),
     .otg_vbusoc (otg_vbusoc),
     .spdif (spdif));
 


### PR DESCRIPTION
Adding some more build options to cover modes specific to AD7944

## PR Type
- [ ] Bug fix (change that fixes an issue)
- [x] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the code style guidelines
- [x] I have performed a self-review of changes
- [x] I have compiled all hdl projects and libraries affected by this PR
- [ ] I have tested in hardware affected projects, at least on relevant boards
- [ ] I have commented my code, at least hard-to-understand parts
- [x] I have signed off all commits from this PR
- [x] I have updated the documentation (wiki pages, ReadMe files, Copyright etc)
- [x] I have not introduced new Warnings/Critical Warnings on compilation
- [ ] I have added new hdl testbenches or updated existing ones
