### PR TITLE
util_axis_fifo: Fix tkeep signal value when KEEP_EN is 0

### DIFF
--- a/library/util_axis_fifo/util_axis_fifo.v
+++ b/library/util_axis_fifo/util_axis_fifo.v
@@ -162,7 +162,7 @@ module util_axis_fifo #(
           end
           assign m_axis_tkeep = axis_tkeep_d;
         end else
-          assign m_axis_tkeep = {DATA_WIDTH/8{1'b1}};
+          assign m_axis_tkeep = 'h0;
 
     end /* zerodeep */
     else
@@ -221,7 +221,7 @@ module util_axis_fifo #(
         end
         assign m_axis_tkeep = axis_tkeep_d;
       end else
-        assign m_axis_tkeep = {DATA_WIDTH/8{1'b1}};
+        assign m_axis_tkeep = 'h0;
 
      end /* !ASYNC_CLK */
 
@@ -293,12 +293,12 @@ module util_axis_fifo #(
       assign m_axis_data = m_axis_data_int_s[DATA_WIDTH-1:0];
     end else if (TLAST_EN) begin
       assign s_axis_data_int_s = {s_axis_tlast, s_axis_data};
-      assign m_axis_tkeep = {DATA_WIDTH/8{1'b1}};
+      assign m_axis_tkeep = 'h0;
       assign m_axis_tlast = m_axis_data_int_s[DATA_WIDTH];
       assign m_axis_data = m_axis_data_int_s[DATA_WIDTH-1:0];
     end else begin
       assign s_axis_data_int_s = {s_axis_data};
-      assign m_axis_tkeep = {DATA_WIDTH/8{1'b1}};
+      assign m_axis_tkeep = 'h0;
       assign m_axis_tlast = 'b0;
       assign m_axis_data = m_axis_data_int_s[DATA_WIDTH-1:0];
     end


### PR DESCRIPTION
## PR Description

Changed the tkeep default value to be 0 regardless of data width then KEEP_EN is set to 0. 
Wasn't tested on any of the project level testbenches or HDL projects and they shouldn't be affected either. 
Tested in the DMAC IP level testbenches found in this repository, fixes a compilation issue and the test as well. 


## PR Type
- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the code style guidelines
- [x] I have performed a self-review of changes
- [ ] I have compiled all hdl projects and libraries affected by this PR
- [ ] I have tested in hardware affected projects, at least on relevant boards
- [ ] I have commented my code, at least hard-to-understand parts
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe files, Copyright etc)
- [x] I have not introduced new Warnings/Critical Warnings on compilation
- [ ] I have added new hdl testbenches or updated existing ones
