### PR TITLE
.gitignore: Ignore folders generated by pyvenv

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -110,3 +110,8 @@ _build
 library/**/.lock
 library/**/interfaces/*.sv
 .backstage_yaml
+bin/
+lib/
+lib64
+pyvenv.cfg
+share/


### PR DESCRIPTION
## PR Description

Python virtual environment is used when building the documentation, in some setups. When activating it, it creates a couple of folders and a cfg file, which should be ignored by git.

- bin/
- lib/
- lib64
- pyvenv.cfg
- share/

## PR Type
- [ ] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the code style guidelines
- [x] I have performed a self-review of changes
- [ ] I have compiled all hdl projects and libraries affected by this PR
- [ ] I have tested in hardware affected projects, at least on relevant boards
- [ ] I have commented my code, at least hard-to-understand parts
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe files, Copyright etc)
- [ ] I have not introduced new Warnings/Critical Warnings on compilation
- [ ] I have added new hdl testbenches or updated existing ones
