### PR TITLE
ad_quadmxfe1_ebz: Fix critical warnings

### DIFF
--- a/projects/ad_quadmxfe1_ebz/common/ad_quadmxfe1_ebz_bd.tcl
+++ b/projects/ad_quadmxfe1_ebz/common/ad_quadmxfe1_ebz_bd.tcl
@@ -1,5 +1,5 @@
 ###############################################################################
-## Copyright (C) 2019-2023 Analog Devices, Inc. All rights reserved.
+## Copyright (C) 2019-2025 Analog Devices, Inc. All rights reserved.
 ### SPDX short identifier: ADIBSD
 ###############################################################################
 
@@ -537,6 +537,13 @@ ad_connect  axi_mxfe_rx_jesd/rx_data_tvalid rx_mxfe_tpl_core/link_valid
 ad_connect ext_sync rx_mxfe_tpl_core/adc_tpl_core/adc_sync_in
 ad_connect rx_mxfe_tpl_core/adc_tpl_core/adc_rst util_mxfe_cpack/reset
 
+ad_ip_instance util_vector_logic manual_sync_or [list \
+      C_SIZE 1 \
+      C_OPERATION {or} \
+    ]
+ad_connect rx_mxfe_tpl_core/adc_tpl_core/adc_sync_manual_req_out manual_sync_or/Op1
+ad_connect manual_sync_or/Res rx_mxfe_tpl_core/adc_tpl_core/adc_sync_manual_req_in
+
 #
 # rx tpl to cpack
 #
@@ -640,6 +647,8 @@ for {set i 0} {$i < $TX_NUM_OF_CONVERTERS} {incr i} {
 }
 
 ad_connect ext_sync tx_mxfe_tpl_core/dac_tpl_core/dac_sync_in
+ad_connect tx_mxfe_tpl_core/dac_tpl_core/dac_sync_manual_req_out manual_sync_or/Op2
+ad_connect manual_sync_or/Res tx_mxfe_tpl_core/dac_tpl_core/dac_sync_manual_req_in
 
 #
 # dac fifo to upack

--- a/projects/ad_quadmxfe1_ebz/vcu118/system_project.tcl
+++ b/projects/ad_quadmxfe1_ebz/vcu118/system_project.tcl
@@ -1,5 +1,5 @@
 ###############################################################################
-## Copyright (C) 2019-2023 Analog Devices, Inc. All rights reserved.
+## Copyright (C) 2019-2025 Analog Devices, Inc. All rights reserved.
 ### SPDX short identifier: ADIBSD
 ###############################################################################
 
@@ -71,7 +71,7 @@ adi_project_files ad_quadmxfe1_ebz_vcu118 [list \
   "$ad_hdl_dir/library/common/ad_iobuf.v" \
   "$ad_hdl_dir/projects/common/vcu118/vcu118_system_constr.xdc" ]
 
-set_property strategy Performance_RefinePlacement [get_runs impl_1]
+set_property strategy Performance_ExtraTimingOpt [get_runs impl_1]
 
 adi_project_run ad_quadmxfe1_ebz_vcu118
 


### PR DESCRIPTION
## PR Description
Fix Critical Warnings for the Quad-MxFE Project on VCU118:

-Connect adc/dac_sync_manual_req_in signals in the BD 
-Change the implementation strategy for better timing closure

Signed-off-by: Filip Gherman <filip.gherman@analog.com>

## PR Type
- [X] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [X] I have followed the code style guidelines
- [X] I have performed a self-review of changes
- [X] I have compiled all hdl projects and libraries affected by this PR
- [X] I have tested in hardware affected projects, at least on relevant boards
- [ ] I have commented my code, at least hard-to-understand parts
- [X] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe files, Copyright etc)
- [X] I have not introduced new Warnings/Critical Warnings on compilation
- [ ] I have added new hdl testbenches or updated existing ones
