### PR TITLE
docs/cn0579: Fixing the make rendering and removing whitespaces

### DIFF
--- a/docs/projects/cn0579/index.rst
+++ b/docs/projects/cn0579/index.rst
@@ -6,16 +6,16 @@ CN0579 HDL project
 Overview
 -------------------------------------------------------------------------------
 
-The :adi:`CN0579 <CN0579>`  is a 4-channel, high resolution, wide bandwidth, 
-high dynamic range, integrated electronics piezoelectric (IEPE)-compatible 
-interface data acquisition (DAQ) system that interfaces with IC piezoelectric 
-(ICP®)/IEPE sensors. The solution provides flexible sensor interfacing to 
-either piezoelectric or micro-electromechanical systems (MEMS) sensor with 
-measurement capabilities that extend the frequency response to DC. 
-The design provides four channels of full bandwidth, synchronized vibration 
-data to the processor, where data analysis can be done locally or on a remote 
-host over Ethernet via standard IIO framework. Large buffers of continuous 
-data can be streamed and analyzed using standard fast Fourier transform (FFT) 
+The :adi:`CN0579 <CN0579>`  is a 4-channel, high resolution, wide bandwidth,
+high dynamic range, integrated electronics piezoelectric (IEPE)-compatible
+interface data acquisition (DAQ) system that interfaces with IC piezoelectric
+(ICP®)/IEPE sensors. The solution provides flexible sensor interfacing to
+either piezoelectric or micro-electromechanical systems (MEMS) sensor with
+measurement capabilities that extend the frequency response to DC.
+The design provides four channels of full bandwidth, synchronized vibration
+data to the processor, where data analysis can be done locally or on a remote
+host over Ethernet via standard IIO framework. Large buffers of continuous
+data can be streamed and analyzed using standard fast Fourier transform (FFT)
 techniques for system characterization and machine learning algorithms.
 
 Supported boards
@@ -45,7 +45,7 @@ Supported carriers
      - :xilinx:`Cora Z7-07S <products/boards-and-kits/1-1qlaz7n.html>`
      - Arduino headers
    * -
-     - :intel:`De10-Nano <content/www/us/en/developer/topic-technology/edge-5g/hardware/fpga-de10-nano.html>` 
+     - :intel:`De10-Nano <content/www/us/en/developer/topic-technology/edge-5g/hardware/fpga-de10-nano.html>`
      - Arduino headers
 
 Block design
@@ -75,9 +75,9 @@ added to the base address from HDL (see more at :ref:`architecture`).
 ==================== =============== ===============
 Instance             Zynq            Cyclone V
 ==================== =============== ===============
-axi_ad77684_adc      0x44A0_0000     0x0002_8000     
-cn0579_dma           0x44A3_0000     0x0003_0000     
-axi_iic_dac*         0x44A4_0000          
+axi_ad77684_adc      0x44A0_0000     0x0002_8000
+cn0579_dma           0x44A3_0000     0x0003_0000
+axi_iic_dac*         0x44A4_0000
 ==================== =============== ===============
 
 .. admonition:: Legend
@@ -102,15 +102,15 @@ I2C connections
      - axi_iic_dac
      - 0x0C
      - AD5696R
-   * - PS** 
+   * - PS**
      - I2C1
-     - 
+     -
      - 0x0C
      - AD5696R
 
 .. admonition:: Legend
    :class: note
-   
+
    -  ``*``  only for Cora Z7-07S
    -  ``**`` only for De10-Nano
 
@@ -125,18 +125,18 @@ SPI connections
      - SPI manager instance
      - SPI subordinate
      - CS
-   * - PS* 
+   * - PS*
      - SPI 0
      - AD7786-4
      - 0
-   * - PL** 
+   * - PL**
      - SYS_SPI
      - AD7786-4
      - 0
 
 .. admonition:: Legend
    :class: note
-   
+
    -  ``*``  only for Cora Z7-07S
    -  ``**`` only for De10-Nano
 
@@ -171,14 +171,14 @@ Below are the Programmable Logic interrupts used in this project.
 ================ === ========== =========== =============== ================
 Instance name    HDL Linux Zynq Actual Zynq Linux Cyclone V Actual Cyclone V
 ================ === ========== =========== =============== ================
-cn0579_dma*      13  57         89          
-axi_iic_dac*     12  56         88          
+cn0579_dma*      13  57         89
+axi_iic_dac*     12  56         88
 cn0579_dma**     5                          45              77
 ================ === ========== =========== =============== ================
 
 .. admonition:: Legend
    :class: note
-   
+
    -  ``*``  only for Cora Z7-07S
    -  ``**`` only for De10-Nano
 
@@ -199,6 +199,7 @@ Make for CoraZ7s project:
 
 .. code-block::
    :linenos:
+
    user@analog:~$ cd hdl/projects/cn0579/coraz7s
    user@analog:~/hdl/projects/cn0579/coraz7s$ make
 
@@ -206,6 +207,7 @@ Make for De10Nano project:
 
 .. code-block::
    :linenos:
+
    user@analog:~$ cd hdl/projects/cn0579/de10nano
    user@analog:~/hdl/projects/cn0579/de10nano$ make
 
@@ -269,9 +271,9 @@ Software related
    - :git-pyadi-iio:`PyADI-IIO CN0579 class <adi/cn0579.py>`
    - :git-pyadi-iio:`PyADI-IIO CN0579 example <examples/cn0579/cn0579_example.py>`
 
--  CN0579 on Cora Z7s Linux device tree 
+-  CN0579 on Cora Z7s Linux device tree
    :git-linux:`zynq-coraz7s-cn0579_i2c.dts <arch/arm/boot/dts/zynq-coraz7s-cn0579_i2c.dts>`
--  CN0579 on De10Nano Linux device tree 
+-  CN0579 on De10Nano Linux device tree
    :git-linux:`arch/arm/boot/dts/socfpga_cyclone5_de10_nano_cn0579_i2c.dts <arch/arm/boot/dts/socfpga_cyclone5_de10_nano_cn0579_i2c.dts>`
 -  AD7768 Linux driver :git-linux:`ad7768.c <drivers/iio/adc/ad7768.c>`
 

--- a/docs/projects/cn0579/index.rst
+++ b/docs/projects/cn0579/index.rst
@@ -1,17 +1,18 @@
 .. _cn0579:
 
 CN0579 HDL project
-================================================================================
+===============================================================================
 
 Overview
 -------------------------------------------------------------------------------
 
-The :adi:`CN0579 <CN0579>` is a 4-channel, high resolution, wide bandwidth,
+The :adi:`CN0579` is a 4-channel, high resolution, wide bandwidth,
 high dynamic range, integrated electronics piezoelectric (IEPE)-compatible
 interface data acquisition (DAQ) system that interfaces with IC piezoelectric
 (ICP®)/IEPE sensors. The solution provides flexible sensor interfacing to
 either piezoelectric or micro-electromechanical systems (MEMS) sensor with
 measurement capabilities that extend the frequency response to DC.
+
 The design provides four channels of full bandwidth, synchronized vibration
 data to the processor, where data analysis can be done locally or on a remote
 host over Ethernet via standard IIO framework. Large buffers of continuous
@@ -21,7 +22,7 @@ techniques for system characterization and machine learning algorithms.
 Supported boards
 -------------------------------------------------------------------------------
 
--  :adi:`CN0579 <CN0579>`
+-  :adi:`CN0579`
 
 Supported devices
 -------------------------------------------------------------------------------
@@ -41,11 +42,11 @@ Supported carriers
    * - Evaluation board
      - Carrier
      - FMC slot
-   * - :adi:`CN0579 <CN0579>`
+   * - :adi:`CN0579`
      - :xilinx:`Cora Z7-07S <products/boards-and-kits/1-1qlaz7n.html>`
      - Arduino headers
    * -
-     - :intel:`De10-Nano <content/www/us/en/developer/topic-technology/edge-5g/hardware/fpga-de10-nano.html>`
+     - :intel:`DE10-Nano <content/www/us/en/developer/topic-technology/edge-5g/hardware/fpga-de10-nano.html>`
      - Arduino headers
 
 Block design
@@ -54,7 +55,7 @@ Block design
 The data path and clock domains are depicted in the below diagram:
 
 .. image:: cn0579_block_diagram.svg
-   :width: 1000
+   :width: 800
    :align: center
    :alt: CN0579 block diagram
 
@@ -62,9 +63,9 @@ Clock scheme
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. image:: cn0579_clock_diagram.svg
-   :width: 800
+   :width: 600
    :align: center
-   :alt: CN0579 clock scheme block diagram
+   :alt: CN0579 clock scheme
 
 CPU/Memory interconnects addresses
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -72,18 +73,18 @@ CPU/Memory interconnects addresses
 The addresses are dependent on the architecture of the FPGA, having an offset
 added to the base address from HDL (see more at :ref:`architecture`).
 
-==================== =============== ===============
-Instance             Zynq            Cyclone V
-==================== =============== ===============
-axi_ad77684_adc      0x44A0_0000     0x0002_8000
-cn0579_dma           0x44A3_0000     0x0003_0000
-axi_iic_dac*         0x44A4_0000
-==================== =============== ===============
+=============== =========== ===========
+Instance        Zynq        Cyclone V
+=============== =========== ===========
+axi_ad77684_adc 0x44A0_0000 0x0002_8000
+cn0579_dma      0x44A3_0000 0x0003_0000
+axi_iic_dac*    0x44A4_0000 ---
+=============== =========== ===========
 
 .. admonition:: Legend
    :class: note
 
-   -  ``*``  instantiated only for Cora Z7-07S
+    ``*`` instantiated only for Cora Z7-07S
 
 I2C connections
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -111,8 +112,8 @@ I2C connections
 .. admonition:: Legend
    :class: note
 
-   -  ``*``  only for Cora Z7-07S
-   -  ``**`` only for De10-Nano
+   -  ``*`` only for Cora Z7-07S
+   -  ``**`` only for DE10-Nano
 
 SPI connections
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -138,7 +139,7 @@ SPI connections
    :class: note
 
    -  ``*`` only for Cora Z7-07S
-   -  ``**`` only for De10-Nano
+   -  ``**`` only for DE10-Nano
 
 GPIOs
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -168,19 +169,19 @@ Interrupts
 
 Below are the Programmable Logic interrupts used in this project.
 
-================ === ========== =========== =============== ================
-Instance name    HDL Linux Zynq Actual Zynq Linux Cyclone V Actual Cyclone V
-================ === ========== =========== =============== ================
-cn0579_dma*      13  57         89
-axi_iic_dac*     12  56         88
-cn0579_dma**     5                          45              77
-================ === ========== =========== =============== ================
+============= === ========== =========== =============== ================
+Instance name HDL Linux Zynq Actual Zynq Linux Cyclone V Actual Cyclone V
+============= === ========== =========== =============== ================
+cn0579_dma*   13  57         89          ---             ---
+axi_iic_dac*  12  56         88          ---             ---
+cn0579_dma**  5   ---        ---         45              77
+============= === ========== =========== =============== ================
 
 .. admonition:: Legend
    :class: note
 
    -  ``*`` only for Cora Z7-07S
-   -  ``**`` only for De10-Nano
+   -  ``**`` only for DE10-Nano
 
 Building the HDL project
 -------------------------------------------------------------------------------
@@ -195,17 +196,17 @@ the HDL repository, and then build the project as follows:
 
 **Linux/Cygwin/WSL**
 
-Make for CoraZ7s project:
+Building the CoraZ7S project:
 
-.. code-block::
+.. code-block:: bash
    :linenos:
 
    user@analog:~$ cd hdl/projects/cn0579/coraz7s
    user@analog:~/hdl/projects/cn0579/coraz7s$ make
 
-Make for De10Nano project:
+Building the DE-10Nano project:
 
-.. code-block::
+.. code-block:: bash
    :linenos:
 
    user@analog:~$ cd hdl/projects/cn0579/de10nano
@@ -220,7 +221,7 @@ Systems related
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 -  :dokuwiki:`[Wiki] EVAL-CN0579-ARDZ User Guide </resources/eval/user-guides/circuits-from-the-lab/cn0579>`
--  :adi:`Circuit Note CN-0579 <media/en/reference-design-documentation/reference-designs/cn0579.pdf>`
+-  :adi:`Circuit Note CN0579 <media/en/reference-design-documentation/reference-designs/cn0579.pdf>`
 
 Hardware related
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -261,7 +262,7 @@ HDL related
      - :ref:`here <util_cpack2>`
 
 Software related
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 -  :dokuwiki:`[Wiki] AD7768 IIO Precision ADC Linux Driver <resources/tools-software/linux-drivers/iio-adc/ad7768>`
 
@@ -272,9 +273,9 @@ Software related
    - :git-pyadi-iio:`PyADI-IIO CN0579 example <examples/cn0579/cn0579_example.py>`
 
 -  CN0579 on Cora Z7s Linux device tree
-   :git-linux:`zynq-coraz7s-cn0579_i2c.dts <arch/arm/boot/dts/zynq-coraz7s-cn0579_i2c.dts>`
--  CN0579 on De10Nano Linux device tree
-   :git-linux:`arch/arm/boot/dts/socfpga_cyclone5_de10_nano_cn0579_i2c.dts <arch/arm/boot/dts/socfpga_cyclone5_de10_nano_cn0579_i2c.dts>`
+   :git-linux:`arch/arm/boot/dts/zynq-coraz7s-cn0579_i2c.dts`
+-  CN0579 on DE-10Nano Linux device tree
+   :git-linux:`arch/arm/boot/dts/socfpga_cyclone5_de10_nano_cn0579_i2c.dts`
 -  AD7768 Linux driver :git-linux:`ad7768.c <drivers/iio/adc/ad7768.c>`
 
 .. include:: ../common/more_information.rst

--- a/docs/projects/cn0579/index.rst
+++ b/docs/projects/cn0579/index.rst
@@ -6,7 +6,7 @@ CN0579 HDL project
 Overview
 -------------------------------------------------------------------------------
 
-The :adi:`CN0579 <CN0579>`  is a 4-channel, high resolution, wide bandwidth,
+The :adi:`CN0579 <CN0579>` is a 4-channel, high resolution, wide bandwidth,
 high dynamic range, integrated electronics piezoelectric (IEPE)-compatible
 interface data acquisition (DAQ) system that interfaces with IC piezoelectric
 (ICP®)/IEPE sensors. The solution provides flexible sensor interfacing to
@@ -137,7 +137,7 @@ SPI connections
 .. admonition:: Legend
    :class: note
 
-   -  ``*``  only for Cora Z7-07S
+   -  ``*`` only for Cora Z7-07S
    -  ``**`` only for De10-Nano
 
 GPIOs
@@ -179,7 +179,7 @@ cn0579_dma**     5                          45              77
 .. admonition:: Legend
    :class: note
 
-   -  ``*``  only for Cora Z7-07S
+   -  ``*`` only for Cora Z7-07S
    -  ``**`` only for De10-Nano
 
 Building the HDL project


### PR DESCRIPTION
## PR Description

The code blocks that describe the make process needed an extra newline for correct rendering and all the unnecessary whitespaces were deleted.


## PR Type
- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the code style guidelines
- [x] I have performed a self-review of changes
- [ ] I have compiled all hdl projects and libraries affected by this PR
- [ ] I have tested in hardware affected projects, at least on relevant boards
- [ ] I have commented my code, at least hard-to-understand parts
- [x] I have signed off all commits from this PR
- [x] I have updated the documentation (wiki pages, ReadMe files, Copyright etc)
- [x] I have not introduced new Warnings/Critical Warnings on compilation
- [ ] I have added new hdl testbenches or updated existing ones
