### PR TITLE
Adding initial Lattice support for spi_engine, axi_dmac, axi_pwm_gen, axi_pulse_gen and axi_clock_monitor IPs.

### DIFF
--- a/library/axi_clock_monitor/Makefile
+++ b/library/axi_clock_monitor/Makefile
@@ -1,5 +1,5 @@
 ####################################################################################
-## Copyright (c) 2018 - 2023 Analog Devices, Inc.
+## Copyright (c) 2018 - 2025 Analog Devices, Inc.
 ### SPDX short identifier: BSD-1-Clause
 ## Auto-generated, do not modify!
 ####################################################################################
@@ -16,5 +16,8 @@ XILINX_DEPS += axi_clock_monitor_ip.tcl
 INTEL_DEPS += ../intel/common/up_clock_mon_constr.sdc
 INTEL_DEPS += ../intel/common/up_rst_constr.sdc
 INTEL_DEPS += axi_clock_monitor_hw.tcl
+
+LATTICE_DEPS += ../common/up_clock_mon.v
+LATTICE_DEPS += axi_clock_monitor_ltt.tcl
 
 include ../scripts/library.mk

--- a/library/axi_clock_monitor/axi_clock_monitor_ltt.tcl
+++ b/library/axi_clock_monitor/axi_clock_monitor_ltt.tcl
@@ -1,0 +1,66 @@
+###############################################################################
+## Copyright (C) 2024 - 2025 Analog Devices, Inc. All rights reserved.
+### SPDX short identifier: ADIBSD
+###############################################################################
+
+source ../../scripts/adi_env.tcl
+source $ad_hdl_dir/library/scripts/adi_ip_lattice.tcl
+
+set mod_data [ipl::parse_module ./axi_clock_monitor.v]
+set ip $::ipl::ip
+
+set ip [ipl::add_ports_from_module -ip $ip -mod_data $mod_data]
+
+set ip [ipl::general \
+    -vlnv "analog.com:ip:axi_clock_monitor:1.0" \
+    -display_name "ADI AXI clock monitor" \
+    -supported_products {*} \
+    -supported_platforms {esi radiant} \
+    -href "https://wiki.analog.com/resources/fpga/docs/axi_clock_monitor" \
+    -category "ADI" \
+    -keywords "ADI IP" \
+    -min_radiant_version "2023.2" \
+    -min_esi_version "2023.2" -ip $ip]
+
+set ip [ipl::add_memory_map -ip $ip \
+    -name "axi_clock_monitor_mem_map" \
+    -description "axi_clock_monitor_mem_map" \
+    -baseAddress 0 \
+    -range 4096 \
+    -width 32]
+
+set ip [ipl::add_axi_interfaces -ip $ip -mod_data $mod_data]
+
+set ip [ipl::set_parameter -ip $ip \
+    -id ID \
+    -type param \
+    -value_type int \
+    -conn_mod axi_clock_monitor \
+    -title {ID} \
+    -default 0 \
+    -output_formatter nostr \
+    -group1 {General configurations} \
+    -group2 Global]
+set ip [ipl::set_parameter -ip $ip \
+    -id NUM_OF_CLOCKS \
+    -type param \
+    -value_type int \
+    -conn_mod axi_clock_monitor \
+    -title {Number of clocks} \
+    -default 1 \
+    -output_formatter nostr \
+    -value_range {(1, 16)} \
+    -group1 {General configurations} \
+    -group2 Global]
+
+for {set i 0} {$i < 16} {incr i} {
+    set ip [ipl::ignore_ports -ip $ip -portlist clock_$i \
+        -expression "not(NUM_OF_CLOCKS > $i)"]
+}
+
+set ip [ipl::add_ip_files -ip $ip -dpath rtl -flist [list \
+    "$ad_hdl_dir/library/common/up_axi.v" \
+    "$ad_hdl_dir/library/common/up_clock_mon.v" \
+    "axi_clock_monitor.v" ]]
+
+ipl::generate_ip $ip

--- a/library/axi_dmac/Makefile
+++ b/library/axi_dmac/Makefile
@@ -63,13 +63,12 @@ INTEL_DEPS += ../util_cdc/sync_gray.v
 INTEL_DEPS += axi_dmac_constr.sdc
 INTEL_DEPS += axi_dmac_hw.tcl
 
+LATTICE_DEPS += ../common/ad_mem.v
 LATTICE_DEPS += ../util_axis_fifo/util_axis_fifo.v
 LATTICE_DEPS += ../util_axis_fifo/util_axis_fifo_address_generator.v
 LATTICE_DEPS += ../util_cdc/sync_bits.v
 LATTICE_DEPS += ../util_cdc/sync_event.v
 LATTICE_DEPS += ../util_cdc/sync_gray.v
-LATTICE_DEPS += axi_dmac_ext_sync.v
-LATTICE_DEPS += axi_dmac_framelock.v
 LATTICE_DEPS += axi_dmac_ltt.tcl
 
 LATTICE_INTERFACE_DEPS += interfaces_ltt

--- a/library/axi_dmac/Makefile
+++ b/library/axi_dmac/Makefile
@@ -1,5 +1,5 @@
 ####################################################################################
-## Copyright (c) 2018 - 2024 Analog Devices, Inc.
+## Copyright (c) 2018 - 2025 Analog Devices, Inc.
 ### SPDX short identifier: BSD-1-Clause
 ## Auto-generated, do not modify!
 ####################################################################################
@@ -62,5 +62,16 @@ INTEL_DEPS += ../util_cdc/sync_event.v
 INTEL_DEPS += ../util_cdc/sync_gray.v
 INTEL_DEPS += axi_dmac_constr.sdc
 INTEL_DEPS += axi_dmac_hw.tcl
+
+LATTICE_DEPS += ../util_axis_fifo/util_axis_fifo.v
+LATTICE_DEPS += ../util_axis_fifo/util_axis_fifo_address_generator.v
+LATTICE_DEPS += ../util_cdc/sync_bits.v
+LATTICE_DEPS += ../util_cdc/sync_event.v
+LATTICE_DEPS += ../util_cdc/sync_gray.v
+LATTICE_DEPS += axi_dmac_ext_sync.v
+LATTICE_DEPS += axi_dmac_framelock.v
+LATTICE_DEPS += axi_dmac_ltt.tcl
+
+LATTICE_INTERFACE_DEPS += interfaces_ltt
 
 include ../scripts/library.mk

--- a/library/axi_dmac/axi_dmac_ltt.tcl
+++ b/library/axi_dmac/axi_dmac_ltt.tcl
@@ -1,0 +1,791 @@
+###############################################################################
+## Copyright (C) 2024 - 2025 Analog Devices, Inc. All rights reserved.
+### SPDX short identifier: ADIBSD
+###############################################################################
+
+source ../../scripts/adi_env.tcl
+source $ad_hdl_dir/library/scripts/adi_ip_lattice.tcl
+
+set mod_data [ipl::parse_module ./axi_dmac.v]
+set ip $::ipl::ip
+
+set ip [ipl::add_ports_from_module -ip $ip -mod_data $mod_data]
+
+set ip [ipl::general -ip $ip -display_name "AXI_DMA ADI"]
+set ip [ipl::general -ip $ip -supported_products {*}]
+set ip [ipl::general -ip $ip -supported_platforms {esi radiant}]
+set ip [ipl::general -ip $ip -href "https://analogdevicesinc.github.io/hdl/library/axi_dmac/index.html"]
+set ip [ipl::general \
+    -vlnv "analog.com:ip:axi_dmac:1.0" \
+    -category "ADI" \
+    -keywords "ADI IP" \
+    -min_radiant_version "2023.2" \
+    -min_esi_version "2023.2" -ip $ip]
+
+set ip [ipl::add_memory_map -ip $ip \
+    -name "axi_dmac_mem_map" \
+    -description "axi_dmac_mem_map" \
+    -baseAddress 0 \
+    -range 65536 \
+    -width 32]
+set ip [ipl::add_address_space -ip $ip \
+    -name "m_dest_axi_aspace" \
+    -range 0x100000000 \
+    -width 32]
+set ip [ipl::add_address_space -ip $ip \
+    -name "m_src_axi_aspace" \
+    -range 0x100000000 \
+    -width 32]
+set ip [ipl::add_address_space -ip $ip \
+    -name "m_sg_axi_aspace" \
+    -range 0x100000000 \
+    -width 32]
+
+set ip [ipl::add_axi_interfaces -ip $ip -mod_data $mod_data]
+
+set ip [ipl::add_interface -ip $ip \
+    -inst_name fifo_wr \
+    -display_name fifo_wr \
+    -description fifo_wr \
+    -master_slave slave \
+    -portmap { \
+        {"fifo_wr_en" "EN"} \
+        {"fifo_wr_din" "DATA"} \
+        {"fifo_wr_overflow" "OVERFLOW"} \
+        {"fifo_wr_xfer_req" "XFER_REQ"} \
+    } \
+    -vlnv {analog.com:ADI:fifo_wr:1.0}]
+
+set ip [ipl::add_interface -ip $ip \
+    -inst_name fifo_rd \
+    -display_name fifo_rd \
+    -description fifo_rd \
+    -master_slave slave \
+    -portmap 	{
+        {"fifo_rd_en" "EN"} \
+        {"fifo_rd_dout" "DATA"} \
+        {"fifo_rd_valid" "VALID"} \
+        {"fifo_rd_underflow" "UNDERFLOW"} \
+    } \
+    -vlnv {analog.com:ADI:fifo_rd:1.0}]
+
+set ip [ipl::add_interface -ip $ip \
+    -inst_name m_framelock \
+    -display_name m_framelock \
+    -description m_framelock \
+    -master_slave master \
+    -portmap {
+        {"m_frame_in" "s2m_framelock"} \
+        {"m_frame_in_valid" "s2m_framelock_valid"} \
+        {"m_frame_out" "m2s_framelock"} \
+        {"m_frame_out_valid" "m2s_framelock_valid"} \
+    } \
+    -vlnv {analog.com:ADI:if_framelock:1.0}]
+
+set ip [ipl::add_interface -ip $ip \
+    -inst_name s_framelock \
+    -display_name s_framelock \
+    -description s_framelock \
+    -master_slave slave \
+    -portmap {
+        {"s_frame_in" "m2s_framelock"} \
+        {"s_frame_in_valid" "m2s_framelock_valid"} \
+        {"s_frame_out" "s2m_framelock"} \
+        {"s_frame_out_valid" "s2m_framelock_valid"} \
+    } \
+    -vlnv {analog.com:ADI:if_framelock:1.0}]
+
+# Do not use a port name as interface name except if you use case differences.
+set ip [ipl::add_interface -ip $ip \
+    -inst_name IRQ \
+    -display_name IRQ \
+    -description IRQ \
+    -master_slave master \
+    -portmap [list {"irq" "IRQ"}] \
+    -vlnv {spiritconsortium.org:busdef.interrupt:interrupt:1.0}]
+
+set ip [ipl::add_ip_files -ip $ip -dpath rtl -flist [list \
+    axi_dmac.v \
+    axi_dmac_regmap.v \
+    axi_dmac_regmap_request.v \
+    ../util_axis_fifo/util_axis_fifo.v \
+    ../util_cdc/sync_bits.v \
+    ../util_axis_fifo/util_axis_fifo_address_generator.v \
+    ../util_cdc/sync_gray.v \
+    ../common/ad_mem.v \
+    ../common/up_axi.v \
+    axi_dmac_transfer.v \
+    axi_dmac_reset_manager.v \
+    dmac_sg.v \
+    splitter.v \
+    axi_dmac_framelock.v \
+    dmac_2d_transfer.v \
+    request_arb.v \
+    dest_axi_mm.v \
+    address_generator.v \
+    inc_id.vh \
+    response_handler.v \
+    resp.vh \
+    dest_axi_stream.v \
+    response_generator.v \
+    dest_fifo_inf.v \
+    src_axi_mm.v \
+    src_axi_stream.v \
+    data_mover.v \
+    ../util_cdc/sync_event.v \
+    src_fifo_inf.v \
+    axi_register_slice.v \
+    axi_dmac_burst_memory.v \
+    axi_dmac_resize_src.v \
+    ../common/ad_mem_asym.v \
+    axi_dmac_resize_dest.v \
+    request_generator.v \
+    axi_dmac_response_manager.v \
+    axi_dmac_ext_sync.v \
+]]
+
+# source
+set ip [ipl::set_parameter -ip $ip \
+    -id DMA_TYPE_SRC \
+    -type param \
+    -value_type int \
+    -conn_mod axi_dmac \
+    -title {Type} \
+    -options {[('Memory-Mapped AXI', 0), ('Streaming AXI', 1), ('FIFO Interface', 2)]} \
+    -default 2 \
+    -output_formatter nostr \
+    -group1 {Source} \
+    -group2 Config]
+set ip [ipl::set_parameter -ip $ip \
+    -id DMA_AXI_PROTOCOL_SRC \
+    -type param \
+    -value_type int \
+    -conn_mod axi_dmac \
+    -title {AXI Protocol} \
+    -options {[('AXI4', 0), ('AXI3', 1)]} \
+    -editable {(DMA_TYPE_SRC == 0)} \
+    -default 0 \
+    -output_formatter nostr \
+    -group1 {Source} \
+    -group2 Config]
+set ip [ipl::set_parameter -ip $ip \
+    -id DMA_DATA_WIDTH_SRC \
+    -type param \
+    -value_type int \
+    -conn_mod axi_dmac \
+    -title {Bus Width} \
+    -options {[16, 32, 64, 128, 256, 512, 1024, 2048]} \
+    -default 64 \
+    -output_formatter nostr \
+    -group1 {Source} \
+    -group2 Config]
+set ip [ipl::set_parameter -ip $ip \
+    -id AXI_SLICE_SRC \
+    -type param \
+    -value_type int \
+    -conn_mod axi_dmac \
+    -title {Insert Register Slice} \
+    -options {[(True, 1), (False, 0)]} \
+    -default 0 \
+    -output_formatter nostr \
+    -group1 {Source} \
+    -group2 Config]
+set ip [ipl::set_parameter -ip $ip \
+    -id AXIS_TUSER_SYNC \
+    -type param \
+    -value_type int \
+    -conn_mod axi_dmac \
+    -title {TUSER Synchronization} \
+    -options {[(True, 1), (False, 0)]} \
+    -editable {(DMA_TYPE_SRC == 1 and SYNC_TRANSFER_START == 1)} \
+    -default 1 \
+    -output_formatter nostr \
+    -group1 {Source} \
+    -group2 Config]
+set ip [ipl::ignore_ports_by_prefix -ip $ip \
+    -mod_data $mod_data \
+    -v_prefix m_src_axi \
+    -expression {not(DMA_TYPE_SRC == 0)}]
+set ip [ipl::ignore_ports_by_prefix -ip $ip \
+    -mod_data $mod_data \
+    -v_prefix s_axis \
+    -expression {not(DMA_TYPE_SRC == 1)}]
+set ip [ipl::ignore_ports_by_prefix -ip $ip \
+    -mod_data $mod_data \
+    -v_prefix fifo_rd \
+    -expression {not(DMA_TYPE_SRC == 2)}]
+
+# destination
+set ip [ipl::set_parameter -ip $ip \
+    -id DMA_TYPE_DEST \
+    -type param \
+    -value_type int \
+    -conn_mod axi_dmac \
+    -title {Type} \
+    -default 2 \
+    -options {[('Memory-Mapped AXI', 0), ('Streaming AXI', 1), ('FIFO Interface', 2)]} \
+    -output_formatter nostr \
+    -group1 {Destination} \
+    -group2 Config]
+set ip [ipl::set_parameter -ip $ip \
+    -id DMA_AXI_PROTOCOL_DEST \
+    -type param \
+    -value_type int \
+    -conn_mod axi_dmac \
+    -title {AXI Protocol} \
+    -options {[('AXI4', 0), ('AXI3', 1)]} \
+    -editable {(DMA_TYPE_DEST == 0)} \
+    -default 0 \
+    -output_formatter nostr \
+    -group1 {Destination} \
+    -group2 Config]
+set ip [ipl::set_parameter -ip $ip \
+    -id DMA_DATA_WIDTH_DEST \
+    -type param \
+    -value_type int \
+    -conn_mod axi_dmac \
+    -title {Bus Width} \
+    -options {[16, 32, 64, 128, 256, 512, 1024, 2048]} \
+    -default 64 \
+    -output_formatter nostr \
+    -group1 {Destination} \
+    -group2 Config]
+set ip [ipl::set_parameter -ip $ip \
+    -id AXI_SLICE_DEST \
+    -type param \
+    -value_type int \
+    -conn_mod axi_dmac \
+    -title {Insert Register Slice} \
+    -options {[(True, 1), (False, 0)]} \
+    -default 0 \
+    -output_formatter nostr \
+    -group1 {Destination} \
+    -group2 Config]
+set ip [ipl::ignore_ports_by_prefix -ip $ip \
+    -mod_data $mod_data \
+    -v_prefix m_dest_axi \
+    -expression {not(DMA_TYPE_DEST == 0)}]
+set ip [ipl::ignore_ports_by_prefix -ip $ip \
+    -mod_data $mod_data \
+    -v_prefix m_axis \
+    -expression {not(DMA_TYPE_DEST == 1)}]
+set ip [ipl::ignore_ports_by_prefix -ip $ip \
+    -mod_data $mod_data \
+    -v_prefix fifo_wr \
+    -expression {not(DMA_TYPE_DEST == 2)}]
+set ip [ipl::ignore_ports -ip $ip \
+    -portlist {sync} \
+    -expression {not((SYNC_TRANSFER_START == 1) and (DMA_TYPE_SRC != 1 or AXIS_TUSER_SYNC != 1))}]
+
+# scatter gather
+set ip [ipl::set_parameter -ip $ip \
+    -id DMA_AXI_PROTOCOL_SG \
+    -type param \
+    -value_type int \
+    -conn_mod axi_dmac \
+    -title {AXI Protocol} \
+    -editable {(DMA_SG_TRANSFER == 1)} \
+    -options {[('AXI4', 0), ('AXI3', 1)]} \
+    -default 0 \
+    -output_formatter nostr \
+    -group1 {Scatter-Gather} \
+    -group2 Config]
+set ip [ipl::set_parameter -ip $ip \
+    -id DMA_DATA_WIDTH_SG \
+    -type param \
+    -value_type int \
+    -conn_mod axi_dmac \
+    -title {Bus Width} \
+    -editable {(DMA_SG_TRANSFER == 1)} \
+    -options {[64]} \
+    -default 64 \
+    -output_formatter nostr \
+    -group1 {Scatter-Gather} \
+    -group2 Config]
+set ip [ipl::ignore_ports_by_prefix -ip $ip \
+    -mod_data $mod_data \
+    -v_prefix m_sg_axi \
+    -expression {(DMA_SG_TRANSFER == 0)}]
+
+# general
+set ip [ipl::set_parameter -ip $ip \
+    -id ID \
+    -type param \
+    -value_type int \
+    -conn_mod axi_dmac \
+    -title {Core ID} \
+    -default 0 \
+    -output_formatter nostr \
+    -group1 {General Configuration} \
+    -group2 Config]
+set ip [ipl::set_parameter -ip $ip \
+    -id DMA_LENGTH_WIDTH \
+    -type param \
+    -value_type int \
+    -conn_mod axi_dmac \
+    -title {DMA Transfer Length Register Width} \
+    -default 24 \
+    -output_formatter nostr \
+    -value_range {(8, 32)} \
+    -group1 {General Configuration} \
+    -group2 Config]
+set ip [ipl::set_parameter -ip $ip \
+    -id FIFO_SIZE \
+    -type param \
+    -value_type int \
+    -conn_mod axi_dmac \
+    -title {Store-and-Forward Memory Size (In Bursts)} \
+    -options {[2, 4, 8, 16, 32]} \
+    -default 8 \
+    -output_formatter nostr \
+    -group1 {General Configuration} \
+    -group2 Config]
+set ip [ipl::set_parameter -ip $ip \
+    -id MAX_BYTES_PER_BURST \
+    -type param \
+    -value_type int \
+    -conn_mod axi_dmac \
+    -title {Maximum Bytes per Burst} \
+    -default 128 \
+    -output_formatter nostr \
+    -group1 {General Configuration} \
+    -group2 Config]
+set ip [ipl::set_parameter -ip $ip \
+    -id AXI_AXCACHE \
+    -type param \
+    -value_type string \
+    -conn_mod axi_dmac \
+    -title {ARCACHE/AWCACHE} \
+    -default 4'b0011 \
+    -output_formatter nostr \
+    -editable {(CACHE_COHERENT == 1)} \
+    -group1 {General Configuration} \
+    -group2 Config]
+set ip [ipl::set_parameter -ip $ip \
+    -id AXI_AXPROT \
+    -type param \
+    -value_type string \
+    -conn_mod axi_dmac \
+    -title {ARPROT/AWPROT} \
+    -default 3'b000 \
+    -output_formatter nostr \
+    -editable {(CACHE_COHERENT == 1)} \
+    -group1 {General Configuration} \
+    -group2 Config]
+
+# features
+set ip [ipl::set_parameter -ip $ip \
+    -id CYCLIC \
+    -type param \
+    -value_type int \
+    -conn_mod axi_dmac \
+    -title {Cyclic Transfer Support} \
+    -options {[(True, 1), (False, 0)]} \
+    -default 0 \
+    -output_formatter nostr \
+    -group1 {Features} \
+    -group2 Config]
+set ip [ipl::set_parameter -ip $ip \
+    -id DMA_SG_TRANSFER \
+    -type param \
+    -value_type int \
+    -conn_mod axi_dmac \
+    -title {SG Transfer Support} \
+    -options {[(True, 1), (False, 0)]} \
+    -default 0 \
+    -output_formatter nostr \
+    -group1 {Features} \
+    -group2 Config]
+set ip [ipl::set_parameter -ip $ip \
+    -id DMA_2D_TRANSFER \
+    -type param \
+    -value_type int \
+    -conn_mod axi_dmac \
+    -title {2D Transfer Support} \
+    -options {[(True, 1), (False, 0)]} \
+    -default 0 \
+    -output_formatter nostr \
+    -group1 {Features} \
+    -group2 Config]
+set ip [ipl::set_parameter -ip $ip \
+    -id USE_EXT_SYNC \
+    -type param \
+    -value_type int \
+    -conn_mod axi_dmac \
+    -title {External Synchronization Support} \
+    -options {[(True, 1), (False, 0)]} \
+    -default 0 \
+    -output_formatter nostr \
+    -group1 {Features} \
+    -group2 Config]
+set ip [ipl::set_parameter -ip $ip \
+    -id SYNC_TRANSFER_START \
+    -type param \
+    -value_type int \
+    -conn_mod axi_dmac \
+    -title {Transfer Start Synchronization Support} \
+    -options {[(True, 1), (False, 0)]} \
+    -default 0 \
+    -output_formatter nostr \
+    -group1 {Features} \
+    -group2 Config]
+set ip [ipl::set_parameter -ip $ip \
+    -id CACHE_COHERENT \
+    -type param \
+    -value_type int \
+    -conn_mod axi_dmac \
+    -title {Cache Coherent} \
+    -options {[(True, 1), (False, 0)]} \
+    -editable {(DMA_TYPE_SRC == 0 or DMA_TYPE_DEST == 0)} \
+    -default 0 \
+    -output_formatter nostr \
+    -group1 {Features} \
+    -group2 Config]
+set ip [ipl::ignore_ports -ip $ip \
+    -portlist {src_ext_sync dest_ext_sync} \
+    -expression {not(USE_EXT_SYNC == 1)}]
+
+# 2D settings
+set ip [ipl::set_parameter -ip $ip \
+    -id DMA_2D_TLAST_MODE \
+    -type param \
+    -value_type int \
+    -conn_mod axi_dmac \
+    -title {AXIS TLAST function} \
+    -options {[('End of Line', 1), ('End of Frame', 0)]} \
+    -default 0 \
+    -output_formatter nostr \
+    -editable {(DMA_2D_TRANSFER == 1)} \
+    -group1 {2D settings} \
+    -group2 Config]
+set ip [ipl::set_parameter -ip $ip \
+    -id FRAMELOCK \
+    -type param \
+    -value_type int \
+    -conn_mod axi_dmac \
+    -title {Framelock Support} \
+    -options {[('End of Line', 1), ('End of Frame', 0)]} \
+    -default 0 \
+    -output_formatter nostr \
+    -editable {(DMA_2D_TRANSFER == 1 and CYCLIC == 1)} \
+    -group1 {2D settings} \
+    -group2 Config]
+set ip [ipl::set_parameter -ip $ip \
+    -id MAX_NUM_FRAMES_WIDTH \
+    -type param \
+    -value_type int \
+    -conn_mod axi_dmac \
+    -title {Max Number Of Frame Buffers} \
+    -options {[('4 buffers', 2), ('8 buffers', 3), ('16 buffers', 4), ('32 buffers', 5)]} \
+    -default 3 \
+    -output_formatter nostr \
+    -editable {(DMA_2D_TRANSFER == 1 and CYCLIC == 1)} \
+    -group1 {2D settings} \
+    -group2 Config]
+set ip [ipl::ignore_ports_by_prefix -ip $ip \
+    -mod_data $mod_data \
+    -v_prefix m_frame \
+    -expression {not(DMA_TYPE_SRC != 0 and DMA_TYPE_DEST == 0 and FRAMELOCK == 1)}]
+set ip [ipl::ignore_ports_by_prefix -ip $ip \
+    -mod_data $mod_data \
+    -v_prefix s_frame \
+    -expression {not(DMA_TYPE_SRC == 0 and DMA_TYPE_DEST != 0 and FRAMELOCK == 1)}]
+
+
+# clock domain configuration
+set ip [ipl::set_parameter -ip $ip \
+    -id ASYNC_CLK_REQ_SRC \
+    -type param \
+    -value_type int \
+    -conn_mod axi_dmac \
+    -title {Request and Source Clock Asynchronous} \
+    -options {[(True, 1), (False, 0)]} \
+    -default 1 \
+    -output_formatter nostr \
+    -group1 {Clock Domain Configuration} \
+    -group2 Config]
+set ip [ipl::set_parameter -ip $ip \
+    -id ASYNC_CLK_SRC_DEST \
+    -type param \
+    -value_type int \
+    -conn_mod axi_dmac \
+    -title {Source and Destination Clock Asynchronous} \
+    -options {[(True, 1), (False, 0)]} \
+    -default 1 \
+    -output_formatter nostr \
+    -group1 {Clock Domain Configuration} \
+    -group2 Config]
+set ip [ipl::set_parameter -ip $ip \
+    -id ASYNC_CLK_DEST_REQ \
+    -type param \
+    -value_type int \
+    -conn_mod axi_dmac \
+    -title {Destination and Request Clock Asynchronous} \
+    -options {[(True, 1), (False, 0)]} \
+    -default 1 \
+    -output_formatter nostr \
+    -group1 {Clock Domain Configuration} \
+    -group2 Config]
+set ip [ipl::set_parameter -ip $ip \
+    -id ASYNC_CLK_REQ_SG \
+    -type param \
+    -value_type int \
+    -conn_mod axi_dmac \
+    -title {Request and Scatter-Gather Clock Asynchronous} \
+    -options {[(True, 1), (False, 0)]} \
+    -default 1 \
+    -output_formatter nostr \
+    -group1 {Clock Domain Configuration} \
+    -group2 Config]
+set ip [ipl::set_parameter -ip $ip \
+    -id ASYNC_CLK_SRC_SG \
+    -type param \
+    -value_type int \
+    -conn_mod axi_dmac \
+    -title {Source and Scatter-Gather Clock Asynchronous} \
+    -options {[(True, 1), (False, 0)]} \
+    -default 1 \
+    -output_formatter nostr \
+    -group1 {Clock Domain Configuration} \
+    -group2 Config]
+set ip [ipl::set_parameter -ip $ip \
+    -id ASYNC_CLK_DEST_SG \
+    -type param \
+    -value_type int \
+    -conn_mod axi_dmac \
+    -title {Destination and Scatter-Gather Clock Asynchronous} \
+    -options {[(True, 1), (False, 0)]} \
+    -default 1 \
+    -output_formatter nostr \
+    -group1 {Clock Domain Configuration} \
+    -group2 Config]
+
+# debug
+set ip [ipl::set_parameter -ip $ip \
+    -id DISABLE_DEBUG_REGISTERS \
+    -type param \
+    -value_type int \
+    -conn_mod axi_dmac \
+    -title {Disable Debug Registers} \
+    -options {[(True, 1), (False, 0)]} \
+    -default 0 \
+    -output_formatter nostr \
+    -group1 {Debug} \
+    -group2 Config]
+set ip [ipl::set_parameter -ip $ip \
+    -id ENABLE_DIAGNOSTICS_IF \
+    -type param \
+    -value_type int \
+    -conn_mod axi_dmac \
+    -title {Enable Diagnostics Interface} \
+    -options {[(True, 1), (False, 0)]} \
+    -default 0 \
+    -output_formatter nostr \
+    -group1 {Debug} \
+    -group2 Config]
+set ip [ipl::ignore_ports -ip $ip \
+    -portlist {dest_diag_level_bursts} \
+    -expression {(ENABLE_DIAGNOSTICS_IF == 0)}]
+
+# hidden
+set ip [ipl::set_parameter -ip $ip \
+    -hidden True \
+    -id DMA_AXI_ADDR_WIDTH \
+    -type param \
+    -value_type int \
+    -conn_mod axi_dmac \
+    -title {DMA AXI Address Width} \
+    -default 32 \
+    -output_formatter nostr \
+    -group1 {Hidden} \
+    -group2 Config]
+set ip [ipl::set_parameter -ip $ip \
+    -hidden True \
+    -id AXI_ID_WIDTH_SRC \
+    -type param \
+    -value_type int \
+    -conn_mod axi_dmac \
+    -title AXI_ID_WIDTH_SRC \
+    -default 1 \
+    -output_formatter nostr \
+    -group1 {Hidden} \
+    -group2 Config]
+set ip [ipl::set_parameter -ip $ip \
+    -hidden True \
+    -id AXI_ID_WIDTH_DEST \
+    -type param \
+    -value_type int \
+    -conn_mod axi_dmac \
+    -title AXI_ID_WIDTH_DEST \
+    -default 1 \
+    -output_formatter nostr \
+    -group1 {Hidden} \
+    -group2 Config]
+set ip [ipl::set_parameter -ip $ip \
+    -hidden True \
+    -id AXI_ID_WIDTH_SG \
+    -type param \
+    -value_type int \
+    -conn_mod axi_dmac \
+    -title AXI_ID_WIDTH_SG \
+    -default 1 \
+    -output_formatter nostr \
+    -group1 {Hidden} \
+    -group2 Config]
+set ip [ipl::set_parameter -ip $ip \
+    -hidden True \
+    -id DMA_AXIS_ID_W \
+    -type param \
+    -value_type int \
+    -conn_mod axi_dmac \
+    -title DMA_AXIS_ID_W \
+    -default 8 \
+    -output_formatter nostr \
+    -group1 {Hidden} \
+    -group2 Config]
+set ip [ipl::set_parameter -ip $ip \
+    -hidden True \
+    -id DMA_AXIS_DEST_W \
+    -type param \
+    -value_type int \
+    -conn_mod axi_dmac \
+    -title DMA_AXIS_DEST_W \
+    -default 4 \
+    -output_formatter nostr \
+    -group1 {Hidden} \
+    -group2 Config]
+set ip [ipl::set_parameter -ip $ip \
+    -hidden True \
+    -id ALLOW_ASYM_MEM \
+    -type param \
+    -value_type int \
+    -conn_mod axi_dmac \
+    -title ALLOW_ASYM_MEM \
+    -default 0 \
+    -output_formatter nostr \
+    -group1 {Hidden} \
+    -group2 Config]
+
+# Autorun
+set ip [ipl::set_parameter -ip $ip \
+    -id AUTORUN \
+    -type param \
+    -value_type int \
+    -conn_mod axi_dmac \
+    -title {Enable AutoRun mode} \
+    -options {[(True, 1), (False, 0)]} \
+    -default 0 \
+    -output_formatter nostr \
+    -group2 {Autorun Settings}]
+set ip [ipl::set_parameter -ip $ip \
+    -id AUTORUN_FLAGS \
+    -type param \
+    -value_type string \
+    -conn_mod axi_dmac \
+    -title {Flags} \
+    -default 32'h00000000 \
+    -output_formatter nostr \
+    -editable {(AUTORUN == 1)} \
+    -group1 {Autorun} \
+    -group2 {Autorun Settings}]
+set ip [ipl::set_parameter -ip $ip \
+    -id AUTORUN_SRC_ADDR \
+    -type param \
+    -value_type string \
+    -conn_mod axi_dmac \
+    -title {Source address} \
+    -default 32'h00000000 \
+    -output_formatter nostr \
+    -editable {(AUTORUN == 1)} \
+    -group1 {Autorun} \
+    -group2 {Autorun Settings}]
+set ip [ipl::set_parameter -ip $ip \
+    -id AUTORUN_DEST_ADDR \
+    -type param \
+    -value_type string \
+    -conn_mod axi_dmac \
+    -title {Destination address} \
+    -default 32'h00000000 \
+    -output_formatter nostr \
+    -editable {(AUTORUN == 1)} \
+    -group1 {Autorun} \
+    -group2 {Autorun Settings}]
+set ip [ipl::set_parameter -ip $ip \
+    -id AUTORUN_X_LENGTH \
+    -type param \
+    -value_type string \
+    -conn_mod axi_dmac \
+    -title {X length} \
+    -default 32'h00000000 \
+    -output_formatter nostr \
+    -editable {(AUTORUN == 1)} \
+    -group1 {Autorun} \
+    -group2 {Autorun Settings}]
+set ip [ipl::set_parameter -ip $ip \
+    -id AUTORUN_Y_LENGTH \
+    -type param \
+    -value_type string \
+    -conn_mod axi_dmac \
+    -title {Y length} \
+    -default 32'h00000000 \
+    -output_formatter nostr \
+    -editable {(AUTORUN == 1)} \
+    -group1 {Autorun} \
+    -group2 {Autorun Settings}]
+set ip [ipl::set_parameter -ip $ip \
+    -id AUTORUN_SRC_STRIDE \
+    -type param \
+    -value_type string \
+    -conn_mod axi_dmac \
+    -title {Source stride} \
+    -default 32'h00000000 \
+    -output_formatter nostr \
+    -editable {(AUTORUN == 1)} \
+    -group1 {Autorun} \
+    -group2 {Autorun Settings}]
+set ip [ipl::set_parameter -ip $ip \
+    -id AUTORUN_DEST_STRIDE \
+    -type param \
+    -value_type string \
+    -conn_mod axi_dmac \
+    -title {Destination stride} \
+    -default 32'h00000000 \
+    -output_formatter nostr \
+    -editable {(AUTORUN == 1)} \
+    -group1 {Autorun} \
+    -group2 {Autorun Settings}]
+set ip [ipl::set_parameter -ip $ip \
+    -id AUTORUN_SG_ADDRESS \
+    -type param \
+    -value_type string \
+    -conn_mod axi_dmac \
+    -title {Scatter-Gather start address} \
+    -default 32'h00000000 \
+    -output_formatter nostr \
+    -editable {(AUTORUN == 1)} \
+    -group1 {Autorun} \
+    -group2 {Autorun Settings}]
+set ip [ipl::set_parameter -ip $ip \
+    -id AUTORUN_FRAMELOCK_CONFIG \
+    -type param \
+    -value_type string \
+    -conn_mod axi_dmac \
+    -title {Framelock config} \
+    -default 32'h00000000 \
+    -output_formatter nostr \
+    -editable {(AUTORUN == 1)} \
+    -group1 {Autorun} \
+    -group2 {Autorun Settings}]
+set ip [ipl::set_parameter -ip $ip \
+    -id AUTORUN_FRAMELOCK_STRIDE \
+    -type param \
+    -value_type string \
+    -conn_mod axi_dmac \
+    -title {Framelock stride} \
+    -default 32'h00000000 \
+    -output_formatter nostr \
+    -editable {(AUTORUN == 1)} \
+    -group1 {Autorun} \
+    -group2 {Autorun Settings}]
+
+ipl::generate_ip $ip

--- a/library/axi_pulse_gen/Makefile
+++ b/library/axi_pulse_gen/Makefile
@@ -1,5 +1,5 @@
 ####################################################################################
-## Copyright (c) 2018 - 2023 Analog Devices, Inc.
+## Copyright (c) 2018 - 2025 Analog Devices, Inc.
 ### SPDX short identifier: BSD-1-Clause
 ## Auto-generated, do not modify!
 ####################################################################################
@@ -17,5 +17,11 @@ XILINX_DEPS += axi_pulse_gen_constr.ttcl
 XILINX_DEPS += axi_pulse_gen_ip.tcl
 
 XILINX_LIB_DEPS += util_cdc
+
+LATTICE_DEPS += ../util_cdc/sync_bits.v
+LATTICE_DEPS += ../util_cdc/sync_data.v
+LATTICE_DEPS += ../util_cdc/sync_event.v
+LATTICE_DEPS += ../util_cdc/sync_gray.v
+LATTICE_DEPS += axi_pulse_gen_ltt.tcl
 
 include ../scripts/library.mk

--- a/library/axi_pulse_gen/Makefile
+++ b/library/axi_pulse_gen/Makefile
@@ -21,7 +21,6 @@ XILINX_LIB_DEPS += util_cdc
 LATTICE_DEPS += ../util_cdc/sync_bits.v
 LATTICE_DEPS += ../util_cdc/sync_data.v
 LATTICE_DEPS += ../util_cdc/sync_event.v
-LATTICE_DEPS += ../util_cdc/sync_gray.v
 LATTICE_DEPS += axi_pulse_gen_ltt.tcl
 
 include ../scripts/library.mk

--- a/library/axi_pulse_gen/axi_pulse_gen_ltt.tcl
+++ b/library/axi_pulse_gen/axi_pulse_gen_ltt.tcl
@@ -1,0 +1,81 @@
+###############################################################################
+## Copyright (C) 2024 - 2025 Analog Devices, Inc. All rights reserved.
+### SPDX short identifier: ADIBSD
+###############################################################################
+
+source ../../scripts/adi_env.tcl
+source $ad_hdl_dir/library/scripts/adi_ip_lattice.tcl
+
+set mod_data [ipl::parse_module ./axi_pulse_gen.v]
+set ip $::ipl::ip
+
+set ip [ipl::add_ports_from_module -ip $ip -mod_data $mod_data]
+
+set ip [ipl::general \
+    -vlnv "analog.com:ip:axi_pulse_gen:1.0" \
+    -display_name "ADI AXI Pulse generator" \
+    -supported_products {*} \
+    -supported_platforms {esi radiant} \
+    -href "https://wiki.analog.com/resources/fpga/docs/axi_pwm_gen" \
+    -category "ADI" \
+    -keywords "ADI IP" \
+    -min_radiant_version "2023.2" \
+    -min_esi_version "2023.2" -ip $ip]
+
+set ip [ipl::add_memory_map -ip $ip \
+    -name "axi_pulse_gen_mem_map" \
+    -description "axi_pulse_gen_mem_map" \
+    -baseAddress 0 \
+    -range 65536 \
+    -width 32]
+
+set ip [ipl::add_axi_interfaces -ip $ip -mod_data $mod_data]
+
+set ip [ipl::set_parameter -ip $ip \
+    -id ASYNC_CLK_EN \
+    -type param \
+    -value_type int \
+    -conn_mod axi_pulse_gen \
+    -title {ASYNC_CLK_EN} \
+    -options {[(True, 1), (False, 0)]} \
+    -default 1 \
+    -output_formatter nostr \
+    -group1 {AXI Pulse Generator} \
+    -group2 Config]
+set ip [ipl::set_parameter -ip $ip \
+    -id PULSE_WIDTH \
+    -type param \
+    -value_type int \
+    -conn_mod axi_pulse_gen \
+    -title {Pulse width} \
+    -default 7 \
+    -output_formatter nostr \
+    -value_range {(0, 2147483647)} \
+    -group1 {AXI Pulse Generator} \
+    -group2 Config]
+set ip [ipl::set_parameter -ip $ip \
+    -id PULSE_PERIOD \
+    -type param \
+    -value_type int \
+    -conn_mod axi_pulse_gen \
+    -title {Pulse period} \
+    -default 10 \
+    -output_formatter nostr \
+    -value_range {(0, 2147483647)} \
+    -group1 {AXI Pulse Generator} \
+    -group2 Config]
+
+set ip [ipl::ignore_ports -ip $ip -portlist ext_clk -expression {(ASYNC_CLK_EN == 0)}]
+
+set ip [ipl::add_ip_files -ip $ip -dpath rtl -flist [list \
+    axi_pulse_gen.v \
+    axi_pulse_gen_regmap.v \
+    ../common/ad_rst.v \
+    ../util_cdc/sync_data.v \
+    ../util_cdc/sync_bits.v \
+    ../util_cdc/sync_event.v \
+    ../common/util_pulse_gen.v \
+    ../common/up_axi.v \
+]]
+
+ipl::generate_ip $ip

--- a/library/axi_pwm_gen/Makefile
+++ b/library/axi_pwm_gen/Makefile
@@ -26,6 +26,7 @@ INTEL_DEPS += axi_pwm_gen_hw.tcl
 
 LATTICE_DEPS += ../util_cdc/sync_bits.v
 LATTICE_DEPS += ../util_cdc/sync_data.v
+LATTICE_DEPS += ../util_cdc/sync_event.v
 LATTICE_DEPS += axi_pwm_gen_ltt.tcl
 
 include ../scripts/library.mk

--- a/library/axi_pwm_gen/Makefile
+++ b/library/axi_pwm_gen/Makefile
@@ -1,5 +1,5 @@
 ####################################################################################
-## Copyright (c) 2018 - 2024 Analog Devices, Inc.
+## Copyright (c) 2018 - 2025 Analog Devices, Inc.
 ### SPDX short identifier: BSD-1-Clause
 ## Auto-generated, do not modify!
 ####################################################################################
@@ -23,5 +23,9 @@ INTEL_DEPS += ../util_cdc/sync_bits.v
 INTEL_DEPS += ../util_cdc/sync_data.v
 INTEL_DEPS += axi_pwm_gen_constr.sdc
 INTEL_DEPS += axi_pwm_gen_hw.tcl
+
+LATTICE_DEPS += ../util_cdc/sync_bits.v
+LATTICE_DEPS += ../util_cdc/sync_data.v
+LATTICE_DEPS += axi_pwm_gen_ltt.tcl
 
 include ../scripts/library.mk

--- a/library/axi_pwm_gen/axi_pwm_gen_ltt.tcl
+++ b/library/axi_pwm_gen/axi_pwm_gen_ltt.tcl
@@ -1,0 +1,180 @@
+###############################################################################
+## Copyright (C) 2024 - 2025 Analog Devices, Inc. All rights reserved.
+### SPDX short identifier: ADIBSD
+###############################################################################
+
+source ../../scripts/adi_env.tcl
+source $ad_hdl_dir/library/scripts/adi_ip_lattice.tcl
+
+set mod_data [ipl::parse_module ./axi_pwm_gen.sv]
+set ip $::ipl::ip
+
+set ip [ipl::add_ports_from_module -ip $ip -mod_data $mod_data]
+
+set ip [ipl::general \
+    -vlnv "analog.com:ip:axi_pwm_gen:1.0" \
+    -display_name "ADI AXI PWM generator" \
+    -supported_products {*} \
+    -supported_platforms {esi radiant} \
+    -href "https://analogdevicesinc.github.io/hdl/library/axi_pwm_gen/index.html" \
+    -category "ADI" \
+    -keywords "ADI IP" \
+    -min_radiant_version "2023.2" \
+    -min_esi_version "2023.2" -ip $ip]
+
+set ip [ipl::add_memory_map -ip $ip \
+    -name "axi_pwm_gen_mem_map" \
+    -description "axi_pwm_gen_mem_map" \
+    -baseAddress 0 \
+    -range 65536 \
+    -width 32]
+
+set ip [ipl::add_axi_interfaces -ip $ip -mod_data $mod_data]
+
+set ip [ipl::set_parameter -ip $ip \
+    -id N_PWMS \
+    -type param \
+    -value_type int \
+    -conn_mod axi_pwm_gen \
+    -title {Number of pwms} \
+    -default 1 \
+    -output_formatter nostr \
+    -value_range {(1, 16)} \
+    -group1 {General configurations} \
+    -group2 Global]
+set ip [ipl::set_parameter -ip $ip \
+    -id ASYNC_CLK_EN \
+    -type param \
+    -value_type int \
+    -conn_mod axi_pwm_gen \
+    -title {ASYNC_CLK_EN} \
+    -options {[(True, 1), (False, 0)]} \
+    -default 1 \
+    -output_formatter nostr \
+    -group1 {General configurations} \
+    -group2 Global]
+set ip [ipl::set_parameter -ip $ip \
+    -id PWM_EXT_SYNC \
+    -type param \
+    -value_type int \
+    -conn_mod axi_pwm_gen \
+    -title {External sync} \
+    -options {[(True, 1), (False, 0)]} \
+    -default 0 \
+    -output_formatter nostr \
+    -group1 {General configurations} \
+    -group2 Global]
+set ip [ipl::set_parameter -ip $ip \
+    -id EXT_ASYNC_SYNC \
+    -type param \
+    -value_type int \
+    -conn_mod axi_pwm_gen \
+    -title {External sync signal is asynchronous} \
+    -options {[(True, 1), (False, 0)]} \
+    -editable {(PWM_EXT_SYNC == 1)} \
+    -default 0 \
+    -output_formatter nostr \
+    -group1 {General configurations} \
+    -group2 Global]
+set ip [ipl::set_parameter -ip $ip \
+    -id EXT_SYNC_PHASE_ALIGN \
+    -type param \
+    -value_type int \
+    -conn_mod axi_pwm_gen \
+    -title {External sync enable phase align} \
+    -options {[(True, 1), (False, 0)]} \
+    -editable {(PWM_EXT_SYNC == 1)} \
+    -default 0 \
+    -output_formatter nostr \
+    -group1 {General configurations} \
+    -group2 Global]
+set ip [ipl::set_parameter -ip $ip \
+    -id SOFTWARE_BRINGUP \
+    -type param \
+    -value_type int \
+    -conn_mod axi_pwm_gen \
+    -title {Require software bringup} \
+    -options {[(True, 1), (False, 0)]} \
+    -default 1 \
+    -output_formatter nostr \
+    -group1 {General configurations} \
+    -group2 Global]
+set ip [ipl::set_parameter -ip $ip \
+    -id FORCE_ALIGN \
+    -type param \
+    -value_type int \
+    -conn_mod axi_pwm_gen \
+    -title {Force align} \
+    -options {[(True, 1), (False, 0)]} \
+    -default 0 \
+    -output_formatter nostr \
+    -group1 {General configurations} \
+    -group2 Global]
+set ip [ipl::set_parameter -ip $ip \
+    -id START_AT_SYNC \
+    -type param \
+    -value_type int \
+    -conn_mod axi_pwm_gen \
+    -title {Start at sync} \
+    -options {[(True, 1), (False, 0)]} \
+    -default 1 \
+    -output_formatter nostr \
+    -group1 {General configurations} \
+    -group2 Global]
+
+for {set i 0} {$i < 16} {incr i} {
+    set ip [ipl::ignore_ports -ip $ip -portlist [list pwm_$i] \
+        -expression "not(N_PWMS > $i)"]
+    set ip [ipl::set_parameter -ip $ip \
+        -id PULSE_${i}_WIDTH \
+        -type param \
+        -value_type int \
+        -conn_mod axi_pwm_gen \
+        -title "PULSE ${i} width" \
+        -default 7 \
+        -output_formatter nostr \
+        -value_range {(0, 2147483647)} \
+        -editable "(N_PWMS > $i)" \
+        -group1 "pwm_$i" \
+        -group2 Global]
+    set ip [ipl::set_parameter -ip $ip \
+        -id PULSE_${i}_PERIOD \
+        -type param \
+        -value_type int \
+        -conn_mod axi_pwm_gen \
+        -title "PULSE ${i} period" \
+        -default 10 \
+        -output_formatter nostr \
+        -value_range {(0, 2147483647)} \
+        -editable "(N_PWMS > $i)" \
+        -group1 "pwm_$i" \
+        -group2 Global]
+    set ip [ipl::set_parameter -ip $ip \
+        -id PULSE_${i}_OFFSET \
+        -type param \
+        -value_type int \
+        -conn_mod axi_pwm_gen \
+        -title "PULSE ${i} offset" \
+        -default 0 \
+        -output_formatter nostr \
+        -value_range {(0, 2147483647)} \
+        -editable "(N_PWMS > $i)" \
+        -group1 "pwm_$i" \
+        -group2 Global]
+}
+
+set ip [ipl::ignore_ports -ip $ip -portlist ext_clk -expression {(ASYNC_CLK_EN == 0)}]
+set ip [ipl::ignore_ports -ip $ip -portlist ext_sync -expression {(PWM_EXT_SYNC == 0)}]
+
+set ip [ipl::add_ip_files -ip $ip -dpath rtl -flist [list \
+    axi_pwm_gen.sv \
+    axi_pwm_gen_regmap.sv \
+    ../common/ad_rst.v \
+    ../util_cdc/sync_data.v \
+    ../util_cdc/sync_bits.v \
+    ../util_cdc/sync_event.v \
+    axi_pwm_gen_1.v \
+    ../common/up_axi.v \
+]]
+
+ipl::generate_ip $ip

--- a/library/interfaces_ltt/Makefile
+++ b/library/interfaces_ltt/Makefile
@@ -1,0 +1,59 @@
+####################################################################################
+####################################################################################
+## Copyright (c) 2024 - 2025 Analog Devices, Inc.
+### SPDX short identifier: BSD-1-Clause
+####################################################################################
+####################################################################################
+HDL_LIBRARY_PATH := ../
+
+include ../../quiet.mk
+include ../scripts/lattice_tool_set.mk
+
+L_DEPS := interfaces_ltt.tcl
+L_DEPS += ../../scripts/adi_env.tcl
+L_DEPS += ../scripts/adi_ip_lattice.tcl
+
+LTT_INTERFACES := analog.com/ADI/fifo_rd/1.0/fifo_rd.xml
+LTT_INTERFACES += analog.com/ADI/fifo_rd/1.0/fifo_rd_rtl.xml
+LTT_INTERFACES += analog.com/ADI/fifo_wr/1.0/fifo_wr.xml
+LTT_INTERFACES += analog.com/ADI/fifo_wr/1.0/fifo_wr_rtl.xml
+LTT_INTERFACES += analog.com/ADI/spi_master/1.0/spi_master.xml
+LTT_INTERFACES += analog.com/ADI/spi_master/1.0/spi_master_rtl.xml
+LTT_INTERFACES += analog.com/ADI/spi_engine_ctrl/1.0/spi_engine_ctrl.xml
+LTT_INTERFACES += analog.com/ADI/spi_engine_ctrl/1.0/spi_engine_ctrl_rtl.xml
+LTT_INTERFACES += analog.com/ADI/spi_engine_offload_ctrl/1.0/spi_engine_offload_ctrl.xml
+LTT_INTERFACES += analog.com/ADI/spi_engine_offload_ctrl/1.0/spi_engine_offload_ctrl_rtl.xml
+LTT_INTERFACES += analog.com/ADI/if_framelock/1.0/if_framelock.xml
+LTT_INTERFACES += analog.com/ADI/if_framelock/1.0/if_framelock_rtl.xml
+
+CLEAN_TARGETS += analog.com/ADI/fifo_rd
+CLEAN_TARGETS += analog.com/ADI/fifo_wr
+CLEAN_TARGETS += analog.com/ADI/spi_master
+CLEAN_TARGETS += analog.com/ADI/spi_engine_ctrl
+CLEAN_TARGETS += analog.com/ADI/spi_engine_offload_ctrl
+CLEAN_TARGETS += analog.com/ADI/if_framelock
+
+ifeq ($(LATTICE_DEFAULT_PATHS),1)
+LTT_INTERFACES := $(LTT_INTERFACES) $(foreach dep,$(LTT_INTERFACES),$(LATTICE_DEFAULT_INTERFACE_PATH)/$(dep))
+CLEAN_TARGETS := $(CLEAN_TARGETS) $(foreach dep,$(CLEAN_TARGETS),$(LATTICE_DEFAULT_INTERFACE_PATH)/$(dep))
+endif
+
+CLEAN_TARGETS += $(wildcard ./*/)
+CLEAN_TARGETS += interfaces_ltt.log
+
+.PHONY: all lattice clean clean-all
+
+all: $(LTT_INTERFACES)
+
+clean: clean-all
+
+clean-all:
+	$(call clean, \
+		$(CLEAN_TARGETS) .lock, \
+		$(HL)ADI$(NC) interfaces for lattice)
+
+$(LTT_INTERFACES): $(L_DEPS)
+	$(call build, \
+		$(LATTICE_IP_TOOL) interfaces_ltt.tcl, \
+		interfaces_ltt.log, \
+		$(HL)ADI$(NC) interfaces for lattice)

--- a/library/interfaces_ltt/interfaces_ltt.tcl
+++ b/library/interfaces_ltt/interfaces_ltt.tcl
@@ -1,0 +1,103 @@
+###############################################################################
+## Copyright (C) 2024 - 2025 Analog Devices, Inc. All rights reserved.
+### SPDX short identifier: ADIBSD
+###############################################################################
+
+source ../../scripts/adi_env.tcl
+source $ad_hdl_dir/library/scripts/adi_ip_lattice.tcl
+
+set if [ipl::create_interface \
+    -vlnv {analog.com:ADI:fifo_wr:1.0} \
+    -directConnection true \
+    -isAddressable false \
+    -description "ADI fifo wr interface" \
+    -ports {
+        {-n DATA -d out -p required}
+        {-n EN -d out -p required -w 1}
+        {-n OVERFLOW -w 1 -p optional -d in}
+        {-n SYNC -p optional -w 1 -d out}
+        {-n XFER_REQ -p optional -w 1 -d in}
+    }]
+ipl::generate_interface $if
+
+set if [ipl::create_interface \
+    -vlnv {analog.com:ADI:fifo_rd:1.0} \
+    -directConnection true \
+    -isAddressable false \
+    -description "ADI fifo rd interface" \
+    -ports {
+        {-n DATA -d in -p required}
+        {-n EN -d out -p required -w 1}
+        {-n UNDERFLOW -d in -p optional -w 1}
+        {-n VALID -d in -p optional -w 1}
+        {-n XFER_REQ -d in -p optional -w 1}
+    }]
+ipl::generate_interface $if
+
+set if [ipl::create_interface \
+    -vlnv {analog.com:ADI:spi_engine_ctrl:1.0} \
+    -directConnection true \
+    -isAddressable false \
+    -description "ADI SPI Engine Control Interface" \
+    -ports {
+        {-n CMD_READY -p required -w 1 -d in}
+        {-n CMD_VALID -p required -w 1 -d out}
+        {-n CMD_DATA -p required -w 16 -d out}
+        {-n SDO_READY -p required -w 1 -d in}
+        {-n SDO_VALID -p required -w 1 -d out}
+        {-n SDO_DATA -p required -d out}
+        {-n SDI_READY -p required -w 1 -d out}
+        {-n SDI_VALID -p required -w 1 -d in}
+        {-n SDI_DATA -p required -d in}
+        {-n SYNC_READY -p required -w 1 -d out}
+        {-n SYNC_VALID -p required -w 1 -d in}
+        {-n SYNC_DATA -p required -w 8 -d in}
+    }]
+ipl::generate_interface $if
+
+set if [ipl::create_interface \
+    -vlnv {analog.com:ADI:spi_engine_offload_ctrl:1.0} \
+    -directConnection true \
+    -isAddressable false \
+    -description "ADI SPI Engine Offload Control Interface" \
+    -ports {
+        {-n CMD_WR_EN -p required -w 1 -d out}
+        {-n CMD_WR_DATA -p required -w 16 -d out}
+        {-n SDO_WR_EN -p required -w 1 -d out}
+        {-n SDO_WR_DATA -p required -d out}
+        {-n ENABLE -p required -w 1 -d out}
+        {-n MEM_RESET -p required -w 1 -d out}
+        {-n ENABLED -p required -w 1 -d in}
+        {-n SYNC_READY -p required -w 1 -d out}
+        {-n SYNC_VALID -p required -w 1 -d in}
+        {-n SYNC_DATA -p required -w 8 -d in}
+    }]
+ipl::generate_interface $if
+
+set if [ipl::create_interface \
+    -vlnv {analog.com:ADI:spi_master:1.0} \
+    -directConnection true \
+    -isAddressable false \
+    -description "SPI Master Interface" \
+    -ports {
+        {-n SCLK -p required -w 1 -d out}
+        {-n SDI -p optional -d in}
+        {-n SDO -p optional -w 1 -d out}
+        {-n SDO_T -p optional -w 1 -d out}
+        {-n THREE_WIRE -p optional -w 1 -d out}
+        {-n CS -p required -d out}
+    }]
+ipl::generate_interface $if
+
+set if [ipl::create_interface \
+    -vlnv {analog.com:ADI:if_framelock:1.0} \
+    -directConnection true \
+    -isAddressable false \
+    -description "AXI DMA framelock Interface." \
+    -ports {
+        {-n s2m_framelock -p required -d in}
+        {-n s2m_framelock_valid -p required -w 1 -d in}
+        {-n m2s_framelock -p required -d out}
+        {-n m2s_framelock_valid -p required -w 1 -d out}
+    }]
+ipl::generate_interface $if

--- a/library/spi_engine/axi_spi_engine/Makefile
+++ b/library/spi_engine/axi_spi_engine/Makefile
@@ -1,5 +1,5 @@
 ####################################################################################
-## Copyright (c) 2018 - 2024 Analog Devices, Inc.
+## Copyright (c) 2018 - 2025 Analog Devices, Inc.
 ### SPDX short identifier: BSD-1-Clause
 ## Auto-generated, do not modify!
 ####################################################################################
@@ -32,5 +32,14 @@ INTEL_DEPS += ../../util_cdc/sync_bits.v
 INTEL_DEPS += ../../util_cdc/sync_gray.v
 INTEL_DEPS += axi_spi_engine_constr.sdc
 INTEL_DEPS += axi_spi_engine_hw.tcl
+
+LATTICE_DEPS += ../../common/ad_mem.v
+LATTICE_DEPS += ../../util_axis_fifo/util_axis_fifo.v
+LATTICE_DEPS += ../../util_axis_fifo/util_axis_fifo_address_generator.v
+LATTICE_DEPS += ../../util_cdc/sync_bits.v
+LATTICE_DEPS += ../../util_cdc/sync_gray.v
+LATTICE_DEPS += axi_spi_engine_ltt.tcl
+
+LATTICE_INTERFACE_DEPS += interfaces_ltt
 
 include ../../scripts/library.mk

--- a/library/spi_engine/axi_spi_engine/axi_spi_engine_ltt.tcl
+++ b/library/spi_engine/axi_spi_engine/axi_spi_engine_ltt.tcl
@@ -1,0 +1,251 @@
+###############################################################################
+## Copyright (C) 2024 - 2025 Analog Devices, Inc. All rights reserved.
+### SPDX short identifier: ADIBSD
+###############################################################################
+
+source ../../../scripts/adi_env.tcl
+source $ad_hdl_dir/library/scripts/adi_ip_lattice.tcl
+
+set mod_data [ipl::parse_module ./axi_spi_engine.v]
+set ip $::ipl::ip
+
+set ip [ipl::add_ports_from_module -ip $ip -mod_data $mod_data]
+# set ip [ipl::add_parameters_from_module -ip $ip -mod_data $mod_data]
+
+set ip [ipl::general \
+    -vlnv "analog.com:ip:axi_spi_engine:1.0" \
+    -category "ADI" \
+    -keywords "ADI IP" \
+    -min_radiant_version "2023.2" \
+    -min_esi_version "2023.2" -ip $ip]
+
+set ip [ipl::general -ip $ip -display_name "AXI SPI Engine ADI"]
+set ip [ipl::general -ip $ip -supported_products {*}]
+set ip [ipl::general -ip $ip -supported_platforms {esi radiant}]
+set ip [ipl::general -ip $ip -href "https://analogdevicesinc.github.io/hdl/library/spi_engine/axi_spi_engine.html#spi-engine-axi"]
+
+# set ip [ipl::add_component_generator -name blabla -generator eval/blabla.py -ip $ip]
+
+set ip [ipl::add_memory_map -ip $ip \
+    -name "axi_spi_engine_mem_map" \
+    -description "axi_spi_engine_mem_map" \
+    -baseAddress 0 \
+    -range 65536 \
+    -width 32]
+
+set ip [ipl::add_axi_interfaces -ip $ip -mod_data $mod_data]
+
+set ip [ipl::add_interface -ip $ip \
+    -inst_name spi_engine_ctrl \
+    -display_name spi_engine_ctrl \
+    -description spi_engine_ctrl \
+    -master_slave master \
+    -portmap { \
+        {"cmd_ready" "CMD_READY"} \
+		{"cmd_valid" "CMD_VALID"} \
+		{"cmd_data" "CMD_DATA"} \
+		{"sdo_data_ready" "SDO_READY"} \
+		{"sdo_data_valid" "SDO_VALID"} \
+		{"sdo_data" "SDO_DATA"} \
+		{"sdi_data_ready" "SDI_READY"} \
+		{"sdi_data_valid" "SDI_VALID"} \
+		{"sdi_data" "SDI_DATA"} \
+		{"sync_ready" "SYNC_READY"} \
+		{"sync_valid" "SYNC_VALID"} \
+		{"sync_data" "SYNC_DATA"} \
+    } \
+    -vlnv {analog.com:ADI:spi_engine_ctrl:1.0}]
+set ip [ipl::add_interface -ip $ip \
+    -inst_name spi_engine_offload_ctrl0 \
+    -display_name spi_engine_offload_ctrl0 \
+    -description spi_engine_offload_ctrl0 \
+    -master_slave master \
+    -portmap { \
+		{"offload0_cmd_wr_en" "CMD_WR_EN"} \
+		{"offload0_cmd_wr_data" "CMD_WR_DATA"} \
+		{"offload0_sdo_wr_en" "SDO_WR_EN"} \
+		{"offload0_sdo_wr_data" "SDO_WR_DATA"} \
+		{"offload0_enable" "ENABLE"} \
+		{"offload0_enabled" "ENABLED"} \
+		{"offload0_mem_reset" "MEM_RESET"} \
+		{"offload_sync_ready" "SYNC_READY"} \
+		{"offload_sync_valid" "SYNC_VALID"} \
+		{"offload_sync_data" "SYNC_DATA"} \
+    } \
+    -vlnv {analog.com:ADI:spi_engine_offload_ctrl:1.0}]
+
+set ip [ipl::add_interface -ip $ip \
+    -inst_name IRQ \
+    -display_name IRQ \
+    -description IRQ \
+    -master_slave master \
+    -portmap [list {"irq" "IRQ"}] \
+    -vlnv {spiritconsortium.org:busdef.interrupt:interrupt:1.0}]
+
+set ip [ipl::add_ip_files -ip $ip -dpath rtl -flist [list \
+    "$ad_hdl_dir/library/common/up_axi.v" \
+    "$ad_hdl_dir/library/common/ad_rst.v" \
+    "$ad_hdl_dir/library/util_cdc/sync_bits.v" \
+    "$ad_hdl_dir/library/util_cdc/sync_gray.v" \
+    "$ad_hdl_dir/library/common/ad_mem.v" \
+    "$ad_hdl_dir/library/util_axis_fifo/util_axis_fifo.v" \
+    "$ad_hdl_dir/library/util_axis_fifo/util_axis_fifo_address_generator.v" \
+    "axi_spi_engine.v" ]]
+
+set ip [ipl::set_parameter -ip $ip \
+    -id ID \
+    -type param \
+    -value_type int \
+    -conn_mod axi_spi_engine \
+    -title {Core ID} \
+    -default 0 \
+    -output_formatter nostr \
+    -value_range {(0, 255)} \
+    -group1 {General Configuration} \
+    -group2 Config]
+set ip [ipl::set_parameter -ip $ip \
+    -id DATA_WIDTH \
+    -type param \
+    -value_type int \
+    -conn_mod axi_spi_engine \
+    -title {Parallel data width} \
+    -default 8 \
+    -output_formatter nostr \
+    -value_range {(8, 256)} \
+    -group1 {General Configuration} \
+    -group2 Config]
+set ip [ipl::set_parameter -ip $ip \
+    -id NUM_OF_SDI \
+    -type param \
+    -value_type int \
+    -conn_mod axi_spi_engine \
+    -title {Number of MISO lines} \
+    -default 1 \
+    -output_formatter nostr \
+    -value_range {(1, 8)} \
+    -group1 {General Configuration} \
+    -group2 Config]
+set ip [ipl::set_parameter -ip $ip \
+    -id MM_IF_TYPE \
+    -type param \
+    -value_type int \
+    -conn_mod axi_spi_engine \
+    -title {Memory Mapped Interface Type} \
+    -default 0 \
+    -options {[('AXI4 Memory Mapped', 0), ('ADI uP FIFO', 1)]} \
+    -output_formatter nostr \
+    -group1 {General Configuration} \
+    -group2 Config]
+set ip [ipl::set_parameter -ip $ip \
+    -id ASYNC_SPI_CLK \
+    -type param \
+    -value_type int \
+    -conn_mod axi_spi_engine \
+    -title {Asynchronous core clock} \
+    -default 0 \
+    -options {[(True, 1), (False, 0)]} \
+    -output_formatter nostr \
+    -group1 {General Configuration} \
+    -group2 Config]
+
+set ip [ipl::set_parameter -ip $ip \
+    -id CMD_FIFO_ADDRESS_WIDTH \
+    -type param \
+    -value_type int \
+    -conn_mod axi_spi_engine \
+    -title {Command FIFO address width} \
+    -default 4 \
+    -output_formatter nostr \
+    -value_range {(1, 16)} \
+    -group1 {Command stream FIFO configuration} \
+    -group2 Config]
+set ip [ipl::set_parameter -ip $ip \
+    -id SYNC_FIFO_ADDRESS_WIDTH \
+    -type param \
+    -value_type int \
+    -conn_mod axi_spi_engine \
+    -title {SYNC FIFO address width} \
+    -default 4 \
+    -output_formatter nostr \
+    -value_range {(1, 16)} \
+    -group1 {Command stream FIFO configuration} \
+    -group2 Config]
+set ip [ipl::set_parameter -ip $ip \
+    -id SDO_FIFO_ADDRESS_WIDTH \
+    -type param \
+    -value_type int \
+    -conn_mod axi_spi_engine \
+    -title {MOSI FIFO address width} \
+    -default 5 \
+    -output_formatter nostr \
+    -value_range {(1, 16)} \
+    -group1 {Command stream FIFO configuration} \
+    -group2 Config]
+set ip [ipl::set_parameter -ip $ip \
+    -id SDI_FIFO_ADDRESS_WIDTH \
+    -type param \
+    -value_type int \
+    -conn_mod axi_spi_engine \
+    -title {MISO FIFO address width} \
+    -default 5 \
+    -output_formatter nostr \
+    -value_range {(1, 16)} \
+    -group1 {Command stream FIFO configuration} \
+    -group2 Config]
+
+set ip [ipl::set_parameter -ip $ip \
+    -id NUM_OFFLOAD \
+    -type param \
+    -value_type int \
+    -conn_mod axi_spi_engine \
+    -title {Number of offloads} \
+    -default 0 \
+    -output_formatter nostr \
+    -value_range {(0, 8)} \
+    -group1 {Offload module configuration} \
+    -group2 Config]
+set ip [ipl::set_parameter -ip $ip \
+    -id OFFLOAD0_CMD_MEM_ADDRESS_WIDTH \
+    -type param \
+    -value_type int \
+    -conn_mod axi_spi_engine \
+    -title {Offload command FIFO address width} \
+    -default 4 \
+    -output_formatter nostr \
+    -editable {(NUM_OFFLOAD > 0)} \
+    -value_range {(1, 16)} \
+    -group1 {Offload module configuration} \
+    -group2 Config]
+set ip [ipl::set_parameter -ip $ip \
+    -id OFFLOAD0_SDO_MEM_ADDRESS_WIDTH \
+    -type param \
+    -value_type int \
+    -conn_mod axi_spi_engine \
+    -title {Offload MOSI FIFO address width} \
+    -default 4 \
+    -output_formatter nostr \
+    -editable {(NUM_OFFLOAD > 0)} \
+    -value_range {(1, 16)} \
+    -group1 {Offload module configuration} \
+    -group2 Config]
+
+set ip [ipl::ignore_ports_by_prefix -ip $ip \
+    -mod_data $mod_data \
+    -v_prefix s_axi \
+    -expression {(MM_IF_TYPE != 0)}]
+set ip [ipl::ignore_ports -ip $ip \
+    -portlist {
+        up_clk
+        up_rstn
+        up_wreq
+        up_waddr
+        up_wdata
+        up_rreq
+        up_raddr
+        up_wack
+        up_rdata
+        up_rack
+    } \
+    -expression {(MM_IF_TYPE != 1)}]
+
+ipl::generate_ip $ip

--- a/library/spi_engine/spi_axis_reorder/Makefile
+++ b/library/spi_engine/spi_axis_reorder/Makefile
@@ -1,5 +1,5 @@
 ####################################################################################
-## Copyright (c) 2018 - 2024 Analog Devices, Inc.
+## Copyright (c) 2018 - 2025 Analog Devices, Inc.
 ### SPDX short identifier: BSD-1-Clause
 ## Auto-generated, do not modify!
 ####################################################################################
@@ -9,5 +9,7 @@ LIBRARY_NAME := spi_axis_reorder
 GENERIC_DEPS += spi_axis_reorder.v
 
 XILINX_DEPS += spi_axis_reorder_ip.tcl
+
+LATTICE_DEPS += spi_axis_reorder_ltt.tcl
 
 include ../../scripts/library.mk

--- a/library/spi_engine/spi_axis_reorder/spi_axis_reorder_ltt.tcl
+++ b/library/spi_engine/spi_axis_reorder/spi_axis_reorder_ltt.tcl
@@ -1,0 +1,64 @@
+###############################################################################
+## Copyright (C) 2024 - 2025 Analog Devices, Inc. All rights reserved.
+### SPDX short identifier: ADIBSD
+###############################################################################
+
+source ../../../scripts/adi_env.tcl
+source $ad_hdl_dir/library/scripts/adi_ip_lattice.tcl
+
+set mod_data [ipl::parse_module ./spi_axis_reorder.v]
+set ip $::ipl::ip
+
+set ip [ipl::add_ports_from_module -ip $ip -mod_data $mod_data]
+
+set ip [ipl::general \
+    -vlnv "analog.com:ip:spi_axis_reorder:1.0" \
+    -category "ADI" \
+    -keywords "ADI IP" \
+    -min_radiant_version "2023.2" \
+    -min_esi_version "2023.2" -ip $ip]
+
+set ip [ipl::general -ip $ip -display_name "AXI SPI Engine AXIS Reorder ADI"]
+set ip [ipl::general -ip $ip -supported_products {*}]
+set ip [ipl::general -ip $ip -supported_platforms {esi radiant}]
+set ip [ipl::general -ip $ip -href "https://analogdevicesinc.github.io/hdl/library/spi_engine/index.html#"]
+
+set ip [ipl::add_interface -ip $ip \
+    -inst_name m_axis \
+    -display_name m_axis \
+    -description m_axis \
+    -master_slave master \
+    -portmap { \
+        {"m_axis_ready" "TREADY"} \
+        {"m_axis_valid" "TVALID"} \
+        {"m_axis_data" "TDATA"}
+    } \
+    -vlnv {amba.com:AMBA4:AXI4Stream:r0p0}]
+
+set ip [ipl::add_interface -ip $ip \
+    -inst_name s_axis \
+    -display_name s_axis \
+    -description s_axis \
+    -master_slave slave \
+    -portmap { \
+        {"s_axis_ready" "TREADY"} \
+        {"s_axis_valid" "TVALID"} \
+        {"s_axis_data" "TDATA"}
+    } \
+    -vlnv {amba.com:AMBA4:AXI4Stream:r0p0}]
+
+set ip [ipl::add_ip_files -ip $ip -dpath rtl -flist [list \
+    "spi_axis_reorder.v" ]]
+
+set ip [ipl::set_parameter -ip $ip \
+    -id NUM_OF_LANES \
+    -type param \
+    -value_type int \
+    -conn_mod spi_axis_reorder \
+    -title {Num Of Lanes} \
+    -default 2 \
+    -output_formatter nostr \
+    -group1 {General Configuration} \
+    -group2 Config]
+
+ipl::generate_ip $ip

--- a/library/spi_engine/spi_engine_execution/Makefile
+++ b/library/spi_engine/spi_engine_execution/Makefile
@@ -1,5 +1,5 @@
 ####################################################################################
-## Copyright (c) 2018 - 2024 Analog Devices, Inc.
+## Copyright (c) 2018 - 2025 Analog Devices, Inc.
 ### SPDX short identifier: BSD-1-Clause
 ## Auto-generated, do not modify!
 ####################################################################################
@@ -20,5 +20,10 @@ XILINX_DEPS += ../../spi_engine/interfaces/spi_engine_rtl.xml
 XILINX_INTERFACE_DEPS += spi_engine/interfaces
 
 INTEL_DEPS += spi_engine_execution_hw.tcl
+
+LATTICE_DEPS += spi_engine_execution_ltt.tcl
+LATTICE_DEPS += spi_engine_execution_shiftreg.v
+
+LATTICE_INTERFACE_DEPS += interfaces_ltt
 
 include ../../scripts/library.mk

--- a/library/spi_engine/spi_engine_execution/spi_engine_execution_ltt.tcl
+++ b/library/spi_engine/spi_engine_execution/spi_engine_execution_ltt.tcl
@@ -1,0 +1,161 @@
+###############################################################################
+## Copyright (C) 2024 - 2025 Analog Devices, Inc. All rights reserved.
+### SPDX short identifier: ADIBSD
+###############################################################################
+
+source ../../../scripts/adi_env.tcl
+source $ad_hdl_dir/library/scripts/adi_ip_lattice.tcl
+
+set mod_data [ipl::parse_module ./spi_engine_execution.v]
+set ip $::ipl::ip
+
+set ip [ipl::add_ports_from_module -ip $ip -mod_data $mod_data]
+
+set ip [ipl::general \
+    -vlnv "analog.com:ip:spi_engine_execution:1.0" \
+    -category "ADI" \
+    -keywords "ADI IP" \
+    -min_radiant_version "2023.2" \
+    -min_esi_version "2023.2" -ip $ip]
+
+set ip [ipl::general -ip $ip -display_name "AXI SPI Engine execution ADI"]
+set ip [ipl::general -ip $ip -supported_products {*}]
+set ip [ipl::general -ip $ip -supported_platforms {esi radiant}]
+set ip [ipl::general -ip $ip -href "https://analogdevicesinc.github.io/hdl/library/spi_engine/spi_engine_execution.html#spi-engine-execution"]
+
+set ip [ipl::add_interface -ip $ip \
+    -inst_name spi_engine_ctrl \
+    -display_name spi_engine_ctrl \
+    -description spi_engine_ctrl \
+    -master_slave slave \
+    -portmap { \
+        {"cmd_ready" "CMD_READY"} \
+        {"cmd_valid" "CMD_VALID"} \
+        {"cmd" "CMD_DATA"} \
+        {"sdo_data_ready" "SDO_READY"} \
+        {"sdo_data_valid" "SDO_VALID"} \
+        {"sdo_data" "SDO_DATA"} \
+        {"sdi_data_ready" "SDI_READY"} \
+        {"sdi_data_valid" "SDI_VALID"} \
+        {"sdi_data" "SDI_DATA"} \
+        {"sync_ready" "SYNC_READY"} \
+        {"sync_valid" "SYNC_VALID"} \
+        {"sync" "SYNC_DATA"} \
+    } \
+    -vlnv {analog.com:ADI:spi_engine_ctrl:1.0}]
+set ip [ipl::add_interface -ip $ip \
+    -inst_name spi_master \
+    -display_name spi_master \
+    -description spi_master \
+    -master_slave master \
+    -portmap { \
+        {"sclk" "SCLK"} \
+        {"sdi" "SDI"} \
+        {"sdo" "SDO"} \
+        {"sdo_t" "SDO_T"} \
+        {"three_wire" "THREE_WIRE"} \
+        {"cs" "CS"} \
+    } \
+    -vlnv {analog.com:ADI:spi_master:1.0}]
+
+set ip [ipl::add_ip_files -ip $ip -dpath rtl -flist [list \
+    "spi_engine_execution.v" \
+    "spi_engine_execution_shiftreg.v" ]]
+
+set ip [ipl::set_parameter -ip $ip \
+    -id DATA_WIDTH \
+    -type param \
+    -value_type int \
+    -conn_mod spi_engine_execution \
+    -title {Parallel data width} \
+    -default 8 \
+    -output_formatter nostr \
+    -value_range {(8, 32)} \
+    -group1 {General Configuration} \
+    -group2 Config]
+set ip [ipl::set_parameter -ip $ip \
+    -id NUM_OF_CS \
+    -type param \
+    -value_type int \
+    -conn_mod spi_engine_execution \
+    -title {Number of CSN lines} \
+    -default 1 \
+    -output_formatter nostr \
+    -value_range {(1, 8)} \
+    -group1 {General Configuration} \
+    -group2 Config]
+set ip [ipl::set_parameter -ip $ip \
+    -id NUM_OF_SDI \
+    -type param \
+    -value_type int \
+    -conn_mod spi_engine_execution \
+    -title {Number of MISO} \
+    -default 1 \
+    -output_formatter nostr \
+    -value_range {(1, 8)} \
+    -group1 {General Configuration} \
+    -group2 Config]
+
+set ip [ipl::set_parameter -ip $ip \
+    -id DEFAULT_SPI_CFG \
+    -type param \
+    -value_type int \
+    -conn_mod spi_engine_execution \
+    -title {Default SPI mode} \
+    -default 0 \
+    -options {[0, 1, 2, 3]} \
+    -output_formatter nostr \
+    -group1 {SPI Configuration} \
+    -group2 Config]
+set ip [ipl::set_parameter -ip $ip \
+    -id DEFAULT_CLK_DIV \
+    -type param \
+    -value_type int \
+    -conn_mod spi_engine_execution \
+    -title {Default SCLK divider} \
+    -default 0 \
+    -output_formatter nostr \
+    -value_range {(0, 255)} \
+    -group1 {SPI Configuration} \
+    -group2 Config]
+
+set ip [ipl::set_parameter -ip $ip \
+    -id SDI_DELAY \
+    -type param \
+    -value_type int \
+    -conn_mod spi_engine_execution \
+    -title {Delay MISO latching} \
+    -default 0 \
+    -options {[(True, 1), (False, 0)]} \
+    -output_formatter nostr \
+    -group1 {MOSI/MISO Configuration} \
+    -group2 Config]
+set ip [ipl::set_parameter -ip $ip \
+    -id SDO_DEFAULT \
+    -type param \
+    -value_type int \
+    -conn_mod spi_engine_execution \
+    -title {MOSI default level} \
+    -default 0 \
+    -options {[0, 1]} \
+    -output_formatter nostr \
+    -group1 {MOSI/MISO Configuration} \
+    -group2 Config]
+
+set ip [ipl::set_parameter -ip $ip \
+    -id ECHO_SCLK \
+    -type param \
+    -value_type int \
+    -conn_mod spi_engine_execution \
+    -title {Echoed SCLK} \
+    -default 0 \
+    -options {[(True, 1), (False, 0)]} \
+    -output_formatter nostr \
+    -group1 {Custom clocking options} \
+    -group2 Config]
+
+set ip [ipl::ignore_ports -ip $ip \
+    -portlist {echo_sclk} \
+    -expression {(ECHO_SCLK != 1)}]
+
+ipl::generate_ip $ip

--- a/library/spi_engine/spi_engine_interconnect/Makefile
+++ b/library/spi_engine/spi_engine_interconnect/Makefile
@@ -19,4 +19,8 @@ XILINX_INTERFACE_DEPS += spi_engine/interfaces
 
 INTEL_DEPS += spi_engine_interconnect_hw.tcl
 
+LATTICE_DEPS += spi_engine_interconnect_ltt.tcl
+
+LATTICE_INTERFACE_DEPS += interfaces_ltt
+
 include ../../scripts/library.mk

--- a/library/spi_engine/spi_engine_interconnect/spi_engine_interconnect_ltt.tcl
+++ b/library/spi_engine/spi_engine_interconnect/spi_engine_interconnect_ltt.tcl
@@ -1,0 +1,96 @@
+###############################################################################
+## Copyright (C) 2024 - 2025 Analog Devices, Inc. All rights reserved.
+### SPDX short identifier: ADIBSD
+###############################################################################
+
+source ../../../scripts/adi_env.tcl
+source $ad_hdl_dir/library/scripts/adi_ip_lattice.tcl
+
+set mod_data [ipl::parse_module ./spi_engine_interconnect.v]
+set ip $::ipl::ip
+
+set ip [ipl::add_ports_from_module -ip $ip -mod_data $mod_data]
+
+set ip [ipl::general \
+    -vlnv "analog.com:ip:spi_engine_interconnect:1.0" \
+    -category "ADI" \
+    -keywords "ADI IP" \
+    -min_radiant_version "2023.2" \
+    -min_esi_version "2023.2" -ip $ip]
+
+set ip [ipl::general -ip $ip -display_name "AXI SPI Engine interconnect ADI"]
+set ip [ipl::general -ip $ip -supported_products {*}]
+set ip [ipl::general -ip $ip -supported_platforms {esi radiant}]
+set ip [ipl::general -ip $ip -href "https://analogdevicesinc.github.io/hdl/library/spi_engine/spi_engine_interconnect.html#spi-engine-interconnect"]
+
+set ip [ipl::add_interface -ip $ip \
+    -inst_name m_ctrl \
+    -display_name m_ctrl \
+    -description m_ctrl \
+    -master_slave master \
+    -portmap { \
+        {"m_cmd_ready" "CMD_READY"} \
+        {"m_cmd_valid" "CMD_VALID"} \
+        {"m_cmd_data" "CMD_DATA"} \
+        {"m_sdo_ready" "SDO_READY"} \
+        {"m_sdo_valid" "SDO_VALID"} \
+        {"m_sdo_data" "SDO_DATA"} \
+        {"m_sdi_ready" "SDI_READY"} \
+        {"m_sdi_valid" "SDI_VALID"} \
+        {"m_sdi_data" "SDI_DATA"} \
+        {"m_sync_ready" "SYNC_READY"} \
+        {"m_sync_valid" "SYNC_VALID"} \
+        {"m_sync" "SYNC_DATA"} \
+    } \
+    -vlnv {analog.com:ADI:spi_engine_ctrl:1.0}]
+
+foreach prefix [list "s0" "s1"] {
+    set ip [ipl::add_interface -ip $ip \
+        -inst_name ${prefix}_ctrl \
+        -display_name ${prefix}_ctrl \
+        -description ${prefix}_ctrl \
+        -master_slave slave \
+        -portmap [list \
+			[list [format "%s_cmd_ready" $prefix] "CMD_READY"] \
+			[list [format "%s_cmd_valid" $prefix] "CMD_VALID"] \
+			[list [format "%s_cmd_data" $prefix] "CMD_DATA"] \
+			[list [format "%s_sdo_ready" $prefix] "SDO_READY"] \
+			[list [format "%s_sdo_valid" $prefix] "SDO_VALID"] \
+			[list [format "%s_sdo_data" $prefix] "SDO_DATA"] \
+			[list [format "%s_sdi_ready" $prefix] "SDI_READY"] \
+			[list [format "%s_sdi_valid" $prefix] "SDI_VALID"] \
+			[list [format "%s_sdi_data" $prefix] "SDI_DATA"] \
+			[list [format "%s_sync_ready" $prefix] "SYNC_READY"] \
+			[list [format "%s_sync_valid" $prefix] "SYNC_VALID"] \
+			[list [format "%s_sync" $prefix] "SYNC_DATA"] \
+        ] \
+        -vlnv {analog.com:ADI:spi_engine_ctrl:1.0}]
+}
+
+set ip [ipl::add_ip_files -ip $ip -dpath rtl -flist [list \
+    "spi_engine_interconnect.v" ]]
+
+set ip [ipl::set_parameter -ip $ip \
+    -id DATA_WIDTH \
+    -type param \
+    -value_type int \
+    -conn_mod spi_engine_interconnect \
+    -title {Parallel data width} \
+    -default 8 \
+    -output_formatter nostr \
+    -value_range {(8, 256)} \
+    -group1 {General Configuration} \
+    -group2 Config]
+set ip [ipl::set_parameter -ip $ip \
+    -id NUM_OF_SDI \
+    -type param \
+    -value_type int \
+    -conn_mod spi_engine_interconnect \
+    -title {Number of MISO lines} \
+    -default 1 \
+    -output_formatter nostr \
+    -value_range {(1, 8)} \
+    -group1 {General Configuration} \
+    -group2 Config]
+
+ipl::generate_ip $ip

--- a/library/spi_engine/spi_engine_offload/Makefile
+++ b/library/spi_engine/spi_engine_offload/Makefile
@@ -26,4 +26,10 @@ INTEL_DEPS += ../../util_cdc/sync_bits.v
 INTEL_DEPS += ../../util_cdc/sync_event.v
 INTEL_DEPS += spi_engine_offload_hw.tcl
 
+LATTICE_DEPS += ../../util_cdc/sync_bits.v
+LATTICE_DEPS += ../../util_cdc/sync_event.v
+LATTICE_DEPS += spi_engine_offload_ltt.tcl
+
+LATTICE_INTERFACE_DEPS += interfaces_ltt
+
 include ../../scripts/library.mk

--- a/library/spi_engine/spi_engine_offload/spi_engine_offload_ltt.tcl
+++ b/library/spi_engine/spi_engine_offload/spi_engine_offload_ltt.tcl
@@ -1,0 +1,177 @@
+###############################################################################
+## Copyright (C) 2024 - 2025 Analog Devices, Inc. All rights reserved.
+### SPDX short identifier: ADIBSD
+###############################################################################
+
+source ../../../scripts/adi_env.tcl
+source $ad_hdl_dir/library/scripts/adi_ip_lattice.tcl
+
+set mod_data [ipl::parse_module ./spi_engine_offload.v]
+set ip $::ipl::ip
+
+set ip [ipl::add_ports_from_module -ip $ip -mod_data $mod_data]
+
+set ip [ipl::general \
+    -vlnv "analog.com:ip:spi_engine_offload:1.0" \
+    -category "ADI" \
+    -keywords "ADI IP" \
+    -min_radiant_version "2023.2" \
+    -min_esi_version "2023.2" -ip $ip]
+set ip [ipl::general -ip $ip -display_name "AXI SPI Engine Offload ADI"]
+set ip [ipl::general -ip $ip -supported_products {*}]
+set ip [ipl::general -ip $ip -supported_platforms {esi radiant}]
+set ip [ipl::general -ip $ip -href "https://analogdevicesinc.github.io/hdl/library/spi_engine/spi_engine_offload.html"]
+
+set ip [ipl::add_interface -ip $ip \
+    -inst_name spi_engine_offload_ctrl \
+    -display_name spi_engine_offload_ctrl \
+    -description spi_engine_offload_ctrl \
+    -master_slave slave \
+    -portmap { \
+        { "ctrl_cmd_wr_en" "CMD_WR_EN"} \
+        { "ctrl_cmd_wr_data" "CMD_WR_DATA"} \
+        { "ctrl_sdo_wr_en" "SDO_WR_EN"} \
+        { "ctrl_sdo_wr_data" "SDO_WR_DATA"} \
+        { "ctrl_enable" "ENABLE"} \
+        { "ctrl_enabled" "ENABLED"} \
+        { "ctrl_mem_reset" "MEM_RESET"} \
+        { "status_sync_ready" "SYNC_READY"} \
+        { "status_sync_valid" "SYNC_VALID"} \
+        { "status_sync_data" "SYNC_DATA"} \
+    } \
+    -vlnv {analog.com:ADI:spi_engine_offload_ctrl:1.0}]
+
+set ip [ipl::add_interface -ip $ip \
+    -inst_name spi_engine_ctrl \
+    -display_name spi_engine_ctrl \
+    -description spi_engine_ctrl \
+    -master_slave master \
+    -portmap { \
+        {"cmd_ready" "CMD_READY"} \
+        {"cmd_valid" "CMD_VALID"} \
+        {"cmd" "CMD_DATA"} \
+        {"sdo_data_ready" "SDO_READY"} \
+        {"sdo_data_valid" "SDO_VALID"} \
+        {"sdo_data" "SDO_DATA"} \
+        {"sdi_data_ready" "SDI_READY"} \
+        {"sdi_data_valid" "SDI_VALID"} \
+        {"sdi_data" "SDI_DATA"} \
+        {"sync_ready" "SYNC_READY"} \
+        {"sync_valid" "SYNC_VALID"} \
+        {"sync_data" "SYNC_DATA"} \
+    } \
+    -vlnv {analog.com:ADI:spi_engine_ctrl:1.0}]
+
+set ip [ipl::add_interface -ip $ip \
+    -inst_name offload_sdi \
+    -display_name offload_sdi \
+    -description offload_sdi \
+    -master_slave master \
+    -portmap { \
+        {"offload_sdi_valid" "TVALID"} \
+        {"offload_sdi_ready" "TREADY"} \
+        {"offload_sdi_data" "TDATA"} \
+    } \
+    -vlnv {amba.com:AMBA4:AXI4Stream:r0p0}]
+
+set ip [ipl::add_interface -ip $ip \
+    -inst_name s_axis_sdo \
+    -display_name s_axis_sdo \
+    -description s_axis_sdo \
+    -master_slave slave \
+    -portmap { \
+        {"s_axis_sdo_valid" "TVALID"} \
+        {"s_axis_sdo_ready" "TREADY"} \
+        {"s_axis_sdo_data" "TDATA"} \
+    } \
+    -vlnv {amba.com:AMBA4:AXI4Stream:r0p0}]
+
+set ip [ipl::add_ip_files -ip $ip -dpath rtl -flist [list \
+    "$ad_hdl_dir/library/util_cdc/sync_bits.v" \
+    "$ad_hdl_dir/library/util_cdc/sync_event.v" \
+    "spi_engine_offload.v" ]]
+
+set ip [ipl::set_parameter -ip $ip \
+    -id DATA_WIDTH \
+    -type param \
+    -value_type int \
+    -conn_mod spi_engine_offload \
+    -title {Shift register's data width} \
+    -default 8 \
+    -output_formatter nostr \
+    -value_range {(8, 255)} \
+    -group1 {General Configuration} \
+    -group2 Config]
+set ip [ipl::set_parameter -ip $ip \
+    -id NUM_OF_SDI \
+    -type param \
+    -value_type int \
+    -conn_mod spi_engine_offload \
+    -title {Number of MISO lines} \
+    -default 1 \
+    -output_formatter nostr \
+    -value_range {(1, 8)} \
+    -group1 {General Configuration} \
+    -group2 Config]
+set ip [ipl::set_parameter -ip $ip \
+    -id ASYNC_SPI_CLK \
+    -type param \
+    -value_type int \
+    -conn_mod spi_engine_offload \
+    -title {Asynchronous core clock} \
+    -default 0 \
+    -options {[(True, 1), (False, 0)]} \
+    -output_formatter nostr \
+    -group1 {General Configuration} \
+    -group2 Config]
+set ip [ipl::set_parameter -ip $ip \
+    -id ASYNC_TRIG \
+    -type param \
+    -value_type int \
+    -conn_mod spi_engine_offload \
+    -title {Asynchronous trigger} \
+    -default 0 \
+    -options {[(True, 1), (False, 0)]} \
+    -output_formatter nostr \
+    -group1 {General Configuration} \
+    -group2 Config]
+set ip [ipl::set_parameter -ip $ip \
+    -id SDO_STREAMING \
+    -type param \
+    -value_type int \
+    -conn_mod spi_engine_offload \
+    -title {SDO Streaming} \
+    -default 0 \
+    -options {[(True, 1), (False, 0)]} \
+    -output_formatter nostr \
+    -group1 {General Configuration} \
+    -group2 Config]
+set ip [ipl::ignore_ports_by_prefix -ip $ip \
+    -mod_data $mod_data \
+    -v_prefix s_axis_sdo \
+    -expression {(SDO_STREAMING == 0)}]
+
+set ip [ipl::set_parameter -ip $ip \
+    -id CMD_MEM_ADDRESS_WIDTH \
+    -type param \
+    -value_type int \
+    -conn_mod spi_engine_offload \
+    -title {Command FIFO address width} \
+    -default 4 \
+    -output_formatter nostr \
+    -value_range {(1, 16)} \
+    -group1 {Command stream FIFO configuration} \
+    -group2 Config]
+set ip [ipl::set_parameter -ip $ip \
+    -id SDO_MEM_ADDRESS_WIDTH \
+    -type param \
+    -value_type int \
+    -conn_mod spi_engine_offload \
+    -title {MOSI FIFO address width} \
+    -default 4 \
+    -output_formatter nostr \
+    -value_range {(1, 16)} \
+    -group1 {Command stream FIFO configuration} \
+    -group2 Config]
+
+ipl::generate_ip $ip


### PR DESCRIPTION
Adding: 
* IP scripts:
    - spi_engine:
        * axi_spi_engine_ltt.tcl
        * spi_axis_reorder_ltt.tcl
        * spi_engine_execution_ltt.tcl
        * spi_engine_interconnect_ltt.tcl
        * spi_engine_offload_ltt.tcl
    - axi_dmac_ltt.tcl
    - axi_clock_monitor_ltt.tcl
    - axi_pwm_gen_ltt.tcl
    - axi_pulse_gen_ltt.tcl

* Interface script interfaces_ltt/interfaces_ltt.tcl that contains the following interfaces:
    - spi_master interface
    - spi_engine_offload_ctrl interface
    - spi_engine_ctrl interface
    - fifo_rd interface for axi_dmac
    - fifo_wr interface for axi_dmac
    - if_framelock interface for axi_dmac

Adding/Updating related make files.

## PR Type
- [ ] Bug fix (change that fixes an issue)
- [x] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)
- [ ] Documentation

## PR Checklist
- [x] I have followed the code style guidelines
- [x] I have performed a self-review of changes
- [ ] I have compiled all hdl projects and libraries affected by this PR
- [ ] I have tested in hardware affected projects, at least on relevant boards
- [ ] I have commented my code, at least hard-to-understand parts
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe files, Copyright etc)
- [ ] I have not introduced new Warnings/Critical Warnings on compilation
- [ ] I have added new hdl testbenches or updated existing ones
