### PR TITLE
docs/projects: Fix warnings at build & update Vivado version in Releases page

### DIFF
--- a/docs/projects/ad4170_asdz/index.rst
+++ b/docs/projects/ad4170_asdz/index.rst
@@ -6,7 +6,7 @@ AD4170_ASDZ HDL project
 Overview
 --------------------------------------------------------------------------------
 
-The HDL reference design for the :adi:`AD4170-4` :adi:`AD4190-4`provides
+The HDL reference design for the :adi:`AD4170-4` and :adi:`AD4190-4` provides
 a high resolution, 24-Bit, DC to 50 kHz Input Bandwidth, Multichannel,
 Low Noise Precision Sigma-Delta ADC with PGA.
 
@@ -22,7 +22,7 @@ pseudodifferential inputs. The on-chip low noise gain stage ensures that signals
 of small amplitude can be interfaced directly to the devices.
 
 This project has a :ref:`spi_engine` instance to control and acquire data from
-the AD4170-4  or AD4190-4 24-bit precision ADC. This instance provides support
+the AD4170-4 or AD4190-4 24-bit precision ADC. This instance provides support
 for capturing continuous samples at the maximum sample rate.
 
 Supported boards
@@ -225,8 +225,10 @@ Resources
 Hardware related
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-- Product datasheet: :adi:`AD4170-4`
-- Product datasheet: :adi:`AD4190-4`
+- Products datasheet:
+
+  - :adi:`AD4170-4`
+  - :adi:`AD4190-4`
 
 HDL related
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/projects/ad7616_sdz/index.rst
+++ b/docs/projects/ad7616_sdz/index.rst
@@ -81,18 +81,23 @@ Configuration modes
 
 The following are the parameters of this project that can be configured:
 - INTF: specifies the type of interface used;
+
   - 0 - parallel (default)
   - 1 - serial
+
 - NUM_OF_SDI: number of SDI lines used, **only in serial interface mode**;
+
   - 1 - one SDI line
   - 2 - two SDI lines (default)
 
 Depending on the required interface mode, some hardware modifications need to
 be done on the board:
+
   - SL5 - unmounted - Parallel interface
   - SL5 - mounted - Serial interface
-  This switch is a *hardware* switch. Please rebuild the design if the variable
-  has been changed.
+
+This switch is a *hardware* switch. Please rebuild the design if the variable
+has been changed.
 
 Jumper setup
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/projects/cn0540/index.rst
+++ b/docs/projects/cn0540/index.rst
@@ -356,10 +356,11 @@ Software related
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 - :git-linux:`CN0540 Linux driver source code <drivers/iio/adc/ad7768-1.c>`
-- CN0540 on Cora Z7s Linux device tree
+- CN0540/CoraZ7S Linux device tree
    :git-linux:`arch/arm/boot/dts/xilinx/zynq-coraz7s-cn0540.dts`
-- CN0540 on DE-10Nano Linux device tree
+- CN0540/DE-10Nano Linux device tree
    :git-linux:`arch/arm/boot/dts/intel/socfpga/socfpga_cyclone5_de10_nano_cn0540.dts`
+
 .. include:: ../common/more_information.rst
 
 .. include:: ../common/support.rst

--- a/docs/user_guide/releases.rst
+++ b/docs/user_guide/releases.rst
@@ -28,9 +28,10 @@ following:
 First, disable the version check of the scripts.
 
 The ADI build scripts are making sure that the releases are being run on
-the validated tool version. It will promptly notify the user if he or
-she trying to use an unsupported version of tools. You need to disable
-this check by setting the environment variable ``ADI_IGNORE_VERSION_CHECK``.
+the validated tool version. It will promptly notify the user if he/she is
+trying to use an unsupported version of tools. You need to disable
+this check by setting the environment variable **ADI_IGNORE_VERSION_CHECK**:
+``export ADI_IGNORE_VERSION_CHECK=1``.
 
 Second, make Intel and AMD IP cores version change.
 
@@ -45,7 +46,6 @@ After which, update the Tcl scripts accordingly.
 The versions are specified in the following format.
 
 .. code-block:: tcl
-   :linenos:
 
    add_instance sys_cpu altera_nios2_gen2 16.0
    set sys_mb [create_bd_cell -type ip -vlnv xilinx.com:ip:microblaze:9.5 sys_mb]
@@ -68,9 +68,9 @@ Release branches
      - List of supported projects and IP cores
    * - :git-hdl:`main <main:/>`
      - Quartus Pro 24.2
-     - Vivado 2023.2
-     -
-     -
+     - Vivado 2024.2
+     - ---
+     - ---
    * - :git-hdl:`hdl_2023_r2 <hdl_2023_r2:>`
      - Quartus Pro 23.2
      - Vivado 2023.2


### PR DESCRIPTION
## PR Description

Fixed warnings that were found at doc build and updated the Vivado version in the Releases page.

## PR Type
- [ ] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)
- [x] Documentation

## PR Checklist
- [ ] I have followed the code style guidelines
- [x] I have performed a self-review of changes
- [ ] I have compiled all hdl projects and libraries affected by this PR
- [ ] I have tested in hardware affected projects, at least on relevant boards
- [ ] I have commented my code, at least hard-to-understand parts
- [x] I have signed off all commits from this PR
- [x] I have updated the documentation (wiki pages, ReadMe files, Copyright etc)
- [ ] I have not introduced new Warnings/Critical Warnings on compilation
- [ ] I have added new hdl testbenches or updated existing ones
