### PR TITLE
fmcomms11: Replace adcfifo/dacfifo with data_offload

### DIFF
--- a/projects/fmcomms11/common/fmcomms11_bd.tcl
+++ b/projects/fmcomms11/common/fmcomms11_bd.tcl
@@ -1,9 +1,10 @@
 ###############################################################################
-## Copyright (C) 2019-2023 Analog Devices, Inc. All rights reserved.
+## Copyright (C) 2019-2025 Analog Devices, Inc. All rights reserved.
 ### SPDX short identifier: ADIBSD
 ###############################################################################
 
 source $ad_hdl_dir/library/jesd204/scripts/jesd204.tcl
+source $ad_hdl_dir/projects/common/xilinx/data_offload_bd.tcl
 
 # JESD204 TX parameters
 set TX_NUM_OF_LANES 8      ; # L
@@ -20,19 +21,15 @@ set RX_NUM_OF_CONVERTERS 1 ; # M
 set RX_SAMPLES_PER_FRAME 4 ; # S
 set RX_SAMPLE_WIDTH 16     ; # N/NP
 
-# Data path FIFO attributes
+# Data path attributes
 
-set adc_fifo_name axi_ad9625_fifo
+set adc_offload_name ad9625_data_offload
 set adc_data_width 256
 set adc_dma_data_width 64
 
-set dac_fifo_name axi_ad9162_fifo
+set dac_offload_name ad9162_data_offload
 set dac_data_width 256
 set dac_dma_data_width 256
-
-# DAC FIFO bypass
-
-create_bd_port -dir I dac_fifo_bypass
 
 # dac peripherals
 
@@ -68,7 +65,17 @@ ad_ip_instance axi_dmac axi_ad9162_dma [list \
   DMA_DATA_WIDTH_DEST 256 \
 ]
 
-ad_dacfifo_create $dac_fifo_name $dac_data_width $dac_dma_data_width $dac_fifo_address_width
+ad_data_offload_create $dac_offload_name \
+                       1 \
+                       $dac_offload_type \
+                       $dac_offload_size \
+                       $dac_dma_data_width \
+                       $dac_data_width \
+                       $plddr_offload_axi_data_width
+
+ad_ip_parameter $dac_offload_name/i_data_offload CONFIG.HAS_BYPASS 0
+ad_ip_parameter $dac_offload_name/i_data_offload CONFIG.SYNC_EXT_ADD_INTERNAL_CDC 0
+ad_connect $dac_offload_name/sync_ext GND
 
 # adc peripherals
 
@@ -99,7 +106,17 @@ ad_ip_instance axi_dmac axi_ad9625_dma [list \
   DMA_DATA_WIDTH_DEST 64 \
 ]
 
-ad_adcfifo_create $adc_fifo_name $adc_data_width $adc_dma_data_width $adc_fifo_address_width
+ad_data_offload_create $adc_offload_name \
+                       0 \
+                       $adc_offload_type \
+                       $adc_offload_size \
+                       $adc_data_width \
+                       $adc_dma_data_width \
+                       $plddr_offload_axi_data_width
+
+ad_ip_parameter $adc_offload_name/i_data_offload CONFIG.HAS_BYPASS 0
+ad_ip_parameter $adc_offload_name/i_data_offload CONFIG.SYNC_EXT_ADD_INTERNAL_CDC 0
+ad_connect $adc_offload_name/sync_ext GND
 
 # shared transceiver core
 
@@ -141,22 +158,18 @@ for {set i 0} {$i < $TX_NUM_OF_CONVERTERS} {incr i} {
   ad_connect  axi_ad9162_core/dac_enable_$i  util_ad9162_upack/enable_$i
 }
 
-ad_connect  util_fmcomms11_xcvr/tx_out_clk_0 axi_ad9162_fifo/dac_clk
-ad_connect  axi_ad9162_jesd_rstgen/peripheral_reset axi_ad9162_fifo/dac_rst
-ad_connect  $sys_cpu_clk axi_ad9162_fifo/dma_clk
-ad_connect  $sys_cpu_reset axi_ad9162_fifo/dma_rst
+ad_connect  util_fmcomms11_xcvr/tx_out_clk_0 $dac_offload_name/m_axis_aclk
+ad_connect  axi_ad9162_jesd_rstgen/peripheral_aresetn $dac_offload_name/m_axis_aresetn
+ad_connect  $sys_cpu_clk $dac_offload_name/s_axis_aclk
+ad_connect  $sys_cpu_resetn $dac_offload_name/s_axis_aresetn
 ad_connect  $sys_cpu_clk axi_ad9162_dma/m_axis_aclk
 ad_connect  $sys_cpu_resetn axi_ad9162_dma/m_src_axi_aresetn
-ad_connect  util_ad9162_upack/s_axis_valid VCC
-ad_connect  util_ad9162_upack/s_axis_ready axi_ad9162_fifo/dac_valid
-ad_connect  util_ad9162_upack/s_axis_data axi_ad9162_fifo/dac_data
-ad_connect  axi_ad9162_core/dac_dunf axi_ad9162_fifo/dac_dunf
-ad_connect  axi_ad9162_fifo/dma_xfer_req axi_ad9162_dma/m_axis_xfer_req
-ad_connect  axi_ad9162_fifo/dma_ready axi_ad9162_dma/m_axis_ready
-ad_connect  axi_ad9162_fifo/dma_data axi_ad9162_dma/m_axis_data
-ad_connect  axi_ad9162_fifo/dma_valid axi_ad9162_dma/m_axis_valid
-ad_connect  axi_ad9162_fifo/dma_xfer_last axi_ad9162_dma/m_axis_last
-ad_connect  dac_fifo_bypass axi_ad9162_fifo/bypass
+
+ad_connect  util_ad9162_upack/s_axis $dac_offload_name/m_axis
+ad_connect  axi_ad9162_core/dac_dunf util_ad9162_upack/fifo_rd_underflow
+
+ad_connect  $dac_offload_name/s_axis axi_ad9162_dma/m_axis
+ad_connect  $dac_offload_name/init_req axi_ad9162_dma/m_axis_xfer_req
 
 # connections (adc)
 
@@ -167,18 +180,23 @@ ad_connect  axi_ad9625_jesd/rx_sof axi_ad9625_core/link_sof
 ad_connect  axi_ad9625_jesd/rx_data_tdata axi_ad9625_core/link_data
 ad_connect  axi_ad9625_jesd/rx_data_tvalid axi_ad9625_core/link_valid
 
-ad_connect  util_fmcomms11_xcvr/rx_out_clk_0 axi_ad9625_fifo/adc_clk
-ad_connect  axi_ad9625_jesd_rstgen/peripheral_reset axi_ad9625_fifo/adc_rst
-ad_connect  axi_ad9625_core/adc_valid_0 axi_ad9625_fifo/adc_wr
-ad_connect  axi_ad9625_core/adc_data_0 axi_ad9625_fifo/adc_wdata
-ad_connect  $sys_cpu_clk axi_ad9625_fifo/dma_clk
+ad_connect  util_fmcomms11_xcvr/rx_out_clk_0 $adc_offload_name/s_axis_aclk
+ad_connect  axi_ad9625_jesd_rstgen/peripheral_aresetn $adc_offload_name/s_axis_aresetn
+
+ad_connect  axi_ad9625_core/adc_valid_0 $adc_offload_name/s_axis_tvalid
+ad_connect  axi_ad9625_core/adc_data_0 $adc_offload_name/s_axis_tdata
+ad_connect  axi_ad9625_core/adc_dovf GND
+
+ad_connect  $adc_offload_name/s_axis_tlast GND
+ad_connect  $adc_offload_name/s_axis_tkeep VCC
+
+ad_connect  $sys_cpu_clk $adc_offload_name/m_axis_aclk
 ad_connect  $sys_cpu_clk axi_ad9625_dma/s_axis_aclk
+ad_connect  $sys_cpu_resetn $adc_offload_name/m_axis_aresetn
 ad_connect  $sys_cpu_resetn axi_ad9625_dma/m_dest_axi_aresetn
-ad_connect  axi_ad9625_fifo/dma_wr axi_ad9625_dma/s_axis_valid
-ad_connect  axi_ad9625_fifo/dma_wdata axi_ad9625_dma/s_axis_data
-ad_connect  axi_ad9625_fifo/dma_wready axi_ad9625_dma/s_axis_ready
-ad_connect  axi_ad9625_fifo/dma_xfer_req axi_ad9625_dma/s_axis_xfer_req
-ad_connect  axi_ad9625_core/adc_dovf axi_ad9625_fifo/adc_wovf
+
+ad_connect  $adc_offload_name/m_axis axi_ad9625_dma/s_axis
+ad_connect  $adc_offload_name/init_req axi_ad9625_dma/s_axis_xfer_req
 
 # interconnect (cpu)
 
@@ -186,10 +204,12 @@ ad_cpu_interconnect 0x44A60000 axi_ad9162_xcvr
 ad_cpu_interconnect 0x44A00000 axi_ad9162_core
 ad_cpu_interconnect 0x44A90000 axi_ad9162_jesd
 ad_cpu_interconnect 0x7c420000 axi_ad9162_dma
+ad_cpu_interconnect 0x7c430000 $dac_offload_name
 ad_cpu_interconnect 0x44A50000 axi_ad9625_xcvr
 ad_cpu_interconnect 0x44A10000 axi_ad9625_core
 ad_cpu_interconnect 0x44AA0000 axi_ad9625_jesd
 ad_cpu_interconnect 0x7c400000 axi_ad9625_dma
+ad_cpu_interconnect 0x7c410000 $adc_offload_name
 
 # gt uses hp3, and 100MHz clock for both DRP and AXI4
 

--- a/projects/fmcomms11/zc706/Makefile
+++ b/projects/fmcomms11/zc706/Makefile
@@ -1,5 +1,5 @@
 ####################################################################################
-## Copyright (c) 2018 - 2023 Analog Devices, Inc.
+## Copyright (c) 2018 - 2025 Analog Devices, Inc.
 ### SPDX short identifier: BSD-1-Clause
 ## Auto-generated, do not modify!
 ####################################################################################
@@ -12,8 +12,9 @@ M_DEPS += ../../scripts/adi_pd.tcl
 M_DEPS += ../../common/zc706/zc706_system_constr.xdc
 M_DEPS += ../../common/zc706/zc706_system_bd.tcl
 M_DEPS += ../../common/zc706/zc706_plddr3_constr.xdc
-M_DEPS += ../../common/zc706/zc706_plddr3_adcfifo_bd.tcl
-M_DEPS += ../../common/xilinx/dacfifo_bd.tcl
+M_DEPS += ../../common/zc706/zc706_plddr3_data_offload_bd.tcl
+M_DEPS += ../../common/xilinx/data_offload_bd.tcl
+M_DEPS += ../../../library/util_hbm/scripts/adi_util_hbm.tcl
 M_DEPS += ../../../library/jesd204/scripts/jesd204.tcl
 M_DEPS += ../../../library/common/ad_iobuf.v
 
@@ -22,6 +23,7 @@ LIB_DEPS += axi_dmac
 LIB_DEPS += axi_hdmi_tx
 LIB_DEPS += axi_spdif_tx
 LIB_DEPS += axi_sysid
+LIB_DEPS += data_offload
 LIB_DEPS += jesd204/ad_ip_jesd204_tpl_adc
 LIB_DEPS += jesd204/ad_ip_jesd204_tpl_dac
 LIB_DEPS += jesd204/axi_jesd204_rx
@@ -29,9 +31,9 @@ LIB_DEPS += jesd204/axi_jesd204_tx
 LIB_DEPS += jesd204/jesd204_rx
 LIB_DEPS += jesd204/jesd204_tx
 LIB_DEPS += sysid_rom
-LIB_DEPS += util_dacfifo
+LIB_DEPS += util_do_ram
+LIB_DEPS += util_hbm
 LIB_DEPS += util_pack/util_upack2
-LIB_DEPS += xilinx/axi_adcfifo
 LIB_DEPS += xilinx/axi_adxcvr
 LIB_DEPS += xilinx/util_adxcvr
 

--- a/projects/fmcomms11/zc706/system_bd.tcl
+++ b/projects/fmcomms11/zc706/system_bd.tcl
@@ -1,33 +1,33 @@
 ###############################################################################
-## Copyright (C) 2019-2023 Analog Devices, Inc. All rights reserved.
+## Copyright (C) 2019-2025 Analog Devices, Inc. All rights reserved.
 ### SPDX short identifier: ADIBSD
 ###############################################################################
 
+## Offload attributes
+set adc_offload_type 1                      ; ## PL_DDR
+set adc_offload_size [expr 1024*1024*1024]  ; ## 1 GB
+
+set dac_offload_type 0                   ; ## BRAM
+set dac_offload_size [expr 1*1024*1024]  ; ## 1 MB
+
+set plddr_offload_axi_data_width 512
+
 # instantiate the base design
 source $ad_hdl_dir/projects/common/zc706/zc706_system_bd.tcl
-
-# load all the FIFO related proccesses
-source $ad_hdl_dir/projects/common/zc706/zc706_plddr3_adcfifo_bd.tcl
-source $ad_hdl_dir/projects/common/xilinx/dacfifo_bd.tcl
-# NOTE: to swap the resources comment the two lines above, and uncomment to two line below
-#source $ad_hdl_dir/projects/common/zc706/zc706_plddr3_dacfifo_bd.tcl
-#source $ad_hdl_dir/projects/common/xilinx/adcfifo_bd.tcl
-
-# the DAC FIFO has a 500KSMP depth - 1 Mbyte
-set dac_fifo_address_width 15
-
-# by default PLDDR is used (1 Gbyte), this varible should be ignored
-set adc_fifo_address_width 15
-
+source $ad_hdl_dir/projects/common/zc706/zc706_plddr3_data_offload_bd.tcl
 source ../common/fmcomms11_bd.tcl
 source $ad_hdl_dir/projects/scripts/adi_pd.tcl
+
+ad_plddr_data_offload_create $adc_offload_name
 
 #system ID
 ad_ip_parameter axi_sysid_0 CONFIG.ROM_ADDR_BITS 9
 ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "$mem_init_sys_file_path/mem_init_sys.txt"
 ad_ip_parameter rom_sys_0 CONFIG.ROM_ADDR_BITS 9
 
-set sys_cstring "DAC_FIFO_ADDR_WIDTH=$dac_fifo_address_width\
-ADC_FIFO_ADDR_WIDTH=$adc_fifo_address_width"
+set sys_cstring "DAC_OFFLOAD:TYPE=$dac_offload_type\
+SIZE=$dac_offload_size\
+ADC_OFFLOAD:TYPE=$adc_offload_type\
+SIZE=$adc_offload_size"
 
 sysid_gen_sys_init_file $sys_cstring

--- a/projects/fmcomms11/zc706/system_top.v
+++ b/projects/fmcomms11/zc706/system_top.v
@@ -1,6 +1,6 @@
 // ***************************************************************************
 // ***************************************************************************
-// Copyright (C) 2019-2023 Analog Devices, Inc. All rights reserved.
+// Copyright (C) 2019-2025 Analog Devices, Inc. All rights reserved.
 //
 // In this HDL repository, there are many different and unique modules, consisting
 // of various HDL (Verilog or VHDL) components. The individual modules are
@@ -311,7 +311,6 @@ module system_top (
     .tx_data_7_p (tx_data_p[7]),
     .tx_ref_clk_0 (trx_ref_clk),
     .tx_sync_0 (tx_sync),
-    .tx_sysref_0 (1'b0),
-    .dac_fifo_bypass (gpio_o[60]));
+    .tx_sysref_0 (1'b0));
 
 endmodule


### PR DESCRIPTION
## PR Description

This commit adds support for the Data Offload IP, replacing the dacfifo/adcfifo IPs.

## PR Type
- [ ] Bug fix (change that fixes an issue)
- [x] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the code style guidelines
- [x] I have performed a self-review of changes
- [x] I have compiled all hdl projects and libraries affected by this PR
- [ ] I have tested in hardware affected projects, at least on relevant boards
- [x] I have commented my code, at least hard-to-understand parts
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe files, Copyright etc)
- [ ] I have not introduced new Warnings/Critical Warnings on compilation
- [x] I have added new hdl testbenches or updated existing ones
