### PR TITLE
Lattice support for ad738x_fmc project on LFCPNX-EVN (lfcpnx) carrier board.

### DIFF
--- a/docs/user_guide/build_hdl.rst
+++ b/docs/user_guide/build_hdl.rst
@@ -849,14 +849,15 @@ The **sof** file is used to program the device.
 
 The Lattice build is in a very early version. We are just adding the first
 version of library infrastructure support.
-Currently, we only have a single early-version base design that builds almost
-like the other ones. For Lattice, there are separate tools for creating
+Currently, we only have a single supported project the **ad738x_fmc** for
+**LFCPNX-EVN** carrier board, in ``hdl/projects/ad738x_fmc/lfcpnx`` folder.
+For Lattice, there are separate tools for creating
 a block design **(Propel Builder)** and building an HDL design **(Radiant)**.
 
 To build a project, go to the carrier folder and run ``make``. For now, you can
-try to build the only base design we have available for
-**CertusPro-NX Evaluation Board** by entering the base design directory and
-running ``make``.
+try to build the **ad738x_fmc** project that we have available for
+**CertusPro-NX Evaluation Board** by entering the
+``hdl/projects/ad738x_fmc/lfcpnx`` directory and running ``make``.
 
 .. shell:: bash
 

--- a/library/interfaces_ltt/Makefile
+++ b/library/interfaces_ltt/Makefile
@@ -25,6 +25,8 @@ LTT_INTERFACES += analog.com/ADI/spi_engine_offload_ctrl/1.0/spi_engine_offload_
 LTT_INTERFACES += analog.com/ADI/spi_engine_offload_ctrl/1.0/spi_engine_offload_ctrl_rtl.xml
 LTT_INTERFACES += analog.com/ADI/if_framelock/1.0/if_framelock.xml
 LTT_INTERFACES += analog.com/ADI/if_framelock/1.0/if_framelock_rtl.xml
+LTT_INTERFACES += analog.com/ADI/spi_engine_interconnect_ctrl/1.0/spi_engine_interconnect_ctrl.xml
+LTT_INTERFACES += analog.com/ADI/spi_engine_interconnect_ctrl/1.0/spi_engine_interconnect_ctrl_rtl.xml
 
 CLEAN_TARGETS += analog.com/ADI/fifo_rd
 CLEAN_TARGETS += analog.com/ADI/fifo_wr
@@ -32,6 +34,7 @@ CLEAN_TARGETS += analog.com/ADI/spi_master
 CLEAN_TARGETS += analog.com/ADI/spi_engine_ctrl
 CLEAN_TARGETS += analog.com/ADI/spi_engine_offload_ctrl
 CLEAN_TARGETS += analog.com/ADI/if_framelock
+CLEAN_TARGETS += analog.com/ADI/spi_engine_interconnect_ctrl
 
 ifeq ($(LATTICE_DEFAULT_PATHS),1)
 LTT_INTERFACES := $(LTT_INTERFACES) $(foreach dep,$(LTT_INTERFACES),$(LATTICE_DEFAULT_INTERFACE_PATH)/$(dep))

--- a/library/interfaces_ltt/interfaces_ltt.tcl
+++ b/library/interfaces_ltt/interfaces_ltt.tcl
@@ -75,6 +75,16 @@ set if [ipl::create_interface \
 ipl::generate_interface $if
 
 set if [ipl::create_interface \
+    -vlnv {analog.com:ADI:spi_engine_interconnect_ctrl:1.0} \
+    -directConnection true \
+    -isAddressable false \
+    -description "ADI SPI Engine Interconnect Control Interface" \
+    -ports {
+        {-n INTERCONNECT_DIR -p required -w 1 -d out}
+    }]
+ipl::generate_interface $if
+
+set if [ipl::create_interface \
     -vlnv {analog.com:ADI:spi_master:1.0} \
     -directConnection true \
     -isAddressable false \

--- a/library/spi_engine/spi_engine_interconnect/spi_engine_interconnect_ltt.tcl
+++ b/library/spi_engine/spi_engine_interconnect/spi_engine_interconnect_ltt.tcl
@@ -67,6 +67,16 @@ foreach prefix [list "s0" "s1"] {
         -vlnv {analog.com:ADI:spi_engine_ctrl:1.0}]
 }
 
+set ip [ipl::add_interface -ip $ip \
+    -inst_name s_interconnect_ctrl \
+    -display_name s_interconnect_ctrl \
+    -description spi_engine_interconnect_ctrl \
+    -master_slave slave \
+    -portmap { \
+        {"interconnect_dir" "INTERCONNECT_DIR"} \
+    } \
+    -vlnv {analog.com:ADI:spi_engine_interconnect_ctrl:1.0}]
+
 set ip [ipl::add_ip_files -ip $ip -dpath rtl -flist [list \
     "spi_engine_interconnect.v" ]]
 

--- a/library/spi_engine/spi_engine_offload/spi_engine_offload_ltt.tcl
+++ b/library/spi_engine/spi_engine_offload/spi_engine_offload_ltt.tcl
@@ -63,6 +63,16 @@ set ip [ipl::add_interface -ip $ip \
     -vlnv {analog.com:ADI:spi_engine_ctrl:1.0}]
 
 set ip [ipl::add_interface -ip $ip \
+    -inst_name m_interconnect_ctrl \
+    -display_name m_interconnect_ctrl \
+    -description spi_engine_interconnect_ctrl \
+    -master_slave master \
+    -portmap { \
+        {"interconnect_dir" "INTERCONNECT_DIR"} \
+    } \
+    -vlnv {analog.com:ADI:spi_engine_interconnect_ctrl:1.0}]
+
+set ip [ipl::add_interface -ip $ip \
     -inst_name offload_sdi \
     -display_name offload_sdi \
     -description offload_sdi \

--- a/projects/ad738x_fmc/common/ad738x_pb.tcl
+++ b/projects/ad738x_fmc/common/ad738x_pb.tcl
@@ -1,0 +1,166 @@
+###############################################################################
+## Copyright (C) 2024 Analog Devices, Inc. All rights reserved.
+### SPDX short identifier: ADIBSD
+###############################################################################
+
+########### This file contains only the tcl commands for importing lib ########
+########### components and the assembly of the design. ########################
+
+## configure ip components and add to design. #################################
+# set dir [pwd]
+# cd $ad_hdl_dir/library/axi_dmac
+# source ./axi_dmac_ltt.tcl
+# cd $ad_hdl_dir/library/axi_pwm_gen
+# source ./axi_pwm_gen_ltt.tcl
+# cd $ad_hdl_dir/library/spi_engine/axi_spi_engine
+# source ./axi_spi_engine_ltt.tcl
+# cd $ad_hdl_dir/library/spi_engine/spi_engine_offload
+# source ./spi_engine_offload_ltt.tcl
+# cd $ad_hdl_dir/library/spi_engine/spi_engine_interconnect
+# source ./spi_engine_interconnect_ltt.tcl
+# cd $ad_hdl_dir/library/spi_engine/spi_engine_execution
+# source ./spi_engine_execution_ltt.tcl
+# cd $dir
+
+adi_ip_update $project_name -vlnv {latticesemi.com:ip:axi_interc0:2.0.1} \
+  -meta_vlnv {latticesemi.com:ip:axi_interconnect:2.0.1} \
+  -cfg_value {
+    EXT_MAS_AXI_ID_WIDTH:1,
+    EXT_SLV_AXI_ID_WIDTH:8,
+    TOTAL_EXTMAS_CNT:2,
+    TOTAL_EXTSLV_CNT:5,
+    ext_slv_axi_protocol_2:1,
+    ext_slv_axi_protocol_3:1,
+    ext_slv_axi_protocol_4:1
+  } \
+  -ip_iname "axi_interc0_inst"
+adi_ip_instance -vlnv {analog.com:ip:axi_spi0:1.0} \
+  -meta_vlnv {analog.com:ip:axi_spi_engine:1.0} \
+  -cfg_value {
+    ASYNC_SPI_CLK:0,
+    DATA_WIDTH:16,
+    MM_IF_TYPE:0,
+    NUM_OFFLOAD:1,
+    NUM_OF_SDI:4
+  } \
+  -ip_iname "axi_spi0_inst"
+adi_ip_instance -vlnv {analog.com:ip:pwm0:1.0} \
+  -meta_vlnv {analog.com:ip:axi_pwm_gen:1.0} \
+  -cfg_value {
+    ASYNC_CLK_EN:0,
+    PULSE_0_PERIOD:120,
+    PULSE_0_WIDTH:10
+  } \
+  -ip_iname "pwm0_inst"
+adi_ip_instance -vlnv {analog.com:ip:spi_offload0:1.0} \
+  -meta_vlnv {analog.com:ip:spi_engine_offload:1.0} \
+  -cfg_value {
+    ASYNC_SPI_CLK:0,
+    DATA_WIDTH:16,
+    NUM_OF_SDI:4
+  } \
+  -ip_iname "spi_offload0_inst"
+adi_ip_instance -vlnv {analog.com:ip:dmac0:1.0} \
+  -meta_vlnv {analog.com:ip:axi_dmac:1.0} \
+  -cfg_value {
+    ASYNC_CLK_DEST_REQ:0,
+    ASYNC_CLK_DEST_SG:0,
+    ASYNC_CLK_REQ_SG:0,
+    ASYNC_CLK_REQ_SRC:0,
+    ASYNC_CLK_SRC_DEST:0,
+    ASYNC_CLK_SRC_SG:0,
+    AXI_SLICE_DEST:1,
+    AXI_SLICE_SRC:0,
+    DMA_DATA_WIDTH_DEST:32,
+    DMA_DATA_WIDTH_SRC:64,
+    DMA_TYPE_DEST:0,
+    DMA_TYPE_SRC:1
+  } \
+  -ip_iname "dmac0_inst"
+adi_ip_instance -vlnv {analog.com:ip:spi_interc0:1.0} \
+  -meta_vlnv {analog.com:ip:spi_engine_interconnect:1.0} \
+  -cfg_value {DATA_WIDTH:16,NUM_OF_SDI:4} \
+  -ip_iname "spi_interc0_inst"
+adi_ip_instance -vlnv {analog.com:ip:spi_exec0:1.0} \
+  -meta_vlnv {analog.com:ip:spi_engine_execution:1.0} \
+  -cfg_value {
+    DATA_WIDTH:16,
+    NUM_OF_SDI:4,
+    SDI_DELAY:1
+  } \
+  -ip_iname "spi_exec0_inst"
+adi_ip_instance -vlnv {latticesemi.com:ip:sysmem_dmac0:2.3.0} \
+  -meta_vlnv {latticesemi.com:ip:system_memory:2.3.0} \
+  -cfg_value {
+    ADDR_DEPTH:8192,
+    INTERFACE:AXI4,
+    MEMORY_TYPE:LRAM
+  } \
+  -ip_iname "sysmem_dmac0_inst"
+
+sbp_connect_net -name [sbp_get_nets -from $project_name/pll0_inst *clkop*] \
+  "$project_name/pwm0_inst/s_axi_aclk" \
+  "$project_name/axi_spi0_inst/s_axi_aclk" \
+  "$project_name/axi_spi0_inst/spi_clk" \
+  "$project_name/spi_offload0_inst/spi_clk" \
+  "$project_name/spi_offload0_inst/ctrl_clk" \
+  "$project_name/dmac0_inst/s_axi_aclk" \
+  "$project_name/dmac0_inst/s_axis_aclk" \
+  "$project_name/dmac0_inst/m_dest_axi_aclk" \
+  "$project_name/spi_interc0_inst/clk" \
+  "$project_name/spi_exec0_inst/clk" \
+  "$project_name/sysmem_dmac0_inst/axi_aclk_i"
+
+sbp_connect_net -name [sbp_get_nets -from $project_name/cpu0_inst *resetn*] \
+  "$project_name/pwm0_inst/s_axi_aresetn" \
+  "$project_name/axi_spi0_inst/s_axi_aresetn" \
+  "$project_name/dmac0_inst/s_axi_aresetn" \
+  "$project_name/dmac0_inst/m_dest_axi_aresetn" \
+  "$project_name/sysmem_dmac0_inst/axi_resetn_i"
+
+sbp_connect_net "$project_name/axi_spi0_inst/spi_resetn" \
+  "$project_name/spi_offload0_inst/spi_resetn" \
+  "$project_name/spi_interc0_inst/resetn" \
+  "$project_name/spi_exec0_inst/resetn"
+
+sbp_connect_interface_net "$project_name/axi_spi0_inst/IRQ" \
+  "$project_name/cpu0_inst/IRQ_S7"
+sbp_connect_interface_net "$project_name/dmac0_inst/IRQ" \
+  "$project_name/cpu0_inst/IRQ_S6"
+
+sbp_connect_interface_net $project_name/spi_offload0_inst/spi_engine_offload_ctrl \
+  $project_name/axi_spi0_inst/spi_engine_offload_ctrl0
+sbp_connect_interface_net $project_name/dmac0_inst/s_axis \
+  $project_name/spi_offload0_inst/offload_sdi
+sbp_connect_interface_net $project_name/spi_interc0_inst/s0_ctrl \
+  $project_name/spi_offload0_inst/spi_engine_ctrl
+sbp_connect_interface_net $project_name/spi_interc0_inst/s1_ctrl \
+  $project_name/axi_spi0_inst/spi_engine_ctrl
+sbp_connect_interface_net $project_name/spi_exec0_inst/spi_engine_ctrl \
+  $project_name/spi_interc0_inst/m_ctrl
+sbp_connect_interface_net $project_name/axi_interc0_inst/AXIL_M04 \
+  $project_name/pwm0_inst/s_axi
+sbp_connect_interface_net $project_name/axi_interc0_inst/AXIL_M03 \
+  $project_name/axi_spi0_inst/s_axi
+sbp_connect_interface_net $project_name/axi_interc0_inst/AXI_S01 \
+  $project_name/dmac0_inst/m_dest_axi
+sbp_connect_net $project_name/spi_offload0_inst/trigger \
+  $project_name/pwm0_inst/pwm_0
+sbp_connect_interface_net $project_name/dmac0_inst/s_axi \
+  $project_name/axi_interc0_inst/AXIL_M02
+sbp_connect_interface_net $project_name/axi_interc0_inst/AXI_M01 \
+  $project_name/sysmem_dmac0_inst/AXI_S0
+sbp_connect_interface_net $project_name/spi_offload0_inst/m_interconnect_ctrl \
+  $project_name/spi_interc0_inst/s_interconnect_ctrl
+
+sbp_export_interfaces $project_name/spi_exec0_inst/spi_master
+sbp_rename -name  {spi_master0} $project_name/spi_exec0_inst_spi_master_interface
+
+sbp_assign_addr_seg -offset 'h40020000 $project_name/axi_interc0_inst/AXIL_M03 \
+  $project_name/axi_spi0_inst/s_axi
+sbp_assign_addr_seg -offset 'h00300000 $project_name/axi_interc0_inst/AXI_M01 \
+  $project_name/sysmem_dmac0_inst/AXI_S0
+sbp_assign_addr_seg -offset 'h40010000 $project_name/axi_interc0_inst/AXIL_M02 \
+  $project_name/dmac0_inst/s_axi
+sbp_assign_addr_seg -offset 'h40030000 $project_name/axi_interc0_inst/AXIL_M04 \
+  $project_name/pwm0_inst/s_axi

--- a/projects/ad738x_fmc/lfcpnx/Makefile
+++ b/projects/ad738x_fmc/lfcpnx/Makefile
@@ -1,0 +1,22 @@
+####################################################################################
+## Copyright (c) 2023 - 2024 Analog Devices, Inc.
+### SPDX short identifier: BSD-1-Clause
+## Auto-generated, do not modify!
+####################################################################################
+
+PROJECT_NAME := ad738x_fmc_lfcpnx
+
+M_DEPS += system_constr.pdc
+M_DEPS += ../../common/lfcpnx/lfcpnx_system_constr.pdc
+M_DEPS += ../../../projects/scripts/adi_pd.tcl
+M_DEPS += ../../../projects/common/lfcpnx/lfcpnx_system_pb.tcl
+M_DEPS += ../../../projects/ad738x_fmc/common/ad738x_pb.tcl
+
+LIB_DEPS += axi_dmac
+LIB_DEPS += axi_pwm_gen
+LIB_DEPS += spi_engine/axi_spi_engine
+LIB_DEPS += spi_engine/spi_engine_execution
+LIB_DEPS += spi_engine/spi_engine_interconnect
+LIB_DEPS += spi_engine/spi_engine_offload
+
+include ../../scripts/project-lattice.mk

--- a/projects/ad738x_fmc/lfcpnx/system_constr.pdc
+++ b/projects/ad738x_fmc/lfcpnx/system_constr.pdc
@@ -1,0 +1,21 @@
+###############################################################################
+## Copyright (C) 2024 Analog Devices, Inc. All rights reserved.
+### SPDX short identifier: ADIBSD
+###############################################################################
+
+# spi_engine
+ldc_set_location -site {AD12} [get_ports cs];           #G7 FMC_LA00_CLK_N  PB112B_3
+ldc_set_location -site {AF4} [get_ports sdo];           #H7 FMC_LA02_P      PB150A_3
+ldc_set_location -site {Y5} [get_ports {sdi_bus[0]}];   #D8 FMC_LA01_CLK_P  PB148A_3
+ldc_set_location -site {AA5} [get_ports {sdi_bus[1]}];  #D9 FMC_LA01_CLK_N  PB148B_3
+ldc_set_location -site {AF3} [get_ports {sdi_bus[2]}];  #H8 FMC_LA02_N      PB150B_3
+ldc_set_location -site {AD4} [get_ports {sdi_bus[3]}];  #G9 FMC_LA03_P      PB152A_3
+ldc_set_location -site {AC12} [get_ports sclk];         #G6 FMC_LA00_CLK_P  PB112A_3
+
+ldc_set_port -iobuf {IO_TYPE=LVCMOS18H} [get_ports cs]
+ldc_set_port -iobuf {IO_TYPE=LVCMOS18H} [get_ports sdo]
+ldc_set_port -iobuf {IO_TYPE=LVCMOS18H} [get_ports {sdi_bus[0]}]
+ldc_set_port -iobuf {IO_TYPE=LVCMOS18H} [get_ports {sdi_bus[1]}]
+ldc_set_port -iobuf {IO_TYPE=LVCMOS18H} [get_ports {sdi_bus[2]}]
+ldc_set_port -iobuf {IO_TYPE=LVCMOS18H} [get_ports {sdi_bus[3]}]
+ldc_set_port -iobuf {IO_TYPE=LVCMOS18H} [get_ports sclk]

--- a/projects/ad738x_fmc/lfcpnx/system_pb.tcl
+++ b/projects/ad738x_fmc/lfcpnx/system_pb.tcl
@@ -1,0 +1,10 @@
+###############################################################################
+## Copyright (C) 2024 Analog Devices, Inc. All rights reserved.
+### SPDX short identifier: ADIBSD
+###############################################################################
+
+source $ad_hdl_dir/projects/scripts/adi_pd.tcl
+
+set timer_en 0
+source $ad_hdl_dir/projects/common/lfcpnx/lfcpnx_system_pb.tcl
+source $ad_hdl_dir/projects/ad738x_fmc/common/ad738x_pb.tcl

--- a/projects/ad738x_fmc/lfcpnx/system_project.tcl
+++ b/projects/ad738x_fmc/lfcpnx/system_project.tcl
@@ -1,0 +1,23 @@
+###############################################################################
+## Copyright (C) 2024 Analog Devices, Inc. All rights reserved.
+### SPDX short identifier: ADIBSD
+###############################################################################
+
+source ../../../scripts/adi_env.tcl
+source $ad_hdl_dir/projects/scripts/adi_project_lattice.tcl
+
+
+adi_project ad738x_fmc_lfcpnx
+adi_project_files_default ad738x_fmc_lfcpnx
+
+adi_project_files ad738x_fmc_lfcpnx -flist [list \
+  system_top.v \
+  ../../common/lfcpnx/lfcpnx_system_constr.pdc \
+  system_constr.pdc]
+
+adi_project_run ad738x_fmc_lfcpnx \
+  -cmd_list { \
+    {prj_clean_impl -impl $impl} \
+    {prj_set_strategy_value -strategy Strategy1 bit_ip_eval=True} \
+    {prj_set_strategy_value -strategy Strategy1 syn_frequency=100}
+  }

--- a/projects/ad738x_fmc/lfcpnx/system_project_pb.tcl
+++ b/projects/ad738x_fmc/lfcpnx/system_project_pb.tcl
@@ -1,0 +1,9 @@
+###############################################################################
+## Copyright (C) 2024 Analog Devices, Inc. All rights reserved.
+### SPDX short identifier: ADIBSD
+###############################################################################
+
+source ../../../scripts/adi_env.tcl
+source $ad_hdl_dir/projects/scripts/adi_project_lattice_pb.tcl
+
+adi_project_pb ad738x_fmc_lfcpnx

--- a/projects/ad738x_fmc/lfcpnx/system_top.v
+++ b/projects/ad738x_fmc/lfcpnx/system_top.v
@@ -1,0 +1,101 @@
+// ***************************************************************************
+// ***************************************************************************
+// Copyright (C) 2024 Analog Devices, Inc. All rights reserved.
+//
+// In this HDL repository, there are many different and unique modules, consisting
+// of various HDL (Verilog or VHDL) components. The individual modules are
+// developed independently, and may be accompanied by separate and unique license
+// terms.
+//
+// The user should read each of these license terms, and understand the
+// freedoms and responsibilities that he or she has by using this source/core.
+//
+// This core is distributed in the hope that it will be useful, but WITHOUT ANY
+// WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+// A PARTICULAR PURPOSE.
+//
+// Redistribution and use of source or resulting binaries, with or without modification
+// of this file, are permitted under one of the following two license terms:
+//
+//   1. The GNU General Public License version 2 as published by the
+//      Free Software Foundation, which can be found in the top level directory
+//      of this repository (LICENSE_GPL2), and also online at:
+//      <https://www.gnu.org/licenses/old-licenses/gpl-2.0.html>
+//
+// OR
+//
+//   2. An ADI specific BSD license, which can be found in the top level directory
+//      of this repository (LICENSE_ADIBSD), and also on-line at:
+//      https://github.com/analogdevicesinc/hdl/blob/main/LICENSE_ADIBSD
+//      This will allow to generate bit files and not release the source code,
+//      as long as it attaches to an ADI device.
+//
+// ***************************************************************************
+// ***************************************************************************
+
+`timescale 1ns/100ps
+
+module system_top (
+  input           clk_125,
+  input           resetn,
+
+  input           sw_4,
+  input           sw_5,
+  input   [7:0]   dip_sw_1_to_8,
+  output  [23:0]  leds_0_to_23,
+
+  input           uart_rx,
+  output          uart_tx,
+
+  input           spi_miso,
+  output          spi_sclk,
+  output          spi_ssn,
+  output          spi_mosi,
+
+  input   [3:0]   sdi_bus,
+  output          cs,
+  output          sdo,
+  output          sclk,
+
+  inout           iic_scl,
+  inout           iic_sda
+);
+
+  wire    [31:0]  gpio0_o;
+  wire    [31:0]  gpio0_i;
+  wire    [31:0]  gpio0_en_o;
+
+  wire    [31:0]  gpio1_o;
+  wire    [31:0]  gpio1_i;
+  wire    [31:0]  gpio1_en_o;
+
+  assign leds_0_to_23 = gpio0_o[23:0];
+  assign gpio0_i[31:24] = dip_sw_1_to_8;
+  assign gpio1_i[31:30] = {sw_5, sw_4};
+  assign gpio1_i[29:0] = gpio1_o[29:0];
+
+  ad738x_fmc_lfcpnx ad738x_fmc_lfcpnx_inst (
+    .gpio0_o(gpio0_o),
+    .gpio0_i(gpio0_i),
+    .gpio0_en_o(gpio0_en_o),
+    .gpio1_o(gpio1_o),
+    .gpio1_i(gpio1_i),
+    .gpio1_en_o(gpio1_en_o),
+    .scl_io (iic_scl),
+    .sda_io (iic_sda),
+    .rstn_i (resetn),
+    .ssn_o (spi_ssn),
+    .mosi_o (spi_mosi),
+    .sclk_o (spi_sclk),
+    .miso_i (spi_miso),
+    .rxd_i (uart_rx),
+    .txd_o (uart_tx),
+    .clk_125 (clk_125),
+    .spi_master0_cs_port(cs),
+    .spi_master0_sclk_port(sclk),
+    .spi_master0_sdi_portbus(sdi_bus),
+    .spi_master0_sdo_port(sdo),
+    .spi_master0_sdo_t_port(),
+    .spi_master0_three_wire_port());
+
+endmodule

--- a/projects/common/lfcpnx/lfcpnx_system_pb.tcl
+++ b/projects/common/lfcpnx/lfcpnx_system_pb.tcl
@@ -19,24 +19,24 @@ set conf_dir $ad_hdl_dir/projects/common/lfcpnx/ipcfg
 # set ip_download_path ${env(USERPROFILE)}/PropelIPLocal # by default on windows
 
 ## configure ip components and add to design. #################################
-adi_ip_instance -vlnv {latticesemi.com:ip:cpu0:2.4.0} \
-  -meta_vlnv {latticesemi.com:ip:riscv_rtos:2.4.0} \
+adi_ip_instance -vlnv {latticesemi.com:ip:cpu0:2.5.0} \
+  -meta_vlnv {latticesemi.com:ip:riscv_rtos:2.5.0} \
   -cfg_value {
     TCM_ENABLE: true,
     IRQ_NUM: 16,
     UART_EN: true
   } \
   -ip_iname "cpu0_inst"
-adi_ip_instance -vlnv {latticesemi.com:ip:gpio0:1.6.2} \
-  -meta_vlnv {latticesemi.com:ip:gpio:1.6.2} \
+adi_ip_instance -vlnv {latticesemi.com:ip:gpio0:1.7.0} \
+  -meta_vlnv {latticesemi.com:ip:gpio:1.7.0} \
   -cfg_value {
     IO_LINES_COUNT: 32,
     EXTERNAL_BUF: true,
     DIRECTION_DEF_VAL_INPUT: 00FFFFFF
   } \
   -ip_iname "gpio0_inst"
-adi_ip_instance -vlnv {latticesemi.com:ip:gpio1:1.6.2} \
-  -meta_vlnv {latticesemi.com:ip:gpio:1.6.2} \
+adi_ip_instance -vlnv {latticesemi.com:ip:gpio1:1.7.0} \
+  -meta_vlnv {latticesemi.com:ip:gpio:1.7.0} \
   -cfg_value {
     IO_LINES_COUNT: 32,
     EXTERNAL_BUF: true,
@@ -48,11 +48,12 @@ adi_ip_instance -vlnv {latticesemi.com:ip:spi0:2.1.0} \
   -cfg_value {
     DATA_WIDTH: 8,
     FIFO_DEPTH: 256,
+    INTERFACE: APB,
     SYS_CLOCK_FREQ: 100
   } \
   -ip_iname "spi0_inst"
-adi_ip_instance -vlnv {latticesemi.com:ip:i2c0:2.0.1} \
-  -meta_vlnv {latticesemi.com:ip:i2c_controller:2.0.1} \
+adi_ip_instance -vlnv {latticesemi.com:ip:i2c0:2.2.0} \
+  -meta_vlnv {latticesemi.com:ip:i2c_controller:2.2.0} \
   -cfg_value {
     SYS_CLOCK_FREQ: 100
   } \
@@ -70,34 +71,27 @@ adi_ip_instance -vlnv {latticesemi.com:ip:axi_interc0:2.0.1} \
   -meta_vlnv {latticesemi.com:ip:axi_interconnect:2.0.1} \
   -cfg_value {
     TOTAL_EXTMAS_CNT: 1,
-    TOTAL_EXTSLV_CNT: 4,
+    TOTAL_EXTSLV_CNT: 2,
     EXT_MAS_AXI_ID_WIDTH: 1,
     EXT_SLV_AXI_ID_WIDTH: 8
   } \
   -ip_iname "axi_interc0_inst"
-adi_ip_instance -vlnv {latticesemi.com:ip:axi_ahb0:1.1.1} \
-  -meta_vlnv {latticesemi.com:ip:axi2ahb_bridge:1.1.1} \
-  -cfg_value {} \
-  -ip_iname "axi_ahb0_inst"
-adi_ip_instance -vlnv {latticesemi.com:ip:axi_apb0:1.1.1} \
-  -meta_vlnv {latticesemi.com:ip:axi2apb_bridge:1.1.1} \
+adi_ip_instance -vlnv {latticesemi.com:ip:axi_apb0:1.3.0} \
+  -meta_vlnv {latticesemi.com:ip:axi2apb_bridge:1.3.0} \
   -cfg_value {} \
   -ip_iname "axi_apb0_inst"
-adi_ip_instance -vlnv {latticesemi.com:ip:axi_apb1:1.1.1} \
-  -meta_vlnv {latticesemi.com:ip:axi2apb_bridge:1.1.1} \
-  -cfg_value {} \
-  -ip_iname "axi_apb1_inst"
-adi_ip_instance -vlnv {latticesemi.com:ip:axi_apb2:1.1.1} \
-  -meta_vlnv {latticesemi.com:ip:axi2apb_bridge:1.1.1} \
-  -cfg_value {} \
-  -ip_iname "axi_apb2_inst"
+adi_ip_instance -vlnv {latticesemi.com:module:apb_interconnect0:1.2.1} \
+  -meta_vlnv {latticesemi.com:module:apb_interconnect:1.2.1} \
+  -cfg_value {TOTAL_MASTER_CNT:1,TOTAL_SLAVE_CNT:4} \
+  -ip_iname "apb_interconnect0_inst"
 adi_ip_instance -vlnv {latticesemi.com:ip:sysmem0:2.3.0} \
   -meta_vlnv latticesemi.com:ip:system_memory:2.3.0 \
   -cfg_value {
     INTERFACE: AXI4,
     ADDR_DEPTH: 8192,
     ID_WIDTH: 1,
-    REGMODE_S0: true
+    REGMODE_S0: true,
+    MEMORY_TYPE:LRAM
   } \
   -ip_iname "sysmem0_inst"
 adi_ip_instance -vlnv {latticesemi.com:ip:tcm0:1.5.0} \
@@ -149,10 +143,8 @@ sbp_connect_net "$project_name/cpu0_inst/system_resetn_o" \
   "$project_name/sysmem0_inst/axi_resetn_i" \
   "$project_name/tcm0_inst/sys_rst_n" \
   "$project_name/axi_interc0_inst/axi_aresetn_i" \
-  "$project_name/axi_ahb0_inst/aresetn_i" \
   "$project_name/axi_apb0_inst/aresetn_i" \
-  "$project_name/axi_apb1_inst/aresetn_i" \
-  "$project_name/axi_apb2_inst/aresetn_i" \
+  "$project_name/apb_interconnect0_inst/apb_presetn_i" \
   "$project_name/spi0_inst/rst_n_i" \
   "$project_name/i2c0_inst/rst_n_i" \
   "$project_name/gpio0_inst/resetn_i" \
@@ -169,10 +161,8 @@ sbp_connect_net "$project_name/pll0_inst/clkop_o" \
   "$project_name/sysmem0_inst/axi_aclk_i" \
   "$project_name/axi_interc0_inst/axi_aclk_i" \
   "$project_name/tcm0_inst/sys_clk" \
-  "$project_name/axi_ahb0_inst/aclk_i" \
   "$project_name/axi_apb0_inst/aclk_i" \
-  "$project_name/axi_apb1_inst/aclk_i" \
-  "$project_name/axi_apb2_inst/aclk_i" \
+  "$project_name/apb_interconnect0_inst/apb_pclk_i" \
   "$project_name/spi0_inst/clk_i" \
   "$project_name/i2c0_inst/clk_i" \
   "$project_name/gpio0_inst/clk_i" \
@@ -212,22 +202,18 @@ sbp_connect_net "$project_name/spi0_inst/ssn_o" \
   "$project_name/ssn_o"
 
 sbp_connect_interface_net "$project_name/axi_interc0_inst/AXI_M00" \
-  "$project_name/axi_ahb0_inst/AXI4_S"
-sbp_connect_interface_net "$project_name/axi_interc0_inst/AXI_M01" \
   "$project_name/axi_apb0_inst/AXI4_S"
-sbp_connect_interface_net "$project_name/axi_interc0_inst/AXI_M02" \
-  "$project_name/axi_apb1_inst/AXI4_S"
-sbp_connect_interface_net "$project_name/axi_interc0_inst/AXI_M03" \
-  "$project_name/axi_apb2_inst/AXI4_S"
-sbp_connect_interface_net "$project_name/axi_ahb0_inst/AHBL_M" \
-  "$project_name/spi0_inst/AHBL_S0"
+sbp_connect_interface_net "$project_name/axi_apb0_inst/APB3_M" \
+  "$project_name/apb_interconnect0_inst/APB_S00"
+sbp_connect_interface_net "$project_name/apb_interconnect0_inst/APB_M00" \
+  "$project_name/spi0_inst/APB_S0"
 sbp_connect_interface_net "$project_name/cpu0_inst/AXI_M_INSTR" \
   "$project_name/sysmem0_inst/AXI_S0"
-sbp_connect_interface_net "$project_name/axi_apb0_inst/APB3_M" \
+sbp_connect_interface_net "$project_name/apb_interconnect0_inst/APB_M01" \
   "$project_name/i2c0_inst/APB_S0"
-sbp_connect_interface_net "$project_name/axi_apb1_inst/APB3_M" \
+sbp_connect_interface_net "$project_name/apb_interconnect0_inst/APB_M02" \
   "$project_name/gpio0_inst/APB_S0"
-sbp_connect_interface_net "$project_name/axi_apb2_inst/APB3_M" \
+sbp_connect_interface_net "$project_name/apb_interconnect0_inst/APB_M03" \
   "$project_name/gpio1_inst/APB_S0"
 sbp_connect_interface_net "$project_name/cpu0_inst/AXI_M_DATA" \
   "$project_name/axi_interc0_inst/AXI_S00"
@@ -244,14 +230,14 @@ sbp_connect_interface_net "$project_name/gpio0_inst/INTR" \
 sbp_connect_interface_net "$project_name/gpio1_inst/INTR" \
   "$project_name/cpu0_inst/IRQ_S5"
 
-sbp_assign_addr_seg -offset 'h40004000 "$project_name/axi_apb2_inst/APB3_M" \
+sbp_assign_addr_seg -offset 'h40004000 "$project_name/apb_interconnect0_inst/APB_M03" \
   "$project_name/gpio1_inst/APB_S0"
-sbp_assign_addr_seg -offset 'h40003000 "$project_name/axi_apb1_inst/APB3_M" \
+sbp_assign_addr_seg -offset 'h40003000 "$project_name/apb_interconnect0_inst/APB_M02" \
   "$project_name/gpio0_inst/APB_S0"
-sbp_assign_addr_seg -offset 'h40002000 "$project_name/axi_apb0_inst/APB3_M" \
+sbp_assign_addr_seg -offset 'h40002000 "$project_name/apb_interconnect0_inst/APB_M01" \
   "$project_name/i2c0_inst/APB_S0"
-sbp_assign_addr_seg -offset 'h40000000 "$project_name/axi_ahb0_inst/AHBL_M" \
-  "$project_name/spi0_inst/AHBL_S0"
+sbp_assign_addr_seg -offset 'h40000000 "$project_name/apb_interconnect0_inst/APB_M00" \
+  "$project_name/spi0_inst/APB_S0"
 sbp_assign_addr_seg -offset 'h00000000 "$project_name/cpu0_inst/LOCAL_BUS_M_DATA" \
   "$project_name/tcm0_inst/LOCAL_BUS_DATA"
 sbp_assign_addr_seg -offset 'h00200000 "$project_name/cpu0_inst/AXI_M_INSTR" \
@@ -260,23 +246,13 @@ sbp_assign_addr_seg -offset 'h00000000 "$project_name/cpu0_inst/LOCAL_BUS_M_INST
   "$project_name/tcm0_inst/LOCAL_BUS_INSTR"
 
 if {$timer_en == 1} {
-  adi_ip_update $project_name -vlnv {latticesemi.com:ip:axi_interc0:2.0.1} \
-    -meta_vlnv {latticesemi.com:ip:axi_interc0:2.0.1} \
-    -cfg_value {
-      TOTAL_EXTMAS_CNT: 1,
-      TOTAL_EXTSLV_CNT: 5,
-      EXT_MAS_AXI_ID_WIDTH: 1,
-      EXT_SLV_AXI_ID_WIDTH: 8
-    } \
-    -ip_iname "axi_interc0_inst"
+  adi_ip_update $project_name -vlnv {latticesemi.com:module:apb_interconnect0:1.2.1} \
+    -meta_vlnv {latticesemi.com:module:apb_interconnect:1.2.1} \
+    -cfg_value {TOTAL_MASTER_CNT:1,TOTAL_SLAVE_CNT:5} \
+    -ip_iname "apb_interconnect0_inst"
 
-  adi_ip_instance -vlnv {latticesemi.com:ip:axi_apb3:1.1.1} \
-    -meta_vlnv {latticesemi.com:ip:axi2apb_bridge:1.1.1} \
-    -cfg_value {} \
-    -ip_iname "axi_apb3_inst"
-
-  adi_ip_instance -vlnv {latticesemi.com:ip:timer0:1.3.1} \
-    -meta_vlnv {latticesemi.com:ip:gp_timer:1.3.1} \
+  adi_ip_instance -vlnv {latticesemi.com:ip:timer0:1.4.0} \
+    -meta_vlnv {latticesemi.com:ip:gp_timer:1.4.0} \
     -cfg_value {
       t1_cnt_up: count-up,
       T1_PERIOD_WIDTH: 32,
@@ -296,22 +272,17 @@ if {$timer_en == 1} {
     -ip_iname "timer0_inst"
 
   sbp_connect_net -name [sbp_get_nets -from $project_name/pll0_inst *clkop*] \
-    "$project_name/timer0_inst/clk_i" \
-    "$project_name/axi_apb3_inst/aclk_i"
+    "$project_name/timer0_inst/clk_i"
 
   sbp_connect_net -name [sbp_get_nets -from $project_name/cpu0_inst *resetn*] \
-    "$project_name/timer0_inst/rst_n_i" \
-    "$project_name/axi_apb3_inst/aresetn_i"
+    "$project_name/timer0_inst/rst_n_i"
 
-  sbp_connect_interface_net "$project_name/axi_interc0_inst/AXI_M04" \
-    "$project_name/axi_apb3_inst/AXI4_S"
-
-  sbp_connect_interface_net "$project_name/axi_apb3_inst/APB3_M" \
+  sbp_connect_interface_net "$project_name/apb_interconnect0_inst/APB_M04" \
     "$project_name/timer0_inst/APB_S0"
 
   sbp_connect_interface_net "$project_name/timer0_inst/INTR" \
     "$project_name/cpu0_inst/IRQ_S6"
 
-  sbp_assign_addr_seg -offset 'h40005000 "$project_name/axi_apb3_inst/APB3_M" \
+  sbp_assign_addr_seg -offset 'h40005000 "$project_name/apb_interconnect0_inst/APB_M04" \
     "$project_name/timer0_inst/APB_S0"
 }


### PR DESCRIPTION
## PR Description

- Adding `spi_engine_interconnect_ctrl` interface to `spi_engine` IPs.
- `projects/common/lfcpnx`: Updating base design and IP versions.
- `ad738x_fmc/lfcpnx:` Adding suport for **Lattice LFCPNX-EVN** carrier.
- `docs/user_guide/build_hdl.rst:` Updates for first project.

## PR Type
- [ ] Bug fix (change that fixes an issue)
- [x] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)
- [ ] Documentation

## PR Checklist
- [x] I have followed the code style guidelines
- [x] I have performed a self-review of changes
- [x] I have compiled all hdl projects and libraries affected by this PR
- [x] I have tested in hardware affected projects, at least on relevant boards
- [x] I have commented my code, at least hard-to-understand parts
- [x] I have signed off all commits from this PR
- [x] I have updated the documentation (wiki pages, ReadMe files, Copyright etc)
- [ ] I have not introduced new Warnings/Critical Warnings on compilation
- [ ] I have added new hdl testbenches or updated existing ones
