### PR TITLE
docs: Change wavedrom script url

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -40,6 +40,10 @@ validate_links = False
 todo_include_todos = True
 todo_emit_warnings = True
 
+# -- WaveDrom configuration ---------------------------------------------------
+
+online_wavedrom_js_url = "https://cdnjs.cloudflare.com/ajax/libs/wavedrom/3.1.0"
+
 # -- Options for HTML output --------------------------------------------------
 
 html_theme = 'cosmic'


### PR DESCRIPTION
## PR Description

Use Cloudfare CDN for improved uptime and speed.
Fixes wavedrom.com downtime taking down the doc or making it slow to load.
It is the recommended url at https://cdnjs.cloudflare.com/ajax/libs/wavedrom/3.1.0/wavedrom.min.js

## PR Type
- [X] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [ ] I have followed the code style guidelines
- [ ] I have performed a self-review of changes
- [ ] I have compiled all hdl projects and libraries affected by this PR
- [ ] I have tested in hardware affected projects, at least on relevant boards
- [ ] I have commented my code, at least hard-to-understand parts
- [ ] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe files, Copyright etc)
- [ ] I have not introduced new Warnings/Critical Warnings on compilation
- [ ] I have added new hdl testbenches or updated existing ones
