### PR TITLE
Updates stingray next stable

### DIFF
--- a/library/axi_dmac/data_mover.v
+++ b/library/axi_dmac/data_mover.v
@@ -96,13 +96,10 @@ module data_mover #(
   reg active = 1'b0;
   reg last_eot = 1'b0;
   reg last_non_eot = 1'b0;
-
   reg needs_sync = 1'b0;
-  wire has_sync = ~needs_sync | s_axi_sync;
 
-  wire s_axi_sync_valid = has_sync & s_axi_valid;
+  wire has_sync;
   wire transfer_abort_s;
-
   wire last_load;
   wire last;
   wire early_tlast;
@@ -110,14 +107,14 @@ module data_mover #(
   assign xfer_req = active;
 
   assign response_id = id;
-
   assign source_id = id;
   assign source_eot = eot || early_tlast;
-
   assign last = eot ? last_eot : last_non_eot;
 
+  assign has_sync = ~needs_sync | s_axi_sync;
+
   assign s_axi_ready = (pending_burst & active) & ~transfer_abort_s & has_sync;
-  assign m_axi_valid = s_axi_sync_valid & s_axi_ready;
+  assign m_axi_valid = s_axi_valid & s_axi_ready;
   assign m_axi_data = s_axi_data;
   assign m_axi_last = last || early_tlast;
   assign m_axi_partial_burst = early_tlast;

--- a/library/axi_dmac/data_mover.v
+++ b/library/axi_dmac/data_mover.v
@@ -1,6 +1,6 @@
 // ***************************************************************************
 // ***************************************************************************
-// Copyright (C) 2014-2023 Analog Devices, Inc. All rights reserved.
+// Copyright (C) 2014-2024 Analog Devices, Inc. All rights reserved.
 //
 // In this HDL repository, there are many different and unique modules, consisting
 // of various HDL (Verilog or VHDL) components. The individual modules are
@@ -116,7 +116,7 @@ module data_mover #(
 
   assign last = eot ? last_eot : last_non_eot;
 
-  assign s_axi_ready = (pending_burst & active) & ~transfer_abort_s;
+  assign s_axi_ready = (pending_burst & active) & ~transfer_abort_s & has_sync;
   assign m_axi_valid = s_axi_sync_valid & s_axi_ready;
   assign m_axi_data = s_axi_data;
   assign m_axi_last = last || early_tlast;

--- a/projects/ad9081_fmca_ebz_x_band/zcu102/system_bd.tcl
+++ b/projects/ad9081_fmca_ebz_x_band/zcu102/system_bd.tcl
@@ -1,5 +1,5 @@
 ###############################################################################
-## Copyright (C) 2022-2023 Analog Devices, Inc. All rights reserved.
+## Copyright (C) 2022-2024 Analog Devices, Inc. All rights reserved.
 ### SPDX short identifier: ADIBSD
 ###############################################################################
 
@@ -157,6 +157,8 @@ ad_cpu_interrupt ps-9 mb-7 axi_spi_fmc/ip2intc_irpt
 
 ad_cpu_interconnect 0x45300000 axi_spi_fmc
 
+# changes on the AD9081 block design
+
 # Connect TDD
 create_bd_port -dir I tdd_sync
 create_bd_port -dir O tdd_enabled
@@ -166,8 +168,48 @@ create_bd_port -dir O tdd_tx_stingray_en
 
 set tdd_sync_in_net [get_bd_nets -of_objects [find_bd_objs -relation connected_to [get_bd_pins axi_tdd_0/sync_in]]]
 set tdd_sync_in_pin [get_bd_pins axi_tdd_0/sync_in]
-ad_disconnect $tdd_sync_in_net $tdd_sync_in_pin
+
+set adc_do_m_axis_clk_net [get_bd_nets -of_objects [find_bd_objs -relation connected_to [get_bd_pins $adc_data_offload_name/m_axis_aclk]]]
+set adc_do_m_axis_clk_pin [get_bd_pins $adc_data_offload_name/m_axis_aclk]
+
+set adc_dma_s_axis_clk_net [get_bd_nets -of_objects [find_bd_objs -relation connected_to [get_bd_pins axi_mxfe_rx_dma/s_axis_aclk]]]
+set adc_dma_s_axis_clk_pin [get_bd_pins axi_mxfe_rx_dma/s_axis_aclk]
+
+set adc_do_m_axis_rst_net [get_bd_nets -of_objects [find_bd_objs -relation connected_to [get_bd_pins $adc_data_offload_name/m_axis_aresetn]]]
+set adc_do_m_axis_rst_pin [get_bd_pins $adc_data_offload_name/m_axis_aresetn]
+
+set adc_dma_m_dest_rst_net [get_bd_nets -of_objects [find_bd_objs -relation connected_to [get_bd_pins axi_mxfe_rx_dma/m_dest_axi_aresetn]]]
+set adc_dma_m_dest_rst_pin [get_bd_pins axi_mxfe_rx_dma/m_dest_axi_aresetn]
+
+set hp1_fdp_aclk_net [get_bd_nets -of_objects [find_bd_objs -relation connected_to [get_bd_pins sys_ps8/saxihp1_fpd_aclk]]]
+set hp1_fdp_aclk_pin [get_bd_pins sys_ps8/saxihp1_fpd_aclk]
+
+set axi_hp1_interconnect_aclk_net [get_bd_nets -of_objects [find_bd_objs -relation connected_to [get_bd_pins axi_hp1_interconnect/aclk]]]
+set axi_hp1_interconnect_aclk_pin [get_bd_pins axi_hp1_interconnect/aclk]
+
+ad_disconnect $hp1_fdp_aclk_net              $hp1_fdp_aclk_pin
+ad_disconnect $tdd_sync_in_net               $tdd_sync_in_pin
+ad_disconnect $adc_do_m_axis_clk_net         $adc_do_m_axis_clk_pin
+ad_disconnect $adc_dma_s_axis_clk_net        $adc_dma_s_axis_clk_pin
+ad_disconnect $adc_do_m_axis_rst_net         $adc_do_m_axis_rst_pin
+ad_disconnect $adc_dma_m_dest_rst_net        $adc_dma_m_dest_rst_pin
+ad_disconnect $axi_hp1_interconnect_aclk_net $axi_hp1_interconnect_aclk_pin
+
+ad_ip_parameter axi_hp1_interconnect CONFIG.NUM_CLKS 1
+
+ad_connect  rx_device_clk  $adc_data_offload_name/m_axis_aclk
+ad_connect  rx_device_clk  axi_mxfe_rx_dma/s_axis_aclk
+ad_connect  $sys_dma_clk   sys_ps8/saxihp1_fpd_aclk
+ad_connect  $sys_dma_clk   axi_hp1_interconnect/aclk
+
+ad_connect  rx_device_clk_rstgen/peripheral_aresetn $adc_data_offload_name/m_axis_aresetn
+ad_connect  rx_device_clk_rstgen/peripheral_aresetn axi_mxfe_rx_dma/m_dest_axi_aresetn
+
+ad_ip_parameter axi_mxfe_rx_dma CONFIG.SYNC_TRANSFER_START 1
+ad_ip_parameter axi_mxfe_rx_dma CONFIG.DMA_LENGTH_WIDTH 30
+
 ad_connect axi_tdd_0/sync_in tdd_sync
+ad_connect axi_tdd_0/tdd_channel_1 axi_mxfe_rx_dma/s_axis_user
 ad_connect axi_tdd_0/tdd_channel_2 tdd_enabled
 ad_connect axi_tdd_0/tdd_channel_3 tdd_rx_mxfe_en
 ad_connect axi_tdd_0/tdd_channel_4 tdd_tx_mxfe_en

--- a/projects/ad9081_fmca_ebz_x_band/zcu102/system_bd.tcl
+++ b/projects/ad9081_fmca_ebz_x_band/zcu102/system_bd.tcl
@@ -178,9 +178,6 @@ set adc_dma_s_axis_clk_pin [get_bd_pins axi_mxfe_rx_dma/s_axis_aclk]
 set adc_do_m_axis_rst_net [get_bd_nets -of_objects [find_bd_objs -relation connected_to [get_bd_pins $adc_data_offload_name/m_axis_aresetn]]]
 set adc_do_m_axis_rst_pin [get_bd_pins $adc_data_offload_name/m_axis_aresetn]
 
-set adc_dma_m_dest_rst_net [get_bd_nets -of_objects [find_bd_objs -relation connected_to [get_bd_pins axi_mxfe_rx_dma/m_dest_axi_aresetn]]]
-set adc_dma_m_dest_rst_pin [get_bd_pins axi_mxfe_rx_dma/m_dest_axi_aresetn]
-
 set hp1_fdp_aclk_net [get_bd_nets -of_objects [find_bd_objs -relation connected_to [get_bd_pins sys_ps8/saxihp1_fpd_aclk]]]
 set hp1_fdp_aclk_pin [get_bd_pins sys_ps8/saxihp1_fpd_aclk]
 
@@ -192,7 +189,6 @@ ad_disconnect $tdd_sync_in_net               $tdd_sync_in_pin
 ad_disconnect $adc_do_m_axis_clk_net         $adc_do_m_axis_clk_pin
 ad_disconnect $adc_dma_s_axis_clk_net        $adc_dma_s_axis_clk_pin
 ad_disconnect $adc_do_m_axis_rst_net         $adc_do_m_axis_rst_pin
-ad_disconnect $adc_dma_m_dest_rst_net        $adc_dma_m_dest_rst_pin
 ad_disconnect $axi_hp1_interconnect_aclk_net $axi_hp1_interconnect_aclk_pin
 
 ad_ip_parameter axi_hp1_interconnect CONFIG.NUM_CLKS 1
@@ -203,7 +199,6 @@ ad_connect  $sys_dma_clk   sys_ps8/saxihp1_fpd_aclk
 ad_connect  $sys_dma_clk   axi_hp1_interconnect/aclk
 
 ad_connect  rx_device_clk_rstgen/peripheral_aresetn $adc_data_offload_name/m_axis_aresetn
-ad_connect  rx_device_clk_rstgen/peripheral_aresetn axi_mxfe_rx_dma/m_dest_axi_aresetn
 
 ad_ip_parameter axi_mxfe_rx_dma CONFIG.SYNC_TRANSFER_START 1
 ad_ip_parameter axi_mxfe_rx_dma CONFIG.DMA_LENGTH_WIDTH 30


### PR DESCRIPTION
## PR Description

This commit changes the following:
- The RX TDD sync can be performed through both the DO and DMAC.
- The clock domain crossing is performed in the DMA instead of the DO.
- The RX DMA length width was increased to allow large buffer captures.
- The DMAC s_axi_ready signal is gated with has_sync.

## PR Type
- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the code style guidelines
- [x] I have performed a self-review of changes
- [ ] I have compiled all hdl projects and libraries affected by this PR
- [x] I have tested in hardware affected projects, at least on relevant boards
- [ ] I have commented my code, at least hard-to-understand parts
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe files, Copyright etc)
- [x] I have not introduced new Warnings/Critical Warnings on compilation
- [ ] I have added new hdl testbenches or updated existing ones
