### PR TITLE
library/scripts/adi_ip_xilinx: adi_ip_files update

### DIFF
--- a/library/scripts/adi_ip_xilinx.tcl
+++ b/library/scripts/adi_ip_xilinx.tcl
@@ -305,12 +305,20 @@ proc adi_ip_create {ip_name} {
 #
 proc adi_ip_files {ip_name ip_files} {
   set proj_fileset [get_filesets sources_1]
+  set design_source_files [list]
+  set constraint_files [list]
   foreach m_file $ip_files {
     if {[file extension $m_file] eq ".xdc"} {
-      add_files -norecurse -fileset constrs_1 $m_file
+      lappend constraint_files $m_file
     } else {
-      add_files -norecurse -scan_for_includes -fileset $proj_fileset $m_file
+      lappend design_source_files $m_file
     }
+  }
+  if {$design_source_files != {}} {
+    add_files -norecurse -scan_for_includes -fileset $proj_fileset $design_source_files
+  }
+  if {$constraint_files != {}} {
+    add_files -norecurse -fileset constrs_1 $constraint_files
   }
   set_property "top" "$ip_name" $proj_fileset
 }


### PR DESCRIPTION
## PR Description

Creates a list for design sources and constraints and then imports all the files at once in their respective category.
A critical warning appeared when importing large amount of files into an IP one by one, as the script was working up until this point. This now creates separate lists after checking the file type and imports all of the files at once. This way the critical warning doesn't appear and the build time is faster as well. 


## PR Type
- [ ] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the code style guidelines
- [x] I have performed a self-review of changes
- [ ] I have compiled all hdl projects and libraries affected by this PR
- [ ] I have tested in hardware affected projects, at least on relevant boards
- [ ] I have commented my code, at least hard-to-understand parts
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe files, Copyright etc)
- [x] I have not introduced new Warnings/Critical Warnings on compilation
- [ ] I have added new hdl testbenches or updated existing ones
