### PR TITLE
Script to link the TB and HDL repos

### DIFF
--- a/scripts/env_link.sh
+++ b/scripts/env_link.sh
@@ -1,0 +1,84 @@
+###########################################################
+# env_link.sh
+# This script has the sole role to link HDL and TB repos
+# no matter their location
+###########################################################
+
+# Example usage:
+# Make the script executable:
+# chmod +x env_link.sh
+# Run the script with an absolute or relative path to the testbenches directory:
+# ./env_link.sh /absolute/path/to/testbenches
+# or
+# ./env_link.sh ../relative/path/to/testbenches
+# If no argument is provided, the script will search for the testbenches directory:
+# ./env_link.sh
+# 
+# Note, you can also run the script by running:
+# source env_tcl.sh {same_instructions_as_above} or
+# bash env_tcl.sh {same_instructions_as_above}
+
+# Function to recursively search for a directory
+search_directory() {
+    local dir=$1
+    local target=$2
+    while [ "$dir" != "/" ]; do
+        if [ -d "$dir/$target" ]; then
+            echo "$dir/$target"
+            return 0
+        fi
+        dir=$(dirname "$dir")
+    done
+    return 1
+}
+
+# Function to convert a relative path to an absolute path
+to_absolute_path() {
+    local path=$1
+    if [ -d "$path" ]; then
+        (cd "$path" && pwd)
+    else
+        echo "$path"
+    fi
+}
+
+# Check if the HDL path is already exported
+if [[ $ADI_HDL_DIR == *"hdl"* ]]; then
+    echo "HDL path already exported!"
+else
+    echo "HDL path not exported, will export now ..."
+    # Check if we are in a directory that contains "hdl"
+    if [[ $(pwd) == *"hdl"* ]]; then
+        hdl_path=$(pwd | sed 's|\(.*hdl\).*|\1|')
+        export ADI_HDL_DIR="${hdl_path}"
+        echo "HDL directory exported as $ADI_HDL_DIR"
+    else
+        echo "Not in an HDL directory"
+    fi
+fi
+
+# Check if the TB path is already exported
+if [[ $ADI_TB_DIR == *"testbenches"* ]]; then
+    echo "Testbenches path already exported!"
+else
+    echo "Testbenches path not exported, will export now ..."
+    # Use the provided argument or search for the testbenches directory
+    abs_path_to_tb=$1
+    if [ -n "$abs_path_to_tb" ]; then
+        abs_path_to_tb=$(to_absolute_path "$abs_path_to_tb")
+        if [ -d "$abs_path_to_tb" ]; then
+            export ADI_TB_DIR="$abs_path_to_tb"
+            echo "Testbenches directory exported as $ADI_TB_DIR"
+        else
+            echo "Provided path does not exist"
+        fi
+    else
+        tb_path=$(search_directory "$(pwd)" "testbenches")
+        if [ -n "$tb_path" ]; then
+            export ADI_TB_DIR="$tb_path"
+            echo "Testbenches directory found and exported as $ADI_TB_DIR"
+        else
+            echo "Testbenches directory not found"
+        fi
+    fi
+fi


### PR DESCRIPTION
## PR Description

This script is made so that you can have both repos in different places & link them so that all the functionalities would still work. 
You no longer need to clone TB repo in HDL repo. This change is made in the context of 'workspace versioning' feature which will soon be implemented. A very similar script will be added in the TB repo, for the same purpose.
Left an example on how to use the script, in the comments. 

Also thought about adding a READEME.md file for the /scripts folder which will briefly explain the two scripts.

## PR Type
- [ ] Bug fix (change that fixes an issue)
- [x] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the code style guidelines
- [x] I have performed a self-review of changes
- [x] I have compiled all hdl projects and libraries affected by this PR
- [ ] I have tested in hardware affected projects, at least on relevant boards
- [x] I have commented my code, at least hard-to-understand parts
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe files, Copyright etc)
- [x] I have not introduced new Warnings/Critical Warnings on compilation
- [ ] I have added new hdl testbenches or updated existing ones
