### PR TITLE
[bug] Fix intel projects that are failing on CI

### DIFF
--- a/library/intel/adi_jesd204/adi_jesd204_hw.tcl
+++ b/library/intel/adi_jesd204/adi_jesd204_hw.tcl
@@ -1,5 +1,5 @@
 ###############################################################################
-## Copyright (C) 2016-2024 Analog Devices, Inc. All rights reserved.
+## Copyright (C) 2016-2025 Analog Devices, Inc. All rights reserved.
 ### SPDX short identifier: ADIJESD204
 ###############################################################################
 
@@ -345,6 +345,7 @@ proc jesd204_compose {} {
   set data_path_width [get_parameter_value "DATA_PATH_WIDTH"]
   set link_mode [get_parameter_value "LINK_MODE"]
 
+  set sip_tile ""
   set sip_tile_info [quartus::device::get_part_info -sip_tile $device]
   regexp -nocase {([a-z])\-tile} $sip_tile_info -> sip_tile
   set sip_tile [string toupper $sip_tile]

--- a/projects/ad4052_ardz/de10nano/system_project.tcl
+++ b/projects/ad4052_ardz/de10nano/system_project.tcl
@@ -19,26 +19,26 @@ set_location_assignment PIN_AG11  -to i2c_scl     ; ## Arduino_SCL
 
 # ad4052 interface
 
-set_location_assignment PIN_AH12 -to adc_spi_sclk ; ## Arduino_IO13   
-set_location_assignment PIN_AH11 -to adc_spi_sdi  ; ## Arduino_IO12   
-set_location_assignment PIN_AG16 -to adc_spi_sdo  ; ## Arduino_IO11   
-set_location_assignment PIN_AF15 -to adc_spi_cs   ; ## Arduino_IO10   
-set_location_assignment PIN_AG8  -to adc_cnv      ; ## Arduino_IO06   
-set_location_assignment PIN_AE15 -to adc_gp0      ; ## Arduino_IO09   
-set_location_assignment PIN_AF17 -to adc_gp1      ; ## Arduino_IO08   
+set_location_assignment PIN_AH12 -to adc_spi_sclk ; ## Arduino_IO13
+set_location_assignment PIN_AH11 -to adc_spi_sdi  ; ## Arduino_IO12
+set_location_assignment PIN_AG16 -to adc_spi_sdo  ; ## Arduino_IO11
+set_location_assignment PIN_AF15 -to adc_spi_cs   ; ## Arduino_IO10
+set_location_assignment PIN_AG8  -to adc_cnv      ; ## Arduino_IO06
+set_location_assignment PIN_AE15 -to adc_gp0      ; ## Arduino_IO09
+set_location_assignment PIN_AF17 -to adc_gp1      ; ## Arduino_IO08
 
 
 set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to i2c_scl
 set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to i2c_sda
 
 set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to adc_spi_sclk
-set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to adc_spi_sdi 
-set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to adc_spi_sdo 
-set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to adc_spi_cs  
-set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to adc_cnv 
-set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to adc_gp0     
-set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to adc_gp1     
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to adc_spi_sdi
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to adc_spi_sdo
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to adc_spi_cs
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to adc_cnv
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to adc_gp0
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to adc_gp1
 
 set_global_assignment -name OPTIMIZATION_MODE "HIGH PERFORMANCE EFFORT"
-       
+
 execute_flow -compile

--- a/projects/daq2/a10soc/system_project.tcl
+++ b/projects/daq2/a10soc/system_project.tcl
@@ -1,5 +1,5 @@
 ###############################################################################
-## Copyright (C) 2017-2023 Analog Devices, Inc. All rights reserved.
+## Copyright (C) 2017-2023, 2025 Analog Devices, Inc. All rights reserved.
 ### SPDX short identifier: ADIBSD
 ###############################################################################
 
@@ -136,5 +136,6 @@ set_instance_assignment -name IO_STANDARD "1.8 V" -to spi_dir
 
 # set optimization to get a better timing closure
 set_global_assignment -name OPTIMIZATION_MODE "HIGH PERFORMANCE EFFORT"
+set_global_assignment -name PLACEMENT_EFFORT_MULTIPLIER 1.2
 
 execute_flow -compile


### PR DESCRIPTION
## PR Description

- When Intel changed the way the sip_tile information is returned, I used a regex to extract the value and then converted it to uppercase, on a10soc, the quartus::device::get_part_info -sip_tile returns an empty string and the sip_tile variable is not initialized resulting in a build error.

- bumps the required version for ad4052_ardz to 23.1std so that it doesn't fail on  CI.
- increases the placement effort for daq2/a10soc to pass the timing on CI

## PR Type
- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the code style guidelines
- [x] I have performed a self-review of changes
- [x] I have compiled all hdl projects and libraries affected by this PR
- [ ] I have tested in hardware affected projects, at least on relevant boards
- [ ] I have commented my code, at least hard-to-understand parts
- [ ] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe files, Copyright etc)
- [ ] I have not introduced new Warnings/Critical Warnings on compilation
- [ ] I have added new hdl testbenches or updated existing ones
