### PR TITLE
projects/ad4630_fmc: Add VADJ values in READMEs

### DIFF
--- a/projects/ad4630_fmc/README.md
+++ b/projects/ad4630_fmc/README.md
@@ -3,6 +3,7 @@
 - Evaluation board product page: [EVAL-AD4630-FMC](https://www.analog.com/eval-ad4630-24)
 - System documentation: TO BE ADDED
 - HDL project documentation: https://analogdevicesinc.github.io/hdl/projects/ad4630_fmc/index.html
+- Evaluation board VADJ range: 1.2V - 3.3V
 
 ## Supported parts
 

--- a/projects/ad4630_fmc/zed/README.md
+++ b/projects/ad4630_fmc/zed/README.md
@@ -1,4 +1,8 @@
+<!-- no_no_os -->
+
 # AD4630-FMC/ZED HDL Project
+
+- VADJ with which it was tested in hardware: 2.5V
 
 ## Building the project
 
@@ -21,7 +25,7 @@ The overwritable parameters from the environment are:
 
 - CLK_MODE: clocking mode of the device's digital interface
   - 0 - SPI (default)
-  - 1 - Echo-clock or Master clock 
+  - 1 - Echo-clock or Master clock
 - NUM_OF_SDI: the number of MOSI lines of the SPI interface
   - 1 - Interleaved
   - 2 - 1LPC
@@ -42,7 +46,7 @@ This specific command is equivalent to running `make` only:
 
 ```
 make CLK_MODE=0 NUM_OF_SDI=4 CAPTURE_ZONE=2 DDR_EN=0
-``` 
+```
 
 Corresponding device trees:
 - [zynq-zed-adv7511-ad4630-24.dts](https://github.com/analogdevicesinc/linux/blob/main/arch/arm/boot/dts/xilinx/zynq-zed-adv7511-ad4630-24.dts)
@@ -56,7 +60,7 @@ Corresponding device trees:
 make CLK_MODE=0 NUM_OF_SDI=2 CAPTURE_ZONE=2 DDR_EN=0
 ```
 
-Corresponding device trees: 
+Corresponding device trees:
 
 - [zynq-zed-adv7511-ad4030-24.dts](https://github.com/analogdevicesinc/linux/blob/main/arch/arm/boot/dts/xilinx/zynq-zed-adv7511-ad4030-24.dts)
 - [zynq-zed-adv7511-ad4032-24.dts](https://github.com/analogdevicesinc/linux/blob/main/arch/arm/boot/dts/xilinx/zynq-zed-adv7511-ad4032-24.dts)


### PR DESCRIPTION
## PR Description

Add VADJ value in **AD4630_FMC** project.

## PR Type
- [ ] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)
- [X] Documentation

## PR Checklist
- [X] I have followed the code style guidelines
- [X] I have performed a self-review of changes
- [X] I have compiled all hdl projects and libraries affected by this PR
- [ ] I have tested in hardware affected projects, at least on relevant boards
- [ ] I have commented my code, at least hard-to-understand parts
- [ ] I have signed off all commits from this PR
- [X] I have updated the documentation (wiki pages, ReadMe files, Copyright etc)
- [X] I have not introduced new Warnings/Critical Warnings on compilation
- [ ] I have added new hdl testbenches or updated existing ones
