### PR TITLE
projects/common: Add Kria 26 SOM base design

### DIFF
--- a/projects/common/k26/Makefile
+++ b/projects/common/k26/Makefile
@@ -1,0 +1,16 @@
+####################################################################################
+## Copyright (C) 2025 Analog Devices, Inc.
+### SPDX short identifier: BSD-1-Clause
+## Auto-generated, do not modify!
+####################################################################################
+
+PROJECT_NAME := template_k26
+
+M_DEPS += ../../scripts/adi_pd.tcl
+M_DEPS += ../../common/k26/k26_system_constr.xdc
+M_DEPS += ../../common/k26/k26_system_bd.tcl
+
+LIB_DEPS += axi_sysid
+LIB_DEPS += sysid_rom
+
+include ../../scripts/project-xilinx.mk

--- a/projects/common/k26/k26_system_bd.tcl
+++ b/projects/common/k26/k26_system_bd.tcl
@@ -1,0 +1,154 @@
+###############################################################################
+## Copyright (C) 2025 Analog Devices, Inc. All rights reserved.
+### SPDX short identifier: ADIBSD
+###############################################################################
+
+set CACHE_COHERENCY true
+
+# create board design
+# set Kria SOM240_1 connector to KV260 evaluation carrier
+set_property board_connections {som240_1_connector xilinx.com:kv260_carrier:som240_1_connector:1.3} [current_project]
+
+# default ports
+
+create_bd_port -dir O -from 2 -to 0 spi0_csn
+create_bd_port -dir O spi0_sclk
+create_bd_port -dir O spi0_mosi
+create_bd_port -dir I spi0_miso
+
+create_bd_port -dir I -from 94 -to 0 gpio_i
+create_bd_port -dir O -from 94 -to 0 gpio_o
+create_bd_port -dir O -from 94 -to 0 gpio_t
+
+# instance: sys_ps8
+
+ad_ip_instance zynq_ultra_ps_e sys_ps8
+apply_bd_automation -rule xilinx.com:bd_rule:zynq_ultra_ps_e \
+  -config {apply_board_preset 1}  [get_bd_cells sys_ps8]
+
+set_property -dict "CONFIG.PSU__PSS_REF_CLK__FREQMHZ 33.333333333 CONFIG.PSU__DDRC__CWL 16" [get_bd_cells sys_ps8]
+ad_ip_parameter sys_ps8 CONFIG.PSU__USE__M_AXI_GP0 0
+ad_ip_parameter sys_ps8 CONFIG.PSU__USE__M_AXI_GP1 0
+ad_ip_parameter sys_ps8 CONFIG.PSU__USE__M_AXI_GP2 1
+ad_ip_parameter sys_ps8 CONFIG.PSU__MAXIGP2__DATA_WIDTH 32
+ad_ip_parameter sys_ps8 CONFIG.PSU__FPGA_PL0_ENABLE 1
+ad_ip_parameter sys_ps8 CONFIG.PSU__CRL_APB__PL0_REF_CTRL__SRCSEL {IOPLL}
+ad_ip_parameter sys_ps8 CONFIG.PSU__CRL_APB__PL0_REF_CTRL__FREQMHZ 100
+ad_ip_parameter sys_ps8 CONFIG.PSU__FPGA_PL1_ENABLE 1
+ad_ip_parameter sys_ps8 CONFIG.PSU__FPGA_PL2_ENABLE 1
+ad_ip_parameter sys_ps8 CONFIG.PSU__CRL_APB__PL1_REF_CTRL__SRCSEL {IOPLL}
+ad_ip_parameter sys_ps8 CONFIG.PSU__CRL_APB__PL1_REF_CTRL__FREQMHZ 250
+ad_ip_parameter sys_ps8 CONFIG.PSU__CRL_APB__PL2_REF_CTRL__SRCSEL {IOPLL}
+ad_ip_parameter sys_ps8 CONFIG.PSU__CRL_APB__PL2_REF_CTRL__FREQMHZ 500
+ad_ip_parameter sys_ps8 CONFIG.PSU__USE__IRQ0 1
+ad_ip_parameter sys_ps8 CONFIG.PSU__USE__IRQ1 1
+ad_ip_parameter sys_ps8 CONFIG.PSU__GPIO_EMIO__PERIPHERAL__ENABLE 1
+
+set_property -dict [list \
+  CONFIG.PSU__SPI0__PERIPHERAL__ENABLE 1 \
+  CONFIG.PSU__SPI0__PERIPHERAL__IO {EMIO} \
+  CONFIG.PSU__SPI0__GRP_SS1__ENABLE 1 \
+  CONFIG.PSU__SPI0__GRP_SS2__ENABLE 1 \
+  CONFIG.PSU__CRL_APB__SPI0_REF_CTRL__FREQMHZ 100 \
+] [get_bd_cells sys_ps8]
+
+# processor system reset instances for all the three system clocks
+
+ad_ip_instance proc_sys_reset sys_rstgen
+ad_ip_parameter sys_rstgen CONFIG.C_EXT_RST_WIDTH 1
+ad_ip_instance proc_sys_reset sys_250m_rstgen
+ad_ip_parameter sys_250m_rstgen CONFIG.C_EXT_RST_WIDTH 1
+ad_ip_instance proc_sys_reset sys_500m_rstgen
+ad_ip_parameter sys_500m_rstgen CONFIG.C_EXT_RST_WIDTH 1
+
+# system reset/clock definitions
+
+ad_connect  sys_cpu_clk sys_ps8/pl_clk0
+ad_connect  sys_250m_clk sys_ps8/pl_clk1
+ad_connect  sys_500m_clk sys_ps8/pl_clk2
+
+ad_connect  sys_ps8/pl_resetn0 sys_rstgen/ext_reset_in
+ad_connect  sys_cpu_clk sys_rstgen/slowest_sync_clk
+ad_connect  sys_ps8/pl_resetn0 sys_250m_rstgen/ext_reset_in
+ad_connect  sys_250m_clk sys_250m_rstgen/slowest_sync_clk
+ad_connect  sys_ps8/pl_resetn0 sys_500m_rstgen/ext_reset_in
+ad_connect  sys_500m_clk sys_500m_rstgen/slowest_sync_clk
+
+ad_connect  sys_cpu_reset sys_rstgen/peripheral_reset
+ad_connect  sys_cpu_resetn sys_rstgen/peripheral_aresetn
+ad_connect  sys_250m_reset sys_250m_rstgen/peripheral_reset
+ad_connect  sys_250m_resetn sys_250m_rstgen/peripheral_aresetn
+ad_connect  sys_500m_reset sys_500m_rstgen/peripheral_reset
+ad_connect  sys_500m_resetn sys_500m_rstgen/peripheral_aresetn
+
+# generic system clocks&resets pointers
+
+set sys_cpu_clk            [get_bd_nets sys_cpu_clk]
+set sys_dma_clk            [get_bd_nets sys_250m_clk]
+set sys_iodelay_clk        [get_bd_nets sys_500m_clk]
+
+set  sys_cpu_reset         [get_bd_nets sys_cpu_reset]
+set  sys_cpu_resetn        [get_bd_nets sys_cpu_resetn]
+set  sys_dma_reset         [get_bd_nets sys_250m_reset]
+set  sys_dma_resetn        [get_bd_nets sys_250m_resetn]
+set  sys_iodelay_reset     [get_bd_nets sys_500m_reset]
+set  sys_iodelay_resetn    [get_bd_nets sys_500m_resetn]
+
+# gpio
+
+ad_connect  gpio_i sys_ps8/emio_gpio_i
+ad_connect  gpio_o sys_ps8/emio_gpio_o
+ad_connect  gpio_t sys_ps8/emio_gpio_t
+
+# spi
+
+ad_ip_instance xlconcat spi0_csn_concat
+ad_ip_parameter spi0_csn_concat CONFIG.NUM_PORTS 3
+ad_connect  sys_ps8/emio_spi0_ss_o_n spi0_csn_concat/In0
+ad_connect  sys_ps8/emio_spi0_ss1_o_n spi0_csn_concat/In1
+ad_connect  sys_ps8/emio_spi0_ss2_o_n spi0_csn_concat/In2
+ad_connect  spi0_csn_concat/dout spi0_csn
+ad_connect  sys_ps8/emio_spi0_sclk_o spi0_sclk
+ad_connect  sys_ps8/emio_spi0_m_o spi0_mosi
+ad_connect  sys_ps8/emio_spi0_m_i spi0_miso
+ad_connect  sys_ps8/emio_spi0_ss_i_n VCC
+ad_connect  sys_ps8/emio_spi0_sclk_i GND
+ad_connect  sys_ps8/emio_spi0_s_i GND
+
+ad_ip_instance xlconcat sys_concat_intc_0
+ad_ip_parameter sys_concat_intc_0 CONFIG.NUM_PORTS 8
+
+ad_ip_instance xlconcat sys_concat_intc_1
+ad_ip_parameter sys_concat_intc_1 CONFIG.NUM_PORTS 8
+
+ad_connect  sys_concat_intc_0/dout sys_ps8/pl_ps_irq0
+ad_connect  sys_concat_intc_1/dout sys_ps8/pl_ps_irq1
+
+ad_connect  sys_concat_intc_1/In7 GND
+ad_connect  sys_concat_intc_1/In6 GND
+ad_connect  sys_concat_intc_1/In5 GND
+ad_connect  sys_concat_intc_1/In4 GND
+ad_connect  sys_concat_intc_1/In3 GND
+ad_connect  sys_concat_intc_1/In2 GND
+ad_connect  sys_concat_intc_1/In1 GND
+ad_connect  sys_concat_intc_1/In0 GND
+
+ad_connect  sys_concat_intc_0/In7 GND
+ad_connect  sys_concat_intc_0/In6 GND
+ad_connect  sys_concat_intc_0/In5 GND
+ad_connect  sys_concat_intc_0/In4 GND
+ad_connect  sys_concat_intc_0/In3 GND
+ad_connect  sys_concat_intc_0/In2 GND
+ad_connect  sys_concat_intc_0/In1 GND
+ad_connect  sys_concat_intc_0/In0 GND
+
+# system id
+
+ad_ip_instance axi_sysid axi_sysid_0
+ad_ip_instance sysid_rom rom_sys_0
+
+ad_connect  axi_sysid_0/rom_addr   	rom_sys_0/rom_addr
+ad_connect  axi_sysid_0/sys_rom_data   	rom_sys_0/rom_data
+ad_connect  sys_cpu_clk                 rom_sys_0/clk
+
+ad_cpu_interconnect 0x45000000 axi_sysid_0

--- a/projects/common/k26/k26_system_constr.xdc
+++ b/projects/common/k26/k26_system_constr.xdc
@@ -1,0 +1,7 @@
+###############################################################################
+## Copyright (C) 2025 Analog Devices, Inc. All rights reserved.
+### SPDX short identifier: ADIBSD
+###############################################################################
+
+# constraints
+set_property BITSTREAM.CONFIG.OVERTEMPSHUTDOWN ENABLE [current_design]

--- a/projects/common/k26/system_bd.tcl
+++ b/projects/common/k26/system_bd.tcl
@@ -1,0 +1,14 @@
+###############################################################################
+## Copyright (C) 2025 Analog Devices, Inc. All rights reserved.
+### SPDX short identifier: ADIBSD
+###############################################################################
+
+source $ad_hdl_dir/projects/scripts/adi_pd.tcl
+source $ad_hdl_dir/projects/common/k26/k26_system_bd.tcl
+
+#system ID
+ad_ip_parameter axi_sysid_0 CONFIG.ROM_ADDR_BITS 9
+ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "$mem_init_sys_file_path/mem_init_sys.txt"
+ad_ip_parameter rom_sys_0 CONFIG.ROM_ADDR_BITS 9
+
+sysid_gen_sys_init_file

--- a/projects/common/k26/system_project.tcl
+++ b/projects/common/k26/system_project.tcl
@@ -1,0 +1,16 @@
+###############################################################################
+## Copyright (C) 2025 Analog Devices, Inc. All rights reserved.
+### SPDX short identifier: ADIBSD
+###############################################################################
+
+source ../../../scripts/adi_env.tcl
+source $ad_hdl_dir/projects/scripts/adi_project_xilinx.tcl
+source $ad_hdl_dir/projects/scripts/adi_board.tcl
+
+adi_project template_k26
+adi_project_files template_k26 [list \
+  "system_top.v" \
+  "$ad_hdl_dir/projects/common/k26/k26_system_constr.xdc" \
+]
+
+adi_project_run template_k26

--- a/projects/common/k26/system_top.v
+++ b/projects/common/k26/system_top.v
@@ -1,0 +1,56 @@
+// ***************************************************************************
+// ***************************************************************************
+// Copyright (C) 2025 Analog Devices, Inc. All rights reserved.
+//
+// In this HDL repository, there are many different and unique modules, consisting
+// of various HDL (Verilog or VHDL) components. The individual modules are
+// developed independently, and may be accompanied by separate and unique license
+// terms.
+//
+// The user should read each of these license terms, and understand the
+// freedoms and responsibilities that he or she has by using this source/core.
+//
+// This core is distributed in the hope that it will be useful, but WITHOUT ANY
+// WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+// A PARTICULAR PURPOSE.
+//
+// Redistribution and use of source or resulting binaries, with or without modification
+// of this file, are permitted under one of the following two license terms:
+//
+//   1. The GNU General Public License version 2 as published by the
+//      Free Software Foundation, which can be found in the top level directory
+//      of this repository (LICENSE_GPL2), and also online at:
+//      <https://www.gnu.org/licenses/old-licenses/gpl-2.0.html>
+//
+// OR
+//
+//   2. An ADI specific BSD license, which can be found in the top level directory
+//      of this repository (LICENSE_ADIBSD), and also on-line at:
+//      https://github.com/analogdevicesinc/hdl/blob/main/LICENSE_ADIBSD
+//      This will allow to generate bit files and not release the source code,
+//      as long as it attaches to an ADI device.
+//
+// ***************************************************************************
+// ***************************************************************************
+
+`timescale 1ns/100ps
+
+module system_top ();
+
+  wire    [94:0]  gpio_i;
+  wire    [94:0]  gpio_o;
+
+  assign gpio_i = gpio_o;
+
+  // instantiations
+  system_wrapper i_system_wrapper (
+    .gpio_i (gpio_i),
+    .gpio_o (gpio_o),
+    .gpio_t (),
+
+    .spi0_csn (),
+    .spi0_miso (1'b0),
+    .spi0_mosi (),
+    .spi0_sclk ());
+
+endmodule


### PR DESCRIPTION
## PR Description

Adds the Kria 26 SOM standalone base desgin.


## PR Type
- [ ] Bug fix (change that fixes an issue)
- [x] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)
- [ ] Documentation

## PR Checklist
- [x] I have followed the code style guidelines
- [x] I have performed a self-review of changes
- [x] I have compiled all hdl projects and libraries affected by this PR
- [ ] I have tested in hardware affected projects, at least on relevant boards
- [x] I have commented my code, at least hard-to-understand parts
- [x] I have signed off all commits from this PR
- [x] I have updated the documentation (wiki pages, ReadMe files, Copyright etc)
- [x] I have not introduced new Warnings/Critical Warnings on compilation
- [ ] I have added new hdl testbenches or updated existing ones
