### PR TITLE
Add support for AD408X on ZedBoard 

### DIFF
--- a/docs/library/axi_ad408x/block_diagram.svg
+++ b/docs/library/axi_ad408x/block_diagram.svg
@@ -1,0 +1,944 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="164.72443mm"
+   height="136.0146mm"
+   viewBox="0 0 164.72443 136.0146"
+   version="1.1"
+   id="svg5"
+   inkscape:version="1.1.2 (b8e25be833, 2022-02-05)"
+   sodipodi:docname="block_diagram.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+     id="namedview7"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:document-units="mm"
+     showgrid="false"
+     inkscape:zoom="0.74029882"
+     inkscape:cx="441.03812"
+     inkscape:cy="282.31843"
+     inkscape:window-width="1920"
+     inkscape:window-height="1017"
+     inkscape:window-x="-8"
+     inkscape:window-y="-8"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="g60184-9-7-8" />
+  <defs
+     id="defs2">
+    <marker
+       style="overflow:visible"
+       id="marker51146"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="TriangleInM"
+       inkscape:isstock="true">
+      <path
+         transform="scale(-0.4)"
+         style="fill:context-stroke;fill-rule:evenodd;stroke:context-stroke;stroke-width:1pt"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         id="path51144" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="TriangleOutM"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="TriangleOutM"
+       inkscape:isstock="true">
+      <path
+         transform="scale(0.4)"
+         style="fill:context-stroke;fill-rule:evenodd;stroke:context-stroke;stroke-width:1pt"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         id="path42194" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="TriangleInM"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="TriangleInM"
+       inkscape:isstock="true">
+      <path
+         transform="scale(-0.4)"
+         style="fill:context-stroke;fill-rule:evenodd;stroke:context-stroke;stroke-width:1pt"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         id="path42185" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="marker51120"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Sstart"
+       inkscape:isstock="true">
+      <path
+         transform="matrix(0.2,0,0,0.2,1.2,0)"
+         style="fill:context-stroke;fill-rule:evenodd;stroke:context-stroke;stroke-width:1pt"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path51118" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="marker42654"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Sstart"
+       inkscape:isstock="true">
+      <path
+         transform="matrix(0.2,0,0,0.2,1.2,0)"
+         style="fill:context-stroke;fill-rule:evenodd;stroke:context-stroke;stroke-width:1pt"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path42652" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="Arrow1Send"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Send"
+       inkscape:isstock="true">
+      <path
+         transform="matrix(-0.2,0,0,-0.2,-1.2,0)"
+         style="fill:context-stroke;fill-rule:evenodd;stroke:context-stroke;stroke-width:1pt"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path42064" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="Arrow1Sstart"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Sstart"
+       inkscape:isstock="true">
+      <path
+         transform="matrix(0.2,0,0,0.2,1.2,0)"
+         style="fill:context-stroke;fill-rule:evenodd;stroke:context-stroke;stroke-width:1pt"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path42061" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="Arrow2Mstart"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow2Mstart"
+       inkscape:isstock="true">
+      <path
+         transform="scale(0.6)"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         style="fill:context-stroke;fill-rule:evenodd;stroke:context-stroke;stroke-width:0.625;stroke-linejoin:round"
+         id="path42073" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="marker42620"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Mend"
+       inkscape:isstock="true">
+      <path
+         transform="matrix(-0.4,0,0,-0.4,-4,0)"
+         style="fill:context-stroke;fill-rule:evenodd;stroke:context-stroke;stroke-width:1pt"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path42618" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="Arrow1Mend"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Mend"
+       inkscape:isstock="true">
+      <path
+         transform="matrix(-0.4,0,0,-0.4,-4,0)"
+         style="fill:context-stroke;fill-rule:evenodd;stroke:context-stroke;stroke-width:1pt"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path42058" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="Arrow1Mstart"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Mstart"
+       inkscape:isstock="true">
+      <path
+         transform="matrix(0.4,0,0,0.4,4,0)"
+         style="fill:context-stroke;fill-rule:evenodd;stroke:context-stroke;stroke-width:1pt"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path42055" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="marker42319"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Lstart"
+       inkscape:isstock="true">
+      <path
+         transform="matrix(0.8,0,0,0.8,10,0)"
+         style="fill:context-stroke;fill-rule:evenodd;stroke:context-stroke;stroke-width:1pt"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path42317" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="Arrow1Lstart"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Lstart"
+       inkscape:isstock="true">
+      <path
+         transform="matrix(0.8,0,0,0.8,10,0)"
+         style="fill:context-stroke;fill-rule:evenodd;stroke:context-stroke;stroke-width:1pt"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path42049" />
+    </marker>
+    <rect
+       x="298.96634"
+       y="469.9407"
+       width="124.17132"
+       height="41.072052"
+       id="rect24670" />
+    <rect
+       x="378.24493"
+       y="188.16731"
+       width="192.94313"
+       height="49.66853"
+       id="rect20396" />
+    <rect
+       x="505.75934"
+       y="440.80817"
+       width="91.509193"
+       height="18.625698"
+       id="rect4760" />
+    <rect
+       x="505.75934"
+       y="440.80817"
+       width="91.509193"
+       height="18.625698"
+       id="rect4760-6" />
+    <rect
+       x="298.96634"
+       y="469.9407"
+       width="124.17132"
+       height="41.072052"
+       id="rect24670-6" />
+    <marker
+       style="overflow:visible"
+       id="marker42654-4"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Sstart"
+       inkscape:isstock="true">
+      <path
+         transform="matrix(0.2,0,0,0.2,1.2,0)"
+         style="fill:context-stroke;fill-rule:evenodd;stroke:context-stroke;stroke-width:1pt"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path42652-7" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="marker46681"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Sstart"
+       inkscape:isstock="true">
+      <path
+         transform="matrix(0.2,0,0,0.2,1.2,0)"
+         style="fill:context-stroke;fill-rule:evenodd;stroke:context-stroke;stroke-width:1pt"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path46679" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="TriangleInM-0"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="TriangleInM"
+       inkscape:isstock="true">
+      <path
+         transform="scale(-0.4)"
+         style="fill:context-stroke;fill-rule:evenodd;stroke:context-stroke;stroke-width:1pt"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         id="path42185-3" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="marker51146-9"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="TriangleInM"
+       inkscape:isstock="true">
+      <path
+         transform="scale(-0.4)"
+         style="fill:context-stroke;fill-rule:evenodd;stroke:context-stroke;stroke-width:1pt"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         id="path51144-3" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="TriangleOutM-6"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="TriangleOutM"
+       inkscape:isstock="true">
+      <path
+         transform="scale(0.4)"
+         style="fill:context-stroke;fill-rule:evenodd;stroke:context-stroke;stroke-width:1pt"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         id="path42194-3" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="TriangleOutM-4"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="TriangleOutM"
+       inkscape:isstock="true">
+      <path
+         transform="scale(0.4)"
+         style="fill:context-stroke;fill-rule:evenodd;stroke:context-stroke;stroke-width:1pt"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         id="path42194-0" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="TriangleOutM-45"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="TriangleOutM"
+       inkscape:isstock="true">
+      <path
+         transform="scale(0.4)"
+         style="fill:context-stroke;fill-rule:evenodd;stroke:context-stroke;stroke-width:1pt"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         id="path42194-03" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="TriangleOutM-6-1"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="TriangleOutM"
+       inkscape:isstock="true">
+      <path
+         transform="scale(0.4)"
+         style="fill:context-stroke;fill-rule:evenodd;stroke:context-stroke;stroke-width:1pt"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         id="path42194-3-3" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="TriangleOutM-8"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="TriangleOutM"
+       inkscape:isstock="true">
+      <path
+         transform="scale(0.4)"
+         style="fill:context-stroke;fill-rule:evenodd;stroke:context-stroke;stroke-width:1pt"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         id="path42194-38" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="TriangleOutM-6-7"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="TriangleOutM"
+       inkscape:isstock="true">
+      <path
+         transform="scale(0.4)"
+         style="fill:context-stroke;fill-rule:evenodd;stroke:context-stroke;stroke-width:1pt"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         id="path42194-3-36" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="TriangleOutM-45-3"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="TriangleOutM"
+       inkscape:isstock="true">
+      <path
+         transform="scale(0.4)"
+         style="fill:context-stroke;fill-rule:evenodd;stroke:context-stroke;stroke-width:1pt"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         id="path42194-03-5" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="TriangleOutM-6-1-7"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="TriangleOutM"
+       inkscape:isstock="true">
+      <path
+         transform="scale(0.4)"
+         style="fill:context-stroke;fill-rule:evenodd;stroke:context-stroke;stroke-width:1pt"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         id="path42194-3-3-0" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="TriangleOutM-45-3-2"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="TriangleOutM"
+       inkscape:isstock="true">
+      <path
+         transform="scale(0.4)"
+         style="fill:context-stroke;fill-rule:evenodd;stroke:context-stroke;stroke-width:1pt"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         id="path42194-03-5-4" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="TriangleOutM-6-1-7-6"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="TriangleOutM"
+       inkscape:isstock="true">
+      <path
+         transform="scale(0.4)"
+         style="fill:context-stroke;fill-rule:evenodd;stroke:context-stroke;stroke-width:1pt"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         id="path42194-3-3-0-2" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="TriangleOutM-6-1-7-6-7"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="TriangleOutM"
+       inkscape:isstock="true">
+      <path
+         transform="scale(0.4)"
+         style="fill:context-stroke;fill-rule:evenodd;stroke:context-stroke;stroke-width:1pt"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         id="path42194-3-3-0-2-2" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="TriangleOutM-45-3-2-9"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="TriangleOutM"
+       inkscape:isstock="true">
+      <path
+         transform="scale(0.4)"
+         style="fill:context-stroke;fill-rule:evenodd;stroke:context-stroke;stroke-width:1pt"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         id="path42194-03-5-4-1" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="TriangleOutM-45-7"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="TriangleOutM"
+       inkscape:isstock="true">
+      <path
+         transform="scale(0.4)"
+         style="fill:context-stroke;fill-rule:evenodd;stroke:context-stroke;stroke-width:1pt"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         id="path42194-03-3" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="TriangleOutM-6-1-9"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="TriangleOutM"
+       inkscape:isstock="true">
+      <path
+         transform="scale(0.4)"
+         style="fill:context-stroke;fill-rule:evenodd;stroke:context-stroke;stroke-width:1pt"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         id="path42194-3-3-6" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="TriangleOutM-45-7-3"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="TriangleOutM"
+       inkscape:isstock="true">
+      <path
+         transform="scale(0.4)"
+         style="fill:context-stroke;fill-rule:evenodd;stroke:context-stroke;stroke-width:1pt"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         id="path42194-03-3-3" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="TriangleOutM-6-1-9-9"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="TriangleOutM"
+       inkscape:isstock="true">
+      <path
+         transform="scale(0.4)"
+         style="fill:context-stroke;fill-rule:evenodd;stroke:context-stroke;stroke-width:1pt"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         id="path42194-3-3-6-9" />
+    </marker>
+  </defs>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(-36.901624,-34.12943)">
+    <rect
+       style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#a01414;stroke-width:0.426;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:0.0426, 0.0426;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect19131"
+       width="79.912064"
+       height="46.609386"
+       x="82.291443"
+       y="51.194382" />
+    <rect
+       style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#a01414;stroke-width:0.426002;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:0.0426002, 0.0426002;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect19131-2"
+       width="79.912064"
+       height="12.441323"
+       x="80.086197"
+       y="152.95148" />
+    <rect
+       style="fill:#ffcccc;fill-opacity:1;fill-rule:evenodd;stroke:#a01414;stroke-width:0.426;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:0.0426, 0.0426;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect958"
+       width="30.195099"
+       height="23.444344"
+       x="87.362427"
+       y="71.033249" />
+    <rect
+       style="fill:#ffcccc;fill-opacity:1;fill-rule:evenodd;stroke:#a01414;stroke-width:0.426;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:0.0426, 0.0426;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect958-1"
+       width="36.765831"
+       height="27.993313"
+       x="82.294746"
+       y="105.21623" />
+    <text
+       xml:space="preserve"
+       transform="matrix(0.28749283,0,0,0.26458333,-55.938679,-36.897189)"
+       id="text4758"
+       style="font-size:14px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial, Normal';white-space:pre;shape-inside:url(#rect4760);stroke-width:0.959329"><tspan
+         x="505.75977"
+         y="453.41916"
+         id="tspan97024">ad_serdes_in</tspan></text>
+    <rect
+       style="fill:#ffcccc;fill-opacity:1;fill-rule:evenodd;stroke:#a01414;stroke-width:0.426;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:0.0426, 0.0426;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect958-2"
+       width="30.195099"
+       height="23.444344"
+       x="126.42592"
+       y="70.791069" />
+    <text
+       xml:space="preserve"
+       transform="matrix(0.28749283,0,0,0.26458333,-11.520597,-36.760299)"
+       id="text4758-5"
+       style="font-size:14px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial, Normal';white-space:pre;shape-inside:url(#rect4760-6);stroke-width:0.959329"><tspan
+         x="505.75977"
+         y="453.41916"
+         id="tspan97026">ad_pack</tspan></text>
+    <text
+       xml:space="preserve"
+       transform="scale(0.26458333)"
+       id="text20394"
+       style="font-size:32px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial, Normal';white-space:pre;shape-inside:url(#rect20396)" />
+    <text
+       xml:space="preserve"
+       style="font-size:8.46667px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial, Normal';stroke-width:0.264583"
+       x="99.571869"
+       y="61.663799"
+       id="text21502"><tspan
+         sodipodi:role="line"
+         id="tspan21500"
+         style="stroke-width:0.264583"
+         x="99.571869"
+         y="61.663799">ad408x_phy</tspan></text>
+    <text
+       xml:space="preserve"
+       transform="matrix(0.26458333,0,0,0.26458333,6.9183558,-6.8946301)"
+       id="text24668"
+       style="font-size:16px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial, Normal';white-space:pre;shape-inside:url(#rect24670)"><tspan
+         x="298.9668"
+         y="484.35348"
+         id="tspan97028">ADC COMMON</tspan></text>
+    <rect
+       style="fill:#ffcccc;fill-opacity:1;fill-rule:evenodd;stroke:#a01414;stroke-width:0.426;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:0.0426, 0.0426;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect958-1-1"
+       width="36.765831"
+       height="27.993313"
+       x="123.8987"
+       y="104.96352" />
+    <text
+       xml:space="preserve"
+       transform="matrix(0.26458333,0,0,0.26458333,48.522326,-7.1473654)"
+       id="text24668-1"
+       style="font-size:16px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial, Normal';white-space:pre;shape-inside:url(#rect24670-6)"><tspan
+         x="298.9668"
+         y="484.35348"
+         id="tspan97030">ADC CHANNEL</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-size:8.46667px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial, Normal';stroke-width:0.264583"
+       x="106.22202"
+       y="161.33513"
+       id="text41823"><tspan
+         sodipodi:role="line"
+         id="tspan41821"
+         style="stroke-width:0.264583"
+         x="106.22202"
+         y="161.33513">UP_AXI</tspan></text>
+    <path
+       style="fill:#a01414;fill-opacity:1;stroke:#a01414;stroke-width:1.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:20;stroke-opacity:1;marker-start:url(#TriangleInM);marker-end:url(#marker51146)"
+       d="m 143.67158,137.48313 c 0,11.24204 0,10.80967 0,10.80967"
+       id="path42520-2" />
+    <path
+       style="fill:#a01414;fill-opacity:1;stroke:#a01414;stroke-width:1.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:20;stroke-opacity:1;marker-start:url(#TriangleInM-0);marker-end:url(#marker51146-9)"
+       d="m 99.1787,137.55545 c 0,11.24204 0,10.80967 0,10.80967"
+       id="path42520-2-7" />
+    <rect
+       style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#071414;stroke-width:0.4;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:75.5906;stroke-opacity:1"
+       id="rect46745"
+       width="97.391693"
+       height="135.61461"
+       x="70.765343"
+       y="34.32943" />
+    <text
+       xml:space="preserve"
+       style="font-size:6.35px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial, Normal';stroke-width:0.264583"
+       x="85.776176"
+       y="43.602886"
+       id="text49535"><tspan
+         sodipodi:role="line"
+         id="tspan49533"
+         style="font-size:6.35px;stroke-width:0.264583"
+         x="85.776176"
+         y="43.602886">AXI-AD408X IP arhitecture</tspan></text>
+    <g
+       id="g60184"
+       transform="translate(2.1444043,-19.478339)">
+      <path
+         style="fill:none;stroke:#000000;stroke-width:0.665;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#TriangleOutM)"
+         d="m 34.75722,63.438628 c 31.451263,0 31.451263,0 31.451263,0"
+         id="path51036" />
+      <path
+         style="fill:none;stroke:#000000;stroke-width:0.665;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#TriangleOutM-6)"
+         d="m 34.974187,68.442238 c 31.451263,0 31.451263,0 31.451263,0"
+         id="path51036-9" />
+      <text
+         xml:space="preserve"
+         style="font-size:3.175px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial, Normal';stroke-width:0.264583"
+         x="42.798737"
+         y="62.009022"
+         id="text56451"><tspan
+           sodipodi:role="line"
+           id="tspan56449"
+           style="font-size:3.175px;stroke-width:0.264583"
+           x="42.798737"
+           y="62.009022">dclk_in_p</tspan></text>
+      <text
+         xml:space="preserve"
+         style="font-size:3.175px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial, Normal';stroke-width:0.264583"
+         x="42.533909"
+         y="67.386765"
+         id="text56451-1"><tspan
+           sodipodi:role="line"
+           id="tspan56449-8"
+           style="font-size:3.175px;stroke-width:0.264583"
+           x="42.533909"
+           y="67.386765">dclk_in_n</tspan></text>
+    </g>
+    <g
+       id="g60184-9"
+       transform="translate(2.6649667,14.510511)">
+      <path
+         style="fill:none;stroke:#000000;stroke-width:0.665;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#TriangleOutM-45)"
+         d="m 34.75722,63.438628 c 31.451263,0 31.451263,0 31.451263,0"
+         id="path51036-1" />
+      <path
+         style="fill:none;stroke:#000000;stroke-width:0.665;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#TriangleOutM-6-1)"
+         d="m 34.974187,68.442238 c 31.451263,0 31.451263,0 31.451263,0"
+         id="path51036-9-3" />
+      <text
+         xml:space="preserve"
+         style="font-size:3.175px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial, Normal';stroke-width:0.264583"
+         x="42.798737"
+         y="62.009022"
+         id="text56451-4"><tspan
+           sodipodi:role="line"
+           id="tspan56449-9"
+           style="font-size:3.175px;stroke-width:0.264583"
+           x="42.798737"
+           y="62.009022">data_a_in_p</tspan></text>
+      <text
+         xml:space="preserve"
+         style="font-size:3.175px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial, Normal';stroke-width:0.264583"
+         x="42.533909"
+         y="67.386765"
+         id="text56451-1-1"><tspan
+           sodipodi:role="line"
+           id="tspan56449-8-0"
+           style="font-size:3.175px;stroke-width:0.264583"
+           x="42.533909"
+           y="67.386765">data_a_in_n</tspan></text>
+    </g>
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.665;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#TriangleOutM-45-7)"
+       d="m 168.06865,97.950412 c 31.45126,0 31.45126,0 31.45126,0"
+       id="path51036-1-1" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.665;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#TriangleOutM-6-1-9)"
+       d="m 168.28562,102.95404 c 31.45126,0 31.45126,0 31.45126,0"
+       id="path51036-9-3-4" />
+    <text
+       xml:space="preserve"
+       style="font-size:3.175px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial, Normal';stroke-width:0.264583"
+       x="178.31998"
+       y="96.520813"
+       id="text56451-4-5"><tspan
+         sodipodi:role="line"
+         id="tspan56449-9-3"
+         style="font-size:3.175px;stroke-width:0.264583"
+         x="178.31998"
+         y="96.520813">adc_clk</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-size:3.175px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial, Normal';stroke-width:0.264583"
+       x="177.10378"
+       y="101.89853"
+       id="text56451-1-1-1"><tspan
+         sodipodi:role="line"
+         id="tspan56449-8-0-5"
+         style="font-size:3.175px;stroke-width:0.264583"
+         x="177.10378"
+         y="101.89853">adc_valid</tspan></text>
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.665;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#TriangleOutM-45-7-3)"
+       d="m 168.03213,108.63632 c 31.45126,0 31.45126,0 31.45126,0"
+       id="path51036-1-1-7" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.665;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#TriangleOutM-6-1-9-9)"
+       d="m 168.2491,113.63994 c 31.45126,0 31.45126,0 31.45126,0"
+       id="path51036-9-3-4-7" />
+    <text
+       xml:space="preserve"
+       style="font-size:3.175px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial, Normal';stroke-width:0.264583"
+       x="173.29549"
+       y="107.20667"
+       id="text56451-4-5-8"><tspan
+         sodipodi:role="line"
+         id="tspan56449-9-3-5"
+         style="font-size:3.175px;stroke-width:0.264583"
+         x="173.29549"
+         y="107.20667">adc_data[31:0]</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-size:3.175px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial, Normal';stroke-width:0.264583"
+       x="177.19833"
+       y="112.58442"
+       id="text56451-1-1-1-8"><tspan
+         sodipodi:role="line"
+         id="tspan56449-8-0-5-7"
+         style="font-size:3.175px;stroke-width:0.264583"
+         x="177.19833"
+         y="112.58442">adc_dovf</tspan></text>
+    <g
+       id="g60184-9-7"
+       transform="translate(2.7820545,28.463008)">
+      <path
+         style="fill:none;stroke:#000000;stroke-width:0.665;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#TriangleOutM-45-3)"
+         d="m 34.75722,63.438628 c 31.451263,0 31.451263,0 31.451263,0"
+         id="path51036-1-6" />
+      <path
+         style="fill:none;stroke:#000000;stroke-width:0.665;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#TriangleOutM-6-1-7)"
+         d="m 34.974187,68.442238 c 31.451263,0 31.451263,0 31.451263,0"
+         id="path51036-9-3-1" />
+      <text
+         xml:space="preserve"
+         style="font-size:3.175px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial, Normal';stroke-width:0.264583"
+         x="42.798737"
+         y="62.009022"
+         id="text56451-4-1"><tspan
+           sodipodi:role="line"
+           id="tspan56449-9-9"
+           style="font-size:3.175px;stroke-width:0.264583"
+           x="42.798737"
+           y="62.009022">data_b_in_p</tspan></text>
+      <text
+         xml:space="preserve"
+         style="font-size:3.175px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial, Normal';stroke-width:0.264583"
+         x="42.533909"
+         y="67.386765"
+         id="text56451-1-1-2"><tspan
+           sodipodi:role="line"
+           id="tspan56449-8-0-4"
+           style="font-size:3.175px;stroke-width:0.264583"
+           x="42.533909"
+           y="67.386765">data_b_in_n</tspan></text>
+    </g>
+    <g
+       id="g60184-9-7-8"
+       transform="translate(2.4315881,46.422394)">
+      <path
+         style="fill:none;stroke:#000000;stroke-width:0.665;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#TriangleOutM-45-3-2)"
+         d="m 34.75722,63.438628 c 31.451263,0 31.451263,0 31.451263,0"
+         id="path51036-1-6-5" />
+      <text
+         xml:space="preserve"
+         style="font-size:3.175px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial, Normal';stroke-width:0.264583"
+         x="36.977898"
+         y="62.009022"
+         id="text56451-4-1-1"><tspan
+           sodipodi:role="line"
+           id="tspan56449-9-9-4"
+           style="font-size:3.175px;stroke-width:0.264583"
+           x="36.977898"
+           y="62.009022">sync_n</tspan></text>
+      <path
+         style="fill:none;stroke:#000000;stroke-width:0.665;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#TriangleOutM-45-3-2-9)"
+         d="m 34.776354,75.385046 c 31.451263,0 31.451263,0 31.451263,0"
+         id="path51036-1-6-5-1" />
+      <text
+         xml:space="preserve"
+         style="font-size:3.175px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial, Normal';stroke-width:0.264583"
+         x="36.997032"
+         y="73.955444"
+         id="text56451-4-1-1-9"><tspan
+           sodipodi:role="line"
+           id="tspan56449-9-9-4-2"
+           style="font-size:3.175px;stroke-width:0.264583"
+           x="36.997032"
+           y="73.955444">delay_clk</tspan></text>
+      <text
+         xml:space="preserve"
+         style="font-size:3.175px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial, Normal';stroke-width:0.264583"
+         x="36.71307"
+         y="67.386765"
+         id="text56451-1-1-2-8"><tspan
+           sodipodi:role="line"
+           id="tspan56449-8-0-4-5"
+           style="font-size:3.175px;stroke-width:0.264583"
+           x="36.71307"
+           y="67.386765">filter_data_ready_n</tspan></text>
+      <path
+         style="fill:none;stroke:#000000;stroke-width:0.665;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#TriangleOutM-6-1-7-6-7)"
+         d="m 34.955054,68.810651 c 31.451263,0 31.451263,0 31.451263,0"
+         id="path51036-9-3-1-5-0" />
+      <rect
+         style="fill:#7abcf3;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.665001;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:75.5906;stroke-opacity:1"
+         id="rect74626"
+         width="19.033195"
+         height="10.543322"
+         x="38.291756"
+         y="106.78917" />
+      <path
+         sodipodi:type="star"
+         style="fill:#7abcf3;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:2.73046;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:75.5906;stroke-opacity:1"
+         id="path74844"
+         inkscape:flatsided="false"
+         sodipodi:sides="3"
+         sodipodi:cx="101.24738"
+         sodipodi:cy="501.22232"
+         sodipodi:r1="27.111477"
+         sodipodi:r2="13.512807"
+         sodipodi:arg1="2.0709582"
+         sodipodi:arg2="3.1181558"
+         inkscape:rounded="0"
+         inkscape:randomized="0"
+         d="m 88.245597,525.01278 -0.50731,-23.47379 -0.593149,-23.47177 20.582552,11.29755 20.62372,11.2222 -20.07524,12.17624 z"
+         transform="matrix(0.26410124,0.00752196,-0.00651346,0.22440977,37.423684,-1.149287)"
+         inkscape:transform-center-x="-1.7756101"
+         inkscape:transform-center-y="0.0084030343" />
+      <text
+         xml:space="preserve"
+         style="font-size:3.43958px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial, Normal';stroke-width:0.264583"
+         x="42.75819"
+         y="113.10739"
+         id="text85729"><tspan
+           sodipodi:role="line"
+           id="tspan85727"
+           style="font-size:3.43958px;stroke-width:0.264583"
+           x="42.75819"
+           y="113.10739">S_AXI_MM</tspan></text>
+    </g>
+    <g
+       id="g60184-5"
+       transform="translate(2.239019,-7.538183)">
+      <path
+         style="fill:none;stroke:#000000;stroke-width:0.665;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#TriangleOutM-8)"
+         d="m 34.75722,63.438628 c 31.451263,0 31.451263,0 31.451263,0"
+         id="path51036-3" />
+      <path
+         style="fill:none;stroke:#000000;stroke-width:0.665;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#TriangleOutM-6-7)"
+         d="m 34.974187,68.442238 c 31.451263,0 31.451263,0 31.451263,0"
+         id="path51036-9-8" />
+      <text
+         xml:space="preserve"
+         style="font-size:3.175px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial, Normal';stroke-width:0.264583"
+         x="42.798737"
+         y="62.009022"
+         id="text56451-13"><tspan
+           sodipodi:role="line"
+           id="tspan56449-3"
+           style="font-size:3.175px;stroke-width:0.264583"
+           x="42.798737"
+           y="62.009022">cnv_in_p</tspan></text>
+      <text
+         xml:space="preserve"
+         style="font-size:3.175px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial, Normal';stroke-width:0.264583"
+         x="42.533909"
+         y="67.386765"
+         id="text56451-1-6"><tspan
+           sodipodi:role="line"
+           id="tspan56449-8-7"
+           style="font-size:3.175px;stroke-width:0.264583"
+           x="42.533909"
+           y="67.386765">cnv_in_n</tspan></text>
+    </g>
+  </g>
+</svg>

--- a/docs/library/axi_ad408x/index.rst
+++ b/docs/library/axi_ad408x/index.rst
@@ -1,0 +1,230 @@
+.. _axi_ad408x:
+
+AXI AD408x
+================================================================================
+
+.. hdl-component-diagram::
+
+The :git-hdl:`AXI AD408x <library/axi_ad408x>` IP core can be used to interface
+the :adi:`AD4080` device.
+This documentation only covers the IP core and requires one to be
+familiar with the device, for a complete and better understanding.
+
+More about the generic framework interfacing ADCs can be read in :ref:`axi_adc`.
+
+Features
+--------------------------------------------------------------------------------
+
+* AXI Lite control/status interface
+* Programmable line delays
+* DDR data stream selection
+* Single/dual lane data stream selection
+* Bit-slip capability for synchronization
+* Filtered data support
+* Programmable decimation rate support
+* Xilinx devices compatible
+
+Files
+--------------------------------------------------------------------------------
+
+.. list-table::
+   :header-rows: 1
+
+   * - Name
+     - Description
+   * - :git-hdl:`library/axi_ad408x/axi_ad408x.v`
+     - Verilog source for the AXI AD408x.
+   * - :git-hdl:`library/axi_ad408x/ad408x_phy.v`
+     - Verilog source for the AXI AD408x physical interface.
+   * - :git-hdl:`library/axi_ad408x/axi_ad408x_ip.tcl`
+     - IP definition file (AMD tools)
+
+Block Diagram
+--------------------------------------------------------------------------------
+
+.. image:: block_diagram.svg
+   :alt: AXI AD408x block diagram
+
+Configuration Parameters
+--------------------------------------------------------------------------------
+
+.. hdl-parameters::
+
+   * - ID
+     - Core ID should be unique for each IP in the system
+   * - FPGA_TECHNOLOGY
+     - Used to select between FPGA devices, auto set in project.
+
+Interface
+--------------------------------------------------------------------------------
+
+.. hdl-interfaces::
+
+   * - filter_data_ready_n
+     - Signals when the filtered data is ready at the interface
+   * - sync_n
+     - Signals when the clock is disabled and the design should be in reset
+   * - cnv_in_p
+     - LVDS input positive side of differential CNV signal
+   * - cnv_in_n
+     - LVDS input negative side of differential CNV signal
+   * - dclk_in_p
+     - LVDS input positive side of differential reference clock signal
+   * - dclk_in_n
+     - LVDS input negative side of differential reference clock signal
+   * - data_a_in_p
+     - LVDS input positive side of differential data line A signal
+   * - data_a_in_n
+     - LVDS input negative side of differential data line A signal
+   * - data_b_in_p
+     - LVDS input positive side of differential data line B signal
+   * - data_b_in_n
+     - LVDS input negative side of differential data line B signal
+   * - delay_clk
+     - Delay clock input for IO_DELAY control, 200 MHz (7 series) or 300 MHz
+       (Ultrascale)
+   * - adc_clk
+     - The clock used to shift data out of the IP
+   * - adc_valid
+     - Indicates valid data
+   * - adc_data
+     - Received data output
+   * - adc_dovf
+     - Data overflow. Must be connected to the DMA
+   * - s_axi
+     - Standard AXI Slave Memory Map interface
+
+Internal Interface Description
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The axi_ad408x operates as follows:
+
+* The LVDS data is deserialized by the
+  :git-hdl:`ad_serdes_in<library/xilinx/common/ad_serdes_in.v>` module with
+  a 1:8 ratio.
+* After deserialization, the data is sent to the
+  :git-hdl:`ad_pack<library/common/ad_pack.v>` module, which packs the 8-bit
+  data into a 20-bit format.
+* When the bit-slip (synchronization process) is enabled, the software
+  configures the ADC to output a fixed pattern, and the interface module will
+  adjust the data alignment until the pattern is captured.
+* When the filter is enabled, the adc_valid signal is gated by the
+  filter_data_ready_n signal, and the data is sent to the output only when the
+  filtered data is available.
+
+Register Map
+--------------------------------------------------------------------------------
+
+The register map of the core contains instances of several generic register maps
+like ADC common, ADC channel,
+:git-hdl:`up_delay_cntrl <library/common/up_delay_cntrl.v>`.
+The following table presents the base addresses of each instance, after it you
+can find the detailed description of each generic register map.
+
+The absolute address of a register should be calculated by adding the instance
+base address to the registers relative address.
+
+.. list-table:: Register Map base addresses for axi_ad408x
+   :header-rows: 1
+
+   * - DWORD
+     - BYTE
+     - Name
+     - Description
+   * - 0x0000
+     - 0x0000
+     - BASE
+     - See the `Base <#hdl-regmap-COMMON>`__ table for more details.
+   * - 0x0000
+     - 0x0000
+     - RX COMMON
+     - See the `ADC Common <#hdl-regmap-ADC_COMMON>`__ table for more details.
+   * - 0x0000
+     - 0x0000
+     - RX CHANNELS
+     - See the `ADC Channel <#hdl-regmap-ADC_CHANNEL>`__ table for more details.
+   * - 0x0000
+     - 0x0800
+     - IO_DELAY_CNTRL
+     - See the `I/O Delay Control <#hdl-regmap-DELAY_CNTRL>`__ table for more details.
+
+.. hdl-regmap::
+   :name: COMMON
+   :no-type-info:
+
+.. hdl-regmap::
+   :name: ADC_COMMON
+   :no-type-info:
+
+.. hdl-regmap::
+   :name: ADC_CHANNEL
+   :no-type-info:
+
+.. hdl-regmap::
+   :name: IO_DELAY_CNTRL
+   :no-type-info:
+
+Design Guidelines
+--------------------------------------------------------------------------------
+
+The control of the AD408x chip is done through a SPI interface, which is needed
+at system level.
+
+The *ADC interface signals* must be connected directly to the top file of the
+design, as I/O primitives are part of the IP.
+
+The example design uses a DMA to move the data from the output of the IP to
+memory.
+
+If the data needs to be processed in HDL before moving it to the memory, it can be
+done at the output of the IP (at system level) or inside of the ADC channel
+module (at IP level).
+
+The example design uses a processor to program all the registers. If no
+processor is available in your system, you can create your own IP starting from
+the interface module.
+
+Software Guidelines
+--------------------------------------------------------------------------------
+
+.. list-table:: Main registers used to control the AXI AD408x IP
+   :header-rows: 1
+
+   * - Name
+     - Register
+     - BIT
+     - Description
+   * - BITSLIP_ENABLE
+     - 0x44 (ADC Common)
+     - 3
+     - Enables the sync process.
+   * - NUM_LANES
+     - 0x44 (ADC Common)
+     - [12:8]
+     - Controls the number of lanes enabled.
+   * - FILTER_ENABLE
+     - 0x4C (ADC Common)
+     - 0
+     - Controls the filter status.
+   * - SELF_SYNC
+     - 0x4C (ADC Common)
+     - 1
+     - Controls if the data capture synchronization is done through CNV signal or bit-slip.
+   * - SYNC_STATUS
+     - 0x68 (ADC Common)
+     - 0
+     - States the synchronization status.
+
+Software Suppport
+--------------------------------------------------------------------------------
+* Linux support at :git-linux:`/`
+
+References
+-------------------------------------------------------------------------------
+
+* HDL IP core at :git-hdl:`library/axi_ad408x`
+* HDL project at :git-hdl:`projects/ad408x_fmc_evb`
+* HDL project documentation at :ref:`ad408x_fmc_evb`
+* :adi:`AD4080`
+* :xilinx:`Zynq-7000 SoC Overview <support/documentation/data_sheets/ds190-Zynq-7000-Overview.pdf>`
+* :xilinx:`Zynq-7000 SoC Packaging and Pinout <support/documentation/user_guides/ug865-Zynq-7000-Pkg-Pinout.pdf>`

--- a/docs/library/index.rst
+++ b/docs/library/index.rst
@@ -24,6 +24,7 @@ ADC/DAC
    :maxdepth: 1
 
    axi_ad3552r/index
+   axi_ad408x/index
    axi_ad485x/index
    axi_ad7606x/index
    axi_ad7616/index

--- a/docs/projects/ad408x_fmc_evb/ad408x_fmc_clock_scheme.svg
+++ b/docs/projects/ad408x_fmc_evb/ad408x_fmc_clock_scheme.svg
@@ -1,0 +1,536 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="319.44089mm"
+   height="86.798576mm"
+   viewBox="0 0 319.44089 86.798574"
+   version="1.1"
+   id="svg92524"
+   sodipodi:docname="ad408x_fmc_clock_scheme.svg"
+   inkscape:version="1.1.2 (0a00cf5339, 2022-02-04)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+     id="namedview92526"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:document-units="mm"
+     showgrid="false"
+     inkscape:zoom="0.74029883"
+     inkscape:cx="759.8283"
+     inkscape:cy="52.006026"
+     inkscape:window-width="1920"
+     inkscape:window-height="990"
+     inkscape:window-x="0"
+     inkscape:window-y="28"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="layer1" />
+  <defs
+     id="defs92521">
+    <marker
+       style="overflow:visible"
+       id="Arrow1Lend"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Lend"
+       inkscape:isstock="true">
+      <path
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         style="fill:context-stroke;fill-rule:evenodd;stroke:context-stroke;stroke-width:1pt"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path42052" />
+    </marker>
+    <rect
+       x="155.69173"
+       y="396.39307"
+       width="153.7814"
+       height="94.561234"
+       id="rect105127" />
+    <marker
+       style="overflow:visible"
+       id="Arrow1Lend-3"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Lend"
+       inkscape:isstock="true">
+      <path
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         style="fill:context-stroke;fill-rule:evenodd;stroke:context-stroke;stroke-width:1pt"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path42052-2" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="Arrow1Lend-3-4"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Lend"
+       inkscape:isstock="true">
+      <path
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         style="fill:context-stroke;fill-rule:evenodd;stroke:context-stroke;stroke-width:1pt"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path42052-2-7" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="Arrow1Lend-3-2"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Lend"
+       inkscape:isstock="true">
+      <path
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         style="fill:context-stroke;fill-rule:evenodd;stroke:context-stroke;stroke-width:1pt"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path42052-2-2" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="Arrow1Lend-3-4-2"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Lend"
+       inkscape:isstock="true">
+      <path
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         style="fill:context-stroke;fill-rule:evenodd;stroke:context-stroke;stroke-width:1pt"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path42052-2-7-9" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="Arrow1Lend-3-1"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Lend"
+       inkscape:isstock="true">
+      <path
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         style="fill:context-stroke;fill-rule:evenodd;stroke:context-stroke;stroke-width:1pt"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path42052-2-5" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="Arrow1Lend-3-4-6"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Lend"
+       inkscape:isstock="true">
+      <path
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         style="fill:context-stroke;fill-rule:evenodd;stroke:context-stroke;stroke-width:1pt"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path42052-2-7-2" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="Arrow1Lend-3-23"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Lend"
+       inkscape:isstock="true">
+      <path
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         style="fill:context-stroke;fill-rule:evenodd;stroke:context-stroke;stroke-width:1pt"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path42052-2-0" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="Arrow1Lend-3-4-9"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Lend"
+       inkscape:isstock="true">
+      <path
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         style="fill:context-stroke;fill-rule:evenodd;stroke:context-stroke;stroke-width:1pt"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path42052-2-7-5" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="Arrow1Lend-3-1-7"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Lend"
+       inkscape:isstock="true">
+      <path
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         style="fill:context-stroke;fill-rule:evenodd;stroke:context-stroke;stroke-width:1pt"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path42052-2-5-7" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="Arrow1Lend-3-4-6-8"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Lend"
+       inkscape:isstock="true">
+      <path
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         style="fill:context-stroke;fill-rule:evenodd;stroke:context-stroke;stroke-width:1pt"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path42052-2-7-2-7" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="Arrow1Lend-3-4-2-6"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Lend"
+       inkscape:isstock="true">
+      <path
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         style="fill:context-stroke;fill-rule:evenodd;stroke:context-stroke;stroke-width:1pt"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path42052-2-7-9-2" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="Arrow1Lend-3-2-9"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Lend"
+       inkscape:isstock="true">
+      <path
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         style="fill:context-stroke;fill-rule:evenodd;stroke:context-stroke;stroke-width:1pt"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path42052-2-2-1" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="Arrow1Lend-3-4-2-6-0"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Lend"
+       inkscape:isstock="true">
+      <path
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         style="fill:context-stroke;fill-rule:evenodd;stroke:context-stroke;stroke-width:1pt"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path42052-2-7-9-2-6" />
+    </marker>
+  </defs>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(14.472543,-63.808551)">
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.465001;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#Arrow1Lend-3-2)"
+       d="m 147.77261,68.502743 104.72779,0.0178"
+       id="path112105-4-9" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.465;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#Arrow1Lend-3-4-2)"
+       d="m 147.95763,76.966803 104.46243,0.0178"
+       id="path112105-4-3-9" />
+    <rect
+       style="fill:#aaccee;fill-opacity:1;fill-rule:evenodd;stroke:#003366;stroke-width:0.665001;stroke-linecap:round;stroke-linejoin:round;stroke-dashoffset:75.5906;stroke-opacity:1"
+       id="rect92805"
+       width="47.534294"
+       height="30.379061"
+       x="30.379061"
+       y="97.736717" />
+    <rect
+       style="fill:#aaccee;fill-opacity:1;fill-rule:evenodd;stroke:#003366;stroke-width:0.665001;stroke-linecap:round;stroke-linejoin:round;stroke-dashoffset:75.5906;stroke-opacity:1"
+       id="rect92805-43"
+       width="25.042"
+       height="16.984877"
+       x="-14.140042"
+       y="104.43381" />
+    <rect
+       style="fill:#aaccee;fill-opacity:1;fill-rule:evenodd;stroke:#003366;stroke-width:0.665;stroke-linecap:round;stroke-linejoin:round;stroke-dashoffset:75.5906;stroke-opacity:1"
+       id="rect92805-1"
+       width="47.176895"
+       height="44.85379"
+       x="175.82666"
+       y="99.52372" />
+    <rect
+       style="fill:#ffcccc;fill-opacity:1;fill-rule:evenodd;stroke:#a01414;stroke-width:0.665002;stroke-linecap:round;stroke-linejoin:round;stroke-dashoffset:75.5906;stroke-opacity:1"
+       id="rect92805-1-8"
+       width="51.465702"
+       height="86.133575"
+       x="253.17015"
+       y="64.141052" />
+    <text
+       xml:space="preserve"
+       style="font-size:8.46667px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial, Normal';stroke-width:0.264583"
+       x="270.91635"
+       y="108.41707"
+       id="text103547"><tspan
+         sodipodi:role="line"
+         id="tspan103545"
+         style="stroke-width:0.264583"
+         x="270.91635"
+         y="108.41707">FPGA</tspan></text>
+    <text
+       xml:space="preserve"
+       transform="matrix(0.26458333,0,0,0.26458333,-5.0544095,4.4623283)"
+       id="text105125"
+       style="font-size:32px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial, Normal';white-space:pre;shape-inside:url(#rect105127)"><tspan
+         x="155.69141"
+         y="425.21672"
+         id="tspan3582">ADF4350</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-size:4.23333px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial, Normal';stroke-width:0.264583"
+       x="-13.346734"
+       y="114.64844"
+       id="text110315"><tspan
+         sodipodi:role="line"
+         id="tspan110313"
+         style="font-size:4.23333px;stroke-width:0.264583"
+         x="-13.346734"
+         y="114.64844">CLK 25MHz</tspan></text>
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.465;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#Arrow1Lend)"
+       d="m 11.685477,112.91591 17.561169,0.0178"
+       id="path112105" />
+    <g
+       id="g6763">
+      <path
+         style="fill:none;stroke:#000000;stroke-width:0.465;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#Arrow1Lend-3)"
+         d="m 77.721384,110.72117 24.325296,0.0178"
+         id="path112105-4" />
+      <path
+         style="fill:none;stroke:#000000;stroke-width:0.465;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#Arrow1Lend-3-4)"
+         d="m 77.895159,119.18523 24.325291,0.0178"
+         id="path112105-4-3" />
+      <text
+         xml:space="preserve"
+         style="font-size:2.11667px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial, Normal';stroke-width:0.264583"
+         x="80.526627"
+         y="109.72063"
+         id="text115047"><tspan
+           sodipodi:role="line"
+           id="tspan115045"
+           style="font-size:2.11667px;stroke-width:0.264583"
+           x="80.526627"
+           y="109.72063">CLK_SRC_P</tspan></text>
+      <text
+         xml:space="preserve"
+         style="font-size:2.11667px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial, Normal';stroke-width:0.264583"
+         x="81.122955"
+         y="118.24358"
+         id="text115047-6"><tspan
+           sodipodi:role="line"
+           id="tspan115045-8"
+           style="font-size:2.11667px;stroke-width:0.264583"
+           x="81.122955"
+           y="118.24358">CLK_SRC_N</tspan></text>
+    </g>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.64583px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;stroke-width:0.264583"
+       x="188.39386"
+       y="67.278091"
+       id="text115047-0"><tspan
+         sodipodi:role="line"
+         id="tspan115045-6"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.64583px;font-family:Arial;-inkscape-font-specification:'Arial, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;stroke-width:0.264583"
+         x="188.39386"
+         y="67.278091">CNV_COPY_P/FPGACLK_P</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.64583px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;stroke-width:0.264583"
+       x="187.95558"
+       y="75.548325"
+       id="text115047-6-5"><tspan
+         sodipodi:role="line"
+         id="tspan115045-8-0"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.64583px;font-family:Arial;-inkscape-font-specification:'Arial, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;stroke-width:0.264583"
+         x="187.95558"
+         y="75.548325">CNV_COPY_N/FPGACLK_N</tspan></text>
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.46036;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#Arrow1Lend-3-4-2-6)"
+       d="m 157.28848,108.24675 0.002,-15.64636 94.84445,-0.37125"
+       id="path112105-4-3-9-7"
+       sodipodi:nodetypes="ccc" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.470947;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#Arrow1Lend-3-4-2-6-0)"
+       d="M 153.33145,116.9325 153.22522,84.832549 252.57877,84.46166"
+       id="path112105-4-3-9-7-2"
+       sodipodi:nodetypes="ccc" />
+    <rect
+       style="fill:#aaccee;fill-opacity:1;fill-rule:evenodd;stroke:#003366;stroke-width:0.708381;stroke-linecap:round;stroke-linejoin:round;stroke-dashoffset:75.5906;stroke-opacity:1"
+       id="rect92805-4"
+       width="47.534294"
+       height="80.906189"
+       x="103.26736"
+       y="64.186104" />
+    <text
+       xml:space="preserve"
+       style="font-size:8.46667px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial, Normal';stroke-width:0.264583"
+       x="110.97943"
+       y="104.88981"
+       id="text113123"><tspan
+         sodipodi:role="line"
+         id="tspan113121"
+         style="stroke-width:0.264583"
+         x="110.97943"
+         y="104.88981">AD9508</tspan></text>
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.465;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#Arrow1Lend-3-1)"
+       d="m 150.98577,130.86917 24.3253,0.0178"
+       id="path112105-4-0" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.465;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#Arrow1Lend-3-4-6)"
+       d="m 151.15955,139.33323 24.32529,0.0178"
+       id="path112105-4-3-1" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.465;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#Arrow1Lend-3-1-7)"
+       d="m 223.19461,122.19527 28.93852,0.0178"
+       id="path112105-4-0-7" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.465;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#Arrow1Lend-3-4-6-8)"
+       d="m 223.40134,130.65933 28.93851,0.0178"
+       id="path112105-4-3-1-0" />
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.64583px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;stroke-width:0.264583"
+       x="156.43681"
+       y="129.86862"
+       id="text115047-8"><tspan
+         sodipodi:role="line"
+         id="tspan115045-62"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.64583px;font-family:Arial;-inkscape-font-specification:'Arial, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;stroke-width:0.264583"
+         x="156.43681"
+         y="129.86862">CNV_P</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.64583px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;stroke-width:0.264583"
+       x="230.48453"
+       y="121.01176"
+       id="text115047-8-2"><tspan
+         sodipodi:role="line"
+         id="tspan115045-62-3"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.64583px;font-family:Arial;-inkscape-font-specification:'Arial, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;stroke-width:0.264583"
+         x="230.48453"
+         y="121.01176">DCO+</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.64583px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;stroke-width:0.264583"
+       x="230.56631"
+       y="129.74864"
+       id="text115047-8-2-4"><tspan
+         sodipodi:role="line"
+         id="tspan115045-62-3-0"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.64583px;font-family:Arial;-inkscape-font-specification:'Arial, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;stroke-width:0.264583"
+         x="230.56631"
+         y="129.74864">DCO-</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.64583px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;stroke-width:0.264583"
+       x="156.50398"
+       y="138.39159"
+       id="text115047-6-7"><tspan
+         sodipodi:role="line"
+         id="tspan115045-8-3"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.64583px;font-family:Arial;-inkscape-font-specification:'Arial, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;stroke-width:0.264583"
+         x="156.50398"
+         y="138.39159">CNV_N</tspan></text>
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.467102;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#Arrow1Lend-3-23)"
+       d="m 151.13665,108.53162 24.5457,0.0178"
+       id="path112105-4-2" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.468839;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#Arrow1Lend-3-4-9)"
+       d="m 151.12753,116.99568 24.72859,0.0178"
+       id="path112105-4-3-94" />
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.64583px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;stroke-width:0.264583"
+       x="158.39557"
+       y="107.53109"
+       id="text115047-9"><tspan
+         sodipodi:role="line"
+         id="tspan115045-1"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.64583px;font-family:Arial;-inkscape-font-specification:'Arial, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;stroke-width:0.264583"
+         x="158.39557"
+         y="107.53109">CLK_P</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.64583px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;stroke-width:0.264583"
+       x="158.46274"
+       y="116.05404"
+       id="text115047-6-8"><tspan
+         sodipodi:role="line"
+         id="tspan115045-8-2"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.64583px;font-family:Arial;-inkscape-font-specification:'Arial, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;stroke-width:0.264583"
+         x="158.46274"
+         y="116.05404">CLK_N</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.64583px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;stroke-width:0.264583"
+       x="200.50499"
+       y="82.952736"
+       id="text115047-9-6"><tspan
+         sodipodi:role="line"
+         id="tspan115045-1-1"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.64583px;font-family:Arial;-inkscape-font-specification:'Arial, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;stroke-width:0.264583"
+         x="200.50499"
+         y="82.952736">CLK_P</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.64583px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;stroke-width:0.264583"
+       x="200.57216"
+       y="91.47567"
+       id="text115047-6-8-8"><tspan
+         sodipodi:role="line"
+         id="tspan115045-8-2-7"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.64583px;font-family:Arial;-inkscape-font-specification:'Arial, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;stroke-width:0.264583"
+         x="200.57216"
+         y="91.47567">CLK_N</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-size:8.46667px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial, Normal';stroke-width:0.264583"
+       x="183.53621"
+       y="125.18881"
+       id="text25969"><tspan
+         sodipodi:role="line"
+         id="tspan25967"
+         style="stroke-width:0.264583"
+         x="183.53621"
+         y="125.18881">AD4080</tspan></text>
+    <ellipse
+       style="fill:#000002;fill-opacity:1;stroke-width:0.265635;stroke-miterlimit:10"
+       id="path2137"
+       cx="157.38033"
+       cy="108.39342"
+       rx="0.72363561"
+       ry="0.77846354" />
+    <ellipse
+       style="fill:#000002;fill-opacity:1;stroke-width:0.265635;stroke-miterlimit:10"
+       id="path2137-9"
+       cx="153.39703"
+       cy="116.97462"
+       rx="0.72363561"
+       ry="0.77846354" />
+  </g>
+</svg>

--- a/docs/projects/ad408x_fmc_evb/ad408x_fmc_evb_zed_block_diagram.svg
+++ b/docs/projects/ad408x_fmc_evb/ad408x_fmc_evb_zed_block_diagram.svg
@@ -1,0 +1,1672 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="160.82281mm"
+   height="132.78648mm"
+   viewBox="0 0 160.82281 132.78648"
+   version="1.1"
+   id="svg29591"
+   inkscape:version="1.1.2 (0a00cf5339, 2022-02-04)"
+   sodipodi:docname="ad408x_fmc_evb_zed_block_diagram.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+     id="namedview29593"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:document-units="mm"
+     showgrid="false"
+     inkscape:zoom="1.0469406"
+     inkscape:cx="418.83943"
+     inkscape:cy="197.24137"
+     inkscape:window-width="1920"
+     inkscape:window-height="990"
+     inkscape:window-x="0"
+     inkscape:window-y="28"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="layer1" />
+  <defs
+     id="defs29588">
+    <marker
+       inkscape:stockid="TriangleInM"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="TriangleInM-7-1"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         inkscape:connector-curvature="0"
+         id="path4660-1-6"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="scale(-0.4)" />
+    </marker>
+    <marker
+       inkscape:stockid="TriangleOutM"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker9011"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         inkscape:connector-curvature="0"
+         id="path9009"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="scale(0.4)" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker1216-7"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="TriangleOutM">
+      <path
+         transform="scale(0.4)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         id="path1214-5"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker1216-9-3"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="TriangleOutM">
+      <path
+         transform="scale(0.4)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         id="path1214-1-6"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker1216-0-3"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="TriangleOutM">
+      <path
+         transform="scale(0.4)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         id="path1214-3-7"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker1216-0-3-9"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="TriangleOutM">
+      <path
+         transform="scale(0.4)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         id="path1214-3-7-7"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker1216"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="TriangleOutM"
+       inkscape:collect="always">
+      <path
+         transform="scale(0.4)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         id="path1214"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker1216-9"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="TriangleOutM">
+      <path
+         transform="scale(0.4)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         id="path1214-1"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:stockid="TriangleInM"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker30716"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         inkscape:connector-curvature="0"
+         id="path30714"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="scale(-0.4)" />
+    </marker>
+    <marker
+       inkscape:stockid="TriangleOutM"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="TriangleOutM-2-8"
+       style="overflow:visible"
+       inkscape:isstock="true"
+       inkscape:collect="always">
+      <path
+         inkscape:connector-curvature="0"
+         id="path4669-5-5"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="scale(0.4)" />
+    </marker>
+    <marker
+       inkscape:stockid="TriangleInM"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="TriangleInM-7"
+       style="overflow:visible"
+       inkscape:isstock="true"
+       inkscape:collect="always">
+      <path
+         inkscape:connector-curvature="0"
+         id="path4660-1"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="scale(-0.4)" />
+    </marker>
+    <marker
+       inkscape:stockid="TriangleOutM"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="TriangleOutM-2"
+       style="overflow:visible"
+       inkscape:isstock="true"
+       inkscape:collect="always">
+      <path
+         inkscape:connector-curvature="0"
+         id="path4669-5"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="scale(0.4)" />
+    </marker>
+    <marker
+       inkscape:stockid="TriangleInM"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="TriangleInM"
+       style="overflow:visible"
+       inkscape:isstock="true"
+       inkscape:collect="always">
+      <path
+         id="path4660"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="scale(-0.4)"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:stockid="TriangleOutM"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="TriangleOutM"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path4669"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="scale(0.4)"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <rect
+       x="505.75934"
+       y="440.80817"
+       width="91.509193"
+       height="18.625698"
+       id="rect4760" />
+    <rect
+       x="505.75934"
+       y="440.80817"
+       width="91.509193"
+       height="18.625698"
+       id="rect4760-6" />
+    <rect
+       x="298.96634"
+       y="469.9407"
+       width="124.17132"
+       height="41.072052"
+       id="rect24670" />
+    <rect
+       x="298.96634"
+       y="469.9407"
+       width="124.17132"
+       height="41.072052"
+       id="rect24670-6" />
+    <marker
+       style="overflow:visible"
+       id="TriangleInM-3"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="TriangleInM"
+       inkscape:isstock="true">
+      <path
+         transform="scale(-0.4)"
+         style="fill:context-stroke;fill-rule:evenodd;stroke:context-stroke;stroke-width:1pt"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         id="path42185" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="marker51146"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="TriangleInM"
+       inkscape:isstock="true">
+      <path
+         transform="scale(-0.4)"
+         style="fill:context-stroke;fill-rule:evenodd;stroke:context-stroke;stroke-width:1pt"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         id="path51144" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="TriangleInM-0"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="TriangleInM"
+       inkscape:isstock="true">
+      <path
+         transform="scale(-0.4)"
+         style="fill:context-stroke;fill-rule:evenodd;stroke:context-stroke;stroke-width:1pt"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         id="path42185-3" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="marker51146-9"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="TriangleInM"
+       inkscape:isstock="true">
+      <path
+         transform="scale(-0.4)"
+         style="fill:context-stroke;fill-rule:evenodd;stroke:context-stroke;stroke-width:1pt"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         id="path51144-3" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="TriangleOutM-0"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="TriangleOutM"
+       inkscape:isstock="true">
+      <path
+         transform="scale(0.4)"
+         style="fill:context-stroke;fill-rule:evenodd;stroke:context-stroke;stroke-width:1pt"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         id="path42194" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="TriangleOutM-6"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="TriangleOutM"
+       inkscape:isstock="true">
+      <path
+         transform="scale(0.4)"
+         style="fill:context-stroke;fill-rule:evenodd;stroke:context-stroke;stroke-width:1pt"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         id="path42194-3" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="TriangleOutM-45"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="TriangleOutM"
+       inkscape:isstock="true">
+      <path
+         transform="scale(0.4)"
+         style="fill:context-stroke;fill-rule:evenodd;stroke:context-stroke;stroke-width:1pt"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         id="path42194-03" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="TriangleOutM-6-1"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="TriangleOutM"
+       inkscape:isstock="true">
+      <path
+         transform="scale(0.4)"
+         style="fill:context-stroke;fill-rule:evenodd;stroke:context-stroke;stroke-width:1pt"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         id="path42194-3-3" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="TriangleOutM-45-7"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="TriangleOutM"
+       inkscape:isstock="true">
+      <path
+         transform="scale(0.4)"
+         style="fill:context-stroke;fill-rule:evenodd;stroke:context-stroke;stroke-width:1pt"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         id="path42194-03-3" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="TriangleOutM-6-1-9"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="TriangleOutM"
+       inkscape:isstock="true">
+      <path
+         transform="scale(0.4)"
+         style="fill:context-stroke;fill-rule:evenodd;stroke:context-stroke;stroke-width:1pt"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         id="path42194-3-3-6" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="TriangleOutM-45-7-3"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="TriangleOutM"
+       inkscape:isstock="true">
+      <path
+         transform="scale(0.4)"
+         style="fill:context-stroke;fill-rule:evenodd;stroke:context-stroke;stroke-width:1pt"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         id="path42194-03-3-3" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="TriangleOutM-6-1-9-9"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="TriangleOutM"
+       inkscape:isstock="true">
+      <path
+         transform="scale(0.4)"
+         style="fill:context-stroke;fill-rule:evenodd;stroke:context-stroke;stroke-width:1pt"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         id="path42194-3-3-6-9" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="TriangleOutM-45-3"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="TriangleOutM"
+       inkscape:isstock="true">
+      <path
+         transform="scale(0.4)"
+         style="fill:context-stroke;fill-rule:evenodd;stroke:context-stroke;stroke-width:1pt"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         id="path42194-03-5" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="TriangleOutM-6-1-7"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="TriangleOutM"
+       inkscape:isstock="true">
+      <path
+         transform="scale(0.4)"
+         style="fill:context-stroke;fill-rule:evenodd;stroke:context-stroke;stroke-width:1pt"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         id="path42194-3-3-0" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="TriangleOutM-45-3-2"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="TriangleOutM"
+       inkscape:isstock="true">
+      <path
+         transform="scale(0.4)"
+         style="fill:context-stroke;fill-rule:evenodd;stroke:context-stroke;stroke-width:1pt"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         id="path42194-03-5-4" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="TriangleOutM-45-3-2-9"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="TriangleOutM"
+       inkscape:isstock="true">
+      <path
+         transform="scale(0.4)"
+         style="fill:context-stroke;fill-rule:evenodd;stroke:context-stroke;stroke-width:1pt"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         id="path42194-03-5-4-1" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="TriangleOutM-6-1-7-6-7"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="TriangleOutM"
+       inkscape:isstock="true">
+      <path
+         transform="scale(0.4)"
+         style="fill:context-stroke;fill-rule:evenodd;stroke:context-stroke;stroke-width:1pt"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         id="path42194-3-3-0-2-2" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="TriangleOutM-8"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="TriangleOutM"
+       inkscape:isstock="true">
+      <path
+         transform="scale(0.4)"
+         style="fill:context-stroke;fill-rule:evenodd;stroke:context-stroke;stroke-width:1pt"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         id="path42194-38" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="TriangleOutM-6-7"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="TriangleOutM"
+       inkscape:isstock="true">
+      <path
+         transform="scale(0.4)"
+         style="fill:context-stroke;fill-rule:evenodd;stroke:context-stroke;stroke-width:1pt"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         id="path42194-3-36" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker1216-4"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="TriangleOutM"
+       inkscape:collect="always">
+      <path
+         transform="scale(0.4)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         id="path1214-51"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker1216-9-6"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="TriangleOutM">
+      <path
+         transform="scale(0.4)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         id="path1214-1-4"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker1216-71"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="TriangleOutM"
+       inkscape:collect="always">
+      <path
+         transform="scale(0.4)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         id="path1214-8"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker1216-9-9"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="TriangleOutM">
+      <path
+         transform="scale(0.4)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         id="path1214-1-7"
+         inkscape:connector-curvature="0" />
+    </marker>
+  </defs>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(-45.687375,-26.530943)">
+    <rect
+       style="display:inline;vector-effect:none;fill:none;fill-opacity:1;stroke:#3f4b55;stroke-width:0.333552;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:0.333552, 1.00066;stroke-dashoffset:0;stroke-opacity:1;shape-rendering:crispEdges;enable-background:new"
+       id="rect6078-6"
+       width="76.035355"
+       height="86.956375"
+       x="79.388474"
+       y="69.981445"
+       inkscape:export-xdpi="224.36"
+       inkscape:export-ydpi="224.36"
+       inkscape:export-filename="C:\workspace\ad\ghdl\docs\block_diagrams\cn0577\cn0577_block_diagram.png" />
+    <rect
+       style="display:inline;fill:none;fill-opacity:1;stroke:#3f4b55;stroke-width:0.436;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:0.436,1.308;stroke-dashoffset:0;stroke-opacity:1;shape-rendering:crispEdges;enable-background:new"
+       id="rect6078"
+       width="45.067265"
+       height="73.748421"
+       x="156.29265"
+       y="78.586243"
+       inkscape:export-xdpi="224.36"
+       inkscape:export-ydpi="224.36"
+       inkscape:export-filename="C:\workspace\ad\ghdl\docs\block_diagrams\cn0577\cn0577_block_diagram.png" />
+    <rect
+       style="fill:#fefdfe;fill-opacity:1;fill-rule:evenodd;stroke:#071414;stroke-width:0.4;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:75.5906;stroke-opacity:1"
+       id="rect46745"
+       width="48.594585"
+       height="66.989983"
+       x="110.19932"
+       y="79.802864" />
+    <rect
+       style="display:inline;fill:#000000;fill-opacity:0;fill-rule:nonzero;stroke:#000000;stroke-width:0.330549;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:0;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;shape-rendering:crispEdges;enable-background:new"
+       id="rect4477"
+       width="156.8378"
+       height="116.72887"
+       x="45.85265"
+       y="42.423283"
+       inkscape:export-filename="C:\workspace\ad\ghdl\docs\block_diagrams\cn0577\cn0577_block_diagram.png"
+       inkscape:export-xdpi="224.36"
+       inkscape:export-ydpi="224.36" />
+    <path
+       sodipodi:nodetypes="cc"
+       inkscape:connector-curvature="0"
+       id="path4518"
+       d="M 133.57232,45.349186 V 40.279672"
+       style="display:inline;fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:0.396875;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-start:url(#TriangleInM);marker-end:url(#TriangleOutM);shape-rendering:crispEdges;enable-background:new"
+       inkscape:export-filename="C:\workspace\ad\ghdl\docs\block_diagrams\cn0577\cn0577_block_diagram.png"
+       inkscape:export-xdpi="224.36"
+       inkscape:export-ydpi="224.36" />
+    <path
+       sodipodi:nodetypes="cc"
+       inkscape:connector-curvature="0"
+       id="path4518-5"
+       d="M 140.48242,45.347446 V 40.304278"
+       style="display:inline;fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:0.396875;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-start:url(#TriangleInM-7);marker-end:url(#TriangleOutM-2);shape-rendering:crispEdges;enable-background:new"
+       inkscape:export-filename="C:\workspace\ad\ghdl\docs\block_diagrams\cn0577\cn0577_block_diagram.png"
+       inkscape:export-xdpi="224.36"
+       inkscape:export-ydpi="224.36" />
+    <path
+       sodipodi:nodetypes="cc"
+       inkscape:connector-curvature="0"
+       id="path4518-5-9"
+       d="M 147.39251,45.34172 V 40.272264"
+       style="display:inline;fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:0.396875;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-start:url(#TriangleInM-7-1);marker-end:url(#TriangleOutM-2-8);shape-rendering:crispEdges;enable-background:new"
+       inkscape:export-filename="C:\workspace\ad\ghdl\docs\block_diagrams\cn0577\cn0577_block_diagram.png"
+       inkscape:export-xdpi="224.36"
+       inkscape:export-ydpi="224.36" />
+    <rect
+       transform="scale(-1,1)"
+       style="display:inline;fill:#ebebeb;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.500933;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:0;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;shape-rendering:crispEdges"
+       id="rect4136"
+       width="111.22163"
+       height="19.844805"
+       x="-164.83311"
+       y="46.539265"
+       inkscape:export-filename="C:\workspace\ad\ghdl\docs\block_diagrams\cn0577\cn0577_block_diagram.png"
+       inkscape:export-xdpi="224.36"
+       inkscape:export-ydpi="224.36" />
+    <path
+       style="display:inline;fill:#a2dcea;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.529167;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;shape-rendering:crispEdges"
+       d="M 157.54764,46.715505 V 66.42975"
+       id="path4179"
+       inkscape:connector-curvature="0"
+       inkscape:export-filename="C:\workspace\ad\ghdl\docs\block_diagrams\cn0577\cn0577_block_diagram.png"
+       inkscape:export-xdpi="224.36"
+       inkscape:export-ydpi="224.36" />
+    <path
+       style="display:inline;fill:#a2dcea;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.529167;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;shape-rendering:crispEdges"
+       d="M 150.76627,46.715505 V 66.42975"
+       id="path4179-9"
+       inkscape:connector-curvature="0"
+       inkscape:export-filename="C:\workspace\ad\ghdl\docs\block_diagrams\cn0577\cn0577_block_diagram.png"
+       inkscape:export-xdpi="224.36"
+       inkscape:export-ydpi="224.36" />
+    <path
+       style="display:inline;fill:#a2dcea;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.529167;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;shape-rendering:crispEdges"
+       d="M 123.64077,46.715505 V 66.42975"
+       id="path4179-0"
+       inkscape:connector-curvature="0"
+       inkscape:export-filename="C:\workspace\ad\ghdl\docs\block_diagrams\cn0577\cn0577_block_diagram.png"
+       inkscape:export-xdpi="224.36"
+       inkscape:export-ydpi="224.36" />
+    <path
+       style="display:inline;fill:#a2dcea;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.529167;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;shape-rendering:crispEdges"
+       d="M 130.42215,46.715505 V 66.42975"
+       id="path4179-4"
+       inkscape:connector-curvature="0"
+       inkscape:export-filename="C:\workspace\ad\ghdl\docs\block_diagrams\cn0577\cn0577_block_diagram.png"
+       inkscape:export-xdpi="224.36"
+       inkscape:export-ydpi="224.36" />
+    <path
+       style="display:inline;fill:#a2dcea;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.529167;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;shape-rendering:crispEdges"
+       d="M 137.20352,46.715505 V 66.42975"
+       id="path4179-7"
+       inkscape:connector-curvature="0"
+       inkscape:export-filename="C:\workspace\ad\ghdl\docs\block_diagrams\cn0577\cn0577_block_diagram.png"
+       inkscape:export-xdpi="224.36"
+       inkscape:export-ydpi="224.36" />
+    <path
+       style="display:inline;fill:#a2dcea;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.529167;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;shape-rendering:crispEdges"
+       d="M 143.98489,46.715505 V 66.42975"
+       id="path4179-41"
+       inkscape:connector-curvature="0"
+       inkscape:export-filename="C:\workspace\ad\ghdl\docs\block_diagrams\cn0577\cn0577_block_diagram.png"
+       inkscape:export-xdpi="224.36"
+       inkscape:export-ydpi="224.36" />
+    <path
+       style="display:inline;fill:#a2dcea;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.529167;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;shape-rendering:crispEdges"
+       d="M 116.8594,46.715505 V 66.42975"
+       id="path4179-0-3"
+       inkscape:connector-curvature="0"
+       inkscape:export-filename="C:\workspace\ad\ghdl\docs\block_diagrams\cn0577\cn0577_block_diagram.png"
+       inkscape:export-xdpi="224.36"
+       inkscape:export-ydpi="224.36" />
+    <text
+       transform="matrix(0,-1.0072219,0.9928299,0,0,0)"
+       id="text4229"
+       y="142.68727"
+       x="-62.18874"
+       style="font-style:normal;font-weight:normal;font-size:3.175px;line-height:0%;font-family:Arial;letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;shape-rendering:crispEdges"
+       xml:space="preserve"
+       inkscape:export-filename="C:\workspace\ad\ghdl\docs\block_diagrams\cn0577\cn0577_block_diagram.png"
+       inkscape:export-xdpi="224.36"
+       inkscape:export-ydpi="224.36"><tspan
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:2.97656px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial Bold';stroke-width:0.264583px"
+         y="142.68727"
+         x="-62.18874"
+         id="tspan4231"
+         sodipodi:role="line">Ethernet</tspan></text>
+    <text
+       transform="matrix(0,-1.0072219,0.9928299,0,0,0)"
+       id="text4233"
+       y="149.24825"
+       x="-60.271706"
+       style="font-style:normal;font-weight:normal;font-size:3.175px;line-height:0%;font-family:Arial;letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;shape-rendering:crispEdges"
+       xml:space="preserve"
+       inkscape:export-filename="C:\workspace\ad\ghdl\docs\block_diagrams\cn0577\cn0577_block_diagram.png"
+       inkscape:export-xdpi="224.36"
+       inkscape:export-ydpi="224.36"><tspan
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:2.97656px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial Bold';stroke-width:0.264583px"
+         y="149.24825"
+         x="-60.271706"
+         id="tspan4235"
+         sodipodi:role="line">UART</tspan></text>
+    <text
+       transform="matrix(0,-1.0072219,0.9928299,0,0,0)"
+       id="text4237"
+       y="136.0764"
+       x="-60.204849"
+       style="font-style:normal;font-weight:normal;font-size:3.175px;line-height:0%;font-family:Arial;letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;shape-rendering:crispEdges"
+       xml:space="preserve"
+       inkscape:export-filename="C:\workspace\ad\ghdl\docs\block_diagrams\cn0577\cn0577_block_diagram.png"
+       inkscape:export-xdpi="224.36"
+       inkscape:export-ydpi="224.36"><tspan
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:2.97656px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial Bold';stroke-width:0.264583px"
+         y="136.0764"
+         x="-60.204849"
+         id="tspan4239"
+         sodipodi:role="line">DDRx</tspan></text>
+    <text
+       transform="matrix(0,-1.0072219,0.9928299,0,0,0)"
+       id="text4241"
+       y="162.90863"
+       x="-58.415714"
+       style="font-style:normal;font-weight:normal;font-size:3.175px;line-height:0%;font-family:Arial;letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;shape-rendering:crispEdges"
+       xml:space="preserve"
+       inkscape:export-filename="C:\workspace\ad\ghdl\docs\block_diagrams\cn0577\cn0577_block_diagram.png"
+       inkscape:export-xdpi="224.36"
+       inkscape:export-ydpi="224.36"><tspan
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:2.97656px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial Bold';stroke-width:0.264583px"
+         y="162.90863"
+         x="-58.415714"
+         id="tspan4243"
+         sodipodi:role="line">SPI</tspan></text>
+    <text
+       transform="matrix(0,-1.0072219,0.9928299,0,0,0)"
+       id="text4245"
+       y="156.43456"
+       x="-58.398273"
+       style="font-style:normal;font-weight:normal;font-size:3.175px;line-height:0%;font-family:Arial;letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;shape-rendering:crispEdges"
+       xml:space="preserve"
+       inkscape:export-filename="C:\workspace\ad\ghdl\docs\block_diagrams\cn0577\cn0577_block_diagram.png"
+       inkscape:export-xdpi="224.36"
+       inkscape:export-ydpi="224.36"><tspan
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:2.97656px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial Bold';stroke-width:0.264583px"
+         y="156.43456"
+         x="-58.398273"
+         id="tspan4247"
+         sodipodi:role="line">I<tspan
+   style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:2.97656px;font-family:Arial;-inkscape-font-specification:'Arial Bold';baseline-shift:super;stroke-width:0.264583px"
+   id="tspan4485">2</tspan>C</tspan></text>
+    <text
+       transform="matrix(0,-1.0072219,0.9928299,0,0,0)"
+       id="text4251"
+       y="129.04584"
+       x="-63.036072"
+       style="font-style:normal;font-weight:normal;font-size:3.175px;line-height:0%;font-family:Arial;letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;shape-rendering:crispEdges"
+       xml:space="preserve"
+       inkscape:export-filename="C:\workspace\ad\ghdl\docs\block_diagrams\cn0577\cn0577_block_diagram.png"
+       inkscape:export-xdpi="224.36"
+       inkscape:export-ydpi="224.36"><tspan
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:2.97656px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial Bold';stroke-width:0.264583px"
+         y="129.04584"
+         x="-63.036072"
+         id="tspan4253"
+         sodipodi:role="line">Interrupts</tspan></text>
+    <text
+       transform="scale(0.9928299,1.0072219)"
+       id="text4311"
+       y="27.874945"
+       x="82.596695"
+       style="font-style:normal;font-weight:normal;font-size:3.175px;line-height:0%;font-family:Arial;letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;shape-rendering:crispEdges"
+       xml:space="preserve"><tspan
+         y="27.874945"
+         x="82.596695"
+         id="tspan4313"
+         sodipodi:role="line"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:3.96875px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial Bold';stroke-width:0.264583px" /></text>
+    <text
+       transform="matrix(0,-1.0072219,0.9928299,0,0,0)"
+       id="text4301"
+       y="121.95177"
+       x="-60.131454"
+       style="font-style:normal;font-weight:normal;font-size:3.175px;line-height:0%;font-family:Arial;letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;shape-rendering:crispEdges"
+       xml:space="preserve"
+       inkscape:export-filename="C:\workspace\ad\ghdl\docs\block_diagrams\cn0577\cn0577_block_diagram.png"
+       inkscape:export-xdpi="224.36"
+       inkscape:export-ydpi="224.36"><tspan
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:2.97656px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial Bold';stroke-width:0.264583px"
+         y="121.95177"
+         x="-60.131454"
+         id="tspan4303"
+         sodipodi:role="line">Timer</tspan></text>
+    <rect
+       style="display:inline;vector-effect:none;fill:#ffcccc;fill-opacity:1;fill-rule:nonzero;stroke:#a01414;stroke-width:0.264583;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;shape-rendering:crispEdges;enable-background:new"
+       id="rect4589"
+       width="3.9288628"
+       height="4.2094946"
+       x="53.282852"
+       y="36.366516"
+       inkscape:export-xdpi="224.36"
+       inkscape:export-ydpi="224.36"
+       inkscape:export-filename="C:\workspace\ad\ghdl\docs\block_diagrams\cn0577\cn0577_block_diagram.png" />
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;font-size:3.175px;line-height:0%;font-family:Arial;letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;shape-rendering:crispEdges;enable-background:new"
+       x="58.305683"
+       y="39.394981"
+       id="text4595"
+       inkscape:export-xdpi="224.36"
+       inkscape:export-ydpi="224.36"
+       inkscape:export-filename="C:\workspace\ad\ghdl\docs\block_diagrams\cn0577\cn0577_block_diagram.png"><tspan
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:3.30729px;line-height:1.25;font-family:Arial;-inkscape-font-specification:Arial;stroke-width:0.264583px"
+         sodipodi:role="line"
+         id="tspan4597"
+         x="58.305683"
+         y="39.394981">Receive path</tspan></text>
+    <rect
+       style="display:inline;vector-effect:none;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.486876;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:0;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;shape-rendering:crispEdges;enable-background:new"
+       id="rect4487"
+       width="6.6456137"
+       height="53.193066"
+       x="55.800285"
+       y="85.137817"
+       inkscape:export-xdpi="224.36"
+       inkscape:export-ydpi="224.36"
+       inkscape:export-filename="C:\workspace\ad\ghdl\docs\block_diagrams\cn0577\cn0577_block_diagram.png" />
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:3.88056px;line-height:0%;font-family:Arial;-inkscape-font-specification:'Arial, Bold';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;shape-rendering:crispEdges;enable-background:new"
+       x="-136.32645"
+       y="60.250889"
+       id="text4489"
+       transform="rotate(-90)"
+       inkscape:export-xdpi="224.36"
+       inkscape:export-ydpi="224.36"
+       inkscape:export-filename="C:\workspace\ad\ghdl\docs\block_diagrams\cn0577\cn0577_block_diagram.png"><tspan
+         sodipodi:role="line"
+         id="tspan4491"
+         x="-136.32645"
+         y="60.250889"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:3.88056px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial, Bold';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;stroke-width:0.264583px">MEMORY INTERCONNECT</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;font-size:3.175px;line-height:0%;font-family:Arial;letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:0.858696;stroke:none;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;shape-rendering:crispEdges;enable-background:new"
+       x="179.62912"
+       y="57.091106"
+       id="text4482"
+       inkscape:export-xdpi="224.36"
+       inkscape:export-ydpi="224.36"
+       inkscape:export-filename="C:\workspace\ad\ghdl\docs\block_diagrams\cn0577\cn0577_block_diagram.png"><tspan
+         sodipodi:role="line"
+         x="179.62912"
+         y="57.091106"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:5.29167px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:0.858696;stroke-width:0.264583px"
+         id="tspan3725">ZedBoard</tspan></text>
+    <rect
+       style="display:inline;vector-effect:none;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.478442;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:0;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;shape-rendering:crispEdges;enable-background:new"
+       id="rect4488"
+       width="7.645824"
+       height="92.035782"
+       x="198.63475"
+       y="65.548294"
+       inkscape:export-xdpi="224.36"
+       inkscape:export-ydpi="224.36"
+       inkscape:export-filename="C:\workspace\ad\ghdl\docs\block_diagrams\cn0577\cn0577_block_diagram.png" />
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;font-size:3.175px;line-height:0%;font-family:Arial;letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;shape-rendering:crispEdges;enable-background:new"
+       x="-136.48291"
+       y="204.2204"
+       id="text4491"
+       transform="rotate(-90)"
+       inkscape:export-xdpi="224.36"
+       inkscape:export-ydpi="224.36"
+       inkscape:export-filename="C:\workspace\ad\ghdl\docs\block_diagrams\cn0577\cn0577_block_diagram.png"><tspan
+         sodipodi:role="line"
+         id="tspan4493"
+         x="-136.48291"
+         y="204.2204"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:4.63021px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial Bold';stroke-width:0.264583px">FMC CONNECTOR</tspan></text>
+    <rect
+       style="display:inline;fill:none;fill-opacity:1;stroke:#3f4b55;stroke-width:0.538112;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:0.538112, 1.61435;stroke-dashoffset:0;stroke-opacity:1;shape-rendering:crispEdges;enable-background:new"
+       id="rect6057"
+       width="27.030113"
+       height="86.814651"
+       x="48.339287"
+       y="69.953239"
+       inkscape:export-xdpi="224.36"
+       inkscape:export-ydpi="224.36"
+       inkscape:export-filename="C:\workspace\ad\ghdl\docs\block_diagrams\cn0577\cn0577_block_diagram.png" />
+    <rect
+       y="73.397713"
+       x="72.880264"
+       height="73.077057"
+       width="9.149436"
+       id="rect5786"
+       style="display:inline;vector-effect:none;fill:#ffcccc;fill-opacity:1;fill-rule:nonzero;stroke:#a01414;stroke-width:0.225601;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;shape-rendering:crispEdges;enable-background:new"
+       inkscape:export-xdpi="224.36"
+       inkscape:export-ydpi="224.36"
+       inkscape:export-filename="C:\workspace\ad\ghdl\docs\block_diagrams\cn0577\cn0577_block_diagram.png" />
+    <text
+       transform="rotate(-90)"
+       id="text5788"
+       y="79.038582"
+       x="-114.37154"
+       style="font-style:normal;font-weight:normal;font-size:3.175px;line-height:0%;font-family:Arial;letter-spacing:0px;word-spacing:0px;display:inline;fill:#28170b;fill-opacity:1;stroke:none;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;shape-rendering:crispEdges;enable-background:new"
+       xml:space="preserve"
+       inkscape:export-xdpi="224.36"
+       inkscape:export-ydpi="224.36"
+       inkscape:export-filename="C:\workspace\ad\ghdl\docs\block_diagrams\cn0577\cn0577_block_diagram.png"><tspan
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:4.63021px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial Bold';fill:#28170b;stroke:none;stroke-width:0.264583px;stroke-opacity:1"
+         y="79.038582"
+         x="-114.37154"
+         id="tspan5790"
+         sodipodi:role="line">DMA</tspan></text>
+    <text
+       transform="scale(0.9928299,1.0072219)"
+       id="text4311-0"
+       y="57.409237"
+       x="69.524628"
+       style="font-style:normal;font-weight:normal;font-size:3.175px;line-height:0%;font-family:Arial;letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;shape-rendering:crispEdges;enable-background:new"
+       xml:space="preserve"
+       inkscape:export-filename="C:\workspace\ad\ghdl\docs\block_diagrams\cn0577\cn0577_block_diagram.png"
+       inkscape:export-xdpi="224.36"
+       inkscape:export-ydpi="224.36"><tspan
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:3.96875px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial Bold';stroke-width:0.264583px"
+         y="57.409237"
+         x="69.524628"
+         id="tspan4313-9"
+         sodipodi:role="line">ARM (Zynq) </tspan></text>
+    <g
+       id="g5654"
+       style="display:inline;fill:#a01414;fill-opacity:1;stroke:#a01414;stroke-width:0.91193;stroke-opacity:1;shape-rendering:crispEdges;enable-background:new"
+       transform="matrix(0.32827811,0,0,0.26434798,19.943177,-34.962379)"
+       inkscape:export-filename="C:\workspace\ad\ghdl\docs\block_diagrams\cn0577\cn0577_block_diagram.png"
+       inkscape:export-xdpi="224.36"
+       inkscape:export-ydpi="224.36">
+      <path
+         inkscape:connector-curvature="0"
+         id="path5656"
+         d="m 130.73937,546.2302 10.03208,14.84925 v -6.80591 l 20.46375,-3e-5 c 0,-16.08362 0,0 0,-16.08362 l -20.46375,3e-5 v -6.80591 l -10.03208,14.84925"
+         style="fill:#a01414;fill-opacity:1;fill-rule:evenodd;stroke:#a01414;stroke-width:0.91193px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1"
+         sodipodi:nodetypes="cccccccc" />
+    </g>
+    <g
+       id="g5654-3"
+       style="display:inline;fill:#a01414;fill-opacity:1;stroke:#a01414;stroke-width:0.57429;stroke-opacity:1;shape-rendering:crispEdges;enable-background:new"
+       transform="matrix(0.80784318,0,0,0.27086297,-22.589664,-39.068558)"
+       inkscape:export-filename="C:\workspace\ad\ghdl\docs\block_diagrams\cn0577\cn0577_block_diagram.png"
+       inkscape:export-xdpi="224.36"
+       inkscape:export-ydpi="224.36">
+      <path
+         inkscape:connector-curvature="0"
+         id="path5656-0"
+         d="m 130.73937,546.2302 10.03208,14.84925 v -6.80591 l 20.46375,-3e-5 c 0,-16.08362 0,0 0,-16.08362 l -20.46375,3e-5 v -6.80591 l -10.03208,14.84925"
+         style="fill:#a01414;fill-opacity:1;fill-rule:evenodd;stroke:#a01414;stroke-width:0.57429px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1"
+         sodipodi:nodetypes="cccccccc" />
+    </g>
+    <g
+       id="g5654-2"
+       style="display:inline;fill:#a01414;fill-opacity:1;stroke:#a01414;stroke-opacity:1;shape-rendering:crispEdges;enable-background:new"
+       transform="matrix(0.46245287,0,0,0.26458333,24.934835,-101.65513)" />
+    <text
+       id="text11366-4-8"
+       y="76.660919"
+       x="112.0732"
+       style="font-style:normal;font-weight:normal;font-size:3.175px;line-height:0%;font-family:Arial;letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;shape-rendering:crispEdges;enable-background:new"
+       xml:space="preserve"><tspan
+         id="tspan11370-7-5"
+         y="76.660919"
+         x="112.0732"
+         sodipodi:role="line"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:3.30729px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:center;text-anchor:middle;stroke-width:0.264583px" /></text>
+    <path
+       sodipodi:nodetypes="cc"
+       inkscape:connector-curvature="0"
+       id="path1206"
+       d="M 198.39343,93.188272 H 160.98307"
+       style="fill:none;stroke:#000000;stroke-width:0.529167;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#marker1216);shape-rendering:crispEdges" />
+    <path
+       sodipodi:nodetypes="cc"
+       inkscape:connector-curvature="0"
+       id="path1206-9"
+       d="M 198.66335,98.320588 H 161.25301"
+       style="display:inline;fill:none;stroke:#000000;stroke-width:0.529167;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#marker1216-9);shape-rendering:crispEdges;enable-background:new" />
+    <text
+       id="text2401"
+       y="95.740036"
+       x="168.36563"
+       style="font-style:normal;font-weight:normal;font-size:4.42089px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583;shape-rendering:crispEdges"
+       xml:space="preserve"
+       transform="scale(1.0443046,0.95757502)"><tspan
+         style="font-size:3.68407px;stroke-width:0.264583"
+         y="95.740036"
+         x="168.36563"
+         id="tspan2399"
+         sodipodi:role="line">DA_p</tspan></text>
+    <text
+       id="text2401-0"
+       y="101.55558"
+       x="168.4097"
+       style="font-style:normal;font-weight:normal;font-size:4.42089px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583;shape-rendering:crispEdges"
+       xml:space="preserve"
+       transform="scale(1.0443046,0.95757502)"><tspan
+         style="font-size:3.68407px;stroke-width:0.264583"
+         y="101.55558"
+         x="168.4097"
+         id="tspan2399-27"
+         sodipodi:role="line">DA_n</tspan></text>
+    <path
+       sodipodi:nodetypes="cc"
+       inkscape:connector-curvature="0"
+       id="path1206-5"
+       d="M 198.38955,108.54186 H 160.9792"
+       style="fill:none;stroke:#000000;stroke-width:0.529167;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#marker1216-4);shape-rendering:crispEdges" />
+    <path
+       sodipodi:nodetypes="cc"
+       inkscape:connector-curvature="0"
+       id="path1206-9-1"
+       d="M 198.65947,113.67417 H 161.24913"
+       style="display:inline;fill:none;stroke:#000000;stroke-width:0.529167;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#marker1216-9-6);shape-rendering:crispEdges;enable-background:new" />
+    <text
+       id="text2401-7"
+       y="111.77386"
+       x="168.36203"
+       style="font-style:normal;font-weight:normal;font-size:4.42089px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583;shape-rendering:crispEdges"
+       xml:space="preserve"
+       transform="scale(1.0443046,0.95757502)"><tspan
+         style="font-size:3.68407px;stroke-width:0.264583"
+         y="111.77386"
+         x="168.36203"
+         id="tspan2399-4"
+         sodipodi:role="line">DB_p</tspan></text>
+    <text
+       id="text2401-0-2"
+       y="117.58939"
+       x="168.4061"
+       style="font-style:normal;font-weight:normal;font-size:4.42089px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583;shape-rendering:crispEdges"
+       xml:space="preserve"
+       transform="scale(1.0443046,0.95757502)"><tspan
+         style="font-size:3.68407px;stroke-width:0.264583"
+         y="117.58939"
+         x="168.4061"
+         id="tspan2399-27-7"
+         sodipodi:role="line">DB_n</tspan></text>
+    <g
+       style="display:inline;shape-rendering:crispEdges;enable-background:new"
+       id="ddr"
+       transform="matrix(0.37593397,0,0,0.37593391,-17.27073,-132.78758)"
+       inkscape:export-filename="C:\workspace\ad\ghdl\docs\block_diagrams\cn0577\cn0577_block_diagram.png"
+       inkscape:export-xdpi="224.36"
+       inkscape:export-ydpi="224.36">
+      <rect
+         style="opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.8;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+         id="rect8406"
+         width="29.358675"
+         height="11.248666"
+         x="-453.55264"
+         y="391.80267"
+         transform="rotate(-90)" />
+      <rect
+         style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.67501;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.673913"
+         id="rect8408"
+         width="4.6139379"
+         height="6.8413563"
+         x="-451.4805"
+         y="394.00632"
+         transform="rotate(-90)" />
+      <rect
+         y="394.00632"
+         x="-444.69791"
+         height="6.8413563"
+         width="4.6139379"
+         id="rect8410"
+         style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.67501;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.673913"
+         transform="rotate(-90)" />
+      <rect
+         y="394.00632"
+         x="-431.13275"
+         height="6.8413563"
+         width="4.6139379"
+         id="rect8414"
+         style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.67501;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.673913"
+         transform="rotate(-90)" />
+      <rect
+         style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.67501;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.673913"
+         id="rect8416"
+         width="4.6139379"
+         height="6.8413563"
+         x="-437.91531"
+         y="394.00632"
+         transform="rotate(-90)" />
+      <path
+         style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:0.5506;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         d="m 402.9495,451.34818 h 3.46837 v -24.7395 h -3.63159"
+         id="path8420"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cccc" />
+      <path
+         style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1.067;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         d="M 406.04958,449.00384 H 404.6091"
+         id="path8422"
+         inkscape:connector-curvature="0" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path8424"
+         d="M 406.04958,430.92913 H 404.6091"
+         style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1.067;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+      <path
+         style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1.067;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         d="M 406.04958,433.33004 H 404.6091"
+         id="path8426"
+         inkscape:connector-curvature="0" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path8428"
+         d="M 406.04958,435.45913 H 404.6091"
+         style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1.067;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+      <path
+         style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1.067;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         d="M 406.04958,437.86003 H 404.6091"
+         id="path8430"
+         inkscape:connector-curvature="0" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path8432"
+         d="M 406.04958,439.98913 H 404.6091"
+         style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1.067;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+      <path
+         style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1.067;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         d="M 406.04958,442.34471 H 404.6091"
+         id="path8434"
+         inkscape:connector-curvature="0" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path8436"
+         d="M 406.04958,444.51915 H 404.6091"
+         style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1.067;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+      <path
+         style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1.067;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         d="M 406.04958,446.82944 H 404.6091"
+         id="path8438"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1.067;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         d="M 406.04958,430.92913 H 404.6091"
+         id="path8440"
+         inkscape:connector-curvature="0" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path8450"
+         d="M 406.04958,428.80003 H 404.6091"
+         style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1.067;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    </g>
+    <g
+       style="display:inline;shape-rendering:crispEdges;enable-background:new"
+       id="g8892"
+       transform="matrix(0.26458333,0,0,0.26458333,40.080594,-84.382617)"
+       inkscape:export-filename="C:\workspace\ad\ghdl\docs\block_diagrams\cn0577\cn0577_block_diagram.png"
+       inkscape:export-xdpi="224.36"
+       inkscape:export-ydpi="224.36">
+      <rect
+         y="431.09491"
+         x="366.68005"
+         height="23.063002"
+         width="26.832939"
+         id="rect8762"
+         style="opacity:1;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:1.33851;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+      <path
+         inkscape:connector-curvature="0"
+         id="rect8764"
+         d="m 371.84168,433.47704 h 16.31637 c 1.2826,0 2.31516,1.03257 2.31516,2.31517 v 13.22948 c 0,1.28259 -1.03256,2.31515 -2.31516,2.31515 h -16.31637 c -1.2826,0 -2.31516,-1.03256 -2.31516,-2.31515 v -13.22948 c 0,-1.2826 1.03256,-2.31517 2.31516,-2.31517 z"
+         style="opacity:1;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:1.2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+      <g
+         style="fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-opacity:1"
+         transform="matrix(1.2472877,0,0,1.2472877,-94.749819,-45.663902)"
+         id="g8811">
+        <path
+           id="rect8801"
+           d="m 371.16019,393.86166 h 6.77743 v 5.24892 h -6.77743 z"
+           style="opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:#ffffff;stroke-width:0.479248;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+           inkscape:connector-curvature="0" />
+        <path
+           id="rect8809"
+           d="m 383.3136,393.86166 h 6.77743 v 5.24892 h -6.77743 z"
+           style="opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:#ffffff;stroke-width:0.479248;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+           inkscape:connector-curvature="0" />
+      </g>
+      <path
+         sodipodi:nodetypes="ccccc"
+         inkscape:connector-curvature="0"
+         id="path8818"
+         d="m 369.52814,445.26083 h 5.8318 v 2.82613 h 1.54776 v 3.24584"
+         style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1.2;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+      <path
+         style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1.2;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         d="m 390.47422,445.29053 h -5.89282 v 2.80734 h -1.56397 v 3.22427"
+         id="path8820"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccccc" />
+      <rect
+         y="447.10886"
+         x="369.1405"
+         height="3.8938534"
+         width="4.5168324"
+         id="rect8824"
+         style="opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.973;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+      <rect
+         style="opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.973;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+         id="rect8826"
+         width="4.5168324"
+         height="3.8938534"
+         x="386.27451"
+         y="447.10886" />
+      <rect
+         y="433.60046"
+         x="371.85117"
+         height="5.1640501"
+         width="1.2438545"
+         id="rect8828"
+         style="opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.308598;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+      <rect
+         style="opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.308598;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+         id="rect8830"
+         width="1.2438545"
+         height="5.1640501"
+         x="384.39578"
+         y="433.60046" />
+      <rect
+         y="433.60046"
+         x="381.88687"
+         height="5.1640501"
+         width="1.2438545"
+         id="rect8832"
+         style="opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.308598;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+      <rect
+         style="opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.308598;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+         id="rect8834"
+         width="1.2438545"
+         height="5.1640501"
+         x="379.37793"
+         y="433.60046" />
+      <rect
+         y="433.60046"
+         x="376.86902"
+         height="5.1640501"
+         width="1.2438545"
+         id="rect8836"
+         style="opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.308598;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+      <rect
+         style="opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.308598;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+         id="rect8838"
+         width="1.2438545"
+         height="5.1640501"
+         x="374.36008"
+         y="433.60046" />
+      <rect
+         style="opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.308598;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+         id="rect8840"
+         width="1.2438545"
+         height="5.1640501"
+         x="386.90469"
+         y="433.60046" />
+    </g>
+    <g
+       id="uart"
+       transform="matrix(0,-0.10973853,0.10973855,0,102.98407,90.423989)"
+       style="display:inline;stroke-width:2.41103;stroke-miterlimit:4;stroke-dasharray:none;shape-rendering:crispEdges;enable-background:new"
+       inkscape:export-filename="C:\workspace\ad\ghdl\docs\block_diagrams\cn0577\cn0577_block_diagram.png"
+       inkscape:export-xdpi="224.36"
+       inkscape:export-ydpi="224.36">
+      <rect
+         ry="4.5"
+         y="388.11218"
+         x="490.75"
+         height="28.75"
+         width="70"
+         id="rect8910"
+         style="opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:2.41103;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+      <path
+         sodipodi:nodetypes="sssssssss"
+         inkscape:connector-curvature="0"
+         id="rect8912"
+         d="m 507.25,394.11218 h 37 c 2.493,0 5.47668,2.20628 4.5,4.5 l -3.3,7.75 c -0.97668,2.29372 -3.507,4.5 -6,4.5 h -27.8 c -2.493,0 -4.37391,-2.22795 -5.4,-4.5 l -3.5,-7.75 c -1.02609,-2.27205 2.007,-4.5 4.5,-4.5 z"
+         style="opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:2.41103;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+      <circle
+         r="3.1875"
+         cy="402.48718"
+         cx="497.5126"
+         id="path8915"
+         style="opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:2.41103;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+      <circle
+         style="opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:2.41103;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+         id="circle8917"
+         cx="554.13763"
+         cy="402.48718"
+         r="3.1875" />
+      <ellipse
+         ry="1.0625"
+         rx="1"
+         cy="399.79968"
+         cx="513.7403"
+         id="path8919"
+         style="opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:2.41103;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+      <ellipse
+         ry="1.0625"
+         rx="1"
+         cy="399.79968"
+         cx="537.7403"
+         id="ellipse8923"
+         style="opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:2.41103;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+      <ellipse
+         style="opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:2.41103;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+         id="ellipse8925"
+         cx="531.7403"
+         cy="399.79968"
+         rx="1"
+         ry="1.0625" />
+      <ellipse
+         ry="1.0625"
+         rx="1"
+         cy="399.79968"
+         cx="525.7403"
+         id="ellipse8927"
+         style="opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:2.41103;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+      <ellipse
+         style="opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:2.41103;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+         id="ellipse8929"
+         cx="519.7403"
+         cy="399.79968"
+         rx="1"
+         ry="1.0625" />
+      <ellipse
+         style="opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:2.41103;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+         id="ellipse8921"
+         cx="516.7403"
+         cy="405.79968"
+         rx="1"
+         ry="1.0625" />
+      <ellipse
+         ry="1.0625"
+         rx="1"
+         cy="405.79968"
+         cx="534.7403"
+         id="ellipse8931"
+         style="opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:2.41103;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+      <ellipse
+         style="opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:2.41103;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+         id="ellipse8933"
+         cx="528.7403"
+         cy="405.79968"
+         rx="1"
+         ry="1.0625" />
+      <ellipse
+         ry="1.0625"
+         rx="1"
+         cy="405.79968"
+         cx="522.7403"
+         id="ellipse8935"
+         style="opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:2.41103;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+    </g>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:3.43958px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Bold';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;letter-spacing:0px;word-spacing:0px;display:inline;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.268639;shape-rendering:crispEdges;enable-background:new"
+       x="64.748016"
+       y="112.67403"
+       id="text2401-61-1-54-8"
+       transform="scale(1.0162353,0.98402408)"
+       inkscape:export-filename="C:\workspace\ad\ghdl\docs\block_diagrams\cn0577\cn0577_block_diagram.png"
+       inkscape:export-xdpi="224.36"
+       inkscape:export-ydpi="224.36"><tspan
+         sodipodi:role="line"
+         id="tspan2399-9-2-70-3"
+         x="64.748016"
+         y="112.67403"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:3.43958px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Bold';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;fill:#ffffff;fill-opacity:1;stroke-width:0.268639">64</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:3.43958px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Bold';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;letter-spacing:0px;word-spacing:0px;display:inline;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.269;stroke-miterlimit:4;stroke-dasharray:none;shape-rendering:crispEdges;enable-background:new"
+       x="92.421837"
+       y="111.93877"
+       id="text2401-61-1-54-8-3"
+       transform="scale(1.0162353,0.98402408)"
+       inkscape:export-filename="C:\workspace\ad\ghdl\docs\block_diagrams\cn0577\cn0577_block_diagram.png"
+       inkscape:export-xdpi="224.36"
+       inkscape:export-ydpi="224.36"><tspan
+         sodipodi:role="line"
+         id="tspan2399-9-2-70-3-9"
+         x="92.421837"
+         y="111.93877"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:3.43958px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Bold';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;fill:#ffffff;fill-opacity:1;stroke-width:0.269;stroke-miterlimit:4;stroke-dasharray:none">32</tspan></text>
+    <rect
+       style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#a01414;stroke-width:0.426;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:0.0426, 0.0426;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect19131"
+       width="39.872944"
+       height="23.023788"
+       x="115.95037"
+       y="88.13372" />
+    <rect
+       style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#a01414;stroke-width:0.426002;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:0.0426002, 0.0426002;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect19131-2"
+       width="39.872944"
+       height="6.1456804"
+       x="114.85004"
+       y="138.39899" />
+    <rect
+       style="fill:#ffcccc;fill-opacity:1;fill-rule:evenodd;stroke:#a01414;stroke-width:0.426;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:0.0426, 0.0426;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect958"
+       width="15.066154"
+       height="11.580877"
+       x="138.83858"
+       y="97.383614" />
+    <rect
+       style="fill:#ffcccc;fill-opacity:1;fill-rule:evenodd;stroke:#a01414;stroke-width:0.426;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:0.0426, 0.0426;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect958-1"
+       width="18.344688"
+       height="13.827947"
+       x="115.95206"
+       y="114.81905" />
+    <text
+       xml:space="preserve"
+       transform="matrix(0.1434475,0,0,0.13069708,67.337038,44.068862)"
+       id="text4758"
+       style="font-size:14px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial, Normal';white-space:pre;shape-inside:url(#rect4760);stroke-width:1.93234"><tspan
+         x="505.75977"
+         y="453.41916"
+         id="tspan1523">ad_serdes_in</tspan></text>
+    <rect
+       style="fill:#ffcccc;fill-opacity:1;fill-rule:evenodd;stroke:#a01414;stroke-width:0.426;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:0.0426, 0.0426;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect958-2"
+       width="15.066154"
+       height="11.580877"
+       x="117.95731"
+       y="97.263992" />
+    <text
+       xml:space="preserve"
+       transform="matrix(0.1434475,0,0,0.13069708,49.127482,44.136482)"
+       id="text4758-5"
+       style="font-size:14px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial, Normal';white-space:pre;shape-inside:url(#rect4760-6);stroke-width:1.93234"><tspan
+         x="505.75977"
+         y="453.41916"
+         id="tspan1525">ad_pack</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-size:4.20337px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial, Normal';stroke-width:0.264583"
+       x="123.9485"
+       y="93.775139"
+       id="text21502"
+       transform="scale(1.0050352,0.99499002)"><tspan
+         sodipodi:role="line"
+         id="tspan21500"
+         style="stroke-width:0.264583"
+         x="123.9485"
+         y="93.775139">ad408x_phy</tspan></text>
+    <text
+       xml:space="preserve"
+       transform="matrix(0.13201657,0,0,0.13069708,78.342228,59.439291)"
+       id="text24668"
+       style="font-size:16px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial, Normal';white-space:pre;shape-inside:url(#rect24670);stroke-width:2.01426"><tspan
+         x="298.9668"
+         y="484.35348"
+         id="tspan1527">ADC COMMON</tspan></text>
+    <rect
+       style="fill:#ffcccc;fill-opacity:1;fill-rule:evenodd;stroke:#a01414;stroke-width:0.426;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:0.0426, 0.0426;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect958-1-1"
+       width="18.344688"
+       height="13.827947"
+       x="136.71077"
+       y="114.69421" />
+    <text
+       xml:space="preserve"
+       transform="matrix(0.13201657,0,0,0.13069708,99.100946,59.314451)"
+       id="text24668-1"
+       style="font-size:16px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial, Normal';white-space:pre;shape-inside:url(#rect24670-6);stroke-width:2.01426"><tspan
+         x="298.9668"
+         y="484.35348"
+         id="tspan1529">ADC CHANNEL</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-size:4.20337px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial, Normal';stroke-width:0.264583"
+       x="127.25005"
+       y="143.25801"
+       id="text41823"
+       transform="scale(1.0050352,0.99499002)"><tspan
+         sodipodi:role="line"
+         id="tspan41821"
+         style="stroke-width:0.264583"
+         x="127.25005"
+         y="143.25801">UP_AXI</tspan></text>
+    <path
+       style="fill:#a01414;fill-opacity:1;stroke:#a01414;stroke-width:0.6;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:20;stroke-opacity:1;marker-start:url(#TriangleInM-3);marker-end:url(#marker51146)"
+       d="m 146.57665,130.75804 c 0,5.55326 0,5.33969 0,5.33969"
+       id="path42520-2" />
+    <path
+       style="fill:#a01414;fill-opacity:1;stroke:#a01414;stroke-width:0.6;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:20;stroke-opacity:1;marker-start:url(#TriangleInM-0);marker-end:url(#marker51146-9)"
+       d="m 124.37647,130.79376 c 0,5.55327 0,5.33969 0,5.33969"
+       id="path42520-2-7" />
+    <text
+       xml:space="preserve"
+       style="font-size:3.15252px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial, Normal';stroke-width:0.264583"
+       x="124.64314"
+       y="85.316605"
+       id="text49535"
+       transform="scale(1.0050352,0.99499002)"><tspan
+         sodipodi:role="line"
+         id="tspan49533"
+         style="font-size:3.15252px;stroke-width:0.264583"
+         x="124.64314"
+         y="85.316605">AXI-AD408X IP </tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.64583px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;stroke-width:0.264583"
+       x="49.604683"
+       y="154.91524"
+       id="text41772"><tspan
+         sodipodi:role="line"
+         id="tspan41770"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.64583px;font-family:Arial;-inkscape-font-specification:'Arial, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;stroke-width:0.264583"
+         x="49.604683"
+         y="154.91524">DMA_CLK=100MHz</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.64583px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;stroke-width:0.264583"
+       x="81.975174"
+       y="154.93251"
+       id="text41772-4"><tspan
+         sodipodi:role="line"
+         id="tspan41770-2"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.64583px;font-family:Arial;-inkscape-font-specification:'Arial, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;stroke-width:0.264583"
+         x="81.975174"
+         y="154.93251">REF_CLK= DCO_CLK(400MHz) / 4 </tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.64583px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;stroke-width:0.264583"
+       x="157.8167"
+       y="149.63438"
+       id="text41772-4-7"><tspan
+         sodipodi:role="line"
+         id="tspan41770-2-5"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.64583px;font-family:Arial;-inkscape-font-specification:'Arial, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;stroke-width:0.264583"
+         x="157.8167"
+         y="149.63438">REF_CLK= DCO_CLK(400MHz) </tspan></text>
+    <path
+       sodipodi:nodetypes="cc"
+       inkscape:connector-curvature="0"
+       id="path1206-6"
+       d="M 198.38955,132.66641 H 160.9792"
+       style="fill:none;stroke:#000000;stroke-width:0.529167;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#marker1216-71);shape-rendering:crispEdges" />
+    <path
+       sodipodi:nodetypes="cc"
+       inkscape:connector-curvature="0"
+       id="path1206-9-12"
+       d="M 198.65949,137.79872 H 161.24913"
+       style="display:inline;fill:none;stroke:#000000;stroke-width:0.529167;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#marker1216-9-9);shape-rendering:crispEdges;enable-background:new" />
+    <text
+       id="text2401-3"
+       y="136.96724"
+       x="166.88876"
+       style="font-style:normal;font-weight:normal;font-size:4.42089px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583;shape-rendering:crispEdges"
+       xml:space="preserve"
+       transform="scale(1.0443046,0.95757502)"><tspan
+         style="font-size:3.68407px;stroke-width:0.264583"
+         y="136.96724"
+         x="166.88876"
+         id="tspan2399-3"
+         sodipodi:role="line">DCO_p</tspan></text>
+    <text
+       id="text2401-0-8"
+       y="142.78278"
+       x="166.93283"
+       style="font-style:normal;font-weight:normal;font-size:4.42089px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583;shape-rendering:crispEdges"
+       xml:space="preserve"
+       transform="scale(1.0443046,0.95757502)"><tspan
+         style="font-size:3.68407px;stroke-width:0.264583"
+         y="142.78278"
+         x="166.93283"
+         id="tspan2399-27-77"
+         sodipodi:role="line">DCO_n</tspan></text>
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.498128;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-start:url(#TriangleInM-7-1);marker-end:url(#marker9011)"
+       d="m 160.90442,67.943553 -0.0847,5.47847 35.73134,-0.02886 v 0 0"
+       id="path54607"
+       sodipodi:nodetypes="ccccc" />
+    <text
+       xml:space="preserve"
+       style="font-size:2.11667px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial, Normal';stroke-width:0.264583"
+       x="163.6947"
+       y="71.951813"
+       id="text59898"><tspan
+         sodipodi:role="line"
+         id="tspan59896"
+         style="font-size:2.11667px;stroke-width:0.264583"
+         x="163.6947"
+         y="71.951813">AD4080/ADF4350/AD9508 SPI</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;font-size:10.5833px;line-height:1.25;font-family:sans-serif;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+       x="160.59171"
+       y="152.51469"
+       id="text3594"><tspan
+         sodipodi:role="line"
+         id="tspan3592"
+         style="stroke-width:0.264583" /></text>
+  </g>
+</svg>

--- a/docs/projects/ad408x_fmc_evb/index.rst
+++ b/docs/projects/ad408x_fmc_evb/index.rst
@@ -1,0 +1,263 @@
+.. _ad408x_fmc_evb:
+
+AD408X-FMC-EVB HDL project
+================================================================================
+
+Overview
+-------------------------------------------------------------------------------
+
+The :adi:`EVAL-AD4080-FMC <EVAL-AD4080-FMC>` is designed to demonstrate the
+:adi:`AD4080 <AD4080>`
+performance.
+
+The :adi:`EVAL-AD4080-FMC <EVAL-AD4080-FMC>`  HDL design supports the following
+:adi:`AD4080 <AD4080>` features:
+
+* Single/Dual lane DDR data capture
+* Self synchronization using the fixed pattern and bit-slip feature
+* Capturing digital averaging filter with up to 2^10 decimation
+* Analog-to-digital converter (ADC) configuration via serial peripheral
+  interface (SPI)
+* Sampling rate capability between 1.25 MSPS and 40 MSPS
+
+The :adi:`EVAL-AD4080-FMC <EVAL-AD4080-FMC>` evaluation board was designed for
+use with the Digilent ZedBoard via the field programmable gate array(FPGA)
+mezzanine card (FMC) connector.
+
+Supported boards
+-------------------------------------------------------------------------------
+
+-  :adi:`EVAL-AD4080-FMC <EVAL-AD4080-FMC>`
+
+Supported devices
+-------------------------------------------------------------------------------
+-  :adi:`AD4080`
+-  :adi:`AD9508`
+-  :adi:`ADF4350`
+-  :adi:`LT6236`
+-  :adi:`ADP7182`
+-  :adi:`ADA4945-1`
+
+Supported carriers
+-------------------------------------------------------------------------------
+
+.. list-table::
+   :widths: 35 35 30
+   :header-rows: 1
+
+   * - Evaluation board
+     - Carrier
+     - FMC slot
+   * - :adi:`EVAL-AD4080-FMC <EVAL-AD4080-FMC>`
+     - :xilinx:`ZedBoard <products/boards-and-kits/1-8dyf-11.html>`
+     - FMC-LPC
+
+Block design
+-------------------------------------------------------------------------------
+
+.. warning::
+    The VADJ for the Zedboard must be set to 2.5V.
+
+Block diagram
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The data path and clock domains are depicted in the below diagram:
+
+.. image:: ../ad408x_fmc_evb/ad408x_fmc_evb_zed_block_diagram.svg
+   :width: 800
+   :align: center
+   :alt: EVAL-AD4080-FMC/ZedBoard block diagram
+
+Clock scheme
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. image:: ../ad408x_fmc_evb/ad408x_fmc_clock_scheme.svg
+   :width: 800
+   :align: center
+   :alt: EVAL-AD4080-FMC/ZedBoard block diagram
+
+CPU/Memory interconnects addresses
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The addresses are dependent on the architecture of the FPGA, having an offset
+added to the base address from HDL (see more at :ref:`architecture`).
+
+
+==================== ===============
+Instance             Zynq/Microblaze
+==================== ===============
+axi_ad4080_adc       0x44A0_0000
+axi_ad4080_dma       0x44A3_0000
+==================== ===============
+
+SPI connections
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. list-table::
+   :widths: 25 25 25 25
+   :header-rows: 1
+
+   * - SPI type
+     - SPI manager instance
+     - SPI subordinate
+     - CS
+   * - PS
+     - SPI 0
+     - AD4080
+     - 0
+   * - PS
+     - SPI 1
+     - AD9508
+     - 0
+   * - PS
+     - SPI 1
+     - ADF4350
+     - 1
+
+GPIOs
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. list-table::
+   :widths: 25 20 20 20 15
+   :header-rows: 2
+
+   * - GPIO signal
+     - Direction
+     - HDL GPIO EMIO
+     - Software GPIO
+     - Software GPIO
+   * -
+     - (from FPGA view)
+     -
+     - Zynq-7000
+     - Zynq MP
+   * - sync_req
+     - OUT
+     - 37
+     - 91
+     - 115
+   * - pwrgd
+     - IN
+     - 36
+     - 90
+     - 114
+   * - adf435x_lock
+     - IN
+     - 35
+     - 89
+     - 113
+   * - gpio3_fmc
+     - INOUT
+     - 34
+     - 88
+     - 112
+   * - gpio3_fmc
+     - INOUT
+     - 33
+     - 87
+     - 111
+
+Interrupts
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Below are the Programmable Logic interrupts used in this project.
+
+================ === ========== ===========
+Instance name    HDL Linux Zynq Actual Zynq
+================ === ========== ===========
+axi_ad4080_dma   13  57         89
+================ === ========== ===========
+
+Building the HDL project
+-------------------------------------------------------------------------------
+
+The design is built upon ADI's generic HDL reference design framework.
+ADI distributes the bit/elf files of these projects as part of the
+:dokuwiki:`ADI Kuiper Linux <resources/tools-software/linux-software/kuiper-linux>`.
+If you want to build the sources, ADI makes them available on the
+:git-hdl:`HDL repository </>`. To get the source you must
+`clone <https://git-scm.com/book/en/v2/Git-Basics-Getting-a-Git-Repository>`__
+the HDL repository, and then build the project as follows:
+
+**Linux/Cygwin/WSL**
+
+.. code-block::
+   :linenos:
+
+   user@analog:~$ cd hdl/projects/ad408x_fmc_evb/zed
+   user@analog:~/hdl/projects/ad408x_fmc_evb/zed$ make
+
+A more comprehensive build guide can be found in the :ref:`build_hdl` user guide.
+
+Resources
+-------------------------------------------------------------------------------
+
+Systems related
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+- `UG-2214, User Guide | EVAL-AD4080 <https://www.analog.com/media/en/technical-documentation/user-guides/eval-ad4080-ug-2214.pdf>`__
+
+Hardware related
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+-  Product datasheets:
+
+   -  :adi:`AD4080`
+   -  :adi:`AD9508`
+   -  :adi:`ADF4350`
+   -  :adi:`LT6236`
+   -  :adi:`ADP7182`
+   -  :adi:`ADA4945-1`
+
+HDL related
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+-  :git-hdl:`AD408x-FMC-EVB HDL project source code <projects/ad408x_fmc_evb>`
+
+.. list-table::
+   :widths: 30 35 35
+   :header-rows: 1
+
+   * - IP name
+     - Source code link
+     - Documentation link
+   * - AXI_AD408X
+     - :git-hdl:`library/axi_ad408x`
+     - :ref:`here <axi_ad408x>`
+   * - AXI_CLKGEN
+     - :git-hdl:`library/axi_clkgen`
+     - :ref:`here <axi_clkgen>`
+   * - AXI_DMAC
+     - :git-hdl:`library/axi_dmac`
+     - :ref:`here <axi_dmac>`
+   * - AXI_HDMI_TX
+     - :git-hdl:`library/axi_hdmi_tx`
+     - :ref:`here <axi_hdmi_tx>`
+   * - AXI_I2S_ADI
+     - :git-hdl:`library/axi_i2s_adi`
+     - —
+   * - AXI_SPDIF_TX
+     - :git-hdl:`library/axi_spdif_tx`
+     - 	—
+   * - SYSID_ROM
+     - :git-hdl:`library/sysid_rom`
+     - :ref:`here <axi_sysid>`
+   * - UTIL_I2C_MIXER
+     - :git-hdl:`library/util_i2c_mixer`
+     - 	—
+
+Software related
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+-  Python support:
+
+   -  `PyADI-IIO documentation <https://analogdevicesinc.github.io/pyadi-iio/>`__
+   -  `PyADI-IIO example <https://github.com/analogdevicesinc/pyadi-iio/blob/ad4080/examples/ad4080_example.py>`__
+   -  `PyADI-IIO class <https://github.com/analogdevicesinc/pyadi-iio/blob/ad4080/adi/ad4080.py>`__
+   -  AD4080-FMC-EVB Linux device tree :git-linux:`zynq-zed-adv7511-ad4080.dts
+      <arch/arm/boot/dts/zynq-zed-adv7511-ad4080.dts>`
+   -  AD4080 Linux driver :git-linux:`ad4080.c <drivers/iio/adc/ad4080.c>`
+
+.. include:: ../common/more_information.rst
+
+.. include:: ../common/support.rst

--- a/docs/projects/index.rst
+++ b/docs/projects/index.rst
@@ -20,6 +20,7 @@ Contents
 
    AD-GMSL2ETH-SL <ad_gmsl2eth_sl/index>
    AD3552R-EVB <ad3552r_evb/index>
+   AD408X-FMC-EVB <ad408x_fmc_evb/index>
    AD4110-SDZ <ad4110/index>
    AD411x-AD717x <ad411x_ad717x/index>
    AD4134-FMC <ad4134_fmc/index>

--- a/library/axi_ad408x/Makefile
+++ b/library/axi_ad408x/Makefile
@@ -1,0 +1,34 @@
+####################################################################################
+## Copyright (c) 2018 - 2024 Analog Devices, Inc.
+### SPDX short identifier: BSD-1-Clause
+## Auto-generated, do not modify!
+####################################################################################
+
+LIBRARY_NAME := axi_ad408x
+
+GENERIC_DEPS += ../common/ad_datafmt.v
+GENERIC_DEPS += ../common/ad_pack.v
+GENERIC_DEPS += ../common/ad_rst.v
+GENERIC_DEPS += ../common/up_adc_channel.v
+GENERIC_DEPS += ../common/up_adc_common.v
+GENERIC_DEPS += ../common/up_axi.v
+GENERIC_DEPS += ../common/up_clock_mon.v
+GENERIC_DEPS += ../common/up_delay_cntrl.v
+GENERIC_DEPS += ../common/up_xfer_cntrl.v
+GENERIC_DEPS += ../common/up_xfer_status.v
+GENERIC_DEPS += ad408x_phy.v
+GENERIC_DEPS += axi_ad408x.v
+
+XILINX_DEPS += ../xilinx/common/ad_data_clk.v
+XILINX_DEPS += ../xilinx/common/ad_data_in.v
+XILINX_DEPS += ../xilinx/common/ad_dcfilter.v
+XILINX_DEPS += ../xilinx/common/ad_rst_constr.xdc
+XILINX_DEPS += ../xilinx/common/ad_serdes_in.v
+XILINX_DEPS += ../xilinx/common/up_clock_mon_constr.xdc
+XILINX_DEPS += ../xilinx/common/up_xfer_cntrl_constr.xdc
+XILINX_DEPS += ../xilinx/common/up_xfer_status_constr.xdc
+XILINX_DEPS += axi_ad408x_ip.tcl
+
+XILINX_LIB_DEPS += util_cdc
+
+include ../scripts/library.mk

--- a/library/axi_ad408x/ad408x_phy.v
+++ b/library/axi_ad408x/ad408x_phy.v
@@ -1,0 +1,391 @@
+// ***************************************************************************
+// ***************************************************************************
+// Copyright (C) 2022-2024 Analog Devices, Inc. All rights reserved.
+//
+// In this HDL repository, there are many different and unique modules, consisting
+// of various HDL(Verilog or VHDL) components. The individual modules are
+// developed independently, and may be accompanied by separate and unique license
+// terms.
+//
+// The user should read each of these license terms, and understand the
+// freedoms and responsibilities that he or she has by using this source/core.
+//
+// This core is distributed in the hope that it will be useful, but WITHOUT ANY
+// WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+// A PARTICULAR PURPOSE.
+//
+// Redistribution and use of source or resulting binaries, with or without modification
+// of this file, are permitted under one of the following two license terms:
+//
+//   1. The GNU General Public License version 2 as published by the
+//      Free Software Foundation, which can be found in the top level directory
+//      of this repository(LICENSE_GPL2), and also online at:
+//      <https://www.gnu.org/licenses/old-licenses/gpl-2.0.html>
+//
+// OR
+//
+//   2. An ADI specific BSD license, which can be found in the top level directory
+//      of this repository(LICENSE_ADIBSD), and also on-line at:
+//      https://github.com/analogdevicesinc/hdl/blob/main/LICENSE_ADIBSD
+//      This will allow to generate bit files and not release the source code,
+//      as long as it attaches to an ADI device.
+//
+// ***************************************************************************
+// ***************************************************************************
+
+`timescale 1ns/100ps
+
+module ad408x_phy #(
+  parameter FPGA_TECHNOLOGY = 0,
+  parameter DRP_WIDTH = 5,
+  parameter NUM_LANES = 2,  // Max number of lanes is 2
+  parameter IODELAY_CTRL = 1,
+  parameter IO_DELAY_GROUP = "dev_if_delay_group"
+) (
+  // device interface
+  input                             dclk_in_n,
+  input                             dclk_in_p,
+  input                             data_a_in_n,
+  input                             data_a_in_p,
+  input                             data_b_in_n,
+  input                             data_b_in_p,
+  input                             cnv_in_p,
+  input                             cnv_in_n,
+
+  input                             sync_n,
+  input        [4:0]                num_lanes,
+  input                             self_sync,
+  input                             bitslip_enable,
+  input                             filter_enable,
+  input                             filter_rdy_n,
+
+  // delay interface(for IDELAY macros)
+  input                             up_clk,
+  input   [NUM_LANES-1:0]           up_adc_dld,
+  input   [DRP_WIDTH*NUM_LANES-1:0] up_adc_dwdata,
+  output  [DRP_WIDTH*NUM_LANES-1:0] up_adc_drdata,
+  input                             delay_clk,
+  input                             delay_rst,
+  output                            delay_locked,
+
+  // internal reset and clocks
+  input                             adc_rst,
+  output                            adc_clk,
+
+  // Output data
+  output      [31:0]                adc_data,
+  output                            adc_valid,
+
+  // Synchronization signals used when CNV signal is not present
+  output                            sync_status
+);
+
+  // Use always DDR mode for SERDES, useful for SDR mode to adjust capture
+  localparam DDR_OR_SDR_N    = 1;
+  localparam CMOS_LVDS_N     = 0; // Use always LVDS mode
+  localparam SEVEN_SERIES    = 1;
+  localparam ULTRASCALE      = 2;
+  localparam ULTRASCALE_PLUS = 3;
+
+// Assumptions:
+//  A replica of sync_n on the external board serves as a reset signal
+//  for the clock received on the dclk_in_n/p pairs
+//  Clock will stay low if sync_n is low, once sync_n deasserts after an
+//  undefined amount of time the clock will start to toggle, glitch-less
+//  having a smooth start.
+//  Framing information will be reconstructed based on this assumption.
+//
+// Serdes reset
+//
+//  When deasserted synchronously with CLKDIV, internal logic re-times this
+//  deassertion to the first rising edge of CLK
+//  The reset signal should only be deasserted when it is known that CLK
+//  and CLKDIV are stable and present, and should be a minimum of two CLKDIV pulses
+//  wide. After deassertion of reset, the output is not valid until after two CLKDIV cycles.
+// Serdes factor
+//  A sample has 20 bits, this can be transferred either on one lane or two
+//  lanes,DDR.
+//
+//                                             clk_div per sample
+//   single_lane  | dclk per sample | /5    | /4
+//   0            | 5               | 1     | 1.25
+//   1            | 10              | 2     | 2.5
+//
+//   To accommodate all cases a serdes factor of 10 could be used in DDR mode
+//   with a clock division of 5. This requires a cascaded serdes
+//   configuration. However this will work only in 7 series devices.
+//   Instead a serdes factor of 8 is used to support ultrascale devices too
+//  (which do not have the cascaded mode with a factor of 10). This requires
+//   additional packer circuitry from 4/8/16 bits to 20 bits depending on
+//   mode.
+//
+// Serdes output valid
+//   The latency of serdes in 7 series is two div_clk cycles. Output valid of
+//   the serdes will assert two cock cycles later its reset de-asserts.
+
+  wire                 fall_filter_ready;
+  wire                 adc_clk_in_fast;
+  wire [ 4:0]          shift_cnt_value;
+  wire                 shift_cnt_en_s;
+  wire [15:0]          serdes_data_16;
+  wire [ 7:0]          serdes_data_0;
+  wire [ 7:0]          serdes_data_1;
+  wire [ 7:0]          serdes_data_8;
+  wire [19:0]          pattern_value;
+  wire [19:0]          packed_16_20;
+  wire [19:0]          packed_8_20;
+  wire                 adc_clk_div;
+  wire [NUM_LANES-1:0] serdes_in_p;
+  wire [NUM_LANES-1:0] serdes_in_n;
+  wire                 clk_in_s;
+  wire [NUM_LANES-1:0] data_s0;
+  wire [NUM_LANES-1:0] data_s1;
+  wire [NUM_LANES-1:0] data_s2;
+  wire [NUM_LANES-1:0] data_s3;
+  wire [NUM_LANES-1:0] data_s4;
+  wire [NUM_LANES-1:0] data_s5;
+  wire [NUM_LANES-1:0] data_s6;
+  wire [NUM_LANES-1:0] data_s7;
+
+  reg  [5:0]  serdes_reset = 6'b000110;
+  reg         sync_status_int = 1'b0;
+  reg  [1:0]  serdes_valid = 2'b00;
+  reg  [3:0]  filter_rdy_n_d = 'b0;
+  reg         shift_cnt_en = 1'b0;
+  reg         packed_data_valid_d;
+  reg         packed_data_valid;
+  reg  [19:0] adc_data_shifted;
+  reg  [ 4:0] shift_cnt = 5'd0;
+  reg  [19:0] packed_data_d;
+  reg  [19:0] packed_data;
+  reg         slip_dd;
+  reg         slip_d;
+
+  assign fall_filter_ready = filter_rdy_n_d[3] & ~filter_rdy_n_d[2];
+  assign sync_status       = sync_status_int;
+  assign single_lane       = num_lanes[0];
+  assign adc_clk           = adc_clk_div;
+  assign pattern_value     = 20'hac5d6;
+  assign shift_cnt_value   = 'd19;
+
+  IBUFGDS i_clk_in_ibuf(
+    .I(dclk_in_p),
+    .IB(dclk_in_n),
+    .O(clk_in_s));
+
+  generate
+  if(FPGA_TECHNOLOGY == SEVEN_SERIES) begin
+
+    BUFIO i_clk_buf(
+      .I(clk_in_s),
+      .O(adc_clk_in_fast));
+
+    BUFR #(
+      .BUFR_DIVIDE("4")
+    ) i_div_clk_buf (
+      .CLR(~sync_n),
+      .CE(1'b1),
+      .I(clk_in_s),
+      .O(adc_clk_div));
+
+  end else begin
+
+    BUFGCE #(
+      .CE_TYPE("SYNC"),
+      .IS_CE_INVERTED(1'b0),
+      .IS_I_INVERTED(1'b0)
+    ) i_clk_buf_fast(
+      .O(adc_clk_in_fast),
+      .CE(1'b1),
+      .I(clk_in_s));
+
+    BUFGCE_DIV #(
+      .BUFGCE_DIVIDE(4),
+      .IS_CE_INVERTED(1'b0),
+      .IS_CLR_INVERTED(1'b0),
+      .IS_I_INVERTED(1'b0)
+    ) i_div_clk_buf(
+      .O(adc_clk_div),
+      .CE(1'b1),
+      .CLR(~sync_n),
+      .I(clk_in_s));
+
+  end
+  endgenerate
+
+  assign serdes_in_p = {data_b_in_p, data_a_in_p};
+  assign serdes_in_n = {data_b_in_n, data_a_in_n};
+
+  // Min 2 div_clk cycles once div_clk is running after deassertion of sync
+  // Control externally the reset of serdes for precise timing
+
+  always @(posedge adc_clk_div or negedge sync_n) begin
+    if(~sync_n) begin
+      serdes_reset <= 6'b000110;
+    end else begin
+      serdes_reset <= {serdes_reset[4:0],1'b0};
+    end
+  end
+  assign serdes_reset_s = serdes_reset[5];
+
+  ad_serdes_in #(
+    .CMOS_LVDS_N(CMOS_LVDS_N),
+    .FPGA_TECHNOLOGY(FPGA_TECHNOLOGY),
+    .IODELAY_CTRL(IODELAY_CTRL),
+    .IODELAY_GROUP(IO_DELAY_GROUP),
+    .DDR_OR_SDR_N(DDR_OR_SDR_N),
+    .DATA_WIDTH(NUM_LANES),
+    .DRP_WIDTH(DRP_WIDTH),
+    .SERDES_FACTOR(8),
+    .EXT_SERDES_RESET(1)
+  ) i_serdes(
+    .rst(serdes_reset_s),
+    .ext_serdes_rst(serdes_reset_s),
+    .clk(adc_clk_in_fast),
+    .div_clk(adc_clk_div),
+    .data_s0(data_s0),
+    .data_s1(data_s1),
+    .data_s2(data_s2),
+    .data_s3(data_s3),
+    .data_s4(data_s4),
+    .data_s5(data_s5),
+    .data_s6(data_s6),
+    .data_s7(data_s7),
+    .data_in_p(serdes_in_p),
+    .data_in_n(serdes_in_n),
+    .up_clk(up_clk),
+    .up_dld(up_adc_dld),
+    .up_dwdata(up_adc_dwdata),
+    .up_drdata(up_adc_drdata),
+    .delay_clk(delay_clk),
+    .delay_rst(delay_rst),
+    .delay_locked(delay_locked));
+
+  assign {serdes_data_1[0],serdes_data_0[0]} = data_s0;  // f-e latest bit received
+  assign {serdes_data_1[1],serdes_data_0[1]} = data_s1;  // r-e
+  assign {serdes_data_1[2],serdes_data_0[2]} = data_s2;  // f-e
+  assign {serdes_data_1[3],serdes_data_0[3]} = data_s3;  // r-e
+  assign {serdes_data_1[4],serdes_data_0[4]} = data_s4;  // f-e
+  assign {serdes_data_1[5],serdes_data_0[5]} = data_s5;  // r-e
+  assign {serdes_data_1[6],serdes_data_0[6]} = data_s6;  // f-e
+  assign {serdes_data_1[7],serdes_data_0[7]} = data_s7;  // r-e oldest bit received
+
+  // Assert serdes valid after 2 clock cycles is pulled out of reset
+
+  always @(posedge adc_clk_div) begin
+    if(serdes_reset_s) begin
+      serdes_valid <= 2'b00;
+    end else begin
+      serdes_valid <= {serdes_valid[0],1'b1};
+    end
+  end
+
+  // for DDR(single lane) take data from a single lane
+
+  assign serdes_data_8 = serdes_data_0;
+
+  // For DDR dual lane interleave the two sedres outputs;
+
+  assign serdes_data_16 = {serdes_data_0[7],
+                           serdes_data_1[7],
+                           serdes_data_0[6],
+                           serdes_data_1[6],
+                           serdes_data_0[5],
+                           serdes_data_1[5],
+                           serdes_data_0[4],
+                           serdes_data_1[4],
+                           serdes_data_0[3],
+                           serdes_data_1[3],
+                           serdes_data_0[2],
+                           serdes_data_1[2],
+                           serdes_data_0[1],
+                           serdes_data_1[1],
+                           serdes_data_0[0],
+                           serdes_data_1[0]};
+
+  ad_pack #(
+    .I_W(8),
+    .O_W(20),
+    .UNIT_W(1),
+    .ALIGN_TO_MSB(1)
+  ) i_ad_pack_8 (
+    .clk(adc_clk_div),
+    .reset(~serdes_valid[0]),
+    .idata(serdes_data_8),
+    .ivalid(serdes_valid[1]),
+    .odata(packed_8_20),
+    .ovalid(pack8_valid));
+
+  ad_pack #(
+    .I_W(16),
+    .O_W(20),
+    .UNIT_W(1),
+    .ALIGN_TO_MSB(1)
+  ) i_ad_pack_16 (
+    .clk(adc_clk_div),
+    .reset(~serdes_valid[0]),
+    .idata(serdes_data_16),
+    .ivalid(serdes_valid[1]),
+    .odata(packed_16_20),
+    .ovalid(pack16_valid));
+
+  always @(*) begin
+    case(single_lane)
+      1'b0 : packed_data = packed_16_20;
+      1'b1 : packed_data = packed_8_20;
+    endcase
+  end
+
+  always @(*) begin
+    case(single_lane)
+      1'b0 : packed_data_valid = pack16_valid;
+      1'b1 : packed_data_valid = pack8_valid;
+    endcase
+  end
+
+  // Align data
+  // Use different rotations based on selected mode
+  // Latency from first clock edge post sync_n deasertion to the first valid
+  // output of the packer should be constant allowing for a constant rotation every time.
+
+  always @(posedge adc_clk_div) begin
+    if(packed_data_valid) begin
+      packed_data_d <= packed_data;
+    end
+  end
+
+  always @(posedge adc_clk_div) begin
+    slip_d <= bitslip_enable;
+    slip_dd <= slip_d;
+    if(serdes_reset_s || adc_data_shifted == pattern_value)
+      shift_cnt_en <= 1'b0;
+    else if(slip_d & ~slip_dd)
+      shift_cnt_en <= 1'b1;
+  end
+
+  always @(posedge adc_clk_div) begin
+    if(shift_cnt_en) begin
+      if(shift_cnt == shift_cnt_value || serdes_reset_s) begin
+        shift_cnt <= 0;
+        sync_status_int <= 1'b0;
+      end else if( adc_data_shifted != pattern_value &&(packed_data_valid_d & ~packed_data_valid) ) begin
+        shift_cnt <= shift_cnt + 1;
+      end
+      if(adc_data_shifted == pattern_value) begin
+        sync_status_int <= 1'b1;
+      end
+    end
+  end
+
+  always @(posedge adc_clk_div) begin
+    adc_data_shifted <= {packed_data_d,packed_data} >> shift_cnt;
+    packed_data_valid_d <= packed_data_valid;
+    filter_rdy_n_d <= {filter_rdy_n_d[2:0], filter_rdy_n};
+  end
+
+  // Sign extend to 32 bits
+
+  assign adc_data  = {{12{adc_data_shifted[19]}},adc_data_shifted};
+  assign adc_valid = filter_enable ?  (packed_data_valid_d & fall_filter_ready) : packed_data_valid_d;
+
+endmodule

--- a/library/axi_ad408x/axi_ad408x.v
+++ b/library/axi_ad408x/axi_ad408x.v
@@ -1,0 +1,357 @@
+// ***************************************************************************
+// ***************************************************************************
+// Copyright (C) 2022-2024 Analog Devices, Inc. All rights reserved.
+//
+// In this HDL repository, there are many different and unique modules, consisting
+// of various HDL(Verilog or VHDL) components. The individual modules are
+// developed independently, and may be accompanied by separate and unique license
+// terms.
+//
+// The user should read each of these license terms, and understand the
+// freedoms and responsibilities that he or she has by using this source/core.
+//
+// This core is distributed in the hope that it will be useful, but WITHOUT ANY
+// WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+// A PARTICULAR PURPOSE.
+//
+// Redistribution and use of source or resulting binaries, with or without modification
+// of this file, are permitted under one of the following two license terms:
+//
+//   1. The GNU General Public License version 2 as published by the
+//      Free Software Foundation, which can be found in the top level directory
+//      of this repository(LICENSE_GPL2), and also online at:
+//      <https://www.gnu.org/licenses/old-licenses/gpl-2.0.html>
+//
+// OR
+//
+//   2. An ADI specific BSD license, which can be found in the top level directory
+//      of this repository(LICENSE_ADIBSD), and also on-line at:
+//      https://github.com/analogdevicesinc/hdl/blob/main/LICENSE_ADIBSD
+//      This will allow to generate bit files and not release the source code,
+//      as long as it attaches to an ADI device.
+//
+// ***************************************************************************
+// ***************************************************************************
+
+`timescale 1ns/100ps
+
+module axi_ad408x #(
+  parameter   ID = 0,
+  parameter   FPGA_TECHNOLOGY = 0
+) (
+
+  // ADC interface
+
+  input                   dclk_in_p,
+  input                   dclk_in_n,
+
+  input                   data_a_in_p,
+  input                   data_a_in_n,
+  input                   data_b_in_p,
+  input                   data_b_in_n,
+
+  input                   cnv_in_p,
+  input                   cnv_in_n,
+
+  input                   sync_n,
+  input                   filter_data_ready_n,
+
+  // output data interface
+
+  output                  adc_clk,
+  output      [ 31:0]     adc_data,
+  output                  adc_valid,
+  input                   adc_dovf,
+
+  // delay interface
+
+  input                   delay_clk,
+
+  // AXI interface
+
+  input                   s_axi_aclk,
+  input                   s_axi_aresetn,
+  input                   s_axi_awvalid,
+  input         [15:0]    s_axi_awaddr,
+  output                  s_axi_awready,
+  input                   s_axi_wvalid,
+  input         [31:0]    s_axi_wdata,
+  input         [ 3:0]    s_axi_wstrb,
+  output                  s_axi_wready,
+  output                  s_axi_bvalid,
+  output        [ 1:0]    s_axi_bresp,
+  input                   s_axi_bready,
+  input                   s_axi_arvalid,
+  input         [15:0]    s_axi_araddr,
+  output                  s_axi_arready,
+  output                  s_axi_rvalid,
+  output        [ 1:0]    s_axi_rresp,
+  output        [31:0]    s_axi_rdata,
+  input                   s_axi_rready,
+  input         [ 2:0]    s_axi_awprot,
+  input         [ 2:0]    s_axi_arprot
+);
+
+  localparam DELAY_CTRL_NUM_LANES = 2;
+  localparam DELAY_CTRL_DRP_WIDTH = 5;
+
+  // internal signals
+
+  wire  [DELAY_CTRL_DRP_WIDTH*DELAY_CTRL_NUM_LANES-1:0]  up_dwdata;
+  wire  [DELAY_CTRL_DRP_WIDTH*DELAY_CTRL_NUM_LANES-1:0]  up_drdata;
+  wire  [DELAY_CTRL_NUM_LANES-1:0]                       up_dld;
+
+  wire    [7:0]    adc_custom_control_s;
+  wire   [ 4:0]    adc_num_lanes;
+  wire             bitslip_enable;
+  wire             filter_enable;
+  wire             delay_locked;
+  wire             sync_status;
+  wire             adc_enable;
+  wire             adc_clk_s;
+  wire             adc_rst_s;
+  wire             delay_rst;
+  wire             self_sync;
+
+  wire             up_rstn;
+  wire             up_clk;
+  wire   [13:0]    up_waddr_s;
+  wire   [13:0]    up_raddr_s;
+  wire             up_sel_s;
+  wire             up_wr_s;
+  wire   [13:0]    up_addr_s;
+  wire   [31:0]    up_wdata_s;
+  wire   [31:0]    up_rdata_s  [0:2];
+  wire             up_rack_s   [0:2];
+  wire             up_wack_s   [0:2];
+
+  reg    [31:0]    up_rdata_r;
+  reg              up_rack_r;
+  reg              up_wack_r;
+  reg    [31:0]    up_rdata = 'd0;
+  reg              up_rack  = 'd0;
+  reg              up_wack  = 'd0;
+
+  integer j;
+
+  assign adc_clk = adc_clk_s;
+  assign up_clk  = s_axi_aclk;
+  assign up_rstn = s_axi_aresetn;
+
+  assign self_sync     = adc_custom_control_s[1];
+  assign filter_enable = adc_custom_control_s[0];
+
+  always @(*) begin
+    up_rdata_r = 'h00;
+    up_rack_r = 'h00;
+    up_wack_r = 'h00;
+    for(j = 0; j < 3; j=j+1) begin
+      up_rack_r = up_rack_r | up_rack_s[j];
+      up_wack_r = up_wack_r | up_wack_s[j];
+      up_rdata_r = up_rdata_r | up_rdata_s[j];
+    end
+  end
+
+  always @(negedge up_rstn or posedge up_clk) begin
+    if(up_rstn == 0) begin
+      up_rdata <= 'd0;
+      up_rack <= 'd0;
+      up_wack <= 'd0;
+    end else begin
+      up_rdata <= up_rdata_r;
+      up_rack <= up_rack_r;
+      up_wack <= up_wack_r;
+    end
+  end
+
+  up_adc_channel #(
+    .CHANNEL_ID(0)
+  ) ad408x_channel_0 (
+    .adc_clk(adc_clk_s),
+    .adc_rst(adc_rst_s),
+    .adc_enable(adc_enable),
+    .adc_iqcor_enb(),
+    .adc_dcfilt_enb(),
+    .adc_dfmt_se(),
+    .adc_dfmt_type(),
+    .adc_dfmt_enable(),
+    .adc_dcfilt_offset(),
+    .adc_dcfilt_coeff(),
+    .adc_iqcor_coeff_1(),
+    .adc_iqcor_coeff_2(),
+    .adc_pnseq_sel(),
+    .adc_data_sel(),
+    .adc_pn_err(1'b0),
+    .adc_pn_oos(1'b0),
+    .adc_or(),
+    .adc_read_data(),
+    .adc_status_header('b0),
+    .adc_crc_err('b0),
+    .up_adc_crc_err(),
+    .up_adc_pn_err(),
+    .up_adc_pn_oos(),
+    .up_adc_or(),
+    .up_usr_datatype_be(),
+    .up_usr_datatype_signed(),
+    .up_usr_datatype_shift(),
+    .up_usr_datatype_total_bits(),
+    .up_usr_datatype_bits(),
+    .up_usr_decimation_m(),
+    .up_usr_decimation_n(),
+    .adc_usr_datatype_be(1'b0),
+    .adc_usr_datatype_signed(1'b1),
+    .adc_usr_datatype_shift(8'd0),
+    .adc_usr_datatype_total_bits(8'd32),
+    .adc_usr_datatype_bits(8'd32),
+    .adc_usr_decimation_m(16'd1),
+    .adc_usr_decimation_n(16'd1),
+    .up_rstn(up_rstn),
+    .up_clk(up_clk),
+    .up_wreq(up_wreq_s),
+    .up_waddr(up_waddr_s),
+    .up_wdata(up_wdata_s),
+    .up_wack(up_wack_s[0]),
+    .up_rreq(up_rreq_s),
+    .up_raddr(up_raddr_s),
+    .up_rdata(up_rdata_s[0]),
+    .up_rack(up_rack_s[0]));
+
+  up_adc_common #(
+    .ID(ID)
+  ) i_up_adc_common (
+    .mmcm_rst(),
+    .adc_clk(adc_clk_s),
+    .adc_rst(adc_rst_s),
+    .adc_r1_mode(),
+    .adc_pin_mode(),
+    .adc_status('h00),
+    .adc_sync_status(sync_status),
+    .adc_status_ovf(adc_dovf),
+    .adc_custom_control(adc_custom_control_s),
+    .adc_clk_ratio(32'd2),
+    .adc_start_code(),
+    .adc_sref_sync(),
+    .adc_sync(bitslip_enable),
+    .adc_num_lanes(adc_num_lanes),
+    .up_pps_rcounter(32'b0),
+    .up_pps_status(1'b0),
+    .up_pps_irq_mask(),
+    .up_adc_ce(),
+    .up_status_pn_err(1'b0),
+    .up_status_pn_oos(1'b0),
+    .up_status_or(1'b0),
+    .up_drp_sel(),
+    .up_drp_wr(),
+    .up_drp_addr(),
+    .up_drp_wdata(),
+    .up_drp_rdata(32'd0),
+    .up_drp_ready(1'd0),
+    .up_drp_locked(1'd1),
+    .adc_config_wr(),
+    .adc_config_ctrl(),
+    .adc_config_rd('d0),
+    .adc_ctrl_status('d0),
+    .up_usr_chanmax_out(),
+    .up_usr_chanmax_in(1),
+    .up_adc_gpio_in(32'b0),
+    .up_adc_gpio_out(),
+    .up_rstn(up_rstn),
+    .up_clk(up_clk),
+    .up_wreq(up_wreq_s),
+    .up_waddr(up_waddr_s),
+    .up_wdata(up_wdata_s),
+    .up_wack(up_wack_s[1]),
+    .up_rreq(up_rreq_s),
+    .up_raddr(up_raddr_s),
+    .up_rdata(up_rdata_s[1]),
+    .up_rack(up_rack_s[1]));
+
+ // ad4080 interface module
+
+  ad408x_phy #(
+    .FPGA_TECHNOLOGY(FPGA_TECHNOLOGY),
+    .IODELAY_CTRL(1)
+  ) ad408x_interface (
+    .dclk_in_n(dclk_in_n),
+    .dclk_in_p(dclk_in_p),
+    .data_a_in_n(data_a_in_n),
+    .data_a_in_p(data_a_in_p),
+    .data_b_in_n(data_b_in_n),
+    .data_b_in_p(data_b_in_p),
+    .cnv_in_p(cnv_in_p),
+    .cnv_in_n(cnv_in_n),
+    .num_lanes(adc_num_lanes),
+    .self_sync(self_sync),
+    .up_clk(up_clk),
+    .up_adc_dld(up_dld),
+    .up_adc_dwdata(up_dwdata),
+    .up_adc_drdata(up_drdata),
+    .delay_clk(delay_clk),
+    .delay_rst(delay_rst),
+    .delay_locked(delay_locked),
+    .adc_rst(adc_rst_s),
+    .adc_clk(adc_clk_s),
+    .adc_data(adc_data),
+    .adc_valid(adc_valid),
+    .bitslip_enable(bitslip_enable),
+    .sync_status(sync_status),
+    .filter_enable(filter_enable),
+    .filter_rdy_n(filter_data_ready_n),
+    .sync_n(sync_n));
+
+  // adc delay control
+
+  up_delay_cntrl #(
+    .DATA_WIDTH(DELAY_CTRL_NUM_LANES),
+    .DRP_WIDTH(DELAY_CTRL_DRP_WIDTH),
+    .BASE_ADDRESS(6'h02)
+  ) i_delay_cntrl (
+    .delay_clk(delay_clk),
+    .delay_rst(delay_rst),
+    .delay_locked(delay_locked),
+    .up_dld(up_dld),
+    .up_dwdata(up_dwdata),
+    .up_drdata(up_drdata),
+    .up_rstn(up_rstn),
+    .up_clk(up_clk),
+    .up_wreq(up_wreq_s),
+    .up_waddr(up_waddr_s),
+    .up_wdata(up_wdata_s),
+    .up_wack(up_wack_s[2]),
+    .up_rreq(up_rreq_s),
+    .up_raddr(up_raddr_s),
+    .up_rdata(up_rdata_s[2]),
+    .up_rack(up_rack_s[2]));
+
+  // up bus interface
+
+  up_axi i_up_axi(
+    .up_rstn(up_rstn),
+    .up_clk(up_clk),
+    .up_axi_awvalid(s_axi_awvalid),
+    .up_axi_awaddr(s_axi_awaddr),
+    .up_axi_awready(s_axi_awready),
+    .up_axi_wvalid(s_axi_wvalid),
+    .up_axi_wdata(s_axi_wdata),
+    .up_axi_wstrb(s_axi_wstrb),
+    .up_axi_wready(s_axi_wready),
+    .up_axi_bvalid(s_axi_bvalid),
+    .up_axi_bresp(s_axi_bresp),
+    .up_axi_bready(s_axi_bready),
+    .up_axi_arvalid(s_axi_arvalid),
+    .up_axi_araddr(s_axi_araddr),
+    .up_axi_arready(s_axi_arready),
+    .up_axi_rvalid(s_axi_rvalid),
+    .up_axi_rresp(s_axi_rresp),
+    .up_axi_rdata(s_axi_rdata),
+    .up_axi_rready(s_axi_rready),
+    .up_wreq(up_wreq_s),
+    .up_waddr(up_waddr_s),
+    .up_wdata(up_wdata_s),
+    .up_wack(up_wack),
+    .up_rreq(up_rreq_s),
+    .up_raddr(up_raddr_s),
+    .up_rdata(up_rdata),
+    .up_rack(up_rack));
+
+endmodule

--- a/library/axi_ad408x/axi_ad408x_ip.tcl
+++ b/library/axi_ad408x/axi_ad408x_ip.tcl
@@ -1,0 +1,50 @@
+###############################################################################
+## Copyright (C) 2022-2024 Analog Devices, Inc. All rights reserved.
+### SPDX short identifier: ADIBSD
+###############################################################################
+
+source ../../scripts/adi_env.tcl
+source $ad_hdl_dir/library/scripts/adi_ip_xilinx.tcl
+
+adi_ip_create axi_ad408x
+
+adi_ip_files axi_ad408x [list \
+  "$ad_hdl_dir/library/xilinx/common/ad_serdes_in.v" \
+  "$ad_hdl_dir/library/common/ad_pack.v" \
+  "$ad_hdl_dir/library/common/ad_rst.v" \
+  "$ad_hdl_dir/library/xilinx/common/ad_data_clk.v" \
+  "$ad_hdl_dir/library/xilinx/common/ad_data_in.v" \
+  "$ad_hdl_dir/library/xilinx/common/ad_dcfilter.v" \
+  "$ad_hdl_dir/library/common/ad_datafmt.v" \
+  "$ad_hdl_dir/library/common/up_xfer_status.v" \
+  "$ad_hdl_dir/library/common/up_xfer_cntrl.v" \
+  "$ad_hdl_dir/library/common/up_clock_mon.v" \
+  "$ad_hdl_dir/library/common/up_delay_cntrl.v" \
+  "$ad_hdl_dir/library/common/up_adc_common.v" \
+  "$ad_hdl_dir/library/common/up_adc_channel.v" \
+  "$ad_hdl_dir/library/common/up_axi.v" \
+  "$ad_hdl_dir/library/xilinx/common/up_xfer_cntrl_constr.xdc" \
+  "$ad_hdl_dir/library/xilinx/common/ad_rst_constr.xdc" \
+  "$ad_hdl_dir/library/xilinx/common/up_xfer_status_constr.xdc" \
+  "$ad_hdl_dir/library/xilinx/common/up_clock_mon_constr.xdc" \
+  "ad408x_phy.v" \
+  "axi_ad408x.v" ]
+
+adi_ip_properties axi_ad408x
+
+adi_ip_add_core_dependencies [list \
+  analog.com:$VIVADO_IP_LIBRARY:util_cdc:1.0 \
+]
+
+adi_init_bd_tcl
+adi_ip_bd axi_ad408x "bd/bd.tcl"
+
+set_property driver_value 0 [ipx::get_ports *dovf* -of_objects [ipx::current_core]]
+
+ipx::infer_bus_interface adc_clk xilinx.com:signal:clock_rtl:1.0 [ipx::current_core]
+ipx::infer_bus_interface delay_clk xilinx.com:signal:clock_rtl:1.0 [ipx::current_core]
+
+adi_add_auto_fpga_spec_params
+
+ipx::create_xgui_files [ipx::current_core]
+ipx::save_core [ipx::current_core]

--- a/projects/ad408x_fmc_evb/Makefile
+++ b/projects/ad408x_fmc_evb/Makefile
@@ -1,0 +1,7 @@
+####################################################################################
+## Copyright (c) 2018 - 2024 Analog Devices, Inc.
+### SPDX short identifier: BSD-1-Clause
+## Auto-generated, do not modify!
+####################################################################################
+
+include ../scripts/project-toplevel.mk

--- a/projects/ad408x_fmc_evb/README.md
+++ b/projects/ad408x_fmc_evb/README.md
@@ -1,0 +1,10 @@
+# AD408X-FMC-EVB HDL Project
+
+Here are some pointers to help you:
+  * [Board Product Page](https://www.analog.com/AD408X-FMC-EVB)
+  * Parts : [AD4080, 20-Bit, 40MSPS, Differential SAR ADC](https://www.analog.com/ad4080)
+  * Parts : [ADF4350, Wideband Synthesizer with Integrated VCO](https://www.analog.com/adf4350)
+  * Parts : [AD9508, 1.65 GHz Clock Fanout Buffer with Output Dividers and Delay Adjust](https://www.analog.com/ad9508)
+  * Project Doc: https://analogdevicesinc.github.io/hdl/projects/ad408x_fmc_evb/index.html
+  * HDL Doc: https://analogdevicesinc.github.io/hdl/projects/ad408x_fmc_evb/index.html
+  * Linux Drivers: https://wiki.analog.com/resources/tools-software/linux-drivers-all

--- a/projects/ad408x_fmc_evb/common/ad408x_fmc_evb.txt
+++ b/projects/ad408x_fmc_evb/common/ad408x_fmc_evb.txt
@@ -1,0 +1,38 @@
+FMC_pin   FMC_port         Schematic_name     System_top_name     IOSTANDARD  Termination
+
+# ad408x_fmc_evb
+					             
+H4        FMC_CLK0_M2C_P   DCO_P              dco_p               LVDS_25     DIFF_TERM
+H5        FMC_CLK0_M2C_N   DCO_N              dco_n               LVDS_25     DIFF_TERM
+H7        FMC_LA02_P       DA_P               da_p                LVDS_25     DIFF_TERM
+H8        FMC_LA02_N       DA_N               da_n                LVDS_25     DIFF_TERM
+G9        FMC_LA03_P       DB_P               db_p                LVDS_25     DIFF_TERM
+G10       FMC_LA03_N       DB_N               db_n                LVDS_25     DIFF_TERM
+G2        FMC_CLK1_M2C_P  FPGACLK_P           cnv_in_p            LVDS_25     DIFF_TERM
+G3        FMC_CLK1_M2C_N  FPGACLK_N           cnv_in_n            LVDS_25     DIFF_TERM
+C11       FMC_LA06_N      GPIO1_FMC           gpio1_fmc           LVCMOS25    NA
+D14       FMC_LA09_P      GPIO2_FMC           gpio2_fmc           LVCMOS25    NA
+D15       FMC_LA09_N      GPIO3_FMC           gpio3_fmc           LVCMOS25    NA
+H16       FMC_LA11_P      GP0_DIR             gp0_dir             LVCMOS25    NA
+C15       FMC_LA10_N      GP1_DIR             gp1_dir             LVCMOS25    NA
+G15       FMC_LA12_P      GP2_DIR             gp2_dir             LVCMOS25    NA
+H17       FMC_LA11_N      GP3_DIR             gp3_dir             LVCMOS25    NA
+H19       FMC_LA15_P      EN_PSU              en_psu              LVCMOS25    NA
+H20       FMC_LA15_N      PWRGD               pwrgd               LVCMOS25    NA
+H22       FMC_LA19_P      PD_V33B             pd_v33b             LVCMOS25    NA
+G16       FMC_LA12_N      OSC_EN              osc_en              LVCMOS25    NA
+G12       FMC_LA08_P      CS_N_SRC            ad4080_csn          LVCMOS25    NA
+H14       FMC_LA07_N      SCLK_SRC            ad4080_sclk         LVCMOS25    NA
+G13       FMC_LA08_N      SDIO_SRC            ad4080_mosi         LVCMOS25    NA
+H13       FMC_LA07_P      GPIO0_FMC           ad4080_miso         LVCMOS25    NA
+C19       FMC_LA14_N      CS1_0               ad9508_csn          LVCMOS25    NA
+C22       FMC_LA18_CC_P   CS1_1               adf4350_csn         LVCMOS25    NA
+D18       FMC_LA13_N      SCLK1               ad9508_adf4350_sclk LVCMOS25    NA
+D17       FMC_LA13_P      SDO_1               ad9508_adf4350_miso LVCMOS25    NA
+C18       FMC_LA14_P      SDIN1               ad9508_adf4350_mosi LVCMOS25    NA
+H28       FMC_LA24_P      DOA_FMC             doa_fmc             LVCMOS25    NA
+H29       FMC_LA24_N      DOB_FMC             dob_fmc             LVCMOS25    NA
+G18       FMC_LA16_P      DOC_FMC             doc_fmc             LVCMOS25    NA
+G19       FMC_LA16_N      DOD_FMC             dod_fmc             LVCMOS25    NA
+C10       FMC_LA06_P      AD9508_SYNC         ad9508_sync         LVCMOS25    NA
+C23       FMC_LA18_CC_N   ADF435X_LOCK        adf435x_lock        LVCMOS25    NA

--- a/projects/ad408x_fmc_evb/common/ad408x_fmc_evb_bd.tcl
+++ b/projects/ad408x_fmc_evb/common/ad408x_fmc_evb_bd.tcl
@@ -1,0 +1,79 @@
+###############################################################################
+## Copyright (C) 2022-2024 Analog Devices, Inc. All rights reserved.
+### SPDX short identifier: ADIBSD
+###############################################################################
+
+# ad4080 interface
+
+create_bd_port -dir I dco_p
+create_bd_port -dir I dco_n
+create_bd_port -dir I da_p
+create_bd_port -dir I da_n
+create_bd_port -dir I db_p
+create_bd_port -dir I db_n
+create_bd_port -dir I sync_n
+create_bd_port -dir I cnv_in_p
+create_bd_port -dir I cnv_in_n
+create_bd_port -dir I filter_data_ready_n
+create_bd_port -dir I fpga_ref_clk
+create_bd_port -dir I fpga_100_clk
+
+# ad408x_clock_monitor
+
+ad_ip_instance axi_clock_monitor ad408x_clock_monitor
+ad_ip_parameter ad408x_clock_monitor CONFIG.NUM_OF_CLOCKS 2
+
+ad_connect fpga_ref_clk  ad408x_clock_monitor/clock_0
+ad_connect fpga_100_clk  ad408x_clock_monitor/clock_1
+
+# axi_ad408x
+
+ad_ip_instance axi_ad408x axi_ad4080_adc
+
+# dma for rx data
+
+ad_ip_instance axi_dmac axi_ad4080_dma
+ad_ip_parameter axi_ad4080_dma CONFIG.DMA_TYPE_SRC 2
+ad_ip_parameter axi_ad4080_dma CONFIG.DMA_TYPE_DEST 0
+ad_ip_parameter axi_ad4080_dma CONFIG.CYCLIC 0
+ad_ip_parameter axi_ad4080_dma CONFIG.SYNC_TRANSFER_START 0
+ad_ip_parameter axi_ad4080_dma CONFIG.AXI_SLICE_SRC 1
+ad_ip_parameter axi_ad4080_dma CONFIG.AXI_SLICE_DEST 0
+ad_ip_parameter axi_ad4080_dma CONFIG.DMA_2D_TRANSFER 0
+ad_ip_parameter axi_ad4080_dma CONFIG.DMA_DATA_WIDTH_SRC 32
+ad_ip_parameter axi_ad4080_dma CONFIG.DMA_DATA_WIDTH_DEST 64
+
+# connect interface to axi_ad4080_adc
+
+ad_connect dco_p                axi_ad4080_adc/dclk_in_p
+ad_connect dco_n                axi_ad4080_adc/dclk_in_n
+ad_connect da_p                 axi_ad4080_adc/data_a_in_p
+ad_connect da_n                 axi_ad4080_adc/data_a_in_n
+ad_connect db_p                 axi_ad4080_adc/data_b_in_p
+ad_connect db_n                 axi_ad4080_adc/data_b_in_n
+ad_connect sync_n               axi_ad4080_adc/sync_n
+ad_connect cnv_in_p             axi_ad4080_adc/cnv_in_p
+ad_connect cnv_in_n             axi_ad4080_adc/cnv_in_n
+ad_connect filter_data_ready_n  axi_ad4080_adc/filter_data_ready_n
+ad_connect $sys_iodelay_clk     axi_ad4080_adc/delay_clk
+
+# connect datapath
+
+ad_connect axi_ad4080_adc/adc_data  axi_ad4080_dma/fifo_wr_din
+ad_connect axi_ad4080_adc/adc_valid axi_ad4080_dma/fifo_wr_en
+ad_connect axi_ad4080_adc/adc_dovf  axi_ad4080_dma/fifo_wr_overflow
+
+# system runs on phy's received clock
+
+ad_connect axi_ad4080_adc/adc_clk axi_ad4080_dma/fifo_wr_clk
+
+ad_connect $sys_cpu_resetn axi_ad4080_dma/m_dest_axi_aresetn
+
+ad_cpu_interconnect 0x44A00000 axi_ad4080_adc
+ad_cpu_interconnect 0x44A30000 axi_ad4080_dma
+ad_cpu_interconnect 0x44A40000 ad408x_clock_monitor
+
+ad_mem_hp1_interconnect $sys_cpu_clk sys_ps7/S_AXI_HP1
+ad_mem_hp1_interconnect $sys_cpu_clk axi_ad4080_dma/m_dest_axi
+
+ad_cpu_interrupt ps-13 mb-12 axi_ad4080_dma/irq

--- a/projects/ad408x_fmc_evb/zed/Makefile
+++ b/projects/ad408x_fmc_evb/zed/Makefile
@@ -1,0 +1,26 @@
+####################################################################################
+## Copyright (c) 2018 - 2024 Analog Devices, Inc.
+### SPDX short identifier: BSD-1-Clause
+## Auto-generated, do not modify!
+####################################################################################
+
+PROJECT_NAME := ad408x_fmc_evb_zed
+
+M_DEPS += ../common/ad408x_fmc_evb_bd.tcl
+M_DEPS += ../../scripts/adi_pd.tcl
+M_DEPS += ../../common/zed/zed_system_constr.xdc
+M_DEPS += ../../common/zed/zed_system_bd.tcl
+M_DEPS += ../../../library/common/ad_iobuf.v
+
+LIB_DEPS += axi_ad408x
+LIB_DEPS += axi_clock_monitor
+LIB_DEPS += axi_clkgen
+LIB_DEPS += axi_dmac
+LIB_DEPS += axi_hdmi_tx
+LIB_DEPS += axi_i2s_adi
+LIB_DEPS += axi_spdif_tx
+LIB_DEPS += axi_sysid
+LIB_DEPS += sysid_rom
+LIB_DEPS += util_i2c_mixer
+
+include ../../scripts/project-xilinx.mk

--- a/projects/ad408x_fmc_evb/zed/system_bd.tcl
+++ b/projects/ad408x_fmc_evb/zed/system_bd.tcl
@@ -1,0 +1,17 @@
+###############################################################################
+## Copyright (C) 2022-2024 Analog Devices, Inc. All rights reserved.
+### SPDX short identifier: ADIBSD
+###############################################################################
+
+source $ad_hdl_dir/projects/common/zed/zed_system_bd.tcl
+source ../common/ad408x_fmc_evb_bd.tcl
+source $ad_hdl_dir/projects/scripts/adi_pd.tcl
+
+#system ID
+
+set mem_init_sys_path [get_env_param ADI_PROJECT_DIR ""]mem_init_sys.txt;
+ad_ip_parameter axi_sysid_0 CONFIG.ROM_ADDR_BITS 9
+ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "[pwd]/$mem_init_sys_path"
+ad_ip_parameter rom_sys_0 CONFIG.ROM_ADDR_BITS 9
+
+sysid_gen_sys_init_file

--- a/projects/ad408x_fmc_evb/zed/system_constr.xdc
+++ b/projects/ad408x_fmc_evb/zed/system_constr.xdc
@@ -1,0 +1,59 @@
+###############################################################################
+## Copyright (C) 2022-2024 Analog Devices, Inc. All rights reserved.
+### SPDX short identifier: ADIBSD
+###############################################################################
+
+set_property -dict {PACKAGE_PIN L18 IOSTANDARD LVDS_25 DIFF_TERM 1} [get_ports dco_p];    ## H4 FMC_CLK0_M2C_P IO_L12P_T1_MRCC_34
+set_property -dict {PACKAGE_PIN L19 IOSTANDARD LVDS_25 DIFF_TERM 1} [get_ports dco_n];    ## H5 FMC_CLK0_M2C_N IO_L12N_T1_MRCC_34
+
+set_property -dict {PACKAGE_PIN P17 IOSTANDARD LVDS_25 DIFF_TERM 1} [get_ports da_p];     ## H7 FMC_LA02_P IO_L20P_T3_34
+set_property -dict {PACKAGE_PIN P18 IOSTANDARD LVDS_25 DIFF_TERM 1} [get_ports da_n];     ## H8 FMC_LA02_N IO_L20N_T3_34
+
+set_property -dict {PACKAGE_PIN N22 IOSTANDARD LVDS_25 DIFF_TERM 1} [get_ports db_p];     ## G9 FMC_LA03_P IO_L16P_T2_34
+set_property -dict {PACKAGE_PIN P22 IOSTANDARD LVDS_25 DIFF_TERM 1} [get_ports db_n];     ## G10 FMC_LA03_N IO_L16N_T2_34
+
+set_property -dict {PACKAGE_PIN D18 IOSTANDARD LVDS_25 DIFF_TERM 1} [get_ports fpgaclk_p]; ##   CLK1_M2C_P  G2   IO_L12P_T1_MRCC_35
+set_property -dict {PACKAGE_PIN C19 IOSTANDARD LVDS_25 DIFF_TERM 1} [get_ports fpgaclk_n]; ##   CLK1_M2C_N  G3   IO_L12N_T1_MRCC_35
+
+set_property -dict {PACKAGE_PIN N19 IOSTANDARD LVDS_25  DIFF_TERM 1} [get_ports clk_p];   ##   LA01_CC_P   D8   IO_L14P_T2_SRCC_34
+set_property -dict {PACKAGE_PIN N20 IOSTANDARD LVDS_25  DIFF_TERM 1} [get_ports clk_n];   ##   LA01_CC_N   D9   IO_L14N_T2_SRCC_34
+
+set_property -dict {PACKAGE_PIN L22 IOSTANDARD LVCMOS25} [get_ports gpio1_fmc];           ## C11 FMC_LA06_N IO_L10N_T1_34
+set_property -dict {PACKAGE_PIN R20 IOSTANDARD LVCMOS25} [get_ports gpio2_fmc];           ## D14 FMC_LA09_P IO_L17P_T2_34
+set_property -dict {PACKAGE_PIN R21 IOSTANDARD LVCMOS25} [get_ports gpio3_fmc];           ## D15 FMC_LA09_N IO_L17N_T2_34
+
+set_property -dict {PACKAGE_PIN N17 IOSTANDARD LVCMOS25} [get_ports gp0_dir];             ## H16 FMC_LA11_P IO_L5P_T0_34
+set_property -dict {PACKAGE_PIN T19 IOSTANDARD LVCMOS25} [get_ports gp1_dir];             ## C15 FMC_LA10_N IO_L22N_T3_34
+set_property -dict {PACKAGE_PIN P20 IOSTANDARD LVCMOS25} [get_ports gp2_dir];             ## G15 FMC_LA12_P IO_L18P_T2_34
+set_property -dict {PACKAGE_PIN N18 IOSTANDARD LVCMOS25} [get_ports gp3_dir];             ## H17 FMC_LA11_N IO_L5N_T0_34
+
+set_property -dict {PACKAGE_PIN J16 IOSTANDARD LVCMOS25} [get_ports en_psu];              ## H19 FMC_LA15_P IO_L2P_T0_34
+set_property -dict {PACKAGE_PIN J17 IOSTANDARD LVCMOS25} [get_ports pwrgd];               ## H20 FMC_LA15_N IO_L2N_T0_34
+set_property -dict {PACKAGE_PIN G15 IOSTANDARD LVCMOS25} [get_ports pd_v33b];             ## H22 FMC_LA19_P IO_L4P_T0_35
+set_property -dict {PACKAGE_PIN P21 IOSTANDARD LVCMOS25} [get_ports osc_en];              ## G16 FMC_LA12_N IO_L18N_T2_34
+
+
+set_property -dict {PACKAGE_PIN J21 IOSTANDARD LVCMOS25} [get_ports ad4080_csn];          ## G12 FMC_LA08_P IO_L8P_T1_34
+set_property -dict {PACKAGE_PIN T17 IOSTANDARD LVCMOS25} [get_ports ad4080_sclk];         ## H14 FMC_LA07_N IO_L21N_T3_DQS_34
+set_property -dict {PACKAGE_PIN J22 IOSTANDARD LVCMOS25} [get_ports ad4080_mosi];         ## G13 FMC_LA08_N IO_L8N_T1_34
+set_property -dict {PACKAGE_PIN T16 IOSTANDARD LVCMOS25} [get_ports ad4080_miso];         ## H13 FMC_LA07_P IO_L21P_T3_DQS_34
+
+set_property -dict {PACKAGE_PIN K20 IOSTANDARD LVCMOS25} [get_ports ad9508_csn];          ## C19 FMC_LA14_N IO_L11N_T1_SRCC_34
+set_property -dict {PACKAGE_PIN D20 IOSTANDARD LVCMOS25} [get_ports adf4350_csn];         ## C22 FMC_LA18_CC_P IO_L14P_T2_AD4P_SRCC_35
+set_property -dict {PACKAGE_PIN M17 IOSTANDARD LVCMOS25} [get_ports ad9508_adf4350_sclk]; ## D18 FMC_LA13_N IO_L4N_T0_34
+set_property -dict {PACKAGE_PIN L17 IOSTANDARD LVCMOS25} [get_ports ad9508_adf4350_miso]; ## D17 FMC_LA13_P IO_L4P_T0_34
+set_property -dict {PACKAGE_PIN K19 IOSTANDARD LVCMOS25} [get_ports ad9508_adf4350_mosi]; ## C18 FMC_LA14_P IO_L11P_T1_SRCC_34
+
+set_property -dict {PACKAGE_PIN B19 IOSTANDARD LVCMOS25} [get_ports doa_fmc];             ## H28 FMC_LA24_P IO_L10P_T1_AD11P_35
+set_property -dict {PACKAGE_PIN B20 IOSTANDARD LVCMOS25} [get_ports dob_fmc];             ## H29 FMC_LA24_N IO_L10N_T1_AD11N_35
+set_property -dict {PACKAGE_PIN J20 IOSTANDARD LVCMOS25} [get_ports doc_fmc];             ## G18 FMC_LA16_P IO_L9P_T1_DQS_34
+set_property -dict {PACKAGE_PIN K21 IOSTANDARD LVCMOS25} [get_ports dod_fmc];             ## G19 FMC_LA16_N IO_L9N_T1_DQS_34
+
+set_property -dict {PACKAGE_PIN L21 IOSTANDARD LVCMOS25} [get_ports ad9508_sync];         ## C10 FMC_LA06_P IO_L10P_T1_34
+set_property -dict {PACKAGE_PIN C20 IOSTANDARD LVCMOS25} [get_ports adf435x_lock];        ## C23 FMC_LA18_CC_N IO_L14N_T2_AD4N_SRCC_35
+
+# clocks
+
+create_clock -period 2.500 -name dco_clk  [get_ports dco_p]
+create_clock -period 25.00 -name ref_clk  [get_ports clk_p]
+create_clock -period 10.00 -name fpga_clk [get_ports fpgaclk_p]

--- a/projects/ad408x_fmc_evb/zed/system_project.tcl
+++ b/projects/ad408x_fmc_evb/zed/system_project.tcl
@@ -1,0 +1,17 @@
+###############################################################################
+## Copyright (C) 2022-2024 Analog Devices, Inc. All rights reserved.
+### SPDX short identifier: ADIBSD
+###############################################################################
+
+source ../../../scripts/adi_env.tcl
+source $ad_hdl_dir/projects/scripts/adi_project_xilinx.tcl
+source $ad_hdl_dir/projects/scripts/adi_board.tcl
+
+adi_project ad408x_fmc_evb_zed
+adi_project_files ad408x_fmc_evb_zed [list \
+  "$ad_hdl_dir/library/common/ad_iobuf.v" \
+  "$ad_hdl_dir/projects/common/zed/zed_system_constr.xdc" \
+  "system_constr.xdc" \
+  "system_top.v" ]
+
+adi_project_run ad408x_fmc_evb_zed

--- a/projects/ad408x_fmc_evb/zed/system_top.v
+++ b/projects/ad408x_fmc_evb/zed/system_top.v
@@ -1,0 +1,286 @@
+// ***************************************************************************
+// ***************************************************************************
+// Copyright (C) 2022-2024 Analog Devices, Inc. All rights reserved.
+//
+// In this HDL repository, there are many different and unique modules, consisting
+// of various HDL (Verilog or VHDL) components. The individual modules are
+// developed independently, and may be accompanied by separate and unique license
+// terms.
+//
+// The user should read each of these license terms, and understand the
+// freedoms and responsibilities that he or she has by using this source/core.
+//
+// This core is distributed in the hope that it will be useful, but WITHOUT ANY
+// WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+// A PARTICULAR PURPOSE.
+//
+// Redistribution and use of source or resulting binaries, with or without modification
+// of this file, are permitted under one of the following two license terms:
+//
+//   1. The GNU General Public License version 2 as published by the
+//      Free Software Foundation, which can be found in the top level directory
+//      of this repository (LICENSE_GPL2), and also online at:
+//      <https://www.gnu.org/licenses/old-licenses/gpl-2.0.html>
+//
+// OR
+//
+//   2. An ADI specific BSD license, which can be found in the top level directory
+//      of this repository (LICENSE_ADIBSD), and also on-line at:
+//      https://github.com/analogdevicesinc/hdl/blob/master/LICENSE_ADIBSD
+//      This will allow to generate bit files and not release the source code,
+//      as long as it attaches to an ADI device.
+//
+// ***************************************************************************
+// ***************************************************************************
+
+`timescale 1ns/100ps
+
+module system_top (
+
+  inout   [14:0]  ddr_addr,
+  inout   [ 2:0]  ddr_ba,
+  inout           ddr_cas_n,
+  inout           ddr_ck_n,
+  inout           ddr_ck_p,
+  inout           ddr_cke,
+  inout           ddr_cs_n,
+  inout   [ 3:0]  ddr_dm,
+  inout   [31:0]  ddr_dq,
+  inout   [ 3:0]  ddr_dqs_n,
+  inout   [ 3:0]  ddr_dqs_p,
+  inout           ddr_odt,
+  inout           ddr_ras_n,
+  inout           ddr_reset_n,
+  inout           ddr_we_n,
+
+  inout           fixed_io_ddr_vrn,
+  inout           fixed_io_ddr_vrp,
+  inout   [53:0]  fixed_io_mio,
+  inout           fixed_io_ps_clk,
+  inout           fixed_io_ps_porb,
+  inout           fixed_io_ps_srstb,
+
+  inout   [31:0]  gpio_bd,
+
+  output          hdmi_out_clk,
+  output          hdmi_vsync,
+  output          hdmi_hsync,
+  output          hdmi_data_e,
+  output  [15:0]  hdmi_data,
+
+  output          i2s_mclk,
+  output          i2s_bclk,
+  output          i2s_lrclk,
+  output          i2s_sdata_out,
+  input           i2s_sdata_in,
+
+  output          spdif,
+
+  inout           iic_scl,
+  inout           iic_sda,
+  inout   [ 1:0]  iic_mux_scl,
+  inout   [ 1:0]  iic_mux_sda,
+
+  input           otg_vbusoc,
+
+  // FMC connector
+  // LVDS data interace
+
+  input           dco_p,
+  input           dco_n,
+  input           da_p,
+  input           da_n,
+  input           db_p,
+  input           db_n,
+  input           cnv_in_p,
+  input           cnv_in_n,
+
+  input           fpgaclk_p,
+  input           fpgaclk_n,
+
+  input           clk_p,
+  input           clk_n,
+
+  // GPIOs
+
+  input           doa_fmc,
+  input           dob_fmc,
+  input           doc_fmc,
+  input           dod_fmc,
+
+  output          gp0_dir,
+  output          gp1_dir,
+  output          gp2_dir,
+  output          gp3_dir,
+  input           gpio1_fmc,
+  output          gpio2_fmc,
+  input           gpio3_fmc,
+
+  input           pwrgd,
+  input           adf435x_lock,
+  output          en_psu,
+  output          pd_v33b,
+  output          osc_en,
+  output          ad9508_sync,
+
+  // ADC SPI
+
+  input           ad4080_miso,
+  output          ad4080_sclk,
+  output          ad4080_csn,
+  output          ad4080_mosi,
+
+  // Clock SPI
+
+  input           ad9508_adf4350_miso,
+  output          ad9508_adf4350_sclk,
+  output          ad9508_adf4350_mosi,
+  output          ad9508_csn,
+  output          adf4350_csn
+);
+
+  // internal signals
+
+  wire    [63:0]  gpio_i;
+  wire    [63:0]  gpio_o;
+  wire    [63:0]  gpio_t;
+
+  wire    [ 1:0]  iic_mux_scl_i_s;
+  wire    [ 1:0]  iic_mux_scl_o_s;
+  wire            iic_mux_scl_t_s;
+  wire    [ 1:0]  iic_mux_sda_i_s;
+  wire    [ 1:0]  iic_mux_sda_o_s;
+  wire            iic_mux_sda_t_s;
+
+  wire            filter_data_ready_n;
+  wire            fpga_100_clk;
+  wire            fpga_ref_clk;
+
+  assign gp0_dir        = 1'b0;
+  assign gp1_dir        = 1'b0;
+  assign gp2_dir        = 1'b1;
+  assign gp3_dir        = 1'b0;
+
+  assign filter_data_ready_n  = gpio1_fmc;
+  assign gpio_i[34]           = gpio3_fmc;
+  assign gpio2_fmc            = gpio_o[33];
+
+  assign en_psu         = 1'b1;
+  assign osc_en         = pwrgd;
+  assign pd_v33b        = 1'b1;
+  assign ad9508_sync    = ~gpio_o[37];
+  assign gpio_i[35]     = adf435x_lock;
+  assign gpio_i[36]     = pwrgd;
+  assign gpio_i[63:38]  = gpio_o[63:38];
+
+  IBUFDS i_fpga_clk (
+    .I (clk_p),
+    .IB (clk_n),
+    .O (fpga_ref_clk));
+
+  IBUFDS i_fpga_100_clk (
+    .I (fpgaclk_p),
+    .IB (fpgaclk_n),
+    .O (fpga_100_clk));
+
+  ad_iobuf #(
+    .DATA_WIDTH(32)
+  ) i_gpio_bd (
+    .dio_t({gpio_t[31:0]}),
+    .dio_i({gpio_o[31:0]}),
+    .dio_o({gpio_i[31:0]}),
+    .dio_p({gpio_bd[31:0]}));
+
+  ad_iobuf #(
+    .DATA_WIDTH(2)
+  ) i_iobuf_iic_scl (
+    .dio_t ({iic_mux_scl_t_s,iic_mux_scl_t_s}),
+    .dio_i (iic_mux_scl_o_s),
+    .dio_o (iic_mux_scl_i_s),
+    .dio_p (iic_mux_scl));
+
+  ad_iobuf #(
+    .DATA_WIDTH(2)
+  ) i_iobuf_iic_sda (
+    .dio_t ({iic_mux_sda_t_s,iic_mux_sda_t_s}),
+    .dio_i (iic_mux_sda_o_s),
+    .dio_o (iic_mux_sda_i_s),
+    .dio_p (iic_mux_sda));
+
+  system_wrapper i_system_wrapper (
+    .ddr_addr (ddr_addr),
+    .ddr_ba (ddr_ba),
+    .ddr_cas_n (ddr_cas_n),
+    .ddr_ck_n (ddr_ck_n),
+    .ddr_ck_p (ddr_ck_p),
+    .ddr_cke (ddr_cke),
+    .ddr_cs_n (ddr_cs_n),
+    .ddr_dm (ddr_dm),
+    .ddr_dq (ddr_dq),
+    .ddr_dqs_n (ddr_dqs_n),
+    .ddr_dqs_p (ddr_dqs_p),
+    .ddr_odt (ddr_odt),
+    .ddr_ras_n (ddr_ras_n),
+    .ddr_reset_n (ddr_reset_n),
+    .ddr_we_n (ddr_we_n),
+    .fixed_io_ddr_vrn (fixed_io_ddr_vrn),
+    .fixed_io_ddr_vrp (fixed_io_ddr_vrp),
+    .fixed_io_mio (fixed_io_mio),
+    .fixed_io_ps_clk (fixed_io_ps_clk),
+    .fixed_io_ps_porb (fixed_io_ps_porb),
+    .fixed_io_ps_srstb (fixed_io_ps_srstb),
+    .gpio_i (gpio_i),
+    .gpio_o (gpio_o),
+    .gpio_t (gpio_t),
+    .hdmi_data (hdmi_data),
+    .hdmi_data_e (hdmi_data_e),
+    .hdmi_hsync (hdmi_hsync),
+    .hdmi_out_clk (hdmi_out_clk),
+    .hdmi_vsync (hdmi_vsync),
+    .i2s_bclk (i2s_bclk),
+    .i2s_lrclk (i2s_lrclk),
+    .i2s_mclk (i2s_mclk),
+    .i2s_sdata_in (i2s_sdata_in),
+    .i2s_sdata_out (i2s_sdata_out),
+    .iic_fmc_scl_io (iic_scl),
+    .iic_fmc_sda_io (iic_sda),
+    .iic_mux_scl_i (iic_mux_scl_i_s),
+    .iic_mux_scl_o (iic_mux_scl_o_s),
+    .iic_mux_scl_t (iic_mux_scl_t_s),
+    .iic_mux_sda_i (iic_mux_sda_i_s),
+    .iic_mux_sda_o (iic_mux_sda_o_s),
+    .iic_mux_sda_t (iic_mux_sda_t_s),
+    .otg_vbusoc (otg_vbusoc),
+    .spdif (spdif),
+    .spi0_clk_i (1'b0),
+    .spi0_clk_o (ad4080_sclk),
+    .spi0_csn_0_o (ad4080_csn),
+    .spi0_csn_1_o (),
+    .spi0_csn_2_o (),
+    .spi0_csn_i (1'b1),
+    .spi0_sdi_i (ad4080_miso),
+    .spi0_sdo_i (1'b0),
+    .spi0_sdo_o (ad4080_mosi),
+    .spi1_clk_i (1'b0),
+    .spi1_clk_o (ad9508_adf4350_sclk),
+    .spi1_csn_0_o (ad9508_csn),
+    .spi1_csn_1_o (adf4350_csn),
+    .spi1_csn_2_o (),
+    .spi1_csn_i (1'b1),
+    .spi1_sdi_i (ad9508_adf4350_miso),
+    .spi1_sdo_i (1'b0),
+    .spi1_sdo_o (ad9508_adf4350_mosi),
+    .dco_p (dco_p),
+    .dco_n (dco_n),
+    .da_p (da_p),
+    .da_n (da_n),
+    .db_p (db_p),
+    .db_n (db_n),
+    .cnv_in_p(cnv_in_p),
+    .cnv_in_n(cnv_in_n),
+    .filter_data_ready_n(filter_data_ready_n),
+    .sync_n (ad9508_sync),
+    .fpga_ref_clk(fpga_ref_clk),
+    .fpga_100_clk(fpga_100_clk));
+
+endmodule


### PR DESCRIPTION
## PR Description

This PR adds the following:
- the ad_serdes_in module was modified to allow external reset
- the ad_pack module was modified to allow MSB align 
- the up_adc_common exposes the up_adc_ddr_edgesel, up_adc_num_lanes and up_adc_sdr_ddr_n signals
- AXI_AD408X IP 
- AXI_AD408X IP documentation
- AD4080 project on ZedBoard
- AD4080 project on ZedBoard documentation
## PR Type
- [ ] Bug fix (change that fixes an issue)
- [x] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the code style guidelines
- [x] I have performed a self-review of changes
- [x] I have compiled all hdl projects and libraries affected by this PR
- [x] I have tested in hardware affected projects, at least on relevant boards
- [x] I have commented my code, at least hard-to-understand parts
- [x] I have signed off all commits from this PR
- [x] I have updated the documentation (wiki pages, ReadMe files, Copyright etc)
- [x] I have not introduced new Warnings/Critical Warnings on compilation
- [ ] I have added new hdl testbenches or updated existing ones
