### PR TITLE
library/spi_engine: fix data containing bits beyond word_length

### DIFF
--- a/docs/regmap/adi_regmap_spi_engine.txt
+++ b/docs/regmap/adi_regmap_spi_engine.txt
@@ -9,7 +9,7 @@ ENDTITLE
 REG
 0x00
 VERSION
-Version of the peripheral. Follows semantic versioning. Current version 1.04.02.
+Version of the peripheral. Follows semantic versioning. Current version 1.05.01.
 ENDREG
 
 FIELD
@@ -25,7 +25,7 @@ RO
 ENDFIELD
 
 FIELD
-[7:0] 0x00000000
+[7:0] 0x00000001
 VERSION_PATCH
 RO
 ENDFIELD

--- a/library/spi_engine/axi_spi_engine/axi_spi_engine.v
+++ b/library/spi_engine/axi_spi_engine/axi_spi_engine.v
@@ -133,7 +133,7 @@ module axi_spi_engine #(
   input [7:0] offload_sync_data
 );
 
-  localparam PCORE_VERSION = 'h010500;
+  localparam PCORE_VERSION = 'h010501;
   localparam S_AXI = 0;
   localparam UP_FIFO = 1;
 

--- a/library/spi_engine/spi_engine_execution/spi_engine_execution_shiftreg.v
+++ b/library/spi_engine/spi_engine_execution/spi_engine_execution_shiftreg.v
@@ -175,7 +175,7 @@ module spi_engine_execution_shiftreg #(
         // intended LATCH
         always @(negedge echo_sclk) begin
           if (latch_sdi)
-            sdi_data_latch[i*DATA_WIDTH+:DATA_WIDTH] <= {data_sdi_shift, sdi[i]};
+            sdi_data_latch[i*DATA_WIDTH+:DATA_WIDTH] <= {data_sdi_shift, sdi[i]} & ((1 << word_length) - 1);
         end
       end
 
@@ -207,7 +207,7 @@ module spi_engine_execution_shiftreg #(
         // intended LATCH
         always @(posedge echo_sclk) begin
           if (latch_sdi)
-            sdi_data_latch[i*DATA_WIDTH+:DATA_WIDTH] <= {data_sdi_shift, sdi[i]};
+            sdi_data_latch[i*DATA_WIDTH+:DATA_WIDTH] <= {data_sdi_shift, sdi[i]} & ((1 << word_length) - 1);
         end
       end
 
@@ -270,7 +270,7 @@ module spi_engine_execution_shiftreg #(
         end
       end
 
-      assign sdi_data[i*DATA_WIDTH+:DATA_WIDTH] = data_sdi_shift;
+      assign sdi_data[i*DATA_WIDTH+:DATA_WIDTH] = data_sdi_shift & ((1 << word_length) - 1);
 
     end
 


### PR DESCRIPTION
Here is my naive attempt at a fix. :smiley: I tested it on AD7606C-18.

## PR Description

Fix shift data being shifted beyond word_length in SPI transfers.

In SPI transfers that have word_length (bits per word) that is not 8, 16, or 32, we want the unused bits to all be set to 0. Since the data_sdi_shift register is the same size as DATA_WIDTH, bits are shifted in that register beyond word_length bits. Then this register gets copied to the sdi_data_latch register and eventually makes its way to software. However, some software makes the assumption that the upper bits will be set to 0. Since this isn't the case, it breaks the software.

By adding a mask when we copy data_sdi_shift to sdi_data_latch, we avoid setting those bits.

Fixes: https://github.com/analogdevicesinc/hdl/issues/1695


## PR Type
- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)
- [ ] Documentation

## PR Checklist
- [ ] I have followed the code style guidelines
- [ ] I have performed a self-review of changes
- [ ] I have compiled all hdl projects and libraries affected by this PR
- [x] I have tested in hardware affected projects, at least on relevant boards
- [ ] I have commented my code, at least hard-to-understand parts
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe files, Copyright etc)
- [ ] I have not introduced new Warnings/Critical Warnings on compilation
- [ ] I have added new hdl testbenches or updated existing ones
