### PR TITLE
ad9213_evb: Replace adcfifo with data_offload

### DIFF
--- a/projects/ad9213_evb/common/ad9213_evb_bd.tcl
+++ b/projects/ad9213_evb/common/ad9213_evb_bd.tcl
@@ -1,5 +1,5 @@
 ###############################################################################
-## Copyright (C) 2022-2023 Analog Devices, Inc. All rights reserved.
+## Copyright (C) 2022-2025 Analog Devices, Inc. All rights reserved.
 ### SPDX short identifier: ADIBSD
 ###############################################################################
 
@@ -12,8 +12,9 @@ set RX_SAMPLE_WIDTH 16     ; # N/NP
 set RX_SAMPLES_PER_CHANNEL 32 ; # L * 32 / (M * N)
 
 source $ad_hdl_dir/library/jesd204/scripts/jesd204.tcl
+source $ad_hdl_dir/projects/common/xilinx/data_offload_bd.tcl
 
-set adc_fifo_name axi_ad9213_fifo
+set adc_offload_name ad9213_data_offload
 set adc_data_width 512
 set adc_dma_data_width 512
 
@@ -53,7 +54,15 @@ adi_tpl_jesd204_rx_create rx_ad9213_tpl_core $RX_NUM_OF_LANES \
                                              $RX_SAMPLES_PER_FRAME \
                                              $RX_SAMPLE_WIDTH
 
-ad_adcfifo_create $adc_fifo_name $adc_data_width $adc_dma_data_width $adc_fifo_address_width
+ad_data_offload_create $adc_offload_name \
+                       0 \
+                       $adc_offload_type \
+                       $adc_offload_size \
+                       $adc_data_width \
+                       $adc_dma_data_width
+
+ad_ip_parameter $adc_offload_name/i_data_offload CONFIG.SYNC_EXT_ADD_INTERNAL_CDC 0
+ad_connect $adc_offload_name/sync_ext GND
 
 ad_ip_instance axi_dmac axi_ad9213_dma
 ad_ip_parameter axi_ad9213_dma CONFIG.DMA_TYPE_SRC 1
@@ -112,15 +121,15 @@ delete_bd_objs [get_bd_nets util_adc_xcvr_rx_out_clk_0]
 # connect clocks
 # device clock domain
 ad_connect  glbl_clk_0 rx_ad9213_tpl_core/link_clk
-
-ad_connect  glbl_clk_0 axi_ad9213_fifo/adc_clk
+ad_connect  glbl_clk_0 $adc_offload_name/s_axis_aclk
 
 # dma clock domain
-ad_connect  $sys_cpu_clk axi_ad9213_fifo/dma_clk
+ad_connect  $sys_cpu_clk $adc_offload_name/m_axis_aclk
 ad_connect  $sys_cpu_clk axi_ad9213_dma/s_axis_aclk
 
 # connect resets
-ad_connect  glbl_clk_0_rstgen/peripheral_reset axi_ad9213_fifo/adc_rst
+ad_connect  glbl_clk_0_rstgen/peripheral_aresetn $adc_offload_name/s_axis_aresetn
+ad_connect  $sys_cpu_resetn $adc_offload_name/m_axis_aresetn
 ad_connect  $sys_cpu_resetn axi_ad9213_dma/m_dest_axi_aresetn
 
 # connect dataflow
@@ -128,15 +137,15 @@ ad_connect  axi_ad9213_jesd/rx_sof rx_ad9213_tpl_core/link_sof
 ad_connect  axi_ad9213_jesd/rx_data_tdata rx_ad9213_tpl_core/link_data
 ad_connect  axi_ad9213_jesd/rx_data_tvalid rx_ad9213_tpl_core/link_valid
 
-ad_connect rx_ad9213_tpl_core/adc_valid_0 axi_ad9213_fifo/adc_wr
-ad_connect rx_ad9213_tpl_core/adc_data_0 axi_ad9213_fifo/adc_wdata
+ad_connect  rx_ad9213_tpl_core/adc_valid_0 $adc_offload_name/s_axis_tvalid
+ad_connect  rx_ad9213_tpl_core/adc_data_0 $adc_offload_name/s_axis_tdata
+ad_connect  rx_ad9213_tpl_core/adc_dovf GND
 
-ad_connect rx_ad9213_tpl_core/adc_dovf axi_ad9213_fifo/adc_wovf
+ad_connect  $adc_offload_name/s_axis_tlast GND
+ad_connect  $adc_offload_name/s_axis_tkeep VCC
 
-ad_connect  axi_ad9213_fifo/dma_wr axi_ad9213_dma/s_axis_valid
-ad_connect  axi_ad9213_fifo/dma_wdata axi_ad9213_dma/s_axis_data
-ad_connect  axi_ad9213_fifo/dma_wready axi_ad9213_dma/s_axis_ready
-ad_connect  axi_ad9213_fifo/dma_xfer_req axi_ad9213_dma/s_axis_xfer_req
+ad_connect  $adc_offload_name/m_axis axi_ad9213_dma/s_axis
+ad_connect  $adc_offload_name/init_req axi_ad9213_dma/s_axis_xfer_req
 
 ad_ip_instance axi_quad_spi hmc7044_spi
 ad_ip_parameter hmc7044_spi CONFIG.C_USE_STARTUP 0
@@ -159,6 +168,7 @@ ad_cpu_interconnect 0x44a10000 rx_ad9213_tpl_core
 ad_cpu_interconnect 0x44a90000 axi_ad9213_jesd
 ad_cpu_interconnect 0x44a71000 hmc7044_spi
 ad_cpu_interconnect 0x7c420000 axi_ad9213_dma
+ad_cpu_interconnect 0x7c430000 $adc_offload_name
 
 # interconnect (gt/adc)
 ad_mem_hp0_interconnect $sys_cpu_clk axi_ad9213_xcvr/m_axi

--- a/projects/ad9213_evb/vcu118/Makefile
+++ b/projects/ad9213_evb/vcu118/Makefile
@@ -1,5 +1,5 @@
 ####################################################################################
-## Copyright (c) 2018 - 2024 Analog Devices, Inc.
+## Copyright (c) 2018 - 2025 Analog Devices, Inc.
 ### SPDX short identifier: BSD-1-Clause
 ## Auto-generated, do not modify!
 ####################################################################################
@@ -8,20 +8,23 @@ PROJECT_NAME := ad9213_evb_vcu118
 
 M_DEPS += ../common/ad9213_evb_bd.tcl
 M_DEPS += ../../scripts/adi_pd.tcl
-M_DEPS += ../../common/xilinx/adcfifo_bd.tcl
 M_DEPS += ../../common/vcu118/vcu118_system_constr.xdc
 M_DEPS += ../../common/vcu118/vcu118_system_bd.tcl
+M_DEPS += ../../common/xilinx/data_offload_bd.tcl
+M_DEPS += ../../../library/util_hbm/scripts/adi_util_hbm.tcl
 M_DEPS += ../../../library/jesd204/scripts/jesd204.tcl
 M_DEPS += ../../../library/common/ad_iobuf.v
 M_DEPS += ../../../library/common/ad_3w_spi.v
 
 LIB_DEPS += axi_dmac
 LIB_DEPS += axi_sysid
+LIB_DEPS += data_offload
 LIB_DEPS += jesd204/ad_ip_jesd204_tpl_adc
 LIB_DEPS += jesd204/axi_jesd204_rx
 LIB_DEPS += jesd204/jesd204_rx
 LIB_DEPS += sysid_rom
-LIB_DEPS += util_adcfifo
+LIB_DEPS += util_do_ram
+LIB_DEPS += util_hbm
 LIB_DEPS += xilinx/axi_adxcvr
 LIB_DEPS += xilinx/util_adxcvr
 

--- a/projects/ad9213_evb/vcu118/system_bd.tcl
+++ b/projects/ad9213_evb/vcu118/system_bd.tcl
@@ -1,13 +1,13 @@
 ###############################################################################
-## Copyright (C) 2022-2023 Analog Devices, Inc. All rights reserved.
+## Copyright (C) 2022-2025 Analog Devices, Inc. All rights reserved.
 ### SPDX short identifier: ADIBSD
 ###############################################################################
 
-## FIFO depth is 4Mb - 250k samples (65k samples per converter)
-set adc_fifo_address_width 13
+## Offload attributes
+set adc_offload_type 0                   ; ## BRAM
+set adc_offload_size [expr 512*1024]     ; ## 512 kB
 
 source $ad_hdl_dir/projects/common/vcu118/vcu118_system_bd.tcl
-source $ad_hdl_dir/projects/common/xilinx/adcfifo_bd.tcl
 source ../common/ad9213_evb_bd.tcl
 source $ad_hdl_dir/projects/scripts/adi_pd.tcl
 


### PR DESCRIPTION
## PR Description

This commit adds support for the Data Offload IP, replacing the adcfifo IP.

## PR Type
- [ ] Bug fix (change that fixes an issue)
- [x] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the code style guidelines
- [x] I have performed a self-review of changes
- [x] I have compiled all hdl projects and libraries affected by this PR
- [ ] I have tested in hardware affected projects, at least on relevant boards
- [x] I have commented my code, at least hard-to-understand parts
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe files, Copyright etc)
- [ ] I have not introduced new Warnings/Critical Warnings on compilation
- [x] I have added new hdl testbenches or updated existing ones
