### PR TITLE
Fixes for AD9164 on ZCU102

### DIFF
--- a/projects/dac_fmc_ebz/common/config.tcl
+++ b/projects/dac_fmc_ebz/common/config.tcl
@@ -116,6 +116,7 @@ set params(AD9164,03) {2 3 3 4 1 16 16}
 set params(AD9164,04) {2 4 1 1 1 16 16}
 set params(AD9164,06) {2 6 3 2 1 16 16}
 set params(AD9164,08) {2 8 2 1 1 16 16}
+set params(AD9164,09) {1 8 4 1 1 16 16}
 set params(AD9164,device_code) 3
 
 # AD9171

--- a/projects/dac_fmc_ebz/common/config.tcl
+++ b/projects/dac_fmc_ebz/common/config.tcl
@@ -116,7 +116,6 @@ set params(AD9164,03) {2 3 3 4 1 16 16}
 set params(AD9164,04) {2 4 1 1 1 16 16}
 set params(AD9164,06) {2 6 3 2 1 16 16}
 set params(AD9164,08) {2 8 2 1 1 16 16}
-set params(AD9164,09) {1 8 4 1 1 16 16}
 set params(AD9164,device_code) 3
 
 # AD9171
@@ -166,7 +165,11 @@ proc get_config_param {param} {
   upvar params params
 
   set jesd_params {M L S F HD N NP}
-  set index [lsearch $jesd_params $param]
 
-  return [lindex $params($device,$mode) $index]
+  if {[info exists ::env($param)]} {
+    return $::env($param)
+  } else {
+    set index [lsearch $jesd_params $param]
+    return [lindex $params($device,$mode) $index]
+  }
 }

--- a/projects/dac_fmc_ebz/zcu102/system_bd.tcl
+++ b/projects/dac_fmc_ebz/zcu102/system_bd.tcl
@@ -1,5 +1,5 @@
 ###############################################################################
-## Copyright (C) 2019-2023 Analog Devices Inc. All rights reserved.
+## Copyright (C) 2019-2024 Analog Devices, Inc. All rights reserved.
 ### SPDX short identifier: ADIBSD
 ###############################################################################
 

--- a/projects/dac_fmc_ebz/zcu102/system_bd.tcl
+++ b/projects/dac_fmc_ebz/zcu102/system_bd.tcl
@@ -5,33 +5,53 @@
 
 set dac_fifo_address_width 13
 
+source $ad_hdl_dir/projects/scripts/adi_pd.tcl
 source $ad_hdl_dir/projects/common/zcu102/zcu102_system_bd.tcl
 source $ad_hdl_dir/projects/common/xilinx/dacfifo_bd.tcl
 source ../common/dac_fmc_ebz_bd.tcl
-source $ad_hdl_dir/projects/scripts/adi_pd.tcl
 
-#parameters are for 12.5 GHz Lane Rate
+if {[info exists ::env(ADI_LANE_RATE)]} {
+  set ADI_LANE_RATE [get_env_param ADI_LANE_RATE 15.4]
+} elseif {![info exists ADI_LANE_RATE]} {
+  set ADI_LANE_RATE 15.4
+}
+
+# Common for both 12.5 and 15.4 GHz Lane Rate
 
 ad_ip_parameter util_dac_jesd204_xcvr CONFIG.QPLL_REFCLK_DIV 1
-ad_ip_parameter util_dac_jesd204_xcvr CONFIG.QPLL_CFG2       0xFC1
 ad_ip_parameter util_dac_jesd204_xcvr CONFIG.QPLL_CFG3       0x120
-ad_ip_parameter util_dac_jesd204_xcvr CONFIG.QPLL_CFG0       0x331C
 ad_ip_parameter util_dac_jesd204_xcvr CONFIG.QPLL_FBDIV      40
-ad_ip_parameter util_dac_jesd204_xcvr CONFIG.QPLL_CFG4       0x4
 ad_ip_parameter util_dac_jesd204_xcvr CONFIG.QPLL_CFG1       0xD038
 ad_ip_parameter util_dac_jesd204_xcvr CONFIG.QPLL_CFG1_G3    0xD038
-ad_ip_parameter util_dac_jesd204_xcvr CONFIG.QPLL_CFG2_G3    0xFC1
-ad_ip_parameter util_dac_jesd204_xcvr CONFIG.TX_CLK25_DIV    13
 ad_ip_parameter util_dac_jesd204_xcvr CONFIG.TX_OUT_DIV      1
 ad_ip_parameter util_dac_jesd204_xcvr CONFIG.TXPI_CFG        0x0
 ad_ip_parameter util_dac_jesd204_xcvr CONFIG.A_TXDIFFCTRL    0xC
-ad_ip_parameter util_dac_jesd204_xcvr CONFIG.TX_PI_BIASSET   2
 ad_ip_parameter util_dac_jesd204_xcvr CONFIG.POR_CFG         0x0
-ad_ip_parameter util_dac_jesd204_xcvr CONFIG.PPF0_CFG        0x800
-ad_ip_parameter util_dac_jesd204_xcvr CONFIG.PPF1_CFG        0x600
 ad_ip_parameter util_dac_jesd204_xcvr CONFIG.QPLL_CP         0xFF
 ad_ip_parameter util_dac_jesd204_xcvr CONFIG.QPLL_CP_G3      0xF
-ad_ip_parameter util_dac_jesd204_xcvr CONFIG.QPLL_LPF        0x37F
+
+if { $ADI_LANE_RATE == 15.4 } {
+    ad_ip_parameter util_dac_jesd204_xcvr CONFIG.QPLL_CFG2       0xFC0
+    ad_ip_parameter util_dac_jesd204_xcvr CONFIG.QPLL_CFG0       0x333C
+    ad_ip_parameter util_dac_jesd204_xcvr CONFIG.QPLL_CFG4       0x45
+    ad_ip_parameter util_dac_jesd204_xcvr CONFIG.QPLL_CFG2_G3    0xFC0
+    ad_ip_parameter util_dac_jesd204_xcvr CONFIG.TX_CLK25_DIV    15
+    ad_ip_parameter util_dac_jesd204_xcvr CONFIG.TX_PI_BIASSET   3
+    ad_ip_parameter util_dac_jesd204_xcvr CONFIG.PPF0_CFG        0xF00
+    ad_ip_parameter util_dac_jesd204_xcvr CONFIG.QPLL_LPF        0x31D
+} elseif { $ADI_LANE_RATE == 12.5 } {
+    ad_ip_parameter util_dac_jesd204_xcvr CONFIG.QPLL_CFG2       0xFC1
+    ad_ip_parameter util_dac_jesd204_xcvr CONFIG.QPLL_CFG0       0x331C
+    ad_ip_parameter util_dac_jesd204_xcvr CONFIG.QPLL_CFG4       0x4
+    ad_ip_parameter util_dac_jesd204_xcvr CONFIG.QPLL_CFG2_G3    0xFC1
+    ad_ip_parameter util_dac_jesd204_xcvr CONFIG.TX_CLK25_DIV    13
+    ad_ip_parameter util_dac_jesd204_xcvr CONFIG.TX_PI_BIASSET   2
+    ad_ip_parameter util_dac_jesd204_xcvr CONFIG.PPF0_CFG        0x800
+    ad_ip_parameter util_dac_jesd204_xcvr CONFIG.PPF1_CFG        0x600
+    ad_ip_parameter util_dac_jesd204_xcvr CONFIG.QPLL_LPF        0x37F
+} else {
+    error "ADI_LANE_RATE must be either 12.5 GHz or 15.4GHz"
+}
 
 ad_ip_parameter  dac_jesd204_link/tx   CONFIG.SYSREF_IOB         false
 ad_ip_parameter  dac_dma               CONFIG.DMA_DATA_WIDTH_SRC 128
@@ -52,6 +72,7 @@ LINKS=$ad_project_params(NUM_LINKS)\
 DEVICE_CODE=$ad_project_params(DEVICE_CODE)\
 DAC_DEVICE=$ADI_DAC_DEVICE\
 DAC_MODE=$ADI_DAC_MODE\
+ADI_LANE_RATE=$ADI_LANE_RATE\
 DAC_FIFO_ADDR_WIDTH=$dac_fifo_address_width"
 
 sysid_gen_sys_init_file $sys_cstring

--- a/projects/dac_fmc_ebz/zcu102/system_bd.tcl
+++ b/projects/dac_fmc_ebz/zcu102/system_bd.tcl
@@ -16,6 +16,8 @@ if {[info exists ::env(ADI_LANE_RATE)]} {
   set ADI_LANE_RATE 15.4
 }
 
+set ADI_DEVICE_CODE $ad_project_params(DEVICE_CODE)
+
 # Common for both 12.5 and 15.4 GHz Lane Rate
 
 ad_ip_parameter util_dac_jesd204_xcvr CONFIG.QPLL_REFCLK_DIV 1
@@ -55,7 +57,10 @@ if { $ADI_LANE_RATE == 15.4 } {
 
 ad_ip_parameter  dac_jesd204_link/tx   CONFIG.SYSREF_IOB         false
 ad_ip_parameter  dac_dma               CONFIG.DMA_DATA_WIDTH_SRC 128
-ad_ip_parameter  util_dac_jesd204_xcvr CONFIG.TX_LANE_INVERT     240
+
+if { $ADI_DEVICE_CODE == 3 } {
+  ad_ip_parameter  util_dac_jesd204_xcvr CONFIG.TX_LANE_INVERT     240
+}
 
 #system ID
 ad_ip_parameter axi_sysid_0 CONFIG.ROM_ADDR_BITS 9
@@ -69,7 +74,7 @@ L=$ad_project_params(JESD_L)\
 S=$ad_project_params(JESD_S)\
 NP=$ad_project_params(JESD_NP)\
 LINKS=$ad_project_params(NUM_LINKS)\
-DEVICE_CODE=$ad_project_params(DEVICE_CODE)\
+DEVICE_CODE=$ADI_DEVICE_CODE\
 DAC_DEVICE=$ADI_DAC_DEVICE\
 DAC_MODE=$ADI_DAC_MODE\
 ADI_LANE_RATE=$ADI_LANE_RATE\

--- a/projects/dac_fmc_ebz/zcu102/system_bd.tcl
+++ b/projects/dac_fmc_ebz/zcu102/system_bd.tcl
@@ -1,5 +1,5 @@
 ###############################################################################
-## Copyright (C) 2019-2023 Analog Devices, Inc. All rights reserved.
+## Copyright (C) 2019-2023 Analog Devices Inc. All rights reserved.
 ### SPDX short identifier: ADIBSD
 ###############################################################################
 
@@ -10,27 +10,32 @@ source $ad_hdl_dir/projects/common/xilinx/dacfifo_bd.tcl
 source ../common/dac_fmc_ebz_bd.tcl
 source $ad_hdl_dir/projects/scripts/adi_pd.tcl
 
-ad_ip_parameter util_dac_jesd204_xcvr CONFIG.QPLL_REFCLK_DIV 1
-ad_ip_parameter util_dac_jesd204_xcvr CONFIG.QPLL_CFG2 0xFC0
-ad_ip_parameter util_dac_jesd204_xcvr CONFIG.QPLL_CFG3 0x120
-ad_ip_parameter util_dac_jesd204_xcvr CONFIG.QPLL_CFG0 0x333C
-ad_ip_parameter util_dac_jesd204_xcvr CONFIG.QPLL_FBDIV 40
-ad_ip_parameter util_dac_jesd204_xcvr CONFIG.QPLL_CFG4 0x45
-ad_ip_parameter util_dac_jesd204_xcvr CONFIG.QPLL_CFG1 0xD038
-ad_ip_parameter util_dac_jesd204_xcvr CONFIG.QPLL_CFG1_G3 0xD038
-ad_ip_parameter util_dac_jesd204_xcvr CONFIG.QPLL_CFG2_G3 0xFC0
-ad_ip_parameter util_dac_jesd204_xcvr CONFIG.TX_CLK25_DIV 15
-ad_ip_parameter util_dac_jesd204_xcvr CONFIG.TX_OUT_DIV 1
-ad_ip_parameter util_dac_jesd204_xcvr CONFIG.TXPI_CFG 0x0
-ad_ip_parameter util_dac_jesd204_xcvr CONFIG.A_TXDIFFCTRL 0xC
-ad_ip_parameter util_dac_jesd204_xcvr CONFIG.TX_PI_BIASSET 3
-ad_ip_parameter util_dac_jesd204_xcvr CONFIG.POR_CFG 0x0
-ad_ip_parameter util_dac_jesd204_xcvr CONFIG.PPF0_CFG 0xF00
-ad_ip_parameter util_dac_jesd204_xcvr CONFIG.QPLL_CP 0xFF
-ad_ip_parameter util_dac_jesd204_xcvr CONFIG.QPLL_CP_G3 0xF
-ad_ip_parameter util_dac_jesd204_xcvr CONFIG.QPLL_LPF 0x31D
+#parameters are for 12.5 GHz Lane Rate
 
-ad_ip_parameter dac_jesd204_link/tx CONFIG.SYSREF_IOB false
+ad_ip_parameter util_dac_jesd204_xcvr CONFIG.QPLL_REFCLK_DIV 1
+ad_ip_parameter util_dac_jesd204_xcvr CONFIG.QPLL_CFG2       0xFC1
+ad_ip_parameter util_dac_jesd204_xcvr CONFIG.QPLL_CFG3       0x120
+ad_ip_parameter util_dac_jesd204_xcvr CONFIG.QPLL_CFG0       0x331C
+ad_ip_parameter util_dac_jesd204_xcvr CONFIG.QPLL_FBDIV      40
+ad_ip_parameter util_dac_jesd204_xcvr CONFIG.QPLL_CFG4       0x4
+ad_ip_parameter util_dac_jesd204_xcvr CONFIG.QPLL_CFG1       0xD038
+ad_ip_parameter util_dac_jesd204_xcvr CONFIG.QPLL_CFG1_G3    0xD038
+ad_ip_parameter util_dac_jesd204_xcvr CONFIG.QPLL_CFG2_G3    0xFC1
+ad_ip_parameter util_dac_jesd204_xcvr CONFIG.TX_CLK25_DIV    13
+ad_ip_parameter util_dac_jesd204_xcvr CONFIG.TX_OUT_DIV      1
+ad_ip_parameter util_dac_jesd204_xcvr CONFIG.TXPI_CFG        0x0
+ad_ip_parameter util_dac_jesd204_xcvr CONFIG.A_TXDIFFCTRL    0xC
+ad_ip_parameter util_dac_jesd204_xcvr CONFIG.TX_PI_BIASSET   2
+ad_ip_parameter util_dac_jesd204_xcvr CONFIG.POR_CFG         0x0
+ad_ip_parameter util_dac_jesd204_xcvr CONFIG.PPF0_CFG        0x800
+ad_ip_parameter util_dac_jesd204_xcvr CONFIG.PPF1_CFG        0x600
+ad_ip_parameter util_dac_jesd204_xcvr CONFIG.QPLL_CP         0xFF
+ad_ip_parameter util_dac_jesd204_xcvr CONFIG.QPLL_CP_G3      0xF
+ad_ip_parameter util_dac_jesd204_xcvr CONFIG.QPLL_LPF        0x37F
+
+ad_ip_parameter  dac_jesd204_link/tx   CONFIG.SYSREF_IOB         false
+ad_ip_parameter  dac_dma               CONFIG.DMA_DATA_WIDTH_SRC 128
+ad_ip_parameter  util_dac_jesd204_xcvr CONFIG.TX_LANE_INVERT     240
 
 #system ID
 ad_ip_parameter axi_sysid_0 CONFIG.ROM_ADDR_BITS 9

--- a/projects/dac_fmc_ebz/zcu102/system_constr.xdc
+++ b/projects/dac_fmc_ebz/zcu102/system_constr.xdc
@@ -1,73 +1,76 @@
 ###############################################################################
-## Copyright (C) 2019-2023 Analog Devices, Inc. All rights reserved.
+## Copyright (C) 2019-2024 Analog Devices, Inc. All rights reserved.
 ### SPDX short identifier: ADIBSD
 ###############################################################################
 
-# DAC FMC signals
+# zcu102
+# ad916x device
 
-set_property  -dict {PACKAGE_PIN  AB4 IOSTANDARD LVDS DIFF_TERM_ADV TERM_100} [get_ports tx_sync_p[0]]  ; ## D08  FMC_HPC0_LA01_CC_P        IO_L16P_T2U_N6_QBC_AD3P_66_AB4
-set_property  -dict {PACKAGE_PIN  AC4 IOSTANDARD LVDS DIFF_TERM_ADV TERM_100} [get_ports tx_sync_n[0]]  ; ## D09  FMC_HPC0_LA01_CC_N        IO_L16N_T2U_N7_QBC_AD3N_66_AC4
-set_property  -dict {PACKAGE_PIN  V2  IOSTANDARD LVDS DIFF_TERM_ADV TERM_100} [get_ports tx_sync_p[1]]  ; ## H08  FMC_HPC0_LA02_P           IO_L23P_T3U_N8_66_V2
-set_property  -dict {PACKAGE_PIN  V1  IOSTANDARD LVDS DIFF_TERM_ADV TERM_100} [get_ports tx_sync_n[1]]  ; ## H09  FMC_HPC0_LA02_N           IO_L23N_T3U_N9_66_V1
-set_property  -dict {PACKAGE_PIN  Y4  IOSTANDARD LVDS DIFF_TERM_ADV TERM_100} [get_ports tx_sysref_p]   ; ## G06  FMC_HPC0_LA00_CC_P        IO_L13P_T2L_N0_GC_QBC_66_Y4
-set_property  -dict {PACKAGE_PIN  Y3  IOSTANDARD LVDS DIFF_TERM_ADV TERM_100} [get_ports tx_sysref_n]   ; ## G07  FMC_HPC0_LA00_CC_N        IO_L13N_T2L_N1_GC_QBC_66_Y3
+set_property -dict {PACKAGE_PIN  AB4 IOSTANDARD LVDS DIFF_TERM TRUE} [get_ports tx_sync_p[0]]      ; ## D8   FMC0_LA01_CC_P        IO_L16P_T2U_N6_QBC_AD3P_66
+set_property -dict {PACKAGE_PIN  AC4 IOSTANDARD LVDS DIFF_TERM TRUE} [get_ports tx_sync_n[0]]      ; ## D9   FMC0_LA01_CC_N        IO_L16N_T2U_N7_QBC_AD3N_66
+set_property -dict {PACKAGE_PIN  V2  IOSTANDARD LVDS DIFF_TERM TRUE} [get_ports tx_sync_p[1]]      ; ## H7   FMC0_LA02_P           IO_L23P_T3U_N8_66
+set_property -dict {PACKAGE_PIN  V1  IOSTANDARD LVDS DIFF_TERM TRUE} [get_ports tx_sync_n[1]]      ; ## H8   FMC0_LA02_N           IO_L23N_T3U_N9_66
 
-set_property  -dict {PACKAGE_PIN  AA1 IOSTANDARD LVCMOS18} [get_ports spi_csn_dac]                      ; ## H11  FMC_HPC0_LA04_N           IO_L21N_T3L_N5_AD8N_66_AA1
-set_property  -dict {PACKAGE_PIN  AB3 IOSTANDARD LVCMOS18} [get_ports spi_csn_clk]                      ; ## D11  FMC_HPC0_LA05_P           IO_L20P_T3L_N2_AD1P_66_AB3
-set_property  -dict {PACKAGE_PIN  AA2 IOSTANDARD LVCMOS18} [get_ports spi_miso]                         ; ## H10  FMC_HPC0_LA04_P           IO_L21P_T3L_N4_AD8P_66_AA2
-set_property  -dict {PACKAGE_PIN  Y1  IOSTANDARD LVCMOS18} [get_ports spi_mosi]                         ; ## G10  FMC_HPC0_LA03_N           IO_L22N_T3U_N7_DBC_AD0N_66_Y1
-set_property  -dict {PACKAGE_PIN  Y2  IOSTANDARD LVCMOS18} [get_ports spi_clk]                          ; ## G09  FMC_HPC0_LA03_P           IO_L22P_T3U_N6_DBC_AD0P_66_Y2
-set_property  -dict {PACKAGE_PIN  AC3 IOSTANDARD LVCMOS18} [get_ports spi_en]                           ; ## D12  FMC_HPC0_LA05_N           IO_L20N_T3L_N3_AD1N_66_AC3
-# For AD916(1,2,3,4)-FMC-EBZ
-set_property  -dict {PACKAGE_PIN  W2  IOSTANDARD LVCMOS18} [get_ports spi_csn_clk2]                     ; ## D14  FMC_HPC_LA09_P            IO_L10P_T1_11
+set_property -dict {PACKAGE_PIN  Y4  IOSTANDARD LVDS DIFF_TERM_ADV TERM_100} [get_ports tx_sysref_p] ; ## G6  FMC_HPC0_LA00_CC_P        IO_L13P_T2L_N0_GC_QBC_66_Y4
+set_property -dict {PACKAGE_PIN  Y3  IOSTANDARD LVDS DIFF_TERM_ADV TERM_100} [get_ports tx_sysref_n] ; ## G7  FMC_HPC0_LA00_CC_N        IO_L13N_T2L_N1_GC_QBC_66_Y3
+
+set_property -dict {PACKAGE_PIN G8} [get_ports tx_ref_clk_p] ; ## D4   FMC0_GBTCLK0_M2C_C_P  MGTREFCLK0P_229
+set_property -dict {PACKAGE_PIN G7} [get_ports tx_ref_clk_n] ; ## D5   FMC0_GBTCLK0_M2C_C_N  MGTREFCLK0N_229
+
+set_property -dict {PACKAGE_PIN G4} [get_ports tx_data_p[0]] ; ## C2      FMC0_DP0_C2M_P     MGTHTXP2_229
+set_property -dict {PACKAGE_PIN G3} [get_ports tx_data_n[0]] ; ## C3      FMC0_DP0_C2M_N     MGTHTXN2_229
+set_property -dict {PACKAGE_PIN H6} [get_ports tx_data_p[1]] ; ## A22     FMC0_DP1_C2M_P     MGTHTXP1_229
+set_property -dict {PACKAGE_PIN H5} [get_ports tx_data_n[1]] ; ## A23     FMC0_DP1_C2M_N     MGTHTXN1_229
+set_property -dict {PACKAGE_PIN F6} [get_ports tx_data_p[2]] ; ## A26     FMC0_DP2_C2M_P     MGTHTXP3_229
+set_property -dict {PACKAGE_PIN F5} [get_ports tx_data_n[2]] ; ## A27     FMC0_DP2_C2M_N     MGTHTXN3_229
+set_property -dict {PACKAGE_PIN K6} [get_ports tx_data_p[3]] ; ## A30     FMC0_DP3_C2M_P     MGTHTXP0_229
+set_property -dict {PACKAGE_PIN K5} [get_ports tx_data_n[3]] ; ## A31     FMC0_DP3_C2M_N     MGTHTXN0_229
+set_property -dict {PACKAGE_PIN N4} [get_ports tx_data_p[4]] ; ## B32     FMC0_DP7_C2M_P     MGTHTXP2_228
+set_property -dict {PACKAGE_PIN N3} [get_ports tx_data_n[4]] ; ## B33     FMC0_DP7_C2M_N     MGTHTXN2_228
+set_property -dict {PACKAGE_PIN M6} [get_ports tx_data_p[5]] ; ## A34     FMC0_DP4_C2M_P     MGTHTXP3_228
+set_property -dict {PACKAGE_PIN M5} [get_ports tx_data_n[5]] ; ## A35     FMC0_DP4_C2M_N     MGTHTXN3_228
+set_property -dict {PACKAGE_PIN R4} [get_ports tx_data_p[6]] ; ## B36     FMC0_DP6_C2M_P     MGTHTXP0_228
+set_property -dict {PACKAGE_PIN R3} [get_ports tx_data_n[6]] ; ## B37     FMC0_DP6_C2M_N     MGTHTXN0_228
+set_property -dict {PACKAGE_PIN P6} [get_ports tx_data_p[7]] ; ## A38     FMC0_DP5_C2M_P     MGTHTXP1_228
+set_property -dict {PACKAGE_PIN P5} [get_ports tx_data_n[7]] ; ## A39     FMC0_DP5_C2M_N     MGTHTXN1_228
+
+set_property -dict {PACKAGE_PIN Y2   IOSTANDARD LVCMOS18} [get_ports spi_clk]       ; ## G9   FMC0_LA03_P IO_L22P_T3U_N6_DBC_AD0P_66
+set_property -dict {PACKAGE_PIN AA1  IOSTANDARD LVCMOS18} [get_ports spi_csn_dac]   ; ## H11  FMC0_LA04_N IO_L21N_T3L_N5_AD8N_66
+set_property -dict {PACKAGE_PIN AB3  IOSTANDARD LVCMOS18} [get_ports spi_csn_clk]   ; ## D11  FMC0_LA05_P IO_L24P_T3U_N10_66
+set_property -dict {PACKAGE_PIN W2   IOSTANDARD LVCMOS18} [get_ports spi_csn_clk2]  ; ## D14  FMC0_LA09_P IO_L20P_T3L_N2_AD1P_66
+set_property -dict {PACKAGE_PIN AA2  IOSTANDARD LVCMOS18} [get_ports spi_miso]      ; ## H10  FMC0_LA04_P IO_L21P_T3L_N4_AD8P_66
+set_property -dict {PACKAGE_PIN Y1   IOSTANDARD LVCMOS18} [get_ports spi_mosi]      ; ## G10  FMC0_LA03_N IO_L22N_T3U_N7_DBC_AD0N_66
+set_property -dict {PACKAGE_PIN AC3  IOSTANDARD LVCMOS18} [get_ports spi_en]        ; ## D12  FMC0_LA05_N IO_L20N_T3L_N3_AD1N_66
 
 # For AD9135-FMC-EBZ, AD9136-FMC-EBZ, AD9144-FMC-EBZ, AD9152-FMC-EBZ, AD9154-FMC-EBZ
-set_property  -dict {PACKAGE_PIN  U5  IOSTANDARD LVCMOS18} [get_ports dac_ctrl[0]]                      ; ## H13  FMC_HPC0_LA07_P           IO_L18P_T2U_N10_AD2P_66_U5
-set_property  -dict {PACKAGE_PIN  U4  IOSTANDARD LVCMOS18} [get_ports dac_ctrl[3]]                      ; ## H14  FMC_HPC0_LA07_N           IO_L18N_T2U_N11_AD2N_66_U4
+set_property -dict {PACKAGE_PIN U5   IOSTANDARD LVCMOS18} [get_ports dac_ctrl[0]] ; ## H13  FMC0_LA07_P      IO_L18P_T2U_N10_AD2P_66
+set_property -dict {PACKAGE_PIN U4   IOSTANDARD LVCMOS18} [get_ports dac_ctrl[3]] ; ## H14  FMC_HPC0_LA07_N  IO_L18N_T2U_N11_AD2N_66_U4
 
 # For AD9171-FMC-EBZ, AD9172-FMC-EBZ, AD9173-FMC-EBZ
-set_property  -dict {PACKAGE_PIN  AC2 IOSTANDARD LVCMOS18} [get_ports dac_ctrl[1]]                      ; ## C10  FMC_HPC0_LA06_P           IO_L19P_T3L_N0_DBC_AD9P_66_AC2
-set_property  -dict {PACKAGE_PIN  AC1 IOSTANDARD LVCMOS18} [get_ports dac_ctrl[2]]                      ; ## C11  FMC_HPC0_LA06_N           IO_L19N_T3L_N1_DBC_AD9N_66_AC1
+set_property -dict {PACKAGE_PIN AC2  IOSTANDARD LVCMOS18} [get_ports dac_ctrl[1]] ; ## C10  FMC_HPC0_LA06_P  IO_L19P_T3L_N0_DBC_AD9P_66_AC2
+set_property -dict {PACKAGE_PIN AC1  IOSTANDARD LVCMOS18} [get_ports dac_ctrl[2]] ; ## C11  FMC_HPC0_LA06_N  IO_L19N_T3L_N1_DBC_AD9N_66_AC1
+
 # For AD916(1,2,3,4)-FMC-EBZ
-set_property  -dict {PACKAGE_PIN  W1  IOSTANDARD LVCMOS18} [get_ports dac_ctrl[4]]                      ; ## D15  FMC_HPC_LA09_P            IO_L10N_T1_11
-
-set_property  -dict {PACKAGE_PIN  G8} [get_ports tx_ref_clk_p]                                          ; ## D04  FMC_HPC0_GBTCLK0_M2C_C_P  MGTREFCLK0P_229_G8
-set_property  -dict {PACKAGE_PIN  G7} [get_ports tx_ref_clk_n]                                          ; ## D05  FMC_HPC0_GBTCLK0_M2C_C_N  MGTREFCLK0N_229_G7
-
-set_property  -dict {PACKAGE_PIN  G3} [get_ports tx_data_n[7]]                                          ; ## C03  FMC_HPC0_DP0_C2M_N        MGTHTXN2_229_G3
-set_property  -dict {PACKAGE_PIN  G4} [get_ports tx_data_p[7]]                                          ; ## C02  FMC_HPC0_DP0_C2M_P        MGTHTXP2_229_G4
-set_property  -dict {PACKAGE_PIN  H5} [get_ports tx_data_n[6]]                                          ; ## A23  FMC_HPC0_DP1_C2M_N        MGTHTXN1_229_H5
-set_property  -dict {PACKAGE_PIN  H6} [get_ports tx_data_p[6]]                                          ; ## A22  FMC_HPC0_DP1_C2M_P        MGTHTXP1_229_H6
-set_property  -dict {PACKAGE_PIN  F5} [get_ports tx_data_n[5]]                                          ; ## A27  FMC_HPC0_DP2_C2M_N        MGTHTXN3_229_F5
-set_property  -dict {PACKAGE_PIN  F6} [get_ports tx_data_p[5]]                                          ; ## A26  FMC_HPC0_DP2_C2M_P        MGTHTXP3_229_F6
-set_property  -dict {PACKAGE_PIN  K5} [get_ports tx_data_n[4]]                                          ; ## A31  FMC_HPC0_DP3_C2M_N        MGTHTXN0_229_K5
-set_property  -dict {PACKAGE_PIN  K6} [get_ports tx_data_p[4]]                                          ; ## A30  FMC_HPC0_DP3_C2M_P        MGTHTXP0_229_K6
-set_property  -dict {PACKAGE_PIN  M6} [get_ports tx_data_p[2]]                                          ; ## A34  FMC_HPC0_DP4_C2M_P        MGTHTXP3_228_M6
-set_property  -dict {PACKAGE_PIN  M5} [get_ports tx_data_n[2]]                                          ; ## A35  FMC_HPC0_DP4_C2M_N        MGTHTXN3_228_M5
-set_property  -dict {PACKAGE_PIN  P6} [get_ports tx_data_p[0]]                                          ; ## A38  FMC_HPC0_DP5_C2M_P        MGTHTXP1_228_P6
-set_property  -dict {PACKAGE_PIN  P5} [get_ports tx_data_n[0]]                                          ; ## A39  FMC_HPC0_DP5_C2M_N        MGTHTXN1_228_P5
-set_property  -dict {PACKAGE_PIN  R4} [get_ports tx_data_p[1]]                                          ; ## B36  FMC_HPC0_DP6_C2M_P        MGTHTXP0_228_R4
-set_property  -dict {PACKAGE_PIN  R3} [get_ports tx_data_n[1]]                                          ; ## B37  FMC_HPC0_DP6_C2M_N        MGTHTXN0_228_R3
-set_property  -dict {PACKAGE_PIN  N4} [get_ports tx_data_p[3]]                                          ; ## B32  FMC_HPC0_DP7_C2M_P        MGTHTXP2_228_N4
-set_property  -dict {PACKAGE_PIN  N3} [get_ports tx_data_n[3]]                                          ; ## B33  FMC_HPC0_DP7_C2M_N        MGTHTXN2_228_N3
+set_property -dict {PACKAGE_PIN W1   IOSTANDARD LVCMOS18} [get_ports dac_ctrl[4]] ; ## D15  FMC0_LA09_N      IO_L24N_T3U_N11_66
 
 # PL PMOD 1 header
-set_property  -dict {PACKAGE_PIN  D20 IOSTANDARD LVCMOS33} [get_ports pmod_spi_clk]                     ; ## PMOD1_0                        IO_L8N_HDGC_AD4N_47_D20
-set_property  -dict {PACKAGE_PIN  E20 IOSTANDARD LVCMOS33} [get_ports pmod_spi_csn]                     ; ## PMOD1_1                        IO_L8P_HDGC_AD4P_47_E20
-set_property  -dict {PACKAGE_PIN  D22 IOSTANDARD LVCMOS33} [get_ports pmod_spi_mosi]                    ; ## PMOD1_2                        IO_L7N_HDGC_AD5N_47_D22
-set_property  -dict {PACKAGE_PIN  E22 IOSTANDARD LVCMOS33} [get_ports pmod_spi_miso]                    ; ## PMOD1_3                        IO_L7P_HDGC_AD5P_47_E22
-set_property  -dict {PACKAGE_PIN  F20 IOSTANDARD LVCMOS33} [get_ports pmod_gpio[0]]                     ; ## PMOD1_4                        IO_L6N_HDGC_AD6N_47_F20
-set_property  -dict {PACKAGE_PIN  G20 IOSTANDARD LVCMOS33} [get_ports pmod_gpio[1]]                     ; ## PMOD1_5                        IO_L6P_HDGC_AD6P_47_G20
-set_property  -dict {PACKAGE_PIN  J20 IOSTANDARD LVCMOS33} [get_ports pmod_gpio[2]]                     ; ## PMOD1_6                        IO_L4N_AD8N_47_J20
-set_property  -dict {PACKAGE_PIN  J19 IOSTANDARD LVCMOS33} [get_ports pmod_gpio[3]]                     ; ## PMOD1_7                        IO_L4P_AD8P_47_J19
-
-# clocks
+set_property  -dict {PACKAGE_PIN  D20 IOSTANDARD LVCMOS33} [get_ports pmod_spi_clk]  ; ## PMOD1_0   IO_L8N_HDGC_AD4N_47_D20
+set_property  -dict {PACKAGE_PIN  E20 IOSTANDARD LVCMOS33} [get_ports pmod_spi_csn]  ; ## PMOD1_1   IO_L8P_HDGC_AD4P_47_E20
+set_property  -dict {PACKAGE_PIN  D22 IOSTANDARD LVCMOS33} [get_ports pmod_spi_mosi] ; ## PMOD1_2   IO_L7N_HDGC_AD5N_47_D22
+set_property  -dict {PACKAGE_PIN  E22 IOSTANDARD LVCMOS33} [get_ports pmod_spi_miso] ; ## PMOD1_3   IO_L7P_HDGC_AD5P_47_E22
+set_property  -dict {PACKAGE_PIN  F20 IOSTANDARD LVCMOS33} [get_ports pmod_gpio[0]]  ; ## PMOD1_4   IO_L6N_HDGC_AD6N_47_F20
+set_property  -dict {PACKAGE_PIN  G20 IOSTANDARD LVCMOS33} [get_ports pmod_gpio[1]]  ; ## PMOD1_5   IO_L6P_HDGC_AD6P_47_G20
+set_property  -dict {PACKAGE_PIN  J20 IOSTANDARD LVCMOS33} [get_ports pmod_gpio[2]]  ; ## PMOD1_6   IO_L4N_AD8N_47_J20
+set_property  -dict {PACKAGE_PIN  J19 IOSTANDARD LVCMOS33} [get_ports pmod_gpio[3]]  ; ## PMOD1_7   IO_L4P_AD8P_47_J19
 
 # Max lane rate of 15.4 Gbps
+# ref clock lane_rate/40 or lane_rate/20
+
 create_clock -name tx_ref_clk   -period  2.597 [get_ports tx_ref_clk_p]
 
-# Assumption is that REFCLK and SYSREF have similar propagation delay, 
+# Assumption is that REFCLK and SYSREF have similar propagation delay,
 # and the SYSREF is a source synchronous Center-Aligned signal to REFCLK
+
 set_input_delay -clock [get_clocks tx_ref_clk] \
   [expr [get_property  PERIOD [get_clocks tx_ref_clk]] / 2] \
   [get_ports {tx_sysref_*}]

--- a/projects/dac_fmc_ebz/zcu102/system_top.v
+++ b/projects/dac_fmc_ebz/zcu102/system_top.v
@@ -1,6 +1,6 @@
 // ***************************************************************************
 // ***************************************************************************
-// Copyright (C) 2019-2023 Analog Devices, Inc. All rights reserved.
+// Copyright (C) 2019-2024 Analog Devices, Inc. All rights reserved.
 //
 // In this HDL repository, there are many different and unique modules, consisting
 // of various HDL (Verilog or VHDL) components. The individual modules are
@@ -128,13 +128,13 @@ module system_top #(
 
   // spi_en is active ...
   //   ... high for AD9135-FMC-EBZ, AD9136-FMC-EBZ, AD9144-FMC-EBZ,
-  //   ... low for AD9171-FMC-EBZ, AD9172-FMC-EBZ, AD9173-FMC-EBZ
+  //   ... low for AD9171-FMC-EBZ, AD9172-FMC-EBZ, AD9173-FMC-EBZ, AD9161-FMC-EBZ, AD9162-FMC-EBZ, AD9163-FMC-EBZ, AD9164-FMC-EBZ
   // If you are planning to build a bitstream for just one of those boards you
   // can hardwire the logic level here.
   //
   assign spi_en = (DEVICE_CODE <= 2);
 
-  //                                        9135/9144/9172    916(1,2,3,4)
+  //                                      AD9135/9144/9172   AD916(1,2,3,4)
   assign spi_csn_dac  = spi0_csn[1];
   assign spi_csn_clk  = spi0_csn[0];    //   HMC7044          AD9508
   assign spi_csn_clk2 = spi0_csn[2];    //   NC               ADF4355
@@ -238,7 +238,7 @@ module system_top #(
     .tx_ref_clk_0 (tx_ref_clk),
     .tx_ref_clk_4 (tx_ref_clk),
     .tx_sync_0 (tx_sync[NUM_LINKS-1:0]),
-    .tx_sysref_0 (tx_sysref));
+    .tx_sysref_0 (tx_sysref_loc));
 
   // AD9161/2/4-FMC-EBZ works only in single link,
   // The FMC connector instead of SYNC1 has SYSREF connected to it


### PR DESCRIPTION
## PR Description

- enabling custom modes trough make parameters (M L S F HD N NP)
- changing the source DMA DATA WIDTH to 128
- changing the TX_LANE_INVERT from 0x0F to 0xF0
- updating the xcvr parameters for 12.5GHz lane rate
- cosmetics on the system_constr file

## PR Type
- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the code style guidelines
- [x] I have performed a self-review of changes
- [x] I have compiled all hdl projects and libraries affected by this PR
- [x] I have tested in hardware affected projects, at least on relevant boards
- [ ] I have commented my code, at least hard-to-understand parts
- [x] I have signed off all commits from this PR
- [x] I have updated the documentation (wiki pages, ReadMe files, Copyright etc)
- [x] I have not introduced new Warnings/Critical Warnings on compilation
- [ ] I have added new hdl testbenches or updated existing ones
