### PR TITLE
library/scripts: Fix FPGA_TECHNOLOGY for VCU118

### DIFF
--- a/library/scripts/adi_xilinx_device_info_enc.tcl
+++ b/library/scripts/adi_xilinx_device_info_enc.tcl
@@ -116,7 +116,8 @@ proc adi_device_spec {cellpath param} {
       FPGA_TECHNOLOGY {
           switch  -regexp -- $part {
              ^xc7          {set series_name 7series}
-             ^xc[zv]u      {set series_name ultrascale+}
+             ^xczu         {set series_name ultrascale+}
+             ^xcvu.?.p    {set series_name ultrascale+}
              ^x.zu..?p     {set series_name ultrascale+}
              ^xck26        {set series_name ultrascale+}
              ^xc.u         {set series_name ultrascale }

--- a/library/scripts/adi_xilinx_device_info_enc.tcl
+++ b/library/scripts/adi_xilinx_device_info_enc.tcl
@@ -117,7 +117,7 @@ proc adi_device_spec {cellpath param} {
           switch  -regexp -- $part {
              ^xc7          {set series_name 7series}
              ^xczu         {set series_name ultrascale+}
-             ^xcvu.?.p    {set series_name ultrascale+}
+             ^xcvu.?.p     {set series_name ultrascale+}
              ^x.zu..?p     {set series_name ultrascale+}
              ^xck26        {set series_name ultrascale+}
              ^xc.u         {set series_name ultrascale }

--- a/library/scripts/adi_xilinx_device_info_enc.tcl
+++ b/library/scripts/adi_xilinx_device_info_enc.tcl
@@ -1,5 +1,5 @@
 ###############################################################################
-## Copyright (C) 2019-2023 Analog Devices, Inc. All rights reserved.
+## Copyright (C) 2019-2024 Analog Devices, Inc. All rights reserved.
 ### SPDX short identifier: ADIBSD
 ###############################################################################
 
@@ -116,7 +116,7 @@ proc adi_device_spec {cellpath param} {
       FPGA_TECHNOLOGY {
           switch  -regexp -- $part {
              ^xc7          {set series_name 7series}
-             ^xczu         {set series_name ultrascale+}
+             ^xc[zv]u      {set series_name ultrascale+}
              ^x.zu..?p     {set series_name ultrascale+}
              ^xck26        {set series_name ultrascale+}
              ^xc.u         {set series_name ultrascale }


### PR DESCRIPTION
## PR Description

The FPGA_TECHNOLOGY was identified as Ultrascale for VCU118 and it should be Ultrascale+.

## PR Type
- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the code style guidelines
- [x] I have performed a self-review of changes
- [ ] I have compiled all hdl projects and libraries affected by this PR
- [ ] I have tested in hardware affected projects, at least on relevant boards
- [ ] I have commented my code, at least hard-to-understand parts
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe files, Copyright etc)
- [x] I have not introduced new Warnings/Critical Warnings on compilation
- [ ] I have added new hdl testbenches or updated existing ones
