### PR TITLE
library/spi_engine: fix segmented transfers with echo_sclk

### DIFF
--- a/library/spi_engine/spi_engine_execution/spi_engine_execution.v
+++ b/library/spi_engine/spi_engine_execution/spi_engine_execution.v
@@ -436,7 +436,7 @@ module spi_engine_execution #(
        if (ECHO_SCLK) begin
         transfer_done <= echo_last_bit && last_transfer;
        end else begin
-        transfer_done <= (wait_for_io && io_ready1 && last_transfer) || (!wait_for_io && transfer_active && end_of_word && (last_transfer || !io_ready2)); // same conditions that make (!transfer_active && !wait_for_io)
+        transfer_done <= (wait_for_io && io_ready1 && last_transfer) || (!wait_for_io && transfer_active && end_of_word && last_transfer ); // same conditions that make (!transfer_active && !wait_for_io)
        end
     end
   end

--- a/library/spi_engine/spi_engine_execution/spi_engine_execution.v
+++ b/library/spi_engine/spi_engine_execution/spi_engine_execution.v
@@ -118,6 +118,7 @@ module spi_engine_execution #(
 
   reg last_transfer;
   reg [7:0] word_length = DATA_WIDTH;
+  reg [7:0] last_bit_count = DATA_WIDTH-1;
   reg [7:0] left_aligned = 8'b0;
 
   assign first_bit = ((bit_counter == 'h0) ||  (bit_counter == word_length));
@@ -244,6 +245,7 @@ module spi_engine_execution #(
       sdo_idle_state <= SDO_DEFAULT;
       clk_div <= DEFAULT_CLK_DIV;
       word_length <= DATA_WIDTH;
+      last_bit_count <= DATA_WIDTH-1;
       left_aligned <= 8'b0;
     end else if (exec_write_cmd == 1'b1) begin
       if (cmd[9:8] == REG_CONFIG) begin
@@ -256,6 +258,7 @@ module spi_engine_execution #(
       end else if (cmd[9:8] == REG_WORD_LENGTH) begin
         // the max value of this reg must be DATA_WIDTH
         word_length <= cmd[7:0];
+        last_bit_count <= cmd[7:0] - 1;
         left_aligned <= DATA_WIDTH - cmd[7:0];
       end
     end
@@ -458,7 +461,7 @@ module spi_engine_execution #(
   // end_of_word will signal the end of a transaction, pushing the command
   // stream execution to the next command. end_of_word in normal mode can be
   // generated using the global bit_counter
-  assign last_bit = bit_counter == word_length - 1;
+  assign last_bit = (bit_counter == last_bit_count);
   assign end_of_word = last_bit == 1'b1 && ntx_rx == 1'b1 && clk_div_last == 1'b1;
 
   always @(posedge clk) begin


### PR DESCRIPTION
## PR Description

Currently, segmented transfers (where two transfer instructions of different lenghts are used without deasserting CS to assemble a single SPI transfer) are broken when using echo_sclk. This PR fixes this issue.


## PR Type
- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [ ] I have followed the code style guidelines
- [x] I have performed a self-review of changes
- [ ] I have compiled all hdl projects and libraries affected by this PR
- [ ] I have tested in hardware affected projects, at least on relevant boards
- [x] I have commented my code, at least hard-to-understand parts
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe files, Copyright etc)
- [ ] I have not introduced new Warnings/Critical Warnings on compilation
- [ ] I have added new hdl testbenches or updated existing ones
