### PR TITLE
library/axi_dmac/tb: Updated unit level testbenches after framelock

### DIFF
--- a/library/axi_dmac/tb/dma_read_shutdown_tb
+++ b/library/axi_dmac/tb/dma_read_shutdown_tb
@@ -2,7 +2,7 @@
 
 SOURCE="$0.v"
 SOURCE+=" axi_read_slave.v axi_slave.v"
-SOURCE+=" ../axi_dmac_transfer.v ../request_arb.v ../request_generator.v ../splitter.v"
+SOURCE+=" ../axi_dmac_transfer.v ../request_arb.v ../request_generator.v ../splitter.v ../axi_dmac_ext_sync.v"
 SOURCE+=" ../dmac_2d_transfer.v"
 SOURCE+=" ../axi_dmac_resize_src.v ../axi_dmac_resize_dest.v"
 SOURCE+=" ../axi_dmac_burst_memory.v"

--- a/library/axi_dmac/tb/dma_read_tb
+++ b/library/axi_dmac/tb/dma_read_tb
@@ -2,7 +2,7 @@
 
 SOURCE="dma_read_tb.v"
 SOURCE+=" axi_read_slave.v axi_slave.v"
-SOURCE+=" ../axi_dmac_transfer.v ../dmac_2d_transfer.v ../request_arb.v ../request_generator.v ../splitter.v"
+SOURCE+=" ../axi_dmac_transfer.v ../dmac_2d_transfer.v ../request_arb.v ../request_generator.v ../splitter.v ../axi_dmac_ext_sync.v"
 SOURCE+=" ../axi_dmac_resize_src.v ../axi_dmac_resize_dest.v"
 SOURCE+=" ../axi_dmac_burst_memory.v"
 SOURCE+=" ../axi_dmac_reset_manager.v ../axi_register_slice.v"

--- a/library/axi_dmac/tb/dma_write_shutdown_tb
+++ b/library/axi_dmac/tb/dma_write_shutdown_tb
@@ -2,7 +2,7 @@
 
 SOURCE="$0.v"
 SOURCE+=" axi_write_slave.v axi_slave.v"
-SOURCE+=" ../axi_dmac_transfer.v ../request_arb.v ../request_generator.v ../splitter.v"
+SOURCE+=" ../axi_dmac_transfer.v ../request_arb.v ../request_generator.v ../splitter.v ../axi_dmac_ext_sync.v"
 SOURCE+=" ../dmac_2d_transfer.v"
 SOURCE+=" ../axi_dmac_resize_src.v ../axi_dmac_resize_dest.v"
 SOURCE+=" ../axi_dmac_burst_memory.v"

--- a/library/axi_dmac/tb/dma_write_tb
+++ b/library/axi_dmac/tb/dma_write_tb
@@ -2,7 +2,7 @@
 
 SOURCE="dma_write_tb.v"
 SOURCE+=" axi_write_slave.v axi_slave.v"
-SOURCE+=" ../axi_dmac_transfer.v ../dmac_2d_transfer.v ../request_arb.v ../request_generator.v ../splitter.v"
+SOURCE+=" ../axi_dmac_transfer.v ../dmac_2d_transfer.v ../request_arb.v ../request_generator.v ../splitter.v ../axi_dmac_ext_sync.v"
 SOURCE+=" ../axi_dmac_resize_src.v ../axi_dmac_resize_dest.v"
 SOURCE+=" ../axi_dmac_burst_memory.v"
 SOURCE+=" ../axi_dmac_reset_manager.v ../data_mover.v ../axi_register_slice.v"


### PR DESCRIPTION
## PR Description

Updated 4 unit level testbenches for the AXI_DMAC IP that are looking for the new files introduced by the framelock PR. 
2 of the tests are still failing, waiting for [this PR](https://github.com/analogdevicesinc/hdl/pull/1455) to be merged for the fix. 


## PR Type
- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the code style guidelines
- [x] I have performed a self-review of changes
- [ ] I have compiled all hdl projects and libraries affected by this PR
- [ ] I have tested in hardware affected projects, at least on relevant boards
- [ ] I have commented my code, at least hard-to-understand parts
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe files, Copyright etc)
- [x] I have not introduced new Warnings/Critical Warnings on compilation
- [x] I have added new hdl testbenches or updated existing ones
