### PR TITLE
ad9081_fmca_ebz: common: versal_transceiver: Force progdiv_clk to float

### DIFF
--- a/projects/ad9081_fmca_ebz/common/versal_transceiver.tcl
+++ b/projects/ad9081_fmca_ebz/common/versal_transceiver.tcl
@@ -215,8 +215,8 @@ proc create_versal_phy {
   puts "intf_cfg: ${intf_cfg}"
   puts "assymmetric_mode: ${asymmetric_mode}"
 
-  set rx_progdiv_clock [format %.3f [expr $rx_lane_rate * 1000 / ${clk_divider}]]
-  set tx_progdiv_clock [format %.3f [expr $tx_lane_rate * 1000 / ${clk_divider}]]
+  set rx_progdiv_clock [format %.3f [expr $rx_lane_rate * 1000.0 / ${clk_divider}]]
+  set tx_progdiv_clock [format %.3f [expr $tx_lane_rate * 1000.0 / ${clk_divider}]]
   set preset ${transceiver}-JESD204_64B66B
 
   if {$intf_cfg == "RX"} {


### PR DESCRIPTION
## PR Description
The [rx/tx]_progdiv_clock was truncated if the lane rate was an integer. So for a lane rate of '10', the ref clock calculated was 151.000 instead of 151.515.

## PR Type
- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the code style guidelines
- [x] I have performed a self-review of changes
- [x] I have compiled all hdl projects and libraries affected by this PR
- [ ] I have tested in hardware affected projects, at least on relevant boards
- [ ] I have commented my code, at least hard-to-understand parts
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe files, Copyright etc)
- [x] I have not introduced new Warnings/Critical Warnings on compilation
- [ ] I have added new hdl testbenches or updated existing ones
