### PR TITLE
axi_tdd: Update to version 2.0.b

### DIFF
--- a/docs/library/axi_tdd/index.rst
+++ b/docs/library/axi_tdd/index.rst
@@ -138,7 +138,7 @@ can all be active at the same time.
 The external synchronization capability allows the alignment of frames between
 multiple devices in different locations, for example using a GPSDO 1 PPS output.
 The internal sync signal is generated based on a dedicated counter, when its
-value matches the one defined in ``SYNC_COUNTER_LOW`` / ``SYNC_COUNTER_HIGH``.
+value matches the one defined in ``SYNC_PERIOD_LOW`` / ``SYNC_PERIOD_HIGH``.
 The software generated sync pulse is triggered at an arbitrary point in time
 when writing a ‘1’ value in ``SYNC_SOFT``.
 
@@ -166,8 +166,8 @@ The following registers will not be updated unless the peripheral is disabled:
 - ``STARTUP_DELAY``
 - ``FRAME_LENGTH``
 - ``CHANNEL_POLARITY``
-- ``SYNC_COUNTER_LOW``
-- ``SYNC_COUNTER_HIGH``
+- ``SYNC_PERIOD_LOW``
+- ``SYNC_PERIOD_HIGH``
 - ``CHX_ON``
 - ``CHX_OFF``
 

--- a/docs/regmap/adi_regmap_tdd_gen.txt
+++ b/docs/regmap/adi_regmap_tdd_gen.txt
@@ -9,7 +9,7 @@ ENDTITLE
 REG
 0x0000
 VERSION
-Version of the peripheral. Follows semantic versioning. Current version 2.00.61.
+Version of the peripheral. Follows semantic versioning. Current version 2.00.62.
 ENDREG
 
 FIELD
@@ -25,7 +25,7 @@ R
 ENDFIELD
 
 FIELD
-[7:0] 0x00000061
+[7:0] 0x00000062
 VERSION_PATCH
 R
 ENDFIELD
@@ -252,7 +252,7 @@ FIELD
 [31:0] 0x00000000
 STARTUP_DELAY
 RW
-The initial delay value before the beginning of the first frame; defined in clock cycles.
+The initial delay value before the beginning of the first frame; defined in clock cycles-1.
 ENDFIELD
 
 ############################################################################################
@@ -268,7 +268,7 @@ FIELD
 [31:0] 0x00000000
 FRAME_LENGTH
 RW
-The length of the transmission frame; defined in clock cycles.
+The length of the transmission frame; defined in clock cycles-1.
 ENDFIELD
 
 ############################################################################################
@@ -276,15 +276,15 @@ ENDFIELD
 
 REG
 0x0016
-SYNC_COUNTER_LOW
+SYNC_PERIOD_LOW
 TDD Sync counter
 ENDREG
 
 FIELD
 [31:0] 0x00000000
-SYNC_COUNTER_LOW
+SYNC_PERIOD_LOW
 RW
-The LSB slice of the offset (from sync counter equal zero) when an internal sync pulse is generated. This register is implemented if ''SYNC_COUNT_WIDTH''>0.
+The LSB slice of the internal sync pulse period defined in clock cycles-1. This register is implemented if ''SYNC_COUNT_WIDTH''>0.
 ENDFIELD
 
 ############################################################################################
@@ -292,15 +292,15 @@ ENDFIELD
  
 REG
 0x0017
-SYNC_COUNTER_HIGH
+SYNC_PERIOD_HIGH
 TDD Sync counter
 ENDREG
 
 FIELD
 [31:0] 0x00000000
-SYNC_COUNTER_HIGH
+SYNC_PERIOD_HIGH
 RW
-The MSB slice of the offset (from sync counter equal zero) when an internal sync pulse is generated. This register is implemented if ''SYNC_COUNT_WIDTH''>32.
+The MSB slice of the internal sync pulse period defined in clock cycles-1. This register is implemented if ''SYNC_COUNT_WIDTH''>32.
 ENDFIELD
 
 ############################################################################################

--- a/library/axi_tdd/axi_tdd_channel.sv
+++ b/library/axi_tdd/axi_tdd_channel.sv
@@ -1,6 +1,6 @@
 // ***************************************************************************
 // ***************************************************************************
-// Copyright (C) 2022-2023 Analog Devices, Inc. All rights reserved.
+// Copyright (C) 2022-2024 Analog Devices, Inc. All rights reserved.
 //
 // In this HDL repository, there are many different and unique modules, consisting
 // of various HDL (Verilog or VHDL) components. The individual modules are
@@ -140,7 +140,7 @@ module axi_tdd_channel #(
     if (resetn == 1'b0) begin
       tdd_ch_rst <= 1'b0;
     end else begin
-      if (((tdd_cstate == RUNNING) && (tdd_counter == t_low)) || (tdd_endof_frame == 1'b1)) begin
+      if ((tdd_cstate == RUNNING) && (tdd_counter == t_low)) begin
         tdd_ch_rst <= 1'b1;
       end else begin
         tdd_ch_rst <= 1'b0;
@@ -158,8 +158,6 @@ module axi_tdd_channel #(
       end else begin
         if (tdd_ch_set == 1'b1) begin
           out <= ~ch_pol;
-        end else begin
-          out <= out;
         end
       end
     end

--- a/library/axi_tdd/axi_tdd_pkg.sv
+++ b/library/axi_tdd/axi_tdd_pkg.sv
@@ -1,6 +1,6 @@
 // ***************************************************************************
 // ***************************************************************************
-// Copyright (C) 2022-2023 Analog Devices, Inc. All rights reserved.
+// Copyright (C) 2022-2024 Analog Devices, Inc. All rights reserved.
 //
 // In this HDL repository, there are many different and unique modules, consisting
 // of various HDL (Verilog or VHDL) components. The individual modules are
@@ -42,7 +42,7 @@ package axi_tdd_pkg;
     RUNNING = 2'b11} state_t;
 
   localparam
-    PCORE_VERSION = 32'h00020061,
+    PCORE_VERSION = 32'h00020062,
     PCORE_MAGIC   = 32'h5444444E; // "TDDN", big endian
 
   // register address offset


### PR DESCRIPTION
This patch contains the following updates:
* Remove channel reset at the end of frame
* Fix initial delay length when STARTUP_DELAY = 1
* Rename 'SYNC_COUNTER' registers to 'SYNC_PERIOD'
* Update description for: STARTUP_DELAY, FRAME_LENGTH, SYNC_PERIOD

## PR Type
- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the code style guidelines
- [x] I have performed a self-review of changes
- [x] I have compiled all hdl projects and libraries affected by this PR
- [x] I have tested in hardware affected projects, at least on relevant boards
- [ ] I have commented my code, at least hard-to-understand parts
- [x] I have signed off all commits from this PR
- [x] I have updated the documentation (wiki pages, ReadMe files, Copyright etc)
- [x] I have not introduced new Warnings/Critical Warnings on compilation
- [ ] I have added new hdl testbenches or updated existing ones
