### PR TITLE
library.mk: Fix second run for dependent lib

### DIFF
--- a/library/scripts/library.mk
+++ b/library/scripts/library.mk
@@ -1,5 +1,5 @@
 ####################################################################################
-## Copyright (c) 2018 - 2023 Analog Devices, Inc.
+## Copyright (c) 2018 - 2025 Analog Devices, Inc.
 ## SPDX short identifier: BSD-1-Clause
 ####################################################################################
 
@@ -117,8 +117,8 @@ component.xml: $(XILINX_DEPS) $(_XILINX_INTF_DEPS) $(_XILINX_LIB_DEPS)
 
 $(_XILINX_INTF_DEPS):
 	$(MAKE) -C $(dir $@) $(notdir $@)
-
-$(_XILINX_LIB_DEPS):
+FORCE:
+$(_XILINX_LIB_DEPS): FORCE
 	flock $(dir $@).lock -c "$(MAKE) -C $(dir $@) xilinx"; exit $$?
 
 %.xml:


### PR DESCRIPTION
Starting from when thread building was added, the libraries are only building once After the target file is created it does not go further with checking dates.

This change forces the make through a phony target to properly evaluate.


## PR Type
- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)
- [ ] Documentation

## PR Checklist
- [ ] I have followed the code style guidelines
- [x] I have performed a self-review of changes
- [ ] I have compiled all hdl projects and libraries affected by this PR
- [ ] I have tested in hardware affected projects, at least on relevant boards
- [ ] I have commented my code, at least hard-to-understand parts
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe files, Copyright etc)
- [x] I have not introduced new Warnings/Critical Warnings on compilation
- [ ] I have added new hdl testbenches or updated existing ones
