### PR TITLE
Change the default version of Quartus Standard to 23.1std.1 and Quartus Pro 24.2

### DIFF
--- a/projects/ad411x_ad717x/de10nano/system_project.tcl
+++ b/projects/ad411x_ad717x/de10nano/system_project.tcl
@@ -3,7 +3,7 @@
 ### SPDX short identifier: ADIBSD
 ###############################################################################
 
-set REQUIRED_QUARTUS_VERSION 22.1std.0
+set REQUIRED_QUARTUS_VERSION 23.1std.1
 set QUARTUS_PRO_ISUSED 0
 source ../../../scripts/adi_env.tcl
 source ../../scripts/adi_project_intel.tcl

--- a/projects/ad4170_asdz/de10nano/system_project.tcl
+++ b/projects/ad4170_asdz/de10nano/system_project.tcl
@@ -3,7 +3,7 @@
 ### SPDX short identifier: ADIBSD
 ###############################################################################
 
-set REQUIRED_QUARTUS_VERSION 22.1std.0
+set REQUIRED_QUARTUS_VERSION 23.1std.1
 set QUARTUS_PRO_ISUSED 0
 source ../../../scripts/adi_env.tcl
 source ../../scripts/adi_project_intel.tcl

--- a/projects/ad469x_evb/de10nano/system_project.tcl
+++ b/projects/ad469x_evb/de10nano/system_project.tcl
@@ -3,7 +3,7 @@
 ### SPDX short identifier: ADIBSD
 ###############################################################################
 
-set REQUIRED_QUARTUS_VERSION 22.1std.0
+set REQUIRED_QUARTUS_VERSION 23.1std.1
 set QUARTUS_PRO_ISUSED 0
 source ../../../scripts/adi_env.tcl
 source ../../scripts/adi_project_intel.tcl

--- a/projects/ad57xx_ardz/de10nano/system_project.tcl
+++ b/projects/ad57xx_ardz/de10nano/system_project.tcl
@@ -3,7 +3,7 @@
 ### SPDX short identifier: ADIBSD
 ###############################################################################
 
-set REQUIRED_QUARTUS_VERSION 22.1std.0
+set REQUIRED_QUARTUS_VERSION 23.1std.1
 set QUARTUS_PRO_ISUSED 0
 source ../../../scripts/adi_env.tcl
 source ../../scripts/adi_project_intel.tcl

--- a/projects/ad7124_asdz/de10nano/system_project.tcl
+++ b/projects/ad7124_asdz/de10nano/system_project.tcl
@@ -3,7 +3,7 @@
 ### SPDX short identifier: ADIBSD
 ###############################################################################
 
-set REQUIRED_QUARTUS_VERSION 22.1std.0
+set REQUIRED_QUARTUS_VERSION 23.1std.1
 set QUARTUS_PRO_ISUSED 0
 source ../../../scripts/adi_env.tcl
 source ../../scripts/adi_project_intel.tcl

--- a/projects/ad719x_asdz/de10nano/system_project.tcl
+++ b/projects/ad719x_asdz/de10nano/system_project.tcl
@@ -3,7 +3,7 @@
 ### SPDX short identifier: ADIBSD
 ###############################################################################
 
-set REQUIRED_QUARTUS_VERSION 22.1std.0
+set REQUIRED_QUARTUS_VERSION 23.1std.1
 set QUARTUS_PRO_ISUSED 0
 source ../../../scripts/adi_env.tcl
 source ../../scripts/adi_project_intel.tcl

--- a/projects/ad777x_ardz/de10nano/system_project.tcl
+++ b/projects/ad777x_ardz/de10nano/system_project.tcl
@@ -3,7 +3,7 @@
 ### SPDX short identifier: ADIBSD
 ###############################################################################
 
-set REQUIRED_QUARTUS_VERSION 22.1std.0
+set REQUIRED_QUARTUS_VERSION 23.1std.1
 set QUARTUS_PRO_ISUSED 0
 source ../../../scripts/adi_env.tcl
 source ../../scripts/adi_project_intel.tcl
@@ -22,7 +22,7 @@ set_location_assignment PIN_U14  -to adc_data_in[2] ; ##   P5.5 Arduino_IO04
 set_location_assignment PIN_AG13 -to adc_data_in[3] ; ##   P5.1 Arduino_IO00
 
 set_location_assignment PIN_AF13 -to sdp_convst     ; ##   P5.2 Arduino_IO01
-set_location_assignment PIN_AH8  -to start_n        ; ##   P5.8 Arduino_IO07              
+set_location_assignment PIN_AH8  -to start_n        ; ##   P5.8 Arduino_IO07
 set_location_assignment PIN_AG10 -to reset_n        ; ##   P5.3 Arduino_IO02
 set_location_assignment PIN_AG9  -to sdp_mclk       ; ##   P5.4 Arduino_IO03
 
@@ -31,23 +31,23 @@ set_location_assignment PIN_AG16 -to spi_mosi       ; ##   P4.4 Arduino_IO11
 set_location_assignment PIN_AH11 -to spi_miso       ; ##   P4.5 Arduino_IO12
 set_location_assignment PIN_AH12 -to spi_clk        ; ##   P4.5 Arduino_IO13
 
-set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to adc_clk_in   
-set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to adc_ready_in 
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to adc_clk_in
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to adc_ready_in
 
 set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to adc_data_in[0]
 set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to adc_data_in[1]
 set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to adc_data_in[2]
 set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to adc_data_in[3]
 
-set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to sdp_convst   
-set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to start_n      
-set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to reset_n      
-set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to sdp_convst   
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to sdp_convst
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to start_n
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to reset_n
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to sdp_convst
 set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to sdp_mclk
 
-set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to spi_csn      
-set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to spi_mosi     
-set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to spi_miso     
-set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to spi_clk      
-       
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to spi_csn
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to spi_mosi
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to spi_miso
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to spi_clk
+
 execute_flow -compile

--- a/projects/adv7513/de10nano/system_project.tcl
+++ b/projects/adv7513/de10nano/system_project.tcl
@@ -3,7 +3,7 @@
 ### SPDX short identifier: ADIBSD
 ###############################################################################
 
-set REQUIRED_QUARTUS_VERSION 22.1std.0
+set REQUIRED_QUARTUS_VERSION 23.1std.1
 set QUARTUS_PRO_ISUSED 0
 source ../../../scripts/adi_env.tcl
 source ../../scripts/adi_project_intel.tcl

--- a/projects/arradio/c5soc/system_project.tcl
+++ b/projects/arradio/c5soc/system_project.tcl
@@ -3,7 +3,7 @@
 ### SPDX short identifier: ADIBSD
 ###############################################################################
 
-set REQUIRED_QUARTUS_VERSION 22.1std.0
+set REQUIRED_QUARTUS_VERSION 23.1std.1
 set QUARTUS_PRO_ISUSED 0
 source ../../../scripts/adi_env.tcl
 source ../../scripts/adi_project_intel.tcl
@@ -160,4 +160,3 @@ set_instance_assignment -name WEAK_PULL_UP_RESISTOR ON -to sda
 set_instance_assignment -name AUTO_SHIFT_REGISTER_RECOGNITION OFF -to * -entity axi_ad9361
 
 execute_flow -compile
-

--- a/projects/cn0540/de10nano/system_project.tcl
+++ b/projects/cn0540/de10nano/system_project.tcl
@@ -3,7 +3,7 @@
 ### SPDX short identifier: ADIBSD
 ###############################################################################
 
-set REQUIRED_QUARTUS_VERSION 22.1std.0
+set REQUIRED_QUARTUS_VERSION 23.1std.1
 set QUARTUS_PRO_ISUSED 0
 source ../../../scripts/adi_env.tcl
 source ../../scripts/adi_project_intel.tcl

--- a/projects/cn0561/de10nano/system_project.tcl
+++ b/projects/cn0561/de10nano/system_project.tcl
@@ -3,7 +3,7 @@
 ### SPDX short identifier: ADIBSD
 ###############################################################################
 
-set REQUIRED_QUARTUS_VERSION 22.1std.0
+set REQUIRED_QUARTUS_VERSION 23.1std.1
 set QUARTUS_PRO_ISUSED 0
 
 source ../../../scripts/adi_env.tcl

--- a/projects/cn0579/de10nano/system_project.tcl
+++ b/projects/cn0579/de10nano/system_project.tcl
@@ -3,7 +3,7 @@
 ### SPDX short identifier: ADIBSD
 ###############################################################################
 
-set REQUIRED_QUARTUS_VERSION 22.1std.0
+set REQUIRED_QUARTUS_VERSION 23.1std.1
 set QUARTUS_PRO_ISUSED 0
 source ../../../scripts/adi_env.tcl
 source ../../scripts/adi_project_intel.tcl
@@ -26,11 +26,11 @@ set_location_assignment PIN_AE15 -to adc_ready_in  ; ##   P12.9  Arduino_IO09
 set_location_assignment PIN_AH8  -to adc_data_in[0]; ##   P14.1 Arduino_IO07
 set_location_assignment PIN_AG8  -to adc_data_in[1]; ##   P14.2 Arduino_IO06
 set_location_assignment PIN_U13  -to adc_data_in[2]; ##   P14.3 Arduino_IO05
-set_location_assignment PIN_U14  -to adc_data_in[3]; ##   P14.4 Arduino_IO04 
+set_location_assignment PIN_U14  -to adc_data_in[3]; ##   P14.4 Arduino_IO04
 
-set_location_assignment PIN_AG9  -to shutdown_n    ; ##   P14.5 Arduino_IO03 
+set_location_assignment PIN_AG9  -to shutdown_n    ; ##   P14.5 Arduino_IO03
 set_location_assignment PIN_AG10 -to reset_n       ; ##   P14.6 Arduino_IO02
-           
+
 set_location_assignment PIN_AF15 -to spi_csn       ; ##   P12.8 Arduino_IO10
 set_location_assignment PIN_AG16 -to spi_mosi      ; ##   P12.7 Arduino_IO11
 set_location_assignment PIN_AH11 -to spi_miso      ; ##   P12.6 Arduino_IO12
@@ -39,25 +39,25 @@ set_location_assignment PIN_AH12 -to spi_clk       ; ##   P12.5 Arduino_IO13
 set_location_assignment PIN_AG11 -to dac_i2c_scl   ; ##   P12.1 Arduino_IO15
 set_location_assignment PIN_AH9  -to dac_i2c_sda   ; ##   P12.2 Arduino_IO14
 
-set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to adc_clk_in   
-set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to adc_ready_in 
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to adc_clk_in
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to adc_ready_in
 
 set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to adc_data_in[0]
 set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to adc_data_in[1]
 set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to adc_data_in[2]
 set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to adc_data_in[3]
 
-set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to shutdown_n         
-set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to reset_n      
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to shutdown_n
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to reset_n
 
-set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to spi_csn      
-set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to spi_mosi     
-set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to spi_miso     
-set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to spi_clk     
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to spi_csn
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to spi_mosi
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to spi_miso
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to spi_clk
 
-set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to dac_i2c_scl     
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to dac_i2c_scl
 set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to dac_i2c_sda
-       
+
 set_instance_assignment -name WEAK_PULL_UP_RESISTOR ON -to dac_i2c_scl
 set_instance_assignment -name WEAK_PULL_UP_RESISTOR ON -to dac_i2c_sda
 

--- a/projects/common/c5soc/system_project.tcl
+++ b/projects/common/c5soc/system_project.tcl
@@ -3,7 +3,7 @@
 ### SPDX short identifier: ADIBSD
 ###############################################################################
 
-set REQUIRED_QUARTUS_VERSION 22.1std.0
+set REQUIRED_QUARTUS_VERSION 23.1std.1
 set QUARTUS_PRO_ISUSED 0
 source ../../../scripts/adi_env.tcl
 source ../../scripts/adi_project_intel.tcl

--- a/projects/common/de10nano/system_project.tcl
+++ b/projects/common/de10nano/system_project.tcl
@@ -3,7 +3,7 @@
 ### SPDX short identifier: ADIBSD
 ###############################################################################
 
-set REQUIRED_QUARTUS_VERSION 22.1std.0
+set REQUIRED_QUARTUS_VERSION 23.1std.1
 set QUARTUS_PRO_ISUSED 0
 source ../../../scripts/adi_env.tcl
 source ../../scripts/adi_project_intel.tcl

--- a/projects/dc2677a/c5soc/system_project.tcl
+++ b/projects/dc2677a/c5soc/system_project.tcl
@@ -3,7 +3,7 @@
 ### SPDX short identifier: ADIBSD
 ###############################################################################
 
-set REQUIRED_QUARTUS_VERSION 22.1std.0
+set REQUIRED_QUARTUS_VERSION 23.1std.1
 set QUARTUS_PRO_ISUSED 0
 source ../../../scripts/adi_env.tcl
 source $ad_hdl_dir/projects/scripts/adi_project_intel.tcl

--- a/scripts/adi_env.tcl
+++ b/scripts/adi_env.tcl
@@ -31,7 +31,7 @@ if {[info exists ::env(ADI_IGNORE_VERSION_CHECK)]} {
 
 # Define the supported tool version
 if {![info exists REQUIRED_QUARTUS_VERSION]} {
-  set REQUIRED_QUARTUS_VERSION "23.2.0"
+  set REQUIRED_QUARTUS_VERSION "24.2.0"
 }
 
 # Define the supported tool version


### PR DESCRIPTION
## PR Description

Updated Quartus Std and Pro to latest versions (23.1std.1 and 24.2)

## PR Type
- [ ] Bug fix (change that fixes an issue)
- [x] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the code style guidelines
- [x] I have performed a self-review of changes
- [x] I have compiled all hdl projects and libraries affected by this PR
- [x] I have tested in hardware affected projects, at least on relevant boards
- [x] I have commented my code, at least hard-to-understand parts
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe files, Copyright etc)
- [x] I have not introduced new Warnings/Critical Warnings on compilation
- [ ] I have added new hdl testbenches or updated existing ones
