### PR TITLE
library/spi_engine: SDO Extension upgrade

### DIFF
--- a/docs/library/spi_engine/axi_spi_engine.rst
+++ b/docs/library/spi_engine/axi_spi_engine.rst
@@ -116,8 +116,18 @@ If an application attempts to read data while the FIFO is empty undefined data
 is returned and the state of the FIFO remains unmodified.
 It is possible to read the first entry in the SDI FIFO without removing it by
 reading from the SDI_FIFO_PEEK register.
+It is important to point out that each read represents one active lane of the SPI.
+So, for ``N`` active lanes it is necessary to read ``N`` times. Reading
+always starts from lane 0.
 The number of valid entries in the SDI FIFO register can be queried by reading
-the SDI_FIFO_LEVEL register.
+the SDI_FIFO_LEVEL register. This value must be a multiple of ``NUM_OF_SDIO``.
+
+Data can be inserted into the SDO FIFO by writing to the SDO_FIFO register
+**only the valid lanes**. For example, if there are 4 lanes and just 2 of them
+are enabled, then the programmer must write 2 values to this register. The
+remaining lanes will contain ``SDO_DEFAULT`` value defined in 
+:ref:`spi_engine execution`. The number of valid lanes are defined in
+:ref:`spi_engine configuration-registers`.
 
 If the peripheral is disabled by setting the ENABLE register to 0 any data
 stored in the FIFOs is discarded and the state of the FIFO is reset.

--- a/docs/library/spi_engine/control-interface.rst
+++ b/docs/library/spi_engine/control-interface.rst
@@ -76,7 +76,7 @@ Signal Pins
      - ``sdi_valid``
      - Input
      - Valid signal of the SDI stream
-   * - [(NUM_OF_SDI*DATA_WIDTH-1):0]
+   * - [(NUM_OF_SDIO*DATA_WIDTH-1):0]
      - ``sdi_data``
      - Input
      - Data signal of the SDI stream

--- a/docs/library/spi_engine/instruction-format.rst
+++ b/docs/library/spi_engine/instruction-format.rst
@@ -3,8 +3,9 @@
 SPI Engine Instruction Set Specification
 ================================================================================
 
-The SPI Engine instruction set is a simple 16-bit instruction set of which
-13-bits are currently allocated (bits 15,11,10 are always 0).
+The SPI Engine instruction set is a 16-bit instruction set of which 13-bits are
+currently allocated (bits 15 and 11 are always 0). Bit 10 is only being used by
+the :ref:`spi_engine write-configuration-instruction`.
 
 Instructions
 --------------------------------------------------------------------------------
@@ -12,22 +13,51 @@ Instructions
 Transfer Instruction
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-== == == == == == = = = = = = = = = =
-15 14 13 12 11 10 9 8 7 6 5 4 3 2 1 0
-== == == == == == = = = = = = = = = =
-0  0  0  0  0  0  r w n n n n n n n n
-== == == == == == = = = = = = = = = =
+.. list-table::
+   :header-rows: 1
 
-The transfer instructions perform a low-level SPI transfer. It will generate
-SCLK transitions for the specified amount of cycles according to the SPI
-configuration register. If the r bit is set the SDI pin will be sampled and
-stored in the shift register at the end of each word the data is output on the
-SDI_DATA stream. If the w bit is set the SDO pin will be updated with the data
-received from the SDO_DATA stream. If the w bit is set the sdo_t signal will
-also be set to 0 for the duration of the transfer. If the SDI_DATA stream is not
-able to accept data or the SDO_DATA stream is not able to provide data the
-execution is stalled at the end/start of the transfer until data is
-accepted/becomes available.
+   * - 15
+     - 14
+     - 13
+     - 12
+     - 11
+     - 10
+     - 9
+     - 8
+     - 7
+     - 6
+     - 5
+     - 4
+     - 3
+     - 2
+     - 1
+     - 0
+   * - rv
+     - 0
+     - 0
+     - 0
+     - rv
+     - rv
+     - r
+     - w
+     - n
+     - n
+     - n
+     - n
+     - n
+     - n
+     - n
+     - n
+
+The transfer instruction perform a low-level SPI transfer. It generates SCLK
+transitions for the specified amount of cycles according to the SPI
+configuration register. If the r bit is set, the SDI pin is sampled and stored
+in the shift register up to the end of the word, and then is output in the
+SDI_DATA stream. If the w bit is set, the SDO pin is updated with the data
+received from the SDO_DATA stream. By setting w bit, the sdo_t pin is set to 0
+during the transfer. If the SDI_DATA stream cannot accept any data or SDO_DATA
+stream cannot provide any data, then the execution module is stalled until
+there's no longer any backpressure condition.
 
 .. list-table::
    :widths: 10 15 75
@@ -36,17 +66,20 @@ accepted/becomes available.
    * - Bits
      - Name
      - Description
+   * - rv
+     - Reserved
+     - Reserved bit. Must always be set to 0.
    * - r
      - Read
-     - If set to 1 data will be read from the SDI pin during and the read words
-       will be available on the SDI_DATA interface.
+     - If set to 1, data is read from the SDI pin and the read words are
+       available on the SDI_DATA interface.
    * - w
      - Write
-     - If set to 1 data will be taken from the SDO_DATA interface and output on
+     - If set to 1, data is consumed from the SDO_DATA interface and output on
        the SDO pin.
    * - n
      - Length
-     - n + 1 number of words that will be transferred.
+     - n + 1 number of words to be transferred.
 
 
 .. _spi_engine cs-instruction:
@@ -54,29 +87,59 @@ accepted/becomes available.
 Chip-Select Instruction
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-== == == == == == = = = = = = = = = =
-15 14 13 12 11 10 9 8 7 6 5 4 3 2 1 0
-== == == == == == = = = = = = = = = =
-0  0  0  1  0  0  t t s s s s s s s s
-== == == == == == = = = = = = = = = =
+.. list-table::
+   :header-rows: 1
 
-The chip-select instruction updates the value chip-select output signal of the
-SPI Engine execution module.
+   * - 15
+     - 14
+     - 13
+     - 12
+     - 11
+     - 10
+     - 9
+     - 8
+     - 7
+     - 6
+     - 5
+     - 4
+     - 3
+     - 2
+     - 1
+     - 0
+   * - rv
+     - 0
+     - 0
+     - 1
+     - rv
+     - rv
+     - t
+     - t
+     - s
+     - s
+     - s
+     - s
+     - s
+     - s
+     - s
+     - s
 
-The physical outputs on each pin may be inverted relative to the command
-according to the mask set by :ref:`spi_engine cs-invert-mask-instruction`. The
-Invert Mask acts only on the output registers of the Chip-Select pins. Thus, if
-the last 8 bits of the Chip-Select instruction are 0xFE, only CS[0] will be
-active regardless of polarity. The polarity inversion process (if needed) is
-transparent to the programmer.
+The chip-select instruction updates the value of the chip-select output signal
+of the SPI Engine execution module.
 
-Before and after the update is performed the execution module is paused for the
-specified delay. The length of the delay depends on the module clock frequency,
-the setting of the prescaler register and the parameter :math:`t` of the
-instruction. This delay is inserted before and after the update of the
-chip-select signal, so the total execution time of the chip-select instruction
-is twice the delay, with an added fixed 2 clock cycles (fast clock, not
-prescaled) before for the internal logic.
+The physical output value for every pin may differ from what is defined in this
+instruction depending on the mask set in the
+:ref:`spi_engine cs-invert-mask-instruction`, because this mask acts only on
+the output registers of the Chip-Select pins. Thus, if the last 8 bits of the
+Chip-Select instruction are 0xFE, only CS[0] is active regardless of polarity.
+The polarity inversion process (if needed) is transparent to the programmer.
+
+Before and after any update, the execution module is paused for the specified
+delay. The length of the delay depends on the module clock frequency, the
+value of the prescaler register, and the parameter :math:`t` of the
+instruction. This delay is inserted before and after any update of the
+chip-select signal which results in twice the delay value defined. Furthermore,
+it is necessary to add 2 clock cycles for the internal logic (fast clock, not
+prescaled).
 
 .. math::
 
@@ -93,6 +156,9 @@ prescaled) before for the internal logic.
    * - Bits
      - Name
      - Description
+   * - rv
+     - Reserved
+     - Reserved bit. Must always be set to 0.
    * - t
      - Delay
      - Delay before and after setting the new configuration.
@@ -100,18 +166,50 @@ prescaled) before for the internal logic.
      - Chip-select
      - The new chip-select configuration.
 
+.. _spi_engine write-configuration-instruction:
+
 Configuration Write Instruction
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-== == == == == == = = = = = = = = = =
-15 14 13 12 11 10 9 8 7 6 5 4 3 2 1 0
-== == == == == == = = = = = = = = = =
-0  0  1  0  0  0  r r v v v v v v v v
-== == == == == == = = = = = = = = = =
+.. list-table::
+   :header-rows: 1
 
-The configuration writes instruction updates a
-:ref:`spi_engine configuration-registers`
-of the SPI Engine execution module with a new value.
+   * - 15
+     - 14
+     - 13
+     - 12
+     - 11
+     - 10
+     - 9
+     - 8
+     - 7
+     - 6
+     - 5
+     - 4
+     - 3
+     - 2
+     - 1
+     - 0
+   * - rv
+     - 0
+     - 1
+     - 0
+     - rv
+     - rg
+     - rg
+     - rg
+     - v
+     - v
+     - v
+     - v
+     - v
+     - v
+     - v
+     - v
+
+The configuration write instruction updates the
+:ref:`spi_engine configuration-registers` of the SPI Engine execution module
+with a new value.
 
 .. list-table::
    :widths: 10 15 75
@@ -120,12 +218,18 @@ of the SPI Engine execution module with a new value.
    * - Bits
      - Name
      - Description
-   * - r
+   * - rv
+     - Reserved
+     - Reserved bit. Must always be set to 0.
+   * - rg
      - Register
-     - Configuration register address.
-       2'b00 = :ref:`spi_engine prescaler-configuration-register`
-       2'b01 = :ref:`spi_engine spi-configuration-register`
-       2'b10 = :ref:`spi_engine dynamic-transfer-length-register`.
+     - Configuration register address:
+      
+       - 3'b000 = :ref:`spi_engine prescaler-configuration-register`.
+       - 3'b001 = :ref:`spi_engine spi-configuration-register`.
+       - 3'b010 = :ref:`spi_engine dynamic-transfer-length-register`.
+       - 3'b011 = :ref:`spi_engine sdi-lane-mask-register`.
+       - 3'b100 = :ref:`spi_engine sdo-lane-mask-register`.
    * - v
      - Value
      - New value for the configuration register.
@@ -133,17 +237,44 @@ of the SPI Engine execution module with a new value.
 Synchronize Instruction
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-== == == == == == = = = = = = = = = =
-15 14 13 12 11 10 9 8 7 6 5 4 3 2 1 0
-== == == == == == = = = = = = = = = =
-0  0  1  1  0  0  0 0 n n n n n n n n
-== == == == == == = = = = = = = = = =
+.. list-table::
+   :header-rows: 1
 
-The synchronize instruction generates a synchronization event on the SYNC output
-stream. This can be used to monitor the progress of the command stream. The
-synchronize instruction is also used by the :ref:`spi_engine interconnect`
-module to identify the end of a transaction and re-start the arbitration
-process.
+   * - 15
+     - 14
+     - 13
+     - 12
+     - 11
+     - 10
+     - 9
+     - 8
+     - 7
+     - 6
+     - 5
+     - 4
+     - 3
+     - 2
+     - 1
+     - 0
+   * - rv
+     - 0
+     - 1
+     - 1
+     - rv
+     - rv
+     - 0
+     - 0
+     - v
+     - v
+     - v
+     - v
+     - v
+     - v
+     - v
+     - v
+
+The synchronize instruction generates a synchronization event on the SYNC
+output stream. This can be used to monitor the progress of the command stream.
 
 .. list-table::
    :widths: 10 15 75
@@ -152,24 +283,57 @@ process.
    * - Bits
      - Name
      - Description
-   * - n
+   * - rv
+     - Reserved
+     - Reserved bit. Must always be set to 0.
+   * - v
      - id
      - Value of the generated synchronization event.
 
 Sleep Instruction
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-== == == == == == = = = = = = = = = =
-15 14 13 12 11 10 9 8 7 6 5 4 3 2 1 0
-== == == == == == = = = = = = = = = =
-0  0  1  1  0  0  0 1 t t t t t t t t
-== == == == == == = = = = = = = = = =
+.. list-table::
+   :header-rows: 1
+
+   * - 15
+     - 14
+     - 13
+     - 12
+     - 11
+     - 10
+     - 9
+     - 8
+     - 7
+     - 6
+     - 5
+     - 4
+     - 3
+     - 2
+     - 1
+     - 0
+   * - rv
+     - 0
+     - 1
+     - 1
+     - rv
+     - rv
+     - 0
+     - 1
+     - t
+     - t
+     - t
+     - t
+     - t
+     - t
+     - t
+     - t
 
 The sleep instruction stops the execution of the command stream for the
-specified amount of time. The time is based on the external clock frequency the
-configuration value of the prescaler register and the time parameter of the
-instruction. A fixed delay of two clock cycles (fast, not affected by the prescaler)
-is the minimum, needed by the internal logic.
+specified amount of time. The sleep time relies on the external clock
+frequency, the configuration value of the prescaler register, and the time
+parameter of the instruction. Also, a 2 clock-cycle delay is required for
+internal logic (fast clock, not prescaled).
 
 .. math::
 
@@ -182,38 +346,71 @@ is the minimum, needed by the internal logic.
    * - Bits
      - Name
      - Description
+   * - rv
+     - Reserved
+     - Reserved bit. Must always be set to 0.
    * - t
      - Time
-     - The amount of prescaler cycles to wait, minus one.
+     - The amount of prescaler cycles to wait minus one.
 
 .. _spi_engine cs-invert-mask-instruction:
 
 CS Invert Mask Instruction
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-== == == == == == = = = = = = = = = =
-15 14 13 12 11 10 9 8 7 6 5 4 3 2 1 0
-== == == == == == = = = = = = = = = =
-0  1  0  0  r  r  r r m m m m m m m m
-== == == == == == = = = = = = = = = =
+.. list-table::
+   :header-rows: 1
 
-The CS Invert Mask Instructions allows the user to select on a per-pin basis
+   * - 15
+     - 14
+     - 13
+     - 12
+     - 11
+     - 10
+     - 9
+     - 8
+     - 7
+     - 6
+     - 5
+     - 4
+     - 3
+     - 2
+     - 1
+     - 0
+   * - rv
+     - 1
+     - 0
+     - 0
+     - rv
+     - rv
+     - rv
+     - rv
+     - m
+     - m
+     - m
+     - m
+     - m
+     - m
+     - m
+     - m
+
+The CS Invert Mask Instruction allows the user to select on a per-pin basis
 whether the Chip Select will be active-low (default) or active-high (inverted).
-Note that the Chip-Select instructions should remain the same because the value
-of CS is inverted at the output register, and additional logic (e.g. reset
-counters) occurs when the CS active state is asserted.
 
-Since the physical values on the pins are inverted at the output, the current
-Invert Mask does not affect the use of the :ref:`spi_engine cs-instruction`. As
-an example, a Chip-Select Instruction with the 's' field equal to 0xFE will
+.. note::
+  Chip-Select instruction must remain the same since the value of CS is inverted at
+  the output register. So, current Invert Mask does not affect the use of the
+  :ref:`spi_engine cs-instruction`. Additional logic (e.g. reset counters)
+  occurs when the CS active state is asserted.
+
+For example, a Chip-Select Instruction with the 's' field equal to 0xFE will
 always result in only CS[0] being active. For an Invert Mask of 0xFF, this would
 result on only CS[0] being high. For an Invert Mask of 0x00, this would result
 on only CS[0] being low. For an Invert Mask of 0x01, this would result on all CS
 pins being high, but only CS[0] is active in this case (since it's the only one
 currently treated as active-high).
 
-This was introduced in
-version 1.02.00 of the core.
+**This was introduced in version 1.02.00 of the core.**
 
 .. list-table::
    :widths: 10 15 75
@@ -222,7 +419,7 @@ version 1.02.00 of the core.
    * - Bits
      - Name
      - Description
-   * - r
+   * - rv
      - reserved
      - Reserved for future use. Must always be set to 0.
    * - m
@@ -235,15 +432,15 @@ version 1.02.00 of the core.
 Configuration Registers
 --------------------------------------------------------------------------------
 
-The SPI Engine execution module has a set of 8-bit configuration registers which
-can be used to dynamically modify the behavior of the module at runtime.
+The SPI Engine execution module has a set of 8-bit configuration registers
+which can be used to dynamically modify the behavior of the module at runtime.
 
 .. _spi_engine spi-configuration-register:
 
 SPI Configuration Register
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The SPI configuration register configures various aspects of the low-level SPI
+The SPI configuration register configures several aspects of the low-level SPI
 bus behavior.
 
 .. list-table::
@@ -265,29 +462,81 @@ bus behavior.
      - Configures the output of the three_wire pin.
    * - [1]
      - CPOL
-     - Configures the polarity of the SCLK signal. When 0, the idle state of
-       the SCLK signal is low. When 1, the idle state of the SCLK signal is
-       high.
+     - Configures the polarity of the SCLK signal:
+      
+       - When 0, the idle state of the SCLK signal is low.
+       - When 1, the idle state of the SCLK signal is high.
    * - [0]
      - CPHA
-     - Configures the phase of the SCLK signal. When 0, data is sampled on the
-       leading edge and updated on the trailing edge. When 1, data is
-       sampled on the trailing edge and updated on the leading edge.
+     - Configures the phase of the SCLK signal:
+      
+       - When 0, data is sampled on the leading edge and updated on the
+         trailing edge.
+       - When 1, data is sampled on the trailing edge and updated on the
+         leading edge.
+
+.. _spi_engine sdi-lane-mask-register:
+
+SDI Lane Mask Register
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+This register configures the SDI mask that defines which lanes are active
+(active-high). The user must define a mask that contains up to ``NUM_OF_SDIO``
+lanes (the number of activated lanes cannot be bigger than the number of lanes).
+For now, it is possible to have up to 8 lanes due to the instruction size.
+
+.. list-table::
+   :widths: 10 15 50
+   :header-rows: 1
+
+   * - Bits
+     - Name
+     - Description
+   * - [7:0]
+     - SDI lane mask
+     - Only bits set to 1 have their respective lane active.
+
+
+.. _spi_engine sdo-lane-mask-register:
+
+SDO Lane Mask Register
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+This register configures the SDO mask that defines which lanes are active
+(active-high). The user must define a mask that contains up to ``NUM_OF_SDIO``
+lanes (the number of activated lanes cannot be bigger than the number of lanes).
+For now, it is possible to have up to 8 lanes due to the instruction size.
+
+.. list-table::
+   :widths: 10 15 50
+   :header-rows: 1
+
+   * - Bits
+     - Name
+     - Description
+   * - [7:0]
+     - SDO lane mask
+     - Only bits set to 1 have their respective lane active.
 
 .. _spi_engine prescaler-configuration-register:
 
 Prescaler Configuration Register
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The prescaler configuration register configures the divider that is applied to
+The prescaler configuration register defines the divider that is applied to
 the module clock when generating the SCLK signal and other internal control
-signals used by the sleep and chip-select commands.
+signals used by the sleep and chip-select instructions.
 
-===== ==== =======================
-Bits  Name Description
-===== ==== =======================
-[7:0] div  Prescaler clock divider
-===== ==== =======================
+.. list-table::
+   :widths: 10 15 30
+   :header-rows: 1
+
+   * - Bits
+     - Name
+     - Description
+   * - [7:0]
+     - Div
+     - Prescaler clock divider. The default value of div is 0.
 
 The frequency of the SCLK signal is derived from the module clock frequency
 using the following formula:
@@ -296,9 +545,6 @@ using the following formula:
 
    f\_{sclk} = \frac{f_{clk}}{((div + 1) * 2)}
 
-
-If no prescaler block is present div is 0.
-
 .. _spi_engine dynamic-transfer-length-register:
 
 Dynamic Transfer Length Register
@@ -306,12 +552,17 @@ Dynamic Transfer Length Register
 
 The dynamic transfer length register sets the length (in bits) of a transfer. By
 default, the transfer length is equal to the DATA_WIDTH of the execution module.
-If required the user can reduce this length by setting this register. A general
-rule of thumb is to set the DATA_WIDTH parameter to the largest transfer length
-supported by the target device.
+If required, the user can reduce this length by setting this register. A
+general rule of thumb is to set the DATA_WIDTH parameter to be the largest
+transfer length supported by the target device.
 
-===== ==== =======================
-Bits  Name Description
-===== ==== =======================
-[7:0] div  Dynamic transfer length
-===== ==== =======================
+.. list-table::
+   :widths: 10 15 30
+   :header-rows: 1
+
+   * - Bits
+     - Name
+     - Description
+   * - [7:0]
+     - Div
+     - Dynamic transfer length.

--- a/docs/library/spi_engine/spi_engine.svg
+++ b/docs/library/spi_engine/spi_engine.svg
@@ -1,125 +1,894 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!-- Created with Inkscape (http://www.inkscape.org/) -->
-<svg preserveAspectRatio="xMidYMid slice" version="1.1" viewBox="0 0 590 430" xmlns="http://www.w3.org/2000/svg" xmlns:cc="http://creativecommons.org/ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
- <defs>
-  <marker id="TriangleInM" overflow="visible" orient="auto">
-   <path transform="scale(-.4)" d="m5.77 0-8.65 5v-10l8.65 5z" fill-rule="evenodd" stroke="#000" stroke-width="1pt"/>
-  </marker>
-  <marker id="TriangleOutM" overflow="visible" orient="auto">
-   <path transform="scale(.4)" d="m5.77 0-8.65 5v-10l8.65 5z" fill-rule="evenodd" stroke="#000" stroke-width="1pt"/>
-  </marker>
- </defs>
- <metadata>
-  <rdf:RDF>
-   <cc:Work rdf:about="">
-    <dc:format>image/svg+xml</dc:format>
-    <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
-   </cc:Work>
-  </rdf:RDF>
- </metadata>
- <g transform="translate(-243.46 -391.52)">
-  <path d="m302.94 743.4h-22.651v51.394" fill="none" marker-start="url(#TriangleInM)" stroke="#000" stroke-width="1.6611px"/>
-  <path d="m474.87 745.96h21.522v48.84" fill="none" marker-end="url(#TriangleOutM)" stroke="#000" stroke-width="1.6611px"/>
-  <text x="269.15515" y="814.40948" fill="#000000" font-family="'Liberation Sans'" letter-spacing="0px" word-spacing="0px" style="line-height:0%" xml:space="preserve"><tspan x="269.15515" y="814.40948" font-size="16.611px" style="line-height:1.25">sdi</tspan></text>
-  <text x="481.29056" y="814.40948" fill="#000000" font-family="'Liberation Sans'" letter-spacing="0px" word-spacing="0px" style="line-height:0%" xml:space="preserve"><tspan x="481.29056" y="814.40948" font-size="16.611px" style="line-height:1.25">sdo</tspan></text>
-  <g transform="matrix(1.6611 0 0 1.6611 -164.25 -225.71)">
-   <rect x="286.31" y="573.7" width="95.039" height="18" fill="none" stroke="#2e3436" stroke-linecap="square" stroke-linejoin="round" stroke-width="2"/>
-   <text x="291.52399" y="585.28876" fill="#000000" font-family="'Liberation Sans'" letter-spacing="0px" word-spacing="0px" style="line-height:0%" xml:space="preserve"><tspan x="291.52399" y="585.28876" font-size="10px" style="line-height:1.25">Data Shift Register</tspan></text>
-  </g>
-  <g transform="matrix(1.6611 0 0 1.6611 -136.25 -262.12)">
-   <text x="264.92651" y="403.62927" fill="#000000" font-family="'Liberation Sans'" letter-spacing="0px" word-spacing="0px" style="line-height:0%" xml:space="preserve"><tspan x="264.92651" y="403.62927" font-size="10px" style="line-height:1.25">SDI</tspan></text>
-   <path d="m273.03 591.14v-183.07" fill="none" marker-end="url(#TriangleOutM)" stroke="#000" stroke-width="1px"/>
-   <g transform="translate(-2.2781 -51.385)">
-    <path d="m272.23 532.13 6.1607 6.1607" fill="none" stroke="#000" stroke-width="1px"/>
-    <path d="m272.23 534.13 6.1607 6.1607" fill="none" stroke="#000" stroke-width="1px"/>
-   </g>
-  </g>
-  <g transform="matrix(1.6611 0 0 1.6611 -128.58 -262.12)">
-   <text x="282.72534" y="403.62927" fill="#000000" font-family="'Liberation Sans'" letter-spacing="0px" word-spacing="0px" style="line-height:0%" xml:space="preserve"><tspan x="282.72534" y="403.62927" font-size="10px" style="line-height:1.25">SDO</tspan></text>
-   <g fill="none" stroke="#000" stroke-width="1px">
-    <path d="m292.46 408.08v181.44" marker-end="url(#TriangleOutM)"/>
-    <g transform="translate(-28.214 -49.385)">
-     <path d="m317.59 530.13 6.1607 6.1607"/>
-     <path d="m317.59 532.13 6.1607 6.1607"/>
+
+<svg
+   preserveAspectRatio="xMidYMid slice"
+   version="1.1"
+   viewBox="0 0 593.05115 428.49216"
+   id="svg44"
+   sodipodi:docname="spi_engine.svg"
+   width="593.05115"
+   height="428.49216"
+   inkscape:version="1.3.2 (091e20e, 2023-11-25, custom)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview44"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:zoom="0.94920097"
+     inkscape:cx="454.06612"
+     inkscape:cy="260.74563"
+     inkscape:window-width="1920"
+     inkscape:window-height="1009"
+     inkscape:window-x="-8"
+     inkscape:window-y="54"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="g44" />
+  <defs
+     id="defs2">
+    <marker
+       id="TriangleInM"
+       overflow="visible"
+       orient="auto">
+      <path
+         transform="scale(-0.4)"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         fill-rule="evenodd"
+         stroke="#000000"
+         stroke-width="1pt"
+         id="path1" />
+    </marker>
+    <marker
+       id="TriangleOutM"
+       overflow="visible"
+       orient="auto">
+      <path
+         transform="scale(0.4)"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         fill-rule="evenodd"
+         stroke="#000000"
+         stroke-width="1pt"
+         id="path2" />
+    </marker>
+    <marker
+       id="TriangleOutM-0"
+       overflow="visible"
+       orient="auto">
+      <path
+         transform="scale(0.4)"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         fill-rule="evenodd"
+         stroke="#000000"
+         stroke-width="1pt"
+         id="path2-6" />
+    </marker>
+  </defs>
+  <metadata
+     id="metadata2">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     transform="translate(-234.72654,-387.64905)"
+     id="g44">
+    <path
+       d="M 258.78596,743.4 H 250.289 v 51.394"
+       fill="none"
+       marker-start="url(#TriangleInM)"
+       stroke="#000000"
+       stroke-width="1.6611px"
+       id="path3"
+       sodipodi:nodetypes="ccc" />
+    <path
+       d="m 474.87,745.96 h 21.522 v 48.84"
+       fill="none"
+       marker-end="url(#TriangleOutM)"
+       stroke="#000000"
+       stroke-width="1.6611px"
+       id="path4" />
+    <text
+       x="239.15515"
+       y="814.40948"
+       fill="#000000"
+       font-family="'Liberation Sans'"
+       letter-spacing="0px"
+       word-spacing="0px"
+       style="line-height:0%"
+       xml:space="preserve"
+       id="text4"><tspan
+         x="239.15515"
+         y="814.40948"
+         font-size="16.611px"
+         style="line-height:1.25"
+         id="tspan4">sdi</tspan></text>
+    <text
+       x="481.29056"
+       y="814.40948"
+       fill="#000000"
+       font-family="'Liberation Sans'"
+       letter-spacing="0px"
+       word-spacing="0px"
+       style="line-height:0%"
+       xml:space="preserve"
+       id="text5"><tspan
+         x="481.29056"
+         y="814.40948"
+         font-size="16.611px"
+         style="line-height:1.25"
+         id="tspan5">sdo</tspan></text>
+    <g
+       transform="matrix(1.8643156,0,0,1.6500916,-241.83509,-219.29543)"
+       id="g6">
+      <rect
+         x="274.0777"
+         y="573.75867"
+         width="107.21266"
+         height="17.8827"
+         fill="none"
+         stroke="#2e3436"
+         stroke-linecap="square"
+         stroke-linejoin="round"
+         stroke-width="2.1173"
+         id="rect5" />
+      <text
+         x="285.26703"
+         y="585.2879"
+         fill="#000000"
+         font-family="'Liberation Sans'"
+         letter-spacing="0px"
+         word-spacing="0px"
+         style="line-height:0%"
+         xml:space="preserve"
+         id="text6"><tspan
+           x="285.26703"
+           y="585.2879"
+           font-size="10px"
+           style="line-height:1.25"
+           id="tspan6">Data Shift Register</tspan></text>
     </g>
-   </g>
+    <g
+       transform="matrix(1.6611,0,0,1.6611,-182.25,-262.12)"
+       id="g10">
+      <text
+         x="264.92651"
+         y="403.62927"
+         fill="#000000"
+         font-family="'Liberation Sans'"
+         letter-spacing="0px"
+         word-spacing="0px"
+         style="line-height:0%"
+         xml:space="preserve"
+         id="text7"><tspan
+           x="264.92651"
+           y="403.62927"
+           font-size="10px"
+           style="line-height:1.25"
+           id="tspan7">SDI</tspan></text>
+      <path
+         d="M 273.03,591.14 V 408.07"
+         fill="none"
+         marker-end="url(#TriangleOutM)"
+         stroke="#000000"
+         stroke-width="1px"
+         id="path7" />
+      <g
+         transform="translate(-2.2781,-51.385)"
+         id="g9">
+        <path
+           d="m 272.23,532.13 6.1607,6.1607"
+           fill="none"
+           stroke="#000000"
+           stroke-width="1px"
+           id="path8" />
+        <path
+           d="m 272.23,534.13 6.1607,6.1607"
+           fill="none"
+           stroke="#000000"
+           stroke-width="1px"
+           id="path9" />
+      </g>
+    </g>
+    <g
+       transform="matrix(1.6611,0,0,1.6611,-178.58,-262.12)"
+       id="g14">
+      <text
+         x="282.72534"
+         y="403.62927"
+         fill="#000000"
+         font-family="'Liberation Sans'"
+         letter-spacing="0px"
+         word-spacing="0px"
+         style="line-height:0%"
+         xml:space="preserve"
+         id="text10"><tspan
+           x="282.72534"
+           y="403.62927"
+           font-size="10px"
+           style="line-height:1.25"
+           id="tspan10">SDO</tspan></text>
+      <g
+         fill="none"
+         stroke="#000000"
+         stroke-width="1px"
+         id="g13">
+        <path
+           d="M 292.46,408.08 V 589.52"
+           marker-end="url(#TriangleOutM)"
+           id="path10" />
+        <g
+           transform="translate(-28.214,-49.385)"
+           id="g12">
+          <path
+             d="m 317.59,530.13 6.1607,6.1607"
+             id="path11" />
+          <path
+             d="m 317.59,532.13 6.1607,6.1607"
+             id="path12" />
+        </g>
+      </g>
+    </g>
+    <g
+       transform="matrix(1.6611,0,0,1.6611,-138.46956,-262.72635)"
+       id="g14-7">
+      <text
+         x="282.72534"
+         y="398.81323"
+         fill="#000000"
+         font-family="'Liberation Sans'"
+         letter-spacing="0px"
+         word-spacing="0px"
+         style="line-height:0%"
+         xml:space="preserve"
+         id="text10-7"><tspan
+           sodipodi:role="line"
+           id="tspan45"
+           x="282.72534"
+           y="398.81323"><tspan
+             x="282.72534"
+             y="398.81323"
+             font-size="10px"
+             style="line-height:1.25"
+             id="tspan10-0">offload </tspan></tspan><tspan
+           sodipodi:role="line"
+           id="tspan46"
+           x="282.72534"
+           y="398.81323"><tspan
+             x="282.72534"
+             y="398.81323"
+             font-size="10px"
+             style="line-height:1.25"
+             id="tspan47"
+             dy="7.8699999">active</tspan></tspan></text>
+      <g
+         fill="none"
+         stroke="#000000"
+         stroke-width="1px"
+         id="g13-5">
+        <path
+           d="M 292.46,408.08 V 589.52"
+           marker-end="url(#TriangleOutM-0)"
+           id="path10-7"
+           style="marker-end:url(#TriangleOutM-0)" />
+        <g
+           transform="translate(-28.214,-49.385)"
+           id="g12-9">
+          <path
+             d="m 317.59,530.13 6.1607,6.1607"
+             id="path11-0" />
+          <path
+             d="m 317.59,532.13 6.1607,6.1607"
+             id="path12-3" />
+        </g>
+      </g>
+    </g>
+    <g
+       transform="matrix(1.6611,0,0,1.6611,-276.13,-183.46)"
+       id="g16">
+      <rect
+         x="392.95001"
+         y="443.75"
+         width="103.54"
+         height="57.326"
+         fill="none"
+         stroke="#2e3436"
+         stroke-linecap="square"
+         stroke-linejoin="round"
+         stroke-width="2"
+         id="rect14" />
+      <text
+         x="444.73187"
+         y="463.48257"
+         fill="#000000"
+         font-family="'Liberation Sans'"
+         font-size="10px"
+         letter-spacing="0px"
+         text-anchor="middle"
+         word-spacing="0px"
+         style="line-height:0%"
+         xml:space="preserve"
+         id="text16"><tspan
+           x="444.73187"
+           y="463.48257"
+           text-align="center"
+           style="line-height:1.25"
+           id="tspan14">Multifunction</tspan><tspan
+           x="444.73187"
+           y="472.0856"
+           text-align="center"
+           style="line-height:1.25"
+           id="tspan15">Counter and Compare</tspan><tspan
+           x="444.73187"
+           y="480.6886"
+           text-align="center"
+           style="line-height:1.25"
+           id="tspan16">Unit</tspan></text>
+    </g>
+    <g
+       transform="matrix(1.6611,0,0,1.6611,-344.81,-188.26)"
+       id="g17">
+      <rect
+         x="434.98999"
+         y="388.69"
+         width="49.497002"
+         height="27.274"
+         fill="none"
+         stroke="#2e3436"
+         stroke-dasharray="2, 4"
+         stroke-linecap="square"
+         stroke-linejoin="round"
+         stroke-width="2"
+         id="rect16" />
+      <text
+         x="438.2764"
+         y="405.90323"
+         fill="#000000"
+         font-family="'Liberation Sans'"
+         letter-spacing="0px"
+         word-spacing="0px"
+         style="line-height:0%"
+         xml:space="preserve"
+         id="text17"><tspan
+           x="438.2764"
+           y="405.90323"
+           font-size="10px"
+           style="line-height:1.25"
+           id="tspan17">Prescaler</tspan></text>
+    </g>
+    <path
+       d="m 418.85,509.59 v 33.558"
+       fill="none"
+       marker-end="url(#TriangleOutM)"
+       stroke="#000000"
+       stroke-width="1.6611px"
+       id="path17" />
+    <path
+       d="m 418.85,415.72 v 30.108"
+       fill="none"
+       marker-end="url(#TriangleOutM)"
+       stroke="#000000"
+       stroke-width="1.6611px"
+       id="path18" />
+    <text
+       x="408.78012"
+       y="408.55118"
+       fill="#000000"
+       font-family="'Liberation Sans'"
+       letter-spacing="0px"
+       word-spacing="0px"
+       style="line-height:0%"
+       xml:space="preserve"
+       id="text18"><tspan
+         x="408.78012"
+         y="408.55118"
+         font-size="16.611px"
+         style="line-height:1.25"
+         id="tspan18">clk</tspan></text>
+    <path
+       d="m 421.4,653.25 v 64.193"
+       fill="none"
+       marker-end="url(#TriangleOutM)"
+       stroke="#000000"
+       stroke-width="1.6611px"
+       id="path19" />
+    <text
+       x="427.23248"
+       y="661.8313"
+       fill="#000000"
+       font-family="'Liberation Sans'"
+       letter-spacing="0px"
+       word-spacing="0px"
+       style="line-height:0%"
+       xml:space="preserve"
+       id="text19"><tspan
+         x="427.23248"
+         y="661.8313"
+         font-size="9.9663px"
+         style="line-height:1.25"
+         id="tspan19">trigger</tspan></text>
+    <path
+       d="m 573.42,760.92 v 33.751"
+       fill="none"
+       marker-end="url(#TriangleOutM)"
+       stroke="#000000"
+       stroke-width="1.6611px"
+       id="path20" />
+    <text
+       x="558.86859"
+       y="814.40948"
+       fill="#000000"
+       font-family="'Liberation Sans'"
+       letter-spacing="0px"
+       word-spacing="0px"
+       style="line-height:0%"
+       xml:space="preserve"
+       id="text20"><tspan
+         x="558.86859"
+         y="814.40948"
+         font-size="16.611px"
+         style="line-height:1.25"
+         id="tspan20">sclk</tspan></text>
+    <rect
+       x="506.70001"
+       y="470.89001"
+       width="172.03999"
+       height="39.153"
+       fill="none"
+       stroke="#2e3436"
+       stroke-linecap="square"
+       stroke-linejoin="round"
+       stroke-width="3.3221"
+       id="rect20" />
+    <text
+       x="521.4248"
+       y="496.40375"
+       fill="#000000"
+       font-family="'Liberation Sans'"
+       letter-spacing="0px"
+       word-spacing="0px"
+       style="line-height:0%"
+       xml:space="preserve"
+       id="text21"><tspan
+         x="521.4248"
+         y="496.40375"
+         font-size="16.611px"
+         style="line-height:1.25"
+         id="tspan21">Instruction Decoder</tspan></text>
+    <g
+       transform="matrix(1.6611,0,0,1.6611,-188.63,-262.12)"
+       id="g23">
+      <g
+         transform="translate(118.62,-108.22)"
+         fill="none"
+         stroke="#000000"
+         stroke-width="1px"
+         id="g22">
+        <path
+           d="m 323.62,530.13 6.1607,6.1607"
+           id="path21" />
+        <path
+           d="m 323.62,532.13 6.1607,6.1607"
+           id="path22" />
+      </g>
+      <path
+         d="m 445.32,408.08 v 28.636"
+         fill="none"
+         marker-end="url(#TriangleOutM)"
+         stroke="#000000"
+         stroke-width="1px"
+         id="path23" />
+      <text
+         x="433.90973"
+         y="403.62927"
+         fill="#000000"
+         font-family="'Liberation Sans'"
+         letter-spacing="0px"
+         word-spacing="0px"
+         style="line-height:0%"
+         xml:space="preserve"
+         id="text23"><tspan
+           x="433.90973"
+           y="403.62927"
+           font-size="10px"
+           style="line-height:1.25"
+           id="tspan23">CMD</tspan></text>
+    </g>
+    <g
+       transform="matrix(1.6611,0,0,1.6611,-164.25,-230.61)"
+       id="g24">
+      <rect
+         x="490.70999"
+         y="576.65002"
+         width="57.856998"
+         height="18"
+         fill="none"
+         stroke="#2e3436"
+         stroke-linecap="square"
+         stroke-linejoin="round"
+         stroke-width="2"
+         id="rect23" />
+      <text
+         x="495.54861"
+         y="588.23334"
+         fill="#000000"
+         font-family="'Liberation Sans'"
+         letter-spacing="0px"
+         word-spacing="0px"
+         style="line-height:0%"
+         xml:space="preserve"
+         id="text24"><tspan
+           x="495.54861"
+           y="588.23334"
+           font-size="10px"
+           style="line-height:1.25"
+           id="tspan24">chip-select</tspan></text>
+    </g>
+    <path
+       d="M 698.91,794.67 V 760.919"
+       fill="none"
+       marker-start="url(#TriangleInM)"
+       stroke="#000000"
+       stroke-width="1.6611px"
+       id="path24" />
+    <text
+       x="690.55219"
+       y="812.86035"
+       fill="#000000"
+       font-family="'Liberation Sans'"
+       letter-spacing="0px"
+       word-spacing="0px"
+       style="line-height:0%"
+       xml:space="preserve"
+       id="text25"><tspan
+         x="690.55219"
+         y="812.86035"
+         font-size="16.611px"
+         style="line-height:1.25"
+         id="tspan25">cs</tspan></text>
+    <path
+       d="M 553.43,618.61 H 664.01 V 719.93"
+       fill="none"
+       marker-end="url(#TriangleOutM)"
+       stroke="#000000"
+       stroke-width="1.6611px"
+       id="path25" />
+    <text
+       x="649.83191"
+       y="722.30597"
+       fill="#000000"
+       font-family="'Liberation Sans'"
+       letter-spacing="0px"
+       word-spacing="0px"
+       style="line-height:0%"
+       xml:space="preserve"
+       id="text26"><tspan
+         x="649.83191"
+         y="722.30597"
+         font-size="6.6442px"
+         style="line-height:1.25"
+         id="tspan26">CE</tspan></text>
+    <path
+       d="m 618.13,518.97 v 81.811 h 70.338 l 0.22581,119.15"
+       fill="none"
+       marker-end="url(#TriangleOutM)"
+       stroke="#000000"
+       stroke-width="1.6611px"
+       id="path26" />
+    <text
+       x="678.35834"
+       y="722.16583"
+       fill="#000000"
+       font-family="'Liberation Sans'"
+       letter-spacing="0px"
+       word-spacing="0px"
+       style="line-height:0%"
+       xml:space="preserve"
+       id="text27"><tspan
+         x="678.35834"
+         y="722.16583"
+         font-size="6.6442px"
+         style="line-height:1.25"
+         id="tspan27">D</tspan></text>
+    <text
+       x="690.59619"
+       y="766.43829"
+       fill="#000000"
+       font-family="'Liberation Sans'"
+       letter-spacing="0px"
+       word-spacing="0px"
+       style="line-height:0%"
+       xml:space="preserve"
+       id="text28"><tspan
+         x="690.59619"
+         y="766.43829"
+         font-size="6.6442px"
+         style="line-height:1.25"
+         id="tspan28">Q</tspan></text>
+    <g
+       transform="matrix(1.6611,0,0,1.6611,-164.25,-262.12)"
+       id="g31">
+      <path
+         d="M 462.46,438.77 V 408.076"
+         fill="none"
+         marker-end="url(#TriangleOutM)"
+         stroke="#000000"
+         stroke-width="1px"
+         id="path28" />
+      <text
+         x="448.52087"
+         y="403.62927"
+         fill="#000000"
+         font-family="'Liberation Sans'"
+         letter-spacing="0px"
+         word-spacing="0px"
+         style="line-height:0%"
+         xml:space="preserve"
+         id="text29"><tspan
+           x="448.52087"
+           y="403.62927"
+           font-size="10px"
+           style="line-height:1.25"
+           id="tspan29">SYNC</tspan></text>
+      <g
+         transform="translate(135.76,-108.22)"
+         fill="none"
+         stroke="#000000"
+         stroke-width="1px"
+         id="g30">
+        <path
+           d="m 323.62,530.13 6.1607,6.1607"
+           id="path29" />
+        <path
+           d="m 323.62,532.13 6.1607,6.1607"
+           id="path30" />
+      </g>
+    </g>
+    <g
+       transform="matrix(1.6611,0,0,1.6611,-177.12,-262.12)"
+       fill="none"
+       stroke="#000000"
+       stroke-width="1px"
+       id="g34">
+      <path
+         d="m 416.43,469.61 v 16.25"
+         marker-end="url(#TriangleOutM)"
+         id="path31" />
+      <g
+         transform="translate(89.732,-55.444)"
+         id="g33">
+        <path
+           d="m 323.62,530.13 6.1607,6.1607"
+           id="path32" />
+        <path
+           d="m 323.62,532.13 6.1607,6.1607"
+           id="path33" />
+      </g>
+    </g>
+    <path
+       d="m 502.31,492.25 h -20.218 v -8.3053 h -15.029"
+       fill="none"
+       marker-end="url(#TriangleOutM)"
+       stroke="#000000"
+       stroke-dasharray="1.66106, 3.32211"
+       stroke-width="1.6611"
+       id="path34" />
+    <g
+       transform="matrix(1.6611,0,0,1.6611,282.82,-52.635)"
+       id="g35">
+      <text
+         x="151.66971"
+         y="482.07889"
+         fill="#000000"
+         font-family="'Liberation Sans'"
+         letter-spacing="0px"
+         word-spacing="0px"
+         style="line-height:0%"
+         xml:space="preserve"
+         id="text34"><tspan
+           x="151.66971"
+           y="482.07889"
+           font-size="10px"
+           style="line-height:1.25"
+           id="tspan34">Clock Gen</tspan></text>
+      <rect
+         x="145.34"
+         y="469.5"
+         width="59.213001"
+         height="18"
+         fill="none"
+         stroke="#2e3436"
+         stroke-linecap="square"
+         stroke-linejoin="round"
+         stroke-width="2"
+         id="rect34" />
+    </g>
+    <path
+       d="m 421.07,670.2 h 119.92 v 47.421"
+       fill="none"
+       marker-end="url(#TriangleOutM)"
+       stroke="#000000"
+       stroke-width="1.6611px"
+       id="path35" />
+    <text
+       x="407.35889"
+       y="718.92664"
+       fill="#000000"
+       font-family="'Liberation Sans'"
+       letter-spacing="0px"
+       word-spacing="0px"
+       style="line-height:0%"
+       xml:space="preserve"
+       id="text35"><tspan
+         x="407.35889"
+         y="718.92664"
+         font-size="6.6442px"
+         style="line-height:1.25"
+         id="tspan35">CE</tspan></text>
+    <text
+       x="740.84778"
+       y="812.84009"
+       fill="#000000"
+       font-family="'Liberation Sans'"
+       letter-spacing="0px"
+       word-spacing="0px"
+       style="line-height:0%"
+       xml:space="preserve"
+       id="text36"><tspan
+         x="740.84778"
+         y="812.84009"
+         font-size="16.611px"
+         style="line-height:1.25"
+         id="tspan36">three_wire</tspan></text>
+    <g
+       transform="matrix(1.6611,0,0,1.6611,-339.88,-355.36)"
+       id="g37">
+      <text
+         x="598.7677"
+         y="555.29401"
+         fill="#000000"
+         font-family="'Liberation Sans'"
+         letter-spacing="0px"
+         word-spacing="0px"
+         style="line-height:0%"
+         xml:space="preserve"
+         id="text37"><tspan
+           x="598.7677"
+           y="555.29401"
+           font-size="10px"
+           style="line-height:1.25"
+           id="tspan37">Config</tspan></text>
+      <rect
+         x="592.13"
+         y="544.06"
+         width="43.306999"
+         height="17.302"
+         fill="none"
+         stroke="#2e3436"
+         stroke-linecap="square"
+         stroke-linejoin="round"
+         stroke-width="2"
+         id="rect37" />
+    </g>
+    <g
+       fill="none"
+       stroke="#000000"
+       id="g41"
+       transform="matrix(1.0237672,0,0,0.99980694,-19.637021,0.11863534)">
+      <path
+         d="m 718.99,563.32 h 59.612 v 231.35"
+         marker-end="url(#TriangleOutM)"
+         stroke-width="1.6611px"
+         id="path37" />
+      <g
+         id="g40">
+        <rect
+           x="250.95"
+           y="432.10999"
+           width="574.29999"
+           height="346.16"
+           stroke-linecap="square"
+           stroke-linejoin="round"
+           stroke-width="4.9832"
+           id="rect38" />
+        <rect
+           x="190.86"
+           y="404.01001"
+           width="1.2773"
+           height="0"
+           stroke-linecap="square"
+           stroke-linejoin="round"
+           stroke-width="3.3221"
+           id="rect39" />
+        <path
+           d="M 528.07,548.15 V 520.828"
+           marker-end="url(#TriangleOutM)"
+           stroke-dasharray="1.66106, 3.32211"
+           stroke-width="1.6611"
+           id="path39" />
+        <path
+           d="m 664.75,517.35 v 21.715"
+           marker-end="url(#TriangleOutM)"
+           stroke-dasharray="1.66106, 3.32211"
+           stroke-width="1.6611"
+           id="path40" />
+      </g>
+      <path
+         d="M 639.39,563.32 H 580.907 V 719.35"
+         marker-end="url(#TriangleOutM)"
+         stroke-width="1.6611px"
+         id="path41" />
+    </g>
+    <text
+       x="584.97272"
+       y="699.13763"
+       fill="#000000"
+       font-family="'Liberation Sans'"
+       font-size="9.9663px"
+       letter-spacing="0px"
+       word-spacing="0px"
+       style="line-height:0%"
+       xml:space="preserve"
+       id="text42"><tspan
+         x="584.97272"
+         y="699.13763"
+         style="line-height:1.25"
+         id="tspan41">cpha</tspan><tspan
+         x="584.97272"
+         y="721.73303"
+         style="line-height:1.25"
+         id="tspan42">cpol</tspan></text>
+    <text
+       x="531.49805"
+       y="537.35901"
+       fill="#000000"
+       font-family="'Liberation Sans'"
+       letter-spacing="0px"
+       word-spacing="0px"
+       style="line-height:0%"
+       xml:space="preserve"
+       id="text43"><tspan
+         x="531.49805"
+         y="537.35901"
+         font-size="9.9663px"
+         style="line-height:1.25"
+         id="tspan43">sleep_compare</tspan></text>
+    <path
+       d="M 664.37,465.87 V 416.782"
+       fill="none"
+       marker-end="url(#TriangleOutM)"
+       stroke="#000000"
+       stroke-width="1.6611px"
+       id="path43" />
+    <text
+       x="643.03412"
+       y="408.55118"
+       fill="#000000"
+       font-family="'Liberation Sans'"
+       letter-spacing="0px"
+       word-spacing="0px"
+       style="line-height:0%"
+       xml:space="preserve"
+       id="text44"><tspan
+         x="643.03412"
+         y="408.55118"
+         font-size="16.611px"
+         style="line-height:1.25"
+         id="tspan44">active</tspan></text>
   </g>
-  <g transform="matrix(1.6611 0 0 1.6611 -276.13 -183.46)">
-   <rect x="392.95" y="443.75" width="103.54" height="57.326" fill="none" stroke="#2e3436" stroke-linecap="square" stroke-linejoin="round" stroke-width="2"/>
-   <text x="444.73187" y="463.48257" fill="#000000" font-family="'Liberation Sans'" font-size="10px" letter-spacing="0px" text-anchor="middle" word-spacing="0px" style="line-height:0%" xml:space="preserve"><tspan x="444.73187" y="463.48257" text-align="center" style="line-height:1.25">Multifunction</tspan><tspan x="444.73187" y="472.0856" text-align="center" style="line-height:1.25">Counter and Compare</tspan><tspan x="444.73187" y="480.6886" text-align="center" style="line-height:1.25">Unit</tspan></text>
-  </g>
-  <g transform="matrix(1.6611 0 0 1.6611 -344.81 -188.26)">
-   <rect x="434.99" y="388.69" width="49.497" height="27.274" fill="none" stroke="#2e3436" stroke-dasharray="2, 4" stroke-linecap="square" stroke-linejoin="round" stroke-width="2"/>
-   <text x="438.2764" y="405.90323" fill="#000000" font-family="'Liberation Sans'" letter-spacing="0px" word-spacing="0px" style="line-height:0%" xml:space="preserve"><tspan x="438.2764" y="405.90323" font-size="10px" style="line-height:1.25">Prescaler</tspan></text>
-  </g>
-  <path d="m418.85 509.59v33.558" fill="none" marker-end="url(#TriangleOutM)" stroke="#000" stroke-width="1.6611px"/>
-  <path d="m418.85 415.72v30.108" fill="none" marker-end="url(#TriangleOutM)" stroke="#000" stroke-width="1.6611px"/>
-  <text x="408.78012" y="408.55118" fill="#000000" font-family="'Liberation Sans'" letter-spacing="0px" word-spacing="0px" style="line-height:0%" xml:space="preserve"><tspan x="408.78012" y="408.55118" font-size="16.611px" style="line-height:1.25">clk</tspan></text>
-  <path d="m421.4 653.25v64.193" fill="none" marker-end="url(#TriangleOutM)" stroke="#000" stroke-width="1.6611px"/>
-  <text x="427.23248" y="661.8313" fill="#000000" font-family="'Liberation Sans'" letter-spacing="0px" word-spacing="0px" style="line-height:0%" xml:space="preserve"><tspan x="427.23248" y="661.8313" font-size="9.9663px" style="line-height:1.25">trigger</tspan></text>
-  <path d="m573.42 760.92v33.751" fill="none" marker-end="url(#TriangleOutM)" stroke="#000" stroke-width="1.6611px"/>
-  <text x="558.86859" y="814.40948" fill="#000000" font-family="'Liberation Sans'" letter-spacing="0px" word-spacing="0px" style="line-height:0%" xml:space="preserve"><tspan x="558.86859" y="814.40948" font-size="16.611px" style="line-height:1.25">sclk</tspan></text>
-  <rect x="506.7" y="470.89" width="172.04" height="39.153" fill="none" stroke="#2e3436" stroke-linecap="square" stroke-linejoin="round" stroke-width="3.3221"/>
-  <text x="521.4248" y="496.40375" fill="#000000" font-family="'Liberation Sans'" letter-spacing="0px" word-spacing="0px" style="line-height:0%" xml:space="preserve"><tspan x="521.4248" y="496.40375" font-size="16.611px" style="line-height:1.25">Instruction Decoder</tspan></text>
-  <g transform="matrix(1.6611 0 0 1.6611 -188.63 -262.12)">
-   <g transform="translate(118.62 -108.22)" fill="none" stroke="#000" stroke-width="1px">
-    <path d="m323.62 530.13 6.1607 6.1607"/>
-    <path d="m323.62 532.13 6.1607 6.1607"/>
-   </g>
-   <path d="m445.32 408.08v28.636" fill="none" marker-end="url(#TriangleOutM)" stroke="#000" stroke-width="1px"/>
-   <text x="433.90973" y="403.62927" fill="#000000" font-family="'Liberation Sans'" letter-spacing="0px" word-spacing="0px" style="line-height:0%" xml:space="preserve"><tspan x="433.90973" y="403.62927" font-size="10px" style="line-height:1.25">CMD</tspan></text>
-  </g>
-  <g transform="matrix(1.6611 0 0 1.6611 -164.25 -230.61)">
-   <rect x="490.71" y="576.65" width="57.857" height="18" fill="none" stroke="#2e3436" stroke-linecap="square" stroke-linejoin="round" stroke-width="2"/>
-   <text x="495.54861" y="588.23334" fill="#000000" font-family="'Liberation Sans'" letter-spacing="0px" word-spacing="0px" style="line-height:0%" xml:space="preserve"><tspan x="495.54861" y="588.23334" font-size="10px" style="line-height:1.25">chip-select</tspan></text>
-  </g>
-  <path d="m698.91 794.67v-33.751" fill="none" marker-start="url(#TriangleInM)" stroke="#000" stroke-width="1.6611px"/>
-  <text x="690.55219" y="812.86035" fill="#000000" font-family="'Liberation Sans'" letter-spacing="0px" word-spacing="0px" style="line-height:0%" xml:space="preserve"><tspan x="690.55219" y="812.86035" font-size="16.611px" style="line-height:1.25">cs</tspan></text>
-  <path d="m553.43 618.61h110.58v101.32" fill="none" marker-end="url(#TriangleOutM)" stroke="#000" stroke-width="1.6611px"/>
-  <text x="649.83191" y="722.30597" fill="#000000" font-family="'Liberation Sans'" letter-spacing="0px" word-spacing="0px" style="line-height:0%" xml:space="preserve"><tspan x="649.83191" y="722.30597" font-size="6.6442px" style="line-height:1.25">CE</tspan></text>
-  <path d="m618.13 518.97v81.811h70.338l0.22581 119.15" fill="none" marker-end="url(#TriangleOutM)" stroke="#000" stroke-width="1.6611px"/>
-  <text x="678.35834" y="722.16583" fill="#000000" font-family="'Liberation Sans'" letter-spacing="0px" word-spacing="0px" style="line-height:0%" xml:space="preserve"><tspan x="678.35834" y="722.16583" font-size="6.6442px" style="line-height:1.25">D</tspan></text>
-  <text x="690.59619" y="766.43829" fill="#000000" font-family="'Liberation Sans'" letter-spacing="0px" word-spacing="0px" style="line-height:0%" xml:space="preserve"><tspan x="690.59619" y="766.43829" font-size="6.6442px" style="line-height:1.25">Q</tspan></text>
-  <g transform="matrix(1.6611 0 0 1.6611 -164.25 -262.12)">
-   <path d="m462.46 438.77v-30.694" fill="none" marker-end="url(#TriangleOutM)" stroke="#000" stroke-width="1px"/>
-   <text x="448.52087" y="403.62927" fill="#000000" font-family="'Liberation Sans'" letter-spacing="0px" word-spacing="0px" style="line-height:0%" xml:space="preserve"><tspan x="448.52087" y="403.62927" font-size="10px" style="line-height:1.25">SYNC</tspan></text>
-   <g transform="translate(135.76 -108.22)" fill="none" stroke="#000" stroke-width="1px">
-    <path d="m323.62 530.13 6.1607 6.1607"/>
-    <path d="m323.62 532.13 6.1607 6.1607"/>
-   </g>
-  </g>
-  <g transform="matrix(1.6611 0 0 1.6611 -177.12 -262.12)" fill="none" stroke="#000" stroke-width="1px">
-   <path d="m416.43 469.61v16.25" marker-end="url(#TriangleOutM)"/>
-   <g transform="translate(89.732 -55.444)">
-    <path d="m323.62 530.13 6.1607 6.1607"/>
-    <path d="m323.62 532.13 6.1607 6.1607"/>
-   </g>
-  </g>
-  <path d="m502.31 492.25h-20.218v-8.3053h-15.029" fill="none" marker-end="url(#TriangleOutM)" stroke="#000" stroke-dasharray="1.66105601, 3.32211201" stroke-width="1.6611"/>
-  <g transform="matrix(1.6611 0 0 1.6611 282.82 -52.635)">
-   <text x="151.66971" y="482.07889" fill="#000000" font-family="'Liberation Sans'" letter-spacing="0px" word-spacing="0px" style="line-height:0%" xml:space="preserve"><tspan x="151.66971" y="482.07889" font-size="10px" style="line-height:1.25">Clock Gen</tspan></text>
-   <rect x="145.34" y="469.5" width="59.213" height="18" fill="none" stroke="#2e3436" stroke-linecap="square" stroke-linejoin="round" stroke-width="2"/>
-  </g>
-  <path d="m421.07 670.2h119.92v47.421" fill="none" marker-end="url(#TriangleOutM)" stroke="#000" stroke-width="1.6611px"/>
-  <text x="407.35889" y="718.92664" fill="#000000" font-family="'Liberation Sans'" letter-spacing="0px" word-spacing="0px" style="line-height:0%" xml:space="preserve"><tspan x="407.35889" y="718.92664" font-size="6.6442px" style="line-height:1.25">CE</tspan></text>
-  <text x="740.84778" y="812.84009" fill="#000000" font-family="'Liberation Sans'" letter-spacing="0px" word-spacing="0px" style="line-height:0%" xml:space="preserve"><tspan x="740.84778" y="812.84009" font-size="16.611px" style="line-height:1.25">three_wire</tspan></text>
-  <g transform="matrix(1.6611 0 0 1.6611 -339.88 -355.36)">
-   <text x="598.7677" y="555.29401" fill="#000000" font-family="'Liberation Sans'" letter-spacing="0px" word-spacing="0px" style="line-height:0%" xml:space="preserve"><tspan x="598.7677" y="555.29401" font-size="10px" style="line-height:1.25">Config</tspan></text>
-   <rect x="592.13" y="544.06" width="43.307" height="17.302" fill="none" stroke="#2e3436" stroke-linecap="square" stroke-linejoin="round" stroke-width="2"/>
-  </g>
-  <g fill="none" stroke="#000">
-   <path d="m718.99 563.32h59.612v231.35" marker-end="url(#TriangleOutM)" stroke-width="1.6611px"/>
-   <g>
-    <rect x="250.95" y="432.11" width="574.3" height="346.16" stroke-linecap="square" stroke-linejoin="round" stroke-width="4.9832"/>
-    <rect x="190.86" y="404.01" width="1.2773" height="0" stroke-linecap="square" stroke-linejoin="round" stroke-width="3.3221"/>
-    <path d="m528.07 548.15v-27.322" marker-end="url(#TriangleOutM)" stroke-dasharray="1.66105601, 3.32211201" stroke-width="1.6611"/>
-    <path d="m664.75 517.35v21.715" marker-end="url(#TriangleOutM)" stroke-dasharray="1.66105601, 3.32211201" stroke-width="1.6611"/>
-   </g>
-   <path d="m639.39 563.32h-58.483v156.03" marker-end="url(#TriangleOutM)" stroke-width="1.6611px"/>
-  </g>
-  <text x="584.97272" y="699.13763" fill="#000000" font-family="'Liberation Sans'" font-size="9.9663px" letter-spacing="0px" word-spacing="0px" style="line-height:0%" xml:space="preserve"><tspan x="584.97272" y="699.13763" style="line-height:1.25">cpha</tspan><tspan x="584.97272" y="721.73303" style="line-height:1.25">cpol</tspan></text>
-  <text x="531.49805" y="537.35901" fill="#000000" font-family="'Liberation Sans'" letter-spacing="0px" word-spacing="0px" style="line-height:0%" xml:space="preserve"><tspan x="531.49805" y="537.35901" font-size="9.9663px" style="line-height:1.25">sleep_compare</tspan></text>
-  <path d="m664.37 465.87v-49.088" fill="none" marker-end="url(#TriangleOutM)" stroke="#000" stroke-width="1.6611px"/>
-  <text x="643.03412" y="408.55118" fill="#000000" font-family="'Liberation Sans'" letter-spacing="0px" word-spacing="0px" style="line-height:0%" xml:space="preserve"><tspan x="643.03412" y="408.55118" font-size="16.611px" style="line-height:1.25">active</tspan></text>
- </g>
 </svg>

--- a/docs/library/spi_engine/spi_engine_execution.rst
+++ b/docs/library/spi_engine/spi_engine_execution.rst
@@ -40,8 +40,8 @@ Configuration Parameters
    * - DATA_WIDTH
      - Data width of the parallel data stream. Will define the transaction's
        granularity. Supported values: 8/16/24/32
-   * - NUM_OF_SDI
-     - Number of multiple SDI lines, (min: 1, max: 8)
+   * - NUM_OF_SDIO
+     - Number of multiple SDI/SDO lines, (min: 1, max: 8)
 
 Signal and Interface Pins
 --------------------------------------------------------------------------------
@@ -56,6 +56,8 @@ Signal and Interface Pins
      - :ref:`spi_engine control-interface` subordinate.
        SPI Engine Control stream that contains commands and data for the
        execution module.
+   * - s_offload_active_ctrl
+     - | Defines whether offload mode is active or not (active high).
    * - spi
      - :ref:`spi_engine spi-bus-interface` controller.
        Low-level SPI bus interface that is controlled by peripheral.
@@ -74,6 +76,11 @@ Internally the SPI Engine execution module consists of an instruction encoder
 that translates the incoming commands into an internal control signal, a
 multi-function counter and compares unit that is responsible for handling the
 timing and a shift register which holds the received and transmitted SPI data.
+
+The shift register has a different behavior for offload and FIFO mode. Offload
+mode needs to have all of its lanes active for allowing prefetch of data,
+otherwise it is going to wait for the write instruction. That is controlled
+through the ``s_offload_active_ctrl`` interface.
 
 The module has an optional programmable pre-scaler register that can be used to
 divide the external clock to the counter and compare unit.

--- a/docs/library/spi_engine/spi_engine_interconnect.rst
+++ b/docs/library/spi_engine/spi_engine_interconnect.rst
@@ -8,14 +8,14 @@ SPI Engine Interconnect Module
 The :git-hdl:`SPI Engine Interconnect <library/spi_engine/spi_engine_interconnect>`
 allows connecting multiple :ref:`spi_engine control-interface` managers to a single
 :ref:`spi_engine control-interface` subordinate.
-This enables multiple command stream generators to connect to a single
-:ref:`spi_engine execution` and consequential give them access to the same SPI bus.
-The interconnect modules take care of properly arbitrating between the different
-command streams.
+This enables two command stream generators to connect to a single
+:ref:`spi_engine execution` and consequentially give them access to the same SPI bus.
+The interconnect module is responsible for proper arbitration between the command
+streams.
 
-Combining multiple command stream generators in a design and connecting them to
-a single execution module allows for the creation of flexible and efficient
-designs using standard components.
+Combining two command stream generators in a design and connecting them to a single
+execution module allows the creation of an efficient and flexible design by using
+standard components.
 
 Files
 --------------------------------------------------------------------------------
@@ -40,8 +40,8 @@ Configuration Parameters
 
    * - DATA_WIDTH
      - Data width of the parallel SDI/SDO data interfaces.
-   * - NUM_OF_SDI
-     - Number of SDI lines on the physical SPI interface.
+   * - NUM_OF_SDIO
+     - Number of SDI/SDO lines on the physical SPI interface.
 
 
 Signal and Interface Pins
@@ -50,33 +50,33 @@ Signal and Interface Pins
 .. hdl-interfaces::
 
    * - clk
-     - A signals of the module are synchronous to this clock.
+     - |
    * - resetn
-     - Synchronous active-low reset.
-       Resets the internal state of the module.
+     - | Synchronous active-low reset.
+       | Resets the internal state of the module.
    * - s0_ctrl
      - | :ref:`spi_engine control-interface` subordinate.
-       | Connects to the first control interface manager.
+       | Connects to the offload control interface manager.
    * - s1_ctrl
      - | :ref:`spi_engine control-interface` subordinate.
-       | Connects to the second control interface manager.
+       | Connects to the fifo control interface manager.
    * - m_ctrl
      - | :ref:`spi_engine control-interface` manager.
        | Connects to the control interface subordinate.
+   * - s_interconnect_ctrl
+     - | m_interconnect_ctrl (:ref:`spi_engine offload`) subordinate.
+       | Defines whether offload mode is active or not (active high).
+   * - m_offload_active_ctrl
+     - | Forwards the signals of the s_interconnect_ctrl interface.
+       | Defines whether offload mode is active or not (active high).
 
 Theory of Operation
 --------------------------------------------------------------------------------
 
-The SPI Engine Interconnect module has multiple
-:ref:`spi_engine control-interface` subordinate ports and a single
-:ref:`spi_engine control-interface` manager port.
-It can be used to connect multiple command stream generators to a single command
-execution engine. Arbitration between the streams is done on a priority
-basis, streams with a lower index have higher priority. This means if commands
-are present on two streams arbitration will be granted to the one with the lower
-index. Once arbitration has been granted the port it was granted to stays in
-control until it sends a SYNC command. When the interconnect module sees a SYNC
-command arbitration will be re-evaluated after the SYNC command has been
-completed. This makes sure that once a SPI transaction consisting of multiple
-commands has been started it is able to complete without being interrupted by a
-higher priority stream.
+The SPI Engine Interconnect module has two :ref:`spi_engine control-interface`
+subordinate ports and a single :ref:`spi_engine control-interface` manager
+port. It can be used to connect two command stream generators to a single
+command execution engine. Arbitration between streams is done based on the
+``s_interconnect_ctrl`` interface, there is a copy of this interface to
+``m_offload_active_ctrl`` to indicate whether the stream belongs to offload (s0) or
+fifo mode (s1).

--- a/docs/library/spi_engine/spi_engine_offload.rst
+++ b/docs/library/spi_engine/spi_engine_offload.rst
@@ -45,8 +45,8 @@ Configuration Parameters
    * - DATA_WIDTH
      - Data width of the parallel data stream. Will define the transaction's
        granularity. Supported values: 8/16/24/32
-   * - NUM_OF_SDI
-     - Number of multiple SDI lines, (min: 1, max: 8)
+   * - NUM_OF_SDIO
+     - Number of multiple SDI/SDO lines, (min: 1, max: 8)
    * - SDO_STREAMING
      - Enables the s_axis_sdo interface. This allows for sourcing the SDO data
        stream from a DMA or other similar sources, useful for DACs.
@@ -80,3 +80,5 @@ Signal and Interface Pins
    * - s_axis_sdo
      - Streaming AXI peripheral
        Input stream for SPI data to be sent. Only present when ``SDO_STREAMING`` parameter is set to 1.
+   * - m_interconnect_ctrl
+     - | Defines whether offload mode is active or not (active high).

--- a/docs/projects/ad738x_fmc/index.rst
+++ b/docs/projects/ad738x_fmc/index.rst
@@ -113,14 +113,14 @@ In case of the **Alert Indication Output Pin** functionality:
 
    $make ALERT_SPI_N=1
 
-The **NUM_OF_SDI** configuration parameter defines the number of SDI lines used:
+The **NUM_OF_SDIO** configuration parameter defines the number of SDI lines used:
 **{1, 2, 4}**. By default is set to 1.
 
 For the **ALERT** functionality, the following parameters will be used in make
 command: ALERT_SPI_N.
 
 For the **serial data output** functionality, the following parameters will be
-used in make command: ALERT_SPI_N, NUM_OF_SDI.
+used in make command: ALERT_SPI_N, NUM_OF_SDIO.
 
 Jumper setup
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -317,14 +317,14 @@ the HDL repository, and then build the project as follows:
 .. shell::
 
    $cd hdl/projects/ad738x_fmc/zed
-   $make ALERT_SPI_N=0 NUM_OF_SDI=4
+   $make ALERT_SPI_N=0 NUM_OF_SDIO=4
 
 The result of the Xilinx build, if parameters were used, will be in a folder
 named by the configuration used:
 
 if the following command was run
 
-``make ALERT_SPI_N=0 NUM_OF_SDI=4``
+``make ALERT_SPI_N=0 NUM_OF_SDIO=4``
 
 then the folder name will be:
 

--- a/docs/projects/ad7606x_fmc/index.rst
+++ b/docs/projects/ad7606x_fmc/index.rst
@@ -125,7 +125,7 @@ In case of the **SERIAL** interface:
    - JP5 - Position A - Serial interface
    - JP5 - Position B - Parallel interface
 
-The NUM_OF_SDI configuration parameter defines the number of SDI lines used:
+The NUM_OF_SDIO configuration parameter defines the number of SDI lines used:
 **{1, 2, 4, 8}**. By default is set to 8.
 
 The ADC_N_BITS configuration parameter specifies the ADC resolution:

--- a/docs/projects/ad7616_sdz/index.rst
+++ b/docs/projects/ad7616_sdz/index.rst
@@ -85,7 +85,7 @@ The following are the parameters of this project that can be configured:
   - 0 - parallel (default)
   - 1 - serial
 
-- NUM_OF_SDI: number of SDI lines used, **only in serial interface mode**;
+- NUM_OF_SDIO: number of SDI lines used, **only in serial interface mode**;
 
   - 1 - one SDI line
   - 2 - two SDI lines (default)
@@ -262,14 +262,14 @@ the HDL repository, and then build the project as follows:.
 .. shell::
 
    $cd hdl/projects/ad7616_sdz/zed
-   $make INTF=1 NUM_OF_SDI=2
+   $make INTF=1 NUM_OF_SDIO=2
 
 The result of the build, if parameters were used, will be in a folder named
 by the configuration used:
 
 if the following command was run
 
-``make INTF=1 NUM_OF_SDI=2``
+``make INTF=1 NUM_OF_SDIO=2``
 
 then the folder name will be:
 

--- a/docs/regmap/adi_regmap_spi_engine.txt
+++ b/docs/regmap/adi_regmap_spi_engine.txt
@@ -9,17 +9,17 @@ ENDTITLE
 REG
 0x00
 VERSION
-Version of the peripheral. Follows semantic versioning. Current version 1.04.02.
+Version of the peripheral. Follows semantic versioning. Current version 2.00.00.
 ENDREG
 
 FIELD
-[31:16] 0x0001
+[31:16] 0x0002
 VERSION_MAJOR
 RO
 ENDFIELD
 
 FIELD
-[15:8] 0x05
+[15:8] 0x00000000
 VERSION_MINOR
 RO
 ENDFIELD

--- a/docs/regmap/adi_regmap_spi_engine.txt
+++ b/docs/regmap/adi_regmap_spi_engine.txt
@@ -25,7 +25,7 @@ RO
 ENDFIELD
 
 FIELD
-[7:0] 0x04
+[7:0] 0x00000000
 VERSION_PATCH
 RO
 ENDFIELD
@@ -70,7 +70,7 @@ DATA_WIDTH
 ENDREG
 
 FIELD
-[7:4] NUM_OF_SDI
+[23:16] NUM_OF_SDI
 NUM_OF_SDI
 RO
 Number of SDI.
@@ -78,7 +78,7 @@ It is equal with the maximum supported SDI lines in bits.
 ENDFIELD
 
 FIELD
-[3:0] DATA_WIDTH
+[15:0] DATA_WIDTH
 DATA_WIDTH
 RO
 Data width of the SDI/SDO parallel interface.
@@ -364,21 +364,6 @@ RO
 SDI FIFO register. Reading from this register removes the first entry from the SDI FIFO.
 Reading this register when the SDI FIFO is empty will return undefined data.
 Writing to it has no effect.
-ENDFIELD
-
-############################################################################################
-############################################################################################
-
-REG
-0x3b
-SDI_FIFO_MSB
-ENDREG
-
-FIELD
-[31:0] 
-SDI_FIFO_MSB
-RO
-Store SDI's 32 bits MSB, if exists.
 ENDFIELD
 
 ############################################################################################

--- a/docs/user_guide/ip_cores/use_adi_ips.rst
+++ b/docs/user_guide/ip_cores/use_adi_ips.rst
@@ -191,7 +191,7 @@ the default values for ``sdo_streaming``, ``cmd_mem_addr_width``,
    spi_engine_create "spi_ad463x" 32         1             1          1       $NUM_OF_SDI 0          1
    ad_ip_parameter spi_ad463x/execution CONFIG.DEFAULT_SPI_CFG 1   ;
 
-   ad_ip_parameter spi_ad463x/axi_regmap CONFIG.CFG_INFO_0 $NUM_OF_SDI
+   ad_ip_parameter spi_ad463x/axi_regmap CONFIG.CFG_INFO_0 $NUM_OF_SDIO
    ad_ip_parameter spi_ad463x/axi_regmap CONFIG.CFG_INFO_1 $CAPTURE_ZONE
    ad_ip_parameter spi_ad463x/axi_regmap CONFIG.CFG_INFO_2 $CLK_MODE
    ad_ip_parameter spi_ad463x/axi_regmap CONFIG.CFG_INFO_3 $DDR_EN

--- a/library/spi_engine/axi_spi_engine/Makefile
+++ b/library/spi_engine/axi_spi_engine/Makefile
@@ -20,6 +20,7 @@ XILINX_DEPS += ../../spi_engine/interfaces/spi_engine_offload_ctrl.xml
 XILINX_DEPS += ../../spi_engine/interfaces/spi_engine_offload_ctrl_rtl.xml
 
 XILINX_LIB_DEPS += util_axis_fifo
+XILINX_LIB_DEPS += util_axis_fifo_asym
 XILINX_LIB_DEPS += util_cdc
 
 XILINX_INTERFACE_DEPS += spi_engine/interfaces
@@ -27,16 +28,22 @@ XILINX_INTERFACE_DEPS += spi_engine/interfaces
 INTEL_DEPS += ../../common/ad_mem.v
 INTEL_DEPS += ../../intel/common/up_rst_constr.sdc
 INTEL_DEPS += ../../util_axis_fifo/util_axis_fifo.v
+INTEL_DEPS += ../../util_axis_fifo_asym/util_axis_fifo_asym.v
 INTEL_DEPS += ../../util_axis_fifo/util_axis_fifo_address_generator.v
 INTEL_DEPS += ../../util_cdc/sync_bits.v
+INTEL_DEPS += ../../util_cdc/sync_data.v
+INTEL_DEPS += ../../util_cdc/sync_event.v
 INTEL_DEPS += ../../util_cdc/sync_gray.v
 INTEL_DEPS += axi_spi_engine_constr.sdc
 INTEL_DEPS += axi_spi_engine_hw.tcl
 
 LATTICE_DEPS += ../../common/ad_mem.v
 LATTICE_DEPS += ../../util_axis_fifo/util_axis_fifo.v
+LATTICE_DEPS += ../../util_axis_fifo_asym/util_axis_fifo_asym.v
 LATTICE_DEPS += ../../util_axis_fifo/util_axis_fifo_address_generator.v
 LATTICE_DEPS += ../../util_cdc/sync_bits.v
+LATTICE_DEPS += ../../util_cdc/sync_data.v
+LATTICE_DEPS += ../../util_cdc/sync_event.v
 LATTICE_DEPS += ../../util_cdc/sync_gray.v
 LATTICE_DEPS += axi_spi_engine_ltt.tcl
 

--- a/library/spi_engine/axi_spi_engine/axi_spi_engine.v
+++ b/library/spi_engine/axi_spi_engine/axi_spi_engine.v
@@ -48,7 +48,7 @@ module axi_spi_engine #(
   parameter OFFLOAD0_SDO_MEM_ADDRESS_WIDTH = 4,
   parameter ID = 0,
   parameter [15:0] DATA_WIDTH = 8,
-  parameter [ 7:0] NUM_OF_SDI = 1,
+  parameter [ 7:0] NUM_OF_SDIO = 1,
   parameter CFG_INFO_0 = 0,
   parameter CFG_INFO_1 = 0,
   parameter CFG_INFO_2 = 0,
@@ -106,11 +106,11 @@ module axi_spi_engine #(
 
   input sdo_data_ready,
   output sdo_data_valid,
-  output [(DATA_WIDTH-1):0] sdo_data,
+  output [(DATA_WIDTH)-1:0] sdo_data,
 
   output sdi_data_ready,
   input sdi_data_valid,
-  input [(NUM_OF_SDI * DATA_WIDTH-1):0] sdi_data,
+  input [(NUM_OF_SDIO * DATA_WIDTH)-1:0] sdi_data,
 
   output sync_ready,
   input sync_valid,
@@ -122,7 +122,7 @@ module axi_spi_engine #(
   output [15:0] offload0_cmd_wr_data,
 
   output offload0_sdo_wr_en,
-  output [(DATA_WIDTH-1):0] offload0_sdo_wr_data,
+  output [(DATA_WIDTH)-1:0] offload0_sdo_wr_data,
 
   output offload0_mem_reset,
   output offload0_enable,
@@ -133,9 +133,10 @@ module axi_spi_engine #(
   input [7:0] offload_sync_data
 );
 
-  localparam PCORE_VERSION = 'h010504;
+  localparam PCORE_VERSION = 'h020000;
   localparam S_AXI = 0;
   localparam UP_FIFO = 1;
+  localparam max_num_of_reads = NUM_OF_SDIO-1;
 
   wire clk;
   wire rstn;
@@ -152,18 +153,21 @@ module axi_spi_engine #(
   wire sdo_fifo_almost_empty;
   wire up_sdo_fifo_almost_empty;
 
-  wire [(DATA_WIDTH-1):0] sdo_fifo_in_data;
+  wire [DATA_WIDTH-1:0] sdo_fifo_in_data;
   wire sdo_fifo_in_ready;
   wire sdo_fifo_in_valid;
 
-  wire sdi_fifo_out_data_msb_s;
-  wire [SDI_FIFO_ADDRESS_WIDTH-1:0] sdi_fifo_level;
+  wire [31:0] sdi_fifo_level;
+  reg  [NUM_OF_SDIO*DATA_WIDTH/8-1:0] sdi_fifo_tkeep_int;
+  wire [NUM_OF_SDIO*DATA_WIDTH/8-1:0] sdi_fifo_tkeep;
   wire sdi_fifo_almost_full;
   wire up_sdi_fifo_almost_full;
 
-  wire [(NUM_OF_SDI * DATA_WIDTH-1):0] sdi_fifo_out_data;
+  wire [DATA_WIDTH-1:0] sdi_fifo_out_data;
   wire sdi_fifo_out_ready;
+  reg  find_next_valid_fifo_value;
   wire sdi_fifo_out_valid;
+  reg [3:0] sdi_out_counter;
 
   wire [7:0] sync_fifo_data;
   wire sync_fifo_valid;
@@ -192,15 +196,20 @@ module axi_spi_engine #(
   reg  [7:0] offload_sync_id = 'h00;
   reg        offload_sync_id_pending = 1'b0;
 
+  reg   [2:0] active_lane_count = 1;
+  reg  [SDI_FIFO_ADDRESS_WIDTH-1:0] sdi_input_level = 0;
+  reg  [SDI_FIFO_ADDRESS_WIDTH-1:0] sdi_input_level_next;
+  wire [SDI_FIFO_ADDRESS_WIDTH-1:0] sdi_level_s;
+  wire        sdi_output_read;
+  wire        sdi_output_read_sync;
+
   generate if (MM_IF_TYPE == S_AXI) begin
 
     // assign clock and reset
-
     assign clk = s_axi_aclk;
     assign rstn = s_axi_aresetn;
 
     // interface wrapper
-
     up_axi #(
       .AXI_ADDRESS_WIDTH (16)
     ) i_up_axi (
@@ -242,7 +251,6 @@ module axi_spi_engine #(
   generate if (MM_IF_TYPE == UP_FIFO) begin
 
     // assign clock and reset
-
     assign clk = up_clk;
     assign rstn = up_rstn;
 
@@ -317,23 +325,6 @@ module axi_spi_engine #(
     end
   end
 
-  always @(posedge clk) begin
-    if (rstn == 1'b0) begin
-      up_rack_ff <= 'd0;
-    end else begin
-      up_rack_ff <= up_rreq_s;
-    end
-  end
-
-  generate
-  if (NUM_OF_SDI > 1) begin
-    // Only the first two SDI data can be recovered through AXI regmap
-    assign sdi_fifo_out_data_msb_s = sdi_fifo_out_data[DATA_WIDTH+:DATA_WIDTH];
-  end else begin
-    assign sdi_fifo_out_data_msb_s = sdi_fifo_out_data;
-  end
-  endgenerate
-
   reg [7:0] offload_sdo_mem_address_width = OFFLOAD0_SDO_MEM_ADDRESS_WIDTH;
   reg [7:0] offload_cmd_mem_address_width = OFFLOAD0_CMD_MEM_ADDRESS_WIDTH;
   reg [7:0] sdi_fifo_address_width = SDI_FIFO_ADDRESS_WIDTH;
@@ -345,7 +336,7 @@ module axi_spi_engine #(
       8'h00: up_rdata_ff <= PCORE_VERSION;
       8'h01: up_rdata_ff <= ID;
       8'h02: up_rdata_ff <= up_scratch;
-      8'h03: up_rdata_ff <= {8'b0, NUM_OF_SDI, DATA_WIDTH};
+      8'h03: up_rdata_ff <= {8'b0, NUM_OF_SDIO, DATA_WIDTH};
       8'h04: up_rdata_ff <= {16'b0, offload_sdo_mem_address_width, offload_cmd_mem_address_width};
       8'h05: up_rdata_ff <= {sdi_fifo_address_width, sdo_fifo_address_width, sync_fifo_address_width, cmd_fifo_address_width};
       8'h10: up_rdata_ff <= up_sw_reset;
@@ -356,10 +347,9 @@ module axi_spi_engine #(
       8'h31: up_rdata_ff <= offload_sync_id;
       8'h34: up_rdata_ff <= cmd_fifo_room;
       8'h35: up_rdata_ff <= sdo_fifo_room;
-      8'h36: up_rdata_ff <= (sdi_fifo_out_valid == 1) ? sdi_fifo_level + 1 : sdi_fifo_level; /* beacuse of first-word-fall-through */
+      8'h36: up_rdata_ff <= sdi_level_s;
       8'h3a: up_rdata_ff <= sdi_fifo_out_data[DATA_WIDTH-1:0];
-      8'h3b: up_rdata_ff <= sdi_fifo_out_data_msb_s; /* store SDI's 32 bits MSB, if exists */
-      8'h3c: up_rdata_ff <= sdi_fifo_out_data; /* PEEK register */
+      8'h3c: up_rdata_ff <= sdi_fifo_out_data[DATA_WIDTH-1:0]; /* PEEK register */
       8'h40: up_rdata_ff <= {offload0_enable_reg};
       8'h41: up_rdata_ff <= {offload0_enabled_s};
       8'h80: up_rdata_ff <= CFG_INFO_0;
@@ -421,7 +411,9 @@ module axi_spi_engine #(
     .ASYNC_CLK(ASYNC_SPI_CLK),
     .M_AXIS_REGISTERED(0),
     .ALMOST_EMPTY_THRESHOLD(1),
-    .ALMOST_FULL_THRESHOLD(1)
+    .ALMOST_FULL_THRESHOLD(1),
+    .TLAST_EN(0),
+    .TKEEP_EN(0)
   ) i_cmd_fifo (
     .s_axis_aclk(clk),
     .s_axis_aresetn(up_sw_resetn),
@@ -430,20 +422,23 @@ module axi_spi_engine #(
     .s_axis_data(cmd_fifo_in_data),
     .s_axis_room(cmd_fifo_room),
     .s_axis_tlast(1'b0),
+    .s_axis_tkeep(),
     .s_axis_full(),
     .s_axis_almost_full(),
+
     .m_axis_aclk(spi_clk),
     .m_axis_aresetn(spi_resetn),
     .m_axis_ready(cmd_ready),
     .m_axis_valid(cmd_valid),
     .m_axis_data(cmd_data),
     .m_axis_tlast(),
+    .m_axis_tkeep(),
+    .m_axis_level(),
     .m_axis_empty(),
-    .m_axis_almost_empty(cmd_fifo_almost_empty),
-    .m_axis_level());
+    .m_axis_almost_empty(cmd_fifo_almost_empty));
 
   assign sdo_fifo_in_valid = up_wreq_s == 1'b1 && up_waddr_s == 8'h39;
-  assign sdo_fifo_in_data = up_wdata_s[(DATA_WIDTH-1):0];
+  assign sdo_fifo_in_data = up_wdata_s[DATA_WIDTH-1:0];
 
   util_axis_fifo #(
     .DATA_WIDTH(DATA_WIDTH),
@@ -460,6 +455,7 @@ module axi_spi_engine #(
     .s_axis_data(sdo_fifo_in_data),
     .s_axis_room(sdo_fifo_room),
     .s_axis_tlast(1'b0),
+    .s_axis_tkeep(),
     .s_axis_full(),
     .s_axis_almost_full(),
     .m_axis_aclk(spi_clk),
@@ -468,20 +464,57 @@ module axi_spi_engine #(
     .m_axis_valid(sdo_data_valid),
     .m_axis_data(sdo_data),
     .m_axis_tlast(),
+    .m_axis_tkeep(),
     .m_axis_level(),
     .m_axis_empty(),
     .m_axis_almost_empty(sdo_fifo_almost_empty));
 
-  assign sdi_fifo_out_ready = up_rreq_s == 1'b1 && up_raddr_s == 8'h3a;
+  integer i;
+  always @(posedge spi_clk) begin
+    if (!spi_resetn) begin
+      sdi_fifo_tkeep_int <= {{(NUM_OF_SDIO-1)*(DATA_WIDTH/8){1'b0}},{(DATA_WIDTH/8){1'b1}}};
+      active_lane_count  <= 1;
+    end else begin
+      if (cmd_valid && cmd_ready && cmd_data[15:8] == 8'h23) begin
+        for (i = 0; i < NUM_OF_SDIO; i = i + 1) begin
+          sdi_fifo_tkeep_int[i*DATA_WIDTH/8+:DATA_WIDTH/8] <= {DATA_WIDTH/8{cmd_data[i]}};
+        end
+        active_lane_count <= (cmd_data[7:0] == 8'h01) ? 1 : NUM_OF_SDIO;
+      end
+    end
+  end
+  assign sdi_fifo_tkeep = sdi_fifo_tkeep_int;
 
-  util_axis_fifo #(
-    .DATA_WIDTH(NUM_OF_SDI * DATA_WIDTH),
+  always @(*) begin
+    sdi_input_level_next = sdi_input_level;
+    if (sdi_data_ready && sdi_data_valid) begin
+      sdi_input_level_next = sdi_input_level_next + active_lane_count;
+    end
+    if (sdi_output_read_sync) begin
+      sdi_input_level_next = sdi_input_level_next - 1;
+    end
+  end
+
+  always @(posedge spi_clk) begin
+    if (!spi_resetn) begin
+      sdi_input_level <= 0;
+    end else begin
+      sdi_input_level <= sdi_input_level_next;
+    end
+  end
+
+  util_axis_fifo_asym #(
     .ASYNC_CLK(ASYNC_SPI_CLK),
+    .S_DATA_WIDTH(NUM_OF_SDIO * DATA_WIDTH),
+    .M_DATA_WIDTH(DATA_WIDTH),
     .ADDRESS_WIDTH(SDI_FIFO_ADDRESS_WIDTH),
     .M_AXIS_REGISTERED(0),
     .ALMOST_EMPTY_THRESHOLD(1),
-    .ALMOST_FULL_THRESHOLD(31)
-  ) i_sdi_fifo (
+    .ALMOST_FULL_THRESHOLD(31),
+    .TLAST_EN(0),
+    .TKEEP_EN(1),
+    .REDUCED_FIFO(0)
+  ) i_sdi_fifo(
     .s_axis_aclk(spi_clk),
     .s_axis_aresetn(spi_resetn),
     .s_axis_ready(sdi_data_ready),
@@ -489,17 +522,53 @@ module axi_spi_engine #(
     .s_axis_data(sdi_data),
     .s_axis_room(),
     .s_axis_tlast(),
+    .s_axis_tkeep(sdi_fifo_tkeep),
     .s_axis_full(),
     .s_axis_almost_full(sdi_fifo_almost_full),
     .m_axis_aclk(clk),
     .m_axis_aresetn(up_sw_resetn),
-    .m_axis_ready(sdi_fifo_out_ready),
+    .m_axis_ready(sdi_fifo_out_ready || find_next_valid_fifo_value),
     .m_axis_valid(sdi_fifo_out_valid),
     .m_axis_data(sdi_fifo_out_data),
     .m_axis_tlast(),
+    .m_axis_tkeep(),
     .m_axis_level(sdi_fifo_level),
     .m_axis_empty(),
     .m_axis_almost_empty());
+
+  assign sdi_fifo_out_ready = up_rreq_s == 1'b1 && up_raddr_s == 8'h3a;
+  assign sdi_output_read = (sdi_fifo_out_ready || find_next_valid_fifo_value) && sdi_fifo_out_valid;
+
+  always @(posedge clk) begin
+    if (rstn == 1'b0) begin
+      up_rack_ff <= 'd0;
+    end else begin
+      if (sdi_fifo_out_ready || find_next_valid_fifo_value) begin
+        up_rack_ff <= sdi_fifo_out_valid;
+      end else begin
+        up_rack_ff <= up_rreq_s;
+      end
+    end
+  end
+
+  //the current logic is considering that there is only one active lane in the set of lanes
+  always @(posedge clk) begin
+    if (!up_sw_resetn) begin
+      find_next_valid_fifo_value <= 1'b0;
+      sdi_out_counter <= 4'hf;
+    end else if (sdi_fifo_out_ready) begin
+      find_next_valid_fifo_value <= ~sdi_fifo_out_valid; //only in the next cycle it is possible to check if it is necessary a new read
+      sdi_out_counter <= sdi_fifo_out_valid ? 4'hf : 0;
+    end else begin
+      if (!sdi_fifo_out_valid && sdi_out_counter < max_num_of_reads) begin
+        find_next_valid_fifo_value <= 1'b1;
+        sdi_out_counter <= sdi_out_counter + 1'b1;
+      end else begin
+        find_next_valid_fifo_value <= 1'b0;
+        sdi_out_counter <= 4'hf;
+      end
+    end
+  end
 
   generate if (ASYNC_SPI_CLK) begin
 
@@ -508,7 +577,9 @@ module axi_spi_engine #(
       .DATA_WIDTH(8),
       .ASYNC_CLK(ASYNC_SPI_CLK),
       .ADDRESS_WIDTH(SYNC_FIFO_ADDRESS_WIDTH),
-      .M_AXIS_REGISTERED(0)
+      .M_AXIS_REGISTERED(0),
+      .TLAST_EN(0),
+      .TKEEP_EN(0)
     ) i_sync_fifo (
       .s_axis_aclk(spi_clk),
       .s_axis_aresetn(spi_resetn),
@@ -516,14 +587,21 @@ module axi_spi_engine #(
       .s_axis_valid(sync_valid),
       .s_axis_data(sync_data),
       .s_axis_room(),
+      .s_axis_tlast(),
+      .s_axis_tkeep(),
       .s_axis_full(),
+      .s_axis_almost_full(),
+
       .m_axis_aclk(clk),
       .m_axis_aresetn(up_sw_resetn),
       .m_axis_ready(1'b1),
       .m_axis_valid(sync_fifo_valid),
       .m_axis_data(sync_fifo_data),
+      .m_axis_tlast(),
+      .m_axis_tkeep(),
       .m_axis_level(),
-      .m_axis_empty());
+      .m_axis_empty(),
+      .m_axis_almost_empty());
 
     // synchronization FIFO for the offload command interface
     wire up_offload0_cmd_wr_en_s;
@@ -533,7 +611,9 @@ module axi_spi_engine #(
       .DATA_WIDTH(16),
       .ASYNC_CLK(ASYNC_SPI_CLK),
       .ADDRESS_WIDTH(SYNC_FIFO_ADDRESS_WIDTH),
-      .M_AXIS_REGISTERED(0)
+      .M_AXIS_REGISTERED(0),
+      .TLAST_EN(0),
+      .TKEEP_EN(0)
     ) i_offload_cmd_fifo (
       .s_axis_aclk(clk),
       .s_axis_aresetn(up_sw_resetn),
@@ -541,27 +621,36 @@ module axi_spi_engine #(
       .s_axis_valid(up_offload0_cmd_wr_en_s),
       .s_axis_data(up_offload0_cmd_wr_data_s),
       .s_axis_room(),
+      .s_axis_tlast(),
+      .s_axis_tkeep(),
       .s_axis_full(),
+      .s_axis_almost_full(),
+
       .m_axis_aclk(spi_clk),
       .m_axis_aresetn(spi_resetn),
       .m_axis_ready(1'b1),
       .m_axis_valid(offload0_cmd_wr_en),
       .m_axis_data(offload0_cmd_wr_data),
+      .m_axis_tlast(),
+      .m_axis_tkeep(),
       .m_axis_level(),
-      .m_axis_empty());
+      .m_axis_empty(),
+      .m_axis_almost_empty());
 
     assign up_offload0_cmd_wr_en_s = up_wreq_s == 1'b1 && up_waddr_s == 8'h44;
     assign up_offload0_cmd_wr_data_s = up_wdata_s[15:0];
 
     // synchronization FIFO for the offload SDO interface
     wire up_offload0_sdo_wr_en_s;
-    wire [DATA_WIDTH-1:0] up_offload0_sdo_wr_data_s;
+    wire [(DATA_WIDTH-1):0] up_offload0_sdo_wr_data_s;
 
     util_axis_fifo #(
       .DATA_WIDTH(DATA_WIDTH),
       .ASYNC_CLK(ASYNC_SPI_CLK),
       .ADDRESS_WIDTH(SYNC_FIFO_ADDRESS_WIDTH),
-      .M_AXIS_REGISTERED(0)
+      .M_AXIS_REGISTERED(0),
+      .TLAST_EN(0),
+      .TKEEP_EN(0)
     ) i_offload_sdo_fifo (
       .s_axis_aclk(clk),
       .s_axis_aresetn(up_sw_resetn),
@@ -569,14 +658,21 @@ module axi_spi_engine #(
       .s_axis_valid(up_offload0_sdo_wr_en_s),
       .s_axis_data(up_offload0_sdo_wr_data_s),
       .s_axis_room(),
+      .s_axis_tlast(),
+      .s_axis_tkeep(),
       .s_axis_full(),
+      .s_axis_almost_full(),
+
       .m_axis_aclk(spi_clk),
       .m_axis_aresetn(spi_resetn),
       .m_axis_ready(1'b1),
       .m_axis_valid(offload0_sdo_wr_en),
       .m_axis_data(offload0_sdo_wr_data),
+      .m_axis_tlast(),
+      .m_axis_tkeep(),
       .m_axis_level(),
-      .m_axis_empty());
+      .m_axis_empty(),
+      .m_axis_almost_empty());
 
     assign up_offload0_sdo_wr_en_s = up_wreq_s == 1'b1 && up_waddr_s == 8'h45;
     assign up_offload0_sdo_wr_data_s = up_wdata_s[DATA_WIDTH-1:0];
@@ -586,7 +682,9 @@ module axi_spi_engine #(
       .DATA_WIDTH(8),
       .ASYNC_CLK(ASYNC_SPI_CLK),
       .ADDRESS_WIDTH(SYNC_FIFO_ADDRESS_WIDTH),
-      .M_AXIS_REGISTERED(0)
+      .M_AXIS_REGISTERED(0),
+      .TLAST_EN(0),
+      .TKEEP_EN(0)
     ) i_offload_sync_fifo (
       .s_axis_aclk(spi_clk),
       .s_axis_aresetn(spi_resetn),
@@ -594,14 +692,21 @@ module axi_spi_engine #(
       .s_axis_valid(offload_sync_valid),
       .s_axis_data(offload_sync_data),
       .s_axis_room(),
+      .s_axis_tlast(),
+      .s_axis_tkeep(),
       .s_axis_full(),
+      .s_axis_almost_full(),
+
       .m_axis_aclk(clk),
       .m_axis_aresetn(up_sw_resetn),
       .m_axis_ready(1'b1),
       .m_axis_valid(offload_sync_fifo_valid),
       .m_axis_data(offload_sync_fifo_data),
+      .m_axis_tlast(),
+      .m_axis_tkeep(),
       .m_axis_level(),
-      .m_axis_empty());
+      .m_axis_empty(),
+      .m_axis_almost_empty());
 
   end else begin /* ASYNC_SPI_CLK == 0 */
 
@@ -657,5 +762,23 @@ module axi_spi_engine #(
     .out_resetn (up_sw_resetn),
     .out_clk (clk),
     .out_bits ({up_cmd_fifo_almost_empty, up_sdi_fifo_almost_full, up_sdo_fifo_almost_empty}));
+
+  sync_event #(
+    .NUM_OF_EVENTS (1),
+    .ASYNC_CLK (ASYNC_SPI_CLK)
+  ) i_sdi_output_read_sync (
+    .in_clk    (clk),
+    .in_event  (sdi_output_read),
+    .out_clk   (spi_clk),
+    .out_event (sdi_output_read_sync));
+
+  sync_data #(
+    .NUM_OF_BITS  (SDI_FIFO_ADDRESS_WIDTH),
+    .ASYNC_CLK    (ASYNC_SPI_CLK)
+  ) i_sdi_level_sync (
+    .in_clk   (spi_clk),
+    .in_data  (sdi_input_level),
+    .out_clk  (clk),
+    .out_data (sdi_level_s));
 
 endmodule

--- a/library/spi_engine/axi_spi_engine/axi_spi_engine_constr.sdc
+++ b/library/spi_engine/axi_spi_engine/axi_spi_engine_constr.sdc
@@ -3,6 +3,8 @@
 ### SPDX short identifier: ADIBSD
 ###############################################################################
 
-set_false_path  \
-  -to [get_registers  *cdc_sync_stage1*]
+set_false_path -to [get_registers *cdc_sync_stage1*]
 
+set_false_path \
+  -from [get_registers *i_sdi_level_sync*|cdc_hold[*]] \
+  -to   [get_registers *i_sdi_level_sync*|out_data[*]]

--- a/library/spi_engine/axi_spi_engine/axi_spi_engine_constr.ttcl
+++ b/library/spi_engine/axi_spi_engine/axi_spi_engine_constr.ttcl
@@ -32,4 +32,25 @@ set_false_path -quiet \
 set_false_path -quiet \
   -to [get_cells -quiet -hierarchical -filter {NAME =~ *i_fifo_status/cdc_sync_stage1_reg* && IS_SEQUENTIAL}]
 
+set_false_path -quiet \
+  -from [get_cells -hierarchical -filter {NAME =~ *i_sdi_output_read_sync/in_toggle_d1_reg*}] \
+  -to   [get_cells -hierarchical -filter {NAME =~ *i_sdi_output_read_sync/i_sync_out/cdc_sync_stage1_reg* && IS_SEQUENTIAL}]
+
+set_false_path -quiet \
+  -from [get_cells -hierarchical -filter {NAME =~ *i_sdi_output_read_sync/out_toggle_d1_reg*}] \
+  -to   [get_cells -hierarchical -filter {NAME =~ *i_sdi_output_read_sync/i_sync_in/cdc_sync_stage1_reg* && IS_SEQUENTIAL}]
+
+set_false_path -quiet \
+  -from [get_cells -hierarchical -filter {NAME =~ *i_sdi_level_sync/cdc_hold_reg*}] \
+  -to   [get_cells -hierarchical -filter {NAME =~ *i_sdi_level_sync/out_data_reg*}]
+
+set_false_path -quiet \
+  -from [get_cells -hierarchical -filter {NAME =~ *i_sdi_level_sync/in_toggle_d1_reg*}] \
+  -to   [get_cells -hierarchical -filter {NAME =~ *i_sdi_level_sync/i_sync_out/cdc_sync_stage1_reg* && IS_SEQUENTIAL}]
+
+set_false_path -quiet \
+  -from [get_cells -hierarchical -filter {NAME =~ *i_sdi_level_sync/out_toggle_d1_reg*}] \
+  -to   [get_cells -hierarchical -filter {NAME =~ *i_sdi_level_sync/i_sync_in/cdc_sync_stage1_reg* && IS_SEQUENTIAL}]
+
+
 <: } :>

--- a/library/spi_engine/axi_spi_engine/axi_spi_engine_hw.tcl
+++ b/library/spi_engine/axi_spi_engine/axi_spi_engine_hw.tcl
@@ -12,8 +12,11 @@ ad_ip_files axi_spi_engine [list\
   $ad_hdl_dir/library/util_axis_fifo/util_axis_fifo.v \
   $ad_hdl_dir/library/util_axis_fifo/util_axis_fifo_address_generator.v \
   $ad_hdl_dir/library/util_cdc/sync_bits.v \
+  $ad_hdl_dir/library/util_cdc/sync_data.v \
+  $ad_hdl_dir/library/util_cdc/sync_event.v \
   $ad_hdl_dir/library/util_cdc/sync_gray.v \
   $ad_hdl_dir/library/common/ad_mem.v \
+  $ad_hdl_dir/library/util_axis_fifo_asym/util_axis_fifo_asym.v \
   $ad_hdl_dir/library/common/up_axi.v \
   $ad_hdl_dir/library/common/ad_rst.v \
   $ad_hdl_dir/library/intel/common/up_rst_constr.sdc \
@@ -33,7 +36,7 @@ ad_ip_parameter OFFLOAD0_CMD_MEM_ADDRESS_WIDTH INTEGER 4
 ad_ip_parameter OFFLOAD0_SDO_MEM_ADDRESS_WIDTH INTEGER 4
 ad_ip_parameter ID INTEGER 0
 ad_ip_parameter DATA_WIDTH INTEGER 8
-ad_ip_parameter NUM_OF_SDI INTEGER 1
+ad_ip_parameter NUM_OF_SDIO INTEGER 1
 
 proc p_elaboration {} {
 
@@ -41,7 +44,7 @@ proc p_elaboration {} {
 
   set mm_if_type [get_parameter_value "MM_IF_TYPE"]
 
-  set num_of_sdi [get_parameter_value NUM_OF_SDI]
+  set num_of_sdi [get_parameter_value NUM_OF_SDIO]
   set data_width [get_parameter_value DATA_WIDTH]
   set offload_en [get_parameter_value OFFLOAD_EN]
 

--- a/library/spi_engine/axi_spi_engine/axi_spi_engine_ip.tcl
+++ b/library/spi_engine/axi_spi_engine/axi_spi_engine_ip.tcl
@@ -24,6 +24,7 @@ adi_ip_ttcl axi_spi_engine "axi_spi_engine_constr.ttcl"
 adi_ip_add_core_dependencies [list \
 	analog.com:$VIVADO_IP_LIBRARY:util_axis_fifo:1.0 \
 	analog.com:$VIVADO_IP_LIBRARY:util_cdc:1.0 \
+  analog.com:$VIVADO_IP_LIBRARY:util_axis_fifo_asym:1.0 \
 ]
 
 set_property company_url {https://wiki.analog.com/resources/fpga/peripherals/spi_engine/axi} [ipx::current_core]
@@ -194,13 +195,13 @@ set_property -dict [list \
  ] \
  [ipx::get_user_parameters DATA_WIDTH -of_objects $cc]
 
-## NUM_OF_SDI
+## NUM_OF_SDIO
 set_property -dict [list \
   "value_validation_type" "range_long" \
   "value_validation_range_minimum" "1" \
   "value_validation_range_maximum" "8" \
  ] \
- [ipx::get_user_parameters NUM_OF_SDI -of_objects $cc]
+ [ipx::get_user_parameters NUM_OF_SDIO -of_objects $cc]
 
 ## Customize IP Layout
 
@@ -227,11 +228,11 @@ set_property -dict [list \
   "tooltip" "\[DATA_WIDTH\] Define the data interface width"
 ] [ipgui::get_guiparamspec -name "DATA_WIDTH" -component $cc]
 
-ipgui::add_param -name "NUM_OF_SDI" -component $cc -parent $general_group
+ipgui::add_param -name "NUM_OF_SDIO" -component $cc -parent $general_group
 set_property -dict [list \
-  "display_name" "Number of MISO lines" \
-  "tooltip" "\[NUM_OF_SDI\] Define the number of MISO lines" \
-] [ipgui::get_guiparamspec -name "NUM_OF_SDI" -component $cc]
+  "display_name" "Number of MISO/MOSI lines" \
+  "tooltip" "\[NUM_OF_SDIO\] Define the number of MISO/MOSI lines" \
+] [ipgui::get_guiparamspec -name "NUM_OF_SDIO" -component $cc]
 
 ipgui::add_param -name "MM_IF_TYPE" -component $cc -parent $general_group
 set_property -dict [list \

--- a/library/spi_engine/axi_spi_engine/axi_spi_engine_ltt.tcl
+++ b/library/spi_engine/axi_spi_engine/axi_spi_engine_ltt.tcl
@@ -115,11 +115,11 @@ set ip [ipl::set_parameter -ip $ip \
     -group1 {General Configuration} \
     -group2 Config]
 set ip [ipl::set_parameter -ip $ip \
-    -id NUM_OF_SDI \
+    -id NUM_OF_SDIO \
     -type param \
     -value_type int \
     -conn_mod axi_spi_engine \
-    -title {Number of MISO lines} \
+    -title {Number of MISO/MOSI lines} \
     -default 1 \
     -output_formatter nostr \
     -value_range {(1, 8)} \

--- a/library/spi_engine/scripts/spi_engine.tcl
+++ b/library/spi_engine/scripts/spi_engine.tcl
@@ -112,7 +112,7 @@ proc spi_engine_create {args} {
   ad_ip_instance spi_engine_execution $execution
   ad_ip_parameter $execution CONFIG.DATA_WIDTH $data_width
   ad_ip_parameter $execution CONFIG.NUM_OF_CS $num_cs
-  ad_ip_parameter $execution CONFIG.NUM_OF_SDI $num_sdi
+  ad_ip_parameter $execution CONFIG.NUM_OF_SDIO $num_sdi
   ad_ip_parameter $execution CONFIG.SDO_DEFAULT 1
   ad_ip_parameter $execution CONFIG.SDI_DELAY $sdi_delay
   ad_ip_parameter $execution CONFIG.ECHO_SCLK $echo_sclk
@@ -121,7 +121,7 @@ proc spi_engine_create {args} {
   ad_ip_parameter $axi_regmap CONFIG.MM_IF_TYPE 0
   ad_ip_parameter $axi_regmap CONFIG.DATA_WIDTH $data_width
   ad_ip_parameter $axi_regmap CONFIG.OFFLOAD_EN $offload_en
-  ad_ip_parameter $axi_regmap CONFIG.NUM_OF_SDI $num_sdi
+  ad_ip_parameter $axi_regmap CONFIG.NUM_OF_SDIO $num_sdi
   ad_ip_parameter $axi_regmap CONFIG.ASYNC_SPI_CLK $async_spi_clk
   ad_ip_parameter $axi_regmap CONFIG.OFFLOAD0_CMD_MEM_ADDRESS_WIDTH $cmd_mem_addr_width
   ad_ip_parameter $axi_regmap CONFIG.OFFLOAD0_SDO_MEM_ADDRESS_WIDTH $data_mem_addr_width
@@ -135,7 +135,7 @@ proc spi_engine_create {args} {
     ad_ip_instance spi_engine_offload $offload
     ad_ip_parameter $offload CONFIG.DATA_WIDTH $data_width
     ad_ip_parameter $offload CONFIG.ASYNC_SPI_CLK 0
-    ad_ip_parameter $offload CONFIG.NUM_OF_SDI $num_sdi
+    ad_ip_parameter $offload CONFIG.NUM_OF_SDIO $num_sdi
     ad_ip_parameter $offload CONFIG.CMD_MEM_ADDRESS_WIDTH $cmd_mem_addr_width
     ad_ip_parameter $offload CONFIG.SDO_MEM_ADDRESS_WIDTH $data_mem_addr_width
     ad_ip_parameter $offload CONFIG.SDO_STREAMING $sdo_streaming
@@ -143,7 +143,7 @@ proc spi_engine_create {args} {
 
     ad_ip_instance spi_engine_interconnect $interconnect
     ad_ip_parameter $interconnect CONFIG.DATA_WIDTH $data_width
-    ad_ip_parameter $interconnect CONFIG.NUM_OF_SDI $num_sdi
+    ad_ip_parameter $interconnect CONFIG.NUM_OF_SDIO $num_sdi
   }
 
   # Connections based on vendor
@@ -191,6 +191,7 @@ proc spi_engine_create {args} {
       ad_connect $offload/spi_engine_ctrl $interconnect/s0_ctrl
       ad_connect $axi_regmap/spi_engine_ctrl $interconnect/s1_ctrl
       ad_connect $interconnect/m_ctrl $execution/ctrl
+      ad_connect $interconnect/m_offload_active_ctrl $execution/s_offload_active_ctrl
       ad_connect $offload/offload_sdi m_axis_sample
       ad_connect $offload/trigger trigger
 
@@ -240,6 +241,7 @@ proc spi_engine_create {args} {
       ad_connect $offload.sdo_data $interconnect.s0_sdo
       ad_connect $interconnect.s0_sdi $offload.sdi_data
       ad_connect $interconnect.s0_sync $offload.sync
+      ad_connect $interconnect.m_offload_active_ctrl $execution.s_offload_active_ctrl
       ad_connect $axi_regmap.cmd $interconnect.s1_cmd
       ad_connect $axi_regmap.sdo_data $interconnect.s1_sdo
       ad_connect $interconnect.s1_sdi $axi_regmap.sdi_data

--- a/library/spi_engine/spi_engine_execution/Makefile
+++ b/library/spi_engine/spi_engine_execution/Makefile
@@ -8,6 +8,7 @@ LIBRARY_NAME := spi_engine_execution
 
 GENERIC_DEPS += spi_engine_execution.v
 GENERIC_DEPS += spi_engine_execution_shiftreg.v
+GENERIC_DEPS += spi_engine_execution_shiftreg_data_assemble.v
 
 XILINX_DEPS += spi_engine_execution_constr.ttcl
 XILINX_DEPS += spi_engine_execution_ip.tcl
@@ -16,6 +17,8 @@ XILINX_DEPS += ../../spi_engine/interfaces/spi_engine.xml
 XILINX_DEPS += ../../spi_engine/interfaces/spi_engine_ctrl.xml
 XILINX_DEPS += ../../spi_engine/interfaces/spi_engine_ctrl_rtl.xml
 XILINX_DEPS += ../../spi_engine/interfaces/spi_engine_rtl.xml
+XILINX_DEPS += ../../spi_engine/interfaces/spi_engine_interconnect_ctrl.xml
+XILINX_DEPS += ../../spi_engine/interfaces/spi_engine_interconnect_ctrl_rtl.xml
 
 XILINX_INTERFACE_DEPS += spi_engine/interfaces
 

--- a/library/spi_engine/spi_engine_execution/spi_engine_execution.v
+++ b/library/spi_engine/spi_engine_execution/spi_engine_execution.v
@@ -41,13 +41,14 @@ module spi_engine_execution #(
   parameter DEFAULT_SPI_CFG = 0,
   parameter DEFAULT_CLK_DIV = 0,
   parameter DATA_WIDTH = 8,                   // Valid data widths values are 8/16/24/32
-  parameter NUM_OF_SDI = 1,
+  parameter NUM_OF_SDIO = 1,
   parameter [0:0] SDO_DEFAULT = 1'b0,
   parameter ECHO_SCLK = 0,
   parameter [1:0] SDI_DELAY = 2'b00
 ) (
   input clk,
   input resetn,
+  input s_offload_active,
 
   output cmd_ready,
   input cmd_valid,
@@ -55,11 +56,11 @@ module spi_engine_execution #(
 
   input sdo_data_valid,
   output sdo_data_ready,
-  input [(DATA_WIDTH-1):0] sdo_data,
+  input [(DATA_WIDTH)-1:0] sdo_data,
 
   input sdi_data_ready,
   output sdi_data_valid,
-  output [(NUM_OF_SDI * DATA_WIDTH)-1:0] sdi_data,
+  output [(NUM_OF_SDIO * DATA_WIDTH)-1:0] sdi_data,
 
   input sync_ready,
   output reg sync_valid,
@@ -67,9 +68,9 @@ module spi_engine_execution #(
 
   input echo_sclk,
   output reg sclk,
-  output reg sdo,
+  output reg [NUM_OF_SDIO-1:0] sdo,
   output reg sdo_t,
-  input [NUM_OF_SDI-1:0] sdi,
+  input [NUM_OF_SDIO-1:0] sdi,
   output reg [NUM_OF_CS-1:0] cs,
   output reg three_wire
 );
@@ -83,15 +84,15 @@ module spi_engine_execution #(
   localparam MISC_SYNC = 1'b0;
   localparam MISC_SLEEP = 1'b1;
 
-  localparam REG_CLK_DIV = 2'b00;
-  localparam REG_CONFIG = 2'b01;
-  localparam REG_WORD_LENGTH = 2'b10;
+  localparam REG_CLK_DIV = 3'b000;
+  localparam REG_CONFIG = 3'b001;
+  localparam REG_WORD_LENGTH = 3'b010;
+  localparam REG_SDI_LANE_CONFIG = 3'b011;
+  localparam REG_SDO_LANE_CONFIG = 3'b100;
+  localparam ALL_ACTIVE_LANE_MASK = (2 ** NUM_OF_SDIO) - 1; //by default all lanes are enabled
 
   localparam BIT_COUNTER_WIDTH =  DATA_WIDTH > 16 ? 5 :
                                   DATA_WIDTH > 8  ? 4 : 3;
-
-  localparam BIT_COUNTER_CARRY = 2** (BIT_COUNTER_WIDTH + 1);
-  localparam BIT_COUNTER_CLEAR = {{8{1'b1}}, {BIT_COUNTER_WIDTH{1'b0}}, 1'b1};
 
   reg sclk_int = 1'b0;
   reg sdo_t_int = 1'b0;
@@ -99,7 +100,6 @@ module spi_engine_execution #(
   reg idle;
 
   reg [7:0] clk_div_counter = 'h00;
-  reg [7:0] clk_div_counter_next = 'h00;
   reg clk_div_last;
 
   reg [7:0] sleep_counter;
@@ -110,7 +110,6 @@ module spi_engine_execution #(
   reg sleep_counter_increment;
 
   reg trigger = 1'b0;
-  reg trigger_next = 1'b0;
   reg wait_for_io = 1'b0;
   reg transfer_active = 1'b0;
   reg transfer_done = 1'b0;
@@ -119,11 +118,14 @@ module spi_engine_execution #(
   reg echo_last_transfer;
   reg [7:0] word_length = DATA_WIDTH;
   reg [7:0] last_bit_count = DATA_WIDTH-1;
+  reg [7:0] latch_last_bit_count = DATA_WIDTH-2;
   reg [7:0] left_aligned = 8'b0;
-
-  assign first_bit = ((bit_counter == 'h0) ||  (bit_counter == word_length));
-
-  reg [15:0] cmd_d1;
+  // sdi_lane_mask: Stores the SDI lane configuration from REG_SDI_LANE_CONFIG
+  // write commands (cmd[15:8] == 8'h23). While not directly used in this module,
+  // the same command is intercepted by axi_spi_engine to configure sdi_fifo_tkeep_int,
+  // which controls valid lanes in the SDI asymmetric FIFO (util_axis_fifo_asym).
+  reg [7:0] sdi_lane_mask =  ALL_ACTIVE_LANE_MASK;
+  reg [7:0] sdo_lane_mask =  ALL_ACTIVE_LANE_MASK;
 
   reg cpha = DEFAULT_SPI_CFG[0];
   reg cpol = DEFAULT_SPI_CFG[1];
@@ -136,33 +138,40 @@ module spi_engine_execution #(
   reg sdi_enabled = 1'b0;
   reg pending_sdi_data_valid = 1'b0;
   wire sdo_enabled_io;
-  wire sdi_enabled_io;
 
-  wire sdo_int_s;
+  wire [NUM_OF_SDIO-1:0] sdo_int_s;
 
   wire last_bit;
   wire echo_last_bit;
-  wire first_bit;
+  reg first_bit;
   wire end_of_word;
 
-  wire [2:0] inst = cmd[14:12];
-  wire [2:0] inst_d1 = cmd_d1[14:12];
+  //command decoder
+  wire [2:0] inst                 = cmd[14:12];
+  wire       exec_cmd             = cmd_ready && cmd_valid;
+  wire       exec_transfer_cmd    = exec_cmd && inst == CMD_TRANSFER;
+  wire       exec_chipselect_cmd  = exec_cmd && inst == CMD_CHIPSELECT;
+  wire       exec_write_cmd       = exec_cmd && inst == CMD_WRITE;
+  wire       exec_misc_cmd        = exec_cmd && inst == CMD_MISC;
+  wire       exec_cs_inv_cmd      = exec_cmd && inst == CMD_CS_INV;
+  wire       exec_sync_cmd        = exec_misc_cmd && cmd[8] == MISC_SYNC;
 
-  wire exec_cmd = cmd_ready && cmd_valid;
-  wire exec_transfer_cmd = exec_cmd && inst == CMD_TRANSFER;
-  wire exec_cs_inv_cmd = exec_cmd && inst == CMD_CS_INV;
-  wire exec_write_cmd = exec_cmd && inst == CMD_WRITE;
-  wire exec_chipselect_cmd = exec_cmd && inst == CMD_CHIPSELECT;
-  wire exec_misc_cmd = exec_cmd && inst == CMD_MISC;
-  wire exec_sync_cmd = exec_misc_cmd && cmd[8] == MISC_SYNC;
+  reg [15:0] cmd_d1;
+  reg [ 7:0] cmd_d1_time;
+  reg [ 1:0] cmd_d1_delay;
+  reg [ 2:0] cmd_d1_instr;
+  reg        cmd_d1_sleep_instr;
+  reg        exec_transfer_cmd_reg = 1'b0; //avoid comparison in the shiftreg
+  reg        exec_sdo_lane_config_reg = 1'b0; //avoid comparison in the shiftreg data assemble
+  reg        exec_chipselect_cmd_reg = 1'b0; //avoid comparison cs_gen
+  reg        cmd_d1_time_is_zero;
 
   wire trigger_tx;
   wire trigger_rx;
 
-  wire [1:0] cs_sleep_counter = sleep_counter[1:0];
-  wire sleep_counter_compare;
-  wire cs_sleep_counter_compare;
-  wire cs_sleep_early_exit;
+  reg sleep_counter_compare;
+  reg cs_sleep_counter_compare;
+  reg cs_sleep_early_exit;
   reg cs_sleep_repeat;
   reg cs_activate;
 
@@ -176,13 +185,13 @@ module spi_engine_execution #(
   spi_engine_execution_shiftreg #(
     .DEFAULT_SPI_CFG(DEFAULT_SPI_CFG),
     .DATA_WIDTH(DATA_WIDTH),
-    .NUM_OF_SDI(NUM_OF_SDI),
+    .NUM_OF_SDIO(NUM_OF_SDIO),
     .SDI_DELAY(SDI_DELAY),
-    .ECHO_SCLK(ECHO_SCLK),
-    .CMD_TRANSFER(CMD_TRANSFER)
+    .ECHO_SCLK(ECHO_SCLK)
   ) shiftreg (
     .clk(clk),
     .resetn(resetn),
+    .s_offload_active(s_offload_active),
     .sdi(sdi),
     .sdo_int(sdo_int_s),
     .echo_sclk(echo_sclk),
@@ -195,9 +204,14 @@ module spi_engine_execution #(
     .sdo_enabled(sdo_enabled),
     .sdi_enabled(sdi_enabled),
     .current_cmd(cmd_d1),
+    .exec_cmd(exec_transfer_cmd_reg),
+    .exec_sdo_lane_cmd(exec_sdo_lane_config_reg),
     .sdo_idle_state(sdo_idle_state),
     .left_aligned(left_aligned),
     .word_length(word_length),
+    .last_bit_count (last_bit_count),
+    .latch_last_bit_count (latch_last_bit_count),
+    .sdo_lane_mask(sdo_lane_mask),
     .sdo_io_ready(sdo_io_ready),
     .echo_last_bit(echo_last_bit),
     .transfer_active(transfer_active),
@@ -206,10 +220,9 @@ module spi_engine_execution #(
     .first_bit(first_bit),
     .cs_activate(cs_activate));
 
-  assign cs_gen = inst_d1 == CMD_CHIPSELECT
-                  && ((cs_sleep_counter_compare == 1'b1) || cs_sleep_early_exit)
-                  && (cs_sleep_repeat == 1'b0)
-                  && (idle == 1'b0);
+  assign cs_gen = exec_chipselect_cmd_reg
+                  && (cs_sleep_counter_compare || cs_sleep_early_exit)
+                  && (~cs_sleep_repeat) && (~idle);
   assign cmd_ready = idle;
 
   always @(posedge clk) begin
@@ -219,36 +232,64 @@ module spi_engine_execution #(
     end
   end
   assign sdo_enabled_io = (exec_transfer_cmd) ? cmd[8] : sdo_enabled;
-  assign sdi_enabled_io = (exec_transfer_cmd) ? cmd[9] : sdi_enabled;
 
   always @(posedge clk) begin
-    if (cmd_ready & cmd_valid)
-     cmd_d1 <= cmd;
+    if (exec_cmd) begin
+      cmd_d1                   <= cmd;
+      cmd_d1_instr             <= cmd[14:12];
+      cmd_d1_delay             <= cmd[9:8];
+      cmd_d1_sleep_instr       <= cmd[8];
+      cmd_d1_time              <= cmd[7:0];
+      cs_sleep_early_exit      <= ~|cmd[9:8];
+      cmd_d1_time_is_zero      <= ~|cmd[7:0];
+      exec_transfer_cmd_reg    <= (inst == CMD_TRANSFER);
+      exec_chipselect_cmd_reg  <= (inst == CMD_CHIPSELECT);
+      exec_sdo_lane_config_reg <= (inst == CMD_WRITE) && (cmd[10:8] == REG_SDO_LANE_CONFIG);
+    end else begin
+      exec_sdo_lane_config_reg <= 1'b0;
+      sleep_counter_compare <= sleep_counter == cmd_d1_time && clk_div_last && sleep_counter_increment;
+    end
   end
 
   // Load the interface configurations from the 'Configuration Write'
   // instruction
   always @(posedge clk) begin
-    if (resetn == 1'b0) begin
-      cpha <= DEFAULT_SPI_CFG[0];
-      cpol <= DEFAULT_SPI_CFG[1];
-      three_wire <= DEFAULT_SPI_CFG[2];
+    if (!resetn) begin
+      cpha           <= DEFAULT_SPI_CFG[0];
+      cpol           <= DEFAULT_SPI_CFG[1];
+      three_wire     <= DEFAULT_SPI_CFG[2];
       sdo_idle_state <= SDO_DEFAULT;
-      clk_div <= DEFAULT_CLK_DIV;
-      word_length <= DATA_WIDTH;
-      left_aligned <= 8'b0;
-    end else if (exec_write_cmd == 1'b1) begin
-      if (cmd[9:8] == REG_CONFIG) begin
-        cpha <= cmd[0];
-        cpol <= cmd[1];
-        three_wire <= cmd[2];
-        sdo_idle_state <= cmd[3];
-      end else if (cmd[9:8] == REG_CLK_DIV) begin
-        clk_div <= cmd[7:0];
-      end else if (cmd[9:8] == REG_WORD_LENGTH) begin
-        // the max value of this reg must be DATA_WIDTH
-        word_length <= cmd[7:0];
-        left_aligned <= DATA_WIDTH - cmd[7:0]; // needed 1 cycle before transfer_active goes high
+      clk_div        <= DEFAULT_CLK_DIV;
+      word_length    <= DATA_WIDTH;
+      left_aligned   <= 0;
+      sdi_lane_mask  <= ALL_ACTIVE_LANE_MASK;
+      sdo_lane_mask  <= ALL_ACTIVE_LANE_MASK;
+    end else begin
+      if (exec_write_cmd) begin
+        case (cmd[10:8])
+          REG_CLK_DIV         : begin
+                                  clk_div        <= cmd[7:0];
+                                end
+          REG_CONFIG          : begin
+                                  cpha           <= cmd[0];
+                                  cpol           <= cmd[1];
+                                  three_wire     <= cmd[2];
+                                  sdo_idle_state <= cmd[3];
+                                end
+          REG_WORD_LENGTH     : begin
+                                  // the max value of this reg must be DATA_WIDTH
+                                  word_length    <= cmd[7:0];
+                                  // needed 1 cycle before transfer_active goes high
+                                  left_aligned   <= DATA_WIDTH - cmd[7:0];
+                                end
+          REG_SDI_LANE_CONFIG : begin
+                                  sdi_lane_mask  <= cmd[7:0];
+                                end
+          REG_SDO_LANE_CONFIG : begin
+                                  //max number of spi lanes is 8
+                                  sdo_lane_mask  <= cmd[7:0];
+                                end
+        endcase
       end
     end
   end
@@ -256,57 +297,52 @@ module spi_engine_execution #(
   always @(posedge clk) begin
     // we can calculate this from word_length (instead of cmd), with an extra cycle delay
     // because even in the worst case (transfer after config), we still have another cycle before using it
-    last_bit_count <= word_length - 1; // needed when transfer_active goes high
+    last_bit_count       <= word_length - 1; // needed when transfer_active goes high
+    latch_last_bit_count <= word_length - 2;
   end
 
   always @(posedge clk) begin
-    if ((clk_div_last == 1'b0 && idle == 1'b0 && wait_for_io == 1'b0 &&
-      clk_div_counter == 'h01) || clk_div == 'h00)
-      clk_div_last <= 1'b1;
-    else
-      clk_div_last <= 1'b0;
-  end
-
-  always @(posedge clk) begin
-    if (clk_div_last == 1'b1 || idle == 1'b1 || wait_for_io == 1'b1) begin
+    if (~|clk_div_counter || idle || wait_for_io) begin
       clk_div_counter <= clk_div;
-      trigger <= 1'b1;
+      trigger         <= 1'b1;
     end else begin
       clk_div_counter <= clk_div_counter - 1'b1;
-      trigger <= 1'b0;
+      trigger         <= 1'b0;
     end
+    clk_div_last <= ((~clk_div_last && ~idle && ~wait_for_io && clk_div_counter == 8'h1) || ~|clk_div);
   end
 
-  assign trigger_tx = trigger == 1'b1 && ntx_rx == 1'b0;
-  assign trigger_rx = trigger == 1'b1 && ntx_rx == 1'b1;
-
-  assign sleep_counter_compare = sleep_counter == cmd_d1[7:0]+1;
-  assign cs_sleep_counter_compare = cs_sleep_counter == cmd_d1[9:8];
-  assign cs_sleep_early_exit = (cmd_d1[9:8] == 2'b00);
+  assign trigger_tx = trigger && ~ntx_rx;
+  assign trigger_rx = trigger && ntx_rx;
 
   always @(posedge clk) begin
-    if (resetn == 1'b0) begin
+    if (!resetn) begin
       cs_sleep_repeat <= 1'b0;
     end else begin
       if (idle) begin
         cs_sleep_repeat <= 1'b0;
-      end else if (cs_sleep_counter_compare && (inst_d1 == CMD_CHIPSELECT)) begin
+      end else if (cs_sleep_counter_compare && exec_chipselect_cmd_reg) begin
         cs_sleep_repeat <= !cs_sleep_repeat;
       end
     end
   end
 
   always @(posedge clk) begin
-    if (idle == 1'b1) begin
-      bit_counter <= 'h0;
-      transfer_counter <= 'h0;
+    if (idle) begin
+      bit_counter <= 0;
+      first_bit <= 1'b1;
+      transfer_counter <= 0;
       ntx_rx  <= 1'b0;
       sleep_counter_increment <= 1'b0;
-      sleep_counter <= 'h0;
+      sleep_counter <= 0;
+      if (cmd_valid) begin
+        cs_sleep_counter_compare <= 1'b0;
+      end
     end else begin
-      if (clk_div_last == 1'b1 && wait_for_io == 1'b0) begin
+      first_bit <= ((bit_counter + ntx_rx == 0) || (bit_counter == word_length-1));
+      if (clk_div_last && ~wait_for_io) begin
         if (last_bit && transfer_active && ntx_rx) begin
-          bit_counter <= 'h0;
+          bit_counter <= 0;
           transfer_counter <= transfer_counter + 1;
           ntx_rx <= ~ntx_rx;
         end else begin
@@ -316,11 +352,13 @@ module spi_engine_execution #(
           end else begin
             sleep_counter_increment <= ~sleep_counter_increment;
             sleep_counter <= sleep_counter + sleep_counter_increment;
+            cs_sleep_counter_compare <= (sleep_counter[1:0] + sleep_counter_increment) == cmd_d1_delay;
           end
         end
       end
-      if (cs_sleep_counter_compare && !cs_sleep_repeat && inst_d1 == CMD_CHIPSELECT) begin
+      if (cs_sleep_counter_compare && !cs_sleep_repeat && exec_chipselect_cmd_reg) begin
         sleep_counter <= 'h0;
+        cs_sleep_counter_compare <= 1'b0;
       end
     end
   end
@@ -334,13 +372,13 @@ module spi_engine_execution #(
   end
 
   always @(posedge clk) begin
-    if (resetn == 1'b0) begin
+    if (!resetn) begin
       idle <= 1'b1;
     end else begin
       if (exec_transfer_cmd || exec_chipselect_cmd || exec_misc_cmd) begin
         idle <= 1'b0;
       end else begin
-        case (inst_d1)
+        case (cmd_d1_instr)
         CMD_TRANSFER: begin
           if (transfer_done)
             idle <= 1'b1;
@@ -350,7 +388,7 @@ module spi_engine_execution #(
             idle <= 1'b1;
         end
         CMD_MISC: begin
-          case (cmd_d1[8])
+          case (cmd_d1_sleep_instr)
           MISC_SLEEP: begin
             if (sleep_counter_compare)
               idle <= 1'b1;
@@ -367,17 +405,17 @@ module spi_engine_execution #(
   end
 
   always @(posedge clk ) begin
-    if (resetn == 1'b0) begin
-      cs_inv_mask_reg <= 'h0;
+    if (!resetn) begin
+      cs_inv_mask_reg <= 0;
     end else begin
-      if (exec_cs_inv_cmd == 1'b1) begin
+      if (exec_cs_inv_cmd) begin
         cs_inv_mask_reg <= cmd[NUM_OF_CS-1:0];
       end
     end
   end
 
   always @(posedge clk) begin
-    if (resetn == 1'b0) begin
+    if (!resetn) begin
       cs <= 'hff;
     end else if (cs_gen) begin
       cs <= cmd_d1[NUM_OF_CS-1:0]^cs_inv_mask_reg[NUM_OF_CS-1:0];
@@ -385,12 +423,12 @@ module spi_engine_execution #(
   end
 
   always @(posedge clk) begin
-    if (resetn == 1'b0) begin
+    if (!resetn) begin
       sync_valid <= 1'b0;
     end else begin
-      if (exec_sync_cmd == 1'b1) begin
+      if (exec_sync_cmd) begin
         sync_valid <= 1'b1;
-      end else if (sync_ready == 1'b1) begin
+      end else if (sync_ready) begin
         sync_valid <= 1'b0;
       end
     end
@@ -408,24 +446,21 @@ module spi_engine_execution #(
                      (sdo_enabled_io == 1'b0 || last_transfer == 1'b1 || sdo_io_ready == 1'b1);
 
   always @(posedge clk) begin
-    if (idle == 1'b1) begin
+    if (idle) begin
       last_transfer <= 1'b0;
-    end else if (trigger_tx == 1'b1 && transfer_active == 1'b1) begin
-      if (transfer_counter == cmd_d1[7:0])
-        last_transfer <= 1'b1;
-      else
-        last_transfer <= 1'b0;
+    end else if (trigger_tx && transfer_active) begin
+      last_transfer <= (transfer_counter == cmd_d1[7:0]);
     end
   end
 
   always @(posedge clk) begin
-    if (resetn == 1'b0 || idle == 1'b1) begin
+    if (!resetn || idle) begin
       echo_last_transfer    <= 1'b0;
     end else begin
-      if (inst_d1 == CMD_TRANSFER && cmd_d1[7:0] == 0) begin
+      if (exec_transfer_cmd_reg && cmd_d1_time_is_zero) begin
         echo_last_transfer    <= 1'b1;
-      end else if (echo_last_bit == 1'b1) begin
-        if (echo_transfer_counter +1 == cmd_d1[7:0]) begin
+      end else if (echo_last_bit) begin
+        if (echo_transfer_counter + 1 == cmd_d1[7:0]) begin
           echo_last_transfer    <= 1'b1;
         end else begin
           echo_last_transfer    <= 1'b0;
@@ -435,31 +470,30 @@ module spi_engine_execution #(
   end
 
   always @(posedge clk ) begin
-    if (resetn == 1'b0 || idle == 1'b1) begin
+    if (!resetn || idle) begin
       echo_transfer_counter <= 0;
     end else begin
-      if (echo_last_bit == 1'b1) begin
+      if (echo_last_bit) begin
         echo_transfer_counter <= echo_transfer_counter + 1;
       end
     end
   end
 
   always @(posedge clk) begin
-    if (resetn == 1'b0) begin
+    if (!resetn) begin
       transfer_active <= 1'b0;
       wait_for_io <= 1'b0;
     end else begin
-      if (exec_transfer_cmd == 1'b1) begin
-        wait_for_io <= !io_ready1;
+      if (exec_transfer_cmd) begin
+        wait_for_io <= ~io_ready1;
         transfer_active <= io_ready1;
-      end else if (wait_for_io == 1'b1 && io_ready1 == 1'b1) begin
+      end else if (wait_for_io && io_ready1) begin
         wait_for_io <= 1'b0;
-        transfer_active <= !last_transfer;
+        transfer_active <= ~last_transfer;
       end else if (transfer_active == 1'b1 && end_of_word == 1'b1) begin
-        if (last_transfer == 1'b1 || io_ready2 == 1'b0) begin
+        if (last_transfer || ~io_ready2) begin
           transfer_active <= 1'b0;
-        end
-        if (io_ready2 == 1'b0) begin
+        if (~io_ready2)
           wait_for_io <= 1'b1;
         end
       end else if (idle == 1'b1) begin
@@ -470,19 +504,19 @@ module spi_engine_execution #(
   end
 
   always @(posedge clk ) begin
-    if (resetn == 1'b0) begin
+    if (!resetn) begin
       transfer_done <= 1'b0;
     end else begin
       if (ECHO_SCLK) begin
         transfer_done <= echo_last_bit && echo_last_transfer;
       end else begin
-        transfer_done <= (wait_for_io && io_ready1 && last_transfer) || (!wait_for_io && transfer_active && end_of_word && last_transfer );
+        transfer_done <= (wait_for_io && io_ready1 && last_transfer) || (~wait_for_io && transfer_active && end_of_word && last_transfer);
       end
     end
   end
 
   always @(posedge clk) begin
-    if (transfer_active == 1'b1 || wait_for_io == 1'b1)
+    if (transfer_active || wait_for_io)
     begin
       sdo_t_int <= ~sdo_enabled;
     end else begin
@@ -502,10 +536,10 @@ module spi_engine_execution #(
   // stream execution to the next command. end_of_word in normal mode can be
   // generated using the global bit_counter
   assign last_bit = (bit_counter == last_bit_count);
-  assign end_of_word = last_bit == 1'b1 && ntx_rx == 1'b1 && clk_div_last == 1'b1;
+  assign end_of_word = last_bit && ntx_rx && clk_div_last;
 
   always @(posedge clk) begin
-    if (transfer_active == 1'b1) begin
+    if (transfer_active) begin
       sclk_int <= cpol ^ cpha ^ ntx_rx;
     end else begin
       sclk_int <= cpol;

--- a/library/spi_engine/spi_engine_execution/spi_engine_execution_hw.tcl
+++ b/library/spi_engine/spi_engine_execution/spi_engine_execution_hw.tcl
@@ -11,7 +11,8 @@ ad_ip_create spi_engine_execution {SPI Engine Execution}
 set_module_property ELABORATION_CALLBACK p_elaboration
 ad_ip_files spi_engine_execution [list\
   spi_engine_execution.v \
-  spi_engine_execution_shiftreg.v]
+  spi_engine_execution_shiftreg.v \
+  spi_engine_execution_shiftreg_data_assemble.v]
 
 # parameters
 
@@ -19,7 +20,7 @@ ad_ip_parameter NUM_OF_CS INTEGER 1
 ad_ip_parameter DEFAULT_SPI_CFG INTEGER 0
 ad_ip_parameter DEFAULT_CLK_DIV INTEGER 0
 ad_ip_parameter DATA_WIDTH INTEGER 8
-ad_ip_parameter NUM_OF_SDI INTEGER 1
+ad_ip_parameter NUM_OF_SDIO INTEGER 1
 ad_ip_parameter SDO_DEFAULT INTEGER 0
 ad_ip_parameter ECHO_SCLK INTEGER 0
 ad_ip_parameter SDI_DELAY INTEGER 0
@@ -27,13 +28,20 @@ ad_ip_parameter SDI_DELAY INTEGER 0
 proc p_elaboration {} {
 
   set data_width [get_parameter_value DATA_WIDTH]
-  set num_of_sdi [get_parameter_value NUM_OF_SDI]
+  set num_of_sdi [get_parameter_value NUM_OF_SDIO]
   set num_of_cs [get_parameter_value NUM_OF_CS]
 
   # clock and reset interface
 
   ad_interface clock   clk     input 1
   ad_interface reset-n resetn  input 1 if_clk
+
+  # interconnect direction interface
+
+  add_interface s_interconnect_ctrl conduit end
+  add_interface_port s_interconnect_ctrl s_interconnect_dir interconnect_dir input 1
+  set_interface_property s_interconnect_ctrl associatedClock if_clk
+  set_interface_property s_interconnect_ctrl associatedReset if_resetn
 
   # command interface
 
@@ -44,6 +52,13 @@ proc p_elaboration {} {
 
   set_interface_property cmd associatedClock if_clk
   set_interface_property cmd associatedReset if_resetn
+
+  # offload active interface
+
+  add_interface s_offload_active_ctrl conduit end
+  add_interface_port s_offload_active_ctrl s_offload_active interconnect_dir input 1
+  set_interface_property s_offload_active_ctrl associatedClock if_clk
+  set_interface_property s_offload_active_ctrl associatedReset if_resetn
 
   # SDO data interface
 

--- a/library/spi_engine/spi_engine_execution/spi_engine_execution_ip.tcl
+++ b/library/spi_engine/spi_engine_execution/spi_engine_execution_ip.tcl
@@ -11,6 +11,7 @@ adi_ip_files spi_engine_execution [list \
   "spi_engine_execution_constr.ttcl" \
   "spi_engine_execution.v" \
   "spi_engine_execution_shiftreg.v" \
+  "spi_engine_execution_shiftreg_data_assemble.v" \
 ]
 
 adi_ip_properties_lite spi_engine_execution
@@ -41,6 +42,14 @@ adi_add_bus "ctrl" "slave" \
     {"sync" "sync_data"} \
   }
 adi_add_bus_clock "clk" "ctrl" "resetn"
+
+adi_add_bus "s_offload_active_ctrl" "slave" \
+	"analog.com:interface:spi_engine_interconnect_ctrl_rtl:1.0" \
+	"analog.com:interface:spi_engine_interconnect_ctrl:1.0" \
+	{ \
+		{"s_offload_active" "interconnect_dir"} \
+	}
+adi_add_bus_clock "clk" "s_offload_active_ctrl" "resetn"
 
 adi_add_bus "spi" "master" \
   "analog.com:interface:spi_engine_rtl:1.0" \
@@ -75,13 +84,13 @@ set_property -dict [list \
  ] \
  [ipx::get_user_parameters NUM_OF_CS -of_objects $cc]
 
-## NUM_OF_SDI
+## NUM_OF_SDIO
 set_property -dict [list \
   "value_validation_type" "range_long" \
   "value_validation_range_minimum" "1" \
   "value_validation_range_maximum" "8" \
  ] \
- [ipx::get_user_parameters NUM_OF_SDI -of_objects $cc]
+ [ipx::get_user_parameters NUM_OF_SDIO -of_objects $cc]
 
 ## DEFAULT_SPI_CFG
 set_property -dict [list \
@@ -157,11 +166,11 @@ set_property -dict [list \
   "tooltip" "\[NUM_OF_CS\] Define the number of chip select lines" \
 ] [ipgui::get_guiparamspec -name "NUM_OF_CS" -component $cc]
 
-ipgui::add_param -name "NUM_OF_SDI" -component $cc -parent $general_group
+ipgui::add_param -name "NUM_OF_SDIO" -component $cc -parent $general_group
 set_property -dict [list \
-  "display_name" "Number of MISO lines" \
-  "tooltip" "\[NUM_OF_SDI\] Define the number of MISO lines" \
-] [ipgui::get_guiparamspec -name "NUM_OF_SDI" -component $cc]
+  "display_name" "Number of MISO/MOSI lines" \
+  "tooltip" "\[NUM_OF_SDIO\] Define the number of MISO/MOSI lines" \
+] [ipgui::get_guiparamspec -name "NUM_OF_SDIO" -component $cc]
 
 set spi_config_group [ipgui::add_group -name "SPI Configuration" -component $cc \
     -parent $page0 -display_name "SPI Configuration" ]
@@ -182,11 +191,11 @@ set_property -dict [list \
 set mosi_miso_config_group [ipgui::add_group -name "MOSI/MISO Configuration" -component $cc \
     -parent $page0 -display_name "MOSI/MISO Configuration" ]
 
-ipgui::add_param -name "NUM_OF_SDI" -component $cc -parent $mosi_miso_config_group
+ipgui::add_param -name "NUM_OF_SDIO" -component $cc -parent $mosi_miso_config_group
 set_property -dict [list \
-  "display_name" "Number of MISO" \
-  "tooltip" "\[NUM_OF_SDI\] Define the number of MISO lines"
-] [ipgui::get_guiparamspec -name "NUM_OF_SDI" -component $cc]
+  "display_name" "Number of MISO/MOSI" \
+  "tooltip" "\[NUM_OF_SDIO\] Define the number of MISO/MOSI lines"
+] [ipgui::get_guiparamspec -name "NUM_OF_SDIO" -component $cc]
 
 ipgui::add_param -name "SDI_DELAY" -component $cc -parent $mosi_miso_config_group
 set_property -dict [list \

--- a/library/spi_engine/spi_engine_execution/spi_engine_execution_ltt.tcl
+++ b/library/spi_engine/spi_engine_execution/spi_engine_execution_ltt.tcl
@@ -85,11 +85,11 @@ set ip [ipl::set_parameter -ip $ip \
     -group1 {General Configuration} \
     -group2 Config]
 set ip [ipl::set_parameter -ip $ip \
-    -id NUM_OF_SDI \
+    -id NUM_OF_SDIO \
     -type param \
     -value_type int \
     -conn_mod spi_engine_execution \
-    -title {Number of MISO} \
+    -title {Number of MISO/MOSI} \
     -default 1 \
     -output_formatter nostr \
     -value_range {(1, 8)} \

--- a/library/spi_engine/spi_engine_execution/spi_engine_execution_shiftreg.v
+++ b/library/spi_engine/spi_engine_execution/spi_engine_execution_shiftreg.v
@@ -39,25 +39,27 @@ module spi_engine_execution_shiftreg #(
 
   parameter DEFAULT_SPI_CFG = 0,
   parameter DATA_WIDTH = 8,
-  parameter NUM_OF_SDI = 1,
+  parameter NUM_OF_SDIO = 1,
   parameter [1:0] SDI_DELAY = 2'b00,
-  parameter ECHO_SCLK = 0,
-  parameter [2:0]CMD_TRANSFER = 3'b000
+  parameter ECHO_SCLK = 0
 ) (
   input   clk,
   input   resetn,
 
+  //interconnect interface
+  input s_offload_active,
+
   // spi io
-  input   [NUM_OF_SDI-1:0]  sdi,
-  output                    sdo_int,
+  input   [NUM_OF_SDIO-1:0]  sdi,
+  output  [NUM_OF_SDIO-1:0]  sdo_int,
   input                     echo_sclk,
 
   // spi data
-  input   [(DATA_WIDTH-1):0]  sdo_data,
-  input                       sdo_data_valid,
-  output                      sdo_data_ready,
+  input   [(DATA_WIDTH)-1:0]              sdo_data,
+  input                                   sdo_data_valid,
+  output                                  sdo_data_ready,
 
-  output  [(NUM_OF_SDI * DATA_WIDTH-1):0] sdi_data,
+  output  [(NUM_OF_SDIO * DATA_WIDTH)-1:0] sdi_data,
   output reg                              sdi_data_valid,
   input                                   sdi_data_ready,
 
@@ -65,9 +67,14 @@ module spi_engine_execution_shiftreg #(
   input           sdo_enabled,
   input           sdi_enabled,
   input   [15:0]  current_cmd,
+  input           exec_cmd,
+  input           exec_sdo_lane_cmd,
   input           sdo_idle_state,
   input   [ 7:0]  left_aligned,
   input   [ 7:0]  word_length,
+  input   [ 7:0]  last_bit_count,
+  input   [ 7:0]  latch_last_bit_count,
+  input   [ 7:0]  sdo_lane_mask,
 
   // timing from main fsm
   output      sdo_io_ready,
@@ -80,54 +87,70 @@ module spi_engine_execution_shiftreg #(
 );
 
   reg [             7:0] sdi_counter    = 8'b0;
-  reg [(DATA_WIDTH-1):0] data_sdo_shift = 'h0;
   reg [   SDI_DELAY+1:0] trigger_rx_d   = {(SDI_DELAY+2){1'b0}};
-  reg [(DATA_WIDTH-1):0] aligned_sdo_data, sdo_data_reg;
-  reg data_sdo_v;
-  wire sdo_toshiftreg;
+  wire  data_sdo_v; //data_sdo_v == existence of valid data
+  wire sdo_toshiftreg; //it is using the valid data for shifting in this cycle
   wire last_sdi_bit;
   wire trigger_rx_s;
-  wire [2:0] current_instr = current_cmd[14:12];
+  wire index_ready;
+  wire sdo_data_ready_int;
+  wire data_ready_out;
 
-  // sdo data handshake
-  assign sdo_data_ready = (!data_sdo_v) || sdo_toshiftreg;
+  // sdo_data_ready_int is active when two conditions are true:
+  //   ((!data_ready_out) || (sdo_toshiftreg))
+  //      there's room for storing sdo data
+  //    AND
+  //    (s_offload_active || (exec_cmd & index_ready))
+  //      when s_offload_active, it is possible to prefetch
+  //      when !s_offload_active, wait for a write instruction and for end of processing lane mask
+  assign sdo_data_ready_int = ((!data_ready_out) || (sdo_toshiftreg)) && (s_offload_active || (exec_cmd & index_ready));
+  assign sdo_data_ready = sdo_data_ready_int;
   assign sdo_io_ready = data_sdo_v;
-  always @(posedge clk ) begin
-    if (resetn == 1'b0) begin
-      data_sdo_v <= 1'b0;
-    end else begin
-      if (sdo_data_ready && sdo_data_valid) begin
-        data_sdo_v <= 1'b1;
-        sdo_data_reg <= sdo_data;
-      end else if (sdo_toshiftreg) begin
-        data_sdo_v <= 1'b0;
-      end
-    end
-  end
 
-  // pipelined shifter for sdo_data
-  always @(posedge clk ) begin
-    if (resetn == 1'b0) begin
-      aligned_sdo_data <= 0;
-    end else begin
-      aligned_sdo_data <= sdo_data_reg << left_aligned;
-    end
-  end
+  wire [(NUM_OF_SDIO * DATA_WIDTH)-1:0] aligned_sdo_data;
+  spi_engine_execution_shiftreg_data_assemble #(
+    .DATA_WIDTH(DATA_WIDTH),
+    .NUM_OF_SDIO(NUM_OF_SDIO)
+  ) sdo_data_assemble (
+    .clk              (clk),
+    .resetn           (resetn),
+    .data             (sdo_data),
+    .data_ready       (sdo_data_ready_int),
+    .data_valid       (sdo_data_valid),
+    .lane_cfg_valid   (exec_sdo_lane_cmd),
+    .sdo_lane_mask    (sdo_lane_mask),
+    .sdo_idle_state   (sdo_idle_state),
+    .left_shift_count (left_aligned),
+    .lane_cfg_ready   (index_ready),
+    .transfer_active  (transfer_active),
+    .trigger_tx       (trigger_tx),
+    .first_bit        (first_bit),
+    .sdo_enabled      (sdo_enabled),
+    .data_assembled   (aligned_sdo_data),
+    .word_ready       (data_ready_out),
+    .word_ready_aligned (data_sdo_v));
 
-  // Load the SDO parallel data into the SDO shift register. In case of a custom
-  // data width, additional bit shifting must done at load.
-  always @(posedge clk) begin
-    if (!sdo_enabled || (current_instr != CMD_TRANSFER)) begin
-      data_sdo_shift <= {DATA_WIDTH{sdo_idle_state}};
-    end else if (transfer_active == 1'b1 && trigger_tx == 1'b1) begin
-      if (first_bit == 1'b1) begin
-        data_sdo_shift <= aligned_sdo_data;
-      end else begin
-        data_sdo_shift <= {data_sdo_shift[(DATA_WIDTH-2):0], 1'b0};
+  genvar i;
+  generate
+    for (i = 0; i < NUM_OF_SDIO; i = i + 1) begin: g_sdo_shift_reg
+      // Load the SDO parallel data into the SDO shift register.
+      reg [(DATA_WIDTH-1):0] data_sdo_shift = 0;
+      always @(posedge clk) begin
+        if (!sdo_enabled || !exec_cmd) begin
+          data_sdo_shift <= {DATA_WIDTH{sdo_idle_state}};
+        end else if (transfer_active == 1'b1 && trigger_tx == 1'b1) begin
+          if (first_bit == 1'b1) begin
+            data_sdo_shift <= sdo_lane_mask[i] ? aligned_sdo_data[i * DATA_WIDTH+:DATA_WIDTH] : {DATA_WIDTH{sdo_idle_state}};
+          end else begin
+            data_sdo_shift <= {data_sdo_shift[(DATA_WIDTH-2):0], 1'b0};
+          end
+        end
       end
+
+      assign sdo_int[i] = data_sdo_shift[DATA_WIDTH-1];
     end
-  end
-  assign sdo_int = data_sdo_shift[DATA_WIDTH-1];
+  endgenerate
+
   assign sdo_toshiftreg = (transfer_active && trigger_tx && first_bit && sdo_enabled);
 
   // In case of an interface with high clock rate (SCLK > 50MHz), the latch of
@@ -149,20 +172,18 @@ module spi_engine_execution_shiftreg #(
   // used to latch the MISO lines, improving the overall timing margin of the
   // interface.
 
-  genvar i;
-
   // NOTE: SPI configuration (CPOL/PHA) is only hardware configurable at this point, unless ECHO_SCLK=0
   generate
   if (ECHO_SCLK == 1) begin : g_echo_sclk_miso_latch
 
     reg last_sdi_bit_r;
     reg latch_sdi;
-    reg [(NUM_OF_SDI * DATA_WIDTH)-1:0] sdi_data_latch = {(NUM_OF_SDI * DATA_WIDTH){1'b0}};
+    reg [(NUM_OF_SDIO * DATA_WIDTH)-1:0] sdi_data_latch = {(NUM_OF_SDIO * DATA_WIDTH){1'b0}};
 
     if ((DEFAULT_SPI_CFG[1:0] == 2'b01) || (DEFAULT_SPI_CFG[1:0] == 2'b10)) begin : g_echo_miso_nshift_reg
 
       // MISO shift register runs on negative echo_sclk
-      for (i=0; i<NUM_OF_SDI; i=i+1) begin: g_sdi_shift_reg
+      for (i=0; i<NUM_OF_SDIO; i=i+1) begin: g_sdi_shift_reg
         reg [DATA_WIDTH-1:0] data_sdi_shift;
 
         always @(negedge echo_sclk or posedge cs_activate) begin
@@ -187,16 +208,16 @@ module spi_engine_execution_shiftreg #(
           latch_sdi       <= 1'b0;
         end else begin
           // these paths would be unsafe it there wasn't a guarantee of some settling time between word_length changing and a transfer starting
-          latch_sdi       <= (sdi_counter == word_length - 2);
-          last_sdi_bit_r  <= (sdi_counter == word_length - 1);
-          sdi_counter     <= (sdi_counter == word_length - 1) ? 8'b0 : sdi_counter + 1'b1;
+          latch_sdi       <= (sdi_counter == latch_last_bit_count);
+          last_sdi_bit_r  <= (sdi_counter == last_bit_count);
+          sdi_counter     <= (sdi_counter == last_bit_count) ? 8'b0 : sdi_counter + 1'b1;
         end
       end
 
     end else begin : g_echo_miso_pshift_reg
 
       // MISO shift register runs on positive echo_sclk
-      for (i=0; i<NUM_OF_SDI; i=i+1) begin: g_sdi_shift_reg
+      for (i=0; i<NUM_OF_SDIO; i=i+1) begin: g_sdi_shift_reg
         reg [DATA_WIDTH-1:0] data_sdi_shift;
         always @(posedge echo_sclk or posedge cs_activate) begin
           if (cs_activate) begin
@@ -219,23 +240,18 @@ module spi_engine_execution_shiftreg #(
           latch_sdi       <= 1'b0;
         end else begin
           // these paths would be unsafe it there wasn't a guarantee of some settling time between word_length changing and a transfer starting
-          latch_sdi       <= (sdi_counter == word_length - 2);
-          last_sdi_bit_r  <= (sdi_counter == word_length - 1);
-          sdi_counter     <= (sdi_counter == word_length - 1) ? 8'b0 : sdi_counter + 1'b1;
+          latch_sdi       <= (sdi_counter == latch_last_bit_count);
+          last_sdi_bit_r  <= (sdi_counter == last_bit_count);
+          sdi_counter     <= (sdi_counter == last_bit_count) ? 8'b0 : sdi_counter + 1'b1;
         end
       end
 
     end
 
-    reg [3:0] last_sdi_bit_m = 4'b0;
-
-    assign sdi_data = sdi_data_latch;
-    assign last_sdi_bit = last_sdi_bit_r;
-    assign echo_last_bit =  !last_sdi_bit_m[3] && last_sdi_bit_m[2];
-
     // sdi_data_valid is synchronous to SPI clock, so synchronize the
     // last_sdi_bit to SPI clock
 
+    reg [3:0] last_sdi_bit_m = 4'b0;
     always @(posedge clk) begin
       if (cs_activate) begin
         last_sdi_bit_m <= 4'b0;
@@ -243,6 +259,10 @@ module spi_engine_execution_shiftreg #(
         last_sdi_bit_m <= {last_sdi_bit_m, last_sdi_bit};
       end
     end
+
+    assign sdi_data = sdi_data_latch;
+    assign last_sdi_bit = last_sdi_bit_r;
+    assign echo_last_bit =  !last_sdi_bit_m[3] && last_sdi_bit_m[2];
 
     always @(posedge clk) begin
       if (sdi_enabled == 1'b1 && echo_last_bit) begin
@@ -256,7 +276,7 @@ module spi_engine_execution_shiftreg #(
   else
   begin : g_sclk_miso_latch
 
-    for (i=0; i<NUM_OF_SDI; i=i+1) begin: g_sdi_shift_reg
+    for (i=0; i<NUM_OF_SDIO; i=i+1) begin: g_sdi_shift_reg
 
       reg [DATA_WIDTH-1:0] data_sdi_shift;
 
@@ -274,7 +294,7 @@ module spi_engine_execution_shiftreg #(
 
     end
 
-    assign last_sdi_bit = (sdi_counter == word_length-1);
+    assign last_sdi_bit = (sdi_counter == last_bit_count);
     always @(posedge clk) begin
       if (resetn == 1'b0) begin
         sdi_counter <= 8'b0;

--- a/library/spi_engine/spi_engine_execution/spi_engine_execution_shiftreg_data_assemble.v
+++ b/library/spi_engine/spi_engine_execution/spi_engine_execution_shiftreg_data_assemble.v
@@ -1,0 +1,241 @@
+// ***************************************************************************
+// ***************************************************************************
+// Copyright (C) 2025-2026 Analog Devices, Inc. All rights reserved.
+//
+// In this HDL repository, there are many different and unique modules, consisting
+// of various HDL (Verilog or VHDL) components. The individual modules are
+// developed independently, and may be accompanied by separate and unique license
+// terms.
+//
+// The user should read each of these license terms, and understand the
+// freedoms and responsibilities that he or she has by using this source/core.
+//
+// This core is distributed in the hope that it will be useful, but WITHOUT ANY
+// WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+// A PARTICULAR PURPOSE.
+//
+// Redistribution and use of source or resulting binaries, with or without modification
+// of this file, are permitted under one of the following two license terms:
+//
+//   1. The GNU General Public License version 2 as published by the
+//      Free Software Foundation, which can be found in the top level directory
+//      of this repository (LICENSE_GPL2), and also online at:
+//      <https://www.gnu.org/licenses/old-licenses/gpl-2.0.html>
+//
+// OR
+//
+//   2. An ADI specific BSD license, which can be found in the top level directory
+//      of this repository (LICENSE_ADIBSD), and also on-line at:
+//      https://github.com/analogdevicesinc/hdl/blob/main/LICENSE_ADIBSD
+//      This will allow to generate bit files and not release the source code,
+//      as long as it attaches to an ADI device.
+//
+// ***************************************************************************
+// ***************************************************************************
+
+`timescale 1ns/100ps
+
+module spi_engine_execution_shiftreg_data_assemble #(
+  parameter N_STAGES    = 2,
+  parameter DATA_WIDTH  = 8,
+  parameter NUM_OF_SDIO = 1
+) (
+  input                                   clk,
+  input                                   resetn,
+
+  // Data interface
+  input  [             (DATA_WIDTH)-1:0] data,
+  input                                  data_ready,
+  input                                  data_valid,
+
+  // Lane configuration
+  input                                  lane_cfg_valid,
+  input  [                          7:0] sdo_lane_mask,
+  input                                  sdo_idle_state,
+  input  [                          7:0] left_shift_count,
+  output                                 lane_cfg_ready,
+
+  // Transfer control (from execution FSM)
+  input                                  transfer_active,
+  input                                  trigger_tx,
+  input                                  first_bit,
+  input                                  sdo_enabled,
+
+  // Assembled data output
+  output [(NUM_OF_SDIO*DATA_WIDTH)-1:0] data_assembled,
+  output                                 word_ready,
+  output                                 word_ready_aligned
+);
+
+  // =============================================================================
+  // SDO Data Assembly Module
+  // =============================================================================
+  // Assembles sequential data words into a multi-lane output buffer (aligned_data).
+  // Maps each incoming word to the correct physical SDO lane based on sdo_lane_mask.
+  //
+  // Operation:
+  //   1. Lane mask is parsed when lane_cfg_valid asserts, building lane_lookup[]
+  //      table that maps sequential index to physical lane number.
+  //   2. On each data handshake, active_lane_idx cycles through active lanes.
+  //   3. Data is left-shifted for MSB alignment, then pipelined for timing.
+  //   4. At pipeline output, data is written to aligned_data at the correct lane position.
+  //
+  // Example (NUM_OF_SDIO=4, DATA_WIDTH=8, sdo_lane_mask=4'b1010):
+  //   - lane_lookup[0]=1, lane_lookup[1]=3, last_active_idx=1
+  //   - Handshake 1: data -> aligned_data[15:8]  (lane 1)
+  //   - Handshake 2: data -> aligned_data[31:24] (lane 3), word_ready=1
+  //
+  // Pipeline adds N_STAGES cycles latency from data input to aligned_data output.
+  // =============================================================================
+
+  // Parameter validation
+  initial begin
+    if (N_STAGES < 2) begin
+      $error("N_STAGES must be >= 2 for pipeline to function correctly");
+    end
+  end
+
+  // Output registers
+  reg                                  word_ready_int;
+  reg                                  word_ready_aligned_int;
+
+  // Pipeline registers for timing closure
+  reg [                  N_STAGES-1:0] word_ready_pipe;
+  reg [(NUM_OF_SDIO * DATA_WIDTH)-1:0] aligned_data;
+  reg [              (DATA_WIDTH)-1:0] data_reg;
+  reg [     (N_STAGES*DATA_WIDTH)-1:0] data_pipe_reg;
+
+  // Lane indexing and mapping
+  reg [             3:0] active_lane_idx  = 0;  // Current active lane being processed (0 to last_active_idx)
+  reg [             3:0] last_active_idx  = 0;  // Index of last active lane (num_active_lanes - 1)
+  reg [             3:0] lane_lookup [0:7];     // Lookup table: sequential index -> physical lane number
+  reg [             3:0] physical_lane    = 0;  // Current physical lane number from lookup
+  reg [(N_STAGES*8)-1:0] bit_position_pipe;  // Pipelined bit position (physical_lane * DATA_WIDTH)
+  reg                    lane_cfg_ready_reg; // Asserted when lane mask processing complete
+
+  // Indicates data is being loaded into shift register (consumption point)
+  wire sdo_toshiftreg = (transfer_active && trigger_tx && first_bit && sdo_enabled);
+  integer i;
+
+  assign data_assembled      = aligned_data;
+  assign word_ready          = word_ready_int;
+  assign word_ready_aligned  = word_ready_aligned_int;
+  assign lane_cfg_ready      = lane_cfg_ready_reg;
+
+  // Register incoming data on handshake
+  always @(posedge clk) begin
+    if (resetn == 1'b0) begin
+      data_reg <= {DATA_WIDTH{sdo_idle_state}};
+    end else begin
+      if (data_ready && data_valid) begin
+        data_reg <= data;
+      end
+    end
+  end
+
+  // Pipeline Registers
+  // Stage 0: Left-shift data for MSB alignment (left_shift_count = DATA_WIDTH - word_length)
+  //          Compute bit position in aligned_data (physical_lane * DATA_WIDTH)
+  // Stages 1+: Propagate data and position through pipeline for timing closure
+  always @(posedge clk) begin
+    word_ready_pipe[0]            <= word_ready_int;
+    bit_position_pipe[0+:8]       <= physical_lane * DATA_WIDTH;
+    data_pipe_reg[0+: DATA_WIDTH] <= data_reg << left_shift_count;
+    for (i = N_STAGES-1; i > 0; i = i - 1) begin
+      word_ready_pipe[i]                       <= word_ready_pipe[i-1];
+      bit_position_pipe[i*8+:8]                <= bit_position_pipe[(i-1)*8+:8];
+      data_pipe_reg[i*DATA_WIDTH+: DATA_WIDTH] <= data_pipe_reg[(i-1)*DATA_WIDTH+: DATA_WIDTH];
+    end
+  end
+
+  // Data Assembly
+  // At pipeline output, write shifted data to aligned_data at the lane's bit position.
+  // Inactive lanes retain sdo_idle_state from reset.
+  always @(posedge clk) begin
+    if (!resetn) begin
+      aligned_data <= {(NUM_OF_SDIO * DATA_WIDTH){sdo_idle_state}};
+    end else begin
+      aligned_data[bit_position_pipe[(N_STAGES-1)*8+:8]+:DATA_WIDTH] <= data_pipe_reg[(N_STAGES-1)*DATA_WIDTH+: DATA_WIDTH];
+    end
+  end
+
+  // Lane Mask Processing
+  // Parses sdo_lane_mask to build lane_lookup[] table.
+  // Example: sdo_lane_mask = 8'b00001010 (lanes 1 and 3 active)
+  //   lane_lookup[0] = 1, lane_lookup[1] = 3, last_active_idx = 1
+  // Processing starts on lane_cfg_valid and completes after NUM_OF_SDIO cycles.
+  reg [3:0] lane_scan_idx;
+  reg [3:0] active_lane_cnt;
+  always @(posedge clk) begin
+    if (!resetn) begin
+      lane_cfg_ready_reg <= 1'b0;
+      active_lane_cnt    <= 0;
+      last_active_idx    <= 0;
+      lane_scan_idx      <= 0;
+    end else begin
+      if (lane_cfg_valid) begin
+        lane_scan_idx      <= 0;
+        lane_cfg_ready_reg <= 1'b0;
+        active_lane_cnt    <= 0;
+        last_active_idx    <= 0;
+      end else begin
+        if (lane_scan_idx < NUM_OF_SDIO) begin
+          if (sdo_lane_mask[lane_scan_idx]) begin
+            lane_lookup[active_lane_cnt] <= lane_scan_idx;
+            last_active_idx <= active_lane_cnt; // avoid subtraction in the handshake counter
+            active_lane_cnt <= active_lane_cnt + 1;
+          end
+          lane_scan_idx      <= lane_scan_idx + 1;
+          lane_cfg_ready_reg <= (lane_scan_idx == NUM_OF_SDIO-1);
+        end
+      end
+    end
+  end
+
+  // physical_lane selects the correct bit position in aligned_data
+  // for the shift register, updated on each handshake
+  always @(posedge clk) begin
+    if (!resetn) begin
+      physical_lane <= 0;
+    end else begin
+      if (data_ready && data_valid) begin
+        physical_lane <= lane_lookup[active_lane_idx];
+      end
+    end
+  end
+
+  // active_lane_idx cycles through active lanes on each handshake,
+  // used to retrieve the correct physical_lane for data alignment
+  always @(posedge clk) begin
+    if (!resetn) begin
+      active_lane_idx <= 0;
+    end else begin
+      if (data_ready && data_valid) begin
+        if (active_lane_idx < last_active_idx) begin
+          active_lane_idx <= active_lane_idx + 1;
+        end else begin
+          active_lane_idx <= 0;
+        end
+      end
+    end
+  end
+
+  // Handshake and Ready Signaling
+  // word_ready_int: Asserted when last active lane's data received (active_lane_idx == last_active_idx).
+  //                 Cleared when shift register consumes the data (sdo_toshiftreg).
+  // word_ready_aligned_int: Pipelined version aligned with data_assembled output timing.
+  always @(posedge clk) begin
+    if (!resetn) begin
+      word_ready_int         <= 1'b0;
+      word_ready_aligned_int <= 1'b0;
+    end else begin
+      word_ready_aligned_int <= word_ready_pipe[N_STAGES-2];
+      if (data_ready && data_valid) begin
+        word_ready_int <= (active_lane_idx == last_active_idx);
+      end else if (sdo_toshiftreg) begin
+        word_ready_int <= 1'b0;
+      end
+    end
+  end
+
+  endmodule

--- a/library/spi_engine/spi_engine_interconnect/spi_engine_interconnect.v
+++ b/library/spi_engine/spi_engine_interconnect/spi_engine_interconnect.v
@@ -1,6 +1,6 @@
 // ***************************************************************************
 // ***************************************************************************
-// Copyright (C) 2015-2025 Analog Devices, Inc. All rights reserved.
+// Copyright (C) 2015-2026 Analog Devices, Inc. All rights reserved.
 //
 // In this HDL repository, there are many different and unique modules, consisting
 // of various HDL (Verilog or VHDL) components. The individual modules are
@@ -38,12 +38,13 @@
 module spi_engine_interconnect #(
 
   parameter DATA_WIDTH = 8, // Valid data widths values are 8/16/24/32
-  parameter NUM_OF_SDI = 1
+  parameter NUM_OF_SDIO = 1
 ) (
   input clk,
   input resetn,
 
-  input interconnect_dir,
+  input s_interconnect_dir,
+  output m_offload_active,
 
   output m_cmd_valid,
   input m_cmd_ready,
@@ -55,7 +56,7 @@ module spi_engine_interconnect #(
 
   input m_sdi_valid,
   output m_sdi_ready,
-  input [(NUM_OF_SDI * DATA_WIDTH-1):0] m_sdi_data,
+  input [(NUM_OF_SDIO * DATA_WIDTH-1):0] m_sdi_data,
 
   input m_sync_valid,
   output m_sync_ready,
@@ -71,7 +72,7 @@ module spi_engine_interconnect #(
 
   output s0_sdi_valid,
   input s0_sdi_ready,
-  output [(NUM_OF_SDI * DATA_WIDTH-1):0] s0_sdi_data,
+  output [(NUM_OF_SDIO * DATA_WIDTH-1):0] s0_sdi_data,
 
   output s0_sync_valid,
   input s0_sync_ready,
@@ -87,15 +88,16 @@ module spi_engine_interconnect #(
 
   output s1_sdi_valid,
   input s1_sdi_ready,
-  output [(NUM_OF_SDI * DATA_WIDTH-1):0] s1_sdi_data,
+  output [(NUM_OF_SDIO * DATA_WIDTH-1):0] s1_sdi_data,
 
   output s1_sync_valid,
   input s1_sync_ready,
   output [7:0] s1_sync
 );
 
-  `define spi_engine_interconnect_mux(s0, s1) (interconnect_dir == 1'b1 ? s0 : s1)
+  `define spi_engine_interconnect_mux(s0, s1) (s_interconnect_dir == 1'b1 ? s0 : s1)
 
+  assign m_offload_active = s_interconnect_dir;
   assign m_cmd_data   = `spi_engine_interconnect_mux(s0_cmd_data, s1_cmd_data);
   assign m_cmd_valid  = `spi_engine_interconnect_mux(s0_cmd_valid, s1_cmd_valid);
   assign s0_cmd_ready = `spi_engine_interconnect_mux(m_cmd_ready, 1'b0);

--- a/library/spi_engine/spi_engine_interconnect/spi_engine_interconnect_hw.tcl
+++ b/library/spi_engine/spi_engine_interconnect/spi_engine_interconnect_hw.tcl
@@ -14,12 +14,12 @@ ad_ip_files spi_engine_interconnect [list\
 # parameters
 
 ad_ip_parameter DATA_WIDTH INTEGER 8
-ad_ip_parameter NUM_OF_SDI INTEGER 1
+ad_ip_parameter NUM_OF_SDIO INTEGER 1
 
 proc p_elaboration {} {
 
   set data_width [get_parameter_value DATA_WIDTH]
-  set num_of_sdi [get_parameter_value NUM_OF_SDI]
+  set num_of_sdi [get_parameter_value NUM_OF_SDIO]
 
   # clock and reset interface
 
@@ -29,7 +29,7 @@ proc p_elaboration {} {
   # interconnect direction interface
 
   add_interface s_interconnect_ctrl conduit end
-  add_interface_port s_interconnect_ctrl interconnect_dir interconnect_dir input 1
+  add_interface_port s_interconnect_ctrl s_interconnect_dir interconnect_dir input 1
   set_interface_property s_interconnect_ctrl associatedClock if_clk
   set_interface_property s_interconnect_ctrl associatedReset if_resetn
 
@@ -42,6 +42,13 @@ proc p_elaboration {} {
 
   set_interface_property m_cmd associatedClock if_clk
   set_interface_property m_cmd associatedReset if_resetn
+
+  # offload active master interface
+
+  add_interface m_offload_active_ctrl conduit end
+  add_interface_port m_offload_active_ctrl m_offload_active interconnect_dir output 1
+  set_interface_property m_offload_active_ctrl associatedClock if_clk
+  set_interface_property m_offload_active_ctrl associatedReset if_resetn
 
   # SDO data master interface
 

--- a/library/spi_engine/spi_engine_interconnect/spi_engine_interconnect_ip.tcl
+++ b/library/spi_engine/spi_engine_interconnect/spi_engine_interconnect_ip.tcl
@@ -43,9 +43,17 @@ adi_add_bus "s_interconnect_ctrl" "slave" \
 	"analog.com:interface:spi_engine_interconnect_ctrl_rtl:1.0" \
 	"analog.com:interface:spi_engine_interconnect_ctrl:1.0" \
 	{ \
-		{"interconnect_dir" "interconnect_dir"} \
+		{"s_interconnect_dir" "interconnect_dir"} \
 	}
 adi_add_bus_clock "clk" "s_interconnect_ctrl" "resetn"
+
+adi_add_bus "m_offload_active_ctrl" "master" \
+	"analog.com:interface:spi_engine_interconnect_ctrl_rtl:1.0" \
+	"analog.com:interface:spi_engine_interconnect_ctrl:1.0" \
+	{ \
+		{"m_offload_active" "interconnect_dir"} \
+	}
+adi_add_bus_clock "clk" "m_offload_active_ctrl" "resetn"
 
 foreach prefix [list "s0" "s1"] {
 	adi_add_bus [format "%s_ctrl" $prefix] "slave" \
@@ -80,13 +88,13 @@ set_property -dict [list \
  ] \
  [ipx::get_user_parameters DATA_WIDTH -of_objects $cc]
 
-## NUM_OF_SDI
+## NUM_OF_SDIO
 set_property -dict [list \
   "value_validation_type" "range_long" \
   "value_validation_range_minimum" "1" \
   "value_validation_range_maximum" "8" \
  ] \
- [ipx::get_user_parameters NUM_OF_SDI -of_objects $cc]
+ [ipx::get_user_parameters NUM_OF_SDIO -of_objects $cc]
 
 ## Customize IP Layout
 
@@ -107,11 +115,11 @@ set_property -dict [list \
   "tooltip" "\[DATA_WIDTH\] Define the data interface width"
 ] [ipgui::get_guiparamspec -name "DATA_WIDTH" -component $cc]
 
-ipgui::add_param -name "NUM_OF_SDI" -component $cc -parent $general_group
+ipgui::add_param -name "NUM_OF_SDIO" -component $cc -parent $general_group
 set_property -dict [list \
-  "display_name" "Number of MISO lines" \
-  "tooltip" "\[NUM_OF_SDI\] Define the number of MISO lines" \
-] [ipgui::get_guiparamspec -name "NUM_OF_SDI" -component $cc]
+  "display_name" "Number of MISO/MOSI lines" \
+  "tooltip" "\[NUM_OF_SDIO\] Define the number of MISO/MOSI lines" \
+] [ipgui::get_guiparamspec -name "NUM_OF_SDIO" -component $cc]
 
 ## Create and save the XGUI file
 ipx::create_xgui_files $cc

--- a/library/spi_engine/spi_engine_interconnect/spi_engine_interconnect_ltt.tcl
+++ b/library/spi_engine/spi_engine_interconnect/spi_engine_interconnect_ltt.tcl
@@ -92,11 +92,11 @@ set ip [ipl::set_parameter -ip $ip \
     -group1 {General Configuration} \
     -group2 Config]
 set ip [ipl::set_parameter -ip $ip \
-    -id NUM_OF_SDI \
+    -id NUM_OF_SDIO \
     -type param \
     -value_type int \
     -conn_mod spi_engine_interconnect \
-    -title {Number of MISO lines} \
+    -title {Number of MISO/MOSI lines} \
     -default 1 \
     -output_formatter nostr \
     -value_range {(1, 8)} \

--- a/library/spi_engine/spi_engine_offload/spi_engine_offload.v
+++ b/library/spi_engine/spi_engine_offload/spi_engine_offload.v
@@ -42,7 +42,7 @@ module spi_engine_offload #(
   parameter CMD_MEM_ADDRESS_WIDTH = 4,
   parameter SDO_MEM_ADDRESS_WIDTH = 4,
   parameter DATA_WIDTH = 8, // Valid data widths values are 8/16/24/32
-  parameter NUM_OF_SDI = 1,
+  parameter NUM_OF_SDIO = 1,
   parameter SDO_STREAMING = 0
 ) (
   input ctrl_clk,
@@ -80,7 +80,7 @@ module spi_engine_offload #(
 
   input sdi_data_valid,
   output sdi_data_ready,
-  input [(NUM_OF_SDI * DATA_WIDTH-1):0] sdi_data,
+  input [(NUM_OF_SDIO * DATA_WIDTH)-1:0] sdi_data,
 
   input sync_valid,
   output sync_ready,
@@ -88,7 +88,7 @@ module spi_engine_offload #(
 
   output offload_sdi_valid,
   input offload_sdi_ready,
-  output [(NUM_OF_SDI * DATA_WIDTH-1):0] offload_sdi_data,
+  output [(NUM_OF_SDIO * DATA_WIDTH)-1:0] offload_sdi_data,
 
   output interconnect_dir
 );

--- a/library/spi_engine/spi_engine_offload/spi_engine_offload_hw.tcl
+++ b/library/spi_engine/spi_engine_offload/spi_engine_offload_hw.tcl
@@ -20,13 +20,13 @@ ad_ip_parameter ASYNC_TRIG INTEGER 0
 ad_ip_parameter CMD_MEM_ADDRESS_WIDTH INTEGER 4
 ad_ip_parameter SDO_MEM_ADDRESS_WIDTH INTEGER 4
 ad_ip_parameter DATA_WIDTH INTEGER 8
-ad_ip_parameter NUM_OF_SDI INTEGER 1
+ad_ip_parameter NUM_OF_SDIO INTEGER 1
 ad_ip_parameter SDO_STREAMING INTEGER 0
 
 proc p_elaboration {} {
 
   set data_width [get_parameter_value DATA_WIDTH]
-  set num_of_sdi [get_parameter_value NUM_OF_SDI]
+  set num_of_sdi [get_parameter_value NUM_OF_SDIO]
   set disabled_intfs {}
 
   # control interface

--- a/library/spi_engine/spi_engine_offload/spi_engine_offload_ip.tcl
+++ b/library/spi_engine/spi_engine_offload/spi_engine_offload_ip.tcl
@@ -132,13 +132,13 @@ set_property -dict [list \
  ] \
  [ipx::get_hdl_parameters SDO_STREAMING -of_objects $cc]
 
-## NUM_OF_SDI
+## NUM_OF_SDIO
 set_property -dict [list \
   "value_validation_type" "range_long" \
   "value_validation_range_minimum" "1" \
   "value_validation_range_maximum" "8" \
  ] \
- [ipx::get_user_parameters NUM_OF_SDI -of_objects $cc]
+ [ipx::get_user_parameters NUM_OF_SDIO -of_objects $cc]
 
 ## DATA_WIDTH
 set_property -dict [list \
@@ -183,11 +183,11 @@ set_property -dict [list \
   "tooltip" "\[DATA_WIDTH\] Define the data interface width"
 ] [ipgui::get_guiparamspec -name "DATA_WIDTH" -component $cc]
 
-ipgui::add_param -name "NUM_OF_SDI" -component $cc -parent $general_group
+ipgui::add_param -name "NUM_OF_SDIO" -component $cc -parent $general_group
 set_property -dict [list \
-  "display_name" "Number of MISO lines" \
-  "tooltip" "\[NUM_OF_SDI\] Define the number of MISO lines" \
-] [ipgui::get_guiparamspec -name "NUM_OF_SDI" -component $cc]
+  "display_name" "Number of MISO/MOSI lines" \
+  "tooltip" "\[NUM_OF_SDIO\] Define the number of MISO/MOSI lines" \
+] [ipgui::get_guiparamspec -name "NUM_OF_SDIO" -component $cc]
 
 ipgui::add_param -name "ASYNC_SPI_CLK" -component $cc -parent $general_group
 set_property -dict [list \

--- a/library/spi_engine/spi_engine_offload/spi_engine_offload_ltt.tcl
+++ b/library/spi_engine/spi_engine_offload/spi_engine_offload_ltt.tcl
@@ -113,11 +113,11 @@ set ip [ipl::set_parameter -ip $ip \
     -group1 {General Configuration} \
     -group2 Config]
 set ip [ipl::set_parameter -ip $ip \
-    -id NUM_OF_SDI \
+    -id NUM_OF_SDIO \
     -type param \
     -value_type int \
     -conn_mod spi_engine_offload \
-    -title {Number of MISO lines} \
+    -title {Number of MISO/MOSI lines} \
     -default 1 \
     -output_formatter nostr \
     -value_range {(1, 8)} \

--- a/projects/ad4052_ardz/common/ad4052_qsys.tcl
+++ b/projects/ad4052_ardz/common/ad4052_qsys.tcl
@@ -115,7 +115,6 @@ add_connection sys_dma_clk.clk_reset axi_dmac_0.m_dest_axi_reset
 # interfaces
 
 add_connection ${spi_engine_hier}_offload.offload_sdi axi_dmac_0.s_axis
-
 # cpu interconnects
 
 ad_cpu_interconnect 0x00020000 axi_dmac_0.s_axi

--- a/projects/ad4052_ardz/coraz7s/system_constr.xdc
+++ b/projects/ad4052_ardz/coraz7s/system_constr.xdc
@@ -15,9 +15,3 @@ set_property -dict {PACKAGE_PIN N18 IOSTANDARD LVCMOS33}          [get_ports adc
 # rename auto-generated clock for SPIEngine to spi_clk - 160MHz
 # NOTE: clk_fpga_0 is the first PL fabric clock, also called $sys_cpu_clk
 create_generated_clock -name spi_clk -source [get_pins -filter name=~*CLKIN1 -of [get_cells -hier -filter name=~*spi_clkgen*i_mmcm]] -master_clock clk_fpga_0 [get_pins -filter name=~*CLKOUT0 -of [get_cells -hier -filter name=~*spi_clkgen*i_mmcm]]
-
-# relax the SDO path to help closing timing at high frequencies
-set_multicycle_path -setup 8 -to [get_cells -hierarchical -filter {NAME=~*/data_sdo_shift_reg[*]}] -from [get_clocks spi_clk]
-set_multicycle_path -hold  7 -to [get_cells -hierarchical -filter {NAME=~*/data_sdo_shift_reg[*]}] -from [get_clocks spi_clk]
-set_multicycle_path -setup 8 -to [get_cells -hierarchical -filter {NAME=~*/spi_adc_execution/inst/left_aligned_reg*}] -from [get_clocks spi_clk]
-set_multicycle_path -hold  7 -to [get_cells -hierarchical -filter {NAME=~*/spi_adc_execution/inst/left_aligned_reg*}] -from [get_clocks spi_clk]

--- a/projects/ad4052_ardz/de10nano/system_project.tcl
+++ b/projects/ad4052_ardz/de10nano/system_project.tcl
@@ -37,6 +37,8 @@ set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to adc_cnv
 set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to adc_gp0
 set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to adc_gp1
 
+#ad4052 requires both options for closing time
+set_global_assignment -name OPTIMIZATION_TECHNIQUE SPEED
 set_global_assignment -name OPTIMIZATION_MODE "HIGH PERFORMANCE EFFORT"
 
 execute_flow -compile

--- a/projects/ad4630_fmc/common/ad463x_bd.tcl
+++ b/projects/ad4630_fmc/common/ad463x_bd.tcl
@@ -7,7 +7,7 @@ source $ad_hdl_dir/library/spi_engine/scripts/spi_engine.tcl
 # system level parameters
 set LANES_PER_CHANNEL   $ad_project_params(LANES_PER_CHANNEL)
 set NUM_OF_CHANNEL      $ad_project_params(NUM_OF_CHANNEL)
-set NUM_OF_SDI          $ad_project_params(NUM_OF_SDI)
+set NUM_OF_SDIO         $ad_project_params(NUM_OF_SDIO)
 set CAPTURE_ZONE        $ad_project_params(CAPTURE_ZONE)
 set CLK_MODE            $ad_project_params(CLK_MODE)
 set DDR_EN              $ad_project_params(DDR_EN)
@@ -21,7 +21,7 @@ if {$INTERLEAVE_MODE == 1} {
   # REORDER is mandatory in interleaved mode
   set NO_REORDER      0
 } else {
-  if {$NUM_OF_SDI > 2} {
+  if {$NUM_OF_SDIO > 2} {
     # REORDER is mandatory when more than 2 lanes are used
     set NO_REORDER      0
   } else {
@@ -29,7 +29,7 @@ if {$INTERLEAVE_MODE == 1} {
   }
 }
 
-puts "build parameters: NUM_OF_SDI: $NUM_OF_SDI ; CAPTURE_ZONE: $CAPTURE_ZONE ; CLK_MODE: $CLK_MODE ; DDR_EN: $DDR_EN ; INTERLEAVE_MODE: $INTERLEAVE_MODE"
+puts "build parameters: NUM_OF_SDIO: $NUM_OF_SDIO ; CAPTURE_ZONE: $CAPTURE_ZONE ; CLK_MODE: $CLK_MODE ; DDR_EN: $DDR_EN ; INTERLEAVE_MODE: $INTERLEAVE_MODE"
 
 # block design ports and interfaces
 # specify the CNV generator's reference clock frequency in MHz
@@ -48,7 +48,7 @@ set max17687_sync_freq 400000
 create_bd_port -dir O ad463x_spi_sclk
 create_bd_port -dir O ad463x_spi_cs
 create_bd_port -dir O ad463x_spi_sdo
-create_bd_port -dir I -from [expr $NUM_OF_SDI-1] -to 0 ad463x_spi_sdi
+create_bd_port -dir I -from [expr $NUM_OF_SDIO-1] -to 0 ad463x_spi_sdi
 
 create_bd_port -dir I ad463x_echo_sclk
 
@@ -70,14 +70,14 @@ ad_connect spi_clk spi_clkgen/clk_0
 
 # create a SPI Engine architecture
 
-#spi_engine_create "spi_ad463x" 32         1            1             1       $NUM_OF_SDI 0          1
+#spi_engine_create "spi_ad463x" 32         1            1             1       $NUM_OF_SDIO 0          1
 
 set hier_spi_engine  spi_ad463x
 set data_width       32
 set async_spi_clk    1
 set offload_en       1
 set num_cs           1
-set num_sdi          $NUM_OF_SDI
+set num_sdi          $NUM_OF_SDIO
 set num_sdo          1
 set sdi_delay        1
 set echo_sclk        1
@@ -86,7 +86,7 @@ spi_engine_create $hier_spi_engine $data_width $async_spi_clk $offload_en $num_c
 
 ad_ip_parameter $hier_spi_engine/${hier_spi_engine}_execution CONFIG.DEFAULT_SPI_CFG 0   ; # latching MISO on positive edge - hardware only
 
-ad_ip_parameter $hier_spi_engine/${hier_spi_engine}_axi_regmap CONFIG.CFG_INFO_0 $NUM_OF_SDI
+ad_ip_parameter $hier_spi_engine/${hier_spi_engine}_axi_regmap CONFIG.CFG_INFO_0 $NUM_OF_SDIO
 ad_ip_parameter $hier_spi_engine/${hier_spi_engine}_axi_regmap CONFIG.CFG_INFO_1 $CAPTURE_ZONE
 ad_ip_parameter $hier_spi_engine/${hier_spi_engine}_axi_regmap CONFIG.CFG_INFO_2 $CLK_MODE
 ad_ip_parameter $hier_spi_engine/${hier_spi_engine}_axi_regmap CONFIG.CFG_INFO_3 $DDR_EN
@@ -113,7 +113,7 @@ ad_ip_parameter sync_generator CONFIG.PULSE_0_WIDTH [expr int(ceil(double($max17
 
 if {$NO_REORDER == 0} {
   ad_ip_instance spi_axis_reorder data_reorder
-  ad_ip_parameter data_reorder CONFIG.NUM_OF_LANES $NUM_OF_SDI
+  ad_ip_parameter data_reorder CONFIG.NUM_OF_LANES $NUM_OF_SDIO
 }
 
 # dma to receive data stream
@@ -128,7 +128,7 @@ if {$NO_REORDER == 0} {
   ad_ip_parameter axi_ad463x_dma CONFIG.DMA_DATA_WIDTH_SRC 64
 } else {
   #REORDER BYPASSED
-  ad_ip_parameter axi_ad463x_dma CONFIG.DMA_DATA_WIDTH_SRC [expr min(32 * $NUM_OF_SDI, 64)]
+  ad_ip_parameter axi_ad463x_dma CONFIG.DMA_DATA_WIDTH_SRC [expr min(32 * $NUM_OF_SDIO, 64)]
 }
 
 ad_ip_parameter axi_ad463x_dma CONFIG.DMA_DATA_WIDTH_DEST 64
@@ -204,7 +204,7 @@ if {$CAPTURE_ZONE == 1} {
       ## SDI is latched by the data capture
       ad_ip_instance ad463x_data_capture data_capture
       ad_ip_parameter data_capture CONFIG.DDR_EN $DDR_EN
-      ad_ip_parameter data_capture CONFIG.NUM_OF_LANES $NUM_OF_SDI
+      ad_ip_parameter data_capture CONFIG.NUM_OF_LANES $NUM_OF_SDIO
 
       ad_connect spi_clk data_capture/clk
       ad_connect ad463x_spi_cs data_capture/csn

--- a/projects/ad4630_fmc/zed/system_project.tcl
+++ b/projects/ad4630_fmc/zed/system_project.tcl
@@ -59,16 +59,16 @@ source $ad_hdl_dir/projects/scripts/adi_board.tcl
 #
 
 if {[get_env_param INTERLEAVE_MODE 0] == 1} {
-  set NUM_OF_SDI      1
+  set NUM_OF_SDIO      1
 } else {
-  set NUM_OF_SDI      [expr {[get_env_param NUM_OF_CHANNEL 2] * [get_env_param LANES_PER_CHANNEL 2]}]
+  set NUM_OF_SDIO      [expr {[get_env_param NUM_OF_CHANNEL 2] * [get_env_param LANES_PER_CHANNEL 2]}]
 }
 
 adi_project ad4630_fmc_zed 0 [list \
   CLK_MODE           [get_env_param CLK_MODE           0] \
   LANES_PER_CHANNEL  [get_env_param LANES_PER_CHANNEL  2] \
   NUM_OF_CHANNEL     [get_env_param NUM_OF_CHANNEL     2] \
-  NUM_OF_SDI         $NUM_OF_SDI                          \
+  NUM_OF_SDIO        $NUM_OF_SDIO                         \
   CAPTURE_ZONE       [get_env_param CAPTURE_ZONE       2] \
   DDR_EN             [get_env_param DDR_EN             0] \
   INTERLEAVE_MODE    [get_env_param INTERLEAVE_MODE    0] ]

--- a/projects/ad4630_fmc/zed/system_top.v
+++ b/projects/ad4630_fmc/zed/system_top.v
@@ -36,7 +36,7 @@
 `timescale 1ns/100ps
 
 module system_top #(
-  parameter NUM_OF_SDI = 2
+  parameter NUM_OF_SDIO = 2
 ) (
   inout   [14:0]  ddr_addr,
   inout   [ 2:0]  ddr_ba,
@@ -86,7 +86,7 @@ module system_top #(
 
   // ad463x SPI configuration interface
 
-  input [NUM_OF_SDI-1:0]  ad463x_spi_sdi,
+  input [NUM_OF_SDIO-1:0]  ad463x_spi_sdi,
   output          ad463x_spi_sdo,
   output          ad463x_spi_sclk,
   output          ad463x_spi_cs,

--- a/projects/ad5766_sdz/common/ad5766_bd.tcl
+++ b/projects/ad5766_sdz/common/ad5766_bd.tcl
@@ -26,7 +26,7 @@ current_bd_instance /spi
 
         ad_ip_parameter execution CONFIG.NUM_OF_CS 1
         ad_ip_parameter axi CONFIG.OFFLOAD_EN 1
-        ad_ip_parameter interconnect CONFIG.NUM_OF_SDI 2
+        ad_ip_parameter interconnect CONFIG.NUM_OF_SDIO 2
 
         ad_connect  axi/spi_engine_offload_ctrl0 axi_ad5766/spi_engine_offload_ctrl
         ad_connect  axi/spi_engine_ctrl interconnect/s0_ctrl

--- a/projects/ad738x_fmc/common/ad738x_bd.tcl
+++ b/projects/ad738x_fmc/common/ad738x_bd.tcl
@@ -6,10 +6,10 @@
 # system level parameter
 
 set ALERT_SPI_N $ad_project_params(ALERT_SPI_N)
-set NUM_OF_SDI $ad_project_params(NUM_OF_SDI)
+set NUM_OF_SDIO $ad_project_params(NUM_OF_SDIO)
 
 puts "build parameter: ALERT_SPI_N: $ALERT_SPI_N"
-puts "build parameter: NUM_OF_SDI: $NUM_OF_SDI"
+puts "build parameter: NUM_OF_SDIO: $NUM_OF_SDIO"
 
 create_bd_intf_port -mode Master -vlnv analog.com:interface:spi_engine_rtl:1.0 ad738x_spi
 
@@ -20,7 +20,7 @@ set data_width       32
 set async_spi_clk    1
 set offload_en       1
 set num_cs           1
-set num_sdi          [expr {$ALERT_SPI_N ? 1 : $NUM_OF_SDI}]
+set num_sdi          [expr {$ALERT_SPI_N ? 1 : $NUM_OF_SDIO}]
 set num_sdo          1
 set sdi_delay        1
 set echo_sclk        0

--- a/projects/ad738x_fmc/common/ad738x_pb.tcl
+++ b/projects/ad738x_fmc/common/ad738x_pb.tcl
@@ -16,10 +16,10 @@ if {![info exists ad_project_params(ALERT_SPI_N)]} {
   set ALERT_SPI_N $ad_project_params(ALERT_SPI_N)
 }
 
-if {![info exists ad_project_params(NUM_OF_SDI)]} {
-  set NUM_OF_SDI 1
+if {![info exists ad_project_params(NUM_OF_SDIO)]} {
+  set NUM_OF_SDIO 1
 } else {
-  set NUM_OF_SDI $ad_project_params(NUM_OF_SDI)
+  set NUM_OF_SDIO $ad_project_params(NUM_OF_SDIO)
 }
 
 if {![info exists ad_project_params(DATA_WIDTH)]} {
@@ -28,9 +28,9 @@ if {![info exists ad_project_params(DATA_WIDTH)]} {
   set DATA_WIDTH $ad_project_params(DATA_WIDTH)
 }
 
-puts "ad738x_pb.tcl: Using ALERT_SPI_N=$ALERT_SPI_N, NUM_OF_SDI=$NUM_OF_SDI, DATA_WIDTH=$DATA_WIDTH"
+puts "ad738x_pb.tcl: Using ALERT_SPI_N=$ALERT_SPI_N, NUM_OF_SDIO=$NUM_OF_SDIO, DATA_WIDTH=$DATA_WIDTH"
 
-set DMA_WIDTH_SRC [expr ${NUM_OF_SDI} * $DATA_WIDTH]
+set DMA_WIDTH_SRC [expr ${NUM_OF_SDIO} * $DATA_WIDTH]
 
 adi_ip_update $project_name -vlnv {latticesemi.com:module:pll0:1.9.1} \
   -meta_vlnv {latticesemi.com:module:pll:1.9.1} \
@@ -63,7 +63,7 @@ adi_ip_instance -vlnv {analog.com:ip:axi_spi0:1.0} \
     DATA_WIDTH:$DATA_WIDTH,
     MM_IF_TYPE:0,
     OFFLOAD_EN:1,
-    NUM_OF_SDI:$NUM_OF_SDI
+    NUM_OF_SDIO:$NUM_OF_SDIO
   }] \
   -ip_iname "axi_spi0_inst"
 adi_ip_instance -vlnv {analog.com:ip:pwm0:1.0} \
@@ -83,7 +83,7 @@ adi_ip_instance -vlnv {analog.com:ip:spi_offload0:1.0} \
   -cfg_value [subst {
     ASYNC_SPI_CLK:0,
     DATA_WIDTH:$DATA_WIDTH,
-    NUM_OF_SDI:$NUM_OF_SDI
+    NUM_OF_SDIO:$NUM_OF_SDIO
   }] \
   -ip_iname "spi_offload0_inst"
 adi_ip_instance -vlnv {analog.com:ip:dmac0:1.0} \
@@ -107,22 +107,22 @@ adi_ip_instance -vlnv {analog.com:ip:spi_interc0:1.0} \
   -meta_vlnv {analog.com:ip:spi_engine_interconnect:1.0} \
   -cfg_value [subst {
     DATA_WIDTH:$DATA_WIDTH,
-    NUM_OF_SDI:$NUM_OF_SDI
+    NUM_OF_SDIO:$NUM_OF_SDIO
   }] \
   -ip_iname "spi_interc0_inst"
 adi_ip_instance -vlnv {analog.com:ip:spi_exec0:1.0} \
   -meta_vlnv {analog.com:ip:spi_engine_execution:1.0} \
   -cfg_value [subst {
     DATA_WIDTH:$DATA_WIDTH,
-    NUM_OF_SDI:$NUM_OF_SDI,
+    NUM_OF_SDIO:$NUM_OF_SDIO,
     SDI_DELAY:1
   }] \
   -ip_iname "spi_exec0_inst"
 
 sbp_add_port -direction out spi_master0_cs
 sbp_add_port -direction out spi_master0_sclk
-if { $NUM_OF_SDI > 1 } {
-sbp_add_port -from [expr $NUM_OF_SDI - 1] -to 0 -direction in spi_master0_sdi
+if { $NUM_OF_SDIO > 1 } {
+sbp_add_port -from [expr $NUM_OF_SDIO - 1] -to 0 -direction in spi_master0_sdi
 } else {
   sbp_add_port -direction in spi_master0_sdi
 }

--- a/projects/ad738x_fmc/lfcpnx/README.md
+++ b/projects/ad738x_fmc/lfcpnx/README.md
@@ -28,7 +28,7 @@ The overwritable parameters from the environment:
 
 - ALERT_SPI_N - If set to 1 the sdi[1] and sdi[3] ports are connected to gpio
   inputs and there is only a single accessible SPI sdi[0] data line for serial data.
-- NUM_OF_SDI - Defines the number of SDI lines used: 1, 2, 4 (if the ALERT_SPI_N=0).
+- NUM_OF_SDIO - Defines the number of SDI lines used: 1, 2, 4 (if the ALERT_SPI_N=0).
 - SYSMEM_INIT_FILE - The file path to the system memory initialization file
   (<path_to>/<sysmem_file>.mem). It can be used to build a project with an
   already initialized system memory, otherwise you can load it using the
@@ -41,7 +41,7 @@ The overwritable parameters from the environment:
 This specific command is equivalent to running `make` only:
 
 ```
-make ALERT_SPI_N=0 NUM_OF_SDI=1
+make ALERT_SPI_N=0 NUM_OF_SDIO=1
 ```
 
 #### Default configuration with SYSMEM_INIT_FILE

--- a/projects/ad738x_fmc/lfcpnx/system_pb.tcl
+++ b/projects/ad738x_fmc/lfcpnx/system_pb.tcl
@@ -9,6 +9,6 @@ source $ad_hdl_dir/projects/common/lfcpnx/lfcpnx_system_pb.tcl
 source $ad_hdl_dir/projects/ad738x_fmc/common/ad738x_pb.tcl
 
 set sys_cstring "ALERT_SPI_N=$ad_project_params(ALERT_SPI_N)\
-NUM_OF_SDI=$ad_project_params(NUM_OF_SDI)"
+NUM_OF_SDIO=$ad_project_params(NUM_OF_SDIO)"
 
 sysid_gen_sys_init_file $sys_cstring

--- a/projects/ad738x_fmc/lfcpnx/system_project_pb.tcl
+++ b/projects/ad738x_fmc/lfcpnx/system_project_pb.tcl
@@ -8,6 +8,6 @@ source $ad_hdl_dir/projects/scripts/adi_project_lattice_pb.tcl
 
 adi_project_pb ad738x_fmc_lfcpnx -parameter_list [list \
   ALERT_SPI_N [get_env_param ALERT_SPI_N 0] \
-  NUM_OF_SDI [get_env_param NUM_OF_SDI 1] \
+  NUM_OF_SDIO [get_env_param NUM_OF_SDIO 1] \
   DATA_WIDTH [get_env_param DATA_WIDTH 16] \
   SYSMEM_INIT_FILE [get_env_param SYSMEM_INIT_FILE ""]]

--- a/projects/ad738x_fmc/lfcpnx/system_top.v
+++ b/projects/ad738x_fmc/lfcpnx/system_top.v
@@ -1,6 +1,6 @@
 // ***************************************************************************
 // ***************************************************************************
-// Copyright (C) 2024-2025 Analog Devices, Inc. All rights reserved.
+// Copyright (C) 2024-2026 Analog Devices, Inc. All rights reserved.
 //
 // In this HDL repository, there are many different and unique modules, consisting
 // of various HDL (Verilog or VHDL) components. The individual modules are
@@ -37,7 +37,7 @@
 
 module system_top #(
   parameter ALERT_SPI_N = 0,
-  parameter NUM_OF_SDI = 4
+  parameter NUM_OF_SDIO = 4
 ) (
   input           clk_125,
   input           resetn,
@@ -72,7 +72,7 @@ module system_top #(
   wire    [31:0]  gpio1_i;
   wire    [31:0]  gpio1_en_o;
 
-  wire    [NUM_OF_SDI-1:0]   sdi_bus_i;
+  wire    [NUM_OF_SDIO-1:0]   sdi_bus_i;
 
   assign leds_0_to_23 = gpio0_o[23:0];
   assign gpio0_i[31:24] = dip_sw_1_to_8;
@@ -82,7 +82,7 @@ module system_top #(
   assign gpio1_i[28] = ALERT_SPI_N ? sdi_bus[1] : 0;
   assign gpio1_i[29] = ALERT_SPI_N ? sdi_bus[3] : 0;
 
-  assign sdi_bus_i = (ALERT_SPI_N == 0) ? sdi_bus[NUM_OF_SDI-1:0] : sdi_bus[0];
+  assign sdi_bus_i = (ALERT_SPI_N == 0) ? sdi_bus[NUM_OF_SDIO-1:0] : sdi_bus[0];
 
   ad738x_fmc_lfcpnx ad738x_fmc_lfcpnx_inst (
     .gpio0_o(gpio0_o),

--- a/projects/ad738x_fmc/lfcpnx/system_v_pb.tcl
+++ b/projects/ad738x_fmc/lfcpnx/system_v_pb.tcl
@@ -19,7 +19,7 @@ adi_ip_instance -vlnv {analog.com:sim_model:sdo_sim:1.0} \
         TRI_STATE_BETWEEN_FRAMES:1,
         SIGNED:0,
         SPI_MODE:3,
-        SDO_LANES:$NUM_OF_SDI
+        SDO_LANES:$NUM_OF_SDIO
     } ] \
     -ip_iname "sdo_sim_inst"
 
@@ -40,7 +40,7 @@ sbp_connect_net ${project_name}_v/dut_inst/spi_master0_cs \
     ${project_name}_v/sdo_sim_inst/cs_n
 sbp_connect_net ${project_name}_v/dut_inst/spi_master0_sclk \
     ${project_name}_v/sdo_sim_inst/sclk
-if {$NUM_OF_SDI > 1} {
+if {$NUM_OF_SDIO > 1} {
     sbp_connect_net ${project_name}_v/sdo_sim_inst/sdo \
         ${project_name}_v/dut_inst/spi_master0_sdi
 } else {

--- a/projects/ad738x_fmc/zed/README.md
+++ b/projects/ad738x_fmc/zed/README.md
@@ -18,10 +18,11 @@ The overwritable parameters from the environment:
 - ALERT_SPI_N pin can operate as a serial data output pin or alert indication output depending on its value:
    - 0 - SDOB-SDOD
    - 1 - ALERT
-- NUM_OF_SDI - Defines the number of SDI lines used: 1, 2, 4
+
+- NUM_OF_SDIO - Defines the number of SDI lines used: 1, 2, 4
 
 For the ALERT functionality, the following parameter will be used in `make` command: ALERT_SPI_N.
-For the serial data output functionality, the following parameters will be used in `make` command: ALERT_SPI_N, NUM_OF_SDI.
+For the serial data output functionality, the following parameters will be used in `make` command: ALERT_SPI_N, NUM_OF_SDIO.
 
 ### Example configurations
 
@@ -30,7 +31,8 @@ For the serial data output functionality, the following parameters will be used 
 This specific command is equivalent to running `make` only:
 
 ```
-make ALERT_SPI_N=0 NUM_OF_SDI=1
+cd projects/ad738x_fmc/zed
+make ALERT_SPI_N=0 NUM_OF_SDIO=1
 ```
 
 Corresponding device tree: [zynq-zed-adv7511-ad7380.dts](https://github.com/analogdevicesinc/linux/blob/main/arch/arm/boot/dts/xilinx/zynq-zed-adv7511-ad7380.dts)

--- a/projects/ad738x_fmc/zed/system_bd.tcl
+++ b/projects/ad738x_fmc/zed/system_bd.tcl
@@ -15,6 +15,6 @@ ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "$mem_init_sys_file_path/mem_init_
 ad_ip_parameter rom_sys_0 CONFIG.ROM_ADDR_BITS 9
 
 set sys_cstring "ALERT_SPI_N=$ad_project_params(ALERT_SPI_N)\
-NUM_OF_SDI=$ad_project_params(NUM_OF_SDI)"
+NUM_OF_SDIO=$ad_project_params(NUM_OF_SDIO)"
 
 sysid_gen_sys_init_file $sys_cstring

--- a/projects/ad738x_fmc/zed/system_project.tcl
+++ b/projects/ad738x_fmc/zed/system_project.tcl
@@ -11,12 +11,12 @@ source $ad_hdl_dir/projects/scripts/adi_board.tcl
 
 # ALERT_SPI_N - SDOB-SDOD/ALERT pin can operate as a serial data output pin or alert indication output
 #  - Options : SDOB-SDOD(0)/ALERT(1)
-# NUM_OF_SDI - Number of SDI lines used
+# NUM_OF_SDIO - Number of SDI lines used
 #  - Options : 1,2,4
 
 adi_project ad738x_fmc_zed 0 [list \
   ALERT_SPI_N [get_env_param ALERT_SPI_N  0]\
-  NUM_OF_SDI [get_env_param NUM_OF_SDI    1] ]
+  NUM_OF_SDIO [get_env_param NUM_OF_SDIO    1] ]
 
 adi_project_files ad738x_fmc_zed [list \
     "$ad_hdl_dir/library/common/ad_iobuf.v" \
@@ -24,7 +24,7 @@ adi_project_files ad738x_fmc_zed [list \
     "system_constr.xdc" \
     "system_top.v" ]
 
-switch [get_env_param NUM_OF_SDI 1] {
+switch [get_env_param NUM_OF_SDIO 1] {
   1 {
     adi_project_files ad738x_fmc_zed [list \
       "system_constr_1sdi.xdc" ]

--- a/projects/ad738x_fmc/zed/system_top.v
+++ b/projects/ad738x_fmc/zed/system_top.v
@@ -1,6 +1,6 @@
 // ***************************************************************************
 // ***************************************************************************
-// Copyright (C) 2019-2024 Analog Devices, Inc. All rights reserved.
+// Copyright (C) 2019-2026 Analog Devices, Inc. All rights reserved.
 //
 // In this HDL repository, there are many different and unique modules, consisting
 // of various HDL (Verilog or VHDL) components. The individual modules are
@@ -37,7 +37,7 @@
 
 module system_top #(
   parameter ALERT_SPI_N = 0,
-  parameter NUM_OF_SDI = 1
+  parameter NUM_OF_SDIO = 1
 ) (
   inout  [14:0] ddr_addr,
   inout  [ 2:0] ddr_ba,
@@ -106,7 +106,7 @@ module system_top #(
   wire [ 1:0] iic_mux_sda_o_s;
   wire        iic_mux_sda_t_s;
 
-  wire [NUM_OF_SDI-1:0] ad738x_spi_sdi_s;
+  wire [NUM_OF_SDIO-1:0] ad738x_spi_sdi_s;
 
   // instantiations
 
@@ -115,7 +115,7 @@ module system_top #(
   assign gpio_i[32] = ALERT_SPI_N ? spi_sdib : 0;
   assign gpio_i[33] = ALERT_SPI_N ? spi_sdid : 0;
 
-  assign ad738x_spi_sdi_s = (ALERT_SPI_N == 0) ? ((NUM_OF_SDI == 1) ? {spi_sdia} : ((NUM_OF_SDI == 4) ? {spi_sdid, spi_sdic, spi_sdib, spi_sdia} : {spi_sdib, spi_sdia})): spi_sdia;
+  assign ad738x_spi_sdi_s = (ALERT_SPI_N == 0) ? ((NUM_OF_SDIO == 1) ? {spi_sdia} : ((NUM_OF_SDIO == 4) ? {spi_sdid, spi_sdic, spi_sdib, spi_sdia} : {spi_sdib, spi_sdia})): spi_sdia;
 
   ad_iobuf #(
     .DATA_WIDTH(32)

--- a/projects/ad7606x_fmc/common/ad7606x_bd.tcl
+++ b/projects/ad7606x_fmc/common/ad7606x_bd.tcl
@@ -5,13 +5,13 @@
 
 # system level parameters
 set INTF $ad_project_params(INTF)
-set NUM_OF_SDI $ad_project_params(NUM_OF_SDI)
+set NUM_OF_SDIO $ad_project_params(NUM_OF_SDIO)
 set ADC_N_BITS $ad_project_params(ADC_N_BITS)
 set ADC_TO_DMA_N_BITS [expr {$ADC_N_BITS == 16 ? 16 : 32}]
 set TOTAL_N_BITS_DMA [expr {$ADC_TO_DMA_N_BITS*8}]
 
 puts "build parameters: INTF: $INTF"
-puts "build parameters: NUM_OF_SDI: $NUM_OF_SDI"
+puts "build parameters: NUM_OF_SDIO: $NUM_OF_SDIO"
 puts "build parameters: ADC_N_BITS: $ADC_N_BITS"
 
 # control lines
@@ -121,7 +121,7 @@ switch $INTF {
     set async_spi_clk    1
     set offload_en       1
     set num_cs           1
-    set num_sdi          $NUM_OF_SDI
+    set num_sdi          $NUM_OF_SDIO
     set num_sdo          1
     set sdi_delay        1
 

--- a/projects/ad7606x_fmc/zed/README.md
+++ b/projects/ad7606x_fmc/zed/README.md
@@ -14,12 +14,12 @@ All of the configuration modes can be found in the chosen chips's data sheet. We
 - INTF - Defines the operation interface
   - 0 - Parallel
   - 1 - Serial
-- NUM_OF_SDI - Defines the number of SDI lines used: 1, 2, 4 or 8
+- NUM_OF_SDIO - Defines the number of SDI lines used: 1, 2, 4 or 8
 - ADC_N_BITS - Specifies the ADC resolution: 16 or 18 bits (only for the Parallel Interface)
 
 For the serial interface (INTF=1), the following parameters will be used in make command:
 - INTF
-- NUM_OF_SDI.
+- NUM_OF_SDIO.
 
 For the parallel interface (INTF=0), the following parameters will be used in make command:
 - INTF
@@ -47,25 +47,25 @@ make INTF=0 ADC_N_BITS=18
 #### Serial interface with 1 SDI line
 
 ```
-make INTF=1 NUM_OF_SDI=1
+make INTF=1 NUM_OF_SDIO=1
 ```
 
 #### Serial interface with 2 SDI lines
 
 ```
-make INTF=1 NUM_OF_SDI=2
+make INTF=1 NUM_OF_SDIO=2
 ```
 
 #### Serial interface with 4 SDI lines
 
 ```
-make INTF=1 NUM_OF_SDI=4
+make INTF=1 NUM_OF_SDIO=4
 ```
 
 #### Serial interface with 8 SDI lines
 
 ```
-make INTF=1 NUM_OF_SDI=8
+make INTF=1 NUM_OF_SDIO=8
 ```
 
 Corresponding no-OS project: [ad7606x-fmc](https://github.com/analogdevicesinc/no-OS/tree/main/projects/ad7606x-fmc)

--- a/projects/ad7606x_fmc/zed/system_bd.tcl
+++ b/projects/ad7606x_fmc/zed/system_bd.tcl
@@ -21,6 +21,6 @@ ad_ip_parameter rom_sys_0 CONFIG.ROM_ADDR_BITS 9
 
 set sys_cstring "INTF=$ad_project_params(INTF)\
 ADC_N_BITS=$ad_project_params(ADC_N_BITS)\
-NUM_OF_SDI=$ad_project_params(NUM_OF_SDI)"
+NUM_OF_SDIO=$ad_project_params(NUM_OF_SDIO)"
 
 sysid_gen_sys_init_file $sys_cstring

--- a/projects/ad7606x_fmc/zed/system_project.tcl
+++ b/projects/ad7606x_fmc/zed/system_project.tcl
@@ -10,18 +10,18 @@ source $ad_hdl_dir/projects/scripts/adi_board.tcl
 # Parameter description
 # INTF - Operation interface
 #  - Options : Parallel(0)/Serial(1)
-# NUM_OF_SDI - Number of SDI lines used
+# NUM_OF_SDIO - Number of SDI lines used
 #  - Options: 1, 2, 4, 8
 # ADC_N_BITS - ADC resolution
 #  - Options: 16, 18
 
-set NUM_OF_SDI [get_env_param NUM_OF_SDI 2]
+set NUM_OF_SDIO [get_env_param NUM_OF_SDIO 2]
 set ADC_N_BITS [get_env_param ADC_N_BITS 16]
 set INTF [get_env_param INTF 0]
 
 adi_project ad7606x_fmc_zed 0 [list \
   INTF $INTF \
-  NUM_OF_SDI $NUM_OF_SDI \
+  NUM_OF_SDIO $NUM_OF_SDIO \
   ADC_N_BITS $ADC_N_BITS \
 ]
 
@@ -36,7 +36,7 @@ switch $INTF {
       "system_constr_pif.xdc"]
   }
   1 {
-    switch $NUM_OF_SDI {
+    switch $NUM_OF_SDIO {
       1 {
         adi_project_files ad7606x_fmc_zed [list \
           "system_top_si.v" \

--- a/projects/ad7606x_fmc/zed/system_top_si.v
+++ b/projects/ad7606x_fmc/zed/system_top_si.v
@@ -1,6 +1,6 @@
 // ***************************************************************************
 // ***************************************************************************
-// Copyright (C) 2023-2024 Analog Devices, Inc. All rights reserved.
+// Copyright (C) 2023-2026 Analog Devices, Inc. All rights reserved.
 //
 // In this HDL repository, there are many different and unique modules, consisting
 // of various HDL (Verilog or VHDL) components. The individual modules are
@@ -36,7 +36,7 @@
 `timescale 1ns/100ps
 
 module system_top #(
-  parameter NUM_OF_SDI = 2
+  parameter NUM_OF_SDIO = 2
 ) (
   inout  [14:0] ddr_addr,
   inout  [ 2:0] ddr_ba,
@@ -86,7 +86,7 @@ module system_top #(
 
   output        ad7606_spi_cs,
   output        ad7606_spi_sclk,
-  input  [NUM_OF_SDI-1:0] ad7606_spi_sdi,
+  input  [NUM_OF_SDIO-1:0] ad7606_spi_sdi,
   output        ad7606_spi_sdo,
 
   inout         adc_serpar,

--- a/projects/ad7616_sdz/common/ad7616_bd.tcl
+++ b/projects/ad7616_sdz/common/ad7616_bd.tcl
@@ -7,10 +7,10 @@
 # system level parameter
 
 set INTF $ad_project_params(INTF)
-set NUM_OF_SDI $ad_project_params(NUM_OF_SDI)
+set NUM_OF_SDIO $ad_project_params(NUM_OF_SDIO)
 
 puts "build parameters: INTF: $INTF"
-puts "build parameters: NUM_OF_SDI: $NUM_OF_SDI"
+puts "build parameters: NUM_OF_SDIO: $NUM_OF_SDIO"
 
 # control lines
 
@@ -55,7 +55,7 @@ if {$INTF == 1} {
   set async_spi_clk 1
   set offload_en    1
   set num_cs        1
-  set num_sdi       $NUM_OF_SDI
+  set num_sdi       $NUM_OF_SDIO
   set sdi_delay     1
   set hier_spi_engine spi_ad7616
 

--- a/projects/ad7616_sdz/zed/README.md
+++ b/projects/ad7616_sdz/zed/README.md
@@ -19,7 +19,7 @@ The overwritable parameter from the environment:
   - 0 - parallel interface (default)
   - 1 - serial interface
 
-- NUM_OF_SDI - specifies the number of SDI lines used when **serial interface** is set;
+- NUM_OF_SDIO - specifies the number of SDI lines used when **serial interface** is set;
   - 1 - one SDI line
   - 2 - two SDI lines (default)
 
@@ -41,10 +41,10 @@ make INTF=0
 #### Serial interface
 
 ```
-make INTF=1 NUM_OF_SDI=1
+make INTF=1 NUM_OF_SDIO=1
 ```
 ```
-make INTF=1 NUM_OF_SDI=2
+make INTF=1 NUM_OF_SDIO=2
 ```
 
 Corresponding No-OS project for both configurations: [ad7616-sdz](https://github.com/analogdevicesinc/no-OS/tree/main/projects/ad7616-sdz)

--- a/projects/ad7616_sdz/zed/system_bd.tcl
+++ b/projects/ad7616_sdz/zed/system_bd.tcl
@@ -20,6 +20,6 @@ ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "$mem_init_sys_file_path/mem_init_
 ad_ip_parameter rom_sys_0 CONFIG.ROM_ADDR_BITS 9
 
 set sys_cstring "INTF=$ad_project_params(INTF)\
-NUM_OF_SDI=$ad_project_params(NUM_OF_SDI)"
+NUM_OF_SDIO=$ad_project_params(NUM_OF_SDIO)"
 
 sysid_gen_sys_init_file $sys_cstring

--- a/projects/ad7616_sdz/zed/system_project.tcl
+++ b/projects/ad7616_sdz/zed/system_project.tcl
@@ -21,7 +21,7 @@ source $ad_hdl_dir/projects/scripts/adi_board.tcl
 # INTF  - Defines the interface type (serial OR parallel)
 #       - 0 - parallel (default)
 #       - 1 - serial
-# NUM_OF_SDI - Number of SDI lines used when **serial interface** is set
+# NUM_OF_SDIO - Number of SDI lines used when **serial interface** is set
 #       - 1 - one SDI line
 #       - 2 - two SDI lines (default)
 #
@@ -33,11 +33,11 @@ source $ad_hdl_dir/projects/scripts/adi_board.tcl
 ##--------------------------------------------------------------
 
 set INTF [get_env_param INTF 0]
-set NUM_OF_SDI [get_env_param NUM_OF_SDI 2]
+set NUM_OF_SDIO [get_env_param NUM_OF_SDIO 2]
 
 adi_project ad7616_sdz_zed 0 [list \
    INTF $INTF \
-   NUM_OF_SDI $NUM_OF_SDI \
+   NUM_OF_SDIO $NUM_OF_SDIO \
 ]
 
 adi_project_files ad7616_sdz_zed [list \
@@ -45,7 +45,7 @@ adi_project_files ad7616_sdz_zed [list \
 
 switch $INTF {
   1 {
-    switch $NUM_OF_SDI {
+    switch $NUM_OF_SDIO {
       1 {
         adi_project_files ad7616_sdz_zed [list \
         "system_top_si.v" \

--- a/projects/ad7616_sdz/zed/system_top_si.v
+++ b/projects/ad7616_sdz/zed/system_top_si.v
@@ -1,6 +1,6 @@
 // ***************************************************************************
 // ***************************************************************************
-// Copyright (C) 2014-2025 Analog Devices, Inc. All rights reserved.
+// Copyright (C) 2014-2026 Analog Devices, Inc. All rights reserved.
 //
 // In this HDL repository, there are many different and unique modules, consisting
 // of various HDL (Verilog or VHDL) components. The individual modules are
@@ -36,7 +36,7 @@
 `timescale 1ns/100ps
 
 module system_top #(
-  parameter NUM_OF_SDI = 2
+  parameter NUM_OF_SDIO = 2
 ) (
   inout  [14:0]           ddr_addr,
   inout  [ 2:0]           ddr_ba,
@@ -78,7 +78,7 @@ module system_top #(
   input                   otg_vbusoc,
   output                  ad7616_spi_sclk,
   output                  ad7616_spi_sdo,
-  input  [NUM_OF_SDI-1:0] ad7616_spi_sdi,
+  input  [NUM_OF_SDIO-1:0] ad7616_spi_sdi,
   output                  ad7616_spi_cs,
   output                  adc_reset_n,
   output                  adc_cnvst,

--- a/projects/adaq7980_sdz/common/adaq7980_bd.tcl
+++ b/projects/adaq7980_sdz/common/adaq7980_bd.tcl
@@ -34,11 +34,11 @@ ad_ip_parameter axi_adaq7980_dma CONFIG.DMA_2D_TRANSFER 0
 ad_ip_parameter axi_adaq7980_dma CONFIG.DMA_DATA_WIDTH_SRC 16
 ad_ip_parameter axi_adaq7980_dma CONFIG.DMA_DATA_WIDTH_DEST 64
 
- # axi_clkgen
+# axi_clkgen
 ad_ip_instance axi_clkgen spi_clkgen
-ad_ip_parameter spi_clkgen CONFIG.CLK0_DIV 5 
-ad_ip_parameter spi_clkgen CONFIG.VCO_DIV 1 
-ad_ip_parameter spi_clkgen CONFIG.VCO_MUL 8 
+ad_ip_parameter spi_clkgen CONFIG.CLK0_DIV 5
+ad_ip_parameter spi_clkgen CONFIG.VCO_DIV 1
+ad_ip_parameter spi_clkgen CONFIG.VCO_MUL 8
 
 ad_connect $sys_cpu_clk spi_clkgen/clk
 ad_connect spi_clk spi_clkgen/clk_0


### PR DESCRIPTION
## PR Description

Upgrade SPI engine to support up to 8 lanes. For that, two new registers were inserted into Configuration Write Instruction, they are responsible for setting the SDI and SDO lane masks. Each bit represents a lane.
This PR also removes register 8'h3b from the SPI Engine regmap.
The testbench for this modification is here: https://github.com/analogdevicesinc/testbenches/pull/240

## PR Type
- [ ] Bug fix (change that fixes an issue)
- [x] New feature (change that adds new functionality)
- [x] Breaking change (has dependencies in other repos or will cause CI to fail)
- [x] Documentation

## PR Checklist
- [x] I have followed the code style guidelines
- [x] I have performed a self-review of changes
- [ ] I have compiled all hdl projects and libraries affected by this PR
- [ ] I have tested in hardware affected projects, at least on relevant boards
- [x] I have commented my code, at least hard-to-understand parts
- [x] I have signed off all commits from this PR
- [x] I have updated the documentation (wiki pages, ReadMe files, Copyright etc)
- [x] I have not introduced new Warnings/Critical Warnings on compilation
- [x] I have added new hdl testbenches or updated existing ones
