### PR TITLE
Infrastructure updates and fixes for Lattice tools version 2023.2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -110,3 +110,8 @@ _build
 library/**/.lock
 library/**/interfaces/*.sv
 .backstage_yaml
+.setting.ini
+MachXO3D_Template01
+ipcfg
+_bld
+radiantc.*

--- a/docs/user_guide/build_hdl.rst
+++ b/docs/user_guide/build_hdl.rst
@@ -788,17 +788,17 @@ This contains the most relevant information that you need to provide.
 
    ~/hdl
    $ls -ltr <ADI_carrier_proj_dir>
-   $ls -ltr <ADI_carrier_proj_dir>/<project_name>
-   $ls -ltr <ADI_carrier_proj_dir>/<project_name>/<project_name>
-   $tail <ADI_carrier_proj_dir>/<project_name>_propel_builder.log
-   $tail <ADI_carrier_proj_dir>/<project_name>_radiant.log
+   $ls -ltr <ADI_carrier_proj_dir>/_bld/<project_name>
+   $ls -ltr <ADI_carrier_proj_dir>/_bld/<project_name>/<project_name>
+   $tail <ADI_carrier_proj_dir>/_bld/<project_name>_propel_builder.log
+   $tail <ADI_carrier_proj_dir>/_bld/<project_name>_radiant.log
 
 Note that if the **Propel Builder** project fails to build, the
 **$(PROJECT_NAME)_radiant.log** may not exist.
 
 If the Propel Builder project was built successfully, the **sge**
 folder should appear in the **<ADI_carrier_proj_dir>/** or in the
-**<ADI_carrier_proj_dir>/<project_name>**.
+**<ADI_carrier_proj_dir>/_bld/<project_name>**.
 The **sge** folder contains the **bsp** folder (Base Support
 Package) and the SoC configuration files.
 
@@ -826,15 +826,15 @@ The **system_pb.tcl** is sourced in **adi_project_pb** procedure.
 The **system_project.tcl** runs second. This file is used to create and build
 the **HDL project** (Radiant). Here we use the output of the Propel Builder
 project as the **configured IPs** that can be found in the
-*<ADI_carrier_proj_dir>/<project_name>/<project_name>/lib* folder and the
+*<ADI_carrier_proj_dir>/_bld/<project_name>/<project_name>/lib* folder and the
 **default block design wrapper** that is the
-*<ADI_carrier_proj_dir>/<project_name>/<project_name>/<project_name>.v*.
+*<ADI_carrier_proj_dir>/_bld/<project_name>/<project_name>/<project_name>.v*.
 
 We add them to the Radiant project, then add our **system_top.v** wrapper,
 the **constraint files** and build the project.
 
 The output is a **.bit** file that by default will appear in the
-**<ADI_carrier_proj_dir>/<project_name>/impl_1** folder if the project was
+**<ADI_carrier_proj_dir>/_bld/<project_name>/impl_1** folder if the project was
 successfully built.
 
 Supported targets of ``make`` command

--- a/docs/user_guide/build_hdl.rst
+++ b/docs/user_guide/build_hdl.rst
@@ -751,7 +751,7 @@ i2c_controller       I2C Controller                 2.0.1
 axi_interconnect     AXI4 Interconnect              1.2.2
 axi2ahb_bridge       AXI4 to AHB-Lite Bridge        1.1.1
 axi2apb_bridge       AXI4 to APB Bridge             1.1.1
-gp_timer             Timer-Counter                  1.3.0
+gp_timer             Timer-Counter                  1.3.1
 ==================== ============================= =======
 
 .. shell:: bash

--- a/projects/common/lfcpnx/lfcpnx_system_constr.pdc
+++ b/projects/common/lfcpnx/lfcpnx_system_constr.pdc
@@ -5,6 +5,8 @@
 
 ldc_set_sysconfig {JTAG_PORT=ENABLE MASTER_SPI_PORT=SERIAL DONE_PORT=ENABLE INITN_PORT=ENABLE PROGRAMN_PORT=ENABLE MCCLK_FREQ=112.5 CONFIG_IOSLEW=FAST BOOTMODE=SINGLE CONFIGIO_VOLTAGE_BANK0=1.8 CONFIGIO_VOLTAGE_BANK1=3.3}
 
+set_clock_uncertainty 0.002 [all_clocks]
+
 #gpio LEDs 0-7
 ldc_set_location -site {N5} [get_ports {leds_0_to_23[0]}]
 ldc_set_location -site {N6} [get_ports {leds_0_to_23[1]}]

--- a/projects/common/lfcpnx/lfcpnx_system_pb.tcl
+++ b/projects/common/lfcpnx/lfcpnx_system_pb.tcl
@@ -260,7 +260,7 @@ sbp_assign_addr_seg -offset 'h00000000 "$project_name/cpu0_inst/LOCAL_BUS_M_INST
   "$project_name/tcm0_inst/LOCAL_BUS_IF_S1"
 
 if {$timer_en == 1} {
-  adi_ip_update -vlnv {latticesemi.com:ip:axi_interc0:1.2.2} \
+  adi_ip_update $project_name -vlnv {latticesemi.com:ip:axi_interc0:1.2.2} \
     -meta_vlnv {latticesemi.com:ip:axi_interconnect:1.2.2} \
     -cfg_value {
       TOTAL_EXTMAS_CNT: 1,
@@ -270,13 +270,13 @@ if {$timer_en == 1} {
     } \
     -ip_iname "axi_interc0_inst"
 
-  adi_ip_instance -vlnv {latticesemi.com:ip:axi_apb3:1.1.0} \
-    -meta_vlnv {latticesemi.com:ip:axi2apb_bridge:1.1.0} \
+  adi_ip_instance -vlnv {latticesemi.com:ip:axi_apb3:1.1.1} \
+    -meta_vlnv {latticesemi.com:ip:axi2apb_bridge:1.1.1} \
     -cfg_value {} \
     -ip_iname "axi_apb3_inst"
 
-  adi_ip_instance -vlnv {latticesemi.com:ip:timer0:1.3.0} \
-    -meta_vlnv {latticesemi.com:ip:gp_timer:1.3.0} \
+  adi_ip_instance -vlnv {latticesemi.com:ip:timer0:1.3.1} \
+    -meta_vlnv {latticesemi.com:ip:gp_timer:1.3.1} \
     -cfg_value {
       t1_cnt_up: count-up,
       T1_PERIOD_WIDTH: 32,

--- a/projects/scripts/adi_project_lattice.tcl
+++ b/projects/scripts/adi_project_lattice.tcl
@@ -44,7 +44,7 @@ proc adi_project {project_name args} {
   puts "\nadi_project:\n"
 
   array set opt [list -dev_select "auto" \
-    -ppath "./$project_name" \
+    -ppath "./_bld/$project_name" \
     -device "" \
     -speed "" \
     -board "" \
@@ -94,7 +94,7 @@ proc adi_project {project_name args} {
 proc adi_project_create {project_name args}  {
   puts "\nadi_project_create:\n"
 
-  array set opt [list -ppath "./$project_name" \
+  array set opt [list -ppath "./_bld/$project_name" \
     -device "" \
     -performance "" \
     -board "" \
@@ -195,8 +195,8 @@ proc adi_project_files_auto {project_name args} {
   puts "\nadi_project_files_auto:\n"
 
   array set opt [list -exts {*.ipx} \
-    -spath ./$project_name/$project_name/lib \
-    -ppath "./$project_name" \
+    -spath ./_bld/$project_name/$project_name/lib \
+    -ppath "./_bld/$project_name" \
     -sdepth "6" \
     -opt_args "" \
     {*}$args]
@@ -287,7 +287,7 @@ proc adi_project_files_auto {project_name args} {
 proc adi_project_files {project_name args} {
   puts "\nadi_project_files:\n"
 
-  array set opt [list -ppath "./$project_name" \
+  array set opt [list -ppath "./_bld/$project_name" \
     -flist "" \
     -opt_args "" \
     {*}$args]
@@ -374,11 +374,11 @@ proc add_update_constraint_file {pfile project_dir ext radiant_project opt_args}
 # Adds the default project files to the Radiant project ($project_name.rdf)
 proc adi_project_files_default {project_name} {
   adi_project_files_auto $project_name -exts {*.ipx} \
-    -spath "./$project_name/$project_name/lib" \
-    -ppath "./$project_name" \
+    -spath "./_bld/$project_name/$project_name/lib" \
+    -ppath "./_bld/$project_name" \
     -sdepth "6"
   adi_project_files $project_name \
-    -flist [list ./$project_name/$project_name/$project_name.v]
+    -flist [list ./_bld/$project_name/$project_name/$project_name.v]
 }
 
 ###############################################################################
@@ -447,7 +447,7 @@ proc adopt_path {full_path_flist base_to_cut {base_to_add ""}} {
 proc adi_project_run {project_name args} {
   puts "\nadi_project_run:\n"
 
-  array set opt [list -ppath "./$project_name" \
+  array set opt [list -ppath "./_bld/$project_name" \
     -mode "export" \
     -impl "impl_1" \
     -top "system_top" \
@@ -516,7 +516,7 @@ proc adi_project_run_cmd {project_name args} {
   puts "\nadi_project_run_cmd:\n"
   set dir [pwd]
 
-  array set opt [list -ppath "./$project_name" -cmd_list "" {*}$args]
+  array set opt [list -ppath "./_bld/$project_name" -cmd_list "" {*}$args]
   set ppath $opt(-ppath)
   set cmd_list $opt(-cmd_list)
 

--- a/projects/scripts/adi_project_lattice_pb.tcl
+++ b/projects/scripts/adi_project_lattice_pb.tcl
@@ -335,7 +335,7 @@ proc adi_ip_instance {args} {
 # \opt[ip_iname] -ip_iname cpu0_inst
 # \opt[ip_niname] -ip_niname new_name_inst
 ###############################################################################
-proc adi_ip_update {args} {
+proc adi_ip_update {project_name args} {
   array set opt [list -cfg_path "./ipcfg" \
     -vlnv "" \
     -ip_path "" \
@@ -353,8 +353,6 @@ proc adi_ip_update {args} {
   puts "adi_ip_update: $ip_iname"
 
   adi_ip_config {*}$args
-
-  global project_name
 
   if {$ip_niname == ""} {
     sbp_replace -vlnv $vlnv -name $ip_iname -component $project_name/$ip_iname

--- a/projects/scripts/adi_project_lattice_pb.tcl
+++ b/projects/scripts/adi_project_lattice_pb.tcl
@@ -43,7 +43,7 @@ proc adi_project_pb {project_name args} {
   set preinst_ip_mod_dir ${env(TOOLRTF)}
 
   array set opt [list -dev_select "auto" \
-    -ppath "." \
+    -ppath "./_bld" \
     -device "" \
     -board "" \
     -speed "" \
@@ -98,7 +98,7 @@ proc adi_project_pb {project_name args} {
 proc adi_project_create_pb {project_name args} {
   puts "\nadi_project_create_pb:\n"
 
-  array set opt [list -ppath "." \
+  array set opt [list -ppath "./_bld" \
     -device "" \
     -board "" \
     -speed "" \
@@ -160,6 +160,10 @@ proc adi_project_create_pb {project_name args} {
 
   set preinst_ip_mod_dir ${env(TOOLRTF)}
   set propel_builder_project_dir "$ppath/$project_name/$project_name"
+
+  if {[file exists $ppath] != 1} {
+    file mkdir $ppath
+  }
 
   sbp_create_project  -name "$project_name" \
     -path $ppath \

--- a/projects/scripts/adi_project_lattice_pb.tcl
+++ b/projects/scripts/adi_project_lattice_pb.tcl
@@ -48,7 +48,7 @@ proc adi_project_pb {project_name args} {
     -board "" \
     -speed "" \
     -language "verilog" \
-    -psc "" \
+    -psc "${env(TOOLRTF)}/../../templates/MachXO3D_Template01/MachXO3D_Template01.psc" \
     -cmd_list {{source ./system_pb.tcl}} \
     {*}$args]
 
@@ -57,6 +57,11 @@ proc adi_project_pb {project_name args} {
   set language $opt(-language)
   set cmd_list $opt(-cmd_list)
   set psc $opt(-psc)
+
+  if {$psc == "${env(TOOLRTF)}/../../templates/MachXO3D_Template01/MachXO3D_Template01.psc"} {
+    update_template
+    set psc ./MachXO3D_Template01/MachXO3D_Template01.psc
+  }
 
   global ad_hdl_dir
 
@@ -156,37 +161,15 @@ proc adi_project_create_pb {project_name args} {
   set preinst_ip_mod_dir ${env(TOOLRTF)}
   set propel_builder_project_dir "$ppath/$project_name/$project_name"
 
-  if {$psc == ""} {
-    file mkdir $propel_builder_project_dir
+  sbp_create_project  -name "$project_name" \
+    -path $ppath \
+    -device $device \
+    -speed $speed \
+    -language $language \
+    -psc $psc
 
-  # Creating the necessary .socproject file for being able to open the Radiant
-  # and Propel SDK from Propel Builder if needed.
-    set file [open "$ppath/$project_name/.socproject" w]
-    puts $file [format {<?xml version="1.0" encoding="UTF-8"?>
-<propelProject>
-  <builder-resource>
-    <socProject sbxfile="./%s/%s.sbx"/>
-  </builder-resource>
-</propelProject>} $project_name $project_name]
-    close $file
-
-    sbp_design new -name $project_name \
-      -path $propel_builder_project_dir/$project_name.sbx \
-      -device $device  \
-      -speed $speed \
-      -language $language \
-      -board $board
-  } else {
-    sbp_create_project  -name "$project_name" \
-      -path $ppath \
-      -device $device \
-      -speed $speed \
-      -language $language \
-      -psc $psc
-
-      foreach port [sbp_get_ports *] {
-        sbp_delete $port -type port
-      }
+  foreach port [sbp_get_ports *] {
+    sbp_delete $port -type port
   }
 
   sbp_design save
@@ -197,24 +180,8 @@ proc adi_project_create_pb {project_name args} {
     eval $cmd
   }
 
-# Workaround for keeping the configured IP folders in Propel Builder 2023.2
-# command line version.
-# The 'sbp_design save' doesn't saves the temporary .lib folder to lib folder,
-# instead deletes if there is anything in lib folder.
-# I am copying the content of .lib (the configured IP cores) to lib after save
-# to keep the configured IP cores for the Radiant project.
-# Also generating the bsp after copying the configured IP cores to lib folder
-# because that's also based on the content of lib folder.
-#
-# Update: - If the psc default template file exists then the save works fine
-# and we do not need to generate the bsp separately also.
   sbp_design save
   sbp_design generate
-
-  if {$psc == ""} {
-    file copy "$propel_builder_project_dir/.lib/latticesemi.com" \
-      "$propel_builder_project_dir/lib"
-  }
 
   # Generating the bsp.
   sbp_design pge sge \
@@ -358,5 +325,57 @@ proc adi_ip_update {project_name args} {
     sbp_replace -vlnv $vlnv -name $ip_iname -component $project_name/$ip_iname
   } else {
     sbp_replace -vlnv $vlnv -name $ip_niname -component $project_name/$ip_iname
+  }
+}
+
+proc update_template {args} {
+  global env
+  array set opt [list -dpath "./" \
+    -template "${env(TOOLRTF)}/../../templates/MachXO3D_Template01" \
+  ]
+
+  set dpath $opt(-dpath)
+  set template $opt(-template)
+
+  if {[file exist $dpath] != 1} {
+      file mkdir $dpath
+  }
+  if {[file exist $dpath/MachXO3D_Template01] == 1} {
+      exec rm -r $dpath/MachXO3D_Template01
+  }
+  file copy -force "${env(TOOLRTF)}/../../templates/MachXO3D_Template01" $dpath
+
+  set regx {\s+file\s+copy\s+}
+
+  puts [pwd]
+  if {[file exist $dpath/MachXO3D_Template01/MachXO3D_Template01.tcl] == 1} {
+    set file [open $dpath/MachXO3D_Template01/MachXO3D_Template01.tcl r]
+    set fdata [read $file]
+    close $file
+    set file [open $dpath/MachXO3D_Template01/MachXO3D_Template01.tcl w]
+    foreach line [split $fdata "\n"] {
+      if {[regexp $regx $line]} {
+        puts $file {    if {[file exist $targetDir] != 1} {file mkdir $targetDir}}
+        puts {    if {[file exist $targetDir] != 1} {file mkdir $targetDir}}
+      }
+      puts $file $line
+      puts $line
+    }
+    close $file
+  }
+  if {[file exist $dpath/MachXO3D_Template01/verification/MachXO3D_Template01_v.tcl] == 1} {
+    set file [open $dpath/MachXO3D_Template01/verification/MachXO3D_Template01_v.tcl r]
+    set fdata [read $file]
+    close $file
+    set file [open $dpath/MachXO3D_Template01/verification/MachXO3D_Template01_v.tcl w]
+    foreach line [split $fdata "\n"] {
+      if {[regexp $regx $line]} {
+        puts $file {    if {[file exist $targetDir] != 1} {file mkdir $targetDir}}
+        puts {    if {[file exist $targetDir] != 1} {file mkdir $targetDir}}
+      }
+      puts $file $line
+      puts $line
+    }
+    close $file
   }
 }

--- a/projects/scripts/project-lattice.mk
+++ b/projects/scripts/project-lattice.mk
@@ -6,29 +6,18 @@
 ################################################################################
 ## Make script for building Lattice projects. ##################################
 #
-# * Make commands: all pb rd rd-force pb-force clean clean-all clean-pb clean-rd.
+# * Make commands: all pb rd rd-force pb-force clean clean-all.
 #
 # * pb: checks if dependencies exist and builds the Propel Builder project.
 #   (block design)
 # * rd: checks for dependencies and builds the Radiant Project
 #   based on Propel Builder Project.
+# * force: you can build the whole project without
+#   checking for dependencies.
 # * pb-force and rd-force: you can build the respective projects without
 #   checking for dependencies.
 # * clean: deletes the whole project and log files.
 # * clean-all: deletes all the generated files during build.
-# * clean-pb: deletes the Propel Builder project files and directories.
-#   After this you can rebuild the Propel Builder project separately by
-#   'make pb' but only if you created the project without using the '-sbc'
-#   template file option wich is used in official project creation command,
-#   because if you create with '-sbc' option the command will not create
-#   the project becouse the first <project_name> folder from
-#   <adi_project_folder>/<project_name>/<project_name> is not deleted,
-#   becouse that contains the Radiant project files. Also deletes the log
-#   file for Propel Builder project.
-# * clean-rd: cleans the content of <adi_project_folder>/<project_name>/
-#   folder ralated to Radiant project except the
-#   <adi_project_folder>/<project_name>/<project_name> folder.
-#   Also deletes the log file for Radiant project.
 #
 # * Note: The limitation for Propel Builder project is that it does not exit
 #   with error code no matter if the design was built or failed to,
@@ -58,7 +47,7 @@ M_DEPS += $(HDL_PROJECT_PATH)scripts/adi_project_lattice_pb.tcl
 M_DEPS += $(HDL_PROJECT_PATH)scripts/adi_project_lattice.tcl
 M_DEPS += $(HDL_PROJECT_PATH)../scripts/adi_env.tcl
 M_DEPS += system_top.v
-M_DEPS += $(PROJECT_NAME)/$(PROJECT_NAME)/$(PROJECT_NAME).v
+M_DEPS += _bld/$(PROJECT_NAME)/$(PROJECT_NAME)/$(PROJECT_NAME).v
 M_DEPS += $(wildcard *system_constr.pdc)
 M_DEPS += $(wildcard *system_constr.sdc)
 
@@ -77,13 +66,18 @@ R_DEPS_FILTER += %adi_env.tcl
 R_DEPS_FILTER += %adi_project_lattice.tcl
 R_DEPS_FILTER += %system_project.tcl
 
-PB_TARGETS += $(PROJECT_NAME)/$(PROJECT_NAME)/$(PROJECT_NAME).sbx
-PB_TARGETS += $(PROJECT_NAME)/$(PROJECT_NAME)/$(PROJECT_NAME).v
+PB_TARGETS += _bld/$(PROJECT_NAME)/$(PROJECT_NAME)/$(PROJECT_NAME).sbx
+PB_TARGETS += _bld/$(PROJECT_NAME)/$(PROJECT_NAME)/$(PROJECT_NAME).v
 
-R_TARGETS += $(PROJECT_NAME)/$(PROJECT_NAME).rdf
-R_TARGETS += $(PROJECT_NAME)/impl_1/$(PROJECT_NAME)_impl_1.bit
+R_TARGETS += _bld/$(PROJECT_NAME)/$(PROJECT_NAME).rdf
+R_TARGETS += _bld/$(PROJECT_NAME)/impl_1/$(PROJECT_NAME)_impl_1.bit
 
-.PHONY: all pb rd rd-force pb-force clean clean-all clean-pb clean-rd
+CLEAN_TARGET += $(wildcard ./*/)
+CLEAN_TARGET += $(wildcard *.log)
+CLEAN_TARGET += $(wildcard ./radiantc.*)
+CLEAN_TARGET += $(filter-out . .. ./. ./.., $(wildcard .*))
+
+.PHONY: all pb rd force rd-force pb-force clean clean-all
 
 all: pb rd
 
@@ -92,41 +86,25 @@ pb: $(PB_TARGETS)
 rd: $(R_TARGETS)
 
 clean:
-	-rm -Rf ${PROJECT_NAME}
-	-rm -f $(wildcard *.log)
-	-rm -Rf ./ipcfg
-	-rm -Rf ./sge
+	$(call clean, \
+		$(CLEAN_TARGET), \
+		$(HL)$(PROJECT_NAME)$(NC) project)
 
 clean-all:
-	-rm -Rf ${PROJECT_NAME}
-	-rm -f $(wildcard *.log)
-	-rm -Rf ./ipcfg
-	-rm -Rf $(filter-out . .. ./. ./.., $(wildcard .*))
-	-rm -Rf ./sge
-
-clean-pb:
-	-rm -Rf $(wildcard $(PROJECT_NAME)/$(PROJECT_NAME)/*)
-	-rm -f $(PROJECT_NAME)/.socproject
-	-rm -Rf ./ipcfg
-	-rm -f $(PROJECT_NAME)_propel_builder.log
-	-rm -Rf ./sge
-
-clean-rd:
-	-rm -Rf $(filter-out $(PROJECT_NAME)/$(PROJECT_NAME) \
-		$(PROJECT_NAME)/.socproject, \
-		$(wildcard $(PROJECT_NAME)/*))
-	-rm -Rf $(filter-out $(PROJECT_NAME)/$(PROJECT_NAME) \
-		$(PROJECT_NAME)/.socproject \
-		$(PROJECT_NAME)/. \
-		$(PROJECT_NAME)/.., $(wildcard $(PROJECT_NAME)/.*))
-	-rm -f $(PROJECT_NAME)_radiant.log
+	$(call clean, \
+		$(CLEAN_TARGET), \
+		$(HL)$(PROJECT_NAME)$(NC) project)
 
 $(PB_TARGETS): $(filter-out $(PB_DEPS_FILTER_OUT),$(filter $(PB_DEPS_FILTER), $(M_DEPS)))
-	-rm -f $(PROJECT_NAME)_propel_builder.log
+	$(call skip_if_missing, \
+		Project, \
+		$(PROJECT_NAME), \
+		true, \
+	rm -Rf $(CLEAN_TARGET) ; \
 	$(call build, \
 		$(PROPEL_BUILDER) system_project_pb.tcl, \
 		$(PROJECT_NAME)_propel_builder.log, \
-		$(HL)$(PROJECT_NAME)$(NC) project)
+		$(HL)$(PROJECT_NAME)$(NC) project))
 	@for file in $(filter $(R_DEPS_FILTER), $(M_DEPS)); do \
 		if [ ! -f $$file ]; then \
 			echo "No [$(HL)$$file$(NC)] found. ... $(RED)FAILED$(NC)"; \
@@ -137,12 +115,14 @@ $(PB_TARGETS): $(filter-out $(PB_DEPS_FILTER_OUT),$(filter $(PB_DEPS_FILTER), $(
 
 $(R_TARGETS): $(filter $(R_DEPS_FILTER), $(M_DEPS))
 	-rm -f $(PROJECT_NAME)_radiant.log
-	-rm -f $(PROJECT_NAME)/system_constr.pdc
-	-rm -f $(PROJECT_NAME)/system_constr.sdc
+	-rm -f _bld/$(PROJECT_NAME)/system_constr.pdc
+	-rm -f _bld/$(PROJECT_NAME)/system_constr.sdc
 	$(call build, \
 		$(RADIANT) system_project.tcl, \
 		$(PROJECT_NAME)_radiant.log, \
 		$(HL)$(PROJECT_NAME)$(NC) project)
+
+force: pb-force rd-force
 
 pb-force:
 	$(call build, \
@@ -155,4 +135,3 @@ rd-force:
 	$(RADIANT) system_project.tcl, \
 	$(PROJECT_NAME)_radiant.log, \
 	$(HL)$(PROJECT_NAME)$(NC) project)
-


### PR DESCRIPTION
## PR Description

* Fixing `adi_ip_update` procedure in `adi_project_lattice_pb.tcl`.
* Updating base design scripts with new usage of `adi_ip_update`.
* Updating IP versions in base design.
* Switching to official project creation with template project.
* Adding workaround fix for template project to work on Linux.
* Updating `make` scripts.
* Updating `adi_project_lattice_pb.tcl`. Adding default build folder for `.gitignore` compatibility.
* Updating `.gitignore`.
* Fixing no clock uncertainty critical warning in base design.
* Updating docs.


## PR Type
- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the code style guidelines
- [x] I have performed a self-review of changes
- [ ] I have compiled all hdl projects and libraries affected by this PR
- [x] I have tested in hardware affected projects, at least on relevant boards
- [x] I have commented my code, at least hard-to-understand parts
- [x] I have signed off all commits from this PR
- [x] I have updated the documentation (wiki pages, ReadMe files, Copyright etc)
- [x] I have not introduced new Warnings/Critical Warnings on compilation
- [ ] I have added new hdl testbenches or updated existing ones
