### PR TITLE
axi_dmac: Fix regmap testbench default value

### DIFF
--- a/library/axi_dmac/tb/regmap_tb.v
+++ b/library/axi_dmac/tb/regmap_tb.v
@@ -171,7 +171,7 @@ module regmap_tb;
     /* Non zero power-on-reset values */
     set_reset_reg_value('h00, 32'h00040563); /* PCORE version register */
     set_reset_reg_value('h0c, 32'h444d4143); /* PCORE magic register */
-    set_reset_reg_value('h10, 32'h00002101); /* Interface Description*/
+    set_reset_reg_value('h10, 32'h00072101); /* Interface Description*/
     set_reset_reg_value('h80, 'h3); /* IRQ mask */
 
     set_reset_reg_value('h40c, 'h3); /* Flags */
@@ -412,6 +412,7 @@ module regmap_tb;
     .irq(irq),
 
     .response_eot(response_eot),
+    .response_sg_desc_id('h0),
     .response_measured_burst_length(response_measured_burst_length),
     .response_partial(response_partial),
     .response_valid(response_valid),


### PR DESCRIPTION
## PR Description

Updated the default value in the testbench. 
Added default value for SG descriptor ID as input, so it has a value to test against. 
Tested, working. 


## PR Type
- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the code style guidelines
- [x] I have performed a self-review of changes
- [ ] I have compiled all hdl projects and libraries affected by this PR
- [ ] I have tested in hardware affected projects, at least on relevant boards
- [ ] I have commented my code, at least hard-to-understand parts
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe files, Copyright etc)
- [x] I have not introduced new Warnings/Critical Warnings on compilation
- [x] I have added new hdl testbenches or updated existing ones
