### PR TITLE
adrv9371x: kcu105/zc706/zcu102: Replace dacfifo with data_offload

### DIFF
--- a/docs/projects/adrv9371x/adrv9371_jesd204b.svg
+++ b/docs/projects/adrv9371x/adrv9371_jesd204b.svg
@@ -2,12 +2,12 @@
 <!-- Created with Inkscape (http://www.inkscape.org/) -->
 
 <svg
-   width="800"
-   height="945"
-   viewBox="0 0 800 945"
+   width="860.23224"
+   height="946"
+   viewBox="0 0 860.23224 946"
    id="svg2"
    version="1.1"
-   inkscape:version="1.3.2 (091e20e, 2023-11-25, custom)"
+   inkscape:version="1.2.1 (9c6d41e410, 2022-07-14)"
    sodipodi:docname="adrv9371_jesd204b.svg"
    style="shape-rendering:crispEdges;enable-background:new"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
@@ -30,9 +30,9 @@
       <path
          inkscape:connector-curvature="0"
          id="path5539"
-         d="m 5.77,0 -8.65,5 0,-10 8.65,5 z"
+         d="M 5.77,0 -2.88,5 V -5 Z"
          style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
-         transform="scale(0.4,0.4)" />
+         transform="scale(0.4)" />
     </marker>
     <marker
        inkscape:stockid="Arrow2Mend"
@@ -46,7 +46,7 @@
          id="path5750"
          style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
          d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
-         transform="scale(-0.6,-0.6)"
+         transform="scale(-0.6)"
          inkscape:connector-curvature="0" />
     </marker>
     <marker
@@ -61,7 +61,7 @@
          id="path4701"
          style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
          d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
-         transform="scale(-0.6,-0.6)"
+         transform="scale(-0.6)"
          inkscape:connector-curvature="0" />
     </marker>
     <marker
@@ -74,7 +74,7 @@
        inkscape:isstock="true">
       <path
          id="path4689"
-         d="M 0,0 5,-5 -12.5,0 5,5 0,0 Z"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
          style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
          transform="matrix(-0.2,0,0,-0.2,-1.2,0)"
          inkscape:connector-curvature="0" />
@@ -88,9 +88,9 @@
        orient="auto"
        inkscape:stockid="TriangleOutM">
       <path
-         transform="scale(0.4,0.4)"
+         transform="scale(0.4)"
          style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
-         d="m 5.77,0 -8.65,5 0,-10 8.65,5 z"
+         d="M 5.77,0 -2.88,5 V -5 Z"
          id="path11407"
          inkscape:connector-curvature="0" />
     </marker>
@@ -103,9 +103,9 @@
        orient="auto"
        inkscape:stockid="TriangleInM">
       <path
-         transform="scale(-0.4,-0.4)"
+         transform="scale(-0.4)"
          style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
-         d="m 5.77,0 -8.65,5 0,-10 8.65,5 z"
+         d="M 5.77,0 -2.88,5 V -5 Z"
          id="path10935"
          inkscape:connector-curvature="0" />
     </marker>
@@ -118,9 +118,9 @@
        orient="auto"
        inkscape:stockid="TriangleOutM">
       <path
-         transform="scale(0.4,0.4)"
+         transform="scale(0.4)"
          style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
-         d="m 5.77,0 -8.65,5 0,-10 8.65,5 z"
+         d="M 5.77,0 -2.88,5 V -5 Z"
          id="path9867"
          inkscape:connector-curvature="0" />
     </marker>
@@ -133,9 +133,9 @@
        orient="auto"
        inkscape:stockid="TriangleInM">
       <path
-         transform="scale(-0.4,-0.4)"
+         transform="scale(-0.4)"
          style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
-         d="m 5.77,0 -8.65,5 0,-10 8.65,5 z"
+         d="M 5.77,0 -2.88,5 V -5 Z"
          id="path9407"
          inkscape:connector-curvature="0" />
     </marker>
@@ -148,9 +148,9 @@
        orient="auto"
        inkscape:stockid="TriangleOutM">
       <path
-         transform="scale(0.4,0.4)"
+         transform="scale(0.4)"
          style="fill:#0000ff;fill-opacity:1;fill-rule:evenodd;stroke:#0000ff;stroke-width:1pt;stroke-opacity:1"
-         d="m 5.77,0 -8.65,5 0,-10 8.65,5 z"
+         d="M 5.77,0 -2.88,5 V -5 Z"
          id="path6455"
          inkscape:connector-curvature="0" />
     </marker>
@@ -165,9 +165,9 @@
       <path
          inkscape:connector-curvature="0"
          id="path6007"
-         d="m 5.77,0 -8.65,5 0,-10 8.65,5 z"
+         d="M 5.77,0 -2.88,5 V -5 Z"
          style="fill:#0000ff;fill-opacity:1;fill-rule:evenodd;stroke:#0000ff;stroke-width:1pt;stroke-opacity:1"
-         transform="scale(-0.4,-0.4)" />
+         transform="scale(-0.4)" />
     </marker>
     <linearGradient
        id="linearGradient29196"
@@ -187,9 +187,9 @@
        inkscape:isstock="true">
       <path
          id="path4580"
-         d="m 5.77,0 -8.65,5 0,-10 8.65,5 z"
+         d="M 5.77,0 -2.88,5 V -5 Z"
          style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
-         transform="scale(0.4,0.4)"
+         transform="scale(0.4)"
          inkscape:connector-curvature="0" />
     </marker>
     <marker
@@ -202,7 +202,7 @@
        inkscape:isstock="true">
       <path
          id="path4450"
-         d="M 0,0 5,-5 -12.5,0 5,5 0,0 Z"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
          style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
          transform="matrix(-0.2,0,0,-0.2,-1.2,0)"
          inkscape:connector-curvature="0" />
@@ -217,9 +217,9 @@
        inkscape:isstock="true">
       <path
          id="path33060"
-         d="M 0,5.65 0,-5.65"
+         d="M 0,5.65 V -5.65"
          style="fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
-         transform="scale(0.8,0.8)"
+         transform="scale(0.8)"
          inkscape:connector-curvature="0" />
     </marker>
     <marker
@@ -232,9 +232,9 @@
        inkscape:isstock="true">
       <path
          id="path33039"
-         d="m 5.77,0 -8.65,5 0,-10 8.65,5 z"
+         d="M 5.77,0 -2.88,5 V -5 Z"
          style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
-         transform="scale(0.2,0.2)"
+         transform="scale(0.2)"
          inkscape:connector-curvature="0" />
     </marker>
     <marker
@@ -247,7 +247,7 @@
        inkscape:isstock="true">
       <path
          id="path33057"
-         d="m 5.77,0 -8.65,5 0,-10 8.65,5 z"
+         d="M 5.77,0 -2.88,5 V -5 Z"
          style="fill:#ffffff;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
          transform="matrix(0.2,0,0,0.2,-0.6,0)"
          inkscape:connector-curvature="0" />
@@ -263,9 +263,9 @@
       <path
          inkscape:connector-curvature="0"
          id="path31481"
-         d="m 5.77,0 -8.65,5 0,-10 8.65,5 z"
+         d="M 5.77,0 -2.88,5 V -5 Z"
          style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
-         transform="scale(0.4,0.4)" />
+         transform="scale(0.4)" />
     </marker>
     <marker
        inkscape:stockid="TriangleOutM"
@@ -278,9 +278,9 @@
       <path
          inkscape:connector-curvature="0"
          id="path30747"
-         d="m 5.77,0 -8.65,5 0,-10 8.65,5 z"
+         d="M 5.77,0 -2.88,5 V -5 Z"
          style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
-         transform="scale(0.4,0.4)" />
+         transform="scale(0.4)" />
     </marker>
     <marker
        inkscape:isstock="true"
@@ -291,9 +291,9 @@
        orient="auto"
        inkscape:stockid="TriangleInM">
       <path
-         transform="scale(-0.4,-0.4)"
+         transform="scale(-0.4)"
          style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
-         d="m 5.77,0 -8.65,5 0,-10 8.65,5 z"
+         d="M 5.77,0 -2.88,5 V -5 Z"
          id="path24670"
          inkscape:connector-curvature="0" />
     </marker>
@@ -306,9 +306,9 @@
        orient="auto"
        inkscape:stockid="TriangleInM">
       <path
-         transform="scale(-0.4,-0.4)"
+         transform="scale(-0.4)"
          style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
-         d="m 5.77,0 -8.65,5 0,-10 8.65,5 z"
+         d="M 5.77,0 -2.88,5 V -5 Z"
          id="path24286"
          inkscape:connector-curvature="0" />
     </marker>
@@ -321,9 +321,9 @@
        orient="auto"
        inkscape:stockid="TriangleInM">
       <path
-         transform="scale(-0.4,-0.4)"
+         transform="scale(-0.4)"
          style="fill:#0000ff;fill-opacity:1;fill-rule:evenodd;stroke:#0000ff;stroke-width:1pt;stroke-opacity:1"
-         d="m 5.77,0 -8.65,5 0,-10 8.65,5 z"
+         d="M 5.77,0 -2.88,5 V -5 Z"
          id="path6790"
          inkscape:connector-curvature="0" />
     </marker>
@@ -345,9 +345,9 @@
        inkscape:isstock="true">
       <path
          id="path4669"
-         d="m 5.77,0 -8.65,5 0,-10 8.65,5 z"
+         d="M 5.77,0 -2.88,5 V -5 Z"
          style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
-         transform="scale(0.4,0.4)"
+         transform="scale(0.4)"
          inkscape:connector-curvature="0" />
     </marker>
     <marker
@@ -361,9 +361,9 @@
        inkscape:collect="always">
       <path
          id="path4660"
-         d="m 5.77,0 -8.65,5 0,-10 8.65,5 z"
+         d="M 5.77,0 -2.88,5 V -5 Z"
          style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
-         transform="scale(-0.4,-0.4)"
+         transform="scale(-0.4)"
          inkscape:connector-curvature="0" />
     </marker>
     <marker
@@ -378,9 +378,9 @@
       <path
          inkscape:connector-curvature="0"
          id="path4660-1"
-         d="m 5.77,0 -8.65,5 0,-10 8.65,5 z"
+         d="M 5.77,0 -2.88,5 V -5 Z"
          style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
-         transform="scale(-0.4,-0.4)" />
+         transform="scale(-0.4)" />
     </marker>
     <marker
        inkscape:stockid="TriangleOutM"
@@ -394,9 +394,9 @@
       <path
          inkscape:connector-curvature="0"
          id="path4669-5"
-         d="m 5.77,0 -8.65,5 0,-10 8.65,5 z"
+         d="M 5.77,0 -2.88,5 V -5 Z"
          style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
-         transform="scale(0.4,0.4)" />
+         transform="scale(0.4)" />
     </marker>
     <marker
        inkscape:stockid="TriangleInM"
@@ -409,9 +409,9 @@
       <path
          inkscape:connector-curvature="0"
          id="path4660-1-6"
-         d="m 5.77,0 -8.65,5 0,-10 8.65,5 z"
+         d="M 5.77,0 -2.88,5 V -5 Z"
          style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
-         transform="scale(-0.4,-0.4)" />
+         transform="scale(-0.4)" />
     </marker>
     <marker
        inkscape:stockid="TriangleOutM"
@@ -425,9 +425,9 @@
       <path
          inkscape:connector-curvature="0"
          id="path4669-5-5"
-         d="m 5.77,0 -8.65,5 0,-10 8.65,5 z"
+         d="M 5.77,0 -2.88,5 V -5 Z"
          style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
-         transform="scale(0.4,0.4)" />
+         transform="scale(0.4)" />
     </marker>
     <marker
        inkscape:isstock="true"
@@ -438,9 +438,9 @@
        orient="auto"
        inkscape:stockid="TriangleInM">
       <path
-         transform="scale(-0.4,-0.4)"
+         transform="scale(-0.4)"
          style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
-         d="m 5.77,0 -8.65,5 0,-10 8.65,5 z"
+         d="M 5.77,0 -2.88,5 V -5 Z"
          id="path6790-1"
          inkscape:connector-curvature="0" />
     </marker>
@@ -453,9 +453,9 @@
        orient="auto"
        inkscape:stockid="TriangleOutM">
       <path
-         transform="scale(0.4,0.4)"
+         transform="scale(0.4)"
          style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
-         d="m 5.77,0 -8.65,5 0,-10 8.65,5 z"
+         d="M 5.77,0 -2.88,5 V -5 Z"
          id="path6860-0"
          inkscape:connector-curvature="0" />
     </marker>
@@ -468,9 +468,9 @@
        orient="auto"
        inkscape:stockid="TriangleInM">
       <path
-         transform="scale(-0.4,-0.4)"
+         transform="scale(-0.4)"
          style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
-         d="m 5.77,0 -8.65,5 0,-10 8.65,5 z"
+         d="M 5.77,0 -2.88,5 V -5 Z"
          id="path6790-1-9"
          inkscape:connector-curvature="0" />
     </marker>
@@ -483,9 +483,9 @@
        orient="auto"
        inkscape:stockid="TriangleOutM">
       <path
-         transform="scale(0.4,0.4)"
+         transform="scale(0.4)"
          style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
-         d="m 5.77,0 -8.65,5 0,-10 8.65,5 z"
+         d="M 5.77,0 -2.88,5 V -5 Z"
          id="path6860-0-8"
          inkscape:connector-curvature="0" />
     </marker>
@@ -498,9 +498,9 @@
        orient="auto"
        inkscape:stockid="TriangleInM">
       <path
-         transform="scale(-0.4,-0.4)"
+         transform="scale(-0.4)"
          style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
-         d="m 5.77,0 -8.65,5 0,-10 8.65,5 z"
+         d="M 5.77,0 -2.88,5 V -5 Z"
          id="path6790-1-4"
          inkscape:connector-curvature="0" />
     </marker>
@@ -513,9 +513,9 @@
        orient="auto"
        inkscape:stockid="TriangleOutM">
       <path
-         transform="scale(0.4,0.4)"
+         transform="scale(0.4)"
          style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
-         d="m 5.77,0 -8.65,5 0,-10 8.65,5 z"
+         d="M 5.77,0 -2.88,5 V -5 Z"
          id="path6860-0-5"
          inkscape:connector-curvature="0" />
     </marker>
@@ -528,9 +528,9 @@
        orient="auto"
        inkscape:stockid="TriangleInM">
       <path
-         transform="scale(-0.4,-0.4)"
+         transform="scale(-0.4)"
          style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
-         d="m 5.77,0 -8.65,5 0,-10 8.65,5 z"
+         d="M 5.77,0 -2.88,5 V -5 Z"
          id="path6790-1-8"
          inkscape:connector-curvature="0" />
     </marker>
@@ -543,9 +543,9 @@
        orient="auto"
        inkscape:stockid="TriangleOutM">
       <path
-         transform="scale(0.4,0.4)"
+         transform="scale(0.4)"
          style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
-         d="m 5.77,0 -8.65,5 0,-10 8.65,5 z"
+         d="M 5.77,0 -2.88,5 V -5 Z"
          id="path6860-0-0"
          inkscape:connector-curvature="0" />
     </marker>
@@ -558,9 +558,9 @@
        orient="auto"
        inkscape:stockid="TriangleInM">
       <path
-         transform="scale(-0.4,-0.4)"
+         transform="scale(-0.4)"
          style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
-         d="m 5.77,0 -8.65,5 0,-10 8.65,5 z"
+         d="M 5.77,0 -2.88,5 V -5 Z"
          id="path12346-6"
          inkscape:connector-curvature="0" />
     </marker>
@@ -575,9 +575,9 @@
       <path
          inkscape:connector-curvature="0"
          id="path12476-1"
-         d="m 5.77,0 -8.65,5 0,-10 8.65,5 z"
+         d="M 5.77,0 -2.88,5 V -5 Z"
          style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
-         transform="scale(0.4,0.4)" />
+         transform="scale(0.4)" />
     </marker>
     <marker
        inkscape:stockid="TriangleInM"
@@ -590,9 +590,9 @@
       <path
          inkscape:connector-curvature="0"
          id="path15645-7"
-         d="m 5.77,0 -8.65,5 0,-10 8.65,5 z"
+         d="M 5.77,0 -2.88,5 V -5 Z"
          style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
-         transform="scale(-0.4,-0.4)" />
+         transform="scale(-0.4)" />
     </marker>
     <marker
        inkscape:isstock="true"
@@ -603,9 +603,9 @@
        orient="auto"
        inkscape:stockid="TriangleOutM">
       <path
-         transform="scale(0.4,0.4)"
+         transform="scale(0.4)"
          style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
-         d="m 5.77,0 -8.65,5 0,-10 8.65,5 z"
+         d="M 5.77,0 -2.88,5 V -5 Z"
          id="path15799-3"
          inkscape:connector-curvature="0" />
     </marker>
@@ -620,9 +620,9 @@
       <path
          inkscape:connector-curvature="0"
          id="path15645-3"
-         d="m 5.77,0 -8.65,5 0,-10 8.65,5 z"
+         d="M 5.77,0 -2.88,5 V -5 Z"
          style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
-         transform="scale(-0.4,-0.4)" />
+         transform="scale(-0.4)" />
     </marker>
     <marker
        inkscape:isstock="true"
@@ -633,9 +633,9 @@
        orient="auto"
        inkscape:stockid="TriangleOutM">
       <path
-         transform="scale(0.4,0.4)"
+         transform="scale(0.4)"
          style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
-         d="m 5.77,0 -8.65,5 0,-10 8.65,5 z"
+         d="M 5.77,0 -2.88,5 V -5 Z"
          id="path15799-7"
          inkscape:connector-curvature="0" />
     </marker>
@@ -650,9 +650,9 @@
       <path
          inkscape:connector-curvature="0"
          id="path15645-9"
-         d="m 5.77,0 -8.65,5 0,-10 8.65,5 z"
+         d="M 5.77,0 -2.88,5 V -5 Z"
          style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
-         transform="scale(-0.4,-0.4)" />
+         transform="scale(-0.4)" />
     </marker>
     <marker
        inkscape:isstock="true"
@@ -663,9 +663,9 @@
        orient="auto"
        inkscape:stockid="TriangleOutM">
       <path
-         transform="scale(0.4,0.4)"
+         transform="scale(0.4)"
          style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
-         d="m 5.77,0 -8.65,5 0,-10 8.65,5 z"
+         d="M 5.77,0 -2.88,5 V -5 Z"
          id="path15799-8"
          inkscape:connector-curvature="0" />
     </marker>
@@ -680,9 +680,9 @@
       <path
          inkscape:connector-curvature="0"
          id="path15645-0"
-         d="m 5.77,0 -8.65,5 0,-10 8.65,5 z"
+         d="M 5.77,0 -2.88,5 V -5 Z"
          style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
-         transform="scale(-0.4,-0.4)" />
+         transform="scale(-0.4)" />
     </marker>
     <marker
        inkscape:isstock="true"
@@ -693,9 +693,9 @@
        orient="auto"
        inkscape:stockid="TriangleOutM">
       <path
-         transform="scale(0.4,0.4)"
+         transform="scale(0.4)"
          style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
-         d="m 5.77,0 -8.65,5 0,-10 8.65,5 z"
+         d="M 5.77,0 -2.88,5 V -5 Z"
          id="path15799-77"
          inkscape:connector-curvature="0" />
     </marker>
@@ -710,9 +710,9 @@
       <path
          inkscape:connector-curvature="0"
          id="path15645-09"
-         d="m 5.77,0 -8.65,5 0,-10 8.65,5 z"
+         d="M 5.77,0 -2.88,5 V -5 Z"
          style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
-         transform="scale(-0.4,-0.4)" />
+         transform="scale(-0.4)" />
     </marker>
     <marker
        inkscape:isstock="true"
@@ -723,9 +723,9 @@
        orient="auto"
        inkscape:stockid="TriangleOutM">
       <path
-         transform="scale(0.4,0.4)"
+         transform="scale(0.4)"
          style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
-         d="m 5.77,0 -8.65,5 0,-10 8.65,5 z"
+         d="M 5.77,0 -2.88,5 V -5 Z"
          id="path15799-0"
          inkscape:connector-curvature="0" />
     </marker>
@@ -740,9 +740,9 @@
       <path
          inkscape:connector-curvature="0"
          id="path15645-2"
-         d="m 5.77,0 -8.65,5 0,-10 8.65,5 z"
+         d="M 5.77,0 -2.88,5 V -5 Z"
          style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
-         transform="scale(-0.4,-0.4)" />
+         transform="scale(-0.4)" />
     </marker>
     <marker
        inkscape:isstock="true"
@@ -753,9 +753,9 @@
        orient="auto"
        inkscape:stockid="TriangleOutM">
       <path
-         transform="scale(0.4,0.4)"
+         transform="scale(0.4)"
          style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
-         d="m 5.77,0 -8.65,5 0,-10 8.65,5 z"
+         d="M 5.77,0 -2.88,5 V -5 Z"
          id="path15799-2"
          inkscape:connector-curvature="0" />
     </marker>
@@ -770,9 +770,9 @@
       <path
          inkscape:connector-curvature="0"
          id="path15645-21"
-         d="m 5.77,0 -8.65,5 0,-10 8.65,5 z"
+         d="M 5.77,0 -2.88,5 V -5 Z"
          style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
-         transform="scale(-0.4,-0.4)" />
+         transform="scale(-0.4)" />
     </marker>
     <marker
        inkscape:isstock="true"
@@ -783,9 +783,9 @@
        orient="auto"
        inkscape:stockid="TriangleOutM">
       <path
-         transform="scale(0.4,0.4)"
+         transform="scale(0.4)"
          style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
-         d="m 5.77,0 -8.65,5 0,-10 8.65,5 z"
+         d="M 5.77,0 -2.88,5 V -5 Z"
          id="path15799-4"
          inkscape:connector-curvature="0" />
     </marker>
@@ -800,9 +800,9 @@
       <path
          inkscape:connector-curvature="0"
          id="path15645-4"
-         d="m 5.77,0 -8.65,5 0,-10 8.65,5 z"
+         d="M 5.77,0 -2.88,5 V -5 Z"
          style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
-         transform="scale(-0.4,-0.4)" />
+         transform="scale(-0.4)" />
     </marker>
     <marker
        inkscape:isstock="true"
@@ -813,9 +813,9 @@
        orient="auto"
        inkscape:stockid="TriangleOutM">
       <path
-         transform="scale(0.4,0.4)"
+         transform="scale(0.4)"
          style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
-         d="m 5.77,0 -8.65,5 0,-10 8.65,5 z"
+         d="M 5.77,0 -2.88,5 V -5 Z"
          id="path15799-27"
          inkscape:connector-curvature="0" />
     </marker>
@@ -830,9 +830,9 @@
       <path
          inkscape:connector-curvature="0"
          id="path15645-77"
-         d="m 5.77,0 -8.65,5 0,-10 8.65,5 z"
+         d="M 5.77,0 -2.88,5 V -5 Z"
          style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
-         transform="scale(-0.4,-0.4)" />
+         transform="scale(-0.4)" />
     </marker>
     <marker
        inkscape:isstock="true"
@@ -843,9 +843,9 @@
        orient="auto"
        inkscape:stockid="TriangleOutM">
       <path
-         transform="scale(0.4,0.4)"
+         transform="scale(0.4)"
          style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
-         d="m 5.77,0 -8.65,5 0,-10 8.65,5 z"
+         d="M 5.77,0 -2.88,5 V -5 Z"
          id="path15799-9"
          inkscape:connector-curvature="0" />
     </marker>
@@ -860,9 +860,9 @@
       <path
          inkscape:connector-curvature="0"
          id="path15645-32"
-         d="m 5.77,0 -8.65,5 0,-10 8.65,5 z"
+         d="M 5.77,0 -2.88,5 V -5 Z"
          style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
-         transform="scale(-0.4,-0.4)" />
+         transform="scale(-0.4)" />
     </marker>
     <marker
        inkscape:isstock="true"
@@ -873,9 +873,9 @@
        orient="auto"
        inkscape:stockid="TriangleOutM">
       <path
-         transform="scale(0.4,0.4)"
+         transform="scale(0.4)"
          style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
-         d="m 5.77,0 -8.65,5 0,-10 8.65,5 z"
+         d="M 5.77,0 -2.88,5 V -5 Z"
          id="path15799-1"
          inkscape:connector-curvature="0" />
     </marker>
@@ -890,9 +890,9 @@
       <path
          inkscape:connector-curvature="0"
          id="path15645-20"
-         d="m 5.77,0 -8.65,5 0,-10 8.65,5 z"
+         d="M 5.77,0 -2.88,5 V -5 Z"
          style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
-         transform="scale(-0.4,-0.4)" />
+         transform="scale(-0.4)" />
     </marker>
     <marker
        inkscape:stockid="TriangleInM"
@@ -905,9 +905,9 @@
       <path
          inkscape:connector-curvature="0"
          id="path15645-20-0"
-         d="m 5.77,0 -8.65,5 0,-10 8.65,5 z"
+         d="M 5.77,0 -2.88,5 V -5 Z"
          style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
-         transform="scale(-0.4,-0.4)" />
+         transform="scale(-0.4)" />
     </marker>
     <marker
        inkscape:stockid="TriangleInM"
@@ -920,9 +920,9 @@
       <path
          inkscape:connector-curvature="0"
          id="path15645-1"
-         d="m 5.77,0 -8.65,5 0,-10 8.65,5 z"
+         d="M 5.77,0 -2.88,5 V -5 Z"
          style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
-         transform="scale(-0.4,-0.4)" />
+         transform="scale(-0.4)" />
     </marker>
     <marker
        inkscape:stockid="TriangleInM"
@@ -935,9 +935,9 @@
       <path
          inkscape:connector-curvature="0"
          id="path15645-1-5"
-         d="m 5.77,0 -8.65,5 0,-10 8.65,5 z"
+         d="M 5.77,0 -2.88,5 V -5 Z"
          style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
-         transform="scale(-0.4,-0.4)" />
+         transform="scale(-0.4)" />
     </marker>
     <marker
        inkscape:stockid="TriangleOutM"
@@ -950,9 +950,9 @@
       <path
          inkscape:connector-curvature="0"
          id="path20479"
-         d="m 5.77,0 -8.65,5 0,-10 8.65,5 z"
+         d="M 5.77,0 -2.88,5 V -5 Z"
          style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
-         transform="scale(0.4,0.4)" />
+         transform="scale(0.4)" />
     </marker>
     <marker
        inkscape:stockid="DiamondMstart"
@@ -965,7 +965,7 @@
       <path
          inkscape:connector-curvature="0"
          id="path5002"
-         d="M 0,-7.0710768 -7.0710894,0 0,7.0710589 7.0710462,0 0,-7.0710768 Z"
+         d="M 0,-7.0710768 -7.0710894,0 0,7.0710589 7.0710462,0 Z"
          style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
          transform="matrix(0.4,0,0,0.4,2.6,0)" />
     </marker>
@@ -978,9 +978,9 @@
        orient="auto"
        inkscape:stockid="TriangleOutM">
       <path
-         transform="scale(0.4,0.4)"
-         style="fill:#000000;fill-opacity:0.64130435;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:0.64130435"
-         d="m 5.77,0 -8.65,5 0,-10 8.65,5 z"
+         transform="scale(0.4)"
+         style="fill:#000000;fill-opacity:0.641304;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:0.641304"
+         d="M 5.77,0 -2.88,5 V -5 Z"
          id="path16785"
          inkscape:connector-curvature="0" />
     </marker>
@@ -993,9 +993,9 @@
        orient="auto"
        inkscape:stockid="TriangleOutM">
       <path
-         transform="scale(0.4,0.4)"
-         style="fill:#000000;fill-opacity:0.45108696;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:0.45108696"
-         d="m 5.77,0 -8.65,5 0,-10 8.65,5 z"
+         transform="scale(0.4)"
+         style="fill:#000000;fill-opacity:0.451087;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:0.451087"
+         d="M 5.77,0 -2.88,5 V -5 Z"
          id="path16975"
          inkscape:connector-curvature="0" />
     </marker>
@@ -1010,9 +1010,9 @@
       <path
          inkscape:connector-curvature="0"
          id="path5047-1-7-3"
-         d="m 5.77,0 -8.65,5 0,-10 8.65,5 z"
+         d="M 5.77,0 -2.88,5 V -5 Z"
          style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
-         transform="scale(-0.4,-0.4)" />
+         transform="scale(-0.4)" />
     </marker>
     <marker
        inkscape:stockid="TriangleInM"
@@ -1025,9 +1025,9 @@
       <path
          inkscape:connector-curvature="0"
          id="path5047-1-7"
-         d="m 5.77,0 -8.65,5 0,-10 8.65,5 z"
+         d="M 5.77,0 -2.88,5 V -5 Z"
          style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
-         transform="scale(-0.4,-0.4)" />
+         transform="scale(-0.4)" />
     </marker>
     <marker
        inkscape:stockid="TriangleInM"
@@ -1040,9 +1040,9 @@
       <path
          inkscape:connector-curvature="0"
          id="path5047-1"
-         d="m 5.77,0 -8.65,5 0,-10 8.65,5 z"
+         d="M 5.77,0 -2.88,5 V -5 Z"
          style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
-         transform="scale(-0.4,-0.4)" />
+         transform="scale(-0.4)" />
     </marker>
     <marker
        inkscape:isstock="true"
@@ -1053,9 +1053,9 @@
        orient="auto"
        inkscape:stockid="TriangleOutM">
       <path
-         transform="scale(0.4,0.4)"
+         transform="scale(0.4)"
          style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
-         d="m 5.77,0 -8.65,5 0,-10 8.65,5 z"
+         d="M 5.77,0 -2.88,5 V -5 Z"
          id="path9188"
          inkscape:connector-curvature="0" />
     </marker>
@@ -1068,9 +1068,9 @@
        orient="auto"
        inkscape:stockid="TriangleInM">
       <path
-         transform="scale(-0.4,-0.4)"
+         transform="scale(-0.4)"
          style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
-         d="m 5.77,0 -8.65,5 0,-10 8.65,5 z"
+         d="M 5.77,0 -2.88,5 V -5 Z"
          id="path6790-1-8-9"
          inkscape:connector-curvature="0" />
     </marker>
@@ -1083,9 +1083,9 @@
        orient="auto"
        inkscape:stockid="TriangleOutM">
       <path
-         transform="scale(0.4,0.4)"
+         transform="scale(0.4)"
          style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
-         d="m 5.77,0 -8.65,5 0,-10 8.65,5 z"
+         d="M 5.77,0 -2.88,5 V -5 Z"
          id="path6860-0-0-8"
          inkscape:connector-curvature="0" />
     </marker>
@@ -1099,9 +1099,9 @@
        inkscape:isstock="true">
       <path
          id="path4580-2"
-         d="m 5.77,0 -8.65,5 0,-10 8.65,5 z"
+         d="M 5.77,0 -2.88,5 V -5 Z"
          style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
-         transform="scale(0.4,0.4)"
+         transform="scale(0.4)"
          inkscape:connector-curvature="0" />
     </marker>
     <marker
@@ -1113,9 +1113,9 @@
        orient="auto"
        inkscape:stockid="TriangleInM">
       <path
-         transform="scale(-0.4,-0.4)"
+         transform="scale(-0.4)"
          style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
-         d="m 5.77,0 -8.65,5 0,-10 8.65,5 z"
+         d="M 5.77,0 -2.88,5 V -5 Z"
          id="path10935-1"
          inkscape:connector-curvature="0" />
     </marker>
@@ -1129,9 +1129,9 @@
        inkscape:stockid="TriangleOutM"
        inkscape:collect="always">
       <path
-         transform="scale(0.4,0.4)"
+         transform="scale(0.4)"
          style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
-         d="m 5.77,0 -8.65,5 0,-10 8.65,5 z"
+         d="M 5.77,0 -2.88,5 V -5 Z"
          id="path11407-6"
          inkscape:connector-curvature="0" />
     </marker>
@@ -1145,9 +1145,9 @@
        inkscape:isstock="true">
       <path
          id="path4580-4"
-         d="m 5.77,0 -8.65,5 0,-10 8.65,5 z"
+         d="M 5.77,0 -2.88,5 V -5 Z"
          style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
-         transform="scale(0.4,0.4)"
+         transform="scale(0.4)"
          inkscape:connector-curvature="0" />
     </marker>
     <marker
@@ -1159,9 +1159,9 @@
        orient="auto"
        inkscape:stockid="TriangleInM">
       <path
-         transform="scale(-0.4,-0.4)"
+         transform="scale(-0.4)"
          style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
-         d="m 5.77,0 -8.65,5 0,-10 8.65,5 z"
+         d="M 5.77,0 -2.88,5 V -5 Z"
          id="path10935-1-0"
          inkscape:connector-curvature="0" />
     </marker>
@@ -1174,9 +1174,9 @@
        orient="auto"
        inkscape:stockid="TriangleOutM">
       <path
-         transform="scale(0.4,0.4)"
+         transform="scale(0.4)"
          style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
-         d="m 5.77,0 -8.65,5 0,-10 8.65,5 z"
+         d="M 5.77,0 -2.88,5 V -5 Z"
          id="path11407-6-4"
          inkscape:connector-curvature="0" />
     </marker>
@@ -1189,9 +1189,9 @@
        orient="auto"
        inkscape:stockid="TriangleInM">
       <path
-         transform="scale(-0.4,-0.4)"
+         transform="scale(-0.4)"
          style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
-         d="m 5.77,0 -8.65,5 0,-10 8.65,5 z"
+         d="M 5.77,0 -2.88,5 V -5 Z"
          id="path10935-1-4"
          inkscape:connector-curvature="0" />
     </marker>
@@ -1205,9 +1205,9 @@
        inkscape:stockid="TriangleOutM"
        inkscape:collect="always">
       <path
-         transform="scale(0.4,0.4)"
+         transform="scale(0.4)"
          style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
-         d="m 5.77,0 -8.65,5 0,-10 8.65,5 z"
+         d="M 5.77,0 -2.88,5 V -5 Z"
          id="path11407-6-5"
          inkscape:connector-curvature="0" />
     </marker>
@@ -1220,9 +1220,9 @@
        orient="auto"
        inkscape:stockid="TriangleInM">
       <path
-         transform="scale(-0.4,-0.4)"
+         transform="scale(-0.4)"
          style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
-         d="m 5.77,0 -8.65,5 0,-10 8.65,5 z"
+         d="M 5.77,0 -2.88,5 V -5 Z"
          id="path10935-1-2"
          inkscape:connector-curvature="0" />
     </marker>
@@ -1234,16 +1234,16 @@
      borderopacity="1.0"
      inkscape:pageopacity="0.0"
      inkscape:pageshadow="2"
-     inkscape:zoom="1.4142136"
-     inkscape:cx="528.56229"
-     inkscape:cy="297.69194"
+     inkscape:zoom="0.7071068"
+     inkscape:cx="173.94826"
+     inkscape:cy="497.09605"
      inkscape:document-units="px"
-     inkscape:current-layer="layer2"
+     inkscape:current-layer="layer1"
      showgrid="true"
-     inkscape:window-width="1920"
-     inkscape:window-height="1122"
-     inkscape:window-x="4791"
-     inkscape:window-y="738"
+     inkscape:window-width="2400"
+     inkscape:window-height="1272"
+     inkscape:window-x="2392"
+     inkscape:window-y="233"
      inkscape:window-maximized="1"
      inkscape:snap-grids="false"
      inkscape:snap-bbox="false"
@@ -1251,11 +1251,12 @@
      units="px"
      inkscape:showpageshadow="2"
      inkscape:pagecheckerboard="0"
-     inkscape:deskcolor="#d1d1d1">
+     inkscape:deskcolor="#d1d1d1"
+     showguides="false">
     <inkscape:grid
        type="xygrid"
        id="grid6887"
-       originx="0"
+       originx="60.232231"
        originy="0"
        spacingy="1"
        spacingx="1"
@@ -1279,25 +1280,25 @@
      id="layer5"
      inkscape:label="connections"
      style="display:inline"
-     transform="translate(0,200.90552)">
+     transform="translate(60.232231,200.90552)">
     <rect
        style="opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
        id="rect4487"
        width="24.426308"
        height="615.23602"
-       x="15.286846"
+       x="-44.712997"
        y="39.381329" />
     <text
        xml:space="preserve"
        style="font-style:normal;font-weight:normal;line-height:0%;font-family:Arial;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
        x="-458.33112"
-       y="33.763428"
+       y="-26.236752"
        id="text4489"
        transform="rotate(-90)"><tspan
          sodipodi:role="line"
          id="tspan4491"
          x="-458.33112"
-         y="33.763428"
+         y="-26.236752"
          style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:17.5px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial Bold'">MEMORY INTERCONNECT</tspan></text>
   </g>
   <g
@@ -1305,14 +1306,14 @@
      id="layer3"
      inkscape:label="sys_frame"
      style="display:inline"
-     transform="translate(0,200.90552)">
+     transform="translate(60.232231,200.90552)">
     <rect
-       style="display:inline;opacity:1;fill:#000000;fill-opacity:0;fill-rule:nonzero;stroke:#000000;stroke-width:2.04336667;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:0;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       style="display:inline;opacity:1;fill:#000000;fill-opacity:0;fill-rule:nonzero;stroke:#000000;stroke-width:2.11817;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:0;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
        id="rect4477"
-       width="770.1889"
-       height="839.76642"
-       x="6.897213"
-       y="-136.53795" />
+       width="827.68182"
+       height="839.69159"
+       x="-51.827911"
+       y="-136.50055" />
     <g
        transform="translate(0,-594.26771)"
        style="display:inline;stroke:#0f3296;stroke-opacity:1;shape-rendering:crispEdges;enable-background:new"
@@ -1324,7 +1325,7 @@
         <path
            inkscape:connector-curvature="0"
            id="path5806"
-           d="m 130.47421,546.58376 10.03208,14.84925 0,-6.80591 12.46375,-3e-5 0,-8.04181 0,-8.04181 -12.46375,3e-5 0,-6.80591 -10.03208,14.84925"
+           d="m 130.47421,546.58376 10.03208,14.84925 v -6.80591 l 12.46375,-3e-5 v -8.04181 -8.04181 l -12.46375,3e-5 v -6.80591 l -10.03208,14.84925"
            style="fill:#0f3296;fill-opacity:1;fill-rule:evenodd;stroke:#0f3296;stroke-width:1px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1"
            sodipodi:nodetypes="ccccccccc" />
       </g>
@@ -1335,7 +1336,7 @@
         <path
            inkscape:connector-curvature="0"
            id="path5810"
-           d="m 130.47421,546.58376 10.03208,14.84925 0,-6.80591 12.76375,-3e-5 0,-8.04181 0,-8.04181 -12.76375,3e-5 0,-6.80591 -10.03208,14.84925"
+           d="m 130.47421,546.58376 10.03208,14.84925 v -6.80591 l 12.76375,-3e-5 v -8.04181 -8.04181 l -12.76375,3e-5 v -6.80591 l -10.03208,14.84925"
            style="fill:#0f3296;fill-opacity:1;fill-rule:evenodd;stroke:#0f3296;stroke-width:1px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1"
            sodipodi:nodetypes="ccccccccc" />
       </g>
@@ -1346,7 +1347,7 @@
         <path
            inkscape:connector-curvature="0"
            id="path5814"
-           d="m 130.47421,546.58376 10.03208,14.84925 0,-6.80591 12.96375,-3e-5 0,-8.04181 0,-8.04181 -12.96375,3e-5 0,-6.80591 -10.03208,14.84925"
+           d="m 130.47421,546.58376 10.03208,14.84925 v -6.80591 l 12.96375,-3e-5 v -8.04181 -8.04181 l -12.96375,3e-5 v -6.80591 l -10.03208,14.84925"
            style="fill:#0f3296;fill-opacity:1;fill-rule:evenodd;stroke:#0f3296;stroke-width:1px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1"
            sodipodi:nodetypes="ccccccccc" />
       </g>
@@ -1357,7 +1358,7 @@
         <path
            inkscape:connector-curvature="0"
            id="path5818"
-           d="m 130.47421,546.58376 10.03208,14.84925 0,-6.80591 12.66375,-3e-5 0,-8.04181 0,-8.04181 -12.66375,3e-5 0,-6.80591 -10.03208,14.84925"
+           d="m 130.47421,546.58376 10.03208,14.84925 v -6.80591 l 12.66375,-3e-5 v -8.04181 -8.04181 l -12.66375,3e-5 v -6.80591 l -10.03208,14.84925"
            style="fill:#0f3296;fill-opacity:1;fill-rule:evenodd;stroke:#0f3296;stroke-width:1px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1"
            sodipodi:nodetypes="ccccccccc" />
       </g>
@@ -1367,7 +1368,7 @@
      inkscape:groupmode="layer"
      id="layer4"
      inkscape:label="sys_text"
-     transform="translate(0,200.90552)"
+     transform="translate(60.232231,200.90552)"
      style="display:inline">
     <text
        xml:space="preserve"
@@ -1433,7 +1434,7 @@
        x="-466.41095"
        y="752.81696"
        id="text10629-4"
-       transform="matrix(0,-1.3097463,0.76350666,0,0,0)"><tspan
+       transform="matrix(0,-1.3097463,0.76350665,0,0,0)"><tspan
          sodipodi:role="line"
          x="-464.15356"
          y="752.81696"
@@ -1470,7 +1471,7 @@
            height="25.05477"
            x="-683.51202"
            y="-406.4104"
-           transform="scale(-1,-1)" />
+           transform="scale(-1)" />
         <text
            xml:space="preserve"
            style="font-style:normal;font-weight:normal;line-height:0%;font-family:Arial;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;shape-rendering:crispEdges;enable-background:new"
@@ -1503,7 +1504,7 @@
        x="-565.77026"
        y="408.85864"
        id="text4598"
-       transform="matrix(0,-1.2017304,0.83213338,0,0,0)"><tspan
+       transform="matrix(0,-1.2017304,0.83213339,0,0,0)"><tspan
          sodipodi:role="line"
          id="tspan4600"
          x="-565.77026"
@@ -1539,13 +1540,13 @@
       <path
          sodipodi:nodetypes="ccccc"
          style="fill:#a01414;fill-opacity:1;fill-rule:evenodd;stroke:#a01414;stroke-width:1px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1"
-         d="m 129.93087,544.16004 10.03208,-14.84925 0,6.80591 15.51405,-3e-5 0,8.04334"
+         d="m 129.93087,544.16004 10.03208,-14.84925 v 6.80591 l 15.51405,-3e-5 v 8.04334"
          id="path5128"
          inkscape:connector-curvature="0" />
       <path
          inkscape:connector-curvature="0"
          id="path5130"
-         d="m 129.93087,544.15698 10.03208,14.84925 0,-6.80591 15.31405,-3e-5 0,-8.04334"
+         d="m 129.93087,544.15698 10.03208,14.84925 v -6.80591 l 15.31405,-3e-5 v -8.04334"
          style="fill:#a01414;fill-opacity:1;fill-rule:evenodd;stroke:#a01414;stroke-width:1px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1"
          sodipodi:nodetypes="ccccc" />
     </g>
@@ -1556,13 +1557,13 @@
       <path
          sodipodi:nodetypes="ccccc"
          style="fill:#a01414;fill-opacity:1;fill-rule:evenodd;stroke:#a01414;stroke-width:1px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1"
-         d="m 129.93087,544.16004 10.03208,-14.84925 0,6.80591 10.81421,-3e-5 0,8.04334"
+         d="m 129.93087,544.16004 10.03208,-14.84925 v 6.80591 l 10.81421,-3e-5 v 8.04334"
          id="path5128-8"
          inkscape:connector-curvature="0" />
       <path
          inkscape:connector-curvature="0"
          id="path5130-3"
-         d="m 129.93087,544.15698 10.03208,14.84925 0,-6.80591 10.81421,-3e-5 0,-8.04334"
+         d="m 129.93087,544.15698 10.03208,14.84925 v -6.80591 l 10.81421,-3e-5 v -8.04334"
          style="fill:#a01414;fill-opacity:1;fill-rule:evenodd;stroke:#a01414;stroke-width:1px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1"
          sodipodi:nodetypes="ccccc" />
     </g>
@@ -1573,13 +1574,13 @@
       <path
          sodipodi:nodetypes="ccccc"
          style="fill:#a01414;fill-opacity:1;fill-rule:evenodd;stroke:#a01414;stroke-width:1px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1"
-         d="m 129.93087,544.16004 10.03208,-14.84925 0,6.80591 11.41409,-3e-5 0,8.04334"
+         d="m 129.93087,544.16004 10.03208,-14.84925 v 6.80591 l 11.41409,-3e-5 v 8.04334"
          id="path5128-8-4"
          inkscape:connector-curvature="0" />
       <path
          inkscape:connector-curvature="0"
          id="path5130-3-5"
-         d="m 129.93087,544.15698 10.03208,14.84925 0,-6.80591 11.41409,-3e-5 0,-8.04334"
+         d="m 129.93087,544.15698 10.03208,14.84925 v -6.80591 l 11.41409,-3e-5 v -8.04334"
          style="fill:#a01414;fill-opacity:1;fill-rule:evenodd;stroke:#a01414;stroke-width:1px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1"
          sodipodi:nodetypes="ccccc" />
     </g>
@@ -1602,13 +1603,13 @@
       <path
          sodipodi:nodetypes="ccccc"
          style="fill:#0f3296;fill-opacity:1;fill-rule:evenodd;stroke:#0f3296;stroke-width:1px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1"
-         d="m 129.93087,544.16004 10.03208,-14.84925 0,6.80591 11.41409,-3e-5 0,8.04334"
+         d="m 129.93087,544.16004 10.03208,-14.84925 v 6.80591 l 11.41409,-3e-5 v 8.04334"
          id="path5128-8-4-4-7"
          inkscape:connector-curvature="0" />
       <path
          inkscape:connector-curvature="0"
          id="path5130-3-5-5-1"
-         d="m 129.93087,544.15698 10.03208,14.84925 0,-6.80591 11.41409,-3e-5 0,-8.04334"
+         d="m 129.93087,544.15698 10.03208,14.84925 v -6.80591 l 11.41409,-3e-5 v -8.04334"
          style="fill:#0f3296;fill-opacity:1;fill-rule:evenodd;stroke:#0f3296;stroke-width:1px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1"
          sodipodi:nodetypes="ccccc" />
     </g>
@@ -1628,7 +1629,7 @@
      inkscape:label="up_frame"
      inkscape:groupmode="layer"
      id="layer1"
-     transform="translate(0,-107.36219)"
+     transform="translate(60.232231,-107.36219)"
      style="display:inline">
     <g
        style="display:inline"
@@ -1660,13 +1661,13 @@
       <path
          sodipodi:nodetypes="ccccc"
          style="fill:#0f3296;fill-opacity:1;fill-rule:evenodd;stroke:#0f3296;stroke-width:1px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1"
-         d="m 129.93087,544.16004 10.03208,-14.84925 0,6.80591 11.41409,-3e-5 0,8.04334"
+         d="m 129.93087,544.16004 10.03208,-14.84925 v 6.80591 l 11.41409,-3e-5 v 8.04334"
          id="path5128-8-4-4"
          inkscape:connector-curvature="0" />
       <path
          inkscape:connector-curvature="0"
          id="path5130-3-5-5"
-         d="m 129.93087,544.15698 10.03208,14.84925 0,-6.80591 11.41409,-3e-5 0,-8.04334"
+         d="m 129.93087,544.15698 10.03208,14.84925 v -6.80591 l 11.41409,-3e-5 v -8.04334"
          style="fill:#0f3296;fill-opacity:1;fill-rule:evenodd;stroke:#0f3296;stroke-width:1px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1"
          sodipodi:nodetypes="ccccc" />
     </g>
@@ -1677,13 +1678,13 @@
       <path
          sodipodi:nodetypes="ccccc"
          style="fill:#0f3296;fill-opacity:1;fill-rule:evenodd;stroke:#0f3296;stroke-width:1px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1"
-         d="m 129.93087,544.16004 10.03208,-14.84925 0,6.80591 16.41432,-3e-5 0,8.04334"
+         d="m 129.93087,544.16004 10.03208,-14.84925 v 6.80591 l 16.41432,-3e-5 v 8.04334"
          id="path5128-8-4-4-7-4"
          inkscape:connector-curvature="0" />
       <path
          inkscape:connector-curvature="0"
          id="path5130-3-5-5-1-1"
-         d="m 129.93087,544.15698 10.03208,14.84925 0,-6.80591 16.41432,-3e-5 0,-8.04334"
+         d="m 129.93087,544.15698 10.03208,14.84925 v -6.80591 l 16.41432,-3e-5 v -8.04334"
          style="fill:#0f3296;fill-opacity:1;fill-rule:evenodd;stroke:#0f3296;stroke-width:1px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1"
          sodipodi:nodetypes="ccccc" />
     </g>
@@ -1707,18 +1708,18 @@
          y="658.67419"
          style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:17.5px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial Bold'">TX JESD LINK</tspan></text>
     <g
-       transform="matrix(-1,0,0,1,193.33596,-124.11672)"
+       transform="matrix(-1,0,0,1,133.33581,-124.11672)"
        style="display:inline;fill:#c8c8c8;fill-opacity:1;shape-rendering:crispEdges;enable-background:new"
        id="g5327">
       <path
          sodipodi:nodetypes="ccccccccc"
          style="fill:#0f3296;fill-opacity:1;fill-rule:evenodd;stroke:#0f3296;stroke-width:1px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1"
-         d="m 130.47421,546.58376 10.03208,14.84925 0,-6.80591 12.46375,-3e-5 0,-8.04181 0,-8.04181 -12.46375,3e-5 0,-6.80591 -10.03208,14.84925"
+         d="m 130.47421,546.58376 10.03208,14.84925 v -6.80591 l 12.46375,-3e-5 v -8.04181 -8.04181 l -12.46375,3e-5 v -6.80591 l -10.03208,14.84925"
          id="path5329"
          inkscape:connector-curvature="0" />
     </g>
     <rect
-       style="display:inline;opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:#0f3296;stroke-width:1.75223482;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;shape-rendering:crispEdges;enable-background:new"
+       style="display:inline;opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:#0f3296;stroke-width:1.75223;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;shape-rendering:crispEdges;enable-background:new"
        id="daccore0"
        width="265.15012"
        height="199.1138"
@@ -1784,14 +1785,14 @@
                sodipodi:role="line">IQ </tspan><tspan
                style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:12.5px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:center;text-anchor:middle"
                id="tspan4580-1"
-               y="722.27789"
+               y="724.7937"
                x="350.12421"
                sodipodi:role="line">Correction</tspan></text>
         </g>
         <g
            id="g5971">
           <g
-             transform="translate(1.49999,0)"
+             transform="translate(1.49999)"
              id="g5848">
             <path
                style="opacity:1;fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;shape-rendering:crispEdges"
@@ -1846,18 +1847,18 @@
              sodipodi:nodetypes="ccccc"
              inkscape:connector-curvature="0"
              id="rect17615-8-1-0"
-             d="m 269.579,666.41165 18.8981,12.22282 0,58.08613 -18.8981,12.22278 z"
+             d="m 269.579,666.41165 18.8981,12.22282 v 58.08613 l -18.8981,12.22278 z"
              style="display:inline;opacity:1;fill:#ebebeb;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;shape-rendering:crispEdges;enable-background:new" />
           <path
              sodipodi:nodetypes="cc"
              inkscape:connector-curvature="0"
              id="path5744"
-             d="m 289,707.86219 24.85225,0"
+             d="m 289,707.86219 h 24.85225"
              style="display:inline;fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;shape-rendering:crispEdges;enable-background:new" />
         </g>
         <path
            style="display:inline;fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#marker5537);shape-rendering:crispEdges;enable-background:new"
-           d="m 390.1765,707.37035 22.62741,0"
+           d="m 390.1765,707.37035 h 22.62741"
            id="path5746"
            inkscape:connector-curvature="0"
            sodipodi:nodetypes="cc" />
@@ -1890,7 +1891,7 @@
        transform="translate(4,-286.01547)">
       <path
          style="fill:#c8c8c8;fill-opacity:1;fill-rule:evenodd;stroke:#0f3296;stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;shape-rendering:crispEdges"
-         d="m 447.48655,733.96144 0,-6.1966 -28.90705,0 c 0,0 -0.0827,-5.53177 -0.083,-8.24218 -1.7e-4,-2.71041 0.082,-8.24219 0.082,-8.24219 l 28.90813,0 0,-6.19659 14.64737,14.43878 z"
+         d="m 447.48655,733.96144 v -6.1966 H 418.5795 c 0,0 -0.0827,-5.53177 -0.083,-8.24218 -1.7e-4,-2.71041 0.082,-8.24219 0.082,-8.24219 h 28.90813 v -6.19659 l 14.64737,14.43878 z"
          id="path34982-7-5-9-2"
          inkscape:connector-curvature="0"
          sodipodi:nodetypes="cccsccccc" />
@@ -1898,11 +1899,11 @@
          sodipodi:nodetypes="cccsccccc"
          inkscape:connector-curvature="0"
          id="path5390"
-         d="m 447.48607,722.99477 0,-6.1966 -26.09807,-4.6e-4 c 0,0 3e-4,-5.53177 0,-8.24218 -1.7e-4,-2.71041 0,-8.24219 0,-8.24219 l 26.09815,4.6e-4 0,-6.19659 14.64737,14.43878 z"
+         d="m 447.48607,722.99477 v -6.1966 l -26.09807,-4.6e-4 c 0,0 3e-4,-5.53177 0,-8.24218 -1.7e-4,-2.71041 0,-8.24219 0,-8.24219 l 26.09815,4.6e-4 v -6.19659 l 14.64737,14.43878 z"
          style="fill:#c8c8c8;fill-opacity:1;fill-rule:evenodd;stroke:#0f3296;stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;shape-rendering:crispEdges" />
       <path
          style="fill:#c8c8c8;fill-opacity:1;fill-rule:evenodd;stroke:#0f3296;stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;shape-rendering:crispEdges"
-         d="m 447.88607,712.0281 0,-6.1966 -23.34807,-4.6e-4 c 0,0 3e-4,-5.53178 0,-8.24218 -1.7e-4,-2.71041 0,-8.24219 0,-8.24219 l 23.34815,4.6e-4 0,-6.19659 14.64737,14.43878 z"
+         d="m 447.88607,712.0281 v -6.1966 l -23.34807,-4.6e-4 c 0,0 3e-4,-5.53178 0,-8.24218 -1.7e-4,-2.71041 0,-8.24219 0,-8.24219 l 23.34815,4.6e-4 v -6.19659 l 14.64737,14.43878 z"
          id="path5392"
          inkscape:connector-curvature="0"
          sodipodi:nodetypes="cccsccccc" />
@@ -1910,11 +1911,11 @@
          sodipodi:nodetypes="cccsccccc"
          inkscape:connector-curvature="0"
          id="path5394"
-         d="m 447.38661,701.06142 0,-6.1966 -19.70261,0 c 0,0 3e-4,-5.53177 0,-8.24218 -1.7e-4,-2.71041 0,-8.24219 0,-8.24219 l 19.70269,0 0,-6.19659 14.64737,14.43878 z"
+         d="m 447.38661,701.06142 v -6.1966 H 427.684 c 0,0 3e-4,-5.53177 0,-8.24218 -1.7e-4,-2.71041 0,-8.24219 0,-8.24219 h 19.70269 v -6.19659 l 14.64737,14.43878 z"
          style="fill:#c8c8c8;fill-opacity:1;fill-rule:evenodd;stroke:#0f3296;stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;shape-rendering:crispEdges" />
     </g>
     <rect
-       style="display:inline;opacity:1;fill:#4cbeef;fill-opacity:0;fill-rule:nonzero;stroke:#a01414;stroke-width:1.75891232;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;shape-rendering:crispEdges;enable-background:new"
+       style="display:inline;opacity:1;fill:#4cbeef;fill-opacity:0;fill-rule:nonzero;stroke:#a01414;stroke-width:1.75891;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;shape-rendering:crispEdges;enable-background:new"
        id="daccore0-6"
        width="267.51556"
        height="199.20163"
@@ -2003,61 +2004,61 @@
          sodipodi:nodetypes="ccccc"
          inkscape:connector-curvature="0"
          id="rect17615-8"
-         d="m 308.88845,597.53506 -15.43356,9.09168 0,43.20616 15.43356,9.09164 z"
+         d="m 308.88845,597.53506 -15.43356,9.09168 v 43.20616 l 15.43356,9.09164 z"
          style="display:inline;opacity:1;fill:#ebebeb;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;shape-rendering:crispEdges;enable-background:new" />
       <circle
          r="0.80001962"
          cy="607.32825"
          cx="372.88"
          id="path4594"
-         style="opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:1.39996076;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+         style="opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:1.39996;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
       <path
          sodipodi:nodetypes="cc"
          inkscape:connector-curvature="0"
          id="path4588"
-         d="m 318.72617,651.30233 -9.67428,0"
+         d="m 318.72617,651.30233 h -9.67428"
          style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
       <path
          sodipodi:nodetypes="cc"
          inkscape:connector-curvature="0"
          id="path4590"
-         d="m 309.28098,607.431 90.01361,0"
+         d="m 309.28098,607.431 h 90.01361"
          style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
       <path
          sodipodi:nodetypes="ccc"
          inkscape:connector-curvature="0"
          id="path4596"
-         d="m 363.718,651.30848 9.17178,0 0,-44.36488"
+         d="m 363.718,651.30848 h 9.17178 V 606.9436"
          style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
       <path
          sodipodi:nodetypes="ccccc"
          inkscape:connector-curvature="0"
          id="rect17615-8-1"
-         d="m 223.7415,597.53506 -15.43356,9.09168 0,43.20616 15.43356,9.09164 z"
+         d="m 223.7415,597.53506 -15.43356,9.09168 v 43.20616 l 15.43356,9.09164 z"
          style="display:inline;opacity:1;fill:#ebebeb;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;shape-rendering:crispEdges;enable-background:new" />
       <path
          sodipodi:nodetypes="cccc"
          inkscape:connector-curvature="0"
          id="path4647"
-         d="m 293.34323,628.21724 -6.38996,0 0,23.22885 -8.273,0"
+         d="m 293.34323,628.21724 h -6.38996 v 23.22885 h -8.273"
          style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
       <path
          sodipodi:nodetypes="ccc"
          inkscape:connector-curvature="0"
          id="path4649"
-         d="m 286.994,628.07979 0,-20.51572 -63.18736,0"
+         d="M 286.994,628.07979 V 607.56407 H 223.80664"
          style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
       <circle
          r="0.80001962"
          cy="628.02197"
          cx="287.06549"
          id="path4594-8"
-         style="display:inline;opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:1.39996076;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;shape-rendering:crispEdges;enable-background:new" />
+         style="display:inline;opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:1.39996;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;shape-rendering:crispEdges;enable-background:new" />
       <path
          sodipodi:nodetypes="cc"
          inkscape:connector-curvature="0"
          id="path4666"
-         d="m 231.994,651.43904 -7.86961,0"
+         d="m 231.994,651.43904 h -7.86961"
          style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
       <path
          sodipodi:nodetypes="cc"
@@ -2069,25 +2070,25 @@
          transform="matrix(1.1885989,0,0,1.1885989,-59.978473,-122.41168)"
          id="g6385">
         <rect
-           style="opacity:1;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#a01414;stroke-width:0.84132671;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+           style="opacity:1;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#a01414;stroke-width:0.841327;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
            id="rect4910"
            width="36.778587"
            height="37.394592"
            x="-669.02423"
            y="318.93008"
-           transform="matrix(0,-1,1,0,0,0)" />
+           transform="rotate(-90)" />
       </g>
       <g
          transform="matrix(1.2167645,0,0,1.2167645,-55.136833,-148.59717)"
          id="g5922">
         <rect
-           style="display:inline;opacity:1;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#a01414;stroke-width:0.82185173;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;shape-rendering:crispEdges;enable-background:new"
+           style="display:inline;opacity:1;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#a01414;stroke-width:0.821852;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;shape-rendering:crispEdges;enable-background:new"
            id="rect4910-9"
            width="35.647327"
            height="37.94709"
            x="-674.91833"
            y="236.10585"
-           transform="matrix(0,-1,1,0,0,0)" />
+           transform="rotate(-90)" />
         <text
            xml:space="preserve"
            style="font-style:normal;font-weight:normal;line-height:0%;font-family:Arial;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
@@ -2101,7 +2102,7 @@
              style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:10.2731px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:center;text-anchor:middle;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none">IQ </tspan><tspan
              sodipodi:role="line"
              x="254.91582"
-             y="667.04547"
+             y="667.31152"
              style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:10.2731px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:center;text-anchor:middle;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none"
              id="tspan5900">Corr</tspan></text>
       </g>
@@ -2113,11 +2114,11 @@
          sodipodi:nodetypes="cccsccccc"
          inkscape:connector-curvature="0"
          id="path5553"
-         d="m 440.60568,966.21144 0,-6.1966 25.30705,0 c 0,0 0.0827,-5.53177 0.083,-8.24218 1.7e-4,-2.71041 -0.082,-8.24219 -0.082,-8.24219 l -25.30813,0 0,-6.19659 -14.64737,14.43878 z"
+         d="m 440.60568,966.21144 v -6.1966 h 25.30705 c 0,0 0.0827,-5.53177 0.083,-8.24218 1.7e-4,-2.71041 -0.082,-8.24219 -0.082,-8.24219 H 440.6056 v -6.19659 l -14.64737,14.43878 z"
          style="fill:#c8c8c8;fill-opacity:1;fill-rule:evenodd;stroke:#a01414;stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;shape-rendering:crispEdges" />
       <path
          style="fill:#c8c8c8;fill-opacity:1;fill-rule:evenodd;stroke:#a01414;stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;shape-rendering:crispEdges"
-         d="m 444.10568,955.24477 0,-6.1966 21.79807,-4.6e-4 c 0,0 -3e-4,-5.53177 0,-8.24218 1.7e-4,-2.71041 0,-8.24219 0,-8.24219 l -21.79815,4.6e-4 0,-6.19659 -14.64737,14.43878 z"
+         d="m 444.10568,955.24477 v -6.1966 l 21.79807,-4.6e-4 c 0,0 -3e-4,-5.53177 0,-8.24218 1.7e-4,-2.71041 0,-8.24219 0,-8.24219 l -21.79815,4.6e-4 v -6.19659 l -14.64737,14.43878 z"
          id="path5555"
          inkscape:connector-curvature="0"
          sodipodi:nodetypes="cccsccccc" />
@@ -2125,11 +2126,11 @@
          sodipodi:nodetypes="cccsccccc"
          inkscape:connector-curvature="0"
          id="path5557"
-         d="m 446.80568,944.2781 0,-6.1966 18.90682,-4.6e-4 c 0,0 0.0827,-5.53178 0.083,-8.24218 1.7e-4,-2.71041 -0.082,-8.24219 -0.082,-8.24219 l -18.9079,4.6e-4 0,-6.19659 -14.64737,14.43878 z"
+         d="m 446.80568,944.2781 v -6.1966 l 18.90682,-4.6e-4 c 0,0 0.0827,-5.53178 0.083,-8.24218 1.7e-4,-2.71041 -0.082,-8.24219 -0.082,-8.24219 l -18.9079,4.6e-4 v -6.19659 l -14.64737,14.43878 z"
          style="fill:#c8c8c8;fill-opacity:1;fill-rule:evenodd;stroke:#a01414;stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;shape-rendering:crispEdges" />
       <path
          style="fill:#c8c8c8;fill-opacity:1;fill-rule:evenodd;stroke:#a01414;stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;shape-rendering:crispEdges"
-         d="m 449.60568,933.31144 0,-6.1966 16.20232,0 c 0,0 -3e-4,-5.53177 0,-8.24218 1.7e-4,-2.71041 0,-8.24219 0,-8.24219 l -16.2024,0 0,-6.19659 -14.64737,14.43878 z"
+         d="m 449.60568,933.31144 v -6.1966 H 465.808 c 0,0 -3e-4,-5.53177 0,-8.24218 1.7e-4,-2.71041 0,-8.24219 0,-8.24219 h -16.2024 v -6.19659 l -14.64737,14.43878 z"
          id="path5559"
          inkscape:connector-curvature="0"
          sodipodi:nodetypes="cccsccccc" />
@@ -2153,22 +2154,22 @@
     <g
        id="g5654"
        style="display:inline;fill:#a01414;fill-opacity:1;stroke:#a01414;stroke-opacity:1;shape-rendering:crispEdges;enable-background:new"
-       transform="translate(-89.793622,108.18371)">
+       transform="translate(-149.79344,108.18371)">
       <path
          inkscape:connector-curvature="0"
          id="path5656"
-         d="m 130.47421,546.58376 10.03208,14.84925 0,-6.80591 12.46375,-3e-5 0,-8.04181 0,-8.04181 -12.46375,3e-5 0,-6.80591 -10.03208,14.84925"
+         d="m 130.47421,546.58376 10.03208,14.84925 v -6.80591 l 12.46375,-3e-5 v -8.04181 -8.04181 l -12.46375,3e-5 v -6.80591 l -10.03208,14.84925"
          style="fill:#a01414;fill-opacity:1;fill-rule:evenodd;stroke:#a01414;stroke-width:1px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1"
          sodipodi:nodetypes="ccccccccc" />
     </g>
     <g
        id="g5654-7"
        style="display:inline;fill:#a01414;fill-opacity:1;stroke:#a01414;stroke-opacity:1;shape-rendering:crispEdges;enable-background:new"
-       transform="translate(-30.270201,107.68368)">
+       transform="matrix(3.6287521,0,0,0.95028517,-432.10378,134.85708)">
       <path
          inkscape:connector-curvature="0"
          id="path5656-4"
-         d="m 130.47421,546.58376 10.03208,14.84925 0,-6.80591 12.46375,-3e-5 0,-8.04181 0,-8.04181 -12.46375,3e-5 0,-6.80591 -10.03208,14.84925"
+         d="m 130.47421,546.58376 10.03208,14.84925 v -6.80591 l 12.46375,-3e-5 v -8.04181 -8.04181 l -12.46375,3e-5 v -6.80591 l -10.03208,14.84925"
          style="fill:#a01414;fill-opacity:1;fill-rule:evenodd;stroke:#a01414;stroke-width:1px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1"
          sodipodi:nodetypes="ccccccccc" />
     </g>
@@ -2183,7 +2184,7 @@
         <path
            sodipodi:nodetypes="ccccccccc"
            style="fill:#a01414;fill-opacity:1;fill-rule:evenodd;stroke:#a01414;stroke-width:1px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1"
-           d="m 130.47421,546.58376 10.03208,14.84925 0,-6.80591 12.46375,-3e-5 0,-8.04181 0,-8.04181 -12.46375,3e-5 0,-6.80591 -10.03208,14.84925"
+           d="m 130.47421,546.58376 10.03208,14.84925 v -6.80591 l 12.46375,-3e-5 v -8.04181 -8.04181 l -12.46375,3e-5 v -6.80591 l -10.03208,14.84925"
            id="path5656-4-7"
            inkscape:connector-curvature="0" />
       </g>
@@ -2194,7 +2195,7 @@
         <path
            sodipodi:nodetypes="ccccccccc"
            style="fill:#a01414;fill-opacity:1;fill-rule:evenodd;stroke:#a01414;stroke-width:1px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1"
-           d="m 130.47421,546.58376 10.03208,14.84925 0,-6.80591 12.46375,-3e-5 0,-8.04181 0,-8.04181 -12.46375,3e-5 0,-6.80591 -10.03208,14.84925"
+           d="m 130.47421,546.58376 10.03208,14.84925 v -6.80591 l 12.46375,-3e-5 v -8.04181 -8.04181 l -12.46375,3e-5 v -6.80591 l -10.03208,14.84925"
            id="path5656-4-7-4"
            inkscape:connector-curvature="0" />
       </g>
@@ -2205,7 +2206,7 @@
         <path
            sodipodi:nodetypes="ccccccccc"
            style="fill:#a01414;fill-opacity:1;fill-rule:evenodd;stroke:#a01414;stroke-width:1px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1"
-           d="m 130.47421,546.58376 10.03208,14.84925 0,-6.80591 12.46375,-3e-5 0,-8.04181 0,-8.04181 -12.46375,3e-5 0,-6.80591 -10.03208,14.84925"
+           d="m 130.47421,546.58376 10.03208,14.84925 v -6.80591 l 12.46375,-3e-5 v -8.04181 -8.04181 l -12.46375,3e-5 v -6.80591 l -10.03208,14.84925"
            id="path5656-4-7-4-6"
            inkscape:connector-curvature="0" />
       </g>
@@ -2216,7 +2217,7 @@
         <path
            sodipodi:nodetypes="ccccccccc"
            style="fill:#a01414;fill-opacity:1;fill-rule:evenodd;stroke:#a01414;stroke-width:1px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1"
-           d="m 130.47421,546.58376 10.03208,14.84925 0,-6.80591 12.46375,-3e-5 0,-8.04181 0,-8.04181 -12.46375,3e-5 0,-6.80591 -10.03208,14.84925"
+           d="m 130.47421,546.58376 10.03208,14.84925 v -6.80591 l 12.46375,-3e-5 v -8.04181 -8.04181 l -12.46375,3e-5 v -6.80591 l -10.03208,14.84925"
            id="path5656-4-7-4-65"
            inkscape:connector-curvature="0" />
       </g>
@@ -2226,7 +2227,7 @@
        style="stroke:#a01414;stroke-opacity:1"
        transform="translate(0,-286)">
       <rect
-         style="opacity:0.87000002;fill:#ffcccc;fill-opacity:1;fill-rule:nonzero;stroke:#a01414;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;shape-rendering:crispEdges"
+         style="opacity:0.87;fill:#ffcccc;fill-opacity:1;fill-rule:nonzero;stroke:#a01414;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;shape-rendering:crispEdges"
          id="rect5679"
          width="27.422144"
          height="196.5643"
@@ -2248,14 +2249,14 @@
     <g
        id="g5779"
        style="stroke:#a01414;stroke-opacity:1"
-       transform="translate(0,-286)">
+       transform="translate(-59.999794,-286)">
       <rect
          y="842.57037"
          x="64.087563"
          height="196.39725"
          width="34.502934"
          id="rect5652"
-         style="opacity:0.87000002;fill:#ffcccc;fill-opacity:1;fill-rule:nonzero;stroke:#a01414;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;shape-rendering:crispEdges" />
+         style="opacity:0.87;fill:#ffcccc;fill-opacity:1;fill-rule:nonzero;stroke:#a01414;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;shape-rendering:crispEdges" />
       <text
          transform="rotate(-90)"
          id="text5775"
@@ -2269,33 +2270,37 @@
            id="tspan5777"
            sodipodi:role="line">ADC DMA</tspan></text>
     </g>
-    <rect
-       y="326.46057"
-       x="64.288002"
-       height="196.39725"
-       width="34.502934"
-       id="rect5786"
-       style="opacity:1;fill:#d2e6eb;fill-opacity:1;fill-rule:nonzero;stroke:#0f3296;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;shape-rendering:crispEdges" />
-    <text
-       transform="rotate(-90)"
-       id="text5788"
-       y="87.802895"
-       x="-466.61047"
-       style="font-style:normal;font-weight:normal;line-height:0%;font-family:Arial;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       xml:space="preserve"><tspan
-         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:17.5px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial Bold';stroke:none;stroke-opacity:1"
+    <g
+       id="g6521"
+       transform="translate(-60.000233)">
+      <rect
+         y="326.46057"
+         x="64.288002"
+         height="196.39725"
+         width="34.502934"
+         id="rect5786"
+         style="opacity:1;fill:#d2e6eb;fill-opacity:1;fill-rule:nonzero;stroke:#0f3296;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;shape-rendering:crispEdges" />
+      <text
+         transform="rotate(-90)"
+         id="text5788"
          y="87.802895"
          x="-466.61047"
-         id="tspan5790"
-         sodipodi:role="line">DAC DMA</tspan></text>
+         style="font-style:normal;font-weight:normal;line-height:0%;font-family:Arial;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+         xml:space="preserve"><tspan
+           style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:17.5px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial Bold';stroke:none;stroke-opacity:1"
+           y="87.802895"
+           x="-466.61047"
+           id="tspan5790"
+           sodipodi:role="line">DAC DMA</tspan></text>
+    </g>
     <g
-       transform="matrix(-1,0,0,1,252.27004,-124.11672)"
+       transform="matrix(-1.0217254,0,0,0.99887847,254.89884,-123.50371)"
        style="display:inline;fill:#0f3296;fill-opacity:1;stroke:#0f3296;stroke-opacity:1;shape-rendering:crispEdges;enable-background:new"
        id="g5792">
       <path
          sodipodi:nodetypes="ccccccccc"
          style="fill:#0f3296;fill-opacity:1;fill-rule:evenodd;stroke:#0f3296;stroke-width:1px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1"
-         d="m 130.47421,546.58376 10.03208,14.84925 0,-6.80591 12.46375,-3e-5 0,-8.04181 0,-8.04181 -12.46375,3e-5 0,-6.80591 -10.03208,14.84925"
+         d="m 130.47421,546.58376 10.03208,14.84925 v -6.80591 l 12.46375,-3e-5 v -8.04181 -8.04181 l -12.46375,3e-5 v -6.80591 l -10.03208,14.84925"
          id="path5794"
          inkscape:connector-curvature="0" />
     </g>
@@ -2319,7 +2324,7 @@
          id="tspan5800"
          sodipodi:role="line">DAC UNPACK</tspan></text>
     <rect
-       style="opacity:1;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#25a862;stroke-width:1.23515844;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:1.23515842, 3.70547526;stroke-dashoffset:0;stroke-opacity:1"
+       style="opacity:1;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#25a862;stroke-width:1.23516;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:1.23516, 3.70548;stroke-dashoffset:0;stroke-opacity:1"
        id="rect6779"
        width="232.97487"
        height="680.10687"
@@ -2327,148 +2332,148 @@
        y="311.87772" />
     <g
        id="ddr"
-       transform="matrix(1.4208528,0,0,1.4208528,-187.98358,-488.82469)">
+       transform="matrix(1.4208528,0,0,1.4208528,-247.98358,-488.82469)">
       <rect
-         style="opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.80000001;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+         style="opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.8;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
          id="rect8406"
          width="29.358675"
          height="11.248666"
          x="-453.55264"
          y="391.80267"
-         transform="matrix(0,-1,1,0,0,0)" />
+         transform="rotate(-90)" />
       <rect
-         style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.67500967;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.67391304"
+         style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.67501;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.673913"
          id="rect8408"
          width="4.6139379"
          height="6.8413563"
          x="-451.4805"
          y="394.00632"
-         transform="matrix(0,-1,1,0,0,0)" />
+         transform="rotate(-90)" />
       <rect
          y="394.00632"
          x="-444.69791"
          height="6.8413563"
          width="4.6139379"
          id="rect8410"
-         style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.67500967;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.67391304"
-         transform="matrix(0,-1,1,0,0,0)" />
+         style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.67501;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.673913"
+         transform="rotate(-90)" />
       <rect
          y="394.00632"
          x="-431.13275"
          height="6.8413563"
          width="4.6139379"
          id="rect8414"
-         style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.67500967;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.67391304"
-         transform="matrix(0,-1,1,0,0,0)" />
+         style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.67501;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.673913"
+         transform="rotate(-90)" />
       <rect
-         style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.67500967;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.67391304"
+         style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.67501;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.673913"
          id="rect8416"
          width="4.6139379"
          height="6.8413563"
          x="-437.91531"
          y="394.00632"
-         transform="matrix(0,-1,1,0,0,0)" />
+         transform="rotate(-90)" />
       <path
-         style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:0.55059952;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-         d="m 402.9495,451.34818 3.46837,0 0,-24.7395 -3.63159,0"
+         style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:0.5506;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         d="m 402.9495,451.34818 h 3.46837 v -24.7395 h -3.63159"
          id="path8420"
          inkscape:connector-curvature="0"
          sodipodi:nodetypes="cccc" />
       <path
-         style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1.06700003;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-         d="m 406.04958,449.00384 -1.44048,0"
+         style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1.067;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         d="M 406.04958,449.00384 H 404.6091"
          id="path8422"
          inkscape:connector-curvature="0" />
       <path
          inkscape:connector-curvature="0"
          id="path8424"
-         d="m 406.04958,430.92913 -1.44048,0"
-         style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1.06700003;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+         d="M 406.04958,430.92913 H 404.6091"
+         style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1.067;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
       <path
-         style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1.06700003;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-         d="m 406.04958,433.33004 -1.44048,0"
+         style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1.067;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         d="M 406.04958,433.33004 H 404.6091"
          id="path8426"
          inkscape:connector-curvature="0" />
       <path
          inkscape:connector-curvature="0"
          id="path8428"
-         d="m 406.04958,435.45913 -1.44048,0"
-         style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1.06700003;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+         d="M 406.04958,435.45913 H 404.6091"
+         style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1.067;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
       <path
-         style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1.06700003;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-         d="m 406.04958,437.86003 -1.44048,0"
+         style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1.067;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         d="M 406.04958,437.86003 H 404.6091"
          id="path8430"
          inkscape:connector-curvature="0" />
       <path
          inkscape:connector-curvature="0"
          id="path8432"
-         d="m 406.04958,439.98913 -1.44048,0"
-         style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1.06700003;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+         d="M 406.04958,439.98913 H 404.6091"
+         style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1.067;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
       <path
-         style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1.06700003;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-         d="m 406.04958,442.34471 -1.44048,0"
+         style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1.067;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         d="M 406.04958,442.34471 H 404.6091"
          id="path8434"
          inkscape:connector-curvature="0" />
       <path
          inkscape:connector-curvature="0"
          id="path8436"
-         d="m 406.04958,444.51915 -1.44048,0"
-         style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1.06700003;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+         d="M 406.04958,444.51915 H 404.6091"
+         style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1.067;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
       <path
-         style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1.06700003;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-         d="m 406.04958,446.82944 -1.44048,0"
+         style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1.067;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         d="M 406.04958,446.82944 H 404.6091"
          id="path8438"
          inkscape:connector-curvature="0" />
       <path
-         style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1.06700003;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-         d="m 406.04958,430.92913 -1.44048,0"
+         style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1.067;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         d="M 406.04958,430.92913 H 404.6091"
          id="path8440"
          inkscape:connector-curvature="0" />
       <path
          inkscape:connector-curvature="0"
          id="path8450"
-         d="m 406.04958,428.80003 -1.44048,0"
-         style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1.06700003;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+         d="M 406.04958,428.80003 H 404.6091"
+         style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1.067;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
     </g>
     <g
        id="g8892"
-       transform="translate(26.777334,-307.87674)">
+       transform="translate(-33.222797,-307.87674)">
       <rect
          y="431.09491"
          x="366.68005"
          height="23.063002"
          width="26.832939"
          id="rect8762"
-         style="opacity:1;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:1.33851159;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+         style="opacity:1;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:1.33851;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
       <path
          inkscape:connector-curvature="0"
          id="rect8764"
-         d="m 371.84168,433.47704 16.31637,0 c 1.2826,0 2.31516,1.03257 2.31516,2.31517 l 0,13.22948 c 0,1.28259 -1.03256,2.31515 -2.31516,2.31515 l -16.31637,0 c -1.2826,0 -2.31516,-1.03256 -2.31516,-2.31515 l 0,-13.22948 c 0,-1.2826 1.03256,-2.31517 2.31516,-2.31517 z"
-         style="opacity:1;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:1.20000005;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+         d="m 371.84168,433.47704 h 16.31637 c 1.2826,0 2.31516,1.03257 2.31516,2.31517 v 13.22948 c 0,1.28259 -1.03256,2.31515 -2.31516,2.31515 h -16.31637 c -1.2826,0 -2.31516,-1.03256 -2.31516,-2.31515 v -13.22948 c 0,-1.2826 1.03256,-2.31517 2.31516,-2.31517 z"
+         style="opacity:1;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:1.2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
       <g
          style="fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-opacity:1"
          transform="matrix(1.2472877,0,0,1.2472877,-94.749819,-45.663902)"
          id="g8811">
         <path
            id="rect8801"
-           d="m 371.16019,393.86166 6.77743,0 0,5.24892 -6.77743,0 z"
-           style="opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:#ffffff;stroke-width:0.47924784;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+           d="m 371.16019,393.86166 h 6.77743 v 5.24892 h -6.77743 z"
+           style="opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:#ffffff;stroke-width:0.479248;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
            inkscape:connector-curvature="0" />
         <path
            id="rect8809"
-           d="m 383.3136,393.86166 6.77743,0 0,5.24892 -6.77743,0 z"
-           style="opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:#ffffff;stroke-width:0.47924784;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+           d="m 383.3136,393.86166 h 6.77743 v 5.24892 h -6.77743 z"
+           style="opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:#ffffff;stroke-width:0.479248;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
            inkscape:connector-curvature="0" />
       </g>
       <path
          sodipodi:nodetypes="ccccc"
          inkscape:connector-curvature="0"
          id="path8818"
-         d="m 369.52814,445.26083 5.8318,0 0,2.82613 1.54776,0 0,3.24584"
-         style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1.20000005;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+         d="m 369.52814,445.26083 h 5.8318 v 2.82613 h 1.54776 v 3.24584"
+         style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1.2;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
       <path
-         style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1.20000005;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-         d="m 390.47422,445.29053 -5.89282,0 0,2.80734 -1.56397,0 0,3.22427"
+         style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1.2;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         d="m 390.47422,445.29053 h -5.89282 v 2.80734 h -1.56397 v 3.22427"
          id="path8820"
          inkscape:connector-curvature="0"
          sodipodi:nodetypes="ccccc" />
@@ -2478,9 +2483,9 @@
          height="3.8938534"
          width="4.5168324"
          id="rect8824"
-         style="opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.97299999;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+         style="opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.973;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
       <rect
-         style="opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.97299999;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+         style="opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.973;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
          id="rect8826"
          width="4.5168324"
          height="3.8938534"
@@ -2492,9 +2497,9 @@
          height="5.1640501"
          width="1.2438545"
          id="rect8828"
-         style="opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.3085978;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+         style="opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.308598;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
       <rect
-         style="opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.3085978;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+         style="opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.308598;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
          id="rect8830"
          width="1.2438545"
          height="5.1640501"
@@ -2506,9 +2511,9 @@
          height="5.1640501"
          width="1.2438545"
          id="rect8832"
-         style="opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.3085978;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+         style="opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.308598;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
       <rect
-         style="opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.3085978;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+         style="opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.308598;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
          id="rect8834"
          width="1.2438545"
          height="5.1640501"
@@ -2520,16 +2525,16 @@
          height="5.1640501"
          width="1.2438545"
          id="rect8836"
-         style="opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.3085978;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+         style="opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.308598;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
       <rect
-         style="opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.3085978;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+         style="opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.308598;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
          id="rect8838"
          width="1.2438545"
          height="5.1640501"
          x="374.36008"
          y="433.60046" />
       <rect
-         style="opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.3085978;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+         style="opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.308598;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
          id="rect8840"
          width="1.2438545"
          height="5.1640501"
@@ -2538,8 +2543,8 @@
     </g>
     <g
        id="uart"
-       transform="matrix(0,-0.41475987,0.41475987,0,265.52275,352.80968)"
-       style="stroke-width:2.41103363;stroke-miterlimit:4;stroke-dasharray:none">
+       transform="matrix(0,-0.41475987,0.41475987,0,205.52264,352.80968)"
+       style="stroke-width:2.41103;stroke-miterlimit:4;stroke-dasharray:none">
       <rect
          ry="4.5"
          y="388.11218"
@@ -2547,21 +2552,21 @@
          height="28.75"
          width="70"
          id="rect8910"
-         style="opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:2.41103363;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+         style="opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:2.41103;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
       <path
          sodipodi:nodetypes="sssssssss"
          inkscape:connector-curvature="0"
          id="rect8912"
-         d="m 507.25,394.11218 37,0 c 2.493,0 5.47668,2.20628 4.5,4.5 l -3.3,7.75 c -0.97668,2.29372 -3.507,4.5 -6,4.5 l -27.8,0 c -2.493,0 -4.37391,-2.22795 -5.4,-4.5 l -3.5,-7.75 c -1.02609,-2.27205 2.007,-4.5 4.5,-4.5 z"
-         style="opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:2.41103363;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+         d="m 507.25,394.11218 h 37 c 2.493,0 5.47668,2.20628 4.5,4.5 l -3.3,7.75 c -0.97668,2.29372 -3.507,4.5 -6,4.5 h -27.8 c -2.493,0 -4.37391,-2.22795 -5.4,-4.5 l -3.5,-7.75 c -1.02609,-2.27205 2.007,-4.5 4.5,-4.5 z"
+         style="opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:2.41103;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
       <circle
          r="3.1875"
          cy="402.48718"
          cx="497.5126"
          id="path8915"
-         style="opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:2.41103363;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+         style="opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:2.41103;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
       <circle
-         style="opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:2.41103363;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+         style="opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:2.41103;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
          id="circle8917"
          cx="554.13763"
          cy="402.48718"
@@ -2572,16 +2577,16 @@
          cy="399.79968"
          cx="513.7403"
          id="path8919"
-         style="opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:2.41103363;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+         style="opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:2.41103;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
       <ellipse
          ry="1.0625"
          rx="1"
          cy="399.79968"
          cx="537.7403"
          id="ellipse8923"
-         style="opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:2.41103363;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+         style="opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:2.41103;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
       <ellipse
-         style="opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:2.41103363;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+         style="opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:2.41103;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
          id="ellipse8925"
          cx="531.7403"
          cy="399.79968"
@@ -2593,16 +2598,16 @@
          cy="399.79968"
          cx="525.7403"
          id="ellipse8927"
-         style="opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:2.41103363;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+         style="opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:2.41103;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
       <ellipse
-         style="opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:2.41103363;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+         style="opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:2.41103;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
          id="ellipse8929"
          cx="519.7403"
          cy="399.79968"
          rx="1"
          ry="1.0625" />
       <ellipse
-         style="opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:2.41103363;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+         style="opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:2.41103;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
          id="ellipse8921"
          cx="516.7403"
          cy="405.79968"
@@ -2614,9 +2619,9 @@
          cy="405.79968"
          cx="534.7403"
          id="ellipse8931"
-         style="opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:2.41103363;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+         style="opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:2.41103;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
       <ellipse
-         style="opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:2.41103363;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+         style="opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:2.41103;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
          id="ellipse8933"
          cx="528.7403"
          cy="405.79968"
@@ -2628,43 +2633,43 @@
          cy="405.79968"
          cx="522.7403"
          id="ellipse8935"
-         style="opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:2.41103363;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+         style="opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:2.41103;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
     </g>
     <rect
        style="display:inline;opacity:1;fill:#ffcccc;fill-opacity:1;fill-rule:nonzero;stroke:#af1414;stroke-width:0;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;shape-rendering:crispEdges;enable-background:new"
        id="rect4587"
        width="15.55635"
        height="15.55635"
-       x="10.720836"
+       x="-49.278999"
        y="131.07272" />
     <text
        xml:space="preserve"
        style="font-style:normal;font-weight:normal;line-height:0%;font-family:Arial;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="35.015091"
+       x="-24.984665"
        y="142.3421"
        id="text4591"><tspan
          style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.5px;line-height:1.25;font-family:Arial;-inkscape-font-specification:Arial"
          sodipodi:role="line"
          id="tspan4593"
-         x="35.015091"
+         x="-24.984665"
          y="142.3421">Receive path</tspan></text>
     <rect
        style="opacity:1;fill:#d2e6eb;fill-opacity:1;fill-rule:nonzero;stroke:#af1414;stroke-width:0;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
        id="rect4589"
-       width="14.849242"
+       width="15.555999"
        height="15.909903"
-       x="10.720836"
+       x="-49.278999"
        y="109.17801" />
     <text
        xml:space="preserve"
        style="font-style:normal;font-weight:normal;line-height:0%;font-family:Arial;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="35.704788"
+       x="-24.294968"
        y="120.62418"
        id="text4595"><tspan
          style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.5px;line-height:1.25;font-family:Arial;-inkscape-font-specification:Arial"
          sodipodi:role="line"
          id="tspan4597"
-         x="35.704788"
+         x="-24.294968"
          y="120.62418">Transmit path</tspan></text>
     <g
        transform="translate(-1.475826,567.52499)"
@@ -2698,7 +2703,7 @@
            height="25.05477"
            x="-683.51202"
            y="-406.4104"
-           transform="scale(-1,-1)" />
+           transform="scale(-1)" />
         <text
            xml:space="preserve"
            style="font-style:normal;font-weight:normal;line-height:0%;font-family:Arial;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;shape-rendering:crispEdges;enable-background:new"
@@ -2744,13 +2749,13 @@
       <path
          sodipodi:nodetypes="ccccc"
          style="fill:#677821;fill-opacity:1;fill-rule:evenodd;stroke:#677821;stroke-width:1px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1"
-         d="m 129.93087,544.16004 10.03208,-14.84925 0,6.80591 14.31388,-3e-5 0,8.04334"
+         d="m 129.93087,544.16004 10.03208,-14.84925 v 6.80591 l 14.31388,-3e-5 v 8.04334"
          id="path5128-4"
          inkscape:connector-curvature="0" />
       <path
          inkscape:connector-curvature="0"
          id="path5130-0"
-         d="m 129.93087,544.15698 10.03208,14.84925 0,-6.80591 14.31388,-3e-5 0,-8.04334"
+         d="m 129.93087,544.15698 10.03208,14.84925 v -6.80591 l 14.31388,-3e-5 v -8.04334"
          style="fill:#677821;fill-opacity:1;fill-rule:evenodd;stroke:#677821;stroke-width:1px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1"
          sodipodi:nodetypes="ccccc" />
     </g>
@@ -2761,13 +2766,13 @@
       <path
          sodipodi:nodetypes="ccccc"
          style="fill:#677821;fill-opacity:1;fill-rule:evenodd;stroke:#677821;stroke-width:1px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1"
-         d="m 129.93087,544.16004 10.03208,-14.84925 0,6.80591 10.81421,-3e-5 0,8.04334"
+         d="m 129.93087,544.16004 10.03208,-14.84925 v 6.80591 l 10.81421,-3e-5 v 8.04334"
          id="path5128-8-0"
          inkscape:connector-curvature="0" />
       <path
          inkscape:connector-curvature="0"
          id="path5130-3-58"
-         d="m 129.93087,544.15698 10.03208,14.84925 0,-6.80591 10.81421,-3e-5 0,-8.04334"
+         d="m 129.93087,544.15698 10.03208,14.84925 v -6.80591 l 10.81421,-3e-5 v -8.04334"
          style="fill:#677821;fill-opacity:1;fill-rule:evenodd;stroke:#677821;stroke-width:1px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1"
          sodipodi:nodetypes="ccccc" />
     </g>
@@ -2778,18 +2783,18 @@
       <path
          sodipodi:nodetypes="ccccc"
          style="fill:#677821;fill-opacity:1;fill-rule:evenodd;stroke:#677821;stroke-width:1px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1"
-         d="m 129.93087,544.16004 10.03208,-14.84925 0,6.80591 11.41409,-3e-5 0,8.04334"
+         d="m 129.93087,544.16004 10.03208,-14.84925 v 6.80591 l 11.41409,-3e-5 v 8.04334"
          id="path5128-8-4-6"
          inkscape:connector-curvature="0" />
       <path
          inkscape:connector-curvature="0"
          id="path5130-3-5-58"
-         d="m 129.93087,544.15698 10.03208,14.84925 0,-6.80591 11.41409,-3e-5 0,-8.04334"
+         d="m 129.93087,544.15698 10.03208,14.84925 v -6.80591 l 11.41409,-3e-5 v -8.04334"
          style="fill:#677821;fill-opacity:1;fill-rule:evenodd;stroke:#677821;stroke-width:1px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1"
          sodipodi:nodetypes="ccccc" />
     </g>
     <rect
-       style="display:inline;opacity:1;fill:#4cbeef;fill-opacity:0;fill-rule:nonzero;stroke:#677821;stroke-width:1.76542485;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;shape-rendering:crispEdges;enable-background:new"
+       style="display:inline;opacity:1;fill:#4cbeef;fill-opacity:0;fill-rule:nonzero;stroke:#677821;stroke-width:1.76542;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;shape-rendering:crispEdges;enable-background:new"
        id="daccore0-6-3"
        width="269.50903"
        height="199.19513"
@@ -2842,61 +2847,61 @@
          sodipodi:nodetypes="ccccc"
          inkscape:connector-curvature="0"
          id="rect17615-8-4"
-         d="m 308.88845,597.53506 -15.43356,9.09168 0,43.20616 15.43356,9.09164 z"
+         d="m 308.88845,597.53506 -15.43356,9.09168 v 43.20616 l 15.43356,9.09164 z"
          style="display:inline;opacity:1;fill:#ebebeb;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;shape-rendering:crispEdges;enable-background:new" />
       <circle
          r="0.80001962"
          cy="607.32825"
          cx="372.88"
          id="path4594-3"
-         style="opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:1.39996076;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+         style="opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:1.39996;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
       <path
          sodipodi:nodetypes="cc"
          inkscape:connector-curvature="0"
          id="path4588-2"
-         d="m 318.72617,651.30233 -9.67428,0"
+         d="m 318.72617,651.30233 h -9.67428"
          style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
       <path
          sodipodi:nodetypes="cc"
          inkscape:connector-curvature="0"
          id="path4590-1"
-         d="m 309.28098,607.431 86.51361,0"
+         d="m 309.28098,607.431 h 86.51361"
          style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
       <path
          sodipodi:nodetypes="ccc"
          inkscape:connector-curvature="0"
          id="path4596-8"
-         d="m 363.718,651.30848 9.17178,0 0,-44.36488"
+         d="m 363.718,651.30848 h 9.17178 V 606.9436"
          style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
       <path
          sodipodi:nodetypes="ccccc"
          inkscape:connector-curvature="0"
          id="rect17615-8-1-3"
-         d="m 223.7415,597.53506 -15.43356,9.09168 0,43.20616 15.43356,9.09164 z"
+         d="m 223.7415,597.53506 -15.43356,9.09168 v 43.20616 l 15.43356,9.09164 z"
          style="display:inline;opacity:1;fill:#ebebeb;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;shape-rendering:crispEdges;enable-background:new" />
       <path
          sodipodi:nodetypes="cccc"
          inkscape:connector-curvature="0"
          id="path4647-2"
-         d="m 293.34323,628.21724 -6.38996,0 0,23.22885 -8.273,0"
+         d="m 293.34323,628.21724 h -6.38996 v 23.22885 h -8.273"
          style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
       <path
          sodipodi:nodetypes="ccc"
          inkscape:connector-curvature="0"
          id="path4649-3"
-         d="m 286.994,628.07979 0,-20.51572 -63.18736,0"
+         d="M 286.994,628.07979 V 607.56407 H 223.80664"
          style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
       <circle
          r="0.80001962"
          cy="628.02197"
          cx="287.06549"
          id="path4594-8-5"
-         style="display:inline;opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:1.39996076;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;shape-rendering:crispEdges;enable-background:new" />
+         style="display:inline;opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:1.39996;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;shape-rendering:crispEdges;enable-background:new" />
       <path
          sodipodi:nodetypes="cc"
          inkscape:connector-curvature="0"
          id="path4666-4"
-         d="m 231.994,651.43904 -7.86961,0"
+         d="m 231.994,651.43904 h -7.86961"
          style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
       <path
          sodipodi:nodetypes="cc"
@@ -2908,25 +2913,25 @@
          transform="matrix(1.1885989,0,0,1.1885989,-59.978473,-122.41168)"
          id="g6385-9">
         <rect
-           style="opacity:1;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#677821;stroke-width:0.84132671;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+           style="opacity:1;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#677821;stroke-width:0.841327;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
            id="rect4910-6"
            width="36.778587"
            height="37.394592"
            x="-669.02423"
            y="318.93008"
-           transform="matrix(0,-1,1,0,0,0)" />
+           transform="rotate(-90)" />
       </g>
       <g
          transform="matrix(1.2167645,0,0,1.2167645,-55.136833,-148.59717)"
          id="g5922-3">
         <rect
-           style="display:inline;opacity:1;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#677821;stroke-width:0.82185173;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;shape-rendering:crispEdges;enable-background:new"
+           style="display:inline;opacity:1;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#677821;stroke-width:0.821852;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;shape-rendering:crispEdges;enable-background:new"
            id="rect4910-9-1"
            width="35.647327"
            height="37.94709"
            x="-674.91833"
            y="236.10585"
-           transform="matrix(0,-1,1,0,0,0)" />
+           transform="rotate(-90)" />
         <text
            xml:space="preserve"
            style="font-style:normal;font-weight:normal;line-height:0%;font-family:Arial;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
@@ -2940,7 +2945,7 @@
              style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:10.2731px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:center;text-anchor:middle;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none">IQ </tspan><tspan
              sodipodi:role="line"
              x="254.91582"
-             y="667.04547"
+             y="667.31152"
              style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:10.2731px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:center;text-anchor:middle;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none"
              id="tspan5900-2">Corr</tspan></text>
       </g>
@@ -2953,11 +2958,11 @@
          sodipodi:nodetypes="cccsccccc"
          inkscape:connector-curvature="0"
          id="path5553-5"
-         d="m 440.60568,966.21144 0,-6.1966 25.30705,0 c 0,0 0.0827,-5.53177 0.083,-8.24218 1.7e-4,-2.71041 -0.082,-8.24219 -0.082,-8.24219 l -25.30813,0 0,-6.19659 -14.64737,14.43878 z"
+         d="m 440.60568,966.21144 v -6.1966 h 25.30705 c 0,0 0.0827,-5.53177 0.083,-8.24218 1.7e-4,-2.71041 -0.082,-8.24219 -0.082,-8.24219 H 440.6056 v -6.19659 l -14.64737,14.43878 z"
          style="fill:#c8c8c8;fill-opacity:1;fill-rule:evenodd;stroke:#677821;stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;shape-rendering:crispEdges" />
       <path
          style="fill:#c8c8c8;fill-opacity:1;fill-rule:evenodd;stroke:#677821;stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;shape-rendering:crispEdges"
-         d="m 444.10568,955.24477 0,-6.1966 21.79807,-4.6e-4 c 0,0 -3e-4,-5.53177 0,-8.24218 1.7e-4,-2.71041 0,-8.24219 0,-8.24219 l -21.79815,4.6e-4 0,-6.19659 -14.64737,14.43878 z"
+         d="m 444.10568,955.24477 v -6.1966 l 21.79807,-4.6e-4 c 0,0 -3e-4,-5.53177 0,-8.24218 1.7e-4,-2.71041 0,-8.24219 0,-8.24219 l -21.79815,4.6e-4 v -6.19659 l -14.64737,14.43878 z"
          id="path5555-4"
          inkscape:connector-curvature="0"
          sodipodi:nodetypes="cccsccccc" />
@@ -2981,22 +2986,22 @@
     <g
        id="g5654-9"
        style="display:inline;fill:#677821;fill-opacity:1;stroke:#677821;stroke-opacity:1;shape-rendering:crispEdges;enable-background:new"
-       transform="translate(-91.269447,335.44099)">
+       transform="translate(-151.26944,335.44099)">
       <path
          inkscape:connector-curvature="0"
          id="path5656-1"
-         d="m 130.47421,546.58376 10.03208,14.84925 0,-6.80591 12.46375,-3e-5 0,-8.04181 0,-8.04181 -12.46375,3e-5 0,-6.80591 -10.03208,14.84925"
+         d="m 130.47421,546.58376 10.03208,14.84925 v -6.80591 l 12.46375,-3e-5 v -8.04181 -8.04181 l -12.46375,3e-5 v -6.80591 l -10.03208,14.84925"
          style="fill:#677821;fill-opacity:1;fill-rule:evenodd;stroke:#677821;stroke-width:1px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1"
          sodipodi:nodetypes="ccccccccc" />
     </g>
     <g
        id="g5654-7-7"
        style="display:inline;fill:#677821;fill-opacity:1;stroke:#677821;stroke-opacity:1;shape-rendering:crispEdges;enable-background:new"
-       transform="translate(-31.746027,334.94096)">
+       transform="matrix(3.6305136,0,0,0.95026042,-433.84874,362.12788)">
       <path
          inkscape:connector-curvature="0"
          id="path5656-4-77"
-         d="m 130.47421,546.58376 10.03208,14.84925 0,-6.80591 12.46375,-3e-5 0,-8.04181 0,-8.04181 -12.46375,3e-5 0,-6.80591 -10.03208,14.84925"
+         d="m 130.47421,546.58376 10.03208,14.84925 v -6.80591 l 12.46375,-3e-5 v -8.04181 -8.04181 l -12.46375,3e-5 v -6.80591 l -10.03208,14.84925"
          style="fill:#677821;fill-opacity:1;fill-rule:evenodd;stroke:#677821;stroke-width:1px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1"
          sodipodi:nodetypes="ccccccccc" />
     </g>
@@ -3011,7 +3016,7 @@
         <path
            sodipodi:nodetypes="ccccccccc"
            style="fill:#677821;fill-opacity:1;fill-rule:evenodd;stroke:#677821;stroke-width:1px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1"
-           d="m 130.47421,546.58376 10.03208,14.84925 0,-6.80591 12.46375,-3e-5 0,-8.04181 0,-8.04181 -12.46375,3e-5 0,-6.80591 -10.03208,14.84925"
+           d="m 130.47421,546.58376 10.03208,14.84925 v -6.80591 l 12.46375,-3e-5 v -8.04181 -8.04181 l -12.46375,3e-5 v -6.80591 l -10.03208,14.84925"
            id="path5656-4-7-3"
            inkscape:connector-curvature="0" />
       </g>
@@ -3022,7 +3027,7 @@
         <path
            sodipodi:nodetypes="ccccccccc"
            style="fill:#677821;fill-opacity:1;fill-rule:evenodd;stroke:#677821;stroke-width:1px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1"
-           d="m 130.47421,546.58376 10.03208,14.84925 0,-6.80591 12.46375,-3e-5 0,-8.04181 0,-8.04181 -12.46375,3e-5 0,-6.80591 -10.03208,14.84925"
+           d="m 130.47421,546.58376 10.03208,14.84925 v -6.80591 l 12.46375,-3e-5 v -8.04181 -8.04181 l -12.46375,3e-5 v -6.80591 l -10.03208,14.84925"
            id="path5656-4-7-4-65-2"
            inkscape:connector-curvature="0" />
       </g>
@@ -3032,7 +3037,7 @@
        style="display:inline;stroke:#677821;stroke-opacity:1;shape-rendering:crispEdges;enable-background:new"
        transform="translate(-1.475826,-58.74272)">
       <rect
-         style="opacity:0.87000002;fill:#cdde87;fill-opacity:1;fill-rule:nonzero;stroke:#677821;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;shape-rendering:crispEdges"
+         style="opacity:0.87;fill:#cdde87;fill-opacity:1;fill-rule:nonzero;stroke:#677821;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;shape-rendering:crispEdges"
          id="rect5679-7"
          width="27.422144"
          height="196.5643"
@@ -3052,44 +3057,44 @@
            sodipodi:role="line">ADC OS PACK</tspan></text>
     </g>
     <rect
-       style="opacity:0.87000002;fill:#cdde87;fill-opacity:1;fill-rule:nonzero;stroke:#677821;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;shape-rendering:crispEdges"
+       style="opacity:0.87;fill:#cdde87;fill-opacity:1;fill-rule:nonzero;stroke:#677821;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;shape-rendering:crispEdges"
        id="rect5652-6"
        width="34.502934"
        height="196.39725"
-       x="62.611736"
+       x="2.611769"
        y="783.82764" />
     <text
        xml:space="preserve"
        style="font-style:normal;font-weight:normal;line-height:0%;font-family:Arial;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;shape-rendering:crispEdges"
        x="-938.41846"
-       y="86.12236"
+       y="26.122248"
        id="text5775-8"
        transform="rotate(-90)"><tspan
          sodipodi:role="line"
          id="tspan5777-7"
          x="-938.41846"
-         y="86.12236"
+         y="26.122248"
          style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:17.5px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial Bold';stroke:none;stroke-opacity:1">ADC OS DMA</tspan></text>
     <rect
        style="display:inline;opacity:1;fill:#cdde87;fill-opacity:1;fill-rule:nonzero;stroke:#af1414;stroke-width:0;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;shape-rendering:crispEdges;enable-background:new"
        id="rect4587-8"
        width="15.55635"
        height="15.55635"
-       x="10.720836"
+       x="-49.278999"
        y="152.79066" />
     <text
        xml:space="preserve"
        style="font-style:normal;font-weight:normal;line-height:0%;font-family:Arial;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;shape-rendering:crispEdges"
-       x="35.015091"
+       x="-24.985247"
        y="164.06004"
        id="text4591-8"><tspan
          style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.5px;line-height:1.25;font-family:Arial;-inkscape-font-specification:Arial"
          sodipodi:role="line"
          id="tspan4593-5"
-         x="35.015091"
+         x="-24.985247"
          y="164.06004">Observation path</tspan></text>
     <rect
-       style="fill:none;fill-rule:evenodd;stroke:#ff4200;stroke-width:2.46881628px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:0.90229887"
+       style="fill:none;fill-rule:evenodd;stroke:#ff4200;stroke-width:2.46882px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:0.902299"
        id="rect5275"
        width="354.53119"
        height="721.88647"
@@ -3106,32 +3111,67 @@
          x="297.50391"
          y="309.40109"
          style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:20px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial Bold';fill:#ff4200;fill-opacity:0.901961;stroke:none;stroke-opacity:1">AD9371 IP</tspan></text>
+    <g
+       transform="matrix(-1,0,0,1,191.98981,-124.11713)"
+       style="display:inline;fill:#0f3296;fill-opacity:1;stroke:#0f3296;stroke-opacity:1;shape-rendering:crispEdges;enable-background:new"
+       id="g5792-4">
+      <path
+         sodipodi:nodetypes="ccccccccc"
+         style="fill:#0f3296;fill-opacity:1;fill-rule:evenodd;stroke:#0f3296;stroke-width:1px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1"
+         d="m 130.47421,546.58376 10.03208,14.84925 v -6.80591 l 12.46375,-3e-5 v -8.04181 -8.04181 l -12.46375,3e-5 v -6.80591 l -10.03208,14.84925"
+         id="path5794-6"
+         inkscape:connector-curvature="0" />
+    </g>
+    <g
+       id="g6521-1"
+       transform="translate(-1.321233,-3.8128906e-4)"
+       style="display:inline;shape-rendering:crispEdges;enable-background:new">
+      <rect
+         y="326.46057"
+         x="64.288002"
+         height="196.39725"
+         width="34.502934"
+         id="rect5786-1"
+         style="opacity:1;fill:#d2e6eb;fill-opacity:1;fill-rule:nonzero;stroke:#0f3296;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;shape-rendering:crispEdges" />
+      <text
+         transform="rotate(-90)"
+         id="text5788-4"
+         y="87.802895"
+         x="-494.51056"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:18.6667px;line-height:0%;font-family:Arial;-inkscape-font-specification:'Arial, Bold';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+         xml:space="preserve"><tspan
+           sodipodi:role="line"
+           id="tspan7780"
+           x="-494.51056"
+           y="87.802895">DATA OFFLOAD</tspan></text>
+    </g>
   </g>
   <g
      inkscape:groupmode="layer"
      id="layer2"
      inkscape:label="up_text"
      style="display:inline;opacity:1"
-     transform="translate(0,200.90552)">
+     transform="translate(60.232231,200.90552)">
     <g
-       id="g11134">
+       id="g11134"
+       transform="translate(-59.999812)">
       <path
          sodipodi:nodetypes="cc"
          inkscape:connector-curvature="0"
          id="path4518"
-         d="m 379.95512,-126.88015 0,-19.16037"
+         d="m 379.95512,-126.88015 v -19.16037"
          style="display:inline;fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-start:url(#TriangleInM);marker-end:url(#TriangleOutM);shape-rendering:crispEdges;enable-background:new" />
       <path
          sodipodi:nodetypes="cc"
          inkscape:connector-curvature="0"
          id="path4518-5"
-         d="m 406.07202,-126.88673 0,-19.06079"
+         d="m 406.07202,-126.88673 v -19.06079"
          style="display:inline;fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-start:url(#TriangleInM-7);marker-end:url(#TriangleOutM-2);shape-rendering:crispEdges;enable-background:new" />
       <path
          sodipodi:nodetypes="cc"
          inkscape:connector-curvature="0"
          id="path4518-5-9"
-         d="m 432.18892,-126.90837 0,-19.16015"
+         d="m 432.18892,-126.90837 v -19.16015"
          style="display:inline;fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-start:url(#TriangleInM-7-1);marker-end:url(#TriangleOutM-2-8);shape-rendering:crispEdges;enable-background:new" />
       <rect
          transform="scale(-1,1)"
@@ -3143,43 +3183,43 @@
          y="-122.32901" />
       <path
          style="display:inline;fill:#a2dcea;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-         d="m 470.5705,-121.71611 0,74.51059"
+         d="m 470.5705,-121.71611 v 74.51059"
          id="path4179"
          inkscape:connector-curvature="0" />
       <path
          style="display:inline;fill:#a2dcea;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-         d="m 444.94011,-121.71611 0,74.51059"
+         d="m 444.94011,-121.71611 v 74.51059"
          id="path4179-9"
          inkscape:connector-curvature="0" />
       <path
          style="display:inline;fill:#a2dcea;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-         d="m 342.41856,-121.71611 0,74.51059"
+         d="m 342.41856,-121.71611 v 74.51059"
          id="path4179-0"
          inkscape:connector-curvature="0" />
       <path
          style="display:inline;fill:#a2dcea;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-         d="m 368.04896,-121.71611 0,74.51059"
+         d="m 368.04896,-121.71611 v 74.51059"
          id="path4179-4"
          inkscape:connector-curvature="0" />
       <path
          style="display:inline;fill:#a2dcea;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-         d="m 393.67935,-121.71611 0,74.51059"
+         d="m 393.67935,-121.71611 v 74.51059"
          id="path4179-7"
          inkscape:connector-curvature="0" />
       <path
          style="display:inline;fill:#a2dcea;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-         d="m 419.30971,-121.71611 0,74.51059"
+         d="m 419.30971,-121.71611 v 74.51059"
          id="path4179-41"
          inkscape:connector-curvature="0" />
       <path
          style="display:inline;fill:#a2dcea;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-         d="m 316.78817,-121.71611 0,74.51059"
+         d="m 316.78817,-121.71611 v 74.51059"
          id="path4179-0-3"
          inkscape:connector-curvature="0" />
       <path
          inkscape:connector-curvature="0"
          id="path4305"
-         d="m 250.24255,-84.94609 -150.919553,0"
+         d="M 250.24255,-84.94609 H 99.322997"
          style="display:inline;fill:#a2dcea;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
       <text
          transform="matrix(0,-1.0072219,0.99282988,0,0,0)"

--- a/docs/projects/adrv9371x/index.rst
+++ b/docs/projects/adrv9371x/index.rst
@@ -162,6 +162,7 @@ axi_adrv9009_rx_jesd      0x44AA_0000     0x84AA_0000
 axi_adrv9009_rx_os_jesd   0x44AB_0000     0x84AB_0000
 axi_adrv9009_rx_dma       0x7C40_0000     0x9C40_0000
 axi_adrv9009_tx_dma       0x7C42_0000     0x9C42_0000
+ad9371_data_offload       0x7C43_0000     0x9C43_0000
 axi_adrv9009_rx_os_dma    0x7C44_0000     0x9C44_0000
 axi_adrv9009_rx_clkgen    0x43C1_0000     0x83C1_0000
 axi_adrv9009_tx_clkgen    0x43C0_0000     0x83C0_0000
@@ -416,12 +417,12 @@ HDL related
    * - UTIL_CPACK2
      - :git-hdl:`library/util_pack/util_cpack2`
      - :ref:`util_upack2`
-   * - AXI_DACFIFO
-     - :git-hdl:`library/xilinx/axi_dacfifo`
-     - :ref:`util_axis_fifo`
-   * - UTIL_DACFIFO
-     - :git-hdl:`library/util_dacfifo`
-     - :ref:`util_rfifo`
+   * - DATA_OFFLOAD
+     - :git-hdl:`library/data_offload`
+     - :ref:`data_offload`
+   * - UTIL_DO_RAM
+     - :git-hdl:`library/util_do_ram`
+     - :ref:`data_offload`
    * - AXI_CLKGEN
      - :git-hdl:`library/axi_clkgen`
      - :ref:`axi_clkgen`

--- a/projects/adrv9371x/kcu105/Makefile
+++ b/projects/adrv9371x/kcu105/Makefile
@@ -1,5 +1,5 @@
 ####################################################################################
-## Copyright (c) 2018 - 2023 Analog Devices, Inc.
+## Copyright (c) 2018 - 2025 Analog Devices, Inc.
 ### SPDX short identifier: BSD-1-Clause
 ## Auto-generated, do not modify!
 ####################################################################################
@@ -8,13 +8,14 @@ PROJECT_NAME := adrv9371x_kcu105
 
 M_DEPS += ../common/adrv9371x_bd.tcl
 M_DEPS += ../../scripts/adi_pd.tcl
-M_DEPS += ../../common/xilinx/dacfifo_bd.tcl
 M_DEPS += ../../common/xilinx/adi_fir_filter_constr.xdc
 M_DEPS += ../../common/xilinx/adi_fir_filter_bd.tcl
 M_DEPS += ../../common/kcu105/kcu105_system_mig.tcl
 M_DEPS += ../../common/kcu105/kcu105_system_lutram_constr.xdc
 M_DEPS += ../../common/kcu105/kcu105_system_constr.xdc
 M_DEPS += ../../common/kcu105/kcu105_system_bd.tcl
+M_DEPS += ../../common/xilinx/data_offload_bd.tcl
+M_DEPS += ../../../library/util_hbm/scripts/adi_util_hbm.tcl
 M_DEPS += ../../../library/util_cdc/sync_bits.v
 M_DEPS += ../../../library/jesd204/scripts/jesd204.tcl
 M_DEPS += ../../../library/common/util_pulse_gen.v
@@ -24,6 +25,7 @@ M_DEPS += ../../../library/common/ad_bus_mux.v
 LIB_DEPS += axi_clkgen
 LIB_DEPS += axi_dmac
 LIB_DEPS += axi_sysid
+LIB_DEPS += data_offload
 LIB_DEPS += jesd204/ad_ip_jesd204_tpl_adc
 LIB_DEPS += jesd204/ad_ip_jesd204_tpl_dac
 LIB_DEPS += jesd204/axi_jesd204_rx
@@ -31,7 +33,8 @@ LIB_DEPS += jesd204/axi_jesd204_tx
 LIB_DEPS += jesd204/jesd204_rx
 LIB_DEPS += jesd204/jesd204_tx
 LIB_DEPS += sysid_rom
-LIB_DEPS += util_dacfifo
+LIB_DEPS += util_do_ram
+LIB_DEPS += util_hbm
 LIB_DEPS += util_pack/util_cpack2
 LIB_DEPS += util_pack/util_upack2
 LIB_DEPS += xilinx/axi_adxcvr

--- a/projects/adrv9371x/kcu105/system_bd.tcl
+++ b/projects/adrv9371x/kcu105/system_bd.tcl
@@ -1,16 +1,16 @@
 ###############################################################################
-## Copyright (C) 2017-2023 Analog Devices, Inc. All rights reserved.
+## Copyright (C) 2017-2025 Analog Devices, Inc. All rights reserved.
 ### SPDX short identifier: ADIBSD
 ###############################################################################
 
-## FIFO depth is 8Mb - 500k samples
-set dac_fifo_address_width 16
-
-## NOTE: With this configuration the #36Kb BRAM utilization is at ~68%
+## Offload attributes
+set dac_offload_type 0                   ; ## BRAM
+set dac_offload_size [expr 1*1024*1024]  ; ## 1 MB
+set plddr_offload_axi_data_width 0
 
 source $ad_hdl_dir/projects/common/kcu105/kcu105_system_bd.tcl
 source $ad_hdl_dir/projects/common/kcu105/kcu105_system_mig.tcl
-source $ad_hdl_dir/projects/common/xilinx/dacfifo_bd.tcl
+source ../common/adrv9371x_bd.tcl
 source $ad_hdl_dir/projects/scripts/adi_pd.tcl
 
 #system ID
@@ -27,13 +27,12 @@ S=$ad_project_params(TX_JESD_S)\
 RX_OS:M=$ad_project_params(RX_OS_JESD_M)\
 L=$ad_project_params(RX_OS_JESD_L)\
 S=$ad_project_params(RX_OS_JESD_S)\
-DAC_FIFO_ADDR_WIDTH=$dac_fifo_address_width"
+DAC_OFFLOAD:TYPE=$dac_offload_type\
+SIZE=$dac_offload_size"
 
 sysid_gen_sys_init_file $sys_cstring
 
 ad_ip_parameter axi_ddr_cntrl CONFIG.ADDN_UI_CLKOUT3_FREQ_HZ 200
-
-source ../common/adrv9371x_bd.tcl
 
 ad_ip_parameter util_ad9371_xcvr CONFIG.QPLL_FBDIV 80
 ad_ip_parameter util_ad9371_xcvr CONFIG.QPLL_REFCLK_DIV 1

--- a/projects/adrv9371x/kcu105/system_top.v
+++ b/projects/adrv9371x/kcu105/system_top.v
@@ -1,6 +1,6 @@
 // ***************************************************************************
 // ***************************************************************************
-// Copyright (C) 2017-2023 Analog Devices, Inc. All rights reserved.
+// Copyright (C) 2017-2025 Analog Devices, Inc. All rights reserved.
 //
 // In this HDL repository, there are many different and unique modules, consisting
 // of various HDL (Verilog or VHDL) components. The individual modules are
@@ -239,7 +239,6 @@ module system_top (
   assign gpio_i[63:60] = gpio_o[63:60];
 
   system_wrapper i_system_wrapper (
-    .dac_fifo_bypass (gpio_o[60]),
     .adc_fir_filter_active (gpio_o[61]),
     .dac_fir_filter_active (gpio_o[62]),
     .c0_ddr4_act_n (ddr4_act_n),

--- a/projects/adrv9371x/zc706/Makefile
+++ b/projects/adrv9371x/zc706/Makefile
@@ -1,5 +1,5 @@
 ####################################################################################
-## Copyright (c) 2018 - 2023 Analog Devices, Inc.
+## Copyright (c) 2018 - 2025 Analog Devices, Inc.
 ### SPDX short identifier: BSD-1-Clause
 ## Auto-generated, do not modify!
 ####################################################################################
@@ -10,10 +10,12 @@ M_DEPS += ../common/adrv9371x_bd.tcl
 M_DEPS += ../../scripts/adi_pd.tcl
 M_DEPS += ../../common/zc706/zc706_system_constr.xdc
 M_DEPS += ../../common/zc706/zc706_system_bd.tcl
-M_DEPS += ../../common/zc706/zc706_plddr3_dacfifo_bd.tcl
+M_DEPS += ../../common/zc706/zc706_plddr3_data_offload_bd.tcl
 M_DEPS += ../../common/zc706/zc706_plddr3_constr.xdc
 M_DEPS += ../../common/xilinx/adi_fir_filter_constr.xdc
 M_DEPS += ../../common/xilinx/adi_fir_filter_bd.tcl
+M_DEPS += ../../common/xilinx/data_offload_bd.tcl
+M_DEPS += ../../../library/util_hbm/scripts/adi_util_hbm.tcl
 M_DEPS += ../../../library/util_cdc/sync_bits.v
 M_DEPS += ../../../library/jesd204/scripts/jesd204.tcl
 M_DEPS += ../../../library/common/util_pulse_gen.v
@@ -25,6 +27,7 @@ LIB_DEPS += axi_dmac
 LIB_DEPS += axi_hdmi_tx
 LIB_DEPS += axi_spdif_tx
 LIB_DEPS += axi_sysid
+LIB_DEPS += data_offload
 LIB_DEPS += jesd204/ad_ip_jesd204_tpl_adc
 LIB_DEPS += jesd204/ad_ip_jesd204_tpl_dac
 LIB_DEPS += jesd204/axi_jesd204_rx
@@ -32,10 +35,11 @@ LIB_DEPS += jesd204/axi_jesd204_tx
 LIB_DEPS += jesd204/jesd204_rx
 LIB_DEPS += jesd204/jesd204_tx
 LIB_DEPS += sysid_rom
+LIB_DEPS += util_do_ram
+LIB_DEPS += util_hbm
 LIB_DEPS += util_pack/util_cpack2
 LIB_DEPS += util_pack/util_upack2
 LIB_DEPS += xilinx/axi_adxcvr
-LIB_DEPS += xilinx/axi_dacfifo
 LIB_DEPS += xilinx/util_adxcvr
 
 include ../../scripts/project-xilinx.mk

--- a/projects/adrv9371x/zc706/system_bd.tcl
+++ b/projects/adrv9371x/zc706/system_bd.tcl
@@ -1,13 +1,19 @@
 ###############################################################################
-## Copyright (C) 2016-2023 Analog Devices, Inc. All rights reserved.
+## Copyright (C) 2016-2025 Analog Devices, Inc. All rights reserved.
 ### SPDX short identifier: ADIBSD
 ###############################################################################
 
-set dac_fifo_address_width 10
+## Offload attributes
+set dac_offload_type 1                      ; ## PL_DDR
+set dac_offload_size [expr 1024*1024*1024]  ; ## 1 GB
+set plddr_offload_axi_data_width 512
 
 source $ad_hdl_dir/projects/common/zc706/zc706_system_bd.tcl
-source $ad_hdl_dir/projects/common/zc706/zc706_plddr3_dacfifo_bd.tcl
+source $ad_hdl_dir/projects/common/zc706/zc706_plddr3_data_offload_bd.tcl
+source ../common/adrv9371x_bd.tcl
 source $ad_hdl_dir/projects/scripts/adi_pd.tcl
+
+ad_plddr_data_offload_create $dac_offload_name
 
 #system ID
 ad_ip_parameter axi_sysid_0 CONFIG.ROM_ADDR_BITS 9
@@ -23,10 +29,9 @@ S=$ad_project_params(TX_JESD_S)\
 RX_OS:M=$ad_project_params(RX_OS_JESD_M)\
 L=$ad_project_params(RX_OS_JESD_L)\
 S=$ad_project_params(RX_OS_JESD_S)\
-DAC_FIFO_ADDR_WIDTH=$dac_fifo_address_width"
+DAC_OFFLOAD:TYPE=$dac_offload_type\
+SIZE=$dac_offload_size"
 
 sysid_gen_sys_init_file $sys_cstring
 
 ad_ip_parameter sys_ps7 CONFIG.PCW_FPGA2_PERIPHERAL_FREQMHZ 200
-
-source ../common/adrv9371x_bd.tcl

--- a/projects/adrv9371x/zc706/system_top.v
+++ b/projects/adrv9371x/zc706/system_top.v
@@ -1,6 +1,6 @@
 // ***************************************************************************
 // ***************************************************************************
-// Copyright (C) 2016-2023 Analog Devices, Inc. All rights reserved.
+// Copyright (C) 2016-2025 Analog Devices, Inc. All rights reserved.
 //
 // In this HDL repository, there are many different and unique modules, consisting
 // of various HDL (Verilog or VHDL) components. The individual modules are
@@ -246,7 +246,6 @@ module system_top (
   assign gpio_i[63:60] = gpio_o[63:60];
 
   system_wrapper i_system_wrapper (
-    .dac_fifo_bypass (gpio_o[60]),
     .adc_fir_filter_active (gpio_o[61]),
     .dac_fir_filter_active (gpio_o[62]),
     .ddr3_addr (ddr3_addr),

--- a/projects/adrv9371x/zcu102/Makefile
+++ b/projects/adrv9371x/zcu102/Makefile
@@ -1,5 +1,5 @@
 ####################################################################################
-## Copyright (c) 2018 - 2023 Analog Devices, Inc.
+## Copyright (c) 2018 - 2025 Analog Devices, Inc.
 ### SPDX short identifier: BSD-1-Clause
 ## Auto-generated, do not modify!
 ####################################################################################
@@ -10,9 +10,10 @@ M_DEPS += ../common/adrv9371x_bd.tcl
 M_DEPS += ../../scripts/adi_pd.tcl
 M_DEPS += ../../common/zcu102/zcu102_system_constr.xdc
 M_DEPS += ../../common/zcu102/zcu102_system_bd.tcl
-M_DEPS += ../../common/xilinx/dacfifo_bd.tcl
 M_DEPS += ../../common/xilinx/adi_fir_filter_constr.xdc
 M_DEPS += ../../common/xilinx/adi_fir_filter_bd.tcl
+M_DEPS += ../../common/xilinx/data_offload_bd.tcl
+M_DEPS += ../../../library/util_hbm/scripts/adi_util_hbm.tcl
 M_DEPS += ../../../library/util_cdc/sync_bits.v
 M_DEPS += ../../../library/jesd204/scripts/jesd204.tcl
 M_DEPS += ../../../library/common/util_pulse_gen.v
@@ -22,6 +23,7 @@ M_DEPS += ../../../library/common/ad_bus_mux.v
 LIB_DEPS += axi_clkgen
 LIB_DEPS += axi_dmac
 LIB_DEPS += axi_sysid
+LIB_DEPS += data_offload
 LIB_DEPS += jesd204/ad_ip_jesd204_tpl_adc
 LIB_DEPS += jesd204/ad_ip_jesd204_tpl_dac
 LIB_DEPS += jesd204/axi_jesd204_rx
@@ -29,7 +31,8 @@ LIB_DEPS += jesd204/axi_jesd204_tx
 LIB_DEPS += jesd204/jesd204_rx
 LIB_DEPS += jesd204/jesd204_tx
 LIB_DEPS += sysid_rom
-LIB_DEPS += util_dacfifo
+LIB_DEPS += util_do_ram
+LIB_DEPS += util_hbm
 LIB_DEPS += util_pack/util_cpack2
 LIB_DEPS += util_pack/util_upack2
 LIB_DEPS += xilinx/axi_adxcvr

--- a/projects/adrv9371x/zcu102/system_bd.tcl
+++ b/projects/adrv9371x/zcu102/system_bd.tcl
@@ -1,15 +1,15 @@
 ###############################################################################
-## Copyright (C) 2017-2023 Analog Devices, Inc. All rights reserved.
+## Copyright (C) 2017-2025 Analog Devices, Inc. All rights reserved.
 ### SPDX short identifier: ADIBSD
 ###############################################################################
 
-## FIFO depth is 16Mb - 1M samples
-set dac_fifo_address_width 17
-
-## NOTE: With this configuration the #36Kb BRAM utilization is at ~51%
+## Offload attributes
+set dac_offload_type 0                   ; ## BRAM
+set dac_offload_size [expr 2*1024*1024]  ; ## 2 MB
+set plddr_offload_axi_data_width 0
 
 source $ad_hdl_dir/projects/common/zcu102/zcu102_system_bd.tcl
-source $ad_hdl_dir/projects/common/xilinx/dacfifo_bd.tcl
+source ../common/adrv9371x_bd.tcl
 source $ad_hdl_dir/projects/scripts/adi_pd.tcl
 
 #system ID
@@ -26,15 +26,14 @@ S=$ad_project_params(TX_JESD_S)\
 RX_OS:M=$ad_project_params(RX_OS_JESD_M)\
 L=$ad_project_params(RX_OS_JESD_L)\
 S=$ad_project_params(RX_OS_JESD_S)\
-DAC_FIFO_ADDR_WIDTH=$dac_fifo_address_width"
+DAC_OFFLOAD:TYPE=$dac_offload_type\
+SIZE=$dac_offload_size"
 
 sysid_gen_sys_init_file $sys_cstring
 
 ad_ip_parameter sys_ps8 CONFIG.PSU__FPGA_PL2_ENABLE 1
 ad_ip_parameter sys_ps8 CONFIG.PSU__CRL_APB__PL2_REF_CTRL__SRCSEL {IOPLL}
 ad_ip_parameter sys_ps8 CONFIG.PSU__CRL_APB__PL2_REF_CTRL__FREQMHZ 200
-
-source ../common/adrv9371x_bd.tcl
 
 ad_ip_parameter axi_ad9371_tx_xcvr CONFIG.TX_DIFFCTRL 6
 

--- a/projects/adrv9371x/zcu102/system_top.v
+++ b/projects/adrv9371x/zcu102/system_top.v
@@ -1,6 +1,6 @@
 // ***************************************************************************
 // ***************************************************************************
-// Copyright (C) 2017-2023 Analog Devices, Inc. All rights reserved.
+// Copyright (C) 2017-2025 Analog Devices, Inc. All rights reserved.
 //
 // In this HDL repository, there are many different and unique modules, consisting
 // of various HDL (Verilog or VHDL) components. The individual modules are
@@ -199,7 +199,6 @@ module system_top (
   assign spi_csn_ad9371 =  spi_csn[1];
 
   system_wrapper i_system_wrapper (
-    .dac_fifo_bypass (gpio_o[60]),
     .adc_fir_filter_active (gpio_o[61]),
     .dac_fir_filter_active (gpio_o[62]),
     .gpio_i (gpio_i),


### PR DESCRIPTION
## PR Description

This commit adds support for the Data Offload IP, replacing the dacfifo IP.

## PR Type
- [ ] Bug fix (change that fixes an issue)
- [x] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)
- [ ] Documentation

## PR Checklist
- [x] I have followed the code style guidelines
- [x] I have performed a self-review of changes
- [ ] I have compiled all hdl projects and libraries affected by this PR
- [ ] I have tested in hardware affected projects, at least on relevant boards
- [x] I have commented my code, at least hard-to-understand parts
- [x] I have signed off all commits from this PR
- [x] I have updated the documentation (wiki pages, ReadMe files, Copyright etc)
- [ ] I have not introduced new Warnings/Critical Warnings on compilation
- [x] I have added new hdl testbenches or updated existing ones
