### PR TITLE
docs/regmap: fix pwm core magic

### DIFF
--- a/docs/regmap/adi_regmap_pwm_gen.txt
+++ b/docs/regmap/adi_regmap_pwm_gen.txt
@@ -61,7 +61,7 @@ Identification number
 ENDREG
 
 FIELD
-[31:0] 0x504C5347
+[31:0] 0x601A3471
 CORE_MAGIC
 RW
 Identification number.


### PR DESCRIPTION
## PR Description

CORE_MAGIC value on the doc did not correspond to the one on RTL, this PR fixes this

## PR Type
- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)
- [x] Documentation

## PR Checklist
- [x] I have followed the code style guidelines
- [x] I have performed a self-review of changes
- [ ] I have compiled all hdl projects and libraries affected by this PR
- [ ] I have tested in hardware affected projects, at least on relevant boards
- [ ] I have commented my code, at least hard-to-understand parts
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe files, Copyright etc)
- [x] I have not introduced new Warnings/Critical Warnings on compilation
- [ ] I have added new hdl testbenches or updated existing ones
