### PR TITLE
projects/scripts/adi_board: ad_cpu_interconnect update

### DIFF
--- a/projects/scripts/adi_board.tcl
+++ b/projects/scripts/adi_board.tcl
@@ -1161,10 +1161,10 @@ proc ad_hpmx_interconnect {p_sel p_address p_name {p_intf_name {}}} {
           set p_address [expr ($p_address + 0x20000000)]
         }
       }
-      puts "create_bd_addr_seg -range $p_seg_range -offset $p_address $sys_addr_cntrl_space $p_seg_name SEG_data_$p_name"
+      puts "create_bd_addr_seg -range $p_seg_range -offset $p_address $sys_addr_cntrl_space $p_seg_name SEG_data_${p_name}_${p_intf_name}"
       create_bd_addr_seg -range $p_seg_range \
         -offset $p_address $sys_addr_cntrl_space \
-        $p_seg_name "SEG_data_${p_name}"
+        $p_seg_name "SEG_data_${p_name}_${p_intf_name}"
     } else {
       assign_bd_address $p_seg_name
     }


### PR DESCRIPTION
## PR Description

Adds the option to connect multiple AXI4 interfaces to the CPU interconnect from the same IP.
Current version of the ad_cpu_interconnect only allows the connection of 1 AXI interface to the CPU. This changes allows us to connect multiple AXI interfaces to the CPU. 


## PR Type
- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the code style guidelines
- [x] I have performed a self-review of changes
- [ ] I have compiled all hdl projects and libraries affected by this PR
- [ ] I have tested in hardware affected projects, at least on relevant boards
- [ ] I have commented my code, at least hard-to-understand parts
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe files, Copyright etc)
- [x] I have not introduced new Warnings/Critical Warnings on compilation
- [ ] I have added new hdl testbenches or updated existing ones
