### PR TITLE
projects/ad9656_fmc: New trans. params

### DIFF
--- a/docs/projects/ad9656_fmc/index.rst
+++ b/docs/projects/ad9656_fmc/index.rst
@@ -68,6 +68,7 @@ The Rx links (ADC Path) operate with the following parameters:
 - RX_DEVICE_CLK: 62.5 MHz
 - REF_CLK: 125MHz
 - JESD204B Lane Rate: 10Gbps
+- Line Rate (LaneRate/4): 2.5Gbps
 - QPLL0 or CPLL
 
 AD9656 FMC Card block diagram
@@ -248,7 +249,7 @@ Software related
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 - :git-no-os:`No-OS project <drivers/adc/ad9656>`
-- :git-no-os:`No-OS driver ad9467.c <drivers/adc/ad9656/ad9656.c>`
+- :git-no-os:`No-OS driver ad9656.c <drivers/adc/ad9656/ad9656.c>`
 
 .. include:: ../common/more_information.rst
 

--- a/projects/ad9656_fmc/common/ad9656_fmc_bd.tcl
+++ b/projects/ad9656_fmc/common/ad9656_fmc_bd.tcl
@@ -1,5 +1,5 @@
 ###############################################################################
-## Copyright (C) 2020-2024 Analog Devices, Inc. All rights reserved.
+## Copyright (C) 2020-2025 Analog Devices, Inc. All rights reserved.
 ### SPDX short identifier: ADIBSD
 ###############################################################################
 
@@ -56,10 +56,25 @@ ad_ip_instance axi_dmac axi_ad9656_rx_dma [list \
 ad_ip_instance util_adxcvr util_ad9656_xcvr [list \
   RX_NUM_OF_LANES $RX_NUM_OF_LANES \
   TX_NUM_OF_LANES 0 \
-  CPLL_FBDIV 4 \
-  CPLL_FBDIV_4_5 5 \
+  CPLL_FBDIV 5 \
+  CPLL_FBDIV_4_5 4 \
   RX_OUT_DIV 2 \
   RX_CLK25_DIV 5 \
+  CPLL_CFG0 0x1FA \
+  CPLL_CFG1 0x23 \
+  CPLL_CFG2 0x2 \
+  CPLL_CFG3 0x0 \
+  RXCDR_CFG0 0x3 \
+  RXCDR_CFG2 0x255 \
+  RXCDR_CFG2_GEN2 0x255 \
+  RXCDR_CFG2_GEN4 0x164 \
+  RXCDR_CFG3 0x12 \
+  RXCDR_CFG3_GEN2 0x12 \
+  RXCDR_CFG3_GEN3 0x12 \
+  RXCDR_CFG3_GEN4 0x12 \
+  RXPI_CFG1 0xFD \
+  RX_WIDEMODE_CDR 0x0 \
+  CH_HSPMUX 0x3C3C \
   ]
 
 # xcvr interfaces


### PR DESCRIPTION
## PR Description

Regenerated the transceiver parameters for AD9656 on ZCU102, thus checking the old ones and adding others which were not present. This was done in order to fix a PN mismatch error, but it didn't solve the issue. The real cause of the problem was from the No-Os driver, which is also fixed and can be found here: https://github.com/analogdevicesinc/no-OS/pull/2508 (merged). Also added to the documentation one extra line specifying the line rate.

## PR Type
- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)
- [x] Documentation

## PR Checklist
- [x] I have followed the code style guidelines
- [x] I have performed a self-review of changes
- [x] I have compiled all hdl projects and libraries affected by this PR
- [x] I have tested in hardware affected projects, at least on relevant boards
- [ ] I have commented my code, at least hard-to-understand parts
- [x] I have signed off all commits from this PR
- [x] I have updated the documentation (wiki pages, ReadMe files, Copyright etc)
- [x] I have not introduced new Warnings/Critical Warnings on compilation
- [ ] I have added new hdl testbenches or updated existing ones
