### PR TITLE
i3c_controller: Bug fixes for I2C devices and lower sclk speed

### DIFF
--- a/docs/library/i3c_controller/i3c_controller_core.rst
+++ b/docs/library/i3c_controller/i3c_controller_core.rst
@@ -34,9 +34,20 @@ Configuration Parameters
 .. hdl-parameters::
 
    * - CLK_MOD
-     - | Clock cycles per bus bit at maximun speed (12.5MHz), set to:
-       | * 8 clock cycles at 100MHz input clock.
-       | * 4 clock cycles at 50MHz input clock.
+     - Clock cycles per bus bit at maximun speed (12.5MHz), set to:
+
+       * 0: 8 clock cycles at 100MHz input clock.
+       * 1: 4 clock cycles at 50MHz input clock.
+   * - I2C_MOD
+     - Further divide open drain speed by power of two,
+       to support slow I2C devices.
+
+       For example, with input clock 100MHz and CLK_MOD=0:
+
+       * 0: 1.5626MHz (no division).
+       * 2 390.6kHz.
+       * 4 97.6kHz.
+
 
 Signal and Interface Pins
 --------------------------------------------------------------------------------

--- a/docs/library/i3c_controller/interface.rst
+++ b/docs/library/i3c_controller/interface.rst
@@ -418,7 +418,7 @@ sampled:
 
 .. warning::
 
-   To not sample the ``bit_mod:sdo`` signal, it will alter the SDA I/O logic and
+   Do not sample the ``bit_mod:sdo`` signal, it will alter the SDA I/O logic and
    the core won't work properly.
 
 The trigger at ``cmd_parser:cmdp_ccc_id`` allows to start the capture at the start

--- a/docs/regmap/adi_regmap_i3c_controller.txt
+++ b/docs/regmap/adi_regmap_i3c_controller.txt
@@ -548,7 +548,7 @@ ENDFIELD
 FIELD
 [8]
 DEV_CHAR_WEN
-W
+WO
 Enable write of the fields.
 ENDFIELD
 
@@ -575,6 +575,7 @@ RW
 Indicate if the device is attached.
 ENDFIELD
 
+FIELD
 [0] 0x0
 DEV_CHAR_IS_I2C
 RW

--- a/library/i3c_controller/i3c_controller_core/i3c_controller_bit_mod.v
+++ b/library/i3c_controller/i3c_controller_core/i3c_controller_bit_mod.v
@@ -163,7 +163,7 @@ module i3c_controller_bit_mod #(
         count <= count + COUNT_INCR;
       end
 
-      if (sm == SM_SETUP) begin
+      if (sm == SM_SETUP || st == `MOD_BIT_CMD_STOP_) begin
         sr <= 1'b0;
       end else if (cmdb_ready) begin
         sr <= 1'b1;
@@ -220,7 +220,7 @@ module i3c_controller_bit_mod #(
                     CLK_MOD ? scl_posedge : i3c_scl_posedge;
 
   assign sdo_w = st == `MOD_BIT_CMD_START_   ? sr_sda :
-                 st == `MOD_BIT_CMD_STOP_    ? 1'b0 :
+                 st == `MOD_BIT_CMD_STOP_    ? ~sr_sda :
                  st == `MOD_BIT_CMD_WRITE_   ? ss[0] :
                  st == `MOD_BIT_CMD_ACK_SDR_ ?
                    (i2c_mode_reg ? 1'b1 : (sm == SM_SCL_HIGH ? rx : 1'b1)) :

--- a/library/i3c_controller/i3c_controller_core/i3c_controller_core.v
+++ b/library/i3c_controller/i3c_controller_core/i3c_controller_core.v
@@ -40,7 +40,8 @@
 
 module i3c_controller_core #(
   parameter MAX_DEVS = 16,
-  parameter CLK_MOD = 0
+  parameter CLK_MOD = 0,
+  parameter I2C_MOD = 0
 ) (
   input         clk,
   input         reset_n,
@@ -170,7 +171,8 @@ module i3c_controller_core #(
     .rmap_ibi_config(rmap_ibi_config));
 
   i3c_controller_bit_mod #(
-    .CLK_MOD(CLK_MOD)
+    .CLK_MOD(CLK_MOD),
+    .I2C_MOD(I2C_MOD)
   ) i_i3c_controller_bit_mod (
     .reset_n(reset_n),
     .clk(clk),

--- a/library/i3c_controller/i3c_controller_core/i3c_controller_core_hw.tcl
+++ b/library/i3c_controller/i3c_controller_core/i3c_controller_core_hw.tcl
@@ -22,6 +22,7 @@ ad_ip_files i3c_controller_core [list \
 
 ad_ip_parameter MAX_DEVS STRING "MAX_DEVS"
 ad_ip_parameter CLK_MOD INTEGER 1
+ad_ip_parameter I2C_MOD INTEGER 0
 
 proc p_elaboration {} {
 
@@ -29,6 +30,7 @@ proc p_elaboration {} {
 
   set max_devs [get_parameter_value "MAX_DEVS"]
   set clk_mod [get_parameter_value "CLK_MOD"]
+  set i2c_mod [get_parameter_value "I2C_MOD"]
 
   # clock and reset interface
 

--- a/library/i3c_controller/i3c_controller_core/i3c_controller_core_ip.tcl
+++ b/library/i3c_controller/i3c_controller_core/i3c_controller_core_ip.tcl
@@ -96,6 +96,13 @@ set_property -dict [list \
 ] \
 [ipx::get_user_parameters CLK_MOD -of_objects $cc]
 
+## I2C_MOD
+set_property -dict [list \
+  "value_validation_type" "list" \
+  "value_validation_list" "0 1 2 3 4" \
+] \
+[ipx::get_user_parameters I2C_MOD -of_objects $cc]
+
 ## Customize IP Layout
 ## Remove the automatically generated GUI page
 ipgui::remove_page -component $cc [ipgui::get_pagespec -name "Page 0" -component $cc]
@@ -120,6 +127,13 @@ set_property -dict [list \
 	"display_name" "Clock cycles per bit" \
   "tooltip" "\[CLK_MOD\] Adjust clock cycles required to modulate the lane bus bits. Set 8 to achieve 12.5MHz at 100Mhz input clock, and 4 at 50MHz." \
 ] [ipgui::get_guiparamspec -name "CLK_MOD" -component $cc]
+
+ipgui::add_param -name "I2C_MOD" -component $cc -parent $general_group
+set_property -dict [list \
+	"widget" "comboBox" \
+	"display_name" "I2C divider" \
+  "tooltip" "\[I2C_MOD\] Further divide (two power) open drain speed to achieve a lower I2C. Set 0 to achieve 1.56MHz at (clk=100MHz, Clock cycles per bit=8), 1 for 781kHz." \
+] [ipgui::get_guiparamspec -name "I2C_MOD" -component $cc]
 
 ## Create and save the XGUI file
 ipx::create_xgui_files $cc

--- a/library/i3c_controller/i3c_controller_core/i3c_controller_word.v
+++ b/library/i3c_controller/i3c_controller_core/i3c_controller_word.v
@@ -262,9 +262,13 @@ module i3c_controller_word (
                 // In I2C, the peripheral cannot stop the SM_TRANSFER.
                 cmd_r <= `MOD_BIT_CMD_WRITE_;
                 if (sdi_ready) begin
-                  cmd_wr <= 1'b0; // ACK
-                end else begin
-                  cmd_wr <= 1'b1; // NACK
+                  if (cmdw_header == `CMDW_STOP_OD) begin
+                    // Peek next command to see if the controller wishes to
+                    // end the SM_TRANSFER.
+                    cmd_wr <= 1'b1; // NACK
+                  end else begin
+                    cmd_wr <= 1'b0; // ACK
+                  end
                 end
               end else begin
                 // SDI

--- a/library/i3c_controller/scripts/i3c_controller_bd.tcl
+++ b/library/i3c_controller/scripts/i3c_controller_bd.tcl
@@ -3,7 +3,7 @@
 ### SPDX short identifier: ADIBSD
 ###############################################################################
 
-proc i3c_controller_create {{name "i3c_controller"} {async_clk 0} {clk_mod 1} {offload 1} {max_devs 16}} {
+proc i3c_controller_create {{name "i3c_controller"} {async_clk 0} {clk_mod 1} {i2c_mod 0} {offload 1} {max_devs 16}} {
 
   create_bd_cell -type hier $name
   current_bd_instance /$name
@@ -27,6 +27,7 @@ proc i3c_controller_create {{name "i3c_controller"} {async_clk 0} {clk_mod 1} {o
   ad_ip_instance i3c_controller_core core
   ad_ip_parameter core CONFIG.MAX_DEVS $max_devs
   ad_ip_parameter core CONFIG.CLK_MOD $clk_mod
+  ad_ip_parameter core CONFIG.i2c_MOD $i2c_mod
 
   ad_connect clk host_interface/s_axi_aclk
   if {$async_clk == 1} {

--- a/library/i3c_controller/scripts/i3c_controller_qsys.tcl
+++ b/library/i3c_controller/scripts/i3c_controller_qsys.tcl
@@ -3,7 +3,7 @@
 ### SPDX short identifier: ADIBSD
 ###############################################################################
 
-proc i3c_controller_create {{name "i3c_controller"} {async_clk 0} {clk_mod 1} {offload 1} {max_devs 16}} {
+proc i3c_controller_create {{name "i3c_controller"} {async_clk 0} {clk_mod 1} {i2c_mod 0} {offload 1} {max_devs 16}} {
   add_instance ${name}_host_interface i3c_controller_host_interface
 
   set_instance_parameter_value ${name}_host_interface {ASYNC_CLK} $async_clk
@@ -13,6 +13,7 @@ proc i3c_controller_create {{name "i3c_controller"} {async_clk 0} {clk_mod 1} {o
 
   set_instance_parameter_value ${name}_core {MAX_DEVS} $max_devs
   set_instance_parameter_value ${name}_core {CLK_MOD} $clk_mod
+  set_instance_parameter_value ${name}_core {I2C_MOD} $i2c_mod
 
   add_connection ${name}_host_interface.sdo  ${name}_core.sdo
   add_connection ${name}_host_interface.cmdp ${name}_core.cmdp


### PR DESCRIPTION
## PR Description

Some rework to better support slow I2C devices (100kHz, 400kHz).
I2C speed can be lower than I3C open drain speed.
The new I2C_MOD allows to configure this speed.

## PR Type
- [X] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the code style guidelines
- [x] I have performed a self-review of changes
- [ ] I have compiled all hdl projects and libraries affected by this PR
- [ ] I have tested in hardware affected projects, at least on relevant boards
- [ ] I have commented my code, at least hard-to-understand parts
- [ ] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe files, Copyright etc)
- [ ] I have not introduced new Warnings/Critical Warnings on compilation
- [ ] I have added new hdl testbenches or updated existing ones
