### PR TITLE
Sysid parameters fixes

### DIFF
--- a/projects/ad9081_fmca_ebz/vpk180/system_bd.tcl
+++ b/projects/ad9081_fmca_ebz/vpk180/system_bd.tcl
@@ -23,11 +23,26 @@ adi_project_files ad9081_fmca_ebz_vpk180 [list \
 source $ad_hdl_dir/projects/ad9081_fmca_ebz/common/ad9081_fmca_ebz_bd.tcl
 source $ad_hdl_dir/projects/scripts/adi_pd.tcl
 
-set mem_init_sys_path [get_env_param ADI_PROJECT_DIR ""]mem_init_sys.txt;
-
 #system ID
-ad_ip_parameter axi_sysid_0 CONFIG.ROM_ADDR_BITS 9
-ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "[pwd]/$mem_init_sys_path"
-ad_ip_parameter rom_sys_0 CONFIG.ROM_ADDR_BITS 9
+ad_ip_parameter axi_sysid_0 CONFIG.ROM_ADDR_BITS 10
+ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "$mem_init_sys_file_path/mem_init_sys.txt"
+ad_ip_parameter rom_sys_0 CONFIG.ROM_ADDR_BITS 10
 
-sysid_gen_sys_init_file
+set sys_cstring "$ad_project_params(JESD_MODE)\
+RX:RATE=$ad_project_params(RX_LANE_RATE)\
+M=$ad_project_params(RX_JESD_M)\
+L=$ad_project_params(RX_JESD_L)\
+S=$ad_project_params(RX_JESD_S)\
+NP=$ad_project_params(RX_JESD_NP)\
+LINKS=$ad_project_params(RX_NUM_LINKS)\
+KS/CH=$ad_project_params(RX_KS_PER_CHANNEL)\
+TX:RATE=$ad_project_params(TX_LANE_RATE)\
+M=$ad_project_params(TX_JESD_M)\
+L=$ad_project_params(TX_JESD_L)\
+S=$ad_project_params(TX_JESD_S)\
+NP=$ad_project_params(TX_JESD_NP)\
+LINKS=$ad_project_params(TX_NUM_LINKS)\
+KS/CH=$ad_project_params(TX_KS_PER_CHANNEL)\
+REF_CLK_RATE:$ad_project_params(REF_CLK_RATE)"
+
+sysid_gen_sys_init_file $sys_cstring 10

--- a/projects/ad9081_fmca_ebz/zcu102/system_bd.tcl
+++ b/projects/ad9081_fmca_ebz/zcu102/system_bd.tcl
@@ -1,5 +1,5 @@
 ###############################################################################
-## Copyright (C) 2019-2023 Analog Devices, Inc. All rights reserved.
+## Copyright (C) 2019-2024 Analog Devices, Inc. All rights reserved.
 ### SPDX short identifier: ADIBSD
 ###############################################################################
 
@@ -44,14 +44,12 @@ L=$ad_project_params(RX_JESD_L)\
 S=$ad_project_params(RX_JESD_S)\
 NP=$ad_project_params(RX_JESD_NP)\
 LINKS=$ad_project_params(RX_NUM_LINKS)\
-TPL_W=$ad_project_params(RX_TPL_WIDTH)\
 TX:RATE=$ad_project_params(TX_LANE_RATE)\
 M=$ad_project_params(TX_JESD_M)\
 L=$ad_project_params(TX_JESD_L)\
 S=$ad_project_params(TX_JESD_S)\
 NP=$ad_project_params(TX_JESD_NP)\
 LINKS=$ad_project_params(TX_NUM_LINKS)\
-TPL_W=$ad_project_params(TX_TPL_WIDTH)\
 SHARED_DEVCLK=$SHARED_DEVCLK\
 TDD:SUPPORT=$TDD_SUPPORT\
 CHANNEL_CNT=$TDD_CHANNEL_CNT\


### PR DESCRIPTION
## PR Description

The ad9081 + zcu102 project was logging two parameters that didn't exist in the project and were always empty so I removed them.

The ad9081 + vpk180 project was missing the logging of the parameters so I added that.

## PR Type
- [ ] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the code style guidelines
- [x] I have performed a self-review of changes
- [x] I have compiled all hdl projects and libraries affected by this PR
- [ ] I have tested in hardware affected projects, at least on relevant boards
- [ ] I have commented my code, at least hard-to-understand parts
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe files, Copyright etc)
- [ ] I have not introduced new Warnings/Critical Warnings on compilation
- [ ] I have added new hdl testbenches or updated existing ones
