### PR TITLE
projects/ad738x_fmc: add DMA gate to SPI offload trigger

### DIFF
--- a/projects/ad738x_fmc/common/ad738x_bd.tcl
+++ b/projects/ad738x_fmc/common/ad738x_bd.tcl
@@ -51,10 +51,17 @@ ad_ip_parameter spi_clkgen CONFIG.VCO_MUL 8
 ad_connect $sys_cpu_clk spi_clkgen/clk
 ad_connect spi_clk spi_clkgen/clk_0
 
+ad_ip_instance util_vector_logic cnv_gate
+ad_ip_parameter cnv_gate CONFIG.C_SIZE 1
+ad_ip_parameter cnv_gate CONFIG.C_OPERATION {and}
+
+ad_connect cnv_gate/Op1 axi_ad738x_dma/s_axis_xfer_req
+ad_connect cnv_gate/Op2 spi_trigger_gen/pwm_0
+
 ad_connect spi_clk spi_trigger_gen/ext_clk
 ad_connect $sys_cpu_clk spi_trigger_gen/s_axi_aclk
 ad_connect sys_cpu_resetn spi_trigger_gen/s_axi_aresetn
-ad_connect spi_trigger_gen/pwm_0 $hier_spi_engine/trigger
+ad_connect cnv_gate/Res $hier_spi_engine/trigger
 
 ad_connect axi_ad738x_dma/s_axis $hier_spi_engine/M_AXIS_SAMPLE
 ad_connect $hier_spi_engine/m_spi ad738x_spi


### PR DESCRIPTION
This is a patch that I have been using locally for quite a while while working on the Linux driver for AD738x. I've also been discussing with @LBFFilho if this is sufficient or if additional fixes are needed, but from a bunch of testing, this seems to be working well.

## PR Description
Add an AND gate to disable the SPI offload trigger when the DMA is full.

Before this change, when NUM_OF_SDI=1, the SPI offload would pause in the middle of a SPI message when the DMA got full which confused both the DMA controller and the ADC chip causing data channels to become misalligned in memory.

After this change, the trigger is prevented from firing when the DMA is full so the SPI message doesn't even start, avoiding the problems mentioned above.

## PR Type
- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)
- [ ] Documentation

## PR Checklist
- [ ] I have followed the code style guidelines
- [x] I have performed a self-review of changes
- [x] I have compiled all hdl projects and libraries affected by this PR
- [x] I have tested in hardware affected projects, at least on relevant boards
- [ ] I have commented my code, at least hard-to-understand parts
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe files, Copyright etc)
- [ ] I have not introduced new Warnings/Critical Warnings on compilation
- [ ] I have added new hdl testbenches or updated existing ones
