### PR TITLE
projects/ad411x_ad717x/de10nano: add pullup for EEPROM I2C

### DIFF
--- a/projects/ad411x_ad717x/de10nano/system_project.tcl
+++ b/projects/ad411x_ad717x/de10nano/system_project.tcl
@@ -47,4 +47,7 @@ set_location_assignment PIN_AH9   -to i2c_sda;   ## Arduino_IO14
 set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to i2c_scl
 set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to i2c_sda
 
+set_instance_assignment -name WEAK_PULL_UP_RESISTOR ON -to i2c_scl
+set_instance_assignment -name WEAK_PULL_UP_RESISTOR ON -to i2c_sda
+
 execute_flow -compile


### PR DESCRIPTION
Add pullup to I2C1 SDA/SCL pins in the ad411x_ad717x project. These are connected to an EEPROM on the EVAL board. Neither the DE10-Nano or the EVAL board has pullup resistors on this bus, so we need to do the pullup in the FPGA.

## PR Description

Please replace this comment with summary, motivation and context of the changes.
List any dependencies required for this change.

You can check the checkboxes below by inserting a 'x' between square brackets
(without any other characters or spaces) or just check them after publishing the PR.

If there is a breaking change, specify dependent PRs in description and
try to push all related PRs at the same time.


## PR Type
- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)
- [ ] Documentation

## PR Checklist
- [x] I have followed the code style guidelines
- [x] I have performed a self-review of changes
- [x] I have compiled all hdl projects and libraries affected by this PR
- [x] I have tested in hardware affected projects, at least on relevant boards
- [ ] I have commented my code, at least hard-to-understand parts
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe files, Copyright etc)
- [ ] I have not introduced new Warnings/Critical Warnings on compilation
- [ ] I have added new hdl testbenches or updated existing ones
