### PR TITLE
docs: Fix mistake in code snippet from Porting page and more

### DIFF
--- a/docs/library/axi_ad3552r/index.rst
+++ b/docs/library/axi_ad3552r/index.rst
@@ -192,7 +192,6 @@ References
 
 * HDL IP core at :git-hdl:`library/axi_ad3552r`
 * HDL project at :git-hdl:`projects/ad3552r_evb`
-* Linux device driver :git-linux:`drivers/iio/dac/ad3552r.c`
 * :adi:`AD3552R`
 * :xilinx:`Zynq-7000 SoC Overview <support/documentation/data_sheets/ds190-Zynq-7000-Overview.pdf>`
 * :xilinx:`Zynq-7000 SoC Packaging and Pinout <support/documentation/user_guides/ug865-Zynq-7000-Pkg-Pinout.pdf>`

--- a/docs/projects/ad5758_sdz/index.rst
+++ b/docs/projects/ad5758_sdz/index.rst
@@ -1,4 +1,4 @@
-.. _ad5758:
+.. _ad5758_sdz:
 
 AD5758-SDZ HDL project
 ================================================================================
@@ -49,7 +49,7 @@ Supported carriers
 Other required hardware
 -------------------------------------------------------------------------------
 
--   :adi:`SDP-S`
+-  :adi:`SDP-S`
 
 Block design
 -------------------------------------------------------------------------------
@@ -64,9 +64,9 @@ The data path and clock domains are depicted in the below diagram:
 Jumper setup
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-================== ================ =============================================
+================== ================ ============================================
 Jumper/Solder link Default Position Description
-================== ================ =============================================
+================== ================ ============================================
 JP1                B                Position B selects the VOUT3 pin of the
                                     :adi:`ADP1031`
 JP2                Inserted         Connects the VLOGIC pin of the :adi:`AD5758`
@@ -86,12 +86,12 @@ JP10               B                Position B selects the :adi:`ADR4525` output
                                     as the input to the REFIN pin
 JP11               Inserted         Selects 3.3 V output of the VLDO pin to the
                                     VLOGIC pin
-JP12               A                Position A selects VOUT2 of the 
+JP12               A                Position A selects VOUT2 of the
                                     :adi:`ADP1031` as the input voltage to the
                                     AVDD2 pin
 JP13               Inserted         Connects VOUT1 of the :adi:`ADP1031` to
                                     the AVDD1 pin
-================== ================ =============================================
+================== ================ ============================================
 
 .. note::
 

--- a/docs/projects/adrv904x/index.rst
+++ b/docs/projects/adrv904x/index.rst
@@ -3,19 +3,24 @@
 ADRV904x HDL reference design
 ===============================================================================
 
-The ADRV904x is a highly integrated, system on chip (SoC) radio frequency (RF) 
-agile transceiver with integrated digital front end (DFE). The SoC contains 
-eight transmitters, two observation receivers for monitoring transmitter 
-channels, eight receivers, integrated LO and clock synthesizers, and digital 
+The ADRV904x is a highly integrated, system on chip (SoC) radio frequency (RF)
+agile transceiver with integrated digital front end (DFE). The SoC contains
+eight transmitters, two observation receivers for monitoring transmitter
+channels, eight receivers, integrated LO and clock synthesizers, and digital
 signal processing functions. The SoC meets the high radio performance and low
 power consumption demanded by cellular infrastructure applications including
 small cell basestation radios, macro 3G/4G/5G systems, and massive MIMO base
 stations.
 
+Supported devices
+-------------------------------------------------------------------------------
+
+-  :adi:`ADRV9040`
+
 Supported boards
 -------------------------------------------------------------------------------
 
--  EVAL-ADRV904x 
+-  :adi:`EVAL-ADRV904x`
 
 Supported carriers
 -------------------------------------------------------------------------------
@@ -27,7 +32,7 @@ Supported carriers
    * - Evaluation board
      - Carrier
      - FMC slot
-   * - EVAL-ADRV904x 
+   * - EVAL-ADRV904x
      - :xilinx:`ZCU102`
      - FMC HPC0
 
@@ -49,7 +54,7 @@ Example block design for Single link; M=16; L=8
 
 The Rx links (ADC Path) operate with the following parameters:
 
--  Rx Deframer parameters: L=8, M=16, F=4, S=1, NP=16, N=16 
+-  Rx Deframer parameters: L=8, M=16, F=4, S=1, NP=16, N=16
 -  Sample Rate: 491.52 MSPS
 -  Dual link: No
 -  RX_DEVICE_CLK: 245.76 MHz (Lane Rate/66)
@@ -59,7 +64,7 @@ The Rx links (ADC Path) operate with the following parameters:
 
 The Tx links (DAC Path) operate with the following parameters:
 
--  Tx Deframer parameters: L=8, M=16, F=4, S=1, NP=16, N=16 
+-  Tx Deframer parameters: L=8, M=16, F=4, S=1, NP=16, N=16
 -  Sample Rate: 491.52 MSPS
 -  Dual link: No
 -  TX_DEVICE_CLK: 245.76 MHz (Lane Rate/66)
@@ -93,8 +98,8 @@ The following are the parameters of this project that can be configured:
    -  64B66B - 64b66b link layer defined in JESD204C
    -  8B10B  - 8b10b link layer defined in JESD204B
 
--  RX_LANE_RATE: lane rate of the Rx link 
--  TX_LANE_RATE: lane rate of the Tx link 
+-  RX_LANE_RATE: lane rate of the Rx link
+-  TX_LANE_RATE: lane rate of the Tx link
 -  [RX/TX]_JESD_M: number of converters per link
 -  [RX/TX]_JESD_L: number of lanes per link
 -  [RX/TX]_JESD_S: number of samples per frame
@@ -116,9 +121,9 @@ The addresses are dependent on the architecture of the FPGA, having an offset
 added to the base address from HDL (see more at :ref:`architecture`).
 
 ==================== ===========
-Instance             ZynqMP     
+Instance             ZynqMP
 ==================== ===========
-axi_adrv904x_tx_jesd 0x84A90000 
+axi_adrv904x_tx_jesd 0x84A90000
 axi_adrv904x_rx_jesd 0x84AA0000
 axi_adrv904x_tx_dma  0x9c420000
 axi_adrv904x_rx_dma  0x9c400000
@@ -143,8 +148,8 @@ SPI connections
      - spi0
      - ADRV904x
      - 0
-   * - 
-     - 
+   * -
+     -
      - AD9528
      - 1
 
@@ -356,9 +361,7 @@ Here you can find the quick start guides available for these evaluation boards:
 Hardware related
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
--  Product datasheets:
-
-   - `<https://www.analog.com/media/radioverse-adrv9026/adrv9040.pdf>`__
+-  Product datasheet: :adi:`ADRV9040 <media/radioverse-adrv9026/adrv9040.pdf>`
 
 HDL related
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -392,7 +395,7 @@ HDL related
      - :ref:`here <data_offload>`
    * - UTIL_DO_RAM
      - :git-hdl:`library/util_do_ram`
-     - :dokuwiki:`[Wiki] </resources/fpga/docs/data_offload>`
+     - :ref:`here <data_offload>`
    * - UTIL_ADXCVR for AMD
      - :git-hdl:`library/xilinx/util_adxcvr`
      - :ref:`here <util_adxcvr>`

--- a/docs/projects/template/index.rst
+++ b/docs/projects/template/index.rst
@@ -3,7 +3,7 @@
 .. _template_project:
 
 Project template
-================================================================================
+===============================================================================
 
 Overview
 -------------------------------------------------------------------------------
@@ -43,7 +43,7 @@ another carrier. Take these tables as an example:**\ \*
      - Carrier
      - FMC slot
    * - :adi:`AD9081-FMCA-EBZ <EVAL-AD9081>`
-     - `A10SoC`_
+     - :intel:`A10SoC <content/www/us/en/products/details/fpga/arria/10/sx/products.html>`
      - FMCA
    * -
      - :xilinx:`VCK190`
@@ -734,9 +734,10 @@ and of the device tree.
 
    -  `AD9081 class documentation <https://analogdevicesinc.github.io/pyadi-iio/devices/adi.ad9081.html>`__
    -  `PyADI-IIO documentation <https://analogdevicesinc.github.io/pyadi-iio/>`__
+   -  `Example link`_
 
 .. include:: ../common/more_information.rst
 
 .. include:: ../common/support.rst
 
-.. _A10SoC: https://www.intel.com/content/www/us/en/products/details/fpga/development-kits/arria/10-sx.html
+.. _Example link: https://www.intel.com/content/www/us/en/products/details/fpga/development-kits/arria/10-sx.html

--- a/docs/user_guide/architecture.rst
+++ b/docs/user_guide/architecture.rst
@@ -445,19 +445,19 @@ Intel platforms
    * - Board name
      - Connector 1
      - Connector 2
-   * - `A10GX <https://www.altera.com/products/boards_and_kits/dev-kits/altera/kit-a10-gx-fpga.html>`__ **
+   * - :intel:`A10GX <content/www/us/en/products/details/fpga/development-kits/arria/10-gx.html>` ** (Arria 10 GX)
      - FMC LPC ()
      - FMC HPC (8 x 17.4 Gbps)
-   * - `A10SoC <https://www.altera.com/products/boards_and_kits/dev-kits/altera/arria-10-soc-development-kit.html>`__
+   * - :intel:`A10SoC <content/www/us/en/products/details/fpga/development-kits/arria/10-sx.html>` (Arria 10 SoC)
      - FMC HPC (8)
      - FMC LPC (8)
-   * - `S10SoC <https://www.intel.com/content/www/us/en/products/details/fpga/development-kits/stratix/10-sx.html>`__
+   * - :intel:`S10SoC </content/www/us/en/products/details/fpga/development-kits/stratix/10-sx.html>` (Stratix 10 SoC)
      - FMC+ (24 @ 28.3 Gbps)
      - FMC+ (24 @ 28.3 Gbps)
-   * - `C5SoC <https://www.terasic.com.tw/cgi-bin/page/archive.pl?Language=English&CategoryNo=167&No=819>`__
+   * - :intel:`C5SoC <content/www/us/en/products/details/fpga/development-kits/cyclone/v-sx.html>` (Cyclone V SoC)
      - HSMC
      - ---
-   * - `DE10-Nano <https://www.intel.com/content/www/us/en/developer/topic-technology/edge-5g/hardware/fpga-de10-nano.html>`__
+   * - :intel:`DE10-Nano <content/www/us/en/developer/topic-technology/edge-5g/hardware/fpga-de10-nano.html>`
      - Arduino shield
      - ---
 
@@ -476,13 +476,13 @@ VADJ values
    * - Board name
      - FMC connector 1
      - FMC connector 2
-   * - `A10GX <https://www.altera.com/products/boards_and_kits/dev-kits/altera/kit-a10-gx-fpga.html>`__
+   * - :intel:`A10GX <content/www/us/en/products/details/fpga/development-kits/arria/10-gx.html>`
      - **\*1.8V**/1.5V/1.35V/1.2V
      - **\*1.8V**/1.5V/1.35V/1.2V
-   * - `A10SoC <https://www.altera.com/products/boards_and_kits/dev-kits/altera/arria-10-soc-development-kit.html>`__
+   * - :intel:`A10SoC <content/www/us/en/products/details/fpga/development-kits/arria/10-sx.html>`
      - **\*1.8V**/1.5V/1.35V/1.25V/1.2V/1.1V
      - **\*1.8V**/1.5V/1.35V/1.2V/1.1V
-   * - `S10SoC <https://www.intel.com/content/www/us/en/products/details/fpga/development-kits/stratix/10-sx.html>`__
+   * - :intel:`S10SoC </content/www/us/en/products/details/fpga/development-kits/stratix/10-sx.html>`
      - **\*3.3V**/1.8V/1.2V
      - **\*3.3V**/1.8V/1.2V
 

--- a/docs/user_guide/porting_project.rst
+++ b/docs/user_guide/porting_project.rst
@@ -113,10 +113,10 @@ the **adi_project_create** process:
 
 .. code:: tcl
 
-   if [regexp "_zcu102$" $project_name] {
-       set p_device "xczu9eg-ffvb1156-1-i-es1"
-       set p_board "xilinx.com:zcu102:part0:1.2"
-       set sys_zynq 2
+   if [regexp "_zcu102" $project_name] {
+     set device "xczu9eg-ffvb1156-2-e"
+     set board [lindex [lsearch -all -inline [get_board_parts] *zcu102*] end]
+     set sys_zynq 2
    }
 
 .. tip::
@@ -128,10 +128,10 @@ the **adi_project_create** process:
 
 The **sys_zynq** constant variable should be set in the following way:
 
-- 0 - 7 Series FPGA (e.g. Kintex7, Virtex7)
-- 1 - Zynq7000 SoC
-- 2 - Zynq UltraScale+ SoC
-- 3 - Versal
+*  0 - 7 Series FPGA (e.g. Kintex7, Virtex7)
+*  1 - Zynq7000 SoC
+*  2 - Zynq UltraScale+ SoC
+*  3 - Versal
 
 Example with an Intel board
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
## PR Description

 * Fix a mistake in the code snippet from Porting an HDL project page
 * Update the links in Architecture, as some of them don't point to the right page and they're not in the right format, and a small change in the template for project doc.
 * library/axi_ad3552r: Remove duplicate link to driver
 * projects/ad5758_sdz: Fix page name
 * projects/adrv904x: Remove trailing whitespaces and update datasheet link and data_offload doc link

## PR Type
- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the code style guidelines
- [x] I have performed a self-review of changes
- [ ] I have compiled all hdl projects and libraries affected by this PR
- [ ] I have tested in hardware affected projects, at least on relevant boards
- [ ] I have commented my code, at least hard-to-understand parts
- [x] I have signed off all commits from this PR
- [x] I have updated the documentation (wiki pages, ReadMe files, Copyright etc)
- [ ] I have not introduced new Warnings/Critical Warnings on compilation
- [ ] I have added new hdl testbenches or updated existing ones
