### PR TITLE
docs: creating new ip: set guidelines for core version

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -139,7 +139,25 @@ and responsibilities that he or she has by using them.
 - If it's the case, to update all the README files of the affected projects
   and IP cores.
 
-Resources:
+## Devicetree bindings & drivers
+
+The IPs typically follow [Semantic Versioning 2.0.0](https://semver.org/)
+and his information must be used in devicetree bindings and drivers to assert
+compatibility. The first stable release version should be higher or equal to
+v1.0.0 and all fields should be treated as decimals.
+
+Devicetree compatibles take the major number prefixed by **v**, for example,
+the **compatible** of *axi_my_ip* v1.2.3 is **adi,axi-my-ip-v1** and the
+**dt-binding** filename is **adi,axi-my-ip.yaml** (no major suffix). Per the
+last paragraph, *adi,axi-my-ip-v0* is **never** appropriate.
+
+Software drivers must parse the **VERSION** register for feature handling
+across versions. The patch number shouldn't have to be handled by software
+drivers, if it seems necessary to, consider incrementing the minor number
+instead.
+
+## Related resources
+
 * [How to write a good commit message](https://cbea.ms/git-commit/) and [another resource](https://gist.github.com/rsp/057481db4dbd999bb7077f211f53f212)
 * [Write better commits, build better projects](https://github.blog/2022-06-30-write-better-commits-build-better-projects/)
 * [Good commit example (but extreme one)](https://dhwthompson.com/2019/my-favourite-git-commit)

--- a/docs/user_guide/contributing.rst
+++ b/docs/user_guide/contributing.rst
@@ -153,7 +153,28 @@ Code-related check list
 #.  If it's the case, to update all the README files of the affected projects
     and IP cores.
 
-Resources:
+.. _contributing devicetree-bindings-drivers:
+
+Devicetree bindings & drivers
+-------------------------------------------------------------------------------
+
+The IPs typically follow `Semantic Versioning 2.0.0 <https://semver.org/>`__
+and his information must be used in devicetree bindings and drivers to assert
+compatibility. The first stable release version should be higher or equal to
+v1.0.0 and all fields should be treated as decimals.
+
+Devicetree compatibles take the major number prefixed by **v**, for example,
+the **compatible** of *axi_my_ip* v1.2.3 is **adi,axi-my-ip-v1** and the
+**dt-binding** filename is **adi,axi-my-ip.yaml** (no major suffix). Per the
+last paragraph, *adi,axi-my-ip-v0* is **never** appropriate.
+
+Software drivers must parse the **VERSION** register for feature handling
+across versions. The patch number shouldn't have to be handled by software
+drivers, if it seems necessary to, consider incrementing the minor number
+instead.
+
+Related resources
+-------------------------------------------------------------------------------
 
 -  `How to write a good commit message <https://cbea.ms/git-commit/>`__
    and `another resource <https://gist.github.com/rsp/057481db4dbd999bb7077f211f53f212>`__

--- a/docs/user_guide/ip_cores/creating_new_ip.rst
+++ b/docs/user_guide/ip_cores/creating_new_ip.rst
@@ -13,7 +13,7 @@ and ``axi_led_control_intel`` for Intel.
 Verilog File
 --------------------------------------------------------------------------------
 
-Lets say you want to make a new IP with the name ``<module_name>``.
+Consider you want to make a new IP with the name ``<module_name>``.
 You must edit the verilog file so that it has the same name (e.g. ``axi_led_control.v``).
 After that, feel free to write the verilog code for your purpose.
 You can also use other instances of modules, but be sure to include them after,
@@ -177,9 +177,9 @@ Examples:
 Importing with Using Method
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The ``USING`` method allows to look-up a register map to import register and
+The ``USING`` method allows looking up a register map to import register and
 fields.
-A register map can look-up multiple register maps by repeating the method for
+A register map can look up multiple register maps by repeating the method for
 each register map, for example:
 
 .. code::
@@ -235,7 +235,7 @@ Some considerations:
 
 * Imported registers shall have non-imported fields, for example, when importing
   a register that is reserved for custom implementation.
-* Imported fields must be inside a imported register, since the field name is not
+* Imported fields must be inside an imported register, since the field name is not
   unique.
 * Multiple fields can be imported from a single ``FIELD`` group.
 * Multiple register maps can be used for lookup. Add each in a different ``USING``
@@ -813,7 +813,7 @@ trying to simulate most of the available options when creating a new IP.
 
       # Generating the IP given as first parameter on the path given as the second
       # parameter. Without the second parameter the IP will be generated in
-      # ./ltt directory and  in the default IP download directory of
+      # ./ltt directory and in the default IP download directory of
       # Lattice Propel Builder (~/PropelIPLocal) if the LATTICE_DEFAULT_PATHS
       # env variable is exported like:
       # 'export LATTICE_DEFAULT_PATHS=1' before running the script or running make.


### PR DESCRIPTION
## PR Description

For historical reasons, we have been creating linux dt-bindings suffixed
with 1.00.a, because that was the default vivado set value, and what
would be outputted by
[SDTGen](https://xilinx-wiki.atlassian.net/wiki/spaces/A/pages/3156475927/Overview+of+System+Device+Tree+Generator+SDTGen).

Nowadays, vivado default is 1.0 and the auto-generated devicetrees never
really matched with the actual devicetree bindings.
To improve overall coherence between hdl and linux, I propose the
following:
* semantic versioning across the board,
* dt-bindings are suffixed by `-v<major>`, and should match the filename
  and compatible
* Bus connected Ips should have the IP-XACT version set to
  `<major>.<minor>.<patch>` (I developed a method to autoset based on
  CORE_VERSION)
* Drivers should print the version reg as %u.%u.%u

New software:
* dt-bindings suffixed by `-v<major>`

Existing software:
* Format patch version as decimal, without bumping, e.g. ‘a’ -> 61
* update drivers to print %u.%u.%u instead of %u.%u.%c


## PR Type
- [ ] Bug fix (change that fixes an issue)
- [X] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)
- [x] Documentation

## PR Checklist
- [x] I have followed the code style guidelines
- [x] I have performed a self-review of changes
- [ ] I have compiled all hdl projects and libraries affected by this PR
- [ ] I have tested in hardware affected projects, at least on relevant boards
- [ ] I have commented my code, at least hard-to-understand parts
- [ ] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe files, Copyright etc)
- [ ] I have not introduced new Warnings/Critical Warnings on compilation
- [ ] I have added new hdl testbenches or updated existing ones
