### PR TITLE
docs: user_guide: architecture: Remove 1.8V support from FM87

### DIFF
--- a/docs/user_guide/architecture.rst
+++ b/docs/user_guide/architecture.rst
@@ -504,8 +504,8 @@ VADJ values
      - **\*3.3V**/1.8V/1.2V
      - **\*3.3V**/1.8V/1.2V
    * - :intel:`FM87 <content/www/us/en/products/details/fpga/development-kits/agilex/si-agi027.html>`
-     - 1.8V/**\*1.2V**
-     - 1.8V/**\*1.2V**
+     - **\*1.2V**
+     - **\*1.2V**
 
 .. note::
 


### PR DESCRIPTION
## PR Description

Although 1.8V is supported on one of the FMCs, it requires a bunch of hardware changes on the FPGA and also not all the IOs have level translators so it's actually possible to burn some of them.


## PR Type
- [ ] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)
- [x] Documentation

## PR Checklist
- [x] I have followed the code style guidelines
- [x] I have performed a self-review of changes
- [ ] I have compiled all hdl projects and libraries affected by this PR
- [ ] I have tested in hardware affected projects, at least on relevant boards
- [ ] I have commented my code, at least hard-to-understand parts
- [x] I have signed off all commits from this PR
- [x] I have updated the documentation (wiki pages, ReadMe files, Copyright etc)
- [ ] I have not introduced new Warnings/Critical Warnings on compilation
- [ ] I have added new hdl testbenches or updated existing ones
