### PR TITLE
docs: projects: ad9081: Small fixes

### DIFF
--- a/docs/projects/ad9081_fmca_ebz/index.rst
+++ b/docs/projects/ad9081_fmca_ebz/index.rst
@@ -165,8 +165,6 @@ Supported carriers
    - R1231, R1234: 1k ohm
    - R1230, R1233: 1k ohm
 
-   :red:`This project requires Quartus Pro 24.1!`
-
 Block design
 -------------------------------------------------------------------------------
 
@@ -255,15 +253,15 @@ Example block design for Single link; M=2; L=8; JESD204C
    .. shell:: bash
 
       $make JESD_MODE=64B66B \
-      $     RX_RATE=16.5     \
-      $     TX_RATE=16.5     \
-      $     RX_JESD_M=2      \
-      $     RX_JESD_L=8      \
-      $     RX_JESD_S=2      \
-      $     RX_JESD_NP=16    \
-      $     TX_JESD_M=2      \
-      $     TX_JESD_L=8      \
-      $     TX_JESD_S=4      \
+      $     RX_LANE_RATE=16.5 \
+      $     TX_LANE_RATE=16.5 \
+      $     RX_JESD_M=2       \
+      $     RX_JESD_L=8       \
+      $     RX_JESD_S=2       \
+      $     RX_JESD_NP=16     \
+      $     TX_JESD_M=2       \
+      $     TX_JESD_L=8       \
+      $     TX_JESD_S=4       \
       $     TX_JESD_NP=8
 
 The Rx link is operating with the following parameters:
@@ -301,9 +299,19 @@ for each project.
    **system_project.tcl** file, located in
    hdl/projects/ad9081_fmca_ebz/$CARRIER/system_project.tcl
 
-.. warning::
+.. important::
 
-   ``Lane Rate = I/Q Sample Rate x M x N' x (10 \ 8) \ L``
+   For JESD204B:
+
+   .. math::
+
+      Lane Rate = \frac{IQ Sample Rate * M * NP * \frac{10}{8}}{L}
+
+   For JESD204C:
+
+   .. math::
+
+      Lane Rate = \frac{IQ Sample Rate * M * NP * \frac{66}{64}}{L}
 
 The following are the parameters of this project that can be configured:
 
@@ -545,8 +553,8 @@ Example for building the project with parameters:
 .. shell::
 
    $cd hdl/projects/ad9081_fmca_ebz/zcu102
-   $make RX_LANE_RATE=2.5 TX_LANE_RATE=2.5     \
-   $     RX_JESD_L=8 RX_JESD_M=4 RX_JESD_S=1   \
+   $make RX_LANE_RATE=2.5 TX_LANE_RATE=2.5 \
+   $     RX_JESD_L=8 RX_JESD_M=4 RX_JESD_S=1 \
    $     RX_JESD_NP=16 TX_JESD_L=8 TX_JESD_M=4 \
    $     TX_JESD_S=1 TX_JESD_NP=16
 


### PR DESCRIPTION
## PR Description

- fixes a make parameter typo that was given as an example
- adds the JESD204C lane rate formula alongside the JESD204B formula
- removes the Quartus Pro 24.1 warning requirement for Agilex

## PR Type
- [ ] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the code style guidelines
- [x] I have performed a self-review of changes
- [ ] I have compiled all hdl projects and libraries affected by this PR
- [ ] I have tested in hardware affected projects, at least on relevant boards
- [ ] I have commented my code, at least hard-to-understand parts
- [x] I have signed off all commits from this PR
- [x] I have updated the documentation (wiki pages, ReadMe files, Copyright etc)
- [ ] I have not introduced new Warnings/Critical Warnings on compilation
- [ ] I have added new hdl testbenches or updated existing ones
