### PR TITLE
up_delay_cntrl: Add core_rst

### DIFF
--- a/library/axi_ad408x/axi_ad408x.v
+++ b/library/axi_ad408x/axi_ad408x.v
@@ -306,6 +306,7 @@ module axi_ad408x #(
     .DRP_WIDTH(DELAY_CTRL_DRP_WIDTH),
     .BASE_ADDRESS(6'h02)
   ) i_delay_cntrl (
+    .core_rst(1'b0),
     .delay_clk(delay_clk),
     .delay_rst(delay_rst),
     .delay_locked(delay_locked),

--- a/library/axi_ad485x/axi_ad485x.v
+++ b/library/axi_ad485x/axi_ad485x.v
@@ -336,6 +336,7 @@ module axi_ad485x #(
         .DATA_WIDTH(1),
         .BASE_ADDRESS(6'h02)
       ) i_delay_cntrl (
+        .core_rst (1'b0),
         .delay_clk (delay_clk),
         .delay_rst (delay_rst),
         .delay_locked (delay_locked),

--- a/library/axi_ad9265/axi_ad9265.v
+++ b/library/axi_ad9265/axi_ad9265.v
@@ -211,6 +211,7 @@ module axi_ad9265 #(
     .DATA_WIDTH(9),
     .BASE_ADDRESS(6'h02)
   ) i_delay_cntrl (
+    .core_rst (1'b0),
     .delay_clk (delay_clk),
     .delay_rst (delay_rst),
     .delay_locked (delay_locked_s),

--- a/library/axi_ad9361/axi_ad9361_rx.v
+++ b/library/axi_ad9361/axi_ad9361_rx.v
@@ -410,8 +410,10 @@ module axi_ad9361_rx #(
   up_delay_cntrl #(
     .INIT_DELAY (INIT_DELAY),
     .DATA_WIDTH (13),
-    .BASE_ADDRESS (6'h02)
+    .BASE_ADDRESS (6'h02),
+    .CUSTOM_RST (1)
   ) i_delay_cntrl (
+    .core_rst (adc_rst),
     .delay_clk (delay_clk),
     .delay_rst (delay_rst),
     .delay_locked (delay_locked),

--- a/library/axi_ad9361/axi_ad9361_tx.v
+++ b/library/axi_ad9361/axi_ad9361_tx.v
@@ -432,6 +432,7 @@ module axi_ad9361_tx #(
     .DATA_WIDTH(16),
     .BASE_ADDRESS(6'h12)
   ) i_delay_cntrl (
+    .core_rst (1'b0),
     .delay_clk (delay_clk),
     .delay_rst (delay_rst),
     .delay_locked (delay_locked),

--- a/library/axi_ad9434/axi_ad9434_core.v
+++ b/library/axi_ad9434/axi_ad9434_core.v
@@ -288,6 +288,7 @@ module axi_ad9434_core #(
     .DATA_WIDTH(13),
     .BASE_ADDRESS(6'h02)
   ) i_delay_cntrl (
+    .core_rst (1'b0),
     .delay_clk (delay_clk),
     .delay_rst (delay_rst),
     .delay_locked (delay_locked),

--- a/library/axi_ad9467/axi_ad9467.v
+++ b/library/axi_ad9467/axi_ad9467.v
@@ -202,6 +202,7 @@ module axi_ad9467#(
     .DATA_WIDTH(9),
     .BASE_ADDRESS(6'h02)
   ) i_delay_cntrl (
+    .core_rst (1'b0),
     .delay_clk (delay_clk),
     .delay_rst (delay_rst),
     .delay_locked (delay_locked_s),

--- a/library/axi_ad9684/axi_ad9684.v
+++ b/library/axi_ad9684/axi_ad9684.v
@@ -339,6 +339,7 @@ module axi_ad9684 #(
   up_delay_cntrl #(
     .DATA_WIDTH(15)
   ) i_delay_cntrl (
+    .core_rst (1'b0),
     .delay_clk (delay_clk),
     .delay_rst (delay_rst),
     .delay_locked (delay_locked_s),

--- a/library/axi_ad9963/axi_ad9963_rx.v
+++ b/library/axi_ad9963/axi_ad9963_rx.v
@@ -290,6 +290,7 @@ module axi_ad9963_rx #(
     .DATA_WIDTH(13),
     .BASE_ADDRESS(6'h02)
   ) i_delay_cntrl (
+    .core_rst (1'b0),
     .delay_clk (delay_clk),
     .delay_rst (delay_rst),
     .delay_locked (delay_locked),

--- a/library/axi_adaq8092/axi_adaq8092.v
+++ b/library/axi_adaq8092/axi_adaq8092.v
@@ -264,6 +264,7 @@ module axi_adaq8092 #(
     .DATA_WIDTH(30),
     .BASE_ADDRESS(6'h02)
   ) i_delay_cntrl (
+    .core_rst (1'b0),
     .delay_clk (delay_clk),
     .delay_rst (delay_rst),
     .delay_locked (delay_locked_s),

--- a/library/axi_adrv9001/axi_adrv9001_core.v
+++ b/library/axi_adrv9001/axi_adrv9001_core.v
@@ -627,6 +627,7 @@ module axi_adrv9001_core #(
     .DISABLE(DISABLE_RX1_SSI),
     .BASE_ADDRESS(6'h02)
   ) i_delay_cntrl_rx1 (
+    .core_rst (1'b0),
     .delay_clk (delay_clk),
     .delay_rst (delay_rx1_rst),
     .delay_locked (delay_rx1_locked),

--- a/library/axi_ltc2387/axi_ltc2387.v
+++ b/library/axi_ltc2387/axi_ltc2387.v
@@ -218,6 +218,7 @@ module axi_ltc2387 #(
     .DATA_WIDTH (2),
     .BASE_ADDRESS (6'h02)
   ) i_delay_cntrl (
+    .core_rst (1'b0),
     .delay_clk (delay_clk),
     .delay_rst (delay_rst),
     .delay_locked (delay_locked_s),

--- a/library/axi_pulsar_lvds/axi_pulsar_lvds.v
+++ b/library/axi_pulsar_lvds/axi_pulsar_lvds.v
@@ -210,6 +210,7 @@ module axi_pulsar_lvds #(
     .DATA_WIDTH (2),
     .BASE_ADDRESS (6'h02)
   ) i_delay_cntrl (
+    .core_rst (1'b0),
     .delay_clk (delay_clk),
     .delay_rst (delay_rst),
     .delay_locked (delay_locked_s),

--- a/library/common/up_delay_cntrl.v
+++ b/library/common/up_delay_cntrl.v
@@ -43,7 +43,8 @@ module up_delay_cntrl #(
   parameter   INIT_DELAY = 0,
   parameter   DATA_WIDTH = 8,
   parameter   DRP_WIDTH = 5,
-  parameter   BASE_ADDRESS = 6'h02
+  parameter   BASE_ADDRESS = 6'h02,
+  parameter   CUSTOM_RST = 0
 ) (
 
   // delay interface
@@ -51,6 +52,7 @@ module up_delay_cntrl #(
   input                           delay_clk,
   output                          delay_rst,
   input                           delay_locked,
+  input                           core_rst,
 
   // io interface
 
@@ -196,12 +198,20 @@ module up_delay_cntrl #(
 
   assign delay_rst = delay_rst_s;
 
-  ad_rst i_delay_rst_reg (
-    .rst_async (up_preset),
-    .clk (delay_clk),
-    .rstn (),
-    .rst (delay_rst_s));
+  if (CUSTOM_RST == 1) begin
+    ad_rst i_delay_rst_reg (
+      .rst_async (core_rst),
+      .clk (delay_clk),
+      .rstn (),
+      .rst (delay_rst_s));
+  end else begin
+    ad_rst i_delay_rst_reg (
+      .rst_async (up_preset),
+      .clk (delay_clk),
+      .rstn (),
+      .rst (delay_rst_s));
+  end
+
   end
   endgenerate
-
 endmodule


### PR DESCRIPTION
## PR Description

Add a parameter for CUSTOM_RST in up_delay_cntrl. By default, the IP will behave the same. When set to 1, the rst_async will be connected to core_rst. This will fix the ad9361 initialization/calibration issues.

Update all the libraries that use the up_delay_cntrl instance, for backwards compatibility, as a new port has been added.

Tested on hardware, using fmcomms5 on zc702 & No-OS.

## PR Type
- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)
- [ ] Documentation

## PR Checklist
- [x] I have followed the code style guidelines
- [x] I have performed a self-review of changes
- [x] I have compiled all hdl projects and libraries affected by this PR
- [x] I have tested in hardware affected projects, at least on relevant boards
- [ ] I have commented my code, at least hard-to-understand parts
- [ ] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe files, Copyright etc)
- [x] I have not introduced new Warnings/Critical Warnings on compilation
- [ ] I have added new hdl testbenches or updated existing ones
