### PR TITLE
projects: Fix project name for pulsar_adc and ad411x_ad717x

### DIFF
--- a/projects/ad411x_ad717x/de10nano/Makefile
+++ b/projects/ad411x_ad717x/de10nano/Makefile
@@ -1,10 +1,10 @@
 ####################################################################################
-## Copyright (c) 2018 - 2024 Analog Devices, Inc.
+## Copyright (c) 2018 - 2025 Analog Devices, Inc.
 ### SPDX short identifier: BSD-1-Clause
 ## Auto-generated, do not modify!
 ####################################################################################
 
-PROJECT_NAME := ad411x_de10nano
+PROJECT_NAME := ad411x_ad717x_de10nano
 
 M_DEPS += ../common/ad411x_ad717x_asdz_qsys.tcl
 M_DEPS += ../../scripts/adi_pd.tcl

--- a/projects/ad411x_ad717x/de10nano/system_project.tcl
+++ b/projects/ad411x_ad717x/de10nano/system_project.tcl
@@ -8,7 +8,7 @@ set QUARTUS_PRO_ISUSED 0
 source ../../../scripts/adi_env.tcl
 source ../../scripts/adi_project_intel.tcl
 
-adi_project ad411x_de10nano
+adi_project ad411x_ad717x_de10nano
 
 source $ad_hdl_dir/projects/common/de10nano/de10nano_system_assign.tcl
 

--- a/projects/pulsar_adc/common/pulsar_adc_pmod.txt
+++ b/projects/pulsar_adc/common/pulsar_adc_pmod.txt
@@ -1,6 +1,6 @@
 Pin            Port               Schematic_name     System_top_name        IOSTANDARD  Termination
 
-# pulsar_adc_pmdz
+# pulsar_adc
 
 4              PMOD_4             SCK                pulsar_adc_spi_sclk    LVCMOS33    #N/A
 3              PMOD_3             SDO                pulsar_adc_spi_sdi     LVCMOS33    #N/A

--- a/projects/pulsar_adc/coraz7s/Makefile
+++ b/projects/pulsar_adc/coraz7s/Makefile
@@ -1,10 +1,10 @@
 ####################################################################################
-## Copyright (c) 2018 - 2024 Analog Devices, Inc.
+## Copyright (c) 2018 - 2025 Analog Devices, Inc.
 ### SPDX short identifier: BSD-1-Clause
 ## Auto-generated, do not modify!
 ####################################################################################
 
-PROJECT_NAME := pulsar_adc_pmdz_coraz7s
+PROJECT_NAME := pulsar_adc_coraz7s
 
 M_DEPS += ../common/pulsar_adc_bd.tcl
 M_DEPS += ../../scripts/adi_pd.tcl

--- a/projects/pulsar_adc/coraz7s/system_project.tcl
+++ b/projects/pulsar_adc/coraz7s/system_project.tcl
@@ -1,5 +1,5 @@
 ###############################################################################
-## Copyright (C) 2016-2024 Analog Devices, Inc. All rights reserved.
+## Copyright (C) 2016-2025 Analog Devices, Inc. All rights reserved.
 ### SPDX short identifier: ADIBSD
 ###############################################################################
 
@@ -7,12 +7,12 @@ source ../../../scripts/adi_env.tcl
 source $ad_hdl_dir/projects/scripts/adi_project_xilinx.tcl
 source $ad_hdl_dir/projects/scripts/adi_board.tcl
 
-adi_project pulsar_adc_pmdz_coraz7s
+adi_project pulsar_adc_coraz7s
 
-adi_project_files pulsar_adc_pmdz_coraz7s [list \
+adi_project_files pulsar_adc_coraz7s [list \
     "$ad_hdl_dir/library/common/ad_iobuf.v" \
     "system_top.v" \
     "system_constr.xdc" \
     "$ad_hdl_dir/projects/common/coraz7s/coraz7s_system_constr.xdc"]
 
-adi_project_run pulsar_adc_pmdz_coraz7s
+adi_project_run pulsar_adc_coraz7s

--- a/projects/pulsar_adc/zed/Makefile
+++ b/projects/pulsar_adc/zed/Makefile
@@ -1,10 +1,10 @@
 ####################################################################################
-## Copyright (c) 2018 - 2024 Analog Devices, Inc.
+## Copyright (c) 2018 - 2025 Analog Devices, Inc.
 ### SPDX short identifier: BSD-1-Clause
 ## Auto-generated, do not modify!
 ####################################################################################
 
-PROJECT_NAME := pulsar_adc_pmdz_zed
+PROJECT_NAME := pulsar_adc_zed
 
 M_DEPS += system_constr_pmod.xdc
 M_DEPS += system_constr_fmc.xdc

--- a/projects/pulsar_adc/zed/system_project.tcl
+++ b/projects/pulsar_adc/zed/system_project.tcl
@@ -1,5 +1,5 @@
 ###############################################################################
-## Copyright (C) 2021-2024 Analog Devices, Inc. All rights reserved.
+## Copyright (C) 2021-2025 Analog Devices, Inc. All rights reserved.
 ### SPDX short identifier: ADIBSD
 ###############################################################################
 
@@ -26,35 +26,34 @@ source $ad_hdl_dir/projects/scripts/adi_board.tcl
 set FMC_N_PMOD [get_env_param FMC_N_PMOD 1]
 set SPI_OP_MODE [get_env_param SPI_OP_MODE 0]
 
-adi_project pulsar_adc_pmdz_zed 0 [list \
+adi_project pulsar_adc_zed 0 [list \
   FMC_N_PMOD    [get_env_param FMC_N_PMOD  1] \
   SPI_OP_MODE   [get_env_param SPI_OP_MODE 0] ]
 
-adi_project_files pulsar_adc_pmdz_zed [list \
+adi_project_files pulsar_adc_zed [list \
   "$ad_hdl_dir/library/common/ad_iobuf.v" \
   "$ad_hdl_dir/projects/common/zed/zed_system_constr.xdc" ]
 
 if {$FMC_N_PMOD == 0} {
-  adi_project_files pulsar_adc_pmdz_zed [list \
+  adi_project_files pulsar_adc_zed [list \
     "system_top_pmod.v" \
     "system_constr_pmod.xdc" ]
 } elseif {$FMC_N_PMOD == 1} {
-    adi_project_files pulsar_adc_pmdz_zed [list \
+    adi_project_files pulsar_adc_zed [list \
       "system_top_fmc.v" \
       "system_constr_fmc.xdc" ]
     if {$SPI_OP_MODE == 0} {
-    adi_project_files pulsar_adc_pmdz_zed [list \
+    adi_project_files pulsar_adc_zed [list \
       "system_constr_fmc_sm0.xdc" ]
     } elseif {$SPI_OP_MODE == 1} {
-    adi_project_files pulsar_adc_pmdz_zed [list \
+    adi_project_files pulsar_adc_zed [list \
       "system_constr_fmc_sm1.xdc" ]
     } elseif {$SPI_OP_MODE == 2} {
-    adi_project_files pulsar_adc_pmdz_zed [list \
+    adi_project_files pulsar_adc_zed [list \
       "system_constr_fmc_sm2.xdc" ]
     }
 } else {
   return -code error [format "ERROR: Invalid eval board type! ..."]
 }
 
-adi_project_run pulsar_adc_pmdz_zed
-
+adi_project_run pulsar_adc_zed


### PR DESCRIPTION
## PR Description

Fixed the project name set in Tcl and Makefile for pulsar_adc and ad411x_ad717x to match the folder name + _carrier.

pulsar_adc_pmdz_coraz7s -> pulsar_adc_coraz7s
pulsar_adc_pmdz_zed -> pulsar_adc_zed
ad411x_de10nano -> ad411x_ad717x_de10nano

## PR Type
- [ ] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the code style guidelines
- [x] I have performed a self-review of changes
- [x] I have compiled all hdl projects and libraries affected by this PR
- [ ] I have tested in hardware affected projects, at least on relevant boards
- [ ] I have commented my code, at least hard-to-understand parts
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe files, Copyright etc)
- [x] I have not introduced new Warnings/Critical Warnings on compilation
- [ ] I have added new hdl testbenches or updated existing ones
