### PR TITLE
daq2/3: Switch to data_offload

### DIFF
--- a/projects/daq2/zc706/Makefile
+++ b/projects/daq2/zc706/Makefile
@@ -1,5 +1,5 @@
 ####################################################################################
-## Copyright (c) 2018 - 2023 Analog Devices, Inc.
+## Copyright (c) 2018 - 2025 Analog Devices, Inc.
 ### SPDX short identifier: BSD-1-Clause
 ## Auto-generated, do not modify!
 ####################################################################################
@@ -11,6 +11,7 @@ M_DEPS += ../common/daq2_bd.tcl
 M_DEPS += ../../scripts/adi_pd.tcl
 M_DEPS += ../../common/zc706/zc706_system_constr.xdc
 M_DEPS += ../../common/zc706/zc706_system_bd.tcl
+M_DEPS += ../../common/zc706/zc706_plddr3_data_offload_bd.tcl
 M_DEPS += ../../common/zc706/zc706_plddr3_constr.xdc
 M_DEPS += ../../common/xilinx/data_offload_bd.tcl
 M_DEPS += ../../../library/util_hbm/scripts/adi_util_hbm.tcl

--- a/projects/daq2/zc706/system_bd.tcl
+++ b/projects/daq2/zc706/system_bd.tcl
@@ -1,5 +1,5 @@
 ###############################################################################
-## Copyright (C) 2014-2023 Analog Devices, Inc. All rights reserved.
+## Copyright (C) 2014-2025 Analog Devices, Inc. All rights reserved.
 ### SPDX short identifier: ADIBSD
 ###############################################################################
 
@@ -16,6 +16,7 @@ set plddr_offload_axi_data_width 512
 
 source $ad_hdl_dir/projects/scripts/adi_pd.tcl
 source $ad_hdl_dir/projects/common/zc706/zc706_system_bd.tcl
+source $ad_hdl_dir/projects/common/zc706/zc706_plddr3_data_offload_bd.tcl
 source ../common/daq2_bd.tcl
 
 ################################################################################
@@ -31,34 +32,7 @@ if {$dac_offload_type} {
 }
 
 if {$adc_offload_type || $dac_offload_type} {
-
-    ad_ip_instance proc_sys_reset axi_rstgen
-    ad_ip_instance mig_7series axi_ddr_cntrl
-    file copy -force $ad_hdl_dir/projects/common/zc706/zc706_plddr3_mig.prj [get_property IP_DIR \
-      [get_ips [get_property CONFIG.Component_Name [get_bd_cells axi_ddr_cntrl]]]]
-    ad_ip_parameter axi_ddr_cntrl CONFIG.XML_INPUT_FILE zc706_plddr3_mig.prj
-
-    # PL-DDR data offload interfaces
-    create_bd_intf_port -mode Slave -vlnv xilinx.com:interface:diff_clock_rtl:1.0 sys_clk
-    create_bd_port -dir I -type rst sys_rst
-    set_property CONFIG.POLARITY ACTIVE_HIGH [get_bd_ports sys_rst]
-    create_bd_intf_port -mode Master -vlnv xilinx.com:interface:ddrx_rtl:1.0 ddr3
-
-    ad_connect axi_ddr_cntrl/ui_clk axi_rstgen/slowest_sync_clk
-    ad_connect axi_ddr_cntrl/ui_clk $offload_name/storage_unit/m_axi_aclk
-    ad_connect axi_ddr_cntrl/S_AXI $offload_name/storage_unit/MAXI_0
-    ad_connect axi_rstgen/peripheral_aresetn $offload_name/storage_unit/m_axi_aresetn
-    ad_connect axi_rstgen/peripheral_aresetn axi_ddr_cntrl/aresetn
-    ad_connect sys_cpu_resetn axi_rstgen/ext_reset_in
-
-    assign_bd_address [get_bd_addr_segs -of_objects [get_bd_cells axi_ddr_cntrl]]
-
-    ad_connect  sys_rst axi_ddr_cntrl/sys_rst
-    ad_connect  sys_clk axi_ddr_cntrl/SYS_CLK
-    ad_connect  ddr3    axi_ddr_cntrl/DDR3
-    ad_connect  axi_ddr_cntrl/device_temp_i GND
-    ad_connect  $offload_name/i_data_offload/ddr_calib_done axi_ddr_cntrl/init_calib_complete
-
+  ad_plddr_data_offload_create $offload_name
 }
 
 ################################################################################

--- a/projects/daq3/common/daq3_bd.tcl
+++ b/projects/daq3/common/daq3_bd.tcl
@@ -1,5 +1,5 @@
 ###############################################################################
-## Copyright (C) 2014-2023 Analog Devices, Inc. All rights reserved.
+## Copyright (C) 2014-2025 Analog Devices, Inc. All rights reserved.
 ### SPDX short identifier: ADIBSD
 ###############################################################################
 
@@ -11,6 +11,7 @@
 #
 
 source $ad_hdl_dir/library/jesd204/scripts/jesd204.tcl
+source $ad_hdl_dir/projects/common/xilinx/data_offload_bd.tcl
 
 # TX parameters
 set TX_NUM_OF_LANES $ad_project_params(TX_JESD_L)      ; # L
@@ -21,7 +22,7 @@ set TX_SAMPLE_WIDTH 16                                 ; # N/NP
 set TX_SAMPLES_PER_CHANNEL [expr $TX_NUM_OF_LANES * 32 / \
                                 ($TX_NUM_OF_CONVERTERS * $TX_SAMPLE_WIDTH)] ; # L * 32 / (M * N)
 
-set dac_fifo_name axi_ad9152_fifo
+set dac_offload_name ad9152_data_offload
 set dac_data_width [expr $TX_SAMPLE_WIDTH * $TX_NUM_OF_CONVERTERS * $TX_SAMPLES_PER_CHANNEL]
 
 # RX parameters
@@ -33,7 +34,7 @@ set RX_SAMPLE_WIDTH 16                                 ; # N/NP
 set RX_SAMPLES_PER_CHANNEL [expr $RX_NUM_OF_LANES * 32 / \
                                 ($RX_NUM_OF_CONVERTERS * $RX_SAMPLE_WIDTH)] ; # L * 32 / (M * N)
 
-set adc_fifo_name axi_ad9680_fifo
+set adc_offload_name ad9680_data_offload
 set adc_data_width [expr $RX_SAMPLE_WIDTH * $RX_NUM_OF_CONVERTERS * $RX_SAMPLES_PER_CHANNEL]
 
 set MAX_TX_NUM_OF_LANES 4
@@ -71,7 +72,16 @@ ad_ip_parameter axi_ad9152_dma CONFIG.CYCLIC 0
 ad_ip_parameter axi_ad9152_dma CONFIG.DMA_DATA_WIDTH_SRC 128
 ad_ip_parameter axi_ad9152_dma CONFIG.DMA_DATA_WIDTH_DEST $dac_data_width
 
-ad_dacfifo_create $dac_fifo_name $dac_data_width $dac_data_width $dac_fifo_address_width
+ad_data_offload_create $dac_offload_name \
+                       1 \
+                       $dac_offload_type \
+                       $dac_offload_size \
+                       $dac_data_width \
+                       $dac_data_width \
+                       $plddr_offload_axi_data_width
+
+ad_ip_parameter $dac_offload_name/i_data_offload CONFIG.SYNC_EXT_ADD_INTERNAL_CDC 0
+ad_connect $dac_offload_name/sync_ext GND
 
 # adc peripherals
 
@@ -109,7 +119,16 @@ ad_ip_parameter axi_ad9680_dma CONFIG.DMA_DATA_WIDTH_SRC $adc_data_width
 ad_ip_parameter axi_ad9680_dma CONFIG.DMA_DATA_WIDTH_DEST 64
 
 if {$sys_zynq == 0 || $sys_zynq == 1} {
-  ad_adcfifo_create $adc_fifo_name $adc_data_width $adc_data_width $adc_fifo_address_width
+  ad_data_offload_create $adc_offload_name \
+                         0 \
+                         $adc_offload_type \
+                         $adc_offload_size \
+                         $adc_data_width \
+                         $adc_data_width \
+                         $plddr_offload_axi_data_width
+
+  ad_ip_parameter $adc_offload_name/i_data_offload CONFIG.SYNC_EXT_ADD_INTERNAL_CDC 0
+  ad_connect $adc_offload_name/sync_ext GND
 }
 
 # shared transceiver core
@@ -153,26 +172,18 @@ for {set i 0} {$i < $TX_NUM_OF_CONVERTERS} {incr i} {
 }
 
 if {$sys_zynq == 0 || $sys_zynq == 1} {
-    ad_connect  $sys_dma_clk axi_ad9152_fifo/dma_clk
-    ad_connect  $sys_dma_reset axi_ad9152_fifo/dma_rst
+    ad_connect  $sys_dma_clk $dac_offload_name/s_axis_aclk
+    ad_connect  $sys_dma_resetn $dac_offload_name/s_axis_aresetn
     ad_connect  $sys_dma_clk axi_ad9152_dma/m_axis_aclk
     ad_connect  $sys_dma_resetn axi_ad9152_dma/m_src_axi_aresetn
-    ad_connect  axi_ad9152_fifo/bypass GND
 }
-ad_connect  util_daq3_xcvr/tx_out_clk_0 axi_ad9152_fifo/dac_clk
-ad_connect  axi_ad9152_jesd_rstgen/peripheral_reset axi_ad9152_fifo/dac_rst
+ad_connect  util_daq3_xcvr/tx_out_clk_0 $dac_offload_name/m_axis_aclk
+ad_connect  axi_ad9152_jesd_rstgen/peripheral_aresetn $dac_offload_name/m_axis_aresetn
+ad_connect  axi_ad9152_upack/s_axis $dac_offload_name/m_axis
 
-# TODO: Add streaming AXI interface for DAC FIFO
-ad_connect  axi_ad9152_upack/s_axis_valid VCC
-ad_connect  axi_ad9152_upack/s_axis_ready axi_ad9152_fifo/dac_valid
-ad_connect  axi_ad9152_upack/s_axis_data axi_ad9152_fifo/dac_data
-
-ad_connect  axi_ad9152_tpl_core/dac_dunf axi_ad9152_fifo/dac_dunf
-ad_connect  axi_ad9152_fifo/dma_xfer_req axi_ad9152_dma/m_axis_xfer_req
-ad_connect  axi_ad9152_fifo/dma_ready axi_ad9152_dma/m_axis_ready
-ad_connect  axi_ad9152_fifo/dma_data axi_ad9152_dma/m_axis_data
-ad_connect  axi_ad9152_fifo/dma_valid axi_ad9152_dma/m_axis_valid
-ad_connect  axi_ad9152_fifo/dma_xfer_last axi_ad9152_dma/m_axis_last
+ad_connect  $dac_offload_name/s_axis axi_ad9152_dma/m_axis
+ad_connect  $dac_offload_name/init_req axi_ad9152_dma/m_axis_xfer_req
+ad_connect  axi_ad9152_tpl_core/dac_dunf axi_ad9152_upack/fifo_rd_underflow
 
 # connections (adc)
 
@@ -183,23 +194,43 @@ ad_connect  axi_ad9680_jesd/rx_data_tdata axi_ad9680_tpl_core/link_data
 ad_connect  axi_ad9680_jesd/rx_data_tvalid axi_ad9680_tpl_core/link_valid
 ad_connect  axi_ad9680_tpl_core/adc_valid_0 axi_ad9680_cpack/fifo_wr_en
 
+ad_ip_instance xlconcat cpack_reset_sources
+ad_ip_parameter cpack_reset_sources config.num_ports {1}
+ad_connect axi_ad9680_jesd_rstgen/peripheral_reset cpack_reset_sources/in0
+
+ad_ip_instance util_reduced_logic cpack_rst_logic
+ad_ip_parameter cpack_rst_logic config.c_operation {or}
+ad_ip_parameter cpack_rst_logic config.c_size {1}
+
 if {$sys_zynq == 0 || $sys_zynq == 1} {
-    ad_connect  util_daq3_xcvr/rx_out_clk_0 axi_ad9680_fifo/adc_clk
-    ad_connect  axi_ad9680_jesd_rstgen/peripheral_reset axi_ad9680_fifo/adc_rst
-    ad_connect  axi_ad9680_cpack/packed_fifo_wr_en axi_ad9680_fifo/adc_wr
-    ad_connect  axi_ad9680_cpack/packed_fifo_wr_data axi_ad9680_fifo/adc_wdata
-    ad_connect  $sys_dma_clk axi_ad9680_fifo/dma_clk
+    ad_connect  util_daq3_xcvr/rx_out_clk_0 $adc_offload_name/s_axis_aclk
+    ad_connect  axi_ad9680_jesd_rstgen/peripheral_aresetn $adc_offload_name/s_axis_aresetn
+    ad_connect  axi_ad9680_cpack/packed_fifo_wr_en $adc_offload_name/s_axis_tvalid
+    ad_connect  axi_ad9680_cpack/packed_fifo_wr_data $adc_offload_name/s_axis_tdata
+    ad_connect  $adc_offload_name/s_axis_tlast GND
+    ad_connect  $adc_offload_name/s_axis_tkeep VCC
+    ad_connect  $sys_dma_clk $adc_offload_name/m_axis_aclk
+    ad_connect  $sys_dma_resetn $adc_offload_name/m_axis_aresetn
     ad_connect  $sys_dma_clk axi_ad9680_dma/s_axis_aclk
     ad_connect  $sys_dma_resetn axi_ad9680_dma/m_dest_axi_aresetn
-    ad_connect  axi_ad9680_fifo/dma_wr axi_ad9680_dma/s_axis_valid
-    ad_connect  axi_ad9680_fifo/dma_wdata axi_ad9680_dma/s_axis_data
-    ad_connect  axi_ad9680_fifo/dma_wready axi_ad9680_dma/s_axis_ready
-    ad_connect  axi_ad9680_fifo/dma_xfer_req axi_ad9680_dma/s_axis_xfer_req
-    ad_connect  axi_ad9680_tpl_core/adc_dovf axi_ad9680_fifo/adc_wovf
+    ad_connect  $adc_offload_name/m_axis axi_ad9680_dma/s_axis
+    ad_connect  $adc_offload_name/init_req axi_ad9680_dma/s_axis_xfer_req
+    ad_connect  axi_ad9680_cpack/fifo_wr_overflow axi_ad9680_tpl_core/adc_dovf
+
+    ad_ip_instance util_vector_logic rx_do_rstout_logic
+    ad_ip_parameter rx_do_rstout_logic config.c_operation {not}
+    ad_ip_parameter rx_do_rstout_logic config.c_size {1}
+
+    ad_connect $adc_offload_name/s_axis_tready rx_do_rstout_logic/op1
+
+    ad_ip_parameter cpack_reset_sources config.num_ports {2}
+    ad_ip_parameter cpack_rst_logic config.c_size {2}
+    ad_connect rx_do_rstout_logic/res cpack_reset_sources/in1
 }
 
 ad_connect  util_daq3_xcvr/rx_out_clk_0 axi_ad9680_cpack/clk
-ad_connect  axi_ad9680_jesd_rstgen/peripheral_reset axi_ad9680_cpack/reset
+ad_connect  cpack_reset_sources/dout cpack_rst_logic/op1
+ad_connect  cpack_rst_logic/res axi_ad9680_cpack/reset
 
 for {set i 0} {$i < $RX_NUM_OF_CONVERTERS} {incr i} {
   ad_connect  axi_ad9680_tpl_core/adc_enable_$i axi_ad9680_cpack/enable_$i
@@ -212,13 +243,15 @@ ad_cpu_interconnect 0x44A60000 axi_ad9152_xcvr
 ad_cpu_interconnect 0x44A04000 axi_ad9152_tpl_core
 ad_cpu_interconnect 0x44A90000 axi_ad9152_jesd
 ad_cpu_interconnect 0x7c420000 axi_ad9152_dma
+ad_cpu_interconnect 0x7c430000 $dac_offload_name
 ad_cpu_interconnect 0x44A50000 axi_ad9680_xcvr
 ad_cpu_interconnect 0x44A10000 axi_ad9680_tpl_core
 ad_cpu_interconnect 0x44AA0000 axi_ad9680_jesd
 ad_cpu_interconnect 0x7c400000 axi_ad9680_dma
 
-
 if {$sys_zynq == 0 || $sys_zynq == 1} {
+    ad_cpu_interconnect 0x7c410000 $adc_offload_name
+
     ad_mem_hp1_interconnect $sys_dma_clk sys_ps7/S_AXI_HP1
     ad_mem_hp1_interconnect $sys_dma_clk axi_ad9152_dma/m_src_axi
     ad_mem_hp2_interconnect $sys_dma_clk sys_ps7/S_AXI_HP2

--- a/projects/daq3/kcu105/Makefile
+++ b/projects/daq3/kcu105/Makefile
@@ -1,5 +1,5 @@
 ####################################################################################
-## Copyright (c) 2018 - 2023 Analog Devices, Inc.
+## Copyright (c) 2018 - 2025 Analog Devices, Inc.
 ### SPDX short identifier: BSD-1-Clause
 ## Auto-generated, do not modify!
 ####################################################################################
@@ -9,15 +9,16 @@ PROJECT_NAME := daq3_kcu105
 M_DEPS += ../common/daq3_spi.v
 M_DEPS += ../common/daq3_bd.tcl
 M_DEPS += ../../scripts/adi_pd.tcl
-M_DEPS += ../../common/xilinx/dacfifo_bd.tcl
-M_DEPS += ../../common/xilinx/adcfifo_bd.tcl
 M_DEPS += ../../common/kcu105/kcu105_system_constr.xdc
 M_DEPS += ../../common/kcu105/kcu105_system_bd.tcl
+M_DEPS += ../../common/xilinx/data_offload_bd.tcl
+M_DEPS += ../../../library/util_hbm/scripts/adi_util_hbm.tcl
 M_DEPS += ../../../library/jesd204/scripts/jesd204.tcl
 M_DEPS += ../../../library/common/ad_iobuf.v
 
 LIB_DEPS += axi_dmac
 LIB_DEPS += axi_sysid
+LIB_DEPS += data_offload
 LIB_DEPS += jesd204/ad_ip_jesd204_tpl_adc
 LIB_DEPS += jesd204/ad_ip_jesd204_tpl_dac
 LIB_DEPS += jesd204/axi_jesd204_rx
@@ -25,8 +26,8 @@ LIB_DEPS += jesd204/axi_jesd204_tx
 LIB_DEPS += jesd204/jesd204_rx
 LIB_DEPS += jesd204/jesd204_tx
 LIB_DEPS += sysid_rom
-LIB_DEPS += util_adcfifo
-LIB_DEPS += util_dacfifo
+LIB_DEPS += util_do_ram
+LIB_DEPS += util_hbm
 LIB_DEPS += util_pack/util_cpack2
 LIB_DEPS += util_pack/util_upack2
 LIB_DEPS += xilinx/axi_adxcvr

--- a/projects/daq3/kcu105/system_bd.tcl
+++ b/projects/daq3/kcu105/system_bd.tcl
@@ -1,21 +1,23 @@
 ###############################################################################
-## Copyright (C) 2015-2023 Analog Devices, Inc. All rights reserved.
+## Copyright (C) 2015-2025 Analog Devices, Inc. All rights reserved.
 ### SPDX short identifier: ADIBSD
 ###############################################################################
 
-## FIFO depth is 4Mb - 250k samples
-set adc_fifo_address_width 16
+## Offload attributes
+set adc_offload_type 0                   ; ## BRAM
+set adc_offload_size [expr 1*1024*1024]  ; ## 1 MB
 
-## FIFO depth is 4Mb - 250k samples
-set dac_fifo_address_width 15
+set dac_offload_type 0                   ; ## BRAM
+set dac_offload_size [expr 512*1024]     ; ## 512 kB
 
-## NOTE: With this configuration the #36Kb BRAM utilization is at ~70%
+set plddr_offload_axi_data_width 0
 
 source $ad_hdl_dir/projects/common/kcu105/kcu105_system_bd.tcl
-source $ad_hdl_dir/projects/common/xilinx/adcfifo_bd.tcl
-source $ad_hdl_dir/projects/common/xilinx/dacfifo_bd.tcl
 source ../common/daq3_bd.tcl
 source $ad_hdl_dir/projects/scripts/adi_pd.tcl
+
+ad_ip_parameter $dac_offload_name/storage_unit CONFIG.RD_DATA_REGISTERED 1
+ad_ip_parameter $dac_offload_name/storage_unit CONFIG.RD_FIFO_ADDRESS_WIDTH 3
 
 #system ID
 ad_ip_parameter axi_sysid_0 CONFIG.ROM_ADDR_BITS 9
@@ -28,8 +30,10 @@ S=$ad_project_params(RX_JESD_S)\
 TX:M=$ad_project_params(TX_JESD_M)\
 L=$ad_project_params(TX_JESD_L)\
 S=$ad_project_params(TX_JESD_S)\
-ADC_FIFO_ADDR_WIDTH=$adc_fifo_address_width\
-DAC_FIFO_ADDR_WIDTH=$dac_fifo_address_width"
+ADC_OFFLOAD:TYPE=$adc_offload_type\
+SIZE=$adc_offload_size\
+DAC_OFFLOAD:TYPE=$dac_offload_type\
+SIZE=$dac_offload_size"
 
 sysid_gen_sys_init_file $sys_cstring
 

--- a/projects/daq3/vcu118/Makefile
+++ b/projects/daq3/vcu118/Makefile
@@ -1,5 +1,5 @@
 ####################################################################################
-## Copyright (c) 2018 - 2023 Analog Devices, Inc.
+## Copyright (c) 2018 - 2025 Analog Devices, Inc.
 ### SPDX short identifier: BSD-1-Clause
 ## Auto-generated, do not modify!
 ####################################################################################
@@ -9,15 +9,16 @@ PROJECT_NAME := daq3_vcu118
 M_DEPS += ../common/daq3_spi.v
 M_DEPS += ../common/daq3_bd.tcl
 M_DEPS += ../../scripts/adi_pd.tcl
-M_DEPS += ../../common/xilinx/dacfifo_bd.tcl
-M_DEPS += ../../common/xilinx/adcfifo_bd.tcl
 M_DEPS += ../../common/vcu118/vcu118_system_constr.xdc
 M_DEPS += ../../common/vcu118/vcu118_system_bd.tcl
+M_DEPS += ../../common/xilinx/data_offload_bd.tcl
+M_DEPS += ../../../library/util_hbm/scripts/adi_util_hbm.tcl
 M_DEPS += ../../../library/jesd204/scripts/jesd204.tcl
 M_DEPS += ../../../library/common/ad_iobuf.v
 
 LIB_DEPS += axi_dmac
 LIB_DEPS += axi_sysid
+LIB_DEPS += data_offload
 LIB_DEPS += jesd204/ad_ip_jesd204_tpl_adc
 LIB_DEPS += jesd204/ad_ip_jesd204_tpl_dac
 LIB_DEPS += jesd204/axi_jesd204_rx
@@ -25,8 +26,8 @@ LIB_DEPS += jesd204/axi_jesd204_tx
 LIB_DEPS += jesd204/jesd204_rx
 LIB_DEPS += jesd204/jesd204_tx
 LIB_DEPS += sysid_rom
-LIB_DEPS += util_adcfifo
-LIB_DEPS += util_dacfifo
+LIB_DEPS += util_do_ram
+LIB_DEPS += util_hbm
 LIB_DEPS += util_pack/util_cpack2
 LIB_DEPS += util_pack/util_upack2
 LIB_DEPS += xilinx/axi_adxcvr

--- a/projects/daq3/vcu118/system_bd.tcl
+++ b/projects/daq3/vcu118/system_bd.tcl
@@ -1,17 +1,18 @@
 ###############################################################################
-## Copyright (C) 2019-2023 Analog Devices, Inc. All rights reserved.
+## Copyright (C) 2019-2025 Analog Devices, Inc. All rights reserved.
 ### SPDX short identifier: ADIBSD
 ###############################################################################
 
-## FIFO depth is 4Mb - 250k samples
-set adc_fifo_address_width 16
+## Offload attributes
+set adc_offload_type 0                   ; ## BRAM
+set adc_offload_size [expr 1*1024*1024]  ; ## 1 MB
 
-## FIFO depth is 4Mb - 250k samples
-set dac_fifo_address_width 15
+set dac_offload_type 0                   ; ## BRAM
+set dac_offload_size [expr 512*1024]     ; ## 512 kB
+
+set plddr_offload_axi_data_width 0
 
 source $ad_hdl_dir/projects/common/vcu118/vcu118_system_bd.tcl
-source $ad_hdl_dir/projects/common/xilinx/adcfifo_bd.tcl
-source $ad_hdl_dir/projects/common/xilinx/dacfifo_bd.tcl
 source ../common/daq3_bd.tcl
 source $ad_hdl_dir/projects/scripts/adi_pd.tcl
 
@@ -26,8 +27,10 @@ S=$ad_project_params(RX_JESD_S)\
 TX:M=$ad_project_params(TX_JESD_M)\
 L=$ad_project_params(TX_JESD_L)\
 S=$ad_project_params(TX_JESD_S)\
-ADC_FIFO_ADDR_WIDTH=$adc_fifo_address_width\
-DAC_FIFO_ADDR_WIDTH=$dac_fifo_address_width"
+ADC_OFFLOAD:TYPE=$adc_offload_type\
+SIZE=$adc_offload_size\
+DAC_OFFLOAD:TYPE=$dac_offload_type\
+SIZE=$dac_offload_size"
 
 sysid_gen_sys_init_file $sys_cstring
 

--- a/projects/daq3/zc706/Makefile
+++ b/projects/daq3/zc706/Makefile
@@ -1,5 +1,5 @@
 ####################################################################################
-## Copyright (c) 2018 - 2023 Analog Devices, Inc.
+## Copyright (c) 2018 - 2025 Analog Devices, Inc.
 ### SPDX short identifier: BSD-1-Clause
 ## Auto-generated, do not modify!
 ####################################################################################
@@ -11,9 +11,10 @@ M_DEPS += ../common/daq3_bd.tcl
 M_DEPS += ../../scripts/adi_pd.tcl
 M_DEPS += ../../common/zc706/zc706_system_constr.xdc
 M_DEPS += ../../common/zc706/zc706_system_bd.tcl
+M_DEPS += ../../common/zc706/zc706_plddr3_data_offload_bd.tcl
 M_DEPS += ../../common/zc706/zc706_plddr3_constr.xdc
-M_DEPS += ../../common/zc706/zc706_plddr3_adcfifo_bd.tcl
-M_DEPS += ../../common/xilinx/dacfifo_bd.tcl
+M_DEPS += ../../common/xilinx/data_offload_bd.tcl
+M_DEPS += ../../../library/util_hbm/scripts/adi_util_hbm.tcl
 M_DEPS += ../../../library/jesd204/scripts/jesd204.tcl
 M_DEPS += ../../../library/common/ad_iobuf.v
 
@@ -22,6 +23,7 @@ LIB_DEPS += axi_dmac
 LIB_DEPS += axi_hdmi_tx
 LIB_DEPS += axi_spdif_tx
 LIB_DEPS += axi_sysid
+LIB_DEPS += data_offload
 LIB_DEPS += jesd204/ad_ip_jesd204_tpl_adc
 LIB_DEPS += jesd204/ad_ip_jesd204_tpl_dac
 LIB_DEPS += jesd204/axi_jesd204_rx
@@ -29,10 +31,10 @@ LIB_DEPS += jesd204/axi_jesd204_tx
 LIB_DEPS += jesd204/jesd204_rx
 LIB_DEPS += jesd204/jesd204_tx
 LIB_DEPS += sysid_rom
-LIB_DEPS += util_dacfifo
+LIB_DEPS += util_do_ram
+LIB_DEPS += util_hbm
 LIB_DEPS += util_pack/util_cpack2
 LIB_DEPS += util_pack/util_upack2
-LIB_DEPS += xilinx/axi_adcfifo
 LIB_DEPS += xilinx/axi_adxcvr
 LIB_DEPS += xilinx/util_adxcvr
 

--- a/projects/daq3/zc706/system_bd.tcl
+++ b/projects/daq3/zc706/system_bd.tcl
@@ -1,21 +1,25 @@
 ###############################################################################
-## Copyright (C) 2014-2023 Analog Devices, Inc. All rights reserved.
+## Copyright (C) 2014-2025 Analog Devices, Inc. All rights reserved.
 ### SPDX short identifier: ADIBSD
 ###############################################################################
 
-## FIFO depth is 1GB, PL_DDR is used
-set adc_fifo_address_width 16
+## Offload attributes
+set adc_offload_type 1                      ; ## PL_DDR
+set adc_offload_size [expr 1024*1024*1024]  ; ## 1 GB
 
-## FIFO depth is 8Mb - 500k samples
-set dac_fifo_address_width 16
+set dac_offload_type 0                   ; ## BRAM
+set dac_offload_size [expr 1*1024*1024]  ; ## 1 MB
 
-## NOTE: With this configuration the #36Kb BRAM utilization is at ~47%
+set plddr_offload_axi_data_width 512
 
 source $ad_hdl_dir/projects/common/zc706/zc706_system_bd.tcl
-source $ad_hdl_dir/projects/common/zc706/zc706_plddr3_adcfifo_bd.tcl
-source $ad_hdl_dir/projects/common/xilinx/dacfifo_bd.tcl
+source $ad_hdl_dir/projects/common/zc706/zc706_plddr3_data_offload_bd.tcl
 source ../common/daq3_bd.tcl
 source $ad_hdl_dir/projects/scripts/adi_pd.tcl
+
+ad_ip_parameter $dac_offload_name/storage_unit CONFIG.RD_DATA_REGISTERED 1
+ad_ip_parameter $dac_offload_name/storage_unit CONFIG.RD_FIFO_ADDRESS_WIDTH 3
+ad_plddr_data_offload_create $adc_offload_name
 
 #system ID
 ad_ip_parameter axi_sysid_0 CONFIG.ROM_ADDR_BITS 9
@@ -28,7 +32,9 @@ S=$ad_project_params(RX_JESD_S)\
 TX:M=$ad_project_params(TX_JESD_M)\
 L=$ad_project_params(TX_JESD_L)\
 S=$ad_project_params(TX_JESD_S)\
-ADC_FIFO_ADDR_WIDTH=$adc_fifo_address_width\
-DAC_FIFO_ADDR_WIDTH=$dac_fifo_address_width"
+ADC_OFFLOAD:TYPE=$adc_offload_type\
+SIZE=$adc_offload_size\
+DAC_OFFLOAD:TYPE=$dac_offload_type\
+SIZE=$dac_offload_size"
 
 sysid_gen_sys_init_file $sys_cstring

--- a/projects/daq3/zc706/system_project.tcl
+++ b/projects/daq3/zc706/system_project.tcl
@@ -1,5 +1,5 @@
 ###############################################################################
-## Copyright (C) 2014-2023 Analog Devices, Inc. All rights reserved.
+## Copyright (C) 2014-2025 Analog Devices, Inc. All rights reserved.
 ### SPDX short identifier: ADIBSD
 ###############################################################################
 

--- a/projects/daq3/zcu102/Makefile
+++ b/projects/daq3/zcu102/Makefile
@@ -1,5 +1,5 @@
 ####################################################################################
-## Copyright (c) 2018 - 2023 Analog Devices, Inc.
+## Copyright (c) 2018 - 2025 Analog Devices, Inc.
 ### SPDX short identifier: BSD-1-Clause
 ## Auto-generated, do not modify!
 ####################################################################################
@@ -11,12 +11,14 @@ M_DEPS += ../common/daq3_bd.tcl
 M_DEPS += ../../scripts/adi_pd.tcl
 M_DEPS += ../../common/zcu102/zcu102_system_constr.xdc
 M_DEPS += ../../common/zcu102/zcu102_system_bd.tcl
-M_DEPS += ../../common/xilinx/dacfifo_bd.tcl
+M_DEPS += ../../common/xilinx/data_offload_bd.tcl
+M_DEPS += ../../../library/util_hbm/scripts/adi_util_hbm.tcl
 M_DEPS += ../../../library/jesd204/scripts/jesd204.tcl
 M_DEPS += ../../../library/common/ad_iobuf.v
 
 LIB_DEPS += axi_dmac
 LIB_DEPS += axi_sysid
+LIB_DEPS += data_offload
 LIB_DEPS += jesd204/ad_ip_jesd204_tpl_adc
 LIB_DEPS += jesd204/ad_ip_jesd204_tpl_dac
 LIB_DEPS += jesd204/axi_jesd204_rx
@@ -24,7 +26,8 @@ LIB_DEPS += jesd204/axi_jesd204_tx
 LIB_DEPS += jesd204/jesd204_rx
 LIB_DEPS += jesd204/jesd204_tx
 LIB_DEPS += sysid_rom
-LIB_DEPS += util_dacfifo
+LIB_DEPS += util_do_ram
+LIB_DEPS += util_hbm
 LIB_DEPS += util_pack/util_cpack2
 LIB_DEPS += util_pack/util_upack2
 LIB_DEPS += xilinx/axi_adxcvr

--- a/projects/daq3/zcu102/system_bd.tcl
+++ b/projects/daq3/zcu102/system_bd.tcl
@@ -1,15 +1,14 @@
 ###############################################################################
-## Copyright (C) 2014-2023 Analog Devices, Inc. All rights reserved.
+## Copyright (C) 2014-2025 Analog Devices, Inc. All rights reserved.
 ### SPDX short identifier: ADIBSD
 ###############################################################################
 
-## FIFO depth is 8Mb - 500k samples
-set dac_fifo_address_width 16
-
-## NOTE: With this configuration the #36Kb BRAM utilization is at ~28%
+## Offload attributes
+set dac_offload_type 0                   ; ## BRAM
+set dac_offload_size [expr 1*1024*1024]  ; ## 1 MB
+set plddr_offload_axi_data_width 0
 
 source $ad_hdl_dir/projects/common/zcu102/zcu102_system_bd.tcl
-source $ad_hdl_dir/projects/common/xilinx/dacfifo_bd.tcl
 source ../common/daq3_bd.tcl
 source $ad_hdl_dir/projects/scripts/adi_pd.tcl
 
@@ -24,7 +23,8 @@ S=$ad_project_params(RX_JESD_S)\
 TX:M=$ad_project_params(TX_JESD_M)\
 L=$ad_project_params(TX_JESD_L)\
 S=$ad_project_params(TX_JESD_S)\
-DAC_FIFO_ADDR_WIDTH=$dac_fifo_address_width"
+DAC_OFFLOAD:TYPE=$dac_offload_type\
+SIZE=$dac_offload_size"
 
 sysid_gen_sys_init_file $sys_cstring
 
@@ -32,8 +32,6 @@ sysid_gen_sys_init_file $sys_cstring
 ad_ip_parameter util_daq3_xcvr CONFIG.CPLL_CFG0 0x03fe
 ad_ip_parameter util_daq3_xcvr CONFIG.CPLL_CFG1 0x0021
 ad_ip_parameter util_daq3_xcvr CONFIG.CPLL_CFG2 0x0203
-
-create_bd_port -dir I dac_fifo_bypass
 
 ad_ip_parameter util_daq3_xcvr CONFIG.QPLL_FBDIV 20
 ad_ip_parameter util_daq3_xcvr CONFIG.QPLL_REFCLK_DIV 1
@@ -72,11 +70,10 @@ ad_connect sys_cpu_resetn sys_dma_rstgen/ext_reset_in
 ad_connect sys_dma_reset sys_dma_rstgen/peripheral_reset
 ad_connect sys_dma_resetn sys_dma_rstgen/peripheral_aresetn
 
-ad_connect sys_dma_clk axi_ad9152_fifo/dma_clk
-ad_connect sys_dma_reset axi_ad9152_fifo/dma_rst
+ad_connect sys_dma_clk $dac_offload_name/s_axis_aclk
+ad_connect sys_dma_resetn $dac_offload_name/s_axis_aresetn
 ad_connect sys_dma_clk axi_ad9152_dma/m_axis_aclk
 ad_connect sys_dma_resetn axi_ad9152_dma/m_src_axi_aresetn
-ad_connect axi_ad9152_fifo/bypass dac_fifo_bypass
 
 ad_connect sys_dma_resetn axi_ad9680_dma/m_dest_axi_aresetn
 ad_connect axi_ad9680_dma/fifo_wr_clk util_daq3_xcvr/rx_out_clk_0

--- a/projects/daq3/zcu102/system_top.v
+++ b/projects/daq3/zcu102/system_top.v
@@ -1,6 +1,6 @@
 // ***************************************************************************
 // ***************************************************************************
-// Copyright (C) 2017-2023 Analog Devices, Inc. All rights reserved.
+// Copyright (C) 2017-2025 Analog Devices, Inc. All rights reserved.
 //
 // In this HDL repository, there are many different and unique modules, consisting
 // of various HDL (Verilog or VHDL) components. The individual modules are
@@ -201,7 +201,6 @@ module system_top (
     .spi1_miso (1'd0),
     .spi1_mosi (),
     .spi1_sclk (),
-    .dac_fifo_bypass(gpio_o[41]),
     .tx_data_0_n (tx_data_n[0]),
     .tx_data_0_p (tx_data_p[0]),
     .tx_data_1_n (tx_data_n[1]),


### PR DESCRIPTION
## PR Description

This commit adds support for the Data Offload IP, replacing the dacfifo/adcfifo IPs.
For DAQ2, the project is updated to import the generic MIG DDR3 configuration script, replacing the local script.

Must be merged after this PR: https://github.com/analogdevicesinc/hdl/pull/1573

## PR Type
- [ ] Bug fix (change that fixes an issue)
- [x] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the code style guidelines
- [x] I have performed a self-review of changes
- [x] I have compiled all hdl projects and libraries affected by this PR
- [ ] I have tested in hardware affected projects, at least on relevant boards
- [x] I have commented my code, at least hard-to-understand parts
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe files, Copyright etc)
- [ ] I have not introduced new Warnings/Critical Warnings on compilation
- [x] I have added new hdl testbenches or updated existing ones
