### PR TITLE
scripts: adi_ip_xilinx: Fix fall through, missing close quote

### DIFF
--- a/library/scripts/adi_ip_xilinx.tcl
+++ b/library/scripts/adi_ip_xilinx.tcl
@@ -435,11 +435,12 @@ proc adi_init_bd_tcl {} {
   foreach i $auto_set_param_list {
     if { [ipx::get_user_parameters $i -of_objects $cc -quiet] ne "" } {
       append auto_set_param "    $i \\\n"
+      set j $i
     }
   }
   if { $auto_set_param ne "" } {
     puts $bd_tcl "  bd::mark_propagate_only \$ip \" \\"
-    regsub "${i} \\\\" $auto_set_param "$i\"" auto_set_param
+    regsub "${j} \\\\" $auto_set_param "$j\"" auto_set_param
     puts $bd_tcl $auto_set_param
   }
 
@@ -447,11 +448,12 @@ proc adi_init_bd_tcl {} {
   foreach i $auto_set_param_list_overwritable {
     if { [ipx::get_user_parameters $i -of_objects $cc -quiet] ne "" } {
       append auto_set_overwritable_param "    $i \\\n"
+      set j $i
     }
   }
   if { $auto_set_overwritable_param ne "" } {
     puts $bd_tcl "  bd::mark_propagate_override \$ip \" \\"
-    regsub "${i} \\\\" $auto_set_overwritable_param "$i\"" auto_set_overwritable_param
+    regsub "${j} \\\\" $auto_set_overwritable_param "$j\"" auto_set_overwritable_param
     puts $bd_tcl $auto_set_overwritable_param
   }
   puts $bd_tcl "  adi_auto_assign_device_spec \$cellpath"


### PR DESCRIPTION
## PR Description

Automatic parameters from adi_xilinx_device_info_enc are injected in
adi_ip_xilinx to codegen the bd/bd.tcl files.
First, it adds the items that are lib user parameters to an array,
suffixed with backslash, then replaces the last item backslash from
info_enc with the closing double quote.
If FPGA_TECHNOLOGY is not in the IP, no double quote is inserted,
and the string is never closed on bd.tcl.
Assign the matched user parameter to an auxiliary variable and
use that on the replace instead.

`j` variable existence is ensured by the ` if { $auto_set_param ne "" }` and `if { $auto_set_overwritable_param ne "" }`, so it lacks a initial define (e.g. `""`)

## PR Type
- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [ ] I have followed the code style guidelines
- [ ] I have performed a self-review of changes
- [ ] I have compiled all hdl projects and libraries affected by this PR
- [ ] I have tested in hardware affected projects, at least on relevant boards
- [ ] I have commented my code, at least hard-to-understand parts
- [ ] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe files, Copyright etc)
- [ ] I have not introduced new Warnings/Critical Warnings on compilation
- [ ] I have added new hdl testbenches or updated existing ones
