### PR TITLE
SPI Engine: fix off-by-one sleep time

### DIFF
--- a/docs/library/spi_engine/instruction-format.rst
+++ b/docs/library/spi_engine/instruction-format.rst
@@ -171,7 +171,7 @@ is the minimum, needed by the internal logic.
 
 .. math::
 
-   sleep\_time = \frac{2+(t) * ((div + 1) * 2)}{f_{clk}}
+   sleep\_time = \frac{2+(t+1) * ((div + 1) * 2)}{f_{clk}}
 
 .. list-table::
    :widths: 10 15 75
@@ -182,7 +182,7 @@ is the minimum, needed by the internal logic.
      - Description
    * - t
      - Time
-     - The amount of time to wait.
+     - The amount of prescaler cycles to wait, minus one.
 
 .. _spi_engine cs-invert-mask-instruction:
 

--- a/library/spi_engine/spi_engine_execution/spi_engine_execution.v
+++ b/library/spi_engine/spi_engine_execution/spi_engine_execution.v
@@ -251,7 +251,7 @@ module spi_engine_execution #(
   assign trigger_tx = trigger == 1'b1 && ntx_rx == 1'b0;
   assign trigger_rx = trigger == 1'b1 && ntx_rx == 1'b1;
 
-  assign sleep_counter_compare = sleep_counter == cmd_d1[7:0];
+  assign sleep_counter_compare = sleep_counter == cmd_d1[7:0]+1;
   assign cs_sleep_counter_compare = cs_sleep_counter == cmd_d1[9:8];
   assign cs_sleep_early_exit = (cmd_d1[9:8] == 2'b00);
 


### PR DESCRIPTION
Fixes error seen in https://github.com/analogdevicesinc/hdl/issues/1389

Somewhat recently, during https://github.com/analogdevicesinc/hdl/pull/1200, while fixing a related bug, I altered the documentation to reflect what was then the behavior of the SPI Engine for the Sleep instruction: it slept for `t` prescaler ticks. 

What I didn't realize back then was that the intended behavior, as seen on the [first SPI Engine commit](https://github.com/analogdevicesinc/hdl/commit/e6b58e8a20fbcf8aade27a951aa32de0e1ce1ef4), is to sleep for `t+1` ticks, and that there had been a regression in the meantime. 

To illustrate, I've made some simple tests, which call the sleep instruction with a parameter of t=4. Expected behavior is for it to sleep for `t+1` ticks, as seen on first commit and as has been documented [in the old wiki](https://wiki.analog.com/resources/fpga/peripherals/spi_engine/instruction_format).

This is with the current main (counts only `t` ticks):
![image](https://github.com/user-attachments/assets/d7138ee2-8bb7-4ac6-aa9f-d36ecf5ffa74)

This is how it was before https://github.com/analogdevicesinc/hdl/pull/1200
(before I changed the doc), it counts each tick as double the duration - that was the bug being solved, but is not relevant to the current PR. At this point, there had already been a regression (counts only `t` ticks):
![image](https://github.com/user-attachments/assets/64d1d9ac-46f3-420c-a9ee-ee1b4c4038cf)

This is the behavior on the first commit for the SPI Engine (counts the correct number of `t+1` ticks):
![image](https://github.com/user-attachments/assets/25ed1181-6108-43b1-8ef6-910de5942416)

## PR Type
- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the code style guidelines
- [x] I have performed a self-review of changes
- [ ] I have compiled all hdl projects and libraries affected by this PR
- [ ] I have tested in hardware affected projects, at least on relevant boards
- [ ] I have commented my code, at least hard-to-understand parts
- [x] I have signed off all commits from this PR
- [x] I have updated the documentation (wiki pages, ReadMe files, Copyright etc)
- [x] I have not introduced new Warnings/Critical Warnings on compilation
- [x] I have added new hdl testbenches or updated existing ones
