### PR TITLE
docs: remove ad7606 build warning

### DIFF
--- a/docs/library/axi_ad7606x/index.rst
+++ b/docs/library/axi_ad7606x/index.rst
@@ -67,8 +67,6 @@ Interface
      - Active low parallel data write control
    * - rx_cs_n
      - Active low chip select
-   * - external_clk
-     - External clock if the corresponding option is enabled
    * - rx_busy
      - Active low busy signal
    * - first_data


### PR DESCRIPTION
This interface no longer exists on the ip, and was causing a warning when building the doc:

`WARNING: library/axi_ad7606x/component.xml: Signal external_clk defined in the hdl-interfaces directive does not exist in the IP-XACT!`

## PR Type
- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the code style guidelines
- [x] I have performed a self-review of changes
- [ ] I have compiled all hdl projects and libraries affected by this PR
- [ ] I have tested in hardware affected projects, at least on relevant boards
- [ ] I have commented my code, at least hard-to-understand parts
- [ ] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe files, Copyright etc)
- [ ] I have not introduced new Warnings/Critical Warnings on compilation
- [ ] I have added new hdl testbenches or updated existing ones
