### PR TITLE
docs/projects/ad57xx_ardz: Fix DE10-Nano Linux GPIO numbers

### DIFF
--- a/docs/projects/ad57xx_ardz/index.rst
+++ b/docs/projects/ad57xx_ardz/index.rst
@@ -194,15 +194,15 @@ The Software GPIO number is calculated as follows:
    * - ad57xx_ardz_ldacb
      - INOUT
      - 34
-     - 2
+     - 17
    * - ad57xx_ardz_clrb
      - INOUT
      - 33
-     - 1
+     - 17
    * - ad57xx_ardz_resetb
      - INOUT
      - 32
-     - 0
+     - 16
 
 Interrupts
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/projects/ad57xx_ardz/index.rst
+++ b/docs/projects/ad57xx_ardz/index.rst
@@ -194,7 +194,7 @@ The Software GPIO number is calculated as follows:
    * - ad57xx_ardz_ldacb
      - INOUT
      - 34
-     - 17
+     - 18
    * - ad57xx_ardz_clrb
      - INOUT
      - 33


### PR DESCRIPTION

## PR Description

According to the devicetree at [1], the GPIO numbers are starting at 16 rather than 0. That devicetree was tested on hardware, so would assume that it really is correct.

[1]: https://github.com/analogdevicesinc/linux/blob/b462ee1d7bd21b940681d526e954782a6ffe8ab0/arch/arm/boot/dts/intel/socfpga/socfpga_cyclone5_de10_nano_ad5791.dts#L101C1-L103C47 

I'm also assuming that this column is for Linux, but it isn't explicit. If this column was meant for something other than Linux, then we would need to add an additional column instead.

## PR Type
- [ ] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)
- [x] Documentation

## PR Checklist
- [ ] I have followed the code style guidelines
- [x] I have performed a self-review of changes
- [ ] I have compiled all hdl projects and libraries affected by this PR
- [ ] I have tested in hardware affected projects, at least on relevant boards
- [ ] I have commented my code, at least hard-to-understand parts
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe files, Copyright etc)
- [ ] I have not introduced new Warnings/Critical Warnings on compilation
- [ ] I have added new hdl testbenches or updated existing ones
