### PR TITLE
projects/ad4052/de10nano: update required quartus version

### DIFF
--- a/projects/ad4052_ardz/de10nano/system_project.tcl
+++ b/projects/ad4052_ardz/de10nano/system_project.tcl
@@ -3,7 +3,7 @@
 ### SPDX short identifier: ADIBSD
 ###############################################################################
 
-set REQUIRED_QUARTUS_VERSION 22.1std.0
+set REQUIRED_QUARTUS_VERSION 23.1std.1
 set QUARTUS_PRO_ISUSED 0
 source ../../../scripts/adi_env.tcl
 source ../../scripts/adi_project_intel.tcl


### PR DESCRIPTION
## PR Description

This project was somehow missed in the recent change to Quartus 23.1std1


## PR Type
- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [ ] I have followed the code style guidelines
- [ ] I have performed a self-review of changes
- [x] I have compiled all hdl projects and libraries affected by this PR
- [ ] I have tested in hardware affected projects, at least on relevant boards
- [ ] I have commented my code, at least hard-to-understand parts
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe files, Copyright etc)
- [ ] I have not introduced new Warnings/Critical Warnings on compilation
- [ ] I have added new hdl testbenches or updated existing ones
