### PR TITLE
unit_level_tb: Fix testbench runs

### DIFF
--- a/library/axi_dmac/tb/dma_read_shutdown_tb.v
+++ b/library/axi_dmac/tb/dma_read_shutdown_tb.v
@@ -36,7 +36,7 @@
 `timescale 1ns/100ps
 
 module dma_read_shutdown_tb;
-  parameter VCD_FILE = {`__FILE__,"cd"};
+  parameter VCD_FILE = {"dma_read_shutdown_tb.vcd"};
 
   `include "tb_base.v"
 

--- a/library/axi_dmac/tb/dma_read_tb.v
+++ b/library/axi_dmac/tb/dma_read_tb.v
@@ -36,7 +36,7 @@
 `timescale 1ns/100ps
 
 module dma_read_tb;
-  parameter VCD_FILE = {`__FILE__,"cd"};
+  parameter VCD_FILE = {"dma_read_tb.vcd"};
   parameter WIDTH_DEST = 32;
   parameter WIDTH_SRC = 32;
   parameter REQ_LEN_INC = 4;

--- a/library/axi_dmac/tb/dma_write_shutdown_tb.v
+++ b/library/axi_dmac/tb/dma_write_shutdown_tb.v
@@ -36,7 +36,7 @@
 `timescale 1ns/100ps
 
 module dma_write_shutdown_tb;
-  parameter VCD_FILE = {`__FILE__,"cd"};
+  parameter VCD_FILE = {"dma_write_shutdown_tb.vcd"};
 
   `include "tb_base.v"
 

--- a/library/axi_dmac/tb/dma_write_tb.v
+++ b/library/axi_dmac/tb/dma_write_tb.v
@@ -36,7 +36,7 @@
 `timescale 1ns/100ps
 
 module dma_write_tb;
-  parameter VCD_FILE = {`__FILE__,"cd"};
+  parameter VCD_FILE = {"dma_write_tb.vcd"};
   parameter WIDTH_DEST = 32;
   parameter WIDTH_SRC = 32;
   parameter REQ_LEN_INC = 4;

--- a/library/axi_dmac/tb/regmap_tb.v
+++ b/library/axi_dmac/tb/regmap_tb.v
@@ -36,7 +36,7 @@
 `timescale 1ns/100ps
 
 module regmap_tb;
-  parameter VCD_FILE = {`__FILE__,"cd"};
+  parameter VCD_FILE = {"regmap_tb.vcd"};
 
   `define TIMEOUT 1000000
   `include "tb_base.v"

--- a/library/axi_dmac/tb/reset_manager_tb.v
+++ b/library/axi_dmac/tb/reset_manager_tb.v
@@ -36,7 +36,7 @@
 `timescale 1ns/100ps
 
 module reset_manager_tb;
-  parameter VCD_FILE = {`__FILE__,"cd"};
+  parameter VCD_FILE = {"reset_manager_tb.vcd"};
 
   `define TIMEOUT 1000000
   `include "tb_base.v"

--- a/library/util_pack/tb/cpack_tb.v
+++ b/library/util_pack/tb/cpack_tb.v
@@ -36,7 +36,7 @@
 `timescale 1ns/100ps
 
 module cpack_tb;
-  parameter VCD_FILE = {`__FILE__,"cd"};
+  parameter VCD_FILE = {"cpack_tb.vcd"};
   parameter NUM_OF_CHANNELS = 4;
   parameter SAMPLES_PER_CHANNEL = 1;
   parameter ENABLE_RANDOM = 0;

--- a/library/util_pack/tb/underflow_tb.v
+++ b/library/util_pack/tb/underflow_tb.v
@@ -36,7 +36,7 @@
 `timescale 1ns/100ps
 
 module underflow_tb;
-  parameter VCD_FILE = {`__FILE__,"cd"};
+  parameter VCD_FILE = {"underflow_tb.vcd"};
   parameter NUM_OF_CHANNELS = 8;
   parameter SAMPLES_PER_CHANNEL = 4;
 

--- a/library/util_pack/tb/upack_tb.v
+++ b/library/util_pack/tb/upack_tb.v
@@ -36,7 +36,7 @@
 `timescale 1ns/100ps
 
 module upack_tb;
-  parameter VCD_FILE = {`__FILE__,"cd"};
+  parameter VCD_FILE = {"upack_tb.vcd"};
   parameter NUM_OF_CHANNELS = 8;
   parameter SAMPLES_PER_CHANNEL = 1;
   parameter ENABLE_RANDOM = 0;


### PR DESCRIPTION
## PR Description

Changed dynamic VCD file name definition to static as Vivado doesn't support system function call at parameters section


## PR Type
- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the code style guidelines
- [x] I have performed a self-review of changes
- [ ] I have compiled all hdl projects and libraries affected by this PR
- [ ] I have tested in hardware affected projects, at least on relevant boards
- [ ] I have commented my code, at least hard-to-understand parts
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe files, Copyright etc)
- [x] I have not introduced new Warnings/Critical Warnings on compilation
- [x] I have added new hdl testbenches or updated existing ones
