### PR TITLE
ad9208_dual_ebz: Replace adcfifo with data_offload

### DIFF
--- a/projects/ad9208_dual_ebz/vcu118/Makefile
+++ b/projects/ad9208_dual_ebz/vcu118/Makefile
@@ -1,5 +1,5 @@
 ####################################################################################
-## Copyright (c) 2018 - 2023 Analog Devices, Inc.
+## Copyright (c) 2018 - 2025 Analog Devices, Inc.
 ### SPDX short identifier: BSD-1-Clause
 ## Auto-generated, do not modify!
 ####################################################################################
@@ -9,19 +9,22 @@ PROJECT_NAME := ad9208_dual_ebz_vcu118
 M_DEPS += ../common/dual_ad9208_bd.tcl
 M_DEPS += ../../scripts/adi_pd.tcl
 M_DEPS += ../../daq3/common/daq3_spi.v
-M_DEPS += ../../common/xilinx/adcfifo_bd.tcl
 M_DEPS += ../../common/vcu118/vcu118_system_constr.xdc
 M_DEPS += ../../common/vcu118/vcu118_system_bd.tcl
+M_DEPS += ../../common/xilinx/data_offload_bd.tcl
+M_DEPS += ../../../library/util_hbm/scripts/adi_util_hbm.tcl
 M_DEPS += ../../../library/jesd204/scripts/jesd204.tcl
 M_DEPS += ../../../library/common/ad_iobuf.v
 
 LIB_DEPS += axi_dmac
 LIB_DEPS += axi_sysid
+LIB_DEPS += data_offload
 LIB_DEPS += jesd204/ad_ip_jesd204_tpl_adc
 LIB_DEPS += jesd204/axi_jesd204_rx
 LIB_DEPS += jesd204/jesd204_rx
 LIB_DEPS += sysid_rom
-LIB_DEPS += util_adcfifo
+LIB_DEPS += util_do_ram
+LIB_DEPS += util_hbm
 LIB_DEPS += util_pack/util_cpack2
 LIB_DEPS += xilinx/axi_adxcvr
 LIB_DEPS += xilinx/util_adxcvr

--- a/projects/ad9208_dual_ebz/vcu118/system_bd.tcl
+++ b/projects/ad9208_dual_ebz/vcu118/system_bd.tcl
@@ -1,13 +1,13 @@
 ###############################################################################
-## Copyright (C) 2019-2023 Analog Devices, Inc. All rights reserved.
+## Copyright (C) 2019-2025 Analog Devices, Inc. All rights reserved.
 ### SPDX short identifier: ADIBSD
 ###############################################################################
 
-## FIFO depth is 4Mb - 250k samples (65k samples per converter)
-set adc_fifo_address_width 13
+## Offload attributes
+set adc_offload_type 0                   ; ## BRAM
+set adc_offload_size [expr 512*1024]     ; ## 512 kB
 
 source $ad_hdl_dir/projects/common/vcu118/vcu118_system_bd.tcl
-source $ad_hdl_dir/projects/common/xilinx/adcfifo_bd.tcl
 source ../common/dual_ad9208_bd.tcl
 source $ad_hdl_dir/projects/scripts/adi_pd.tcl
 


### PR DESCRIPTION
## PR Description

This commit adds support for the Data Offload IP, replacing the adcfifo IP.

## PR Type
- [ ] Bug fix (change that fixes an issue)
- [x] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the code style guidelines
- [x] I have performed a self-review of changes
- [x] I have compiled all hdl projects and libraries affected by this PR
- [ ] I have tested in hardware affected projects, at least on relevant boards
- [x] I have commented my code, at least hard-to-understand parts
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe files, Copyright etc)
- [ ] I have not introduced new Warnings/Critical Warnings on compilation
- [x] I have added new hdl testbenches or updated existing ones
