### PR TITLE
projects: Add README for ad9434_fmc & ad9467_fmc

### DIFF
--- a/docs/projects/ad9434_fmc/index.rst
+++ b/docs/projects/ad9434_fmc/index.rst
@@ -217,7 +217,8 @@ HDL related
 Software related
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-- :git-linux:`Linux device tree zynq-zc706-adv7511-ad9434-fmc-500ebz.dts <arch/arm/boot/dts/zynq-zc706-adv7511-ad9434-fmc-500ebz.dts>`
+- :git-linux:`Linux device tree zynq-zc706-adv7511-ad9434-fmc-500ebz.dts <arch/arm/boot/xilinx/dts/zynq-zc706-adv7511-ad9434-fmc-500ebz.dts>`
+- :git-linux:`Linux device tree zynq-zed-adv7511-ad9434-fmc-500ebz.dts <arch/arm/boot/xilinx/dts/zynq-zed-adv7511-ad9434-fmc-500ebz.dts>`
 - :git-linux:`Linux driver ad9467.c <drivers/iio/adc/ad9467.c>`
   (used for AD9434-FMC as well)
 

--- a/docs/projects/ad9467_fmc/index.rst
+++ b/docs/projects/ad9467_fmc/index.rst
@@ -257,11 +257,11 @@ HDL related
 Software related
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-- AD9467-FMC KC705 Linux device tree :git-linux:`arch/microblaze/boot/dts/kc705_ad9467_fmc.dts`
-- :git-linux:`AD9467-FMC ZedBoard Linux device tree zynq-zed-adv7511-ad9467-fmc-250ebz.dts <arch/arm/boot/dts/zynq-zed-adv7511-ad9467-fmc-250ebz.dts>`
+- :git-linux:`AD9467-FMC KC705 Linux device tree <arch/microblaze/boot/dts/kc705_ad9467_fmc.dts>`
+- :git-linux:`AD9467-FMC ZedBoard Linux device tree zynq-zed-adv7511-ad9467-fmc-250ebz.dts <arch/arm/boot/dts/xilinx/zynq-zed-adv7511-ad9467-fmc-250ebz.dts>`
 - :git-linux:`Linux driver ad9467.c <drivers/iio/adc/ad9467.c>`
 - :dokuwiki:`[Wiki] AD9467-FMC on ZedBoard using ACE </resources/eval/ad9467-fmc-250ebz-zedboard>`
-- :git-no-os:`No-OS project <projects/ad9467>` and :git-no-os:`no-OS driver <drivers/adc/ad9467>`
+- :git-no-os:`No-OS project <projects/ad9467>` and :git-no-os:`No-OS driver <drivers/adc/ad9467>`
 
 .. include:: ../common/more_information.rst
 

--- a/projects/ad9434_fmc/README.md
+++ b/projects/ad9434_fmc/README.md
@@ -1,0 +1,15 @@
+# AD9434-FMC HDL Project
+
+- Evaluation board product page: [EVAL-AD9434](https://www.analog.com/eval-ad9434)
+- System documentation: https://wiki.analog.com/resources/fpga/xilinx/fmc/ad9434
+- HDL project documentation: http://analogdevicesinc.github.io/hdl/projects/ad9434_fmc/index.html
+
+## Supported parts
+
+| Part name                               | Description                                                  |
+|-----------------------------------------|--------------------------------------------------------------|
+| [AD9434](https://www.analog.com/ad9434) | 12-Bit, 370 MSPS/500 MSPS, 1.8 V Analog-to-Digital Converter |
+
+## Building the project
+
+Please enter the folder for the FPGA carrier you want to use and read the README.md.

--- a/projects/ad9434_fmc/Readme.md
+++ b/projects/ad9434_fmc/Readme.md
@@ -1,8 +1,0 @@
-# AD9434-FMC HDL Project
-
-Here are some pointers to help you:
-  * [Board Product Page](https://www.analog.com/eval-ad9434)
-  * Parts : [12-Bit, 370 MSPS/500 MSPS, 1.8 V Analog-to-Digital Converter](https://www.analog.com/ad9434)
-  * Project Doc: https://wiki.analog.com/resources/fpga/xilinx/fmc/ad9434
-  * HDL Doc: https://wiki.analog.com/resources/fpga/xilinx/fmc/ad9434
-  * Linux Drivers: https://wiki.analog.com/resources/tools-software/linux-drivers/iio-adc/axi-adc-hdl

--- a/projects/ad9434_fmc/zc706/README.md
+++ b/projects/ad9434_fmc/zc706/README.md
@@ -1,0 +1,10 @@
+# AD9434-FMC/ZC706 HDL Project
+
+## Building the project
+
+```
+cd projects/ad9434_fmc/zc706
+make
+```
+
+Corresponding device tree: [zynq-zc706-adv7511-ad9434-fmc-500ebz.dts](https://github.com/analogdevicesinc/linux/arch/arm/boot/dts/xilinx/zynq-zc706-adv7511-ad9434-fmc-500ebz.dts)

--- a/projects/ad9434_fmc/zed/README.md
+++ b/projects/ad9434_fmc/zed/README.md
@@ -1,0 +1,10 @@
+# AD9434-FMC/Zed HDL Project
+
+## Building the project
+
+```
+cd projects/ad9434_fmc/zed
+make
+```
+
+Corresponding device tree: [zynq-zed-adv7511-ad9434-fmc-500ebz.dts](https://github.com/analogdevicesinc/linux/blob/eef6f463a90dc47af51a0a7d70f96609ef7d5f35/arch/arm/boot/dts/xilinx/zynq-zed-adv7511-ad9434-fmc-500ebz.dts)

--- a/projects/ad9467_fmc/README.md
+++ b/projects/ad9467_fmc/README.md
@@ -1,0 +1,16 @@
+# AD9467-FMC HDL Project
+
+- Evaluation board product page: [EVAL-AD9467](https://www.analog.com/eval-ad9467)
+- System documentation: https://wiki.analog.com/resources/eval/ad9467-fmc-250ebz
+- HDL project documentation: http://analogdevicesinc.github.io/hdl/projects/ad9467_fmc/index.html
+
+## Supported parts
+
+| Part name                               | Description                                           |
+|-----------------------------------------|-------------------------------------------------------|
+| [AD9467](https://www.analog.com/ad9467) | 16-Bit, 200 MSPS/250 MSPS Analog-to-Digital Converter |
+
+
+## Building the project
+
+Please enter the folder for the FPGA carrier you want to use and read the README.md.

--- a/projects/ad9467_fmc/Readme.md
+++ b/projects/ad9467_fmc/Readme.md
@@ -1,8 +1,0 @@
-# AD9467-FMC HDL Project
-
-Here are some pointers to help you:
-  * [Board Product Page](https://www.analog.com/eval-ad9467)
-  * Parts : [16-Bit, 200 MSPS/250 MSPS Analog-to-Digital Converter](https://www.analog.com/ad9467)
-  * Project Doc: https://wiki.analog.com/resources/fpga/xilinx/fmc/ad9467
-  * HDL Doc: https://wiki.analog.com/resources/fpga/xilinx/fmc/ad9467
-  * Linux Drivers: https://wiki.analog.com/resources/tools-software/linux-drivers/iio-adc/axi-adc-hdl

--- a/projects/ad9467_fmc/kc705/README.md
+++ b/projects/ad9467_fmc/kc705/README.md
@@ -1,0 +1,10 @@
+# AD9467-FMC/KC705 HDL Project
+
+## Building the project
+
+```
+cd projects/ad9467_fmc/kc705
+make
+```
+
+Corresponding device tree: [kc705_ad9467_fmc.dts](https://github.com/analogdevicesinc/linux/blob/main/arch/microblaze/boot/dts/kc705_ad9467_fmc.dts)

--- a/projects/ad9467_fmc/zed/README.md
+++ b/projects/ad9467_fmc/zed/README.md
@@ -1,0 +1,10 @@
+# AD9467-FMC/Zed HDL Project
+
+## Building the project
+
+```
+cd projects/ad9467_fmc/zed
+make
+```
+
+Corresponding device tree: [zynq-zed-adv7511-ad9467-fmc-250ebz.dts](https://github.com/analogdevicesinc/linux/blob/main/arch/arm/boot/dts/xilinx/zynq-zed-adv7511-ad9467-fmc-250ebz.dts)


### PR DESCRIPTION
## PR Description

Update & add README files for ad9434_fmc & ad9467_fmc.
Fix the dts links in the ad9434_fmc & ad9467_fmc documentation.

## PR Type
- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)
- [x] Documentation

## PR Checklist
- [x] I have followed the code style guidelines
- [x] I have performed a self-review of changes
- [ ] I have compiled all hdl projects and libraries affected by this PR
- [ ] I have tested in hardware affected projects, at least on relevant boards
- [ ] I have commented my code, at least hard-to-understand parts
- [x] I have signed off all commits from this PR
- [x] I have updated the documentation (wiki pages, ReadMe files, Copyright etc)
- [x] I have not introduced new Warnings/Critical Warnings on compilation
- [ ] I have added new hdl testbenches or updated existing ones
