### PR TITLE
fmcomms11: Add VADJ value in READMEs

### DIFF
--- a/projects/fmcomms11/README.md
+++ b/projects/fmcomms11/README.md
@@ -3,6 +3,7 @@
 - Evaluation board product page: [AD-FMCOMMS11-EBZ](https://www.analog.com/ad-fmcomms11-ebz)
 - System documentation: https://wiki.analog.com/resources/eval/user-guides/ad-fmcomms11-ebz
 - HDL project documentation: https://analogdevicesinc.github.io/hdl/projects/fmcomms11/index.html
+- Evaluation board VADJ range: 1.2V - 3.3V
 
 ## Supported parts
 

--- a/projects/fmcomms11/zc706/README.md
+++ b/projects/fmcomms11/zc706/README.md
@@ -1,4 +1,8 @@
+<!-- no_build_example, no_no_os -->
+
 # FMCOMMS11/ZC706 HDL Project
+
+- VADJ with which it was tested in hardware: 2.5V
 
 ## Building the project
 


### PR DESCRIPTION
## PR Description

Add VADJ values & flags in fmcomms11 README files.

## PR Type
- [ ] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)
- [x] Documentation

## PR Checklist
- [x] I have followed the code style guidelines
- [x] I have performed a self-review of changes
- [ ] I have compiled all hdl projects and libraries affected by this PR
- [ ] I have tested in hardware affected projects, at least on relevant boards
- [ ] I have commented my code, at least hard-to-understand parts
- [x] I have signed off all commits from this PR
- [x] I have updated the documentation (wiki pages, ReadMe files, Copyright etc)
- [x] I have not introduced new Warnings/Critical Warnings on compilation
- [ ] I have added new hdl testbenches or updated existing ones
