### PR TITLE
projects/ad4052/de10nano: fix timing

### DIFF
--- a/projects/ad4052_ardz/de10nano/system_qsys.tcl
+++ b/projects/ad4052_ardz/de10nano/system_qsys.tcl
@@ -1,5 +1,5 @@
 ###############################################################################
-## Copyright (C) 2024 Analog Devices, Inc. All rights reserved.
+## Copyright (C) 2024-2025 Analog Devices, Inc. All rights reserved.
 ### SPDX short identifier: ADIBSD
 ###############################################################################
 
@@ -13,3 +13,6 @@ set_instance_parameter_value rom_sys_0 {ROM_ADDR_BITS} {9}
 set_instance_parameter_value rom_sys_0 {PATH_TO_FILE} "$mem_init_sys_file_path/mem_init_sys.txt"
 
 sysid_gen_sys_init_file
+
+# Set a lower limit than the default of 4 for pipeline stages on the memnory-mapped interconnect
+set_interconnect_requirement {$system} {qsys_mm.maxAdditionalLatency} {1}


### PR DESCRIPTION
## PR Description

Fix ad4052 occasionally failing timing on current main. 

## PR Type
- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)
- [ ] Documentation

## PR Checklist
- [ ] I have followed the code style guidelines
- [ ] I have performed a self-review of changes
- [x] I have compiled all hdl projects and libraries affected by this PR
- [ ] I have tested in hardware affected projects, at least on relevant boards
- [x] I have commented my code, at least hard-to-understand parts
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe files, Copyright etc)
- [x] I have not introduced new Warnings/Critical Warnings on compilation
- [ ] I have added new hdl testbenches or updated existing ones
