### PR TITLE
library/axi_ltc2387/axi_ltc2387.v: Fix default value for parameters

### DIFF
--- a/library/axi_ltc2387/axi_ltc2387.v
+++ b/library/axi_ltc2387/axi_ltc2387.v
@@ -1,6 +1,6 @@
 // ***************************************************************************
 // ***************************************************************************
-// Copyright (C) 2022-2023 Analog Devices, Inc. All rights reserved.
+// Copyright (C) 2022-2024 Analog Devices, Inc. All rights reserved.
 //
 // In this HDL repository, there are many different and unique modules, consisting
 // of various HDL (Verilog or VHDL) components. The individual modules are
@@ -48,8 +48,8 @@ module axi_ltc2387 #(
   parameter USERPORTS_DISABLE = 0,
   parameter DATAFORMAT_DISABLE = 0,
   parameter ADC_INIT_DELAY = 22,
-  parameter ADC_RES = 16,
-  parameter OUT_RES = 16,
+  parameter ADC_RES = 18, // 18-bit or 16-bit resolution
+  parameter OUT_RES = 32, // 32-bit for ADC_RES=18 or 16-bit for ADC_RES=16
   parameter TWOLANES = 1
 ) (
   input                     delay_clk,


### PR DESCRIPTION
## PR Description

Fixed the default value for the parameters. This way it removes Critical Warnings from the project CN0577/Zed. 
It should actually be ADC_RES=18 and OUT_RES=32.

Tested in hardware with Linux, but not with what's latest on main. That is because there were some changes done in the past month, which affected the functionality of this project.
I tested with the HEAD being at analogdevicesinc/linux@55546255ca63ded5c86f0040801cafa15459a2a8 (the commit right before the changes) and it works as expected.

## PR Type
- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the code style guidelines
- [x] I have performed a self-review of changes
- [x] I have compiled all hdl projects and libraries affected by this PR
- [x] I have tested in hardware affected projects, at least on relevant boards
- [x] I have commented my code, at least hard-to-understand parts
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe files, Copyright etc)
- [x] I have not introduced new Warnings/Critical Warnings on compilation
- [ ] I have added new hdl testbenches or updated existing ones
