### PR TITLE
SPI Engine: fix transfers with echo_sclk

### DIFF
--- a/docs/regmap/adi_regmap_spi_engine.txt
+++ b/docs/regmap/adi_regmap_spi_engine.txt
@@ -9,7 +9,7 @@ ENDTITLE
 REG
 0x00
 VERSION
-Version of the peripheral. Follows semantic versioning. Current version 1.04.00.
+Version of the peripheral. Follows semantic versioning. Current version 1.04.01.
 ENDREG
 
 FIELD
@@ -25,7 +25,7 @@ RO
 ENDFIELD
 
 FIELD
-[7:0] 0x00000000
+[7:0] 0x00000001
 VERSION_PATCH
 RO
 ENDFIELD

--- a/library/spi_engine/axi_spi_engine/axi_spi_engine.v
+++ b/library/spi_engine/axi_spi_engine/axi_spi_engine.v
@@ -133,7 +133,7 @@ module axi_spi_engine #(
   input [7:0] offload_sync_data
 );
 
-  localparam PCORE_VERSION = 'h010400;
+  localparam PCORE_VERSION = 'h010401;
   localparam S_AXI = 0;
   localparam UP_FIFO = 1;
 

--- a/library/spi_engine/spi_engine_execution/spi_engine_execution.v
+++ b/library/spi_engine/spi_engine_execution/spi_engine_execution.v
@@ -107,6 +107,7 @@ module spi_engine_execution #(
   reg [7:0] sleep_counter;
   reg [(BIT_COUNTER_WIDTH-1):0] bit_counter;
   reg [7:0] transfer_counter;
+  reg [7:0] echo_transfer_counter;
   reg ntx_rx;
   reg sleep_counter_increment;
 
@@ -114,9 +115,12 @@ module spi_engine_execution #(
   reg trigger_next = 1'b0;
   reg wait_for_io = 1'b0;
   reg transfer_active = 1'b0;
+  reg transfer_done = 1'b0;
 
   reg last_transfer;
+  reg echo_last_transfer;
   reg [7:0] word_length = DATA_WIDTH;
+  reg [7:0] last_bit_count = DATA_WIDTH-1;
   reg [7:0] left_aligned = 8'b0;
 
   assign first_bit = ((bit_counter == 'h0) ||  (bit_counter == word_length));
@@ -138,6 +142,7 @@ module spi_engine_execution #(
   wire sdo_int_s;
 
   wire last_bit;
+  wire echo_last_bit;
   wire first_bit;
   wire end_of_word;
 
@@ -164,8 +169,6 @@ module spi_engine_execution #(
 
   wire io_ready1;
   wire io_ready2;
-
-  wire end_of_sdi_latch;
 
   wire sdo_io_ready;
 
@@ -197,12 +200,12 @@ module spi_engine_execution #(
     .left_aligned(left_aligned),
     .word_length(word_length),
     .sdo_io_ready(sdo_io_ready),
+    .echo_last_bit(echo_last_bit),
     .transfer_active(transfer_active),
     .trigger_tx(trigger_tx),
     .trigger_rx(trigger_rx),
     .first_bit(first_bit),
-    .cs_activate(cs_activate),
-    .end_of_sdi_latch(end_of_sdi_latch));
+    .cs_activate(cs_activate));
 
   assign cs_gen = inst_d1 == CMD_CHIPSELECT
                   && ((cs_sleep_counter_compare == 1'b1) || cs_sleep_early_exit)
@@ -245,6 +248,7 @@ module spi_engine_execution #(
       sdo_idle_state <= SDO_DEFAULT;
       clk_div <= DEFAULT_CLK_DIV;
       word_length <= DATA_WIDTH;
+      last_bit_count <= DATA_WIDTH-1;
       left_aligned <= 8'b0;
     end else if (exec_write_cmd == 1'b1) begin
       if (cmd[9:8] == REG_CONFIG) begin
@@ -257,6 +261,7 @@ module spi_engine_execution #(
       end else if (cmd[9:8] == REG_WORD_LENGTH) begin
         // the max value of this reg must be DATA_WIDTH
         word_length <= cmd[7:0];
+        last_bit_count <= cmd[7:0] - 1;
         left_aligned <= DATA_WIDTH - cmd[7:0];
       end
     end
@@ -332,7 +337,7 @@ module spi_engine_execution #(
       end else begin
         case (inst_d1)
         CMD_TRANSFER: begin
-          if (transfer_active == 1'b0 && wait_for_io == 1'b0 && end_of_sdi_latch == 1'b1)
+          if (transfer_done)
             idle <= 1'b1;
         end
         CMD_CHIPSELECT: begin
@@ -405,6 +410,32 @@ module spi_engine_execution #(
   end
 
   always @(posedge clk) begin
+    if (resetn == 1'b0 || idle == 1'b1) begin
+      echo_last_transfer    <= 1'b0;
+    end else begin
+      if (inst_d1 == CMD_TRANSFER && cmd_d1[7:0] == 0) begin
+        echo_last_transfer    <= 1'b1;
+      end else if (echo_last_bit == 1'b1) begin
+        if (echo_transfer_counter +1 == cmd_d1[7:0]) begin
+          echo_last_transfer    <= 1'b1;
+        end else begin
+          echo_last_transfer    <= 1'b0;
+        end
+      end
+    end
+  end
+
+  always @(posedge clk ) begin
+    if (resetn == 1'b0 || idle == 1'b1) begin
+      echo_transfer_counter <= 0;
+    end else begin
+      if (echo_last_bit == 1'b1) begin
+        echo_transfer_counter <= echo_transfer_counter + 1;
+      end
+    end
+  end
+
+  always @(posedge clk) begin
     if (resetn == 1'b0) begin
       transfer_active <= 1'b0;
       wait_for_io <= 1'b0;
@@ -421,6 +452,18 @@ module spi_engine_execution #(
         if (io_ready2 == 1'b0)
           wait_for_io <= 1'b1;
       end
+    end
+  end
+
+  always @(posedge clk ) begin
+    if (resetn == 1'b0) begin
+      transfer_done <= 1'b0;
+    end else begin
+       if (ECHO_SCLK) begin
+        transfer_done <= echo_last_bit && echo_last_transfer;
+       end else begin
+        transfer_done <= (wait_for_io && io_ready1 && last_transfer) || (!wait_for_io && transfer_active && end_of_word && last_transfer );
+       end
     end
   end
 
@@ -444,7 +487,7 @@ module spi_engine_execution #(
   // end_of_word will signal the end of a transaction, pushing the command
   // stream execution to the next command. end_of_word in normal mode can be
   // generated using the global bit_counter
-  assign last_bit = bit_counter == word_length - 1;
+  assign last_bit = (bit_counter == last_bit_count);
   assign end_of_word = last_bit == 1'b1 && ntx_rx == 1'b1 && clk_div_last == 1'b1;
 
   always @(posedge clk) begin

--- a/library/spi_engine/spi_engine_execution/spi_engine_execution_shiftreg.v
+++ b/library/spi_engine/spi_engine_execution/spi_engine_execution_shiftreg.v
@@ -71,12 +71,12 @@ module spi_engine_execution_shiftreg #(
 
   // timing from main fsm
   output      sdo_io_ready,
+  output      echo_last_bit,
   input       transfer_active,
   input       trigger_tx,
   input       trigger_rx,
   input       first_bit,
-  input       cs_activate,
-  output      end_of_sdi_latch
+  input       cs_activate
 );
 
   reg [             7:0] sdi_counter    = 8'b0;
@@ -154,9 +154,8 @@ module spi_engine_execution_shiftreg #(
   generate
   if (ECHO_SCLK == 1) begin : g_echo_sclk_miso_latch
 
-    reg [7:0] sdi_counter_d = 8'b0;
-    reg [7:0] sdi_transfer_counter = 8'b0;
-    reg [7:0] num_of_transfers = 8'b0;
+    reg last_sdi_bit_r;
+    reg latch_sdi;
     reg [(NUM_OF_SDI * DATA_WIDTH)-1:0] sdi_data_latch = {(NUM_OF_SDI * DATA_WIDTH){1'b0}};
 
     if ((DEFAULT_SPI_CFG[1:0] == 2'b01) || (DEFAULT_SPI_CFG[1:0] == 2'b10)) begin : g_echo_miso_nshift_reg
@@ -175,18 +174,21 @@ module spi_engine_execution_shiftreg #(
 
         // intended LATCH
         always @(negedge echo_sclk) begin
-          if (last_sdi_bit)
+          if (latch_sdi)
             sdi_data_latch[i*DATA_WIDTH+:DATA_WIDTH] <= {data_sdi_shift, sdi[i]};
         end
       end
 
-      always @(posedge echo_sclk or posedge cs_activate) begin
+      always @(negedge echo_sclk or posedge cs_activate) begin
         if (cs_activate) begin
-          sdi_counter <= 8'b0;
-          sdi_counter_d <= 8'b0;
+          sdi_counter     <= 8'b0;
+          last_sdi_bit_r  <= 1'b0;
+          latch_sdi       <= 1'b0;
         end else begin
-          sdi_counter <= (sdi_counter == word_length-1) ? 8'b0 : sdi_counter + 1'b1;
-          sdi_counter_d <= sdi_counter;
+          // these paths would be unsafe it there wasn't a guarantee of some settling time between word_length changing and a transfer starting
+          latch_sdi       <= (sdi_counter == word_length - 2);
+          last_sdi_bit_r  <= (sdi_counter == word_length - 1);
+          sdi_counter     <= (sdi_counter == word_length - 1) ? 8'b0 : sdi_counter + 1'b1;
         end
       end
 
@@ -204,25 +206,29 @@ module spi_engine_execution_shiftreg #(
         end
         // intended LATCH
         always @(posedge echo_sclk) begin
-          if (last_sdi_bit)
-            sdi_data_latch[i*DATA_WIDTH+:DATA_WIDTH] <= data_sdi_shift;
+          if (latch_sdi)
+            sdi_data_latch[i*DATA_WIDTH+:DATA_WIDTH] <= {data_sdi_shift, sdi[i]};
         end
       end
 
       always @(posedge echo_sclk or posedge cs_activate) begin
         if (cs_activate) begin
-          sdi_counter <= 8'b0;
-          sdi_counter_d <= 8'b0;
+          sdi_counter     <= 8'b0;
+          last_sdi_bit_r  <= 1'b0;
+          latch_sdi       <= 1'b0;
         end else begin
-          sdi_counter <= (sdi_counter == word_length-1) ? 8'b0 : sdi_counter + 1'b1;
-          sdi_counter_d <= sdi_counter;
+          // these paths would be unsafe it there wasn't a guarantee of some settling time between word_length changing and a transfer starting
+          latch_sdi       <= (sdi_counter == word_length - 2);
+          last_sdi_bit_r  <= (sdi_counter == word_length - 1);
+          sdi_counter     <= (sdi_counter == word_length - 1) ? 8'b0 : sdi_counter + 1'b1;
         end
       end
 
     end
 
     assign sdi_data = sdi_data_latch;
-    assign last_sdi_bit = (sdi_counter == 0) && (sdi_counter_d == word_length-1);
+    assign last_sdi_bit = last_sdi_bit_r;
+    assign echo_last_bit =  !last_sdi_bit_m[3] && last_sdi_bit_m[2];
 
     // sdi_data_valid is synchronous to SPI clock, so synchronize the
     // last_sdi_bit to SPI clock
@@ -239,42 +245,16 @@ module spi_engine_execution_shiftreg #(
     always @(posedge clk) begin
       if (cs_activate) begin
         sdi_data_valid <= 1'b0;
-      end else if (sdi_enabled == 1'b1 &&
-                   last_sdi_bit_m[3] == 1'b0 &&
-                   last_sdi_bit_m[2] == 1'b1) begin
+      end else if (sdi_enabled == 1'b1 && echo_last_bit) begin
         sdi_data_valid <= 1'b1;
       end else if (sdi_data_ready == 1'b1) begin
         sdi_data_valid <= 1'b0;
       end
     end
 
-    always @(posedge clk) begin
-      if (cs_activate) begin
-        num_of_transfers <= 8'b0;
-      end else begin
-        if (current_instr == CMD_TRANSFER) begin
-          // current_cmd contains the NUM_OF_TRANSFERS - 1
-          num_of_transfers <= current_cmd[7:0] + 1'b1;
-        end
-      end
-    end
-
-    always @(posedge clk) begin
-      if (cs_activate) begin
-        sdi_transfer_counter <= 0;
-      end else if (last_sdi_bit_m[2] == 1'b0 &&
-                   last_sdi_bit_m[1] == 1'b1) begin
-        sdi_transfer_counter <= sdi_transfer_counter + 1'b1;
-      end
-    end
-
-    assign end_of_sdi_latch = last_sdi_bit_m[2] & (sdi_transfer_counter == num_of_transfers);
-
   end /* g_echo_sclk_miso_latch */
   else
   begin : g_sclk_miso_latch
-
-    assign end_of_sdi_latch = 1'b1;
 
     for (i=0; i<NUM_OF_SDI; i=i+1) begin: g_sdi_shift_reg
 


### PR DESCRIPTION
## PR Description

This PR fixes echo_sclk transfers, which were broken for some cases. Notably, split transfers were problematic, affecting projects like the ad4630. Also fixes another issue where the first transfer would return 0.

tb: https://github.com/analogdevicesinc/testbenches/pull/190

## PR Type
- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the code style guidelines
- [x] I have performed a self-review of changes
- [ ] I have compiled all hdl projects and libraries affected by this PR
- [ ] I have tested in hardware affected projects, at least on relevant boards
- [x] I have commented my code, at least hard-to-understand parts
- [x] I have signed off all commits from this PR
- [x] I have updated the documentation (wiki pages, ReadMe files, Copyright etc)
- [x] I have not introduced new Warnings/Critical Warnings on compilation
- [x] I have added new hdl testbenches or updated existing ones
