### PR TITLE
projects/ad469x_evb: change intel projects to pll-provided 160mhz clock

### DIFF
--- a/projects/ad469x_evb/common/ad469x_qsys.tcl
+++ b/projects/ad469x_evb/common/ad469x_qsys.tcl
@@ -6,9 +6,6 @@
 # receive dma
 set_instance_parameter_value sys_hps {F2SDRAM_Width} {128 64}
 
-# set spi_clk to 160MHz
-set_instance_parameter_value sys_hps {S2FCLK_USER0CLK_FREQ} {160.0}
-
 add_instance axi_dmac_0 axi_dmac
 set_instance_parameter_value axi_dmac_0 {DMA_TYPE_SRC} {1}
 set_instance_parameter_value axi_dmac_0 {DMA_TYPE_DEST} {0}
@@ -65,6 +62,47 @@ set_instance_parameter_value ad469x_trigger_gen {N_PWMS} {1}
 set_instance_parameter_value ad469x_trigger_gen {PULSE_0_PERIOD} {160}
 set_instance_parameter_value ad469x_trigger_gen {PULSE_0_WIDTH} {1}
 
+# spi_clk pll
+
+add_instance spi_clk_pll altera_pll
+set_instance_parameter_value spi_clk_pll {gui_feedback_clock} {Global Clock}
+set_instance_parameter_value spi_clk_pll {gui_operation_mode} {direct}
+set_instance_parameter_value spi_clk_pll {gui_number_of_clocks} {1}
+set_instance_parameter_value spi_clk_pll {gui_output_clock_frequency0} {160}
+set_instance_parameter_value spi_clk_pll {gui_phase_shift0} {0}
+set_instance_parameter_value spi_clk_pll {gui_phase_shift1} {0}
+set_instance_parameter_value spi_clk_pll {gui_phase_shift_deg0} {0.0}
+set_instance_parameter_value spi_clk_pll {gui_phase_shift_deg1} {0.0}
+set_instance_parameter_value spi_clk_pll {gui_phout_division} {1}
+set_instance_parameter_value spi_clk_pll {gui_pll_auto_reset} {Off}
+set_instance_parameter_value spi_clk_pll {gui_pll_bandwidth_preset} {Auto}
+set_instance_parameter_value spi_clk_pll {gui_pll_mode} {Fractional-N PLL}
+set_instance_parameter_value spi_clk_pll {gui_ps_units0} {ps}
+set_instance_parameter_value spi_clk_pll {gui_refclk_switch} {0}
+set_instance_parameter_value spi_clk_pll {gui_reference_clock_frequency} {50.0}
+set_instance_parameter_value spi_clk_pll {gui_switchover_delay} {0}
+set_instance_parameter_value spi_clk_pll {gui_en_reconf} {1}
+
+add_instance spi_clk_pll_reconfig altera_pll_reconfig
+set_instance_parameter_value spi_clk_pll_reconfig {ENABLE_BYTEENABLE} {0}
+set_instance_parameter_value spi_clk_pll_reconfig {ENABLE_MIF} {0}
+set_instance_parameter_value spi_clk_pll_reconfig {MIF_FILE_NAME} {}
+
+add_connection spi_clk_pll.reconfig_from_pll spi_clk_pll_reconfig.reconfig_from_pll
+set_connection_parameter_value spi_clk_pll.reconfig_from_pll/spi_clk_pll_reconfig.reconfig_from_pll endPort {}
+set_connection_parameter_value spi_clk_pll.reconfig_from_pll/spi_clk_pll_reconfig.reconfig_from_pll endPortLSB {0}
+set_connection_parameter_value spi_clk_pll.reconfig_from_pll/spi_clk_pll_reconfig.reconfig_from_pll startPort {}
+set_connection_parameter_value spi_clk_pll.reconfig_from_pll/spi_clk_pll_reconfig.reconfig_from_pll startPortLSB {0}
+set_connection_parameter_value spi_clk_pll.reconfig_from_pll/spi_clk_pll_reconfig.reconfig_from_pll width {0}
+
+add_connection spi_clk_pll.reconfig_to_pll spi_clk_pll_reconfig.reconfig_to_pll
+set_connection_parameter_value spi_clk_pll.reconfig_to_pll/spi_clk_pll_reconfig.reconfig_to_pll endPort {}
+set_connection_parameter_value spi_clk_pll.reconfig_to_pll/spi_clk_pll_reconfig.reconfig_to_pll endPortLSB {0}
+set_connection_parameter_value spi_clk_pll.reconfig_to_pll/spi_clk_pll_reconfig.reconfig_to_pll startPort {}
+set_connection_parameter_value spi_clk_pll.reconfig_to_pll/spi_clk_pll_reconfig.reconfig_to_pll startPortLSB {0}
+set_connection_parameter_value spi_clk_pll.reconfig_to_pll/spi_clk_pll_reconfig.reconfig_to_pll width {0}
+
+
 # exported interface
 
 add_interface ad469x_spi_sclk       clock source
@@ -87,29 +125,34 @@ add_connection axi_spi_engine_0.if_spi_resetn reset_bridge_0.in_reset
 
 # clocks
 
-add_interface ad469x_spi_clk        clock source
-set_interface_property ad469x_spi_clk     EXPORT_OF clock_bridge_0.out_clk
+add_interface ad469x_spi_clk            clock source
+set_interface_property ad469x_spi_clk   EXPORT_OF clock_bridge_0.out_clk
 
+
+add_connection sys_clk.clk spi_clk_pll.refclk
+add_connection sys_clk.clk spi_clk_pll_reconfig.mgmt_clk
 add_connection sys_clk.clk ad469x_trigger_gen.s_axi_clock
 add_connection sys_clk.clk axi_spi_engine_0.s_axi_clock
 add_connection sys_clk.clk axi_dmac_0.s_axi_clock
 
-add_connection sys_dma_clk.clk ad469x_trigger_gen.if_ext_clk
-add_connection sys_dma_clk.clk spi_engine_execution_0.if_clk
-add_connection sys_dma_clk.clk spi_engine_interconnect_0.if_clk
-add_connection sys_dma_clk.clk axi_spi_engine_0.if_spi_clk
-add_connection sys_dma_clk.clk spi_engine_offload_0.if_ctrl_clk
-add_connection sys_dma_clk.clk spi_engine_offload_0.if_spi_clk
-add_connection sys_dma_clk.clk axi_dmac_0.if_s_axis_aclk
+add_connection spi_clk_pll.outclk0 ad469x_trigger_gen.if_ext_clk
+add_connection spi_clk_pll.outclk0 spi_engine_execution_0.if_clk
+add_connection spi_clk_pll.outclk0 spi_engine_interconnect_0.if_clk
+add_connection spi_clk_pll.outclk0 axi_spi_engine_0.if_spi_clk
+add_connection spi_clk_pll.outclk0 spi_engine_offload_0.if_ctrl_clk
+add_connection spi_clk_pll.outclk0 spi_engine_offload_0.if_spi_clk
+add_connection spi_clk_pll.outclk0 axi_dmac_0.if_s_axis_aclk
+add_connection spi_clk_pll.outclk0 clock_bridge_0.in_clk
+
 add_connection sys_dma_clk.clk axi_dmac_0.m_dest_axi_clock
-add_connection sys_dma_clk.clk clock_bridge_0.in_clk
 
 # resets
 
-add_connection sys_clk.clk_reset ad469x_trigger_gen.s_axi_reset
-
+add_connection sys_clk.clk_reset spi_clk_pll.reset
+add_connection sys_clk.clk_reset spi_clk_pll_reconfig.mgmt_reset
 add_connection sys_clk.clk_reset axi_spi_engine_0.s_axi_reset
 add_connection sys_clk.clk_reset axi_dmac_0.s_axi_reset
+add_connection sys_clk.clk_reset ad469x_trigger_gen.s_axi_reset
 
 add_connection axi_spi_engine_0.if_spi_resetn spi_engine_execution_0.if_resetn
 add_connection axi_spi_engine_0.if_spi_resetn spi_engine_interconnect_0.if_resetn


### PR DESCRIPTION
## PR Description

Currently, the ad469x_evb/de10nano tries to use the HPS generated clock as a source of 160MHz clock. 
However, this is automatically limited to 100MHz, due to part limitations: https://github.com/analogdevicesinc/hdl/pull/1749#issuecomment-2921418082

https://www.intel.com/content/www/us/en/support/programmable/articles/000084690.html

This PR changes it so the 160MHz clock is generated by a PLL.


## PR Type
- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)
- [ ] Documentation

## PR Checklist
- [x] I have followed the code style guidelines
- [x] I have performed a self-review of changes
- [x] I have compiled all hdl projects and libraries affected by this PR
- [ ] I have tested in hardware affected projects, at least on relevant boards
- [ ] I have commented my code, at least hard-to-understand parts
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe files, Copyright etc)
- [x] I have not introduced new Warnings/Critical Warnings on compilation
- [ ] I have added new hdl testbenches or updated existing ones
