### PR TITLE
axi_ad9361: Fixup LVDS RX_FRAME (#916)

### DIFF
--- a/library/axi_ad9361/xilinx/axi_ad9361_lvds_if.v
+++ b/library/axi_ad9361/xilinx/axi_ad9361_lvds_if.v
@@ -1,6 +1,6 @@
 // ***************************************************************************
 // ***************************************************************************
-// Copyright (C) 2014-2023 Analog Devices, Inc. All rights reserved.
+// Copyright (C) 2014-2024 Analog Devices, Inc. All rights reserved.
 //
 // In this HDL repository, there are many different and unique modules, consisting
 // of various HDL (Verilog or VHDL) components. The individual modules are
@@ -166,6 +166,7 @@ module axi_ad9361_lvds_if #(
   wire    [ 5:0]      rx_data_0_s;
   wire    [ 1:0]      rx_frame_s;
   wire                locked_s;
+  wire                rx_error;
 
   // drp interface signals
 
@@ -214,16 +215,9 @@ module axi_ad9361_lvds_if #(
   end
 
   // frame check
+  assign rx_error = ^rx_frame;
 
   // delineation
-  reg             rx_error_r1 = 'd0;
-  reg             rx_error_r2 = 'd0;
-
-  always @(posedge l_clk) begin
-    rx_error_r1 <= ~((rx_frame_s == 4'b1100) || (rx_frame_s == 4'b0011));
-    rx_error_r2 <= ~((rx_frame_s == 4'b1111) || (rx_frame_s == 4'b1100) ||
-                     (rx_frame_s == 4'b0000) || (rx_frame_s == 4'b0011));
-  end
 
   always @(posedge l_clk) begin
       case ({rx_r1_mode, rx_frame_s, rx_frame})
@@ -252,11 +246,7 @@ module axi_ad9361_lvds_if #(
   // adc-status
 
   always @(posedge l_clk) begin
-    if (adc_r1_mode == 1'b1) begin
-      adc_status_p <= ~rx_error_r1 & rx_locked;
-    end else begin
-      adc_status_p <= ~rx_error_r2 & rx_locked;
-    end
+    adc_status_p <= ~rx_error & rx_locked;
   end
 
   // transfer to common clock


### PR DESCRIPTION
## PR Description

The rx_error_r* on the axi_ad9361/xilinx/axi_ad9361_lvds_if.v were not implemented properly.
the author intended it to be the inverse of all valid frames combinations {rx_frame, rx_frame_s} but only compared against rx_frame_s.

Checking against all valid frames is also unnecessary, since checking for unequal DDR output values have the same practical effect.
It is also worth noting that at 2RX mode, a frame fulfills the 2 channels in 4 clock cycles, while  {rx_frame, rx_frame_s} looks back only 2 clock cycles.

![image](https://github.com/user-attachments/assets/e853382e-7999-4fd6-80c8-1cb926c8f315)
UG-570, p95

This commit changes rx_error to be a "link stable signal".

Relevant information:
AD9361:
operates in DDR
Linux/no-os drivers set (or leave default):
 *  reg 0x010 value 0xC8, bit 2 -> Rx Frame Pulse Mode : 50% duty cycle
 * reg 0x011 value 0x00, bit 2 -> Invert Rx Frame : don't invert

AXI_AD9361:

rx_r1_mode is [ADC_COMMON 0x0011[2] R1_MODE](https://github.com/analogdevicesinc/hdl/blob/main/docs/regmap/adi_regmap_adc.txt#L83-L88C8) with:
* clear: 2 channels
* set: 1 channel

status is [ADC_COMMON 0x0017 [0] STATUS](https://github.com/analogdevicesinc/hdl/blob/main/docs/regmap/adi_regmap_adc.txt#L212-L252) with:
* clear : error on intf

Aims to fix #916, but does not try to fix the frame skew/unequal ddr output observed in the issue author first screenshot, however, the prior logic may resolve into the error signal never asserting, entering runtime without properly aligning, somewhere around [ad9361_conv.c#ad9361_dig_tune_delay](https://github.com/analogdevicesinc/linux/blob/8077957e8f81d539f05a7a065a6b17a2477c4a89/drivers/iio/adc/ad9361_conv.c#L448-L507).
An unaligned frame results into the following Linux boot log message:
```
SAMPL CLK: 61440000 tuning: RX
  0:1:2:3:4:5:6:7:8:9:a:b:c:d:e:f:
0:# # # # # # # # # # # # # # # #
1:# # # # # # # # # # # # # # # #
ad9361 spi0.0: ad9361_dig_tune_delay: Tuning RX FAILED!
```

Tested on hardware in loopback with single channel, dual channel, single tone, dual tone, and BISPs.
Updates only the xilinx side, since the https://github.com/analogdevicesinc/hdl/commit/83d3bded6312449766385730ab07b3afde1adbfe only edited it, but the error logic could be added to intel also.

## PR Type
- [X] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [X] I have followed the code style guidelines
- [ ] I have performed a self-review of changes
- [ ] I have compiled all hdl projects and libraries affected by this PR
- [ ] I have tested in hardware affected projects, at least on relevant boards
- [ ] I have commented my code, at least hard-to-understand parts
- [ ] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe files, Copyright etc)
- [ ] I have not introduced new Warnings/Critical Warnings on compilation
- [ ] I have added new hdl testbenches or updated existing ones
