### PR TITLE
library/common/ad_mem: Updated RAM initialization mode for Quartus IDE

### DIFF
--- a/library/common/ad_mem.v
+++ b/library/common/ad_mem.v
@@ -54,13 +54,24 @@ module ad_mem #(
   (* ram_style = "block" *)
   reg         [(DATA_WIDTH-1):0]      m_ram[0:((2**ADDRESS_WIDTH)-1)];
 
-  integer i;
-  initial
-    for (i = 0; i < 2 ** ADDRESS_WIDTH; i = i+1)
-      m_ram[i] = {DATA_WIDTH{1'b0}};
+  integer i, j;
+  initial begin
+    if (ADDRESS_WIDTH > 10) begin
+      for (i = 0; i < 2 ** 10; i = i+1) begin
+        for (j = 0; j < 2 ** (ADDRESS_WIDTH-10); j = j+1) begin
+          m_ram[i * 2 ** (ADDRESS_WIDTH-10) + j] = {DATA_WIDTH{1'b0}};
+        end
+      end
+    end else begin
+      for (i = 0; i < 2 ** ADDRESS_WIDTH; i = i+1) begin
+        m_ram[i] = {DATA_WIDTH{1'b0}};
+      end
+    end
+  end
 
-  initial
+  initial begin
     doutb <= {DATA_WIDTH{1'b0}};
+  end
 
   always @(posedge clka) begin
     if (wea == 1'b1) begin


### PR DESCRIPTION
## PR Description

Updated Block RAM initialization which bypasses the default loop limit imposed by the Quartus IDE.


## PR Type
- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)
- [ ] Documentation

## PR Checklist
- [x] I have followed the code style guidelines
- [x] I have performed a self-review of changes
- [ ] I have compiled all hdl projects and libraries affected by this PR
- [ ] I have tested in hardware affected projects, at least on relevant boards
- [ ] I have commented my code, at least hard-to-understand parts
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe files, Copyright etc)
- [x] I have not introduced new Warnings/Critical Warnings on compilation
- [ ] I have added new hdl testbenches or updated existing ones
