### PR TITLE
Add Cache Coherency support on Ultrascale projects

### DIFF
--- a/projects/ad9081_fmca_ebz/common/ad9081_fmca_ebz_bd.tcl
+++ b/projects/ad9081_fmca_ebz/common/ad9081_fmca_ebz_bd.tcl
@@ -1,5 +1,5 @@
 ###############################################################################
-## Copyright (C) 2019-2024 Analog Devices, Inc. All rights reserved.
+## Copyright (C) 2019-2025 Analog Devices, Inc. All rights reserved.
 ### SPDX short identifier: ADIBSD
 ###############################################################################
 
@@ -316,6 +316,7 @@ if {$INTF_CFG != "TX"} {
   } else {
     ad_ip_parameter axi_mxfe_rx_dma CONFIG.DMA_DATA_WIDTH_DEST [expr min(512, $adc_dma_data_width)]
   }
+  ad_ip_parameter axi_mxfe_rx_dma CONFIG.CACHE_COHERENT $CACHE_COHERENCY
 }
 
 # Instantiate DAC (Tx) path
@@ -384,6 +385,7 @@ if {$INTF_CFG != "RX"} {
     ad_ip_parameter axi_mxfe_tx_dma CONFIG.DMA_DATA_WIDTH_SRC [expr min(512, $dac_dma_data_width)]
   }
   ad_ip_parameter axi_mxfe_tx_dma CONFIG.DMA_DATA_WIDTH_DEST $dac_dma_data_width
+  ad_ip_parameter axi_mxfe_tx_dma CONFIG.CACHE_COHERENT $CACHE_COHERENCY
 }
 
 if {$ADI_PHY_SEL == 1} {
@@ -490,8 +492,13 @@ if {$INTF_CFG != "TX"} {
   if {$ADI_PHY_SEL == 1} {
     ad_mem_hp0_interconnect $sys_cpu_clk axi_mxfe_rx_xcvr/m_axi
   }
-  ad_mem_hp1_interconnect $sys_dma_clk sys_ps7/S_AXI_HP1
-  ad_mem_hp1_interconnect $sys_dma_clk axi_mxfe_rx_dma/m_dest_axi
+  if {$CACHE_COHERENCY} {
+    ad_mem_hpc0_interconnect $sys_dma_clk sys_ps8/S_AXI_HPC0
+    ad_mem_hpc0_interconnect $sys_dma_clk axi_mxfe_rx_dma/m_dest_axi
+  } else {
+    ad_mem_hp1_interconnect $sys_dma_clk sys_ps7/S_AXI_HP1
+    ad_mem_hp1_interconnect $sys_dma_clk axi_mxfe_rx_dma/m_dest_axi
+  }
 
   # Interrupts
   ad_cpu_interrupt ps-13 mb-12 axi_mxfe_rx_dma/irq
@@ -541,8 +548,13 @@ if {$INTF_CFG != "RX"} {
   ad_cpu_interconnect 0x7c430000 axi_mxfe_tx_dma
   ad_cpu_interconnect 0x7c440000 $dac_data_offload_name
   # GT / ADC
-  ad_mem_hp2_interconnect $sys_dma_clk sys_ps7/S_AXI_HP2
-  ad_mem_hp2_interconnect $sys_dma_clk axi_mxfe_tx_dma/m_src_axi
+  if {$CACHE_COHERENCY} {
+    ad_mem_hpc1_interconnect $sys_dma_clk sys_ps8/S_AXI_HPC1
+    ad_mem_hpc1_interconnect $sys_dma_clk axi_mxfe_tx_dma/m_src_axi
+  } else {
+    ad_mem_hp2_interconnect $sys_dma_clk sys_ps7/S_AXI_HP2
+    ad_mem_hp2_interconnect $sys_dma_clk axi_mxfe_tx_dma/m_src_axi
+  }
 
   # Interrupts
   ad_cpu_interrupt ps-12 mb-13 axi_mxfe_tx_dma/irq

--- a/projects/ad9083_evb/common/ad9083_evb_bd.tcl
+++ b/projects/ad9083_evb/common/ad9083_evb_bd.tcl
@@ -1,5 +1,5 @@
 ###############################################################################
-## Copyright (C) 2020-2024 Analog Devices, Inc. All rights reserved.
+## Copyright (C) 2020-2025 Analog Devices, Inc. All rights reserved.
 ### SPDX short identifier: ADIBSD
 ###############################################################################
 
@@ -57,6 +57,7 @@ ad_ip_instance axi_dmac axi_ad9083_rx_dma [list \
   DMA_LENGTH_WIDTH 31 \
   DMA_DATA_WIDTH_DEST 128 \
   DMA_DATA_WIDTH_SRC $adc_dma_data_width \
+  CACHE_COHERENT $CACHE_COHERENCY \
 ]
 
 # common cores
@@ -171,8 +172,13 @@ ad_mem_hp1_interconnect $sys_cpu_clk axi_ad9083_rx_xcvr/m_axi
 
 # interconnect (mem/dac)
 
-ad_mem_hp2_interconnect $sys_dma_clk sys_ps7/S_AXI_HP2
-ad_mem_hp2_interconnect $sys_dma_clk axi_ad9083_rx_dma/m_dest_axi
+if {$CACHE_COHERENCY} {
+  ad_mem_hpc0_interconnect $sys_dma_clk sys_ps8/S_AXI_HPC0
+  ad_mem_hpc0_interconnect $sys_dma_clk axi_ad9083_rx_dma/m_dest_axi
+} else {
+  ad_mem_hp2_interconnect $sys_dma_clk sys_ps7/S_AXI_HP2
+  ad_mem_hp2_interconnect $sys_dma_clk axi_ad9083_rx_dma/m_dest_axi
+}
 
 # interrupts
 

--- a/projects/ad9656_fmc/common/ad9656_fmc_bd.tcl
+++ b/projects/ad9656_fmc/common/ad9656_fmc_bd.tcl
@@ -48,6 +48,7 @@ ad_ip_instance axi_dmac axi_ad9656_rx_dma [list \
   AXI_SLICE_SRC false \
   DMA_DATA_WIDTH_DEST 128 \
   FIFO_SIZE 32 \
+  CACHE_COHERENT $CACHE_COHERENCY \
   ]
 
 # common cores
@@ -115,8 +116,13 @@ ad_mem_hp0_interconnect $sys_cpu_clk axi_ad9656_rx_xcvr/m_axi
 
 # interconnect (mem/dac)
 
-ad_mem_hp2_interconnect $sys_dma_clk sys_ps7/S_AXI_HP1
-ad_mem_hp2_interconnect $sys_dma_clk axi_ad9656_rx_dma/m_dest_axi
+if {$CACHE_COHERENCY} {
+  ad_mem_hpc0_interconnect $sys_dma_clk sys_ps8/S_AXI_HPC0
+  ad_mem_hpc0_interconnect $sys_dma_clk axi_ad9656_rx_dma/m_dest_axi
+} else {
+  ad_mem_hp2_interconnect $sys_dma_clk sys_ps7/S_AXI_HP2
+  ad_mem_hp2_interconnect $sys_dma_clk axi_ad9656_rx_dma/m_dest_axi
+}
 
 # interrupts
 

--- a/projects/ad9694_fmc/common/ad9694_fmc_bd.tcl
+++ b/projects/ad9694_fmc/common/ad9694_fmc_bd.tcl
@@ -1,5 +1,5 @@
 ###############################################################################
-## Copyright (C) 2022-2024 Analog Devices, Inc. All rights reserved.
+## Copyright (C) 2022-2025 Analog Devices, Inc. All rights reserved.
 ### SPDX short identifier: ADIBSD
 ###############################################################################
 
@@ -62,6 +62,7 @@ ad_ip_instance axi_dmac axi_ad9694_rx_dma [list \
   DMA_LENGTH_WIDTH 24 \
   DMA_DATA_WIDTH_DEST 128 \
   DMA_DATA_WIDTH_SRC $adc_dma_data_width \
+  CACHE_COHERENT $CACHE_COHERENCY \
   ]
 
 # common cores
@@ -168,8 +169,13 @@ ad_mem_hp0_interconnect $sys_cpu_clk axi_ad9694_rx_xcvr/m_axi
 
 # interconnect (mem/dac)
 
-ad_mem_hp2_interconnect dma_clk_wiz/clk_out1 sys_ps7/S_AXI_HP1
-ad_mem_hp2_interconnect dma_clk_wiz/clk_out1 axi_ad9694_rx_dma/m_dest_axi
+if {$CACHE_COHERENCY} {
+  ad_mem_hpc0_interconnect dma_clk_wiz/clk_out1 sys_ps8/S_AXI_HPC0
+  ad_mem_hpc0_interconnect dma_clk_wiz/clk_out1 axi_ad9694_rx_dma/m_dest_axi
+} else {
+  ad_mem_hp2_interconnect dma_clk_wiz/clk_out1 sys_ps7/S_AXI_HP2
+  ad_mem_hp2_interconnect dma_clk_wiz/clk_out1 axi_ad9694_rx_dma/m_dest_axi
+}
 
 # interrupts
 

--- a/projects/ad9695_fmc/common/ad9695_fmc_bd.tcl
+++ b/projects/ad9695_fmc/common/ad9695_fmc_bd.tcl
@@ -1,5 +1,5 @@
 ###############################################################################
-## Copyright (C) 2022-2024 Analog Devices, Inc. All rights reserved.
+## Copyright (C) 2022-2025 Analog Devices, Inc. All rights reserved.
 ### SPDX short identifier: ADIBSD
 ###############################################################################
 
@@ -62,6 +62,7 @@ ad_ip_instance axi_dmac axi_ad9695_rx_dma [list \
   DMA_LENGTH_WIDTH 24 \
   DMA_DATA_WIDTH_DEST 128 \
   DMA_DATA_WIDTH_SRC $adc_dma_data_width \
+  CACHE_COHERENT $CACHE_COHERENCY \
   ]
 
 # common cores
@@ -159,8 +160,13 @@ ad_mem_hp0_interconnect $sys_cpu_clk axi_ad9695_rx_xcvr/m_axi
 
 # interconnect (mem/dac)
 
-ad_mem_hp2_interconnect dma_clk_wiz/clk_out1 sys_ps7/S_AXI_HP1
-ad_mem_hp2_interconnect dma_clk_wiz/clk_out1 axi_ad9695_rx_dma/m_dest_axi
+if {$CACHE_COHERENCY} {
+  ad_mem_hpc0_interconnect dma_clk_wiz/clk_out1 sys_ps8/S_AXI_HPC0
+  ad_mem_hpc0_interconnect dma_clk_wiz/clk_out1 axi_ad9695_rx_dma/m_dest_axi
+} else {
+  ad_mem_hp2_interconnect dma_clk_wiz/clk_out1 sys_ps7/S_AXI_HP2
+  ad_mem_hp2_interconnect dma_clk_wiz/clk_out1 axi_ad9695_rx_dma/m_dest_axi
+}
 
 # interrupts
 

--- a/projects/ad9783_ebz/common/ad9783_ebz_bd.tcl
+++ b/projects/ad9783_ebz/common/ad9783_ebz_bd.tcl
@@ -1,5 +1,5 @@
 ###############################################################################
-## Copyright (C) 2022-2023 Analog Devices, Inc. All rights reserved.
+## Copyright (C) 2022-2025 Analog Devices, Inc. All rights reserved.
 ### SPDX short identifier: ADIBSD
 ###############################################################################
 
@@ -27,6 +27,7 @@ ad_ip_parameter axi_ad9783_dma CONFIG.AXI_SLICE_SRC 1
 ad_ip_parameter axi_ad9783_dma CONFIG.DMA_DATA_WIDTH_DEST 128
 ad_ip_parameter axi_ad9783_dma CONFIG.DMA_DATA_WIDTH_SRC 128
 ad_ip_parameter axi_ad9783_dma CONFIG.DMA_AXI_PROTOCOL_SRC 1
+ad_ip_parameter axi_ad9783_dma CONFIG.CACHE_COHERENT $CACHE_COHERENCY
 
 # dac-path channel upack
 
@@ -66,8 +67,13 @@ ad_cpu_interconnect 0x7c420000 axi_ad9783_dma
 
 # interconnect (mem/dac)
 
-ad_mem_hp2_interconnect $sys_dma_clk sys_ps7/S_AXI_HP2
-ad_mem_hp2_interconnect $sys_dma_clk axi_ad9783_dma/m_src_axi
+if {$CACHE_COHERENCY} {
+  ad_mem_hpc0_interconnect $sys_dma_clk sys_ps8/S_AXI_HPC0
+  ad_mem_hpc0_interconnect $sys_dma_clk axi_ad9783_dma/m_src_axi
+} else {
+  ad_mem_hp2_interconnect $sys_dma_clk sys_ps7/S_AXI_HP2
+  ad_mem_hp2_interconnect $sys_dma_clk axi_ad9783_dma/m_src_axi
+}
 ad_connect  $sys_dma_resetn axi_ad9783_dma/m_src_axi_aresetn
 
 # interrupts

--- a/projects/adrv9001/common/adrv9001_bd.tcl
+++ b/projects/adrv9001/common/adrv9001_bd.tcl
@@ -1,5 +1,5 @@
 ###############################################################################
-## Copyright (C) 2020-2024 Analog Devices, Inc. All rights reserved.
+## Copyright (C) 2020-2025 Analog Devices, Inc. All rights reserved.
 ### SPDX short identifier: ADIBSD
 ###############################################################################
 
@@ -85,6 +85,7 @@ ad_ip_parameter axi_adrv9001_rx1_dma CONFIG.AXI_SLICE_SRC 0
 ad_ip_parameter axi_adrv9001_rx1_dma CONFIG.AXI_SLICE_DEST 0
 ad_ip_parameter axi_adrv9001_rx1_dma CONFIG.DMA_2D_TRANSFER 0
 ad_ip_parameter axi_adrv9001_rx1_dma CONFIG.DMA_DATA_WIDTH_SRC 64
+ad_ip_parameter axi_adrv9001_rx1_dma CONFIG.CACHE_COHERENT $CACHE_COHERENCY
 
 ad_ip_instance util_cpack2 util_adc_1_pack { \
   NUM_OF_CHANNELS 4 \
@@ -102,6 +103,7 @@ ad_ip_parameter axi_adrv9001_rx2_dma CONFIG.AXI_SLICE_SRC 0
 ad_ip_parameter axi_adrv9001_rx2_dma CONFIG.AXI_SLICE_DEST 0
 ad_ip_parameter axi_adrv9001_rx2_dma CONFIG.DMA_2D_TRANSFER 0
 ad_ip_parameter axi_adrv9001_rx2_dma CONFIG.DMA_DATA_WIDTH_SRC 32
+ad_ip_parameter axi_adrv9001_rx2_dma CONFIG.CACHE_COHERENT $CACHE_COHERENCY
 
 ad_ip_instance util_cpack2 util_adc_2_pack { \
   NUM_OF_CHANNELS 2 \
@@ -119,13 +121,14 @@ ad_ip_parameter axi_adrv9001_tx1_dma CONFIG.AXI_SLICE_SRC 0
 ad_ip_parameter axi_adrv9001_tx1_dma CONFIG.AXI_SLICE_DEST 0
 ad_ip_parameter axi_adrv9001_tx1_dma CONFIG.DMA_2D_TRANSFER 0
 ad_ip_parameter axi_adrv9001_tx1_dma CONFIG.DMA_DATA_WIDTH_DEST 64
+ad_ip_parameter axi_adrv9001_tx1_dma CONFIG.CACHE_COHERENT $CACHE_COHERENCY
 
 ad_ip_instance util_upack2 util_dac_1_upack { \
   NUM_OF_CHANNELS 4 \
   SAMPLE_DATA_WIDTH 16 \
 }
 
-# dma for tx1
+# dma for tx2
 
 ad_ip_instance axi_dmac axi_adrv9001_tx2_dma
 ad_ip_parameter axi_adrv9001_tx2_dma CONFIG.DMA_TYPE_SRC 0
@@ -136,6 +139,7 @@ ad_ip_parameter axi_adrv9001_tx2_dma CONFIG.AXI_SLICE_SRC 0
 ad_ip_parameter axi_adrv9001_tx2_dma CONFIG.AXI_SLICE_DEST 0
 ad_ip_parameter axi_adrv9001_tx2_dma CONFIG.DMA_2D_TRANSFER 0
 ad_ip_parameter axi_adrv9001_tx2_dma CONFIG.DMA_DATA_WIDTH_DEST 32
+ad_ip_parameter axi_adrv9001_tx2_dma CONFIG.CACHE_COHERENT $CACHE_COHERENCY
 
 ad_ip_instance util_upack2 util_dac_2_upack { \
   NUM_OF_CHANNELS 2 \
@@ -280,18 +284,27 @@ ad_cpu_interconnect 0x44A40000  axi_adrv9001_rx2_dma
 ad_cpu_interconnect 0x44A50000  axi_adrv9001_tx1_dma
 ad_cpu_interconnect 0x44A60000  axi_adrv9001_tx2_dma
 
-# memory inteconnect
+# memory interconnect
 
-ad_mem_hp1_interconnect $sys_cpu_clk sys_ps7/S_AXI_HP1
-ad_mem_hp1_interconnect $sys_cpu_clk axi_adrv9001_rx1_dma/m_dest_axi
-ad_mem_hp1_interconnect $sys_cpu_clk axi_adrv9001_rx2_dma/m_dest_axi
-ad_mem_hp1_interconnect $sys_cpu_clk axi_adrv9001_tx1_dma/m_src_axi
-ad_mem_hp1_interconnect $sys_cpu_clk axi_adrv9001_tx2_dma/m_src_axi
+if {$CACHE_COHERENCY} {
+  ad_mem_hpc0_interconnect $sys_cpu_clk sys_ps8/S_AXI_HPC0
+  ad_mem_hpc0_interconnect $sys_cpu_clk axi_adrv9001_rx1_dma/m_dest_axi
+  ad_mem_hpc0_interconnect $sys_cpu_clk axi_adrv9001_rx2_dma/m_dest_axi
+  ad_mem_hpc0_interconnect $sys_cpu_clk axi_adrv9001_tx1_dma/m_src_axi
+  ad_mem_hpc0_interconnect $sys_cpu_clk axi_adrv9001_tx2_dma/m_src_axi
+} else {
+  ad_mem_hp1_interconnect $sys_cpu_clk sys_ps7/S_AXI_HP1
+  ad_mem_hp1_interconnect $sys_cpu_clk axi_adrv9001_rx1_dma/m_dest_axi
+  ad_mem_hp1_interconnect $sys_cpu_clk axi_adrv9001_rx2_dma/m_dest_axi
+  ad_mem_hp1_interconnect $sys_cpu_clk axi_adrv9001_tx1_dma/m_src_axi
+  ad_mem_hp1_interconnect $sys_cpu_clk axi_adrv9001_tx2_dma/m_src_axi
+}
 
 ad_connect $sys_cpu_resetn axi_adrv9001_rx1_dma/m_dest_axi_aresetn
 ad_connect $sys_cpu_resetn axi_adrv9001_rx2_dma/m_dest_axi_aresetn
 ad_connect $sys_cpu_resetn axi_adrv9001_tx1_dma/m_src_axi_aresetn
 ad_connect $sys_cpu_resetn axi_adrv9001_tx2_dma/m_src_axi_aresetn
+
 # interrupts
 
 ad_cpu_interrupt ps-13 mb-12 axi_adrv9001_rx1_dma/irq

--- a/projects/adrv9009/common/adrv9009_bd.tcl
+++ b/projects/adrv9009/common/adrv9009_bd.tcl
@@ -1,5 +1,5 @@
 ###############################################################################
-## Copyright (C) 2018-2024 Analog Devices, Inc. All rights reserved.
+## Copyright (C) 2018-2025 Analog Devices, Inc. All rights reserved.
 ### SPDX short identifier: ADIBSD
 ###############################################################################
 
@@ -109,6 +109,7 @@ ad_ip_parameter axi_adrv9009_tx_dma CONFIG.DMA_DATA_WIDTH_DEST $dac_data_width
 ad_ip_parameter axi_adrv9009_tx_dma CONFIG.MAX_BYTES_PER_BURST 256
 ad_ip_parameter axi_adrv9009_tx_dma CONFIG.AXI_SLICE_DEST true
 ad_ip_parameter axi_adrv9009_tx_dma CONFIG.AXI_SLICE_SRC true
+ad_ip_parameter axi_adrv9009_tx_dma CONFIG.CACHE_COHERENT $CACHE_COHERENCY
 
 ad_data_offload_create $dac_offload_name \
                        1 \
@@ -170,6 +171,7 @@ ad_ip_parameter axi_adrv9009_rx_dma CONFIG.DMA_DATA_WIDTH_SRC $adc_dma_data_widt
 ad_ip_parameter axi_adrv9009_rx_dma CONFIG.MAX_BYTES_PER_BURST 256
 ad_ip_parameter axi_adrv9009_rx_dma CONFIG.AXI_SLICE_DEST true
 ad_ip_parameter axi_adrv9009_rx_dma CONFIG.AXI_SLICE_SRC true
+ad_ip_parameter axi_adrv9009_rx_dma CONFIG.CACHE_COHERENT $CACHE_COHERENCY
 
 # adc-os peripherals
 
@@ -215,6 +217,7 @@ ad_ip_parameter axi_adrv9009_rx_os_dma CONFIG.DMA_DATA_WIDTH_SRC [expr $RX_OS_SA
 ad_ip_parameter axi_adrv9009_rx_os_dma CONFIG.MAX_BYTES_PER_BURST 256
 ad_ip_parameter axi_adrv9009_rx_os_dma CONFIG.AXI_SLICE_DEST true
 ad_ip_parameter axi_adrv9009_rx_os_dma CONFIG.AXI_SLICE_SRC true
+ad_ip_parameter axi_adrv9009_rx_os_dma CONFIG.CACHE_COHERENT $CACHE_COHERENCY
 
 # common cores
 
@@ -456,12 +459,20 @@ ad_mem_hp0_interconnect $sys_cpu_clk axi_adrv9009_rx_os_xcvr/m_axi
 
 # interconnect (mem/dac)
 
-ad_mem_hp1_interconnect $sys_dma_clk sys_ps7/S_AXI_HP1
-ad_mem_hp1_interconnect $sys_dma_clk axi_adrv9009_rx_os_dma/m_dest_axi
-ad_mem_hp2_interconnect $sys_dma_clk sys_ps7/S_AXI_HP2
-ad_mem_hp2_interconnect $sys_dma_clk axi_adrv9009_rx_dma/m_dest_axi
-ad_mem_hp3_interconnect $sys_dma_clk sys_ps7/S_AXI_HP3
-ad_mem_hp3_interconnect $sys_dma_clk axi_adrv9009_tx_dma/m_src_axi
+if {$CACHE_COHERENCY} {
+  ad_mem_hpc0_interconnect $sys_dma_clk sys_ps8/S_AXI_HPC0
+  ad_mem_hpc0_interconnect $sys_dma_clk axi_adrv9009_rx_os_dma/m_dest_axi
+  ad_mem_hpc0_interconnect $sys_dma_clk axi_adrv9009_rx_dma/m_dest_axi
+  ad_mem_hpc1_interconnect $sys_dma_clk sys_ps8/S_AXI_HPC1
+  ad_mem_hpc1_interconnect $sys_dma_clk axi_adrv9009_tx_dma/m_src_axi
+} else {
+  ad_mem_hp1_interconnect $sys_dma_clk sys_ps7/S_AXI_HP1
+  ad_mem_hp1_interconnect $sys_dma_clk axi_adrv9009_rx_os_dma/m_dest_axi
+  ad_mem_hp2_interconnect $sys_dma_clk sys_ps7/S_AXI_HP2
+  ad_mem_hp2_interconnect $sys_dma_clk axi_adrv9009_rx_dma/m_dest_axi
+  ad_mem_hp3_interconnect $sys_dma_clk sys_ps7/S_AXI_HP3
+  ad_mem_hp3_interconnect $sys_dma_clk axi_adrv9009_tx_dma/m_src_axi
+}
 
 # interrupts
 

--- a/projects/adrv9009zu11eg/common/adrv2crr_fmc_bd.tcl
+++ b/projects/adrv9009zu11eg/common/adrv2crr_fmc_bd.tcl
@@ -1,5 +1,5 @@
 ###############################################################################
-## Copyright (C) 2019-2023 Analog Devices, Inc. All rights reserved.
+## Copyright (C) 2019-2025 Analog Devices, Inc. All rights reserved.
 ### SPDX short identifier: ADIBSD
 ###############################################################################
 
@@ -95,8 +95,10 @@ ad_cpu_interconnect 0x41000000 i2s_rx_dma
 ad_cpu_interconnect 0x41001000 i2s_tx_dma
 ad_cpu_interconnect 0x42000000 axi_i2s_adi
 
-ad_mem_hp0_interconnect sys_cpu_clk i2s_tx_dma/m_src_axi
-ad_mem_hp0_interconnect sys_cpu_clk i2s_rx_dma/m_dest_axi
+ad_mem_hp1_interconnect sys_cpu_clk sys_ps8/S_AXI_HP1
+ad_mem_hp1_interconnect sys_cpu_clk i2s_tx_dma/m_src_axi
+ad_mem_hp2_interconnect sys_cpu_clk sys_ps8/S_AXI_HP2
+ad_mem_hp2_interconnect sys_cpu_clk i2s_rx_dma/m_dest_axi
 
 # interrupts
 

--- a/projects/adrv9009zu11eg/common/adrv9009zu11eg_bd.tcl
+++ b/projects/adrv9009zu11eg/common/adrv9009zu11eg_bd.tcl
@@ -1,5 +1,5 @@
 ###############################################################################
-## Copyright (C) 2019-2024 Analog Devices, Inc. All rights reserved.
+## Copyright (C) 2019-2025 Analog Devices, Inc. All rights reserved.
 ### SPDX short identifier: ADIBSD
 ###############################################################################
 
@@ -284,6 +284,9 @@ ad_ip_parameter axi_adrv9009_som_tx_dma CONFIG.AXI_SLICE_DEST 1
 ad_ip_parameter axi_adrv9009_som_tx_dma CONFIG.DMA_2D_TRANSFER 0
 ad_ip_parameter axi_adrv9009_som_tx_dma CONFIG.DMA_DATA_WIDTH_DEST $dac_data_width
 ad_ip_parameter axi_adrv9009_som_tx_dma CONFIG.DMA_DATA_WIDTH_SRC 128
+ad_ip_parameter axi_adrv9009_som_tx_dma CONFIG.CACHE_COHERENT 1
+ad_ip_parameter axi_adrv9009_som_tx_dma CONFIG.AXI_AXCACHE 0b1111
+ad_ip_parameter axi_adrv9009_som_tx_dma CONFIG.AXI_AXPROT 0b010
 
 ad_ip_instance axi_adxcvr axi_adrv9009_som_rx_xcvr
 ad_ip_parameter axi_adrv9009_som_rx_xcvr CONFIG.NUM_OF_LANES $MAX_RX_NUM_OF_LANES
@@ -319,6 +322,9 @@ ad_ip_parameter axi_adrv9009_som_rx_dma CONFIG.FIFO_SIZE 32
 ad_ip_parameter axi_adrv9009_som_rx_dma MAX_BYTES_PER_BURST 256
 ad_ip_parameter axi_adrv9009_som_rx_dma CONFIG.DMA_DATA_WIDTH_SRC $adc_dma_data_width
 ad_ip_parameter axi_adrv9009_som_rx_dma CONFIG.DMA_DATA_WIDTH_DEST 128
+ad_ip_parameter axi_adrv9009_som_rx_dma CONFIG.CACHE_COHERENT 1
+ad_ip_parameter axi_adrv9009_som_rx_dma CONFIG.AXI_AXCACHE 0b1111
+ad_ip_parameter axi_adrv9009_som_rx_dma CONFIG.AXI_AXPROT 0b010
 
 ad_ip_instance axi_adxcvr axi_adrv9009_som_obs_xcvr
 ad_ip_parameter axi_adrv9009_som_obs_xcvr CONFIG.NUM_OF_LANES $MAX_RX_OS_NUM_OF_LANES
@@ -352,6 +358,9 @@ ad_ip_parameter axi_adrv9009_som_obs_dma CONFIG.FIFO_SIZE 32
 ad_ip_parameter axi_adrv9009_som_obs_dma MAX_BYTES_PER_BURST 256
 ad_ip_parameter axi_adrv9009_som_obs_dma CONFIG.DMA_DATA_WIDTH_SRC [expr 32*$RX_OS_NUM_OF_LANES]
 ad_ip_parameter axi_adrv9009_som_obs_dma CONFIG.DMA_DATA_WIDTH_DEST 128
+ad_ip_parameter axi_adrv9009_som_obs_dma CONFIG.CACHE_COHERENT 1
+ad_ip_parameter axi_adrv9009_som_obs_dma CONFIG.AXI_AXCACHE 0b1111
+ad_ip_parameter axi_adrv9009_som_obs_dma CONFIG.AXI_AXPROT 0b010
 
 ad_ip_instance util_adxcvr util_adrv9009_som_xcvr
 ad_ip_parameter util_adrv9009_som_xcvr CONFIG.RX_NUM_OF_LANES [expr $MAX_RX_NUM_OF_LANES+$MAX_RX_OS_NUM_OF_LANES]
@@ -755,23 +764,11 @@ ad_mem_hp0_interconnect sys_cpu_clk axi_adrv9009_som_obs_xcvr/m_axi
 
 # interconnect (mem/dac)
 
-ad_ip_parameter sys_ps8 CONFIG.PSU__USE__S_AXI_GP3 1
-ad_connect sys_dma_clk sys_ps8/saxihp1_fpd_aclk
-ad_connect sys_dma_clk axi_adrv9009_som_obs_dma/m_dest_axi_aclk
-ad_connect sys_dma_resetn axi_adrv9009_som_obs_dma/m_dest_axi_aresetn
-ad_connect axi_adrv9009_som_obs_dma/m_dest_axi sys_ps8/S_AXI_HP1_FPD
-
-ad_ip_parameter sys_ps8 CONFIG.PSU__USE__S_AXI_GP4 1
-ad_connect sys_dma_clk sys_ps8/saxihp2_fpd_aclk
-ad_connect sys_dma_clk axi_adrv9009_som_rx_dma/m_dest_axi_aclk
-ad_connect sys_dma_resetn axi_adrv9009_som_rx_dma/m_dest_axi_aresetn
-ad_connect axi_adrv9009_som_rx_dma/m_dest_axi sys_ps8/S_AXI_HP2_FPD
-
-ad_ip_parameter sys_ps8 CONFIG.PSU__USE__S_AXI_GP5 1
-ad_connect sys_dma_clk sys_ps8/saxihp3_fpd_aclk
-ad_connect sys_dma_clk axi_adrv9009_som_tx_dma/m_src_axi_aclk
-ad_connect sys_dma_resetn axi_adrv9009_som_tx_dma/m_src_axi_aresetn
-ad_connect axi_adrv9009_som_tx_dma/m_src_axi sys_ps8/S_AXI_HP3_FPD
+ad_mem_hpc0_interconnect sys_dma_clk sys_ps8/S_AXI_HPC0
+ad_mem_hpc0_interconnect sys_dma_clk axi_adrv9009_som_obs_dma/m_dest_axi
+ad_mem_hpc0_interconnect sys_dma_clk axi_adrv9009_som_rx_dma/m_dest_axi
+ad_mem_hpc1_interconnect sys_dma_clk sys_ps8/S_AXI_HPC1
+ad_mem_hpc1_interconnect sys_dma_clk axi_adrv9009_som_tx_dma/m_src_axi
 
 # interrupts
 
@@ -782,11 +779,5 @@ ad_cpu_interrupt ps-11 mb-14 axi_adrv9009_som_obs_jesd/irq
 ad_cpu_interrupt ps-12 mb-13 axi_adrv9009_som_tx_jesd/irq
 ad_cpu_interrupt ps-13 mb-12 axi_adrv9009_som_rx_jesd/irq
 
-create_bd_addr_seg -range 0x80000000 -offset 0x00000000 \
-    [get_bd_addr_spaces axi_adrv9009_som_obs_dma/m_dest_axi] [get_bd_addr_segs sys_ps8/SAXIGP3/HP1_DDR_LOW] SEG_sys_ps8_HP1_DDR_LOW
-create_bd_addr_seg -range 0x80000000 -offset 0x00000000 \
-    [get_bd_addr_spaces axi_adrv9009_som_rx_dma/m_dest_axi] [get_bd_addr_segs sys_ps8/SAXIGP4/HP2_DDR_LOW] SEG_sys_ps8_HP2_DDR_LOW
-create_bd_addr_seg -range 0x80000000 -offset 0x00000000 \
-    [get_bd_addr_spaces axi_adrv9009_som_tx_dma/m_src_axi] [get_bd_addr_segs sys_ps8/SAXIGP5/HP3_DDR_LOW] SEG_sys_ps8_HP3_DDR_LOW
 create_bd_addr_seg -range 0x80000000 -offset 0x80000000 \
     [get_bd_addr_spaces axi_tx_fifo/axi] [get_bd_addr_segs ddr4_1/C0_DDR4_MEMORY_MAP/C0_DDR4_ADDRESS_BLOCK] SEG_ddr4_1_C0_DDR4_ADDRESS_BLOCK

--- a/projects/adrv9026/common/adrv9026_bd.tcl
+++ b/projects/adrv9026/common/adrv9026_bd.tcl
@@ -1,5 +1,5 @@
 ###############################################################################
-## Copyright (C) 2023-2024 Analog Devices, Inc. All rights reserved.
+## Copyright (C) 2023-2025 Analog Devices, Inc. All rights reserved.
 ### SPDX short identifier: ADIBSD
 ###############################################################################
 
@@ -88,6 +88,7 @@ ad_ip_parameter axi_adrv9026_tx_dma CONFIG.DMA_DATA_WIDTH_DEST $dac_dma_data_wid
 ad_ip_parameter axi_adrv9026_tx_dma CONFIG.MAX_BYTES_PER_BURST 256
 ad_ip_parameter axi_adrv9026_tx_dma CONFIG.DMA_DATA_WIDTH_SRC 128
 ad_ip_parameter axi_adrv9026_tx_dma CONFIG.FIFO_SIZE 32
+ad_ip_parameter axi_adrv9026_tx_dma CONFIG.CACHE_COHERENT $CACHE_COHERENCY
 
 ad_dacfifo_create $dac_fifo_name $dac_data_width $dac_dma_data_width $dac_fifo_address_width
 
@@ -127,6 +128,7 @@ ad_ip_parameter axi_adrv9026_rx_dma CONFIG.DMA_DATA_WIDTH_SRC [expr 32*$RX_NUM_O
 ad_ip_parameter axi_adrv9026_rx_dma CONFIG.MAX_BYTES_PER_BURST 4096
 ad_ip_parameter axi_adrv9026_rx_dma CONFIG.DMA_DATA_WIDTH_DEST 128
 ad_ip_parameter axi_adrv9026_rx_dma CONFIG.FIFO_SIZE 32
+ad_ip_parameter axi_adrv9026_rx_dma CONFIG.CACHE_COHERENT $CACHE_COHERENCY
 
 # xcvr interfaces
 
@@ -248,10 +250,17 @@ ad_mem_hp0_interconnect $sys_cpu_clk axi_adrv9026_rx_xcvr/m_axi
 
 # interconnect (mem/dac)
 
-ad_mem_hp2_interconnect $sys_dma_clk sys_ps7/S_AXI_HP2
-ad_mem_hp2_interconnect $sys_dma_clk axi_adrv9026_rx_dma/m_dest_axi
-ad_mem_hp3_interconnect $sys_dma_clk sys_ps7/S_AXI_HP3
-ad_mem_hp3_interconnect $sys_dma_clk axi_adrv9026_tx_dma/m_src_axi
+if {$CACHE_COHERENCY} {
+  ad_mem_hpc0_interconnect $sys_dma_clk sys_ps8/S_AXI_HPC0
+  ad_mem_hpc0_interconnect $sys_dma_clk axi_adrv9026_rx_dma/m_dest_axi
+  ad_mem_hpc1_interconnect $sys_dma_clk sys_ps8/S_AXI_HPC1
+  ad_mem_hpc1_interconnect $sys_dma_clk axi_adrv9026_tx_dma/m_src_axi
+} else {
+  ad_mem_hp2_interconnect $sys_dma_clk sys_ps7/S_AXI_HP2
+  ad_mem_hp2_interconnect $sys_dma_clk axi_adrv9026_rx_dma/m_dest_axi
+  ad_mem_hp3_interconnect $sys_dma_clk sys_ps7/S_AXI_HP3
+  ad_mem_hp3_interconnect $sys_dma_clk axi_adrv9026_tx_dma/m_src_axi
+}
 
 # interrupts
 

--- a/projects/adrv904x/common/adrv904x_bd.tcl
+++ b/projects/adrv904x/common/adrv904x_bd.tcl
@@ -1,5 +1,5 @@
 ###############################################################################
-## Copyright (C) 2024 Analog Devices, Inc. All rights reserved.
+## Copyright (C) 2024-2025 Analog Devices, Inc. All rights reserved.
 ### SPDX short identifier: ADIBSD
 ###############################################################################
 
@@ -129,6 +129,7 @@ ad_ip_parameter axi_adrv904x_tx_dma CONFIG.CYCLIC 1
 ad_ip_parameter axi_adrv904x_tx_dma CONFIG.MAX_BYTES_PER_BURST 4096
 ad_ip_parameter axi_adrv904x_tx_dma CONFIG.DMA_DATA_WIDTH_SRC [expr min(512, $dac_dma_data_width)]
 ad_ip_parameter axi_adrv904x_tx_dma CONFIG.DMA_DATA_WIDTH_DEST $dac_dma_data_width
+ad_ip_parameter axi_adrv904x_tx_dma CONFIG.CACHE_COHERENT $CACHE_COHERENCY
 
 # adc peripherals
 
@@ -168,16 +169,17 @@ adi_tpl_jesd204_rx_create rx_adrv904x_tpl_core $RX_NUM_OF_LANES \
                                                $RX_DMA_SAMPLE_WIDTH
 
 ad_ip_instance axi_dmac axi_adrv904x_rx_dma
-  ad_ip_parameter axi_adrv904x_rx_dma CONFIG.DMA_TYPE_SRC 1
-  ad_ip_parameter axi_adrv904x_rx_dma CONFIG.DMA_TYPE_DEST 0
-  ad_ip_parameter axi_adrv904x_rx_dma CONFIG.ID 0
-  ad_ip_parameter axi_adrv904x_rx_dma CONFIG.SYNC_TRANSFER_START 0
-  ad_ip_parameter axi_adrv904x_rx_dma CONFIG.DMA_LENGTH_WIDTH 24
-  ad_ip_parameter axi_adrv904x_rx_dma CONFIG.DMA_2D_TRANSFER 0
-  ad_ip_parameter axi_adrv904x_rx_dma CONFIG.MAX_BYTES_PER_BURST 4096
-  ad_ip_parameter axi_adrv904x_rx_dma CONFIG.CYCLIC 0
-  ad_ip_parameter axi_adrv904x_rx_dma CONFIG.DMA_DATA_WIDTH_SRC $adc_dma_data_width
-  ad_ip_parameter axi_adrv904x_rx_dma CONFIG.DMA_DATA_WIDTH_DEST [expr min(512, $adc_dma_data_width)]
+ad_ip_parameter axi_adrv904x_rx_dma CONFIG.DMA_TYPE_SRC 1
+ad_ip_parameter axi_adrv904x_rx_dma CONFIG.DMA_TYPE_DEST 0
+ad_ip_parameter axi_adrv904x_rx_dma CONFIG.ID 0
+ad_ip_parameter axi_adrv904x_rx_dma CONFIG.SYNC_TRANSFER_START 0
+ad_ip_parameter axi_adrv904x_rx_dma CONFIG.DMA_LENGTH_WIDTH 24
+ad_ip_parameter axi_adrv904x_rx_dma CONFIG.DMA_2D_TRANSFER 0
+ad_ip_parameter axi_adrv904x_rx_dma CONFIG.MAX_BYTES_PER_BURST 4096
+ad_ip_parameter axi_adrv904x_rx_dma CONFIG.CYCLIC 0
+ad_ip_parameter axi_adrv904x_rx_dma CONFIG.DMA_DATA_WIDTH_SRC $adc_dma_data_width
+ad_ip_parameter axi_adrv904x_rx_dma CONFIG.DMA_DATA_WIDTH_DEST [expr min(512, $adc_dma_data_width)]
+ad_ip_parameter axi_adrv904x_rx_dma CONFIG.CACHE_COHERENT $CACHE_COHERENCY
 
 set tx_ref_clk         tx_ref_clk_0
 set rx_ref_clk         rx_ref_clk_0
@@ -365,10 +367,17 @@ ad_mem_hp0_interconnect $sys_cpu_clk axi_adrv904x_rx_xcvr/m_axi
 
 # interconnect (mem/dac)
 
-ad_mem_hp2_interconnect $sys_dma_clk sys_ps7/S_AXI_HP2
-ad_mem_hp2_interconnect $sys_dma_clk axi_adrv904x_rx_dma/m_dest_axi
-ad_mem_hp3_interconnect $sys_dma_clk sys_ps7/S_AXI_HP3
-ad_mem_hp3_interconnect $sys_dma_clk axi_adrv904x_tx_dma/m_src_axi
+if {$CACHE_COHERENCY} {
+  ad_mem_hpc0_interconnect $sys_dma_clk sys_ps8/S_AXI_HPC0
+  ad_mem_hpc0_interconnect $sys_dma_clk axi_adrv904x_rx_dma/m_dest_axi
+  ad_mem_hpc1_interconnect $sys_dma_clk sys_ps8/S_AXI_HPC1
+  ad_mem_hpc1_interconnect $sys_dma_clk axi_adrv904x_tx_dma/m_src_axi
+} else {
+  ad_mem_hp2_interconnect $sys_dma_clk sys_ps7/S_AXI_HP2
+  ad_mem_hp2_interconnect $sys_dma_clk axi_adrv904x_rx_dma/m_dest_axi
+  ad_mem_hp3_interconnect $sys_dma_clk sys_ps7/S_AXI_HP3
+  ad_mem_hp3_interconnect $sys_dma_clk axi_adrv904x_tx_dma/m_src_axi
+}
 
 # interrupts
 

--- a/projects/adrv9371x/common/adrv9371x_bd.tcl
+++ b/projects/adrv9371x/common/adrv9371x_bd.tcl
@@ -1,5 +1,5 @@
 ###############################################################################
-## Copyright (C) 2016-2024 Analog Devices, Inc. All rights reserved.
+## Copyright (C) 2016-2025 Analog Devices, Inc. All rights reserved.
 ### SPDX short identifier: ADIBSD
 ###############################################################################
 
@@ -100,6 +100,7 @@ ad_ip_parameter axi_ad9371_tx_dma CONFIG.ASYNC_CLK_SRC_DEST 1
 ad_ip_parameter axi_ad9371_tx_dma CONFIG.ASYNC_CLK_REQ_SRC 1
 ad_ip_parameter axi_ad9371_tx_dma CONFIG.DMA_2D_TRANSFER 0
 ad_ip_parameter axi_ad9371_tx_dma CONFIG.DMA_DATA_WIDTH_DEST $dac_dma_data_width
+ad_ip_parameter axi_ad9371_tx_dma CONFIG.CACHE_COHERENT $CACHE_COHERENCY
 
 ad_dacfifo_create $dac_fifo_name $dac_data_width $dac_dma_data_width $dac_fifo_address_width
 
@@ -148,6 +149,7 @@ ad_ip_parameter axi_ad9371_rx_dma CONFIG.DMA_2D_TRANSFER 0
 ad_ip_parameter axi_ad9371_rx_dma CONFIG.DMA_DATA_WIDTH_SRC [expr $RX_SAMPLE_WIDTH * \
                                                                   $RX_NUM_OF_CONVERTERS * \
                                                                   $RX_SAMPLES_PER_CHANNEL]
+ad_ip_parameter axi_ad9371_rx_dma CONFIG.CACHE_COHERENT $CACHE_COHERENCY
 
 ad_add_decimation_filter "rx_fir_decimator" 8 $RX_NUM_OF_CONVERTERS 1 {122.88} {122.88} \
                          "$ad_hdl_dir/library/util_fir_int/coefile_int.coe"
@@ -197,6 +199,7 @@ ad_ip_parameter axi_ad9371_rx_os_dma CONFIG.DMA_2D_TRANSFER 0
 ad_ip_parameter axi_ad9371_rx_os_dma CONFIG.DMA_DATA_WIDTH_SRC [expr $RX_OS_SAMPLE_WIDTH * \
                                                                      $RX_OS_NUM_OF_CONVERTERS * \
                                                                      $RX_OS_SAMPLES_PER_CHANNEL]
+ad_ip_parameter axi_ad9371_rx_os_dma CONFIG.CACHE_COHERENT $CACHE_COHERENCY
 
 # common cores
 
@@ -385,11 +388,19 @@ ad_mem_hp3_interconnect $sys_cpu_clk axi_ad9371_rx_os_xcvr/m_axi
 
 # interconnect (mem/dac)
 
-ad_mem_hp1_interconnect $sys_dma_clk sys_ps7/S_AXI_HP1
-ad_mem_hp1_interconnect $sys_dma_clk axi_ad9371_tx_dma/m_src_axi
-ad_mem_hp2_interconnect $sys_dma_clk sys_ps7/S_AXI_HP2
-ad_mem_hp2_interconnect $sys_dma_clk axi_ad9371_rx_dma/m_dest_axi
-ad_mem_hp2_interconnect $sys_dma_clk axi_ad9371_rx_os_dma/m_dest_axi
+if {$CACHE_COHERENCY} {
+  ad_mem_hpc1_interconnect $sys_dma_clk sys_ps8/S_AXI_HPC1
+  ad_mem_hpc1_interconnect $sys_dma_clk axi_ad9371_tx_dma/m_src_axi
+  ad_mem_hpc0_interconnect $sys_dma_clk sys_ps8/S_AXI_HPC0
+  ad_mem_hpc0_interconnect $sys_dma_clk axi_ad9371_rx_dma/m_dest_axi
+  ad_mem_hpc0_interconnect $sys_dma_clk axi_ad9371_rx_os_dma/m_dest_axi
+} else {
+  ad_mem_hp1_interconnect $sys_dma_clk sys_ps7/S_AXI_HP1
+  ad_mem_hp1_interconnect $sys_dma_clk axi_ad9371_tx_dma/m_src_axi
+  ad_mem_hp2_interconnect $sys_dma_clk sys_ps7/S_AXI_HP2
+  ad_mem_hp2_interconnect $sys_dma_clk axi_ad9371_rx_dma/m_dest_axi
+  ad_mem_hp2_interconnect $sys_dma_clk axi_ad9371_rx_os_dma/m_dest_axi
+}
 
 # interrupts
 

--- a/projects/common/ac701/ac701_system_bd.tcl
+++ b/projects/common/ac701/ac701_system_bd.tcl
@@ -1,7 +1,9 @@
 ###############################################################################
-## Copyright (C) 2014-2023 Analog Devices, Inc. All rights reserved.
+## Copyright (C) 2014-2025 Analog Devices, Inc. All rights reserved.
 ### SPDX short identifier: ADIBSD
 ###############################################################################
+
+set CACHE_COHERENCY false
 
 # interface ports
 

--- a/projects/common/coraz7s/coraz7s_system_bd.tcl
+++ b/projects/common/coraz7s/coraz7s_system_bd.tcl
@@ -1,7 +1,9 @@
 ###############################################################################
-## Copyright (C) 2019-2024 Analog Devices, Inc. All rights reserved.
+## Copyright (C) 2019-2025 Analog Devices, Inc. All rights reserved.
 ### SPDX short identifier: ADIBSD
 ###############################################################################
+
+set CACHE_COHERENCY false
 
 # create board design
 # interface ports

--- a/projects/common/kc705/kc705_system_bd.tcl
+++ b/projects/common/kc705/kc705_system_bd.tcl
@@ -1,7 +1,9 @@
 ###############################################################################
-## Copyright (C) 2014-2023 Analog Devices, Inc. All rights reserved.
+## Copyright (C) 2014-2025 Analog Devices, Inc. All rights reserved.
 ### SPDX short identifier: ADIBSD
 ###############################################################################
+
+set CACHE_COHERENCY false
 
 # create board design
 # interface ports

--- a/projects/common/kcu105/kcu105_system_bd.tcl
+++ b/projects/common/kcu105/kcu105_system_bd.tcl
@@ -1,7 +1,9 @@
 ###############################################################################
-## Copyright (C) 2014-2023 Analog Devices, Inc. All rights reserved.
+## Copyright (C) 2014-2025 Analog Devices, Inc. All rights reserved.
 ### SPDX short identifier: ADIBSD
 ###############################################################################
+
+set CACHE_COHERENCY false
 
 # create board design
 # interface ports

--- a/projects/common/kv260/kv260_system_bd.tcl
+++ b/projects/common/kv260/kv260_system_bd.tcl
@@ -1,13 +1,13 @@
 ###############################################################################
-## Copyright (C) 2014-2023 Analog Devices, Inc. All rights reserved.
+## Copyright (C) 2014-2025 Analog Devices, Inc. All rights reserved.
 ### SPDX short identifier: ADIBSD
 ###############################################################################
+
+set CACHE_COHERENCY true
 
 # create board design
 # set Kria SOM240_1 connector to KV260 evaluation carrier
 set_property board_connections {som240_1_connector xilinx.com:kv260_carrier:som240_1_connector:1.3} [current_project]
-
-# default ports
 
 # default ports
 

--- a/projects/common/microzed/microzed_system_bd.tcl
+++ b/projects/common/microzed/microzed_system_bd.tcl
@@ -1,7 +1,9 @@
 ###############################################################################
-## Copyright (C) 2014-2023 Analog Devices, Inc. All rights reserved.
+## Copyright (C) 2014-2025 Analog Devices, Inc. All rights reserved.
 ### SPDX short identifier: ADIBSD
 ###############################################################################
+
+set CACHE_COHERENCY false
 
 # create board design
 # interface ports

--- a/projects/common/vc707/vc707_system_bd.tcl
+++ b/projects/common/vc707/vc707_system_bd.tcl
@@ -1,7 +1,12 @@
 ###############################################################################
-## Copyright (C) 2014-2023 Analog Devices, Inc. All rights reserved.
+## Copyright (C) 2014-2025 Analog Devices, Inc. All rights reserved.
 ### SPDX short identifier: ADIBSD
 ###############################################################################
+
+set CACHE_COHERENCY false
+
+# create board design
+# default ports
 
 create_bd_port -dir I -type rst sys_rst
 create_bd_port -dir I sys_clk_p

--- a/projects/common/vc709/vc709_system_bd.tcl
+++ b/projects/common/vc709/vc709_system_bd.tcl
@@ -1,7 +1,12 @@
 ###############################################################################
-## Copyright (C) 2014-2023 Analog Devices, Inc. All rights reserved.
+## Copyright (C) 2014-2025 Analog Devices, Inc. All rights reserved.
 ### SPDX short identifier: ADIBSD
 ###############################################################################
+
+set CACHE_COHERENCY false
+
+# create board design
+# default ports
 
 create_bd_port -dir I -type rst sys_rst
 create_bd_port -dir I sys_clk_p

--- a/projects/common/vcu118/vcu118_system_bd.tcl
+++ b/projects/common/vcu118/vcu118_system_bd.tcl
@@ -1,7 +1,9 @@
 ###############################################################################
-## Copyright (C) 2019-2023 Analog Devices, Inc. All rights reserved.
+## Copyright (C) 2019-2025 Analog Devices, Inc. All rights reserved.
 ### SPDX short identifier: ADIBSD
 ###############################################################################
+
+set CACHE_COHERENCY false
 
 # create board design
 # interface ports

--- a/projects/common/vcu128/vcu128_system_bd.tcl
+++ b/projects/common/vcu128/vcu128_system_bd.tcl
@@ -1,7 +1,9 @@
 ###############################################################################
-## Copyright (C) 2019-2023 Analog Devices, Inc. All rights reserved.
+## Copyright (C) 2019-2025 Analog Devices, Inc. All rights reserved.
 ### SPDX short identifier: ADIBSD
 ###############################################################################
+
+set CACHE_COHERENCY false
 
 # create board design
 # interface ports

--- a/projects/common/vmk180/vmk180_system_bd.tcl
+++ b/projects/common/vmk180/vmk180_system_bd.tcl
@@ -1,7 +1,9 @@
 ###############################################################################
-## Copyright (C) 2021-2023 Analog Devices, Inc. All rights reserved.
+## Copyright (C) 2021-2025 Analog Devices, Inc. All rights reserved.
 ### SPDX short identifier: ADIBSD
 ###############################################################################
+
+set CACHE_COHERENCY false
 
 # create board design
 # default ports

--- a/projects/common/vpk180/vpk180_system_bd.tcl
+++ b/projects/common/vpk180/vpk180_system_bd.tcl
@@ -1,7 +1,12 @@
 ###############################################################################
-## Copyright (C) 2023 Analog Devices, Inc. All rights reserved.
+## Copyright (C) 2023-2025 Analog Devices, Inc. All rights reserved.
 ### SPDX short identifier: ADIBSD
 ###############################################################################
+
+set CACHE_COHERENCY false
+
+# create board design
+# default ports
 
 create_bd_port -dir O -from 2 -to 0 spi0_csn
 create_bd_port -dir O spi0_sclk

--- a/projects/common/zc702/zc702_system_bd.tcl
+++ b/projects/common/zc702/zc702_system_bd.tcl
@@ -1,7 +1,9 @@
 ###############################################################################
-## Copyright (C) 2014-2023 Analog Devices, Inc. All rights reserved.
+## Copyright (C) 2014-2025 Analog Devices, Inc. All rights reserved.
 ### SPDX short identifier: ADIBSD
 ###############################################################################
+
+set CACHE_COHERENCY false
 
 # create board design
 # interface ports

--- a/projects/common/zc706/zc706_system_bd.tcl
+++ b/projects/common/zc706/zc706_system_bd.tcl
@@ -1,7 +1,9 @@
 ###############################################################################
-## Copyright (C) 2014-2023 Analog Devices, Inc. All rights reserved.
+## Copyright (C) 2014-2025 Analog Devices, Inc. All rights reserved.
 ### SPDX short identifier: ADIBSD
 ###############################################################################
+
+set CACHE_COHERENCY false
 
 # create board design
 # default ports

--- a/projects/common/zcu102/zcu102_system_bd.tcl
+++ b/projects/common/zcu102/zcu102_system_bd.tcl
@@ -1,7 +1,9 @@
 ###############################################################################
-## Copyright (C) 2016-2023 Analog Devices, Inc. All rights reserved.
+## Copyright (C) 2016-2025 Analog Devices, Inc. All rights reserved.
 ### SPDX short identifier: ADIBSD
 ###############################################################################
+
+set CACHE_COHERENCY true
 
 # create board design
 # default ports

--- a/projects/common/zed/zed_system_bd.tcl
+++ b/projects/common/zed/zed_system_bd.tcl
@@ -1,7 +1,9 @@
 ###############################################################################
-## Copyright (C) 2014-2023 Analog Devices, Inc. All rights reserved.
+## Copyright (C) 2014-2025 Analog Devices, Inc. All rights reserved.
 ### SPDX short identifier: ADIBSD
 ###############################################################################
+
+set CACHE_COHERENCY false
 
 # create board design
 # interface ports

--- a/projects/dac_fmc_ebz/common/dac_fmc_ebz_bd.tcl
+++ b/projects/dac_fmc_ebz/common/dac_fmc_ebz_bd.tcl
@@ -1,5 +1,5 @@
 ###############################################################################
-## Copyright (C) 2019-2023 Analog Devices, Inc. All rights reserved.
+## Copyright (C) 2019-2025 Analog Devices, Inc. All rights reserved.
 ### SPDX short identifier: ADIBSD
 ###############################################################################
 
@@ -52,6 +52,7 @@ ad_ip_instance axi_dmac dac_dma [list \
   DMA_TYPE_DEST 1 \
   DMA_DATA_WIDTH_SRC 64 \
   DMA_DATA_WIDTH_DEST $dac_dma_data_width \
+  CACHE_COHERENT $CACHE_COHERENCY \
 ]
 
 ad_dacfifo_create axi_dac_fifo \
@@ -130,8 +131,13 @@ ad_cpu_interconnect 0x7c420000 dac_dma
 
 # interconnect (mem/dac)
 
-ad_mem_hp1_interconnect sys_cpu_clk sys_ps7/S_AXI_HP1
-ad_mem_hp1_interconnect sys_cpu_clk dac_dma/m_src_axi
+if {$CACHE_COHERENCY} {
+  ad_mem_hpc0_interconnect sys_cpu_clk sys_ps8/S_AXI_HPC0
+  ad_mem_hpc0_interconnect sys_cpu_clk dac_dma/m_src_axi
+} else {
+  ad_mem_hp1_interconnect sys_cpu_clk sys_ps7/S_AXI_HP1
+  ad_mem_hp1_interconnect sys_cpu_clk dac_dma/m_src_axi
+}
 
 # interrupts
 

--- a/projects/daq2/common/daq2_bd.tcl
+++ b/projects/daq2/common/daq2_bd.tcl
@@ -1,5 +1,5 @@
 ###############################################################################
-## Copyright (C) 2014-2023 Analog Devices, Inc. All rights reserved.
+## Copyright (C) 2014-2025 Analog Devices, Inc. All rights reserved.
 ### SPDX short identifier: ADIBSD
 ###############################################################################
 
@@ -66,6 +66,7 @@ ad_ip_instance axi_dmac axi_ad9144_dma [list \
   CYCLIC 0 \
   DMA_DATA_WIDTH_SRC 128 \
   DMA_DATA_WIDTH_DEST $dac_data_width \
+  CACHE_COHERENT $CACHE_COHERENCY \
 ]
 
 ad_data_offload_create axi_ad9144_offload \
@@ -115,6 +116,7 @@ ad_ip_instance axi_dmac axi_ad9680_dma [list \
   CYCLIC 0 \
   DMA_DATA_WIDTH_SRC $adc_data_width \
   DMA_DATA_WIDTH_DEST 64 \
+  CACHE_COHERENT $CACHE_COHERENCY \
 ]
 
 ad_data_offload_create axi_ad9680_offload \
@@ -237,10 +239,17 @@ ad_mem_hp3_interconnect $sys_cpu_clk axi_ad9680_xcvr/m_axi
 
 # interconnect (mem/dac)
 
-ad_mem_hp1_interconnect $sys_cpu_clk sys_ps7/S_AXI_HP1
-ad_mem_hp1_interconnect $sys_cpu_clk axi_ad9144_dma/m_src_axi
-ad_mem_hp2_interconnect $sys_cpu_clk sys_ps7/S_AXI_HP2
-ad_mem_hp2_interconnect $sys_cpu_clk axi_ad9680_dma/m_dest_axi
+if {$CACHE_COHERENCY} {
+  ad_mem_hpc1_interconnect $sys_cpu_clk sys_ps8/S_AXI_HPC1
+  ad_mem_hpc1_interconnect $sys_cpu_clk axi_ad9144_dma/m_src_axi
+  ad_mem_hpc0_interconnect $sys_cpu_clk sys_ps8/S_AXI_HPC0
+  ad_mem_hpc0_interconnect $sys_cpu_clk axi_ad9680_dma/m_dest_axi
+} else {
+  ad_mem_hp1_interconnect $sys_cpu_clk sys_ps7/S_AXI_HP1
+  ad_mem_hp1_interconnect $sys_cpu_clk axi_ad9144_dma/m_src_axi
+  ad_mem_hp2_interconnect $sys_cpu_clk sys_ps7/S_AXI_HP2
+  ad_mem_hp2_interconnect $sys_cpu_clk axi_ad9680_dma/m_dest_axi
+}
 
 # interrupts
 

--- a/projects/daq3/common/daq3_bd.tcl
+++ b/projects/daq3/common/daq3_bd.tcl
@@ -1,5 +1,5 @@
 ###############################################################################
-## Copyright (C) 2014-2023 Analog Devices, Inc. All rights reserved.
+## Copyright (C) 2014-2025 Analog Devices, Inc. All rights reserved.
 ### SPDX short identifier: ADIBSD
 ###############################################################################
 
@@ -70,6 +70,7 @@ ad_ip_parameter axi_ad9152_dma CONFIG.DMA_2D_TRANSFER 0
 ad_ip_parameter axi_ad9152_dma CONFIG.CYCLIC 0
 ad_ip_parameter axi_ad9152_dma CONFIG.DMA_DATA_WIDTH_SRC 128
 ad_ip_parameter axi_ad9152_dma CONFIG.DMA_DATA_WIDTH_DEST $dac_data_width
+ad_ip_parameter axi_ad9152_dma CONFIG.CACHE_COHERENT $CACHE_COHERENCY
 
 ad_dacfifo_create $dac_fifo_name $dac_data_width $dac_data_width $dac_fifo_address_width
 
@@ -107,6 +108,7 @@ ad_ip_parameter axi_ad9680_dma CONFIG.DMA_2D_TRANSFER 0
 ad_ip_parameter axi_ad9680_dma CONFIG.CYCLIC 0
 ad_ip_parameter axi_ad9680_dma CONFIG.DMA_DATA_WIDTH_SRC $adc_data_width
 ad_ip_parameter axi_ad9680_dma CONFIG.DMA_DATA_WIDTH_DEST 64
+ad_ip_parameter axi_ad9680_dma CONFIG.CACHE_COHERENT $CACHE_COHERENCY
 
 if {$sys_zynq == 0 || $sys_zynq == 1} {
   ad_adcfifo_create $adc_fifo_name $adc_data_width $adc_data_width $adc_fifo_address_width

--- a/projects/daq3/zcu102/system_bd.tcl
+++ b/projects/daq3/zcu102/system_bd.tcl
@@ -1,5 +1,5 @@
 ###############################################################################
-## Copyright (C) 2014-2023 Analog Devices, Inc. All rights reserved.
+## Copyright (C) 2014-2025 Analog Devices, Inc. All rights reserved.
 ### SPDX short identifier: ADIBSD
 ###############################################################################
 
@@ -83,9 +83,9 @@ ad_connect axi_ad9680_dma/fifo_wr_clk util_daq3_xcvr/rx_out_clk_0
 ad_connect axi_ad9680_cpack/packed_fifo_wr axi_ad9680_dma/fifo_wr
 ad_connect axi_ad9680_cpack/fifo_wr_overflow axi_ad9680_tpl_core/adc_dovf
 
-ad_mem_hp0_interconnect sys_cpu_clk sys_ps7/S_AXI_HP0
+ad_mem_hp0_interconnect sys_cpu_clk sys_ps8/S_AXI_HP0
 ad_mem_hp0_interconnect sys_cpu_clk axi_ad9680_xcvr/m_axi
-ad_mem_hp1_interconnect sys_dma_clk sys_ps7/S_AXI_HP1
-ad_mem_hp1_interconnect sys_dma_clk axi_ad9680_dma/m_dest_axi
-ad_mem_hp3_interconnect sys_dma_clk sys_ps7/S_AXI_HP3
-ad_mem_hp3_interconnect sys_dma_clk axi_ad9152_dma/m_src_axi
+ad_mem_hpc0_interconnect sys_dma_clk sys_ps8/S_AXI_HPC0
+ad_mem_hpc0_interconnect sys_dma_clk axi_ad9680_dma/m_dest_axi
+ad_mem_hpc1_interconnect sys_dma_clk sys_ps8/S_AXI_HPC1
+ad_mem_hpc1_interconnect sys_dma_clk axi_ad9152_dma/m_src_axi

--- a/projects/fmcomms2/common/fmcomms2_bd.tcl
+++ b/projects/fmcomms2/common/fmcomms2_bd.tcl
@@ -1,5 +1,5 @@
 ###############################################################################
-## Copyright (C) 2014-2024 Analog Devices, Inc. All rights reserved.
+## Copyright (C) 2014-2025 Analog Devices, Inc. All rights reserved.
 ### SPDX short identifier: ADIBSD
 ###############################################################################
 
@@ -145,6 +145,7 @@ ad_ip_parameter axi_ad9361_adc_dma CONFIG.DMA_2D_TRANSFER 0
 ad_ip_parameter axi_ad9361_adc_dma CONFIG.DMA_SG_TRANSFER 1
 ad_ip_parameter axi_ad9361_adc_dma CONFIG.DMA_DATA_WIDTH_SRC 64
 ad_ip_parameter axi_ad9361_adc_dma CONFIG.DMA_DATA_WIDTH_SG 64
+ad_ip_parameter axi_ad9361_adc_dma CONFIG.CACHE_COHERENT $CACHE_COHERENCY
 
 ad_connect util_ad9361_divclk/clk_out axi_ad9361_adc_dma/fifo_wr_clk
 ad_connect util_ad9361_adc_pack/packed_fifo_wr axi_ad9361_adc_dma/fifo_wr
@@ -207,6 +208,7 @@ ad_ip_parameter axi_ad9361_dac_dma CONFIG.DMA_2D_TRANSFER 0
 ad_ip_parameter axi_ad9361_dac_dma CONFIG.DMA_SG_TRANSFER 1
 ad_ip_parameter axi_ad9361_dac_dma CONFIG.DMA_DATA_WIDTH_DEST 64
 ad_ip_parameter axi_ad9361_dac_dma CONFIG.DMA_DATA_WIDTH_SG 64
+ad_ip_parameter axi_ad9361_dac_dma CONFIG.CACHE_COHERENT $CACHE_COHERENCY
 
 ad_connect util_ad9361_divclk/clk_out axi_ad9361_dac_dma/m_axis_aclk
 ad_connect axi_ad9361_dac_dma/m_axis util_ad9361_dac_upack/s_axis
@@ -219,13 +221,22 @@ ad_connect $sys_cpu_resetn axi_ad9361_dac_dma/m_sg_axi_aresetn
 ad_cpu_interconnect 0x79020000 axi_ad9361
 ad_cpu_interconnect 0x7C400000 axi_ad9361_adc_dma
 ad_cpu_interconnect 0x7C420000 axi_ad9361_dac_dma
-ad_mem_hp1_interconnect $sys_cpu_clk sys_ps7/S_AXI_HP1
-ad_mem_hp1_interconnect $sys_cpu_clk axi_ad9361_adc_dma/m_dest_axi
-ad_mem_hp2_interconnect $sys_cpu_clk sys_ps7/S_AXI_HP2
-ad_mem_hp2_interconnect $sys_cpu_clk axi_ad9361_dac_dma/m_src_axi
 
-ad_mem_hp2_interconnect $sys_cpu_clk axi_ad9361_dac_dma/m_sg_axi
-ad_mem_hp1_interconnect $sys_cpu_clk axi_ad9361_adc_dma/m_sg_axi
+if {$CACHE_COHERENCY} {
+  ad_mem_hpc0_interconnect $sys_cpu_clk sys_ps8/S_AXI_HPC0
+  ad_mem_hpc0_interconnect $sys_cpu_clk axi_ad9361_adc_dma/m_dest_axi
+  ad_mem_hpc0_interconnect $sys_cpu_clk axi_ad9361_adc_dma/m_sg_axi
+  ad_mem_hpc1_interconnect $sys_cpu_clk sys_ps8/S_AXI_HPC1
+  ad_mem_hpc1_interconnect $sys_cpu_clk axi_ad9361_dac_dma/m_src_axi
+  ad_mem_hpc1_interconnect $sys_cpu_clk axi_ad9361_dac_dma/m_sg_axi
+} else {
+  ad_mem_hp1_interconnect $sys_cpu_clk sys_ps7/S_AXI_HP1
+  ad_mem_hp1_interconnect $sys_cpu_clk axi_ad9361_adc_dma/m_dest_axi
+  ad_mem_hp1_interconnect $sys_cpu_clk axi_ad9361_adc_dma/m_sg_axi
+  ad_mem_hp2_interconnect $sys_cpu_clk sys_ps7/S_AXI_HP2
+  ad_mem_hp2_interconnect $sys_cpu_clk axi_ad9361_dac_dma/m_src_axi
+  ad_mem_hp2_interconnect $sys_cpu_clk axi_ad9361_dac_dma/m_sg_axi
+}
 
 # interrupts
 

--- a/projects/fmcomms5/common/fmcomms5_bd.tcl
+++ b/projects/fmcomms5/common/fmcomms5_bd.tcl
@@ -1,5 +1,5 @@
 ###############################################################################
-## Copyright (C) 2014-2024 Analog Devices, Inc. All rights reserved.
+## Copyright (C) 2014-2025 Analog Devices, Inc. All rights reserved.
 ### SPDX short identifier: ADIBSD
 ###############################################################################
 
@@ -193,6 +193,8 @@ ad_ip_parameter axi_ad9361_adc_dma CONFIG.AXI_SLICE_DEST 0
 ad_ip_parameter axi_ad9361_adc_dma CONFIG.DMA_2D_TRANSFER 0
 ad_ip_parameter axi_ad9361_adc_dma CONFIG.DMA_DATA_WIDTH_SRC 128
 ad_ip_parameter axi_ad9361_adc_dma CONFIG.DMA_DATA_WIDTH_DEST 64
+ad_ip_parameter axi_ad9361_adc_dma CONFIG.CACHE_COHERENT $CACHE_COHERENCY
+
 ad_connect util_ad9361_divclk/clk_out axi_ad9361_adc_dma/fifo_wr_clk
 ad_connect util_ad9361_adc_pack/packed_fifo_wr axi_ad9361_adc_dma/fifo_wr
 ad_connect util_ad9361_adc_pack/packed_sync axi_ad9361_adc_dma/sync
@@ -266,6 +268,7 @@ ad_ip_parameter axi_ad9361_dac_dma CONFIG.AXI_SLICE_DEST 0
 ad_ip_parameter axi_ad9361_dac_dma CONFIG.DMA_2D_TRANSFER 0
 ad_ip_parameter axi_ad9361_dac_dma CONFIG.DMA_DATA_WIDTH_DEST 128
 ad_ip_parameter axi_ad9361_dac_dma CONFIG.DMA_DATA_WIDTH_SRC 64
+ad_ip_parameter axi_ad9361_dac_dma CONFIG.CACHE_COHERENT $CACHE_COHERENCY
 
 ad_connect $sys_dma_resetn axi_ad9361_dac_dma/m_src_axi_aresetn
 ad_connect util_ad9361_divclk/clk_out axi_ad9361_dac_dma/m_axis_aclk
@@ -277,10 +280,18 @@ ad_cpu_interconnect 0x79020000 axi_ad9361_0
 ad_cpu_interconnect 0x7C420000 axi_ad9361_dac_dma
 ad_cpu_interconnect 0x7C400000 axi_ad9361_adc_dma
 ad_cpu_interconnect 0x79040000 axi_ad9361_1
-ad_mem_hp2_interconnect $sys_dma_clk sys_ps7/S_AXI_HP2
-ad_mem_hp2_interconnect $sys_dma_clk axi_ad9361_adc_dma/m_dest_axi
-ad_mem_hp3_interconnect $sys_dma_clk sys_ps7/S_AXI_HP3
-ad_mem_hp3_interconnect $sys_dma_clk axi_ad9361_dac_dma/m_src_axi
+
+if {$CACHE_COHERENCY} {
+  ad_mem_hpc0_interconnect $sys_dma_clk sys_ps8/S_AXI_HPC0
+  ad_mem_hpc0_interconnect $sys_dma_clk axi_ad9361_adc_dma/m_dest_axi
+  ad_mem_hpc1_interconnect $sys_dma_clk sys_ps8/S_AXI_HPC1
+  ad_mem_hpc1_interconnect $sys_dma_clk axi_ad9361_dac_dma/m_src_axi
+} else {
+  ad_mem_hp2_interconnect $sys_dma_clk sys_ps7/S_AXI_HP2
+  ad_mem_hp2_interconnect $sys_dma_clk axi_ad9361_adc_dma/m_dest_axi
+  ad_mem_hp3_interconnect $sys_dma_clk sys_ps7/S_AXI_HP3
+  ad_mem_hp3_interconnect $sys_dma_clk axi_ad9361_dac_dma/m_src_axi
+}
 
 # interrupts
 


### PR DESCRIPTION
## PR Description

This commit enables Cache Coherency on Ultrascale+ projects, leaving it disabled for the other platforms.

## PR Type
- [ ] Bug fix (change that fixes an issue)
- [x] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the code style guidelines
- [x] I have performed a self-review of changes
- [ ] I have compiled all hdl projects and libraries affected by this PR
- [ ] I have tested in hardware affected projects, at least on relevant boards
- [x] I have commented my code, at least hard-to-understand parts
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe files, Copyright etc)
- [ ] I have not introduced new Warnings/Critical Warnings on compilation
- [ ] I have added new hdl testbenches or updated existing ones
