### PR TITLE
makefile: Restore/fix make standalone projects

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,8 +23,9 @@ help:
 
 PROJECTS := $(filter-out $(NO_PROJ), $(notdir $(wildcard projects/*)))
 SUBPROJECTS := $(foreach projname,$(PROJECTS), \
+	$(if $(wildcard projects/$(projname)/system_project.tcl), $(projname) , \
 	$(foreach archname,$(notdir $(subst /Makefile,,$(wildcard projects/$(projname)/*/Makefile))), \
-		$(projname).$(archname)))
+		$(projname).$(archname))))
 
 .PHONY: lib all clean clean-ipcache clean-all $(SUBPROJECTS)
 


### PR DESCRIPTION
## PR Description

Single/no carrier projects are not added to the SUBPROJECTS makefile.
Look for system_project.tcl at project, if it exists, it means it is a standalone project and the subproject wildcard is not needed.
SUBPROJECTS now include:
```diff
169a170,171
> jupiter_sdr
> m2k
170a173
> pluto
173a177,178
> sidekiqz2
> usrpe31x
```
Fixes https://github.com/analogdevicesinc/m2k-fw/blob/master/Makefile#L119 (broken by cb5cf61, requires m2k.standalone -> m2k) rename.

## PR Type
- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)
- [ ] Documentation

## PR Checklist
- [ ] I have followed the code style guidelines
- [ ] I have performed a self-review of changes
- [ ] I have compiled all hdl projects and libraries affected by this PR
- [ ] I have tested in hardware affected projects, at least on relevant boards
- [ ] I have commented my code, at least hard-to-understand parts
- [ ] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe files, Copyright etc)
- [ ] I have not introduced new Warnings/Critical Warnings on compilation
- [ ] I have added new hdl testbenches or updated existing ones
