### PR TITLE
axi_ad9122: Fix DDS second tone control typo

### DIFF
--- a/library/axi_ad9122/axi_ad9122_channel.v
+++ b/library/axi_ad9122/axi_ad9122_channel.v
@@ -1,6 +1,6 @@
 // ***************************************************************************
 // ***************************************************************************
-// Copyright (C) 2014-2023 Analog Devices, Inc. All rights reserved.
+// Copyright (C) 2014-2023, 2025 Analog Devices, Inc. All rights reserved.
 //
 // In this HDL repository, there are many different and unique modules, consisting
 // of various HDL (Verilog or VHDL) components. The individual modules are
@@ -122,7 +122,7 @@ module axi_ad9122_channel #(
     .tone_2_scale (dac_dds_scale_2_s),
     .tone_1_init_offset (dac_dds_init_1_s),
     .tone_2_init_offset (dac_dds_init_2_s),
-    .tone_1_freq_word (dac_dds_init_2_s),
+    .tone_1_freq_word (dac_dds_incr_1_s),
     .tone_2_freq_word (dac_dds_incr_2_s),
     .dac_dds_data (dac_dds_data_s));
 


### PR DESCRIPTION
Fix copy/paste typo that affects the second tone of each channel.

## PR Type
- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the code style guidelines
- [x] I have performed a self-review of changes
- [x] I have compiled all hdl projects and libraries affected by this PR
- [ ] I have tested in hardware affected projects, at least on relevant boards
- [ ] I have commented my code, at least hard-to-understand parts
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe files, Copyright etc)
- [x] I have not introduced new Warnings/Critical Warnings on compilation
- [ ] I have added new hdl testbenches or updated existing ones
