### PR TITLE
library: intel: adi_jesd204: adi_jesd204_hw: Fix sip_tile string

### DIFF
--- a/library/intel/adi_jesd204/adi_jesd204_hw.tcl
+++ b/library/intel/adi_jesd204/adi_jesd204_hw.tcl
@@ -345,8 +345,9 @@ proc jesd204_compose {} {
   set data_path_width [get_parameter_value "DATA_PATH_WIDTH"]
   set link_mode [get_parameter_value "LINK_MODE"]
 
-  set sip_tile [quartus::device::get_part_info -sip_tile $device]
-
+  set sip_tile_info [quartus::device::get_part_info -sip_tile $device]
+  regexp -nocase {([a-z])\-tile} $sip_tile_info -> sip_tile
+  set sip_tile [string toupper $sip_tile]
 
   if {$link_mode == 1} {
     # jesd204b
@@ -442,7 +443,7 @@ proc jesd204_compose {} {
     add_connection sys_clock.clk_reset link_pll_reset_control.reset
     add_connection link_pll_reset_control.pll_powerdown link_pll.pll_powerdown
 
-  } elseif {$device_family == "Stratix 10" && $sip_tile == "{H-Tile}"} {
+  } elseif {$device_family == "Stratix 10" && $sip_tile == "H"} {
 
     send_message info "Instantiate a fpll_s10_htile for link_pll."
     add_instance link_pll altera_xcvr_fpll_s10_htile
@@ -462,7 +463,7 @@ proc jesd204_compose {} {
     set outclk_name "outclk_div1"
     add_connection link_pll.$outclk_name link_clock.in_clk
 
-  } elseif {$device_family == "Stratix 10" && $sip_tile == "E-Tile"} {
+  } elseif {$device_family == "Stratix 10" && $sip_tile == "E"} {
 
     ## No fPLL here, PLL embedded in Native PHY
 


### PR DESCRIPTION
## PR Description

In quartus 24.2 the 'get_part_info -sip_tile' command also returns the number of tiles which made some of the ifs that were matching on the type of tile fail.

## PR Type
- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the code style guidelines
- [x] I have performed a self-review of changes
- [x] I have compiled all hdl projects and libraries affected by this PR
- [ ] I have tested in hardware affected projects, at least on relevant boards
- [ ] I have commented my code, at least hard-to-understand parts
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe files, Copyright etc)
- [x] I have not introduced new Warnings/Critical Warnings on compilation
- [ ] I have added new hdl testbenches or updated existing ones
