### PR TITLE
axi_dmac_regmap_request.v: Updating assignment for up_dma_x_length.

### DIFF
--- a/library/axi_dmac/axi_dmac_regmap_request.v
+++ b/library/axi_dmac/axi_dmac_regmap_request.v
@@ -136,7 +136,8 @@ module axi_dmac_regmap_request #(
 
   reg [DMA_AXI_ADDR_WIDTH-1:BYTES_PER_BEAT_WIDTH_DEST] up_dma_dest_address = DMAC_DEF_DEST_ADDR_DEFAULT;
   reg [DMA_AXI_ADDR_WIDTH-1:BYTES_PER_BEAT_WIDTH_SRC]  up_dma_src_address = DMAC_DEF_SRC_ADDR_DEFAULT;
-  reg [DMA_LENGTH_WIDTH-1:0] up_dma_x_length = {DMAC_DEF_X_LENGTH_DEFAULT,{DMA_LENGTH_ALIGN{1'b1}}};
+  reg [DMA_LENGTH_WIDTH-1:0] up_dma_x_length =
+    {DMAC_DEF_X_LENGTH_DEFAULT[((DMA_LENGTH_WIDTH - 1) - DMA_LENGTH_ALIGN):0], {DMA_LENGTH_ALIGN{1'b1}}};
   reg up_dma_cyclic = AUTORUN_FLAGS_CYCLIC;
   reg up_dma_last = AUTORUN_FLAGS_LAST;
   reg up_dma_enable_tlen_reporting = AUTORUN_FLAGS_TLEN;


### PR DESCRIPTION
## PR Description

- The Lattice Radiant in the default configuration can not automatically infer the array size at concatenation.
- I'm specifying the array size at concatenation to fix the error shown by Lattice Radiant.

## PR Type
- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the code style guidelines
- [x] I have performed a self-review of changes
- [ ] I have compiled all hdl projects and libraries affected by this PR
- [ ] I have tested in hardware affected projects, at least on relevant boards
- [ ] I have commented my code, at least hard-to-understand parts
- [ ] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe files, Copyright etc)
- [ ] I have not introduced new Warnings/Critical Warnings on compilation
- [ ] I have added new hdl testbenches or updated existing ones
