### PR TITLE
scripts: backstage: Warn on missing description

### DIFF
--- a/.github/scripts/gen_backstage_yaml.py
+++ b/.github/scripts/gen_backstage_yaml.py
@@ -1,6 +1,7 @@
 from typing import Dict, List, Tuple
 from os import path, mkdir, walk, chdir
 from glob import glob
+import sys
 import yaml
 import re
 import argparse
@@ -93,7 +94,8 @@ def get_description_parts(
 
 
 def get_description(
-    data: List[str]
+    data: List[str],
+    file: str
 ) -> List[str]:
     desc = []
     directive_lock = False
@@ -109,6 +111,10 @@ def get_description(
             else:
                 continue
         desc.append(d)
+
+    if len(desc) < 3:
+        sys.exit(f"{file}: Missing overview/short-description.")
+
     desc.pop()
     desc.pop()
     return desc
@@ -139,7 +145,7 @@ def get_description_library(
 
     title = data[index-3][:-1]
     data = data[index:]
-    desc = get_description(data)
+    desc = get_description(data, file)
 
     return *get_description_parts(desc), title
 
@@ -182,7 +188,7 @@ def get_description_project(
         index = index+1 if data[index] == '\n' else index
 
     data = data[index:]
-    desc = get_description(data)
+    desc = get_description(data, file)
 
     return *get_description_parts(desc), title
 

--- a/.github/scripts/gen_backstage_yaml.py
+++ b/.github/scripts/gen_backstage_yaml.py
@@ -347,11 +347,12 @@ def concat_and_write_yaml(dir_: str) -> Tuple[List[str], str]:
 
     files: Dict[str, List[str]] = {}
 
+    any_skipped = False;
     for d in targets:
         for d_ in targets[d]:
             if d_ not in targets['main']:
-                print(f"Warning: {d} version of component {d_} not on "
-                      "component (main), skipped")
+                any_skipped = True
+                print(f"Warning: {d}/{d_} not on component (main/*.yaml), skipped")
                 continue
             if d_ in files:
                 files[d_].append('---\n')
@@ -366,6 +367,11 @@ def concat_and_write_yaml(dir_: str) -> Tuple[List[str], str]:
         with open(path.join(dir_, d_), "w") as f:
             for line in files[d_]:
                 f.write(line)
+
+    if any_skipped:
+        print("If the skipped component was renamed on main, "
+              "please update the file name and the subcomponentOf field to match the new name. "
+              "The other fields should be kept the same to preserve history.")
 
     return list(files.keys()), dir_
 


### PR DESCRIPTION
## PR Description

Based on this ci run: https://github.com/analogdevicesinc/hdl/actions/runs/12636173279/job/35207649065

It is required that all libraries and projects contain an overview/short-description at the beginning of the file.

Exit with a message error when it is missing and fix the IndexError.

## PR Type
- [X] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [ ] I have followed the code style guidelines
- [ ] I have performed a self-review of changes
- [ ] I have compiled all hdl projects and libraries affected by this PR
- [ ] I have tested in hardware affected projects, at least on relevant boards
- [ ] I have commented my code, at least hard-to-understand parts
- [ ] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe files, Copyright etc)
- [ ] I have not introduced new Warnings/Critical Warnings on compilation
- [ ] I have added new hdl testbenches or updated existing ones
