### PR TITLE
projects/dac_fmc_ebz: Changes for AD9163

### DIFF
--- a/projects/dac_fmc_ebz/common/config.tcl
+++ b/projects/dac_fmc_ebz/common/config.tcl
@@ -1,5 +1,5 @@
 ###############################################################################
-## Copyright (C) 2019-2023 Analog Devices, Inc. All rights reserved.
+## Copyright (C) 2019-2025 Analog Devices, Inc. All rights reserved.
 ### SPDX short identifier: ADIBSD
 ###############################################################################
 
@@ -103,7 +103,7 @@ set params(AD9162,08) {2 8 2 1 1 16 16}
 set params(AD9162,device_code) 3
 #                 Mode M L S F HD N NP
 set params(AD9163,01) {2 1 1 4 1 16 16}
-set params(AD9163,02) {2 2 2 2 1 16 16}
+set params(AD9163,02) {2 2 1 2 1 16 16}
 set params(AD9163,03) {2 3 3 4 1 16 16}
 set params(AD9163,04) {2 4 1 1 1 16 16}
 set params(AD9163,06) {2 6 3 2 1 16 16}

--- a/projects/dac_fmc_ebz/common/dac_fmc_ebz_bd.tcl
+++ b/projects/dac_fmc_ebz/common/dac_fmc_ebz_bd.tcl
@@ -1,5 +1,5 @@
 ###############################################################################
-## Copyright (C) 2019-2023 Analog Devices, Inc. All rights reserved.
+## Copyright (C) 2019-2025 Analog Devices, Inc. All rights reserved.
 ### SPDX short identifier: ADIBSD
 ###############################################################################
 

--- a/projects/dac_fmc_ebz/common/dac_fmc_ebz_qsys.tcl
+++ b/projects/dac_fmc_ebz/common/dac_fmc_ebz_qsys.tcl
@@ -1,5 +1,5 @@
 ###############################################################################
-## Copyright (C) 2019-2023 Analog Devices, Inc. All rights reserved.
+## Copyright (C) 2019-2025 Analog Devices, Inc. All rights reserved.
 ### SPDX short identifier: ADIBSD
 ###############################################################################
 

--- a/projects/dac_fmc_ebz/zcu102/system_bd.tcl
+++ b/projects/dac_fmc_ebz/zcu102/system_bd.tcl
@@ -1,5 +1,5 @@
 ###############################################################################
-## Copyright (C) 2019-2024 Analog Devices, Inc. All rights reserved.
+## Copyright (C) 2019-2025 Analog Devices Inc. All rights reserved.
 ### SPDX short identifier: ADIBSD
 ###############################################################################
 
@@ -8,17 +8,18 @@ set dac_fifo_address_width 13
 source $ad_hdl_dir/projects/scripts/adi_pd.tcl
 source $ad_hdl_dir/projects/common/zcu102/zcu102_system_bd.tcl
 source $ad_hdl_dir/projects/common/xilinx/dacfifo_bd.tcl
+
 source ../common/dac_fmc_ebz_bd.tcl
 
 if {[info exists ::env(ADI_LANE_RATE)]} {
-  set ADI_LANE_RATE [get_env_param ADI_LANE_RATE 15.4]
+  set ADI_LANE_RATE [get_env_param ADI_LANE_RATE 12.5]
 } elseif {![info exists ADI_LANE_RATE]} {
-  set ADI_LANE_RATE 15.4
+  set ADI_LANE_RATE 12.5
 }
 
 set ADI_DEVICE_CODE $ad_project_params(DEVICE_CODE)
 
-# Common for both 12.5 and 15.4 GHz Lane Rate
+# Common for both 15.4, 12.5 and 4.16 GHz Lane Rate
 
 ad_ip_parameter util_dac_jesd204_xcvr CONFIG.QPLL_REFCLK_DIV 1
 ad_ip_parameter util_dac_jesd204_xcvr CONFIG.QPLL_CFG3       0x120
@@ -51,8 +52,29 @@ if { $ADI_LANE_RATE == 15.4 } {
     ad_ip_parameter util_dac_jesd204_xcvr CONFIG.PPF0_CFG        0x800
     ad_ip_parameter util_dac_jesd204_xcvr CONFIG.PPF1_CFG        0x600
     ad_ip_parameter util_dac_jesd204_xcvr CONFIG.QPLL_LPF        0x37F
+} elseif { $ADI_LANE_RATE == 4.16 } {
+    ad_ip_parameter util_dac_jesd204_xcvr CONFIG.RX_WIDEMODE_CDR           0x0
+    ad_ip_parameter util_dac_jesd204_xcvr CONFIG.RXPI_CFG0                 0x2102
+    ad_ip_parameter util_dac_jesd204_xcvr CONFIG.RXPI_CFG1                 0x45
+    ad_ip_parameter util_dac_jesd204_xcvr CONFIG.RXCDR_CFG3_GEN4           0x12
+    ad_ip_parameter util_dac_jesd204_xcvr CONFIG.CPLL_CFG3                 0x0
+    ad_ip_parameter util_dac_jesd204_xcvr CONFIG.RXCDR_CFG3                0x12
+    ad_ip_parameter util_dac_jesd204_xcvr CONFIG.CH_HSPMUX                 0x2424
+    ad_ip_parameter util_dac_jesd204_xcvr CONFIG.RXCDR_CFG3_GEN3           0x12
+    ad_ip_parameter util_dac_jesd204_xcvr CONFIG.RXCDR_CFG3_GEN2           0x12
+    ad_ip_parameter util_dac_jesd204_xcvr CONFIG.RXCDR_CFG0                0x3
+    ad_ip_parameter util_dac_jesd204_xcvr CONFIG.CPLL_CFG2                 0x2
+    ad_ip_parameter util_dac_jesd204_xcvr CONFIG.RXCDR_CFG2_GEN2           0x256
+    ad_ip_parameter util_dac_jesd204_xcvr CONFIG.CPLL_CFG0                 0x1FA
+    ad_ip_parameter util_dac_jesd204_xcvr CONFIG.CPLL_CFG1                 0x23
+    ad_ip_parameter util_dac_jesd204_xcvr CONFIG.RXCDR_CFG2_GEN4           0x164
+    ad_ip_parameter util_dac_jesd204_xcvr CONFIG.CPLL_FBDIV_4_5            5
+    ad_ip_parameter util_dac_jesd204_xcvr CONFIG.TX_CLK25_DIV              9
+    ad_ip_parameter util_dac_jesd204_xcvr CONFIG.RX_CLK25_DIV              9
+    ad_ip_parameter util_dac_jesd204_xcvr CONFIG.TX_OUT_DIV                2
+    ad_ip_parameter util_dac_jesd204_xcvr CONFIG.CPLL_FBDIV                2
 } else {
-    error "ADI_LANE_RATE must be either 12.5 GHz or 15.4GHz"
+    error "ADI_LANE_RATE must be either 4.16, 12.5 GHz or 15.4GHz"
 }
 
 ad_ip_parameter  dac_jesd204_link/tx   CONFIG.SYSREF_IOB         false

--- a/projects/dac_fmc_ebz/zcu102/system_constr.xdc
+++ b/projects/dac_fmc_ebz/zcu102/system_constr.xdc
@@ -1,5 +1,5 @@
 ###############################################################################
-## Copyright (C) 2019-2024 Analog Devices, Inc. All rights reserved.
+## Copyright (C) 2019-2025 Analog Devices, Inc. All rights reserved.
 ### SPDX short identifier: ADIBSD
 ###############################################################################
 
@@ -66,7 +66,7 @@ set_property  -dict {PACKAGE_PIN  J19 IOSTANDARD LVCMOS33} [get_ports pmod_gpio[
 # Max lane rate of 15.4 Gbps
 # ref clock lane_rate/40 or lane_rate/20
 
-create_clock -name tx_ref_clk   -period  2.597 [get_ports tx_ref_clk_p]
+create_clock -name tx_ref_clk   -period 2.597 [get_ports tx_ref_clk_p]
 
 # Assumption is that REFCLK and SYSREF have similar propagation delay,
 # and the SYSREF is a source synchronous Center-Aligned signal to REFCLK

--- a/projects/dac_fmc_ebz/zcu102/system_project.tcl
+++ b/projects/dac_fmc_ebz/zcu102/system_project.tcl
@@ -1,5 +1,5 @@
 ###############################################################################
-## Copyright (C) 2019-2023 Analog Devices, Inc. All rights reserved.
+## Copyright (C) 2019-2025 Analog Devices, Inc. All rights reserved.
 ### SPDX short identifier: ADIBSD
 ###############################################################################
 

--- a/projects/dac_fmc_ebz/zcu102/system_top.v
+++ b/projects/dac_fmc_ebz/zcu102/system_top.v
@@ -1,6 +1,6 @@
 // ***************************************************************************
 // ***************************************************************************
-// Copyright (C) 2019-2024 Analog Devices, Inc. All rights reserved.
+// Copyright (C) 2019-2025 Analog Devices, Inc. All rights reserved.
 //
 // In this HDL repository, there are many different and unique modules, consisting
 // of various HDL (Verilog or VHDL) components. The individual modules are


### PR DESCRIPTION
## PR Description

These following changes were made for AD9163: 
- Added new transceiver parameters (QPLL1, for GTHE4) for a new supported lane rate: 4.16 GHz
- Modified S parameter for Mode 2 (previous was 2, should've been 1, according to the datasheet)
- Tested in hardware two modes, working as expected:
  - Mode 2 (12.5 GHz, 2 lanes): Works only with external clock source, the J61 jumper must be removed
  - Mode 8 (4.16 GHz, 8 lanes): Works with/without external clock source

Updated the copyright year for the rest of the files.
For each mode, a new devicetree was created, which can be seen in this PR: https://github.com/analogdevicesinc/linux/pull/2711

## PR Type
- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the code style guidelines
- [x] I have performed a self-review of changes
- [x] I have compiled all hdl projects and libraries affected by this PR
- [x] I have tested in hardware affected projects, at least on relevant boards
- [ ] I have commented my code, at least hard-to-understand parts
- [x] I have signed off all commits from this PR
- [x] I have updated the documentation (wiki pages, ReadMe files, Copyright etc)
- [ ] I have not introduced new Warnings/Critical Warnings on compilation
- [ ] I have added new hdl testbenches or updated existing ones
