### PR TITLE
docs/library/util_axis_fifo_asym: Fix address width naming

### DIFF
--- a/docs/library/util_axis_fifo_asym/index.rst
+++ b/docs/library/util_axis_fifo_asym/index.rst
@@ -43,8 +43,8 @@ Configuration Parameters
      - Data width of the Master AXI streaming interface.
    * - S_DATA_WIDTH
      - Data width of the Slave AXI streaming interface.
-   * - S_ADDRESS_WIDTH
-     - Width of the Slave AXI's address, defines the depth of the FIFO.
+   * - ADDRESS_WIDTH
+     - Defines the depth of the FIFO.
    * - ASYNC_CLK
      - Clocking mode. If set, the FIFO operates on asynchronous mode.
    * - M_AXIS_REGISTERED


### PR DESCRIPTION
## PR Description

Fixes ADDRESS_WIDTH parameter naming in configuration parameters.


## PR Type
- [ ] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)
- [x] Documentation

## PR Checklist
- [x] I have followed the code style guidelines
- [x] I have performed a self-review of changes
- [ ] I have compiled all hdl projects and libraries affected by this PR
- [ ] I have tested in hardware affected projects, at least on relevant boards
- [ ] I have commented my code, at least hard-to-understand parts
- [x] I have signed off all commits from this PR
- [x] I have updated the documentation (wiki pages, ReadMe files, Copyright etc)
- [x] I have not introduced new Warnings/Critical Warnings on compilation
- [ ] I have added new hdl testbenches or updated existing ones
