### PR TITLE
docs: Update axi_pwm_gen regmap doc.

### DIFF
--- a/docs/library/axi_pwm_gen/index.rst
+++ b/docs/library/axi_pwm_gen/index.rst
@@ -13,9 +13,9 @@ there is one counter for each pulse.
 Features
 --------------------------------------------------------------------------------
 
-* Up to 16 configurable signals (period, width, offset)
-* External synchronization
-* External clock
+- Up to 16 configurable signals (period, width, offset)
+- External synchronization
+- External clock
 
 Files
 --------------------------------------------------------------------------------
@@ -51,21 +51,22 @@ Configuration Parameters
 
 .. note::
 
-   The pulse period, width and offset are set in number of clock cycles.
-   The clock is the axi clock or if activated, the external clock.
+   The pulse period, width and offset are set in **number of clock cycles**.
+   The clock is the AXI clock or if activated, the external clock.
 
 .. hdl-parameters::
 
    * - ID
-     - Core ID should be unique for each IP in the system.
+     - Core ID should be unique for each IP in the system
    * - ASYNC_CLK_EN
-     - Use external clock, asynchronous to s_axi_aclk.
+       Use external clock, asynchronous to s_axi_aclk (1). Otherwise, use
+       internal clock, s_axi_aclk (0).
    * - N_PWMS
-     - Number of pulses/pwms.
+     - Number of pulses/pwms
    * - PWM_EXT_SYNC
-     - PWM offset counter uses external sync.
+     - PWM offset counter uses external sync
    * - EXT_ASYNC_SYNC
-     - The external sync for pulse 0 is asynchronous.
+     - The external sync for pulse 0 is asynchronous
    * - SOFTWARE_BRINGUP
      - Require software, to bring the core out if reset
    * - EXT_SYNC_PHASE_ALIGN
@@ -91,24 +92,19 @@ Interface
 
 Detailed Description
 --------------------------------------------------------------------------------
-Let's start with some base notions:
+
+Let's start with some basic notions:
 
 - The pulse generators are based on incrementing counters.
-
 - The pulse period starts on the high level interval and ends on the low level.
-
 - By default, all counters start at the same time. When a different phase (delay)
   is needed between the pulses, we can set an offset.
-
 - The offset feature can synchronize channels 0 to 15 relative to an offset
   counter.
-
 - The offset counter will wait for a HIGH -> LOW transition of the
   synchronization pulse (''load_config'' or ''ext_sync'').
   For more info see the below channel phase alignment feature.
-
 - To **disable a PWM channel**, write 0 to its ``period`` register.
-
 - The duty cycle is the ratio between pulse width over pulse period.
 
 The following features can be enabled by setting a flag in the
@@ -121,7 +117,7 @@ The AXI PWM Generator core can be synchronized by an external signal on the
 HIGH -> LOW transition of the ext_sync signal.
 
 The external sync can be used in two modes, based on the external sync align
-feature.
+feature:
 
 - external_sync_align flag is set(1) the ext_sync will trigger a phase align
   at each neg-edge.
@@ -143,16 +139,17 @@ periods end. Software overwritable at runtime.
 
 Start at sync
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
 If active, the pulses will start after the trigger event.
 Otherwise each pulse will start after a period equal to the one for which
 it is set. Software over writable at runtime.
 
 This flags are software overwritable at runtime. Default value is given at build time.
 
--  software bringup = 1
--  start at sync = 1
--  force align = 0
--  ext sync align = 0
+- software bringup = 1
+- start at sync = 1
+- force align = 0
+- ext sync align = 0
 
 Timing Diagrams and examples
 --------------------------------------------------------------------------------
@@ -165,10 +162,10 @@ Timing Diagrams and examples
 
 .. warning::
 
-  The relationship between the offset and channel counters is not 100% accurate.
-  It is meant to highlight the functionality, by helping the reader track the
-  pwm waveforms. If you are interested in the exact timing you will have to
-  simulate the IP.
+   The relationship between the offset and channel counters is not 100% accurate.
+   It is meant to highlight the functionality, by helping the reader track the
+   pwm waveforms. If you are interested in the exact timing you will have to
+   simulate the IP.
 
 The timing diagram below, shows the ``load_config`` functionality with
 force align and start at sync disabled.
@@ -294,5 +291,5 @@ Register Map
 References
 --------------------------------------------------------------------------------
 
-* HDL IP core at :git-hdl:`library/axi_pwm_gen`
-* :dokuwiki:`AXI PWM GEN on wiki <resources/fpga/docs/axi_pwm_gen>`
+- HDL IP core at :git-hdl:`library/axi_pwm_gen`
+- :dokuwiki:`AXI PWM GEN on wiki <resources/fpga/docs/axi_pwm_gen>`

--- a/docs/regmap/adi_regmap_pwm_gen.txt
+++ b/docs/regmap/adi_regmap_pwm_gen.txt
@@ -84,10 +84,11 @@ Loads the new values written in the config registers.
 ENDFIELD
 
 FIELD
-[0] 0x0
+[0] 0x1
 RESET
 RW
-Reset, default is (0x0).
+Reset, default is (0x1). The default value can be changed by HDL at build time, 
+using SOFTWARE_BRINGUP parameter.
 ENDFIELD
 
 ############################################################################################
@@ -101,10 +102,11 @@ ENDREG
 
 FIELD
 [2] 0x0
-EXT_SYNC_ALIGN
+EXT_SYNC_PHASE_ALIGN
 RW
-If active the ext_sync will trigger a phase align at each neg-edge.
+If active, the ext_sync will trigger a phase align at each neg-edge.
 Otherwise the phase align will be armed by a load config toggle.
+This is set by default in HDL, but can be overwritten by software.
 ENDFIELD
 
 FIELD
@@ -135,8 +137,8 @@ Number of pulses
 ENDREG
 
 FIELD
-[31:0] 0x0000
-NB_PULSES
+[31:0] 0x0001
+N_PWMS
 RO
 Number of configurable pulses.
 ENDFIELD
@@ -152,7 +154,7 @@ Pulse n period
 ENDREG
 
 FIELD
-[31:0] 0x0000
+[31:0] 0x000A
 PULSE_PERIOD
 RW
 Pulse duration, defined in number of clock cycles.
@@ -169,7 +171,7 @@ Pulse n width
 ENDREG
 
 FIELD
-[31:0] 0x0000
+[31:0] 0x0007
 PULSE_WIDTH
 RW
 Pulse width (high time), defined in number of clock cycles.


### PR DESCRIPTION
## PR Description

- Updates on the regmap txt, because EXT_SYNC_ALIGN should actually be EXT_SYNC_PHASE_ALIGN, as well as the default values were wrongly set
- Cleanup in the rst documentation

## PR Type
- [ ] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)
- [x] Documentation

## PR Checklist
- [x] I have followed the code style guidelines
- [x] I have performed a self-review of changes
- [ ] I have compiled all hdl projects and libraries affected by this PR
- [ ] I have tested in hardware affected projects, at least on relevant boards
- [ ] I have commented my code, at least hard-to-understand parts
- [x] I have signed off all commits from this PR
- [x] I have updated the documentation (wiki pages, ReadMe files, Copyright etc)
- [ ] I have not introduced new Warnings/Critical Warnings on compilation
- [ ] I have added new hdl testbenches or updated existing ones
