### PR TITLE
SPI Engine: SDO data prefetch

### DIFF
--- a/docs/regmap/adi_regmap_spi_engine.txt
+++ b/docs/regmap/adi_regmap_spi_engine.txt
@@ -9,7 +9,7 @@ ENDTITLE
 REG
 0x00
 VERSION
-Version of the peripheral. Follows semantic versioning. Current version 1.03.01.
+Version of the peripheral. Follows semantic versioning. Current version 1.04.00.
 ENDREG
 
 FIELD
@@ -19,13 +19,13 @@ RO
 ENDFIELD
 
 FIELD
-[15:8] 0x00000003
+[15:8] 0x00000004
 VERSION_MINOR
 RO
 ENDFIELD
 
 FIELD
-[7:0] 0x00000001
+[7:0] 0x00000000
 VERSION_PATCH
 RO
 ENDFIELD

--- a/library/spi_engine/axi_spi_engine/axi_spi_engine.v
+++ b/library/spi_engine/axi_spi_engine/axi_spi_engine.v
@@ -1,6 +1,6 @@
 // ***************************************************************************
 // ***************************************************************************
-// Copyright (C) 2015-2024 Analog Devices, Inc. All rights reserved.
+// Copyright (C) 2015-2025 Analog Devices, Inc. All rights reserved.
 //
 // In this HDL repository, there are many different and unique modules, consisting
 // of various HDL (Verilog or VHDL) components. The individual modules are

--- a/library/spi_engine/axi_spi_engine/axi_spi_engine.v
+++ b/library/spi_engine/axi_spi_engine/axi_spi_engine.v
@@ -133,7 +133,7 @@ module axi_spi_engine #(
   input [7:0] offload_sync_data
 );
 
-  localparam PCORE_VERSION = 'h010301;
+  localparam PCORE_VERSION = 'h010400;
   localparam S_AXI = 0;
   localparam UP_FIFO = 1;
 

--- a/library/spi_engine/spi_engine_execution/spi_engine_execution.v
+++ b/library/spi_engine/spi_engine_execution/spi_engine_execution.v
@@ -132,6 +132,8 @@ module spi_engine_execution #(
 
   reg sdo_enabled = 1'b0;
   reg sdi_enabled = 1'b0;
+  wire sdo_enabled_io;
+  wire sdi_enabled_io;
 
   wire sdo_int_s;
 
@@ -165,7 +167,7 @@ module spi_engine_execution #(
 
   wire end_of_sdi_latch;
 
-  wire sample_sdo;
+  wire sdo_io_ready;
 
   (* direct_enable = "yes" *) wire cs_gen;
 
@@ -194,7 +196,6 @@ module spi_engine_execution #(
     .sdo_idle_state(sdo_idle_state),
     .left_aligned(left_aligned),
     .word_length(word_length),
-    .sample_sdo(sample_sdo),
     .sdo_io_ready(sdo_io_ready),
     .transfer_active(transfer_active),
     .trigger_tx(trigger_tx),
@@ -202,8 +203,6 @@ module spi_engine_execution #(
     .first_bit(first_bit),
     .cs_activate(cs_activate),
     .end_of_sdi_latch(end_of_sdi_latch));
-
-  assign sample_sdo = sdo_data_valid && ((trigger_tx && last_bit) || (wait_for_io || exec_transfer_cmd));
 
   assign cs_gen = inst_d1 == CMD_CHIPSELECT
                   && ((cs_sleep_counter_compare == 1'b1) || cs_sleep_early_exit)
@@ -217,6 +216,8 @@ module spi_engine_execution #(
       sdi_enabled <= cmd[9];
     end
   end
+  assign sdo_enabled_io = (exec_transfer_cmd) ? cmd[8] : sdo_enabled;
+  assign sdi_enabled_io = (exec_transfer_cmd) ? cmd[9] : sdi_enabled;
 
   always @(posedge clk) begin
     if (cmd_ready & cmd_valid)
@@ -388,9 +389,9 @@ module spi_engine_execution #(
   assign sync = cmd_d1[7:0];
 
   assign io_ready1 = (sdi_data_valid == 1'b0 || sdi_data_ready == 1'b1) &&
-          (sdo_enabled == 1'b0 || last_transfer == 1'b1 || sdo_io_ready == 1'b1);
+          (sdo_enabled_io == 1'b0 || sdo_io_ready == 1'b1);
   assign io_ready2 = (sdi_enabled == 1'b0 || sdi_data_ready == 1'b1) &&
-          (sdo_enabled == 1'b0 || last_transfer == 1'b1 || sdo_data_valid == 1'b1);
+          (sdo_enabled_io == 1'b0 || last_transfer == 1'b1 || sdo_io_ready == 1'b1);
 
   always @(posedge clk) begin
     if (idle == 1'b1) begin
@@ -409,14 +410,11 @@ module spi_engine_execution #(
       wait_for_io <= 1'b0;
     end else begin
       if (exec_transfer_cmd == 1'b1) begin
-        wait_for_io <= 1'b1;
-        transfer_active <= 1'b0;
+        wait_for_io <= !io_ready1;
+        transfer_active <= io_ready1;
       end else if (wait_for_io == 1'b1 && io_ready1 == 1'b1) begin
         wait_for_io <= 1'b0;
-        if (last_transfer == 1'b0)
-          transfer_active <= 1'b1;
-        else
-          transfer_active <= 1'b0;
+        transfer_active <= !last_transfer;
       end else if (transfer_active == 1'b1 && end_of_word == 1'b1) begin
         if (last_transfer == 1'b1 || io_ready2 == 1'b0)
           transfer_active <= 1'b0;

--- a/library/spi_engine/spi_engine_execution/spi_engine_execution.v
+++ b/library/spi_engine/spi_engine_execution/spi_engine_execution.v
@@ -1,6 +1,6 @@
 // ***************************************************************************
 // ***************************************************************************
-// Copyright (C) 2015-2024 Analog Devices, Inc. All rights reserved.
+// Copyright (C) 2015-2025 Analog Devices, Inc. All rights reserved.
 //
 // In this HDL repository, there are many different and unique modules, consisting
 // of various HDL (Verilog or VHDL) components. The individual modules are

--- a/library/spi_engine/spi_engine_execution/spi_engine_execution_shiftreg.v
+++ b/library/spi_engine/spi_engine_execution/spi_engine_execution_shiftreg.v
@@ -1,6 +1,6 @@
 // ***************************************************************************
 // ***************************************************************************
-// Copyright (C) 2024 Analog Devices, Inc. All rights reserved.
+// Copyright (C) 2025 Analog Devices, Inc. All rights reserved.
 //
 // In this HDL repository, there are many different and unique modules, consisting
 // of various HDL (Verilog or VHDL) components. The individual modules are

--- a/library/spi_engine/spi_engine_offload/spi_engine_offload.v
+++ b/library/spi_engine/spi_engine_offload/spi_engine_offload.v
@@ -1,6 +1,6 @@
 // ***************************************************************************
 // ***************************************************************************
-// Copyright (C) 2015-2024 Analog Devices, Inc. All rights reserved.
+// Copyright (C) 2015-2025 Analog Devices, Inc. All rights reserved.
 //
 // In this HDL repository, there are many different and unique modules, consisting
 // of various HDL (Verilog or VHDL) components. The individual modules are

--- a/projects/ad4052_ardz/coraz7s/system_project.tcl
+++ b/projects/ad4052_ardz/coraz7s/system_project.tcl
@@ -15,4 +15,6 @@ adi_project_files ad4052_ardz_coraz7s [list \
     "system_constr.xdc" \
     "$ad_hdl_dir/projects/common/coraz7s/coraz7s_system_constr.xdc"]
 
+set_property strategy Performance_Retiming [get_runs impl_1]
+
 adi_project_run ad4052_ardz_coraz7s

--- a/projects/ad4052_ardz/de10nano/system_project.tcl
+++ b/projects/ad4052_ardz/de10nano/system_project.tcl
@@ -1,9 +1,9 @@
 ###############################################################################
-## Copyright (C) 2024 Analog Devices, Inc. All rights reserved.
+## Copyright (C) 2024-2025 Analog Devices, Inc. All rights reserved.
 ### SPDX short identifier: ADIBSD
 ###############################################################################
 
-set REQUIRED_QUARTUS_VERSION 22.1std.0
+set REQUIRED_QUARTUS_VERSION 23.1std.1
 set QUARTUS_PRO_ISUSED 0
 source ../../../scripts/adi_env.tcl
 source ../../scripts/adi_project_intel.tcl


### PR DESCRIPTION
## PR Description

Allows spi_engine_execution get sdo data independently of the instruction command. This reduces the trigger to transfer latency, and opens the door to further pipelining this path or reducing latency even more. 

(this PR should be merged after https://github.com/analogdevicesinc/hdl/pull/1499)


## PR Type
- [ ] Bug fix (change that fixes an issue)
- [x] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the code style guidelines
- [x] I have performed a self-review of changes
- [x] I have compiled all hdl projects and libraries affected by this PR
- [x] I have tested in hardware affected projects, at least on relevant boards
- [x] I have commented my code, at least hard-to-understand parts
- [x] I have signed off all commits from this PR
- [x] I have updated the documentation (wiki pages, ReadMe files, Copyright etc)
- [x] I have not introduced new Warnings/Critical Warnings on compilation
- [x] I have added new hdl testbenches or updated existing ones
