### PR TITLE
docs: Build HDL for Windows update

### DIFF
--- a/docs/user_guide/build_hdl.rst
+++ b/docs/user_guide/build_hdl.rst
@@ -226,8 +226,6 @@ For AMD Xilinx Vivado:
 .. shell:: bash
 
    ~/hdl
-   $source /cygdrive/path_to/Xilinx/Vivado/202x.x/settings64.sh
-
    $export PATH=$PATH:/cygdrive/c/Xilinx/Vivado/202x.x/bin
    $export PATH=$PATH:/cygdrive/c/Xilinx/Vivado_HLS/202x.x/bin
    $export PATH=$PATH:/cygdrive/c/Xilinx/Vitis/202x.x/bin


### PR DESCRIPTION
## PR Description

Removed sourcing recommendation of the settings64.sh, as this is for Windows command line.
Windows path contains `\`, while the Cygwin is expecting `/`.


## PR Type
- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the code style guidelines
- [x] I have performed a self-review of changes
- [ ] I have compiled all hdl projects and libraries affected by this PR
- [ ] I have tested in hardware affected projects, at least on relevant boards
- [ ] I have commented my code, at least hard-to-understand parts
- [x] I have signed off all commits from this PR
- [x] I have updated the documentation (wiki pages, ReadMe files, Copyright etc)
- [x] I have not introduced new Warnings/Critical Warnings on compilation
- [ ] I have added new hdl testbenches or updated existing ones
