### PR TITLE
SPI Engine: execution improvements

### DIFF
--- a/docs/regmap/adi_regmap_spi_engine.txt
+++ b/docs/regmap/adi_regmap_spi_engine.txt
@@ -9,7 +9,7 @@ ENDTITLE
 REG
 0x00
 VERSION
-Version of the peripheral. Follows semantic versioning. Current version 1.03.00.
+Version of the peripheral. Follows semantic versioning. Current version 1.03.01.
 ENDREG
 
 FIELD
@@ -25,7 +25,7 @@ RO
 ENDFIELD
 
 FIELD
-[7:0] 0x00000000
+[7:0] 0x00000001
 VERSION_PATCH
 RO
 ENDFIELD

--- a/library/spi_engine/axi_spi_engine/axi_spi_engine.v
+++ b/library/spi_engine/axi_spi_engine/axi_spi_engine.v
@@ -133,7 +133,7 @@ module axi_spi_engine #(
   input [7:0] offload_sync_data
 );
 
-  localparam PCORE_VERSION = 'h010300;
+  localparam PCORE_VERSION = 'h010301;
   localparam S_AXI = 0;
   localparam UP_FIFO = 1;
 

--- a/library/spi_engine/spi_engine_execution/Makefile
+++ b/library/spi_engine/spi_engine_execution/Makefile
@@ -7,6 +7,7 @@
 LIBRARY_NAME := spi_engine_execution
 
 GENERIC_DEPS += spi_engine_execution.v
+GENERIC_DEPS += spi_engine_execution_shiftreg.v
 
 XILINX_DEPS += spi_engine_execution_constr.ttcl
 XILINX_DEPS += spi_engine_execution_ip.tcl

--- a/library/spi_engine/spi_engine_execution/spi_engine_execution.v
+++ b/library/spi_engine/spi_engine_execution/spi_engine_execution.v
@@ -56,11 +56,11 @@ module spi_engine_execution #(
   input [15:0] cmd,
 
   input sdo_data_valid,
-  output reg sdo_data_ready,
+  output sdo_data_ready,
   input [(DATA_WIDTH-1):0] sdo_data,
 
   input sdi_data_ready,
-  output reg sdi_data_valid,
+  output sdi_data_valid,
   output [(NUM_OF_SDI * DATA_WIDTH)-1:0] sdi_data,
 
   input sync_ready,
@@ -124,8 +124,6 @@ module spi_engine_execution #(
   reg [7:0] left_aligned = 8'b0;
   wire end_of_word;
 
-  reg [7:0] sdi_counter = 8'b0;
-
   assign first_bit = ((bit_counter == 'h0) ||  (bit_counter == word_length));
 
   reg [15:0] cmd_d1;
@@ -139,10 +137,6 @@ module spi_engine_execution #(
 
   reg sdo_enabled = 1'b0;
   reg sdi_enabled = 1'b0;
-
-  reg [(DATA_WIDTH-1):0] data_sdo_shift = 'h0;
-
-  reg [SDI_DELAY+1:0] trigger_rx_d = {(SDI_DELAY+2){1'b0}};
 
   wire [2:0] inst = cmd[14:12];
   wire [2:0] inst_d1 = cmd_d1[14:12];
@@ -166,12 +160,42 @@ module spi_engine_execution #(
 
   wire io_ready1;
   wire io_ready2;
-  wire trigger_rx_s;
 
-  wire last_sdi_bit;
   wire end_of_sdi_latch;
 
   (* direct_enable = "yes" *) wire cs_gen;
+
+  spi_engine_execution_shiftreg #(
+    .DEFAULT_SPI_CFG(DEFAULT_SPI_CFG),
+    .DATA_WIDTH(DATA_WIDTH),                   // Valid data widths values are 8/16/24/32
+    .NUM_OF_SDI(NUM_OF_SDI),
+    .SDI_DELAY(SDI_DELAY),
+    .ECHO_SCLK(ECHO_SCLK),
+    .CMD_TRANSFER(CMD_TRANSFER)
+  ) shiftreg (
+    .clk(clk),
+    .resetn(resetn),
+    .sdi(sdi),
+    .sdo_int(sdo_int_s),
+    .echo_sclk(echo_sclk),
+    .sdo_data(sdo_data),
+    .sdo_data_valid(sdo_data_valid),
+    .sdo_data_ready(sdo_data_ready),
+    .sdi_data(sdi_data),
+    .sdi_data_valid(sdi_data_valid),
+    .sdi_data_ready(sdi_data_ready),
+    .sdo_enabled(sdo_enabled),
+    .sdi_enabled(sdi_enabled),
+    .current_instr(inst_d1),
+    .sdo_idle_state(sdo_idle_state),
+    .left_aligned(left_aligned),
+    .word_length(word_length),
+    .transfer_active(transfer_active),
+    .trigger_tx(trigger_tx),
+    .trigger_rx(trigger_rx),
+    .first_bit(first_bit),
+    .cs_activate(cs_activate),
+    .end_of_sdi_latch(end_of_sdi_latch));
 
   assign cs_gen = inst_d1 == CMD_CHIPSELECT
                   && ((cs_sleep_counter_compare == 1'b1) || cs_sleep_early_exit)
@@ -355,15 +379,6 @@ module spi_engine_execution #(
 
   assign sync = cmd_d1[7:0];
 
-  always @(posedge clk) begin
-    if (resetn == 1'b0)
-      sdo_data_ready <= 1'b0;
-    else if (sdo_enabled == 1'b1 && first_bit == 1'b1 && trigger_tx == 1'b1 && transfer_active == 1'b1)
-      sdo_data_ready <= 1'b1;
-    else if (sdo_data_valid == 1'b1)
-      sdo_data_ready <= 1'b0;
-  end
-
   assign io_ready1 = (sdi_data_valid == 1'b0 || sdi_data_ready == 1'b1) &&
           (sdo_enabled == 1'b0 || last_transfer == 1'b1 || sdo_data_valid == 1'b1);
   assign io_ready2 = (sdi_enabled == 1'b0 || sdi_data_ready == 1'b1) &&
@@ -412,42 +427,6 @@ module spi_engine_execution #(
     end
   end
 
-  // Load the SDO parallel data into the SDO shift register. In case of a custom
-  // data width, additional bit shifting must done at load.
-  always @(posedge clk) begin
-    if (!sdo_enabled || (inst_d1 != CMD_TRANSFER)) begin
-      data_sdo_shift <= {DATA_WIDTH{sdo_idle_state}};
-    end else if (transfer_active == 1'b1 && trigger_tx == 1'b1) begin
-      if (first_bit == 1'b1)
-        data_sdo_shift <= sdo_data << left_aligned;
-      else
-        data_sdo_shift <= {data_sdo_shift[(DATA_WIDTH-2):0], 1'b0};
-    end
-  end
-
-  assign sdo_int_s = data_sdo_shift[DATA_WIDTH-1];
-
-  // In case of an interface with high clock rate (SCLK > 50MHz), the latch of
-  // the SDI line can be delayed with 1, 2 or 3 SPI core clock cycle.
-  // Taking the fact that in high SCLK frequencies the pre-scaler most likely will
-  // be set to 0, to reduce the core clock's speed, this delay will mean that SDI will
-  // be latched at one of the next consecutive SCLK edge.
-
-  always @(posedge clk) begin
-    trigger_rx_d <= {trigger_rx_d, trigger_rx};
-  end
-
-  assign trigger_rx_s = trigger_rx_d[SDI_DELAY+1];
-
-  // Load the serial data into SDI shift register(s), then link it to the output
-  // register of the module
-  // NOTE: ECHO_SCLK mode can be used when the SCLK line is looped back to the FPGA
-  // through an other level shifter, in order to remove the round-trip timing delays
-  // introduced by the level shifters. This can improve the timing significantly
-  // on higher SCLK rates. Devices like ad4630 have an echod SCLK, which can be
-  // used to latch the MISO lines, improving the overall timing margin of the
-  // interface.
-
   always @(posedge clk) begin
     if (!resetn) begin // set cs_activate during reset for a cycle to clear shift reg
       cs_activate <= 1;
@@ -455,175 +434,6 @@ module spi_engine_execution #(
       cs_activate <= ~(&cmd_d1[NUM_OF_CS-1:0]) & cs_gen;
     end
   end
-
-  genvar i;
-
-  // NOTE: SPI configuration (CPOL/PHA) is only hardware configurable at this point
-  generate
-  if (ECHO_SCLK == 1) begin : g_echo_sclk_miso_latch
-
-    reg [7:0] sdi_counter_d = 8'b0;
-    reg [7:0] sdi_transfer_counter = 8'b0;
-    reg [7:0] num_of_transfers = 8'b0;
-    reg [(NUM_OF_SDI * DATA_WIDTH)-1:0] sdi_data_latch = {(NUM_OF_SDI * DATA_WIDTH){1'b0}};
-
-    if ((DEFAULT_SPI_CFG[1:0] == 2'b01) || (DEFAULT_SPI_CFG[1:0] == 2'b10)) begin : g_echo_miso_nshift_reg
-
-      // MISO shift register runs on negative echo_sclk
-      for (i=0; i<NUM_OF_SDI; i=i+1) begin: g_sdi_shift_reg
-        reg [DATA_WIDTH-1:0] data_sdi_shift;
-
-        always @(negedge echo_sclk or posedge cs_activate) begin
-          if (cs_activate) begin
-            data_sdi_shift <= 0;
-          end else begin
-            data_sdi_shift <= {data_sdi_shift, sdi[i]};
-          end
-        end
-
-        // intended LATCH
-        always @(negedge echo_sclk) begin
-          if (last_sdi_bit)
-            sdi_data_latch[i*DATA_WIDTH+:DATA_WIDTH] <= {data_sdi_shift, sdi[i]};
-        end
-
-      end
-
-      always @(posedge echo_sclk or posedge cs_activate) begin
-        if (cs_activate) begin
-          sdi_counter <= 8'b0;
-          sdi_counter_d <= 8'b0;
-        end else begin
-          sdi_counter <= (sdi_counter == word_length-1) ? 8'b0 : sdi_counter + 1'b1;
-          sdi_counter_d <= sdi_counter;
-        end
-      end
-
-    end else begin : g_echo_miso_pshift_reg
-
-      // MISO shift register runs on positive echo_sclk
-      for (i=0; i<NUM_OF_SDI; i=i+1) begin: g_sdi_shift_reg
-        reg [DATA_WIDTH-1:0] data_sdi_shift;
-        always @(posedge echo_sclk or posedge cs_activate) begin
-          if (cs_activate) begin
-            data_sdi_shift <= 0;
-          end else begin
-            data_sdi_shift <= {data_sdi_shift, sdi[i]};
-          end
-        end
-        // intended LATCH
-        always @(posedge echo_sclk) begin
-          if (last_sdi_bit)
-            sdi_data_latch[i*DATA_WIDTH+:DATA_WIDTH] <= data_sdi_shift;
-        end
-      end
-
-      always @(posedge echo_sclk or posedge cs_activate) begin
-        if (cs_activate) begin
-          sdi_counter <= 8'b0;
-          sdi_counter_d <= 8'b0;
-        end else begin
-          sdi_counter <= (sdi_counter == word_length-1) ? 8'b0 : sdi_counter + 1'b1;
-          sdi_counter_d <= sdi_counter;
-        end
-      end
-
-    end
-
-    assign sdi_data = sdi_data_latch;
-    assign last_sdi_bit = (sdi_counter == 0) && (sdi_counter_d == word_length-1);
-
-    // sdi_data_valid is synchronous to SPI clock, so synchronize the
-    // last_sdi_bit to SPI clock
-
-    reg [3:0] last_sdi_bit_m = 4'b0;
-    always @(posedge clk) begin
-      if (cs_activate) begin
-        last_sdi_bit_m <= 4'b0;
-      end else begin
-        last_sdi_bit_m <= {last_sdi_bit_m, last_sdi_bit};
-      end
-    end
-
-    always @(posedge clk) begin
-      if (cs_activate) begin
-        sdi_data_valid <= 1'b0;
-      end else if (sdi_enabled == 1'b1 &&
-                   last_sdi_bit_m[3] == 1'b0 &&
-                   last_sdi_bit_m[2] == 1'b1) begin
-        sdi_data_valid <= 1'b1;
-      end else if (sdi_data_ready == 1'b1) begin
-        sdi_data_valid <= 1'b0;
-      end
-    end
-
-    always @(posedge clk) begin
-      if (cs_activate) begin
-        num_of_transfers <= 8'b0;
-      end else begin
-        if (cmd_d1[15:12] == 4'b0) begin
-          num_of_transfers <= cmd_d1[7:0] + 1'b1; // cmd_d1 contains the NUM_OF_TRANSFERS - 1
-        end
-      end
-    end
-
-    always @(posedge clk) begin
-      if (cs_activate) begin
-        sdi_transfer_counter <= 0;
-      end else if (last_sdi_bit_m[2] == 1'b0 &&
-                   last_sdi_bit_m[1] == 1'b1) begin
-        sdi_transfer_counter <= sdi_transfer_counter + 1'b1;
-      end
-    end
-
-    assign end_of_sdi_latch = last_sdi_bit_m[2] & (sdi_transfer_counter == num_of_transfers);
-
-  end /* g_echo_sclk_miso_latch */
-  else
-  begin : g_sclk_miso_latch
-
-    assign end_of_sdi_latch = 1'b1;
-
-    for (i=0; i<NUM_OF_SDI; i=i+1) begin: g_sdi_shift_reg
-
-      reg [DATA_WIDTH-1:0] data_sdi_shift;
-
-      always @(posedge clk) begin
-        if (cs_activate) begin
-          data_sdi_shift <= 0;
-        end else begin
-          if (trigger_rx_s == 1'b1) begin
-            data_sdi_shift <= {data_sdi_shift, sdi[i]};
-          end
-        end
-      end
-
-      assign sdi_data[i*DATA_WIDTH+:DATA_WIDTH] = data_sdi_shift;
-
-    end
-
-    assign last_sdi_bit = (sdi_counter == word_length-1);
-    always @(posedge clk) begin
-      if (resetn == 1'b0) begin
-        sdi_counter <= 8'b0;
-      end else begin
-        if (trigger_rx_s == 1'b1) begin
-          sdi_counter <= last_sdi_bit ? 8'b0 : sdi_counter + 1'b1;
-        end
-      end
-    end
-
-    always @(posedge clk) begin
-      if (resetn == 1'b0)
-        sdi_data_valid <= 1'b0;
-      else if (sdi_enabled == 1'b1 && last_sdi_bit == 1'b1 && trigger_rx_s == 1'b1)
-        sdi_data_valid <= 1'b1;
-      else if (sdi_data_ready == 1'b1)
-        sdi_data_valid <= 1'b0;
-    end
-
-  end /* g_sclk_miso_latch */
-  endgenerate
 
   // end_of_word will signal the end of a transaction, pushing the command
   // stream execution to the next command. end_of_word in normal mode can be

--- a/library/spi_engine/spi_engine_execution/spi_engine_execution.v
+++ b/library/spi_engine/spi_engine_execution/spi_engine_execution.v
@@ -163,6 +163,8 @@ module spi_engine_execution #(
 
   wire end_of_sdi_latch;
 
+  wire sample_sdo;
+
   (* direct_enable = "yes" *) wire cs_gen;
 
   spi_engine_execution_shiftreg #(
@@ -186,16 +188,20 @@ module spi_engine_execution #(
     .sdi_data_ready(sdi_data_ready),
     .sdo_enabled(sdo_enabled),
     .sdi_enabled(sdi_enabled),
-    .current_instr(inst_d1),
+    .current_cmd(cmd_d1),
     .sdo_idle_state(sdo_idle_state),
     .left_aligned(left_aligned),
     .word_length(word_length),
+    .sample_sdo(sample_sdo),
+    .sdo_io_ready(sdo_io_ready),
     .transfer_active(transfer_active),
     .trigger_tx(trigger_tx),
     .trigger_rx(trigger_rx),
     .first_bit(first_bit),
     .cs_activate(cs_activate),
     .end_of_sdi_latch(end_of_sdi_latch));
+
+  assign sample_sdo = sdo_data_valid && ((trigger_tx && last_bit) || (wait_for_io || exec_transfer_cmd));
 
   assign cs_gen = inst_d1 == CMD_CHIPSELECT
                   && ((cs_sleep_counter_compare == 1'b1) || cs_sleep_early_exit)
@@ -380,7 +386,7 @@ module spi_engine_execution #(
   assign sync = cmd_d1[7:0];
 
   assign io_ready1 = (sdi_data_valid == 1'b0 || sdi_data_ready == 1'b1) &&
-          (sdo_enabled == 1'b0 || last_transfer == 1'b1 || sdo_data_valid == 1'b1);
+          (sdo_enabled == 1'b0 || last_transfer == 1'b1 || sdo_io_ready == 1'b1);
   assign io_ready2 = (sdi_enabled == 1'b0 || sdi_data_ready == 1'b1) &&
           (sdo_enabled == 1'b0 || last_transfer == 1'b1 || sdo_data_valid == 1'b1);
 

--- a/library/spi_engine/spi_engine_execution/spi_engine_execution.v
+++ b/library/spi_engine/spi_engine_execution/spi_engine_execution.v
@@ -96,7 +96,6 @@ module spi_engine_execution #(
   localparam BIT_COUNTER_CLEAR = {{8{1'b1}}, {BIT_COUNTER_WIDTH{1'b0}}, 1'b1};
 
   reg sclk_int = 1'b0;
-  wire sdo_int_s;
   reg sdo_t_int = 1'b0;
 
   reg idle;
@@ -106,7 +105,6 @@ module spi_engine_execution #(
   reg clk_div_last;
 
   reg [7:0] sleep_counter;
-  wire [1:0] cs_sleep_counter = sleep_counter[1:0];
   reg [(BIT_COUNTER_WIDTH-1):0] bit_counter;
   reg [7:0] transfer_counter;
   reg ntx_rx;
@@ -117,12 +115,9 @@ module spi_engine_execution #(
   reg wait_for_io = 1'b0;
   reg transfer_active = 1'b0;
 
-  wire last_bit;
-  wire first_bit;
   reg last_transfer;
   reg [7:0] word_length = DATA_WIDTH;
   reg [7:0] left_aligned = 8'b0;
-  wire end_of_word;
 
   assign first_bit = ((bit_counter == 'h0) ||  (bit_counter == word_length));
 
@@ -138,6 +133,12 @@ module spi_engine_execution #(
   reg sdo_enabled = 1'b0;
   reg sdi_enabled = 1'b0;
 
+  wire sdo_int_s;
+
+  wire last_bit;
+  wire first_bit;
+  wire end_of_word;
+
   wire [2:0] inst = cmd[14:12];
   wire [2:0] inst_d1 = cmd_d1[14:12];
 
@@ -152,6 +153,7 @@ module spi_engine_execution #(
   wire trigger_tx;
   wire trigger_rx;
 
+  wire [1:0] cs_sleep_counter = sleep_counter[1:0];
   wire sleep_counter_compare;
   wire cs_sleep_counter_compare;
   wire cs_sleep_early_exit;
@@ -169,7 +171,7 @@ module spi_engine_execution #(
 
   spi_engine_execution_shiftreg #(
     .DEFAULT_SPI_CFG(DEFAULT_SPI_CFG),
-    .DATA_WIDTH(DATA_WIDTH),                   // Valid data widths values are 8/16/24/32
+    .DATA_WIDTH(DATA_WIDTH),
     .NUM_OF_SDI(NUM_OF_SDI),
     .SDI_DELAY(SDI_DELAY),
     .ECHO_SCLK(ECHO_SCLK),

--- a/library/spi_engine/spi_engine_execution/spi_engine_execution_hw.tcl
+++ b/library/spi_engine/spi_engine_execution/spi_engine_execution_hw.tcl
@@ -10,7 +10,8 @@ source ../../scripts/adi_ip_intel.tcl
 ad_ip_create spi_engine_execution {SPI Engine Execution}
 set_module_property ELABORATION_CALLBACK p_elaboration
 ad_ip_files spi_engine_execution [list\
-  spi_engine_execution.v]
+  spi_engine_execution.v \
+  spi_engine_execution_shiftreg.v]
 
 # parameters
 

--- a/library/spi_engine/spi_engine_execution/spi_engine_execution_ip.tcl
+++ b/library/spi_engine/spi_engine_execution/spi_engine_execution_ip.tcl
@@ -8,8 +8,9 @@ source $ad_hdl_dir/library/scripts/adi_ip_xilinx.tcl
 
 adi_ip_create spi_engine_execution
 adi_ip_files spi_engine_execution [list \
-	"spi_engine_execution_constr.ttcl" \
-	"spi_engine_execution.v" \
+  "spi_engine_execution_constr.ttcl" \
+  "spi_engine_execution.v" \
+  "spi_engine_execution_shiftreg.v" \
 ]
 
 adi_ip_properties_lite spi_engine_execution
@@ -23,35 +24,35 @@ ipx::remove_all_bus_interface [ipx::current_core]
 ## Interface definitions
 
 adi_add_bus "ctrl" "slave" \
-	"analog.com:interface:spi_engine_ctrl_rtl:1.0" \
-	"analog.com:interface:spi_engine_ctrl:1.0" \
-	{
-		{"cmd_ready" "cmd_ready"} \
-		{"cmd_valid" "cmd_valid"} \
-		{"cmd" "cmd_data"} \
-		{"sdo_data_ready" "sdo_ready"} \
-		{"sdo_data_valid" "sdo_valid"} \
-		{"sdo_data" "sdo_data"} \
-		{"sdi_data_ready" "sdi_ready"} \
-		{"sdi_data_valid" "sdi_valid"} \
-		{"sdi_data" "sdi_data"} \
-		{"sync_ready" "sync_ready"} \
-		{"sync_valid" "sync_valid"} \
-		{"sync" "sync_data"} \
-	}
+  "analog.com:interface:spi_engine_ctrl_rtl:1.0" \
+  "analog.com:interface:spi_engine_ctrl:1.0" \
+  {
+    {"cmd_ready" "cmd_ready"} \
+    {"cmd_valid" "cmd_valid"} \
+    {"cmd" "cmd_data"} \
+    {"sdo_data_ready" "sdo_ready"} \
+    {"sdo_data_valid" "sdo_valid"} \
+    {"sdo_data" "sdo_data"} \
+    {"sdi_data_ready" "sdi_ready"} \
+    {"sdi_data_valid" "sdi_valid"} \
+    {"sdi_data" "sdi_data"} \
+    {"sync_ready" "sync_ready"} \
+    {"sync_valid" "sync_valid"} \
+    {"sync" "sync_data"} \
+  }
 adi_add_bus_clock "clk" "ctrl" "resetn"
 
 adi_add_bus "spi" "master" \
-	"analog.com:interface:spi_engine_rtl:1.0" \
-	"analog.com:interface:spi_engine:1.0" \
-	{
-		{"sclk" "sclk"} \
-		{"sdi" "sdi"} \
-		{"sdo" "sdo"} \
-		{"sdo_t" "sdo_t"} \
-		{"three_wire" "three_wire"} \
-		{"cs" "cs"} \
-	}
+  "analog.com:interface:spi_engine_rtl:1.0" \
+  "analog.com:interface:spi_engine:1.0" \
+  {
+    {"sclk" "sclk"} \
+    {"sdi" "sdi"} \
+    {"sdo" "sdo"} \
+    {"sdo_t" "sdo_t"} \
+    {"three_wire" "three_wire"} \
+    {"cs" "cs"} \
+  }
 adi_add_bus_clock "clk" "spi" "resetn"
 
 ## Parameter validations

--- a/library/spi_engine/spi_engine_execution/spi_engine_execution_shiftreg.v
+++ b/library/spi_engine/spi_engine_execution/spi_engine_execution_shiftreg.v
@@ -1,0 +1,295 @@
+// ***************************************************************************
+// ***************************************************************************
+// Copyright (C) 2015-2024 Analog Devices, Inc. All rights reserved.
+//
+// In this HDL repository, there are many different and unique modules, consisting
+// of various HDL (Verilog or VHDL) components. The individual modules are
+// developed independently, and may be accompanied by separate and unique license
+// terms.
+//
+// The user should read each of these license terms, and understand the
+// freedoms and responsibilities that he or she has by using this source/core.
+//
+// This core is distributed in the hope that it will be useful, but WITHOUT ANY
+// WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+// A PARTICULAR PURPOSE.
+//
+// Redistribution and use of source or resulting binaries, with or without modification
+// of this file, are permitted under one of the following two license terms:
+//
+//   1. The GNU General Public License version 2 as published by the
+//      Free Software Foundation, which can be found in the top level directory
+//      of this repository (LICENSE_GPL2), and also online at:
+//      <https://www.gnu.org/licenses/old-licenses/gpl-2.0.html>
+//
+// OR
+//
+//   2. An ADI specific BSD license, which can be found in the top level directory
+//      of this repository (LICENSE_ADIBSD), and also on-line at:
+//      https://github.com/analogdevicesinc/hdl/blob/main/LICENSE_ADIBSD
+//      This will allow to generate bit files and not release the source code,
+//      as long as it attaches to an ADI device.
+//
+// ***************************************************************************
+// ***************************************************************************
+
+`timescale 1ns/100ps
+
+module spi_engine_execution_shiftreg #(
+
+  parameter DEFAULT_SPI_CFG = 0,
+  parameter DATA_WIDTH = 8,                   // Valid data widths values are 8/16/24/32
+  parameter NUM_OF_SDI = 1,
+  parameter [1:0] SDI_DELAY = 2'b00,
+  parameter ECHO_SCLK = 0,
+  parameter [2:0]CMD_TRANSFER = 3'b000
+) (
+  input clk,
+  input resetn,
+
+  // spi io
+  input sdi,
+  output sdo_int,
+  input echo_sclk,
+
+  // spi data
+  input [(DATA_WIDTH-1):0] sdo_data,
+  input sdo_data_valid,
+  output reg sdo_data_ready,
+  output [(NUM_OF_SDI * DATA_WIDTH-1):0] sdi_data,
+  output reg sdi_data_valid,
+  input sdi_data_ready,
+
+  // cfg and status
+  input sdo_enabled,
+  input sdi_enabled,
+  input [2:0] current_instr,
+  input sdo_idle_state,
+  input [7:0] left_aligned,
+  input [7:0] word_length,
+
+  // timing from main fsm
+  input transfer_active,
+  input trigger_tx,
+  input trigger_rx,
+  input first_bit,
+  input cs_activate,
+  output end_of_sdi_latch
+);
+
+  reg [7:0] sdi_counter = 8'b0;
+  reg [(DATA_WIDTH-1):0] data_sdo_shift = 'h0;
+  wire last_sdi_bit;
+  reg [SDI_DELAY+1:0] trigger_rx_d = {(SDI_DELAY+2){1'b0}};
+  wire trigger_rx_s;
+
+  always @(posedge clk) begin
+    if (resetn == 1'b0)
+      sdo_data_ready <= 1'b0;
+    else if (sdo_enabled == 1'b1 && first_bit == 1'b1 && trigger_tx == 1'b1 && transfer_active == 1'b1)
+      sdo_data_ready <= 1'b1;
+    else if (sdo_data_valid == 1'b1)
+      sdo_data_ready <= 1'b0;
+  end
+
+  // Load the SDO parallel data into the SDO shift register. In case of a custom
+  // data width, additional bit shifting must done at load.
+  always @(posedge clk) begin
+    if (!sdo_enabled || (current_instr != CMD_TRANSFER)) begin
+      data_sdo_shift <= {DATA_WIDTH{sdo_idle_state}};
+    end else if (transfer_active == 1'b1 && trigger_tx == 1'b1) begin
+      if (first_bit == 1'b1)
+      data_sdo_shift <= sdo_data << left_aligned; //TODO: check if this could/should be pipelined
+      else
+      data_sdo_shift <= {data_sdo_shift[(DATA_WIDTH-2):0], 1'b0};
+    end
+  end
+  assign sdo_int = data_sdo_shift[DATA_WIDTH-1];
+
+  // In case of an interface with high clock rate (SCLK > 50MHz), the latch of
+  // the SDI line can be delayed with 1, 2 or 3 SPI core clock cycle.
+  // Taking the fact that in high SCLK frequencies the pre-scaler most likely will
+  // be set to 0, to reduce the core clock's speed, this delay will mean that SDI will
+  // be latched at one of the next consecutive SCLK edge.
+  always @(posedge clk) begin
+    trigger_rx_d <= {trigger_rx_d, trigger_rx};
+  end
+  assign trigger_rx_s = trigger_rx_d[SDI_DELAY+1];
+
+  // Load the serial data into SDI shift register(s), then link it to the output
+  // register of the module
+  // NOTE: ECHO_SCLK mode can be used when the SCLK line is looped back to the FPGA
+  // through an other level shifter, in order to remove the round-trip timing delays
+  // introduced by the level shifters. This can improve the timing significantly
+  // on higher SCLK rates. Devices like ad4630 have an echod SCLK, which can be
+  // used to latch the MISO lines, improving the overall timing margin of the
+  // interface.
+
+  genvar i;
+  // NOTE: SPI configuration (CPOL/PHA) is only hardware configurable at this point, unless ECHO_SCLK=0
+  generate
+  if (ECHO_SCLK == 1) begin : g_echo_sclk_miso_latch
+
+    reg [7:0] sdi_counter_d = 8'b0;
+    reg [7:0] sdi_transfer_counter = 8'b0;
+    reg [7:0] num_of_transfers = 8'b0;
+    reg [(NUM_OF_SDI * DATA_WIDTH)-1:0] sdi_data_latch = {(NUM_OF_SDI * DATA_WIDTH){1'b0}};
+
+    if ((DEFAULT_SPI_CFG[1:0] == 2'b01) || (DEFAULT_SPI_CFG[1:0] == 2'b10)) begin : g_echo_miso_nshift_reg
+
+      // MISO shift register runs on negative echo_sclk
+      for (i=0; i<NUM_OF_SDI; i=i+1) begin: g_sdi_shift_reg
+        reg [DATA_WIDTH-1:0] data_sdi_shift;
+
+        always @(negedge echo_sclk or posedge cs_activate) begin
+          if (cs_activate) begin
+            data_sdi_shift <= 0;
+          end else begin
+            data_sdi_shift <= {data_sdi_shift, sdi[i]};
+          end
+        end
+
+        // intended LATCH
+        always @(negedge echo_sclk) begin
+          if (last_sdi_bit)
+            sdi_data_latch[i*DATA_WIDTH+:DATA_WIDTH] <= {data_sdi_shift, sdi[i]};
+        end
+      end
+
+      always @(posedge echo_sclk or posedge cs_activate) begin
+        if (cs_activate) begin
+          sdi_counter <= 8'b0;
+          sdi_counter_d <= 8'b0;
+        end else begin
+          sdi_counter <= (sdi_counter == word_length-1) ? 8'b0 : sdi_counter + 1'b1;
+          sdi_counter_d <= sdi_counter;
+        end
+      end
+
+    end else begin : g_echo_miso_pshift_reg
+
+      // MISO shift register runs on positive echo_sclk
+      for (i=0; i<NUM_OF_SDI; i=i+1) begin: g_sdi_shift_reg
+        reg [DATA_WIDTH-1:0] data_sdi_shift;
+        always @(posedge echo_sclk or posedge cs_activate) begin
+          if (cs_activate) begin
+            data_sdi_shift <= 0;
+          end else begin
+            data_sdi_shift <= {data_sdi_shift, sdi[i]};
+          end
+        end
+        // intended LATCH
+        always @(posedge echo_sclk) begin
+          if (last_sdi_bit)
+            sdi_data_latch[i*DATA_WIDTH+:DATA_WIDTH] <= data_sdi_shift;
+        end
+      end
+
+      always @(posedge echo_sclk or posedge cs_activate) begin
+        if (cs_activate) begin
+          sdi_counter <= 8'b0;
+          sdi_counter_d <= 8'b0;
+        end else begin
+          sdi_counter <= (sdi_counter == word_length-1) ? 8'b0 : sdi_counter + 1'b1;
+          sdi_counter_d <= sdi_counter;
+        end
+      end
+
+    end
+
+    assign sdi_data = sdi_data_latch;
+    assign last_sdi_bit = (sdi_counter == 0) && (sdi_counter_d == word_length-1);
+
+    // sdi_data_valid is synchronous to SPI clock, so synchronize the
+    // last_sdi_bit to SPI clock
+
+    reg [3:0] last_sdi_bit_m = 4'b0; //FIXME: bad synchronizer (cs_activate shouldn't be connected here), also why not just use sync_bits?
+    always @(posedge clk) begin
+      if (cs_activate) begin
+        last_sdi_bit_m <= 4'b0;
+      end else begin
+        last_sdi_bit_m <= {last_sdi_bit_m, last_sdi_bit};
+      end
+    end
+
+    always @(posedge clk) begin
+      if (cs_activate) begin
+        sdi_data_valid <= 1'b0;
+      end else if (sdi_enabled == 1'b1 &&
+                   last_sdi_bit_m[3] == 1'b0 &&
+                   last_sdi_bit_m[2] == 1'b1) begin
+        sdi_data_valid <= 1'b1;
+      end else if (sdi_data_ready == 1'b1) begin
+        sdi_data_valid <= 1'b0;
+      end
+    end
+
+    always @(posedge clk) begin
+      if (cs_activate) begin
+        num_of_transfers <= 8'b0;
+      end else begin
+        if (cmd_d1[15:12] == 4'b0) begin
+          num_of_transfers <= cmd_d1[7:0] + 1'b1; // cmd_d1 contains the NUM_OF_TRANSFERS - 1
+        end
+      end
+    end
+
+    always @(posedge clk) begin
+      if (cs_activate) begin
+        sdi_transfer_counter <= 0;
+      end else if (last_sdi_bit_m[2] == 1'b0 &&
+                   last_sdi_bit_m[1] == 1'b1) begin
+        sdi_transfer_counter <= sdi_transfer_counter + 1'b1;
+      end
+    end
+
+    assign end_of_sdi_latch = last_sdi_bit_m[2] & (sdi_transfer_counter == num_of_transfers);
+
+  end /* g_echo_sclk_miso_latch */
+  else
+  begin : g_sclk_miso_latch
+
+    assign end_of_sdi_latch = 1'b1;
+
+    for (i=0; i<NUM_OF_SDI; i=i+1) begin: g_sdi_shift_reg
+
+      reg [DATA_WIDTH-1:0] data_sdi_shift;
+
+      always @(posedge clk) begin
+        if (cs_activate) begin
+          data_sdi_shift <= 0;
+        end else begin
+          if (trigger_rx_s == 1'b1) begin
+            data_sdi_shift <= {data_sdi_shift, sdi[i]};
+          end
+        end
+      end
+
+      assign sdi_data[i*DATA_WIDTH+:DATA_WIDTH] = data_sdi_shift;
+
+    end
+
+    assign last_sdi_bit = (sdi_counter == word_length-1);
+    always @(posedge clk) begin
+      if (resetn == 1'b0) begin
+        sdi_counter <= 8'b0;
+      end else begin
+        if (trigger_rx_s == 1'b1) begin
+          sdi_counter <= last_sdi_bit ? 8'b0 : sdi_counter + 1'b1;
+        end
+      end
+    end
+
+    always @(posedge clk) begin
+      if (resetn == 1'b0)
+        sdi_data_valid <= 1'b0;
+      else if (sdi_enabled == 1'b1 && last_sdi_bit == 1'b1 && trigger_rx_s == 1'b1)
+        sdi_data_valid <= 1'b1;
+      else if (sdi_data_ready == 1'b1)
+        sdi_data_valid <= 1'b0;
+    end
+
+  end /* g_sclk_miso_latch */
+  endgenerate
+
+endmodule


### PR DESCRIPTION
## PR Description

A couple of improvements to the execution module for the SPI Engine. Mostly code reorganization, but this should improve timing closure for projects using the SPI Engine. 

The changes here should not affect the functionality of the SPI Engine.

- Reorganized the counters
- Moved lower level shift register logic to separate module
- Pipelined barrel shifter on sdo path

## PR Type
- [ ] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the code style guidelines
- [x] I have performed a self-review of changes
- [ ] I have compiled all hdl projects and libraries affected by this PR
- [ ] I have tested in hardware affected projects, at least on relevant boards
- [ ] I have commented my code, at least hard-to-understand parts
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe files, Copyright etc)
- [x] I have not introduced new Warnings/Critical Warnings on compilation
- [x] I have added new hdl testbenches or updated existing ones
