### PR TITLE
Data Offload Integration: adrv9009 AMD/Xilinx Projects

### DIFF
--- a/projects/adrv9009/common/adrv9009_bd.tcl
+++ b/projects/adrv9009/common/adrv9009_bd.tcl
@@ -16,6 +16,7 @@ set MAX_RX_OS_NUM_OF_LANES 2
 set DATAPATH_WIDTH 4
 source $ad_hdl_dir/library/jesd204/scripts/jesd204.tcl
 source $ad_hdl_dir/projects/common/xilinx/adi_fir_filter_bd.tcl
+source $ad_hdl_dir/projects/common/xilinx/data_offload_bd.tcl
 
 # TX parameters
 set TX_NUM_OF_LANES $ad_project_params(TX_JESD_L)      ; # L
@@ -53,14 +54,13 @@ set RX_OS_TPL_WIDTH [ expr { [info exists ad_project_params(RX_OS_TPL_WIDTH)] \
 set RX_OS_DATAPATH_WIDTH [adi_jesd204_calc_tpl_width $DATAPATH_WIDTH $RX_OS_NUM_OF_LANES $RX_OS_NUM_OF_CONVERTERS $RX_OS_SAMPLES_PER_FRAME $RX_OS_SAMPLE_WIDTH $RX_OS_TPL_WIDTH]
 set RX_OS_SAMPLES_PER_CHANNEL [expr $RX_OS_NUM_OF_LANES * 8 * $RX_OS_DATAPATH_WIDTH / ($RX_OS_NUM_OF_CONVERTERS * $RX_OS_SAMPLE_WIDTH)]
 
-set dac_fifo_name axi_adrv9009_dacfifo
+set dac_offload_name adrv9009_data_offload
 set dac_data_width [expr $TX_SAMPLE_WIDTH * $TX_NUM_OF_CONVERTERS * $TX_SAMPLES_PER_CHANNEL]
 
 # adrv9009
 
 create_bd_port -dir I ref_clk
 
-create_bd_port -dir I dac_fifo_bypass
 create_bd_port -dir I adc_fir_filter_active
 create_bd_port -dir I dac_fir_filter_active
 
@@ -110,7 +110,16 @@ ad_ip_parameter axi_adrv9009_tx_dma CONFIG.MAX_BYTES_PER_BURST 256
 ad_ip_parameter axi_adrv9009_tx_dma CONFIG.AXI_SLICE_DEST true
 ad_ip_parameter axi_adrv9009_tx_dma CONFIG.AXI_SLICE_SRC true
 
-ad_dacfifo_create $dac_fifo_name $dac_data_width $dac_data_width $dac_fifo_address_width
+ad_data_offload_create $dac_offload_name \
+                       1 \
+                       $dac_offload_type \
+                       $dac_offload_size \
+                       $dac_data_width \
+                       $dac_data_width \
+                       $plddr_offload_axi_data_width
+
+ad_ip_parameter $dac_offload_name/i_data_offload CONFIG.SYNC_EXT_ADD_INTERNAL_CDC 0
+ad_connect $dac_offload_name/sync_ext GND
 
 # adc peripherals
 
@@ -348,25 +357,18 @@ for {set i 0} {$i < $TX_NUM_OF_CONVERTERS} {incr i} {
 
 ad_connect  tx_fir_interpolator/active dac_fir_filter_active
 
-ad_connect  axi_adrv9009_tx_clkgen/clk_0 axi_adrv9009_dacfifo/dac_clk
-ad_connect  adrv9009_tx_device_clk_rstgen/peripheral_reset axi_adrv9009_dacfifo/dac_rst
+ad_connect  axi_adrv9009_tx_clkgen/clk_0 $dac_offload_name/m_axis_aclk
+ad_connect  adrv9009_tx_device_clk_rstgen/peripheral_aresetn $dac_offload_name/m_axis_aresetn
+ad_connect  util_adrv9009_tx_upack/s_axis $dac_offload_name/m_axis
 
-# TODO: Add streaming AXI interface for DAC FIFO
-ad_connect  util_adrv9009_tx_upack/s_axis_valid VCC
-ad_connect  util_adrv9009_tx_upack/s_axis_ready axi_adrv9009_dacfifo/dac_valid
-ad_connect  util_adrv9009_tx_upack/s_axis_data axi_adrv9009_dacfifo/dac_data
-
-ad_connect  $sys_dma_clk axi_adrv9009_dacfifo/dma_clk
-ad_connect  $sys_dma_reset axi_adrv9009_dacfifo/dma_rst
+ad_connect  $sys_dma_clk $dac_offload_name/s_axis_aclk
+ad_connect  $sys_dma_resetn $dac_offload_name/s_axis_aresetn
 ad_connect  $sys_dma_clk axi_adrv9009_tx_dma/m_axis_aclk
-ad_connect  axi_adrv9009_dacfifo/dma_valid axi_adrv9009_tx_dma/m_axis_valid
-ad_connect  axi_adrv9009_dacfifo/dma_data axi_adrv9009_tx_dma/m_axis_data
-ad_connect  axi_adrv9009_dacfifo/dma_ready axi_adrv9009_tx_dma/m_axis_ready
-ad_connect  axi_adrv9009_dacfifo/dma_xfer_req axi_adrv9009_tx_dma/m_axis_xfer_req
-ad_connect  axi_adrv9009_dacfifo/dma_xfer_last axi_adrv9009_tx_dma/m_axis_last
-ad_connect  axi_adrv9009_dacfifo/dac_dunf tx_adrv9009_tpl_core/dac_dunf
-ad_connect  axi_adrv9009_dacfifo/bypass dac_fifo_bypass
 ad_connect  $sys_dma_resetn axi_adrv9009_tx_dma/m_src_axi_aresetn
+
+ad_connect  $dac_offload_name/s_axis axi_adrv9009_tx_dma/m_axis
+ad_connect  $dac_offload_name/init_req axi_adrv9009_tx_dma/m_axis_xfer_req
+ad_connect  tx_adrv9009_tpl_core/dac_dunf util_adrv9009_tx_upack/fifo_rd_underflow
 
 # connections (adc)
 
@@ -437,6 +439,7 @@ ad_cpu_interconnect 0x44A80000 axi_adrv9009_tx_xcvr
 ad_cpu_interconnect 0x43C00000 axi_adrv9009_tx_clkgen
 ad_cpu_interconnect 0x44A90000 axi_adrv9009_tx_jesd
 ad_cpu_interconnect 0x7c420000 axi_adrv9009_tx_dma
+ad_cpu_interconnect 0x7c430000 $dac_offload_name
 ad_cpu_interconnect 0x44A60000 axi_adrv9009_rx_xcvr
 ad_cpu_interconnect 0x43C10000 axi_adrv9009_rx_clkgen
 ad_cpu_interconnect 0x44AA0000 axi_adrv9009_rx_jesd

--- a/projects/adrv9009/zc706/Makefile
+++ b/projects/adrv9009/zc706/Makefile
@@ -1,5 +1,5 @@
 ####################################################################################
-## Copyright (c) 2018 - 2023 Analog Devices, Inc.
+## Copyright (c) 2018 - 2024 Analog Devices, Inc.
 ### SPDX short identifier: BSD-1-Clause
 ## Auto-generated, do not modify!
 ####################################################################################
@@ -10,11 +10,12 @@ M_DEPS += ../common/adrv9009_bd.tcl
 M_DEPS += ../../scripts/adi_pd.tcl
 M_DEPS += ../../common/zc706/zc706_system_constr.xdc
 M_DEPS += ../../common/zc706/zc706_system_bd.tcl
-M_DEPS += ../../common/zc706/zc706_plddr3_dacfifo_bd.tcl
+M_DEPS += ../../common/zc706/zc706_plddr3_data_offload_bd.tcl
 M_DEPS += ../../common/zc706/zc706_plddr3_constr.xdc
+M_DEPS += ../../common/xilinx/data_offload_bd.tcl
 M_DEPS += ../../common/xilinx/adi_fir_filter_constr.xdc
 M_DEPS += ../../common/xilinx/adi_fir_filter_bd.tcl
-M_DEPS += ../../../library/util_cdc/sync_bits.v
+M_DEPS += ../../../library/util_hbm/scripts/adi_util_hbm.tcl
 M_DEPS += ../../../library/jesd204/scripts/jesd204.tcl
 M_DEPS += ../../../library/common/util_pulse_gen.v
 M_DEPS += ../../../library/common/ad_iobuf.v
@@ -25,6 +26,7 @@ LIB_DEPS += axi_dmac
 LIB_DEPS += axi_hdmi_tx
 LIB_DEPS += axi_spdif_tx
 LIB_DEPS += axi_sysid
+LIB_DEPS += data_offload
 LIB_DEPS += jesd204/ad_ip_jesd204_tpl_adc
 LIB_DEPS += jesd204/ad_ip_jesd204_tpl_dac
 LIB_DEPS += jesd204/axi_jesd204_rx
@@ -32,10 +34,11 @@ LIB_DEPS += jesd204/axi_jesd204_tx
 LIB_DEPS += jesd204/jesd204_rx
 LIB_DEPS += jesd204/jesd204_tx
 LIB_DEPS += sysid_rom
+LIB_DEPS += util_do_ram
+LIB_DEPS += util_hbm
 LIB_DEPS += util_pack/util_cpack2
 LIB_DEPS += util_pack/util_upack2
 LIB_DEPS += xilinx/axi_adxcvr
-LIB_DEPS += xilinx/axi_dacfifo
 LIB_DEPS += xilinx/util_adxcvr
 
 include ../../scripts/project-xilinx.mk

--- a/projects/adrv9009/zc706/system_bd.tcl
+++ b/projects/adrv9009/zc706/system_bd.tcl
@@ -1,12 +1,15 @@
 ###############################################################################
-## Copyright (C) 2016-2023 Analog Devices, Inc. All rights reserved.
+## Copyright (C) 2016-2024 Analog Devices, Inc. All rights reserved.
 ### SPDX short identifier: ADIBSD
 ###############################################################################
 
-set dac_fifo_address_width 10
+## Offload attributes
+set dac_offload_type 1                      ; ## PL_DDR
+set dac_offload_size [expr 1024*1024*1024]  ; ## 1 GB
+set plddr_offload_axi_data_width 512
 
 source $ad_hdl_dir/projects/common/zc706/zc706_system_bd.tcl
-source $ad_hdl_dir/projects/common/zc706/zc706_plddr3_dacfifo_bd.tcl
+source $ad_hdl_dir/projects/common/zc706/zc706_plddr3_data_offload_bd.tcl
 source $ad_hdl_dir/projects/scripts/adi_pd.tcl
 
 #system ID
@@ -23,7 +26,8 @@ S=$ad_project_params(TX_JESD_S)\
 RX_OS:M=$ad_project_params(RX_OS_JESD_M)\
 L=$ad_project_params(RX_OS_JESD_L)\
 S=$ad_project_params(RX_OS_JESD_S)\
-DAC_FIFO_ADDR_WIDTH=$dac_fifo_address_width"
+DAC_OFFLOAD:TYPE=$dac_offload_type\
+SIZE=$dac_offload_size"
 
 sysid_gen_sys_init_file $sys_cstring
 
@@ -43,6 +47,8 @@ set sys_dma_reset         [get_bd_nets sys_250m_reset]
 set sys_dma_resetn        [get_bd_nets sys_250m_resetn]
 
 source ../common/adrv9009_bd.tcl
+
+ad_plddr_data_offload_create $dac_offload_name
 
 ad_ip_parameter axi_adrv9009_rx_dma CONFIG.FIFO_SIZE 32
 ad_ip_parameter axi_adrv9009_rx_os_dma CONFIG.FIFO_SIZE 32

--- a/projects/adrv9009/zc706/system_top.v
+++ b/projects/adrv9009/zc706/system_top.v
@@ -1,6 +1,6 @@
 // ***************************************************************************
 // ***************************************************************************
-// Copyright (C) 2018-2023 Analog Devices, Inc. All rights reserved.
+// Copyright (C) 2018-2024 Analog Devices, Inc. All rights reserved.
 //
 // In this HDL repository, there are many different and unique modules, consisting
 // of various HDL (Verilog or VHDL) components. The individual modules are
@@ -340,7 +340,6 @@ module system_top (
     .dio_p (gpio_bd));
 
   system_wrapper i_system_wrapper (
-    .dac_fifo_bypass (gpio_o[60]),
     .adc_fir_filter_active (gpio_o[61]),
     .dac_fir_filter_active (gpio_o[62]),
     .ddr3_addr (ddr3_addr),

--- a/projects/adrv9009/zcu102/Makefile
+++ b/projects/adrv9009/zcu102/Makefile
@@ -1,5 +1,5 @@
 ####################################################################################
-## Copyright (c) 2018 - 2023 Analog Devices, Inc.
+## Copyright (c) 2018 - 2024 Analog Devices, Inc.
 ### SPDX short identifier: BSD-1-Clause
 ## Auto-generated, do not modify!
 ####################################################################################
@@ -10,10 +10,10 @@ M_DEPS += ../common/adrv9009_bd.tcl
 M_DEPS += ../../scripts/adi_pd.tcl
 M_DEPS += ../../common/zcu102/zcu102_system_constr.xdc
 M_DEPS += ../../common/zcu102/zcu102_system_bd.tcl
-M_DEPS += ../../common/xilinx/dacfifo_bd.tcl
+M_DEPS += ../../common/xilinx/data_offload_bd.tcl
 M_DEPS += ../../common/xilinx/adi_fir_filter_constr.xdc
 M_DEPS += ../../common/xilinx/adi_fir_filter_bd.tcl
-M_DEPS += ../../../library/util_cdc/sync_bits.v
+M_DEPS += ../../../library/util_hbm/scripts/adi_util_hbm.tcl
 M_DEPS += ../../../library/jesd204/scripts/jesd204.tcl
 M_DEPS += ../../../library/common/util_pulse_gen.v
 M_DEPS += ../../../library/common/ad_iobuf.v
@@ -22,6 +22,7 @@ M_DEPS += ../../../library/common/ad_bus_mux.v
 LIB_DEPS += axi_clkgen
 LIB_DEPS += axi_dmac
 LIB_DEPS += axi_sysid
+LIB_DEPS += data_offload
 LIB_DEPS += jesd204/ad_ip_jesd204_tpl_adc
 LIB_DEPS += jesd204/ad_ip_jesd204_tpl_dac
 LIB_DEPS += jesd204/axi_jesd204_rx
@@ -29,7 +30,8 @@ LIB_DEPS += jesd204/axi_jesd204_tx
 LIB_DEPS += jesd204/jesd204_rx
 LIB_DEPS += jesd204/jesd204_tx
 LIB_DEPS += sysid_rom
-LIB_DEPS += util_dacfifo
+LIB_DEPS += util_do_ram
+LIB_DEPS += util_hbm
 LIB_DEPS += util_pack/util_cpack2
 LIB_DEPS += util_pack/util_upack2
 LIB_DEPS += xilinx/axi_adxcvr

--- a/projects/adrv9009/zcu102/system_bd.tcl
+++ b/projects/adrv9009/zcu102/system_bd.tcl
@@ -1,15 +1,14 @@
 ###############################################################################
-## Copyright (C) 2018-2023 Analog Devices, Inc. All rights reserved.
+## Copyright (C) 2018-2024 Analog Devices, Inc. All rights reserved.
 ### SPDX short identifier: ADIBSD
 ###############################################################################
 
-## FIFO depth is 18Mb - 1M samples
-set dac_fifo_address_width 17
-
-## NOTE: With this configuration the #36Kb BRAM utilization is at ~57%
+## Offload attributes
+set dac_offload_type 0                   ; ## BRAM
+set dac_offload_size [expr 2*1024*1024]  ; ## 2 MB
+set plddr_offload_axi_data_width 0
 
 source $ad_hdl_dir/projects/common/zcu102/zcu102_system_bd.tcl
-source $ad_hdl_dir/projects/common/xilinx/dacfifo_bd.tcl
 source $ad_hdl_dir/projects/scripts/adi_pd.tcl
 
 #system ID
@@ -26,7 +25,8 @@ S=$ad_project_params(TX_JESD_S)\
 RX_OS:M=$ad_project_params(RX_OS_JESD_M)\
 L=$ad_project_params(RX_OS_JESD_L)\
 S=$ad_project_params(RX_OS_JESD_S)\
-DAC_FIFO_ADDR_WIDTH=$dac_fifo_address_width"
+DAC_OFFLOAD:TYPE=$dac_offload_type\
+SIZE=$dac_offload_size"
 
 sysid_gen_sys_init_file $sys_cstring
 

--- a/projects/adrv9009/zcu102/system_top.v
+++ b/projects/adrv9009/zcu102/system_top.v
@@ -1,6 +1,6 @@
 // ***************************************************************************
 // ***************************************************************************
-// Copyright (C) 2014-2023 Analog Devices, Inc. All rights reserved.
+// Copyright (C) 2014-2024 Analog Devices, Inc. All rights reserved.
 //
 // In this HDL repository, there are many different and unique modules, consisting
 // of various HDL (Verilog or VHDL) components. The individual modules are
@@ -214,7 +214,6 @@ module system_top (
   assign spi_csn_adrv9009 =  spi_csn[1];
 
   system_wrapper i_system_wrapper (
-    .dac_fifo_bypass (gpio_o[60]),
     .adc_fir_filter_active (gpio_o[61]),
     .dac_fir_filter_active (gpio_o[62]),
     .gpio_i (gpio_i),

--- a/projects/common/zc706/zc706_plddr3_data_offload_bd.tcl
+++ b/projects/common/zc706/zc706_plddr3_data_offload_bd.tcl
@@ -1,0 +1,39 @@
+###############################################################################
+## Copyright (C) 2024 Analog Devices, Inc. All rights reserved.
+### SPDX short identifier: ADIBSD
+###############################################################################
+
+proc ad_plddr_data_offload_create {data_offload_name} {
+
+  upvar ad_hdl_dir ad_hdl_dir
+
+  ad_ip_instance proc_sys_reset axi_rstgen
+  ad_ip_instance mig_7series axi_ddr_cntrl
+  file copy -force $ad_hdl_dir/projects/common/zc706/zc706_plddr3_mig.prj [get_property IP_DIR \
+    [get_ips [get_property CONFIG.Component_Name [get_bd_cells axi_ddr_cntrl]]]]
+  ad_ip_parameter axi_ddr_cntrl CONFIG.XML_INPUT_FILE zc706_plddr3_mig.prj
+
+  # PL-DDR data offload interfaces
+  create_bd_intf_port -mode Slave -vlnv xilinx.com:interface:diff_clock_rtl:1.0 sys_clk
+  create_bd_port -dir I -type rst sys_rst
+  set_property CONFIG.POLARITY ACTIVE_HIGH [get_bd_ports sys_rst]
+  create_bd_intf_port -mode Master -vlnv xilinx.com:interface:ddrx_rtl:1.0 ddr3
+
+  ad_connect axi_ddr_cntrl/ui_clk axi_rstgen/slowest_sync_clk
+  ad_connect axi_ddr_cntrl/ui_clk $data_offload_name/storage_unit/m_axi_aclk
+  ad_connect axi_ddr_cntrl/S_AXI $data_offload_name/storage_unit/MAXI_0
+  ad_connect axi_rstgen/peripheral_aresetn $data_offload_name/storage_unit/m_axi_aresetn
+  ad_connect axi_rstgen/peripheral_aresetn axi_ddr_cntrl/aresetn
+  ad_connect sys_cpu_resetn axi_rstgen/ext_reset_in
+
+  assign_bd_address [get_bd_addr_segs -of_objects [get_bd_cells axi_ddr_cntrl]]
+
+  ad_connect  sys_rst axi_ddr_cntrl/sys_rst
+  ad_connect  sys_clk axi_ddr_cntrl/SYS_CLK
+  ad_connect  ddr3    axi_ddr_cntrl/DDR3
+  ad_connect  axi_ddr_cntrl/device_temp_i GND
+  ad_connect  $data_offload_name/i_data_offload/ddr_calib_done axi_ddr_cntrl/init_calib_complete
+
+  ad_ip_parameter $data_offload_name/storage_unit CONFIG.DDR_BASE_ADDDRESS [format "%d" 0x80000000]
+
+}


### PR DESCRIPTION
## PR Description

These changes integrate the Data Offload in the adrv9009 AMD/Xilinx based projects, replacing the old dacfifo IP.

In addition, a common script is used to import the MIG configuration for the zc706 PL DDR3 use case.


## PR Type
- [ ] Bug fix (change that fixes an issue)
- [x] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the code style guidelines
- [x] I have performed a self-review of changes
- [x] I have compiled all hdl projects and libraries affected by this PR
- [x] I have tested in hardware affected projects, at least on relevant boards
- [x] I have commented my code, at least hard-to-understand parts
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe files, Copyright etc)
- [ ] I have not introduced new Warnings/Critical Warnings on compilation
- [ ] I have added new hdl testbenches or updated existing ones
