### PR TITLE
Fixed PDF library name

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,6 @@
 sphinx
-rst2pdf.pdfbuilder
+matplotlib
+rst2pdf
+svglib
 https://github.com/analogdevicesinc/doctools/releases/download/latest/adi-doctools.tar.gz
 sphinxcontrib.wavedrom


### PR DESCRIPTION
## PR Description

Small bug, wrong library for PDF output in requirments.txt file which contains all the needed dependencies for doc. building. Also, other important libraries involved in the build process were missing.

 The main library needed for PDF export is called rst2pdf. The rest of the libraries are used for improving the
 PDF output. For example:
- matplotlib: rst2pdf supports a math role and a math directive.
You can use them to insert formulae and mathematical notation in
your documents using a subset of LaTeX syntax, but doesn't require
you have LaTeX installed
- svglib: needed for .svg files rendering

## PR Type
- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [ ] I have followed the code style guidelines
- [x] I have performed a self-review of changes
- [ ] I have compiled all hdl projects and libraries affected by this PR
- [ ] I have tested in hardware affected projects, at least on relevant boards
- [ ] I have commented my code, at least hard-to-understand parts
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe files, Copyright etc)
- [ ] I have not introduced new Warnings/Critical Warnings on compilation
- [ ] I have added new hdl testbenches or updated existing ones
