### PR TITLE
i3c_controller: Remove CLK_MOD, set SDA low at Stop, add address width parameters

### DIFF
--- a/docs/library/i3c_controller/i3c_controller_core.rst
+++ b/docs/library/i3c_controller/i3c_controller_core.rst
@@ -33,16 +33,11 @@ Configuration Parameters
 
 .. hdl-parameters::
 
-   * - CLK_MOD
-     - Clock cycles per bus bit at maximun speed (12.5MHz), set to:
-
-       * 0: 8 clock cycles at 100MHz input clock.
-       * 1: 4 clock cycles at 50MHz input clock.
    * - I2C_MOD
      - Further divide open drain speed by power of two,
        to support slow I2C devices.
 
-       For example, with input clock 100MHz and CLK_MOD=0:
+       For example, with input clock 100MHz:
 
        * 0: 1.5626MHz (no division).
        * 2 390.6kHz.

--- a/docs/regmap/adi_regmap_i3c_controller.txt
+++ b/docs/regmap/adi_regmap_i3c_controller.txt
@@ -80,6 +80,91 @@ ENDFIELD
 ############################################################################################
 
 REG
+0x15
+PID_L
+Least significant part of Provisioned ID. The PID value has no effect and is
+present only for conformity with the bus specification.
+ENDREG
+
+FIELD
+[31:16] PART_ID
+PART_ID
+RO
+Device identifier, use the same for all instances of this controller unless ``TYPE_SELECTOR``
+is set to 1'b1.
+ENDFIELD
+
+FIELD
+[15:12] INSTANCE_ID
+INSTANCE_ID
+RO
+Identify the individual device.
+ENDFIELD
+
+FIELD
+[11:0] EXTRA_ID
+EXTRA_ID
+RO
+Extra characteristics field.
+ENDFIELD
+
+############################################################################################
+############################################################################################
+
+REG
+0x16
+PID_H
+Most significant part of Provisioned ID. The PID value has no effect and is
+present only for conformity with bus specification.
+ENDREG
+
+FIELD
+[15:1] MANUF_ID
+MANUF_ID
+RO
+MIPI Manufacturer ID.
+ENDFIELD
+
+FIELD
+[0] TYPE_SELECTOR
+TYPE_SELECTOR
+RO
+1'b1: Random Value, 1'b0: Vendor Fixed Value.
+ENDFIELD
+
+############################################################################################
+############################################################################################
+
+REG
+0x17
+DCR_BCR_DA
+ENDREG
+
+FIELD
+[22:16] DA
+DA
+RW
+Controller dynamic address, used only for conformity, has no effect.
+ENDFIELD
+
+FIELD
+[15:8] 0x40
+BCR
+RO
+Bus characteristics register.
+ENDFIELD
+
+FIELD
+[7:0] 0x00
+DCR
+RO
+Device characteristics register.
+ENDFIELD
+
+############################################################################################
+############################################################################################
+
+REG
 0x20
 IRQ_MASK
 ENDREG
@@ -318,21 +403,21 @@ Writing to it has no effect.
 ENDREG
 
 FIELD
-[23:0] 
+[23:0]
 CMDR_FIFO_ERROR
 RO
 If an error occurred during the transfer.
 ENDFIELD
 
 FIELD
-[19:8] 
+[19:8]
 CMDR_FIFO_BUFFER_LENGTH
 RO
 Unsigned 12-bits transferred payload length.
 ENDFIELD
 
 FIELD
-[7:0] 
+[7:0]
 CMDR_FIFO_SYNC
 RO
 Command synchronization.

--- a/library/i3c_controller/i3c_controller_core/i3c_controller_core.v
+++ b/library/i3c_controller/i3c_controller_core/i3c_controller_core.v
@@ -1,6 +1,6 @@
 // ***************************************************************************
 // ***************************************************************************
-// Copyright (C) 2024 Analog Devices, Inc. All rights reserved.
+// Copyright (C) 2024-2025 Analog Devices, Inc. All rights reserved.
 //
 // In this HDL repository, there are many different and unique modules, consisting
 // of various HDL (Verilog or VHDL) components. The individual modules are
@@ -40,7 +40,6 @@
 
 module i3c_controller_core #(
   parameter MAX_DEVS = 16,
-  parameter CLK_MOD = 0,
   parameter I2C_MOD = 0
 ) (
   input         clk,
@@ -111,8 +110,7 @@ module i3c_controller_core #(
   wire i2c_mode;
 
   i3c_controller_framing #(
-    .MAX_DEVS(MAX_DEVS),
-    .CLK_MOD(CLK_MOD)
+    .MAX_DEVS(MAX_DEVS)
   ) i_i3c_controller_framing (
     .reset_n(reset_n),
     .clk(clk),
@@ -171,7 +169,6 @@ module i3c_controller_core #(
     .rmap_ibi_config(rmap_ibi_config));
 
   i3c_controller_bit_mod #(
-    .CLK_MOD(CLK_MOD),
     .I2C_MOD(I2C_MOD)
   ) i_i3c_controller_bit_mod (
     .reset_n(reset_n),

--- a/library/i3c_controller/i3c_controller_core/i3c_controller_core_hw.tcl
+++ b/library/i3c_controller/i3c_controller_core/i3c_controller_core_hw.tcl
@@ -1,5 +1,5 @@
 ###############################################################################
-## Copyright (C) 2024 Analog Devices, Inc. All rights reserved.
+## Copyright (C) 2024-2025 Analog Devices, Inc. All rights reserved.
 ### SPDX short identifier: ADIBSD
 ###############################################################################
 
@@ -21,7 +21,6 @@ ad_ip_files i3c_controller_core [list \
 # parameters
 
 ad_ip_parameter MAX_DEVS STRING "MAX_DEVS"
-ad_ip_parameter CLK_MOD INTEGER 1
 ad_ip_parameter I2C_MOD INTEGER 0
 
 proc p_elaboration {} {
@@ -29,7 +28,6 @@ proc p_elaboration {} {
   # read parameters
 
   set max_devs [get_parameter_value "MAX_DEVS"]
-  set clk_mod [get_parameter_value "CLK_MOD"]
   set i2c_mod [get_parameter_value "I2C_MOD"]
 
   # clock and reset interface

--- a/library/i3c_controller/i3c_controller_core/i3c_controller_core_ip.tcl
+++ b/library/i3c_controller/i3c_controller_core/i3c_controller_core_ip.tcl
@@ -1,5 +1,5 @@
 ###############################################################################
-## Copyright (C) 2024 Analog Devices, Inc. All rights reserved.
+## Copyright (C) 2024-2025 Analog Devices, Inc. All rights reserved.
 ### SPDX short identifier: ADIBSD
 ###############################################################################
 
@@ -89,13 +89,6 @@ set_property -dict [list \
  ] \
  [ipx::get_user_parameters MAX_DEVS -of_objects $cc]
 
-## CLK_MOD
-set_property -dict [list \
-	"value_validation_type" "pairs" \
-	"value_validation_pairs" {"8" 0 "4" 1} \
-] \
-[ipx::get_user_parameters CLK_MOD -of_objects $cc]
-
 ## I2C_MOD
 set_property -dict [list \
   "value_validation_type" "list" \
@@ -120,13 +113,6 @@ set_property -dict [list \
   "display_name" "Maximum number of peripherals" \
   "tooltip" "\[MAX_DEVS\] Maximum number of peripherals in the bus, counting the controller" \
 ] [ipgui::get_guiparamspec -name "MAX_DEVS" -component $cc]
-
-ipgui::add_param -name "CLK_MOD" -component $cc -parent $general_group
-set_property -dict [list \
-	"widget" "comboBox" \
-	"display_name" "Clock cycles per bit" \
-  "tooltip" "\[CLK_MOD\] Adjust clock cycles required to modulate the lane bus bits. Set 8 to achieve 12.5MHz at 100Mhz input clock, and 4 at 50MHz." \
-] [ipgui::get_guiparamspec -name "CLK_MOD" -component $cc]
 
 ipgui::add_param -name "I2C_MOD" -component $cc -parent $general_group
 set_property -dict [list \

--- a/library/i3c_controller/i3c_controller_core/i3c_controller_framing.v
+++ b/library/i3c_controller/i3c_controller_core/i3c_controller_framing.v
@@ -185,7 +185,6 @@ module i3c_controller_framing #(
       // Delay DAA trigger one word to match last SDI byte.
       cmdp_daa_trigger <= 1'b0;
       if (cmdw_ready) begin
-        daa_trigger <= 1'b0;
         cmdp_daa_trigger <= daa_trigger;
       end
 
@@ -281,13 +280,14 @@ module i3c_controller_framing #(
               `CMDW_DAA_DEV_CHAR: begin
                 dev_char_len <= dev_char_len - 1;
                 if (~|dev_char_len) begin
-                  st  <= `CMDW_DYN_ADDR;
+                  st <= `CMDW_DYN_ADDR;
                   sm <= SM_SETUP_SDO;
                   daa_trigger <= 1'b1;
                 end
               end
               `CMDW_DYN_ADDR: begin
                 st <= j == MAX_DEVS - 1 ? `CMDW_STOP_OD : `CMDW_START;
+                daa_trigger <= 1'b0;
               end
               `CMDW_MSG_SR: begin
                 cmdw_body <= {cmdp_da, cmdp_rnw}; // Be aware of RnW here

--- a/library/i3c_controller/i3c_controller_core/i3c_controller_framing.v
+++ b/library/i3c_controller/i3c_controller_core/i3c_controller_framing.v
@@ -1,6 +1,6 @@
 // ***************************************************************************
 // ***************************************************************************
-// Copyright (C) 2024 Analog Devices, Inc. All rights reserved.
+// Copyright (C) 2024-2025 Analog Devices, Inc. All rights reserved.
 //
 // In this HDL repository, there are many different and unique modules, consisting
 // of various HDL (Verilog or VHDL) components. The individual modules are
@@ -64,8 +64,7 @@
 `include "i3c_controller_word.vh"
 
 module i3c_controller_framing #(
-  parameter MAX_DEVS = 16,
-  parameter CLK_MOD = 0
+  parameter MAX_DEVS = 16
 ) (
   input         clk,
   input         reset_n,
@@ -117,7 +116,7 @@ module i3c_controller_framing #(
 
   // Defines the bus available condition width (> 1us for target)
   // Setting around 0.64us for the controller.
-  localparam BUS_AVAIL = CLK_MOD ? 4 : 5;
+  localparam BUS_AVAIL = 5;
 
   localparam [2:0] SM_SETUP       = 0;
   localparam [2:0] SM_VALIDATE    = 1;

--- a/library/i3c_controller/i3c_controller_host_interface/i3c_controller_host_interface.v
+++ b/library/i3c_controller/i3c_controller_host_interface/i3c_controller_host_interface.v
@@ -1,6 +1,6 @@
 // ***************************************************************************
 // ***************************************************************************
-// Copyright (C) 2024 Analog Devices, Inc. All rights reserved.
+// Copyright (C) 2024-2025 Analog Devices, Inc. All rights reserved.
 //
 // In this HDL repository, there are many different and unique modules, consisting
 // of various HDL (Verilog or VHDL) components. The individual modules are
@@ -36,6 +36,11 @@
 `timescale 1ns/100ps
 
 module i3c_controller_host_interface #(
+  parameter CMD_FIFO_ADDRESS_WIDTH = 4,
+  parameter CMDR_FIFO_ADDRESS_WIDTH = 4,
+  parameter SDO_FIFO_ADDRESS_WIDTH = 5,
+  parameter SDI_FIFO_ADDRESS_WIDTH = 5,
+  parameter IBI_FIFO_ADDRESS_WIDTH = 4,
   parameter ID = 0,
   parameter ASYNC_CLK = 0,
   parameter OFFLOAD = 1
@@ -140,6 +145,11 @@ module i3c_controller_host_interface #(
   endgenerate
 
   i3c_controller_regmap #(
+    .CMD_FIFO_ADDRESS_WIDTH(CMD_FIFO_ADDRESS_WIDTH),
+    .CMDR_FIFO_ADDRESS_WIDTH(CMDR_FIFO_ADDRESS_WIDTH),
+    .SDO_FIFO_ADDRESS_WIDTH(SDO_FIFO_ADDRESS_WIDTH),
+    .SDI_FIFO_ADDRESS_WIDTH(SDI_FIFO_ADDRESS_WIDTH),
+    .IBI_FIFO_ADDRESS_WIDTH(IBI_FIFO_ADDRESS_WIDTH),
     .ID(ID),
     .OFFLOAD(OFFLOAD),
     .ASYNC_CLK(ASYNC_CLK)

--- a/library/i3c_controller/i3c_controller_host_interface/i3c_controller_host_interface.v
+++ b/library/i3c_controller/i3c_controller_host_interface/i3c_controller_host_interface.v
@@ -42,8 +42,14 @@ module i3c_controller_host_interface #(
   parameter SDI_FIFO_ADDRESS_WIDTH = 5,
   parameter IBI_FIFO_ADDRESS_WIDTH = 4,
   parameter ID = 0,
+  parameter DA = 7'h31,
   parameter ASYNC_CLK = 0,
-  parameter OFFLOAD = 1
+  parameter OFFLOAD = 1,
+  parameter PID_MANUF_ID = 15'b0,
+  parameter PID_TYPE_SELECTOR = 1'b1,
+  parameter PID_PART_ID = 16'b0,
+  parameter PID_INSTANCE_ID = 4'b0,
+  parameter PID_EXTRA_ID = 12'b0
 ) (
   input  clk,
   output reset_n,
@@ -151,8 +157,14 @@ module i3c_controller_host_interface #(
     .SDI_FIFO_ADDRESS_WIDTH(SDI_FIFO_ADDRESS_WIDTH),
     .IBI_FIFO_ADDRESS_WIDTH(IBI_FIFO_ADDRESS_WIDTH),
     .ID(ID),
+    .DA(DA),
+    .ASYNC_CLK(ASYNC_CLK),
     .OFFLOAD(OFFLOAD),
-    .ASYNC_CLK(ASYNC_CLK)
+    .PID_MANUF_ID(PID_MANUF_ID),
+    .PID_TYPE_SELECTOR(PID_TYPE_SELECTOR),
+    .PID_PART_ID(PID_PART_ID),
+    .PID_INSTANCE_ID(PID_INSTANCE_ID),
+    .PID_EXTRA_ID(PID_EXTRA_ID)
   ) i_i3c_controller_regmap (
     .s_axi_aclk(s_axi_aclk),
     .s_axi_aresetn(s_axi_aresetn),

--- a/library/i3c_controller/i3c_controller_host_interface/i3c_controller_host_interface_hw.tcl
+++ b/library/i3c_controller/i3c_controller_host_interface/i3c_controller_host_interface_hw.tcl
@@ -1,5 +1,5 @@
 ###############################################################################
-## Copyright (C) 2024 Analog Devices, Inc. All rights reserved.
+## Copyright (C) 2024-2025 Analog Devices, Inc. All rights reserved.
 ### SPDX short identifier: ADIBSD
 ###############################################################################
 
@@ -30,6 +30,11 @@ ad_ip_files i3c_controller_host_interface [list \
 
 # Parameters
 
+ad_ip_parameter CMD_FIFO_ADDRESS_WIDTH INTEGER 4
+ad_ip_parameter CMDR_FIFO_ADDRESS_WIDTH INTEGER 4
+ad_ip_parameter SDO_FIFO_ADDRESS_WIDTH INTEGER 5
+ad_ip_parameter SDI_FIFO_ADDRESS_WIDTH INTEGER 5
+ad_ip_parameter IBI_FIFO_ADDRESS_WIDTH INTEGER 4
 ad_ip_parameter ID INTEGER 0
 ad_ip_parameter ASYNC_CLK INTEGER 0
 ad_ip_parameter OFFLOAD INTEGER 0

--- a/library/i3c_controller/i3c_controller_host_interface/i3c_controller_host_interface_hw.tcl
+++ b/library/i3c_controller/i3c_controller_host_interface/i3c_controller_host_interface_hw.tcl
@@ -36,8 +36,14 @@ ad_ip_parameter SDO_FIFO_ADDRESS_WIDTH INTEGER 5
 ad_ip_parameter SDI_FIFO_ADDRESS_WIDTH INTEGER 5
 ad_ip_parameter IBI_FIFO_ADDRESS_WIDTH INTEGER 4
 ad_ip_parameter ID INTEGER 0
+ad_ip_parameter DA INTEGER 49
 ad_ip_parameter ASYNC_CLK INTEGER 0
 ad_ip_parameter OFFLOAD INTEGER 0
+ad_ip_parameter PID_MANUF_ID INTEGER 0
+ad_ip_parameter PID_TYPE_SELECTOR INTEGER 0
+ad_ip_parameter PID_PART_ID INTEGER 0
+ad_ip_parameter PID_INSTANCE_ID INTEGER 0
+ad_ip_parameter PID_EXTRA_ID INTEGER 0
 
 proc p_elaboration {} {
 

--- a/library/i3c_controller/i3c_controller_host_interface/i3c_controller_host_interface_ip.tcl
+++ b/library/i3c_controller/i3c_controller_host_interface/i3c_controller_host_interface_ip.tcl
@@ -1,5 +1,5 @@
 ###############################################################################
-## Copyright (C) 2024 Analog Devices, Inc. All rights reserved.
+## Copyright (C) 2024-2025 Analog Devices, Inc. All rights reserved.
 ### SPDX short identifier: ADIBSD
 ###############################################################################
 
@@ -105,6 +105,46 @@ set_property -dict [list \
  ] \
  [ipx::get_user_parameters ID -of_objects $cc]
 
+## CMD_FIFO_ADDRESS_WIDTH
+set_property -dict [list \
+  "value_validation_type" "range_long" \
+  "value_validation_range_minimum" "1" \
+  "value_validation_range_maximum" "16" \
+ ] \
+ [ipx::get_user_parameters CMD_FIFO_ADDRESS_WIDTH -of_objects $cc]
+
+## CMDR_FIFO_ADDRESS_WIDTH
+set_property -dict [list \
+  "value_validation_type" "range_long" \
+  "value_validation_range_minimum" "1" \
+  "value_validation_range_maximum" "16" \
+ ] \
+ [ipx::get_user_parameters CMDR_FIFO_ADDRESS_WIDTH -of_objects $cc]
+
+## SDO_FIFO_ADDRESS_WIDTH
+set_property -dict [list \
+  "value_validation_type" "range_long" \
+  "value_validation_range_minimum" "1" \
+  "value_validation_range_maximum" "16" \
+ ] \
+ [ipx::get_user_parameters SDO_FIFO_ADDRESS_WIDTH -of_objects $cc]
+
+## SDI_FIFO_ADDRESS_WIDTH
+set_property -dict [list \
+  "value_validation_type" "range_long" \
+  "value_validation_range_minimum" "1" \
+  "value_validation_range_maximum" "16" \
+ ] \
+ [ipx::get_user_parameters SDI_FIFO_ADDRESS_WIDTH -of_objects $cc]
+
+## IBI_FIFO_ADDRESS_WIDTH
+set_property -dict [list \
+  "value_validation_type" "range_long" \
+  "value_validation_range_minimum" "1" \
+  "value_validation_range_maximum" "16" \
+ ] \
+ [ipx::get_user_parameters IBI_FIFO_ADDRESS_WIDTH -of_objects $cc]
+
 foreach {k v} { \
         "ASYNC_CLK" "false" \
         "OFFLOAD" "false" \
@@ -150,6 +190,40 @@ set_property -dict [list \
   "display_name" "Offload engine" \
   "tooltip" "\[OFFLOAD\] Allows to offload output data to a external receiver, like a DMA" \
 ] [ipgui::get_guiparamspec -name "OFFLOAD" -component $cc]
+
+## Command stream FIFO depth configuration
+set cmd_stream_fifo_group [ipgui::add_group -name "Command stream FIFO configuration" -component $cc \
+    -parent $page0 -display_name "Command stream FIFO configuration" ]
+
+ipgui::add_param -name "CMD_FIFO_ADDRESS_WIDTH" -component $cc -parent $cmd_stream_fifo_group
+set_property -dict [list \
+  "display_name" "Command FIFO address width" \
+  "tooltip" "\[CMD_FIFO_ADDRESS_WIDTH\] Define the depth of the FIFO" \
+] [ipgui::get_guiparamspec -name "CMD_FIFO_ADDRESS_WIDTH" -component $cc]
+
+ipgui::add_param -name "CMDR_FIFO_ADDRESS_WIDTH" -component $cc -parent $cmd_stream_fifo_group
+set_property -dict [list \
+  "display_name" "CMDR FIFO address width" \
+  "tooltip" "\[CMDR_FIFO_ADDRESS_WIDTH\] Define the depth of the FIFO" \
+] [ipgui::get_guiparamspec -name "CMDR_FIFO_ADDRESS_WIDTH" -component $cc]
+
+ipgui::add_param -name "SDO_FIFO_ADDRESS_WIDTH" -component $cc -parent $cmd_stream_fifo_group
+set_property -dict [list \
+  "display_name" "SDO FIFO address width" \
+  "tooltip" "\[SDO_FIFO_ADDRESS_WIDTH\] Define the depth of the FIFO" \
+] [ipgui::get_guiparamspec -name "SDO_FIFO_ADDRESS_WIDTH" -component $cc]
+
+ipgui::add_param -name "SDI_FIFO_ADDRESS_WIDTH" -component $cc -parent $cmd_stream_fifo_group
+set_property -dict [list \
+  "display_name" "SDI FIFO address width" \
+  "tooltip" "\[SDI_FIFO_ADDRESS_WIDTH\] Define the depth of the FIFO" \
+] [ipgui::get_guiparamspec -name "SDI_FIFO_ADDRESS_WIDTH" -component $cc]
+
+ipgui::add_param -name "IBI_FIFO_ADDRESS_WIDTH" -component $cc -parent $cmd_stream_fifo_group
+set_property -dict [list \
+  "display_name" "IBI FIFO address width" \
+  "tooltip" "\[IBI_FIFO_ADDRESS_WIDTH\] Define the depth of the FIFO" \
+] [ipgui::get_guiparamspec -name "SDI_FIFO_ADDRESS_WIDTH" -component $cc]
 
 ## Create and save the XGUI file
 ipx::create_xgui_files $cc

--- a/library/i3c_controller/i3c_controller_host_interface/i3c_controller_host_interface_ip.tcl
+++ b/library/i3c_controller/i3c_controller_host_interface/i3c_controller_host_interface_ip.tcl
@@ -225,6 +225,49 @@ set_property -dict [list \
   "tooltip" "\[IBI_FIFO_ADDRESS_WIDTH\] Define the depth of the FIFO" \
 ] [ipgui::get_guiparamspec -name "SDI_FIFO_ADDRESS_WIDTH" -component $cc]
 
+## Provisioned ID and dynamic address configuration
+set cmd_stream_fifo_group [ipgui::add_group -name "Provisioned ID and dynamic address configuration" -component $cc \
+    -parent $page0 -display_name "Provisioned ID and dynamic address configuration" ]
+
+ipgui::add_param -name "DA" -component $cc -parent $cmd_stream_fifo_group
+set_property -dict [list \
+  "display_name" "Dynamic address" \
+  "tooltip" "\[DA\] Controller dynamic address, used only for conformity, has no effect." \
+] [ipgui::get_guiparamspec -name "DA" -component $cc]
+
+ipgui::add_param -name "PID_MANUF_ID" -component $cc -parent $cmd_stream_fifo_group
+set_property -dict [list \
+  "display_name" "PID - Manufacturer ID" \
+  "tooltip" "\[PID_MANUF_ID\] MIPI Manufacturer ID" \
+] [ipgui::get_guiparamspec -name "PID_MANUF_ID" -component $cc]
+
+ipgui::add_param -name "PID_TYPE_SELECTOR" -component $cc -parent $cmd_stream_fifo_group
+set_property -dict [list \
+  "display_name" "PID - Type selector" \
+  "tooltip" "\[PID_TYPE_SELECTOR\] 1'b1: Random Value, 1'b0: Vendor Fixed Value" \
+] [ipgui::get_guiparamspec -name "PID_TYPE_SELECTOR" -component $cc]
+
+
+ipgui::add_param -name "PID_PART_ID" -component $cc -parent $cmd_stream_fifo_group
+set_property -dict [list \
+  "display_name" "PID - Part ID" \
+  "tooltip" "\[PID_PART_ID\] Device identifier, use the same for all instances of this controller" \
+] [ipgui::get_guiparamspec -name "PID_PART_ID" -component $cc]
+
+
+ipgui::add_param -name "PID_INSTANCE_ID" -component $cc -parent $cmd_stream_fifo_group
+set_property -dict [list \
+  "display_name" "PID - Instance ID" \
+  "tooltip" "\[PID_INSTANCE_ID\] Identify the individual device" \
+] [ipgui::get_guiparamspec -name "PID_INSTANCE_ID" -component $cc]
+
+
+ipgui::add_param -name "PID_EXTRA_ID" -component $cc -parent $cmd_stream_fifo_group
+set_property -dict [list \
+  "display_name" "PID - Extra ID" \
+  "tooltip" "\[PID_EXTRA_ID\] Extra characteristics field" \
+] [ipgui::get_guiparamspec -name "PID_EXTRA_ID" -component $cc]
+
 ## Create and save the XGUI file
 ipx::create_xgui_files $cc
 ipx::save_core $cc

--- a/library/i3c_controller/i3c_controller_host_interface/i3c_controller_regmap.v
+++ b/library/i3c_controller/i3c_controller_host_interface/i3c_controller_regmap.v
@@ -1,6 +1,6 @@
 // ***************************************************************************
 // ***************************************************************************
-// Copyright (C) 2024 Analog Devices, Inc. All rights reserved.
+// Copyright (C) 2024-2025 Analog Devices, Inc. All rights reserved.
 //
 // In this HDL repository, there are many different and unique modules, consisting
 // of various HDL (Verilog or VHDL) components. The individual modules are
@@ -37,9 +37,12 @@
 
 `include "i3c_controller_regmap.vh"
 
-`define ADDRESS_WIDTH 8
-
 module i3c_controller_regmap #(
+  parameter CMD_FIFO_ADDRESS_WIDTH = 4,
+  parameter CMDR_FIFO_ADDRESS_WIDTH = 4,
+  parameter SDO_FIFO_ADDRESS_WIDTH = 5,
+  parameter SDI_FIFO_ADDRESS_WIDTH = 5,
+  parameter IBI_FIFO_ADDRESS_WIDTH = 4,
   parameter ID = 0,
   parameter ASYNC_CLK = 0,
   parameter OFFLOAD = 1,
@@ -138,7 +141,7 @@ module i3c_controller_regmap #(
 
   // CMD FIFO
 
-  wire [`ADDRESS_WIDTH-1:0] cmd_fifo_room;
+  wire [CMD_FIFO_ADDRESS_WIDTH-1:0] cmd_fifo_room;
   wire cmd_fifo_almost_empty;
   wire up_cmd_fifo_almost_empty;
 
@@ -149,7 +152,7 @@ module i3c_controller_regmap #(
   // CMDR FIFO
 
   wire cmdr_fifo_data_msb_s;
-  wire [`ADDRESS_WIDTH-1:0] cmdr_fifo_level;
+  wire [CMDR_FIFO_ADDRESS_WIDTH-1:0] cmdr_fifo_level;
   wire cmdr_fifo_almost_full;
   wire up_cmdr_fifo_almost_full;
 
@@ -160,7 +163,7 @@ module i3c_controller_regmap #(
 
   // SDO FIFO
 
-  wire [`ADDRESS_WIDTH-1:0] sdo_fifo_room;
+  wire [SDO_FIFO_ADDRESS_WIDTH-1:0] sdo_fifo_room;
   wire sdo_fifo_almost_empty;
   wire up_sdo_fifo_almost_empty;
 
@@ -172,7 +175,7 @@ module i3c_controller_regmap #(
   // SDI FIFO
 
   wire sdi_fifo_data_msb_s;
-  wire [`ADDRESS_WIDTH-1:0] sdi_fifo_level;
+  wire [SDI_FIFO_ADDRESS_WIDTH-1:0] sdi_fifo_level;
   wire sdi_fifo_almost_full;
   wire up_sdi_fifo_almost_full;
 
@@ -184,7 +187,7 @@ module i3c_controller_regmap #(
   // IBI FIFO
 
   wire ibi_fifo_data_msb_s;
-  wire [`ADDRESS_WIDTH-1:0] ibi_fifo_level;
+  wire [IBI_FIFO_ADDRESS_WIDTH-1:0] ibi_fifo_level;
   wire ibi_fifo_almost_full;
   wire up_ibi_fifo_almost_full;
 
@@ -576,7 +579,7 @@ module i3c_controller_regmap #(
 
   util_axis_fifo #(
     .DATA_WIDTH(DATA_WIDTH),
-    .ADDRESS_WIDTH(`ADDRESS_WIDTH),
+    .ADDRESS_WIDTH(CMD_FIFO_ADDRESS_WIDTH),
     .ASYNC_CLK(ASYNC_CLK),
     .M_AXIS_REGISTERED(0),
     .ALMOST_EMPTY_THRESHOLD(1),
@@ -608,7 +611,7 @@ module i3c_controller_regmap #(
   util_axis_fifo #(
     .DATA_WIDTH(DATA_WIDTH),
     .ASYNC_CLK(ASYNC_CLK),
-    .ADDRESS_WIDTH(`ADDRESS_WIDTH),
+    .ADDRESS_WIDTH(CMDR_FIFO_ADDRESS_WIDTH),
     .M_AXIS_REGISTERED(0),
     .ALMOST_EMPTY_THRESHOLD(1),
     .ALMOST_FULL_THRESHOLD(31)
@@ -641,7 +644,7 @@ module i3c_controller_regmap #(
   util_axis_fifo #(
     .DATA_WIDTH(DATA_WIDTH),
     .ASYNC_CLK(ASYNC_CLK),
-    .ADDRESS_WIDTH(`ADDRESS_WIDTH),
+    .ADDRESS_WIDTH(SDO_FIFO_ADDRESS_WIDTH),
     .M_AXIS_REGISTERED(0),
     .ALMOST_EMPTY_THRESHOLD(1),
     .ALMOST_FULL_THRESHOLD(1)
@@ -676,7 +679,7 @@ module i3c_controller_regmap #(
   util_axis_fifo #(
     .DATA_WIDTH(DATA_WIDTH),
     .ASYNC_CLK(ASYNC_CLK),
-    .ADDRESS_WIDTH(`ADDRESS_WIDTH),
+    .ADDRESS_WIDTH(SDI_FIFO_ADDRESS_WIDTH),
     .M_AXIS_REGISTERED(0),
     .ALMOST_EMPTY_THRESHOLD(1),
     .ALMOST_FULL_THRESHOLD(31)
@@ -705,7 +708,7 @@ module i3c_controller_regmap #(
   util_axis_fifo #(
     .DATA_WIDTH(DATA_WIDTH),
     .ASYNC_CLK(ASYNC_CLK),
-    .ADDRESS_WIDTH(`ADDRESS_WIDTH),
+    .ADDRESS_WIDTH(IBI_FIFO_ADDRESS_WIDTH),
     .M_AXIS_REGISTERED(0),
     .ALMOST_EMPTY_THRESHOLD(1),
     .ALMOST_FULL_THRESHOLD(31)

--- a/library/i3c_controller/i3c_controller_host_interface/i3c_controller_regmap.v
+++ b/library/i3c_controller/i3c_controller_host_interface/i3c_controller_regmap.v
@@ -124,7 +124,9 @@ module i3c_controller_regmap #(
   output     [3:0] rmap_dev_char_data
 );
 
-  localparam PCORE_VERSION = 'h00000100;
+  localparam [31:0] CORE_VERSION = {16'h0001,     /* MAJOR */
+                                     8'h00,       /* MINOR */
+                                     8'h00};      /* PATCH */
 
   reg [31:0] up_scratch  = 32'h00; // Scratch register
   reg [31:0] up_pid_l  = {PID_PART_ID, PID_INSTANCE_ID, PID_EXTRA_ID};
@@ -371,7 +373,7 @@ module i3c_controller_regmap #(
 
   always @(posedge s_axi_aclk) begin
     case (up_raddr_s[7:0])
-      `I3C_REGMAP_VERSION:        up_rdata_ff <= PCORE_VERSION;
+      `I3C_REGMAP_VERSION:        up_rdata_ff <= CORE_VERSION;
       `I3C_REGMAP_DEVICE_ID:      up_rdata_ff <= ID;
       `I3C_REGMAP_SCRATCH:        up_rdata_ff <= up_scratch;
       `I3C_REGMAP_ENABLE:         up_rdata_ff <= up_sw_reset;

--- a/library/i3c_controller/i3c_controller_host_interface/i3c_controller_regmap.vh
+++ b/library/i3c_controller/i3c_controller_host_interface/i3c_controller_regmap.vh
@@ -1,6 +1,6 @@
 // ***************************************************************************
 // ***************************************************************************
-// Copyright (C) 2024 Analog Devices, Inc. All rights reserved.
+// Copyright (C) 2024-2025 Analog Devices, Inc. All rights reserved.
 //
 // In this HDL repository, there are many different and unique modules, consisting
 // of various HDL (Verilog or VHDL) components. The individual modules are
@@ -40,6 +40,9 @@
 `define I3C_REGMAP_DEVICE_ID        8'h01
 `define I3C_REGMAP_SCRATCH          8'h02
 `define I3C_REGMAP_ENABLE           8'h10
+`define I3C_REGMAP_PID_L            8'h15
+`define I3C_REGMAP_PID_H            8'h16
+`define I3C_REGMAP_DCR_BCR_DA       8'h17
 `define I3C_REGMAP_IRQ_MASK         8'h20
 `define I3C_REGMAP_IRQ_PENDING      8'h21
 `define I3C_REGMAP_IRQ_SOURCE       8'h22

--- a/library/i3c_controller/scripts/i3c_controller_bd.tcl
+++ b/library/i3c_controller/scripts/i3c_controller_bd.tcl
@@ -1,9 +1,9 @@
 ###############################################################################
-## Copyright (C) 2024 Analog Devices, Inc. All rights reserved.
+## Copyright (C) 2024-2025 Analog Devices, Inc. All rights reserved.
 ### SPDX short identifier: ADIBSD
 ###############################################################################
 
-proc i3c_controller_create {{name "i3c_controller"} {async_clk 0} {clk_mod 1} {i2c_mod 0} {offload 1} {max_devs 16}} {
+proc i3c_controller_create {{name "i3c_controller"} {async_clk 0} {i2c_mod 0} {offload 1} {max_devs 16}} {
 
   create_bd_cell -type hier $name
   current_bd_instance /$name
@@ -26,7 +26,6 @@ proc i3c_controller_create {{name "i3c_controller"} {async_clk 0} {clk_mod 1} {i
 
   ad_ip_instance i3c_controller_core core
   ad_ip_parameter core CONFIG.MAX_DEVS $max_devs
-  ad_ip_parameter core CONFIG.CLK_MOD $clk_mod
   ad_ip_parameter core CONFIG.i2c_MOD $i2c_mod
 
   ad_connect clk host_interface/s_axi_aclk

--- a/library/i3c_controller/scripts/i3c_controller_qsys.tcl
+++ b/library/i3c_controller/scripts/i3c_controller_qsys.tcl
@@ -1,9 +1,9 @@
 ###############################################################################
-## Copyright (C) 2024 Analog Devices, Inc. All rights reserved.
+## Copyright (C) 2024-2025 Analog Devices, Inc. All rights reserved.
 ### SPDX short identifier: ADIBSD
 ###############################################################################
 
-proc i3c_controller_create {{name "i3c_controller"} {async_clk 0} {clk_mod 1} {i2c_mod 0} {offload 1} {max_devs 16}} {
+proc i3c_controller_create {{name "i3c_controller"} {async_clk 0} {i2c_mod 0} {offload 1} {max_devs 16}} {
   add_instance ${name}_host_interface i3c_controller_host_interface
 
   set_instance_parameter_value ${name}_host_interface {ASYNC_CLK} $async_clk
@@ -12,7 +12,6 @@ proc i3c_controller_create {{name "i3c_controller"} {async_clk 0} {clk_mod 1} {i
   add_instance ${name}_core i3c_controller_core
 
   set_instance_parameter_value ${name}_core {MAX_DEVS} $max_devs
-  set_instance_parameter_value ${name}_core {CLK_MOD} $clk_mod
   set_instance_parameter_value ${name}_core {I2C_MOD} $i2c_mod
 
   add_connection ${name}_host_interface.sdo  ${name}_core.sdo


### PR DESCRIPTION
## PR Description

Running the core at 50MHz, even though works, provide worst performance and improper stall times.
The target carrier, DE10Nano, can be configured to provide a clk near 100MHz without using a PLL.
Therefore, remove this option and require 100MHz input clock. Also, simplify logic to hold SDA lane always to ground during the bit, avoiding conditions where SDA rises before SCL, not yielding a proper stop bit.

Add address width parameters, because these values affect considerably the resource utilization, therefore, make them user-configurable.

non-sticky interrupt pending
Set interrupt pending on source signal rising edge, to allow clearing
it and then resolving, e.g.:
```c
  static irqreturn_t adi_i3c_controller_irq(int irq, void *data)
  {
          struct adi_i3c_controller *controller = data;
          u32 pending;

          pending = readl_relaxed(controller->regs + REG_IRQ_PENDING);
          writel_relaxed(pending, controller->regs + REG_IRQ_PENDING);
          if (pending & IRQ_PENDING_CMDR_PENDING) {
                  spin_lock(&controller->xferqueue.lock);
                  adi_i3c_controller_end_xfer_locked(controller, pending);
                  spin_unlock(&controller->xferqueue.lock);
          }
          if (pending & IRQ_PENDING_IBI_PENDING)
                  adi_i3c_controller_demux_ibis(controller);
          if (pending & IRQ_PENDING_DAA_PENDING)
                  adi_i3c_controller_handle_da_req(controller);

          return IRQ_HANDLED;
  }
```
Breaking change because removes an user set parameter.

This was tested on hardware by me and a third-party

## PR Type
- [ ] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [x] Breaking change (has dependencies in other repos or will cause CI to fail)
- [ ] Documentation

## PR Checklist
- [ ] I have followed the code style guidelines
- [ ] I have performed a self-review of changes
- [ ] I have compiled all hdl projects and libraries affected by this PR
- [x] I have tested in hardware affected projects, at least on relevant boards
- [ ] I have commented my code, at least hard-to-understand parts
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe files, Copyright etc)
- [ ] I have not introduced new Warnings/Critical Warnings on compilation
- [x] I have added new hdl testbenches or updated existing ones
