### PR TITLE
axi_dmac: Fix Intel RAM critical warning

### DIFF
--- a/library/axi_dmac/axi_dmac_response_manager.v
+++ b/library/axi_dmac/axi_dmac_response_manager.v
@@ -139,7 +139,11 @@ module axi_dmac_response_manager #(
 
   always @(posedge req_clk)
   begin
-    if (response_dest_valid & response_dest_ready) begin
+    if (req_resetn == 1'b0) begin
+      req_eot <= 1'b0;
+      req_response_partial <= 1'b0;
+      req_response_dest_data_burst_length <= 'h0;
+    end else if (response_dest_valid & response_dest_ready) begin
       req_eot <= response_dest_resp_eot;
       req_response_partial <= response_dest_partial;
       req_response_dest_data_burst_length <= response_dest_data_burst_length;


### PR DESCRIPTION
This commit fixes the critical warning: "mixed_port_feed_through_mode" parameter of RAM atom cannot have value "old" when different read and write clocks are used, by adding a reset on the read side.

## PR Type
- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the code style guidelines
- [x] I have performed a self-review of changes
- [ ] I have compiled all hdl projects and libraries affected by this PR
- [ ] I have tested in hardware affected projects, at least on relevant boards
- [ ] I have commented my code, at least hard-to-understand parts
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe files, Copyright etc)
- [x] I have not introduced new Warnings/Critical Warnings on compilation
- [ ] I have added new hdl testbenches or updated existing ones
