### PR TITLE
unit_level_tb: Revert SV support

### DIFF
--- a/library/common/tb/run_tb.sh
+++ b/library/common/tb/run_tb.sh
@@ -19,7 +19,7 @@ case "$SIMULATOR" in
 
 	xsim)
 		# XSim flow
-		xvlog --sv -log ${NAME}_xvlog.log --sourcelibdir . ${SOURCE} || exit 1
+		xvlog -log ${NAME}_xvlog.log --sourcelibdir . ${SOURCE} || exit 1
 		xelab -log ${NAME}_xelab.log -debug all ${NAME} || exit 1
 		if [[ "$MODE" == "-gui" ]]; then
 			echo "log_wave -r *" > xsim_gui_cmd.tcl


### PR DESCRIPTION
## PR Description

Added SystemVerilog support breaks some of the current unit level testbenches.
Removing support for SystemVerilog, until incompatibilities between Verilog and SystemVerilog are understood and fixed. 


## PR Type
- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the code style guidelines
- [x] I have performed a self-review of changes
- [ ] I have compiled all hdl projects and libraries affected by this PR
- [ ] I have tested in hardware affected projects, at least on relevant boards
- [ ] I have commented my code, at least hard-to-understand parts
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe files, Copyright etc)
- [x] I have not introduced new Warnings/Critical Warnings on compilation
- [ ] I have added new hdl testbenches or updated existing ones
