### PR TITLE
projects: common: versal: Fix spi_clk pins

### DIFF
--- a/projects/common/vck190/vck190_system_constr.xdc
+++ b/projects/common/vck190/vck190_system_constr.xdc
@@ -10,8 +10,8 @@ set_property	PACKAGE_PIN	AF43 	[get_ports sys_clk_n]
 set_property	PACKAGE_PIN	AE42	[get_ports sys_clk_p]
 
 # Define SPI clock
-create_clock -name spi0_clk      -period 40   [get_pins -hier */EMIOSPI0SCLKO]
-create_clock -name spi1_clk      -period 40   [get_pins -hier */EMIOSPI1SCLKO]
+create_clock -name spi0_clk      -period 40   [get_pins -hier */EMIOSPI0SCLKO*]
+create_clock -name spi1_clk      -period 40   [get_pins -hier */EMIOSPI1SCLKO*]
 
 # GPIOs
 # (switches, leds and such)

--- a/projects/common/vmk180/vmk180_system_constr.xdc
+++ b/projects/common/vmk180/vmk180_system_constr.xdc
@@ -9,8 +9,8 @@ set_property	PACKAGE_PIN	AF43 	[get_ports sys_clk_n]
 set_property	PACKAGE_PIN	AE42	[get_ports sys_clk_p]
 
 # Define SPI clock
-create_clock -name spi0_clk      -period 40   [get_pins -hier */EMIOSPI0SCLKO]
-create_clock -name spi1_clk      -period 40   [get_pins -hier */EMIOSPI1SCLKO]
+create_clock -name spi0_clk      -period 40   [get_pins -hier */EMIOSPI0SCLKO*]
+create_clock -name spi1_clk      -period 40   [get_pins -hier */EMIOSPI1SCLKO*]
 
 # GPIOs
 # (switches, leds and such)

--- a/projects/common/vpk180/vpk180_system_constr.xdc
+++ b/projects/common/vpk180/vpk180_system_constr.xdc
@@ -9,8 +9,8 @@ set_property	PACKAGE_PIN	BK5 	  [get_ports sys_clk_n]
 set_property	PACKAGE_PIN	BK6	    [get_ports sys_clk_p]
 
 # Define SPI clock
-create_clock -name spi0_clk      -period 40  [get_pins -hier */EMIOSPI0SCLKO]
-create_clock -name spi1_clk      -period 40  [get_pins -hier */EMIOSPI1SCLKO]
+create_clock -name spi0_clk      -period 40  [get_pins -hier */EMIOSPI0SCLKO*]
+create_clock -name spi1_clk      -period 40  [get_pins -hier */EMIOSPI1SCLKO*]
 
 # GPIOs
 # (switches, leds and such)


### PR DESCRIPTION
## PR Description

After we updated Vivado to 2024.2, some critical warnings appeared saying that there are no clocks on the i_system_wrapper/system_i/sys_cips/inst/pspmc_0/inst/PS9_inst/EMIOSPI0SCLKOINT and i_system_wrapper/system_i/sys_cips/inst/pspmc_0/inst/PS9_inst/EMIOSPI1SCLKOINT pins.

This commit fixes the pin names on the spi_clk constraints and removes the critical warning.

## PR Type
- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)
- [ ] Documentation

## PR Checklist
- [x] I have followed the code style guidelines
- [x] I have performed a self-review of changes
- [x] I have compiled all hdl projects and libraries affected by this PR
- [ ] I have tested in hardware affected projects, at least on relevant boards
- [ ] I have commented my code, at least hard-to-understand parts
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe files, Copyright etc)
- [x] I have not introduced new Warnings/Critical Warnings on compilation
- [ ] I have added new hdl testbenches or updated existing ones
