### PR TITLE
adrv9001 regmap: Added Selectable clock parameter

### DIFF
--- a/docs/regmap/adi_regmap_common.txt
+++ b/docs/regmap/adi_regmap_common.txt
@@ -145,6 +145,13 @@ RO
 If set, the ADC has the capability to read raw data in register CHAN_RAW_DATA from adc_channel.
 ENDFIELD
 
+FIELD
+[14] 0x00000000
+SELECTABLE_CLOCK
+RO
+If set, the ADC has the capability to select the reference clock for Tx SSI.
+ENDFIELD
+
 ############################################################################################
 ############################################################################################
 


### PR DESCRIPTION
## PR Description

Added Selectable clock parameter to the ADC/DAC common registermap.
This value was introduced in #1315 .
Branch on which this was tested in the Testbenches repository: [here](https://github.com/analogdevicesinc/testbenches/pull/204)


## PR Type
- [ ] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)
- [ ] Documentation

## PR Checklist
- [x] I have followed the code style guidelines
- [x] I have performed a self-review of changes
- [ ] I have compiled all hdl projects and libraries affected by this PR
- [ ] I have tested in hardware affected projects, at least on relevant boards
- [ ] I have commented my code, at least hard-to-understand parts
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe files, Copyright etc)
- [ ] I have not introduced new Warnings/Critical Warnings on compilation
- [x] I have added new hdl testbenches or updated existing ones
