### PR TITLE
library: xilinx: Add selmap IP

### DIFF
--- a/library/xilinx/axi_selmap/Makefile
+++ b/library/xilinx/axi_selmap/Makefile
@@ -1,0 +1,16 @@
+####################################################################################
+## Copyright (c) 2024 - 2024 Analog Devices, Inc.
+### SPDX short identifier: BSD-1-Clause
+## Auto-generated, do not modify!
+####################################################################################
+
+LIBRARY_NAME := axi_selmap
+
+GENERIC_DEPS += ../../common/up_axi.v
+GENERIC_DEPS += axi_selmap.v
+GENERIC_DEPS += axi_selmap_regmap.v
+GENERIC_DEPS += async_cdc_fifo.v
+
+XILINX_DEPS += axi_selmap_ip.tcl
+
+include ../../scripts/library.mk

--- a/library/xilinx/axi_selmap/async_cdc_fifo.v
+++ b/library/xilinx/axi_selmap/async_cdc_fifo.v
@@ -1,0 +1,104 @@
+// ***************************************************************************
+// ***************************************************************************
+// Copyright (C) 2025 Analog Devices, Inc. All rights reserved.
+//
+// In this HDL repository, there are many different and unique modules, consisting
+// of various HDL (Verilog or VHDL) components. The individual modules are
+// developed independently, and may be accompanied by separate and unique license
+// terms.
+//
+// The user should read each of these license terms, and understand the
+// freedoms and responsibilities that he or she has by using this source/core.
+//
+// This core is distributed in the hope that it will be useful, but WITHOUT ANY
+// WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+// A PARTICULAR PURPOSE.
+//
+// Redistribution and use of source or resulting binaries, with or without modification
+// of this file, are permitted under one of the following two license terms:
+//
+//   1. The GNU General Public License version 2 as published by the
+//      Free Software Foundation, which can be found in the top level directory
+//      of this repository (LICENSE_GPL2), and also online at:
+//      <https://www.gnu.org/licenses/old-licenses/gpl-2.0.html>
+//
+// OR
+//
+//   2. An ADI specific BSD license, which can be found in the top level directory
+//      of this repository (LICENSE_ADIBSD), and also on-line at:
+//      https://github.com/analogdevicesinc/hdl/blob/main/LICENSE_ADIBSD
+//      This will allow to generate bit files and not release the source code,
+//      as long as it attaches to an ADI device.
+//
+// ***************************************************************************
+// ***************************************************************************
+
+module async_cdc_fifo #(
+  parameter DATA_WIDTH = 32,
+  parameter CLK_DIV = 20,
+  parameter FIFO_DEPTH = (CLK_DIV <= 2) ? 4 : 2 ** $clog2(CLK_DIV)
+) (
+  input wire wr_clk,
+  input wire rd_clk,
+  input wire rstn,
+  input wire [DATA_WIDTH-1:0] wr_data,
+  input wire wr_en,
+  input wire rd_en,
+  output reg [DATA_WIDTH-1:0] rd_data,
+  output wire fifo_full,
+  output wire fifo_empty,
+  output wire rd_data_valid
+);
+
+  localparam ADDR_WIDTH = $clog2(FIFO_DEPTH);
+
+  reg [DATA_WIDTH-1:0] fifo[FIFO_DEPTH-1:0];
+  reg [ADDR_WIDTH-0:0] wr_ptr_gray = 0, rd_ptr_gray = 0;
+  reg [ADDR_WIDTH-0:0] wr_ptr_bin = 0, rd_ptr_bin = 0;
+  reg                  rd_data_valid_s = 0;
+
+  function [ADDR_WIDTH:0] bin2gray (input [ADDR_WIDTH:0] binary);
+    bin2gray = binary ^ (binary >> 1);
+  endfunction
+
+  function [ADDR_WIDTH:0] gray2bin (input [ADDR_WIDTH:0] gray);
+  integer i;
+  begin
+    gray2bin = gray;
+    for (i = 1; i <= ADDR_WIDTH; i = i + 1) begin
+      gray2bin = gray2bin ^ (gray >> i);
+    end
+  end
+  endfunction
+
+  always @(posedge wr_clk) begin
+    if (!rstn) begin
+      wr_ptr_gray <= 0;
+      wr_ptr_bin <= 0;
+    end else if (wr_en && !fifo_full) begin
+      fifo[wr_ptr_bin[ADDR_WIDTH-1:0]] <= wr_data;
+      wr_ptr_bin <= wr_ptr_bin + 1;
+      wr_ptr_gray <= bin2gray(wr_ptr_bin + 1);
+    end
+  end
+
+  always @(posedge rd_clk) begin
+    if (!rstn) begin
+      rd_ptr_gray <= 0;
+      rd_ptr_bin <= 0;
+      rd_data_valid_s <= 0;
+    end else if (rd_en && !fifo_empty) begin
+      rd_data_valid_s <= 1;
+      rd_data <= fifo[rd_ptr_bin[ADDR_WIDTH-1:0]];
+      rd_ptr_bin <= rd_ptr_bin + 1;
+      rd_ptr_gray <= bin2gray(rd_ptr_bin + 1);
+    end else begin
+      rd_data_valid_s <= 0;
+    end
+  end
+
+  assign fifo_full = (bin2gray(wr_ptr_bin + 1) == {~rd_ptr_gray[ADDR_WIDTH:ADDR_WIDTH-1], rd_ptr_gray[ADDR_WIDTH-2:0]});
+  assign fifo_empty = (wr_ptr_gray == rd_ptr_gray);
+  assign rd_data_valid = rd_data_valid_s;
+
+endmodule

--- a/library/xilinx/axi_selmap/axi_selmap.v
+++ b/library/xilinx/axi_selmap/axi_selmap.v
@@ -1,0 +1,240 @@
+// ***************************************************************************
+// ***************************************************************************
+// Copyright (C) 2025 Analog Devices, Inc. All rights reserved.
+//
+// In this HDL repository, there are many different and unique modules, consisting
+// of various HDL (Verilog or VHDL) components. The individual modules are
+// developed independently, and may be accompanied by separate and unique license
+// terms.
+//
+// The user should read each of these license terms, and understand the
+// freedoms and responsibilities that he or she has by using this source/core.
+//
+// This core is distributed in the hope that it will be useful, but WITHOUT ANY
+// WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+// A PARTICULAR PURPOSE.
+//
+// Redistribution and use of source or resulting binaries, with or without modification
+// of this file, are permitted under one of the following two license terms:
+//
+//   1. The GNU General Public License version 2 as published by the
+//      Free Software Foundation, which can be found in the top level directory
+//      of this repository (LICENSE_GPL2), and also online at:
+//      <https://www.gnu.org/licenses/old-licenses/gpl-2.0.html>
+//
+// OR
+//
+//   2. An ADI specific BSD license, which can be found in the top level directory
+//      of this repository (LICENSE_ADIBSD), and also on-line at:
+//      https://github.com/analogdevicesinc/hdl/blob/main/LICENSE_ADIBSD
+//      This will allow to generate bit files and not release the source code,
+//      as long as it attaches to an ADI device.
+//
+// ***************************************************************************
+// ***************************************************************************
+
+`timescale 1ns/100ps
+
+module axi_selmap #(
+  parameter DATA_WIDTH = 8,
+  parameter CLK_DIV = 91,
+  parameter FIFO_DEPTH = (CLK_DIV <= 2) ? 4 : 2 ** $clog2(CLK_DIV)
+) (
+
+  // select map interface
+  output  [DATA_WIDTH-1:0] data,
+  output                   cclk,
+  output                   program_b,
+  output                   rdwr_b,
+  output                   csi_b,
+  input                    init_b,
+  input                    done,
+
+  // axi interface
+  input                    s_axi_aclk,
+  input                    s_axi_aresetn,
+  input                    s_axi_awvalid,
+  input   [15:0]           s_axi_awaddr,
+  input   [ 2:0]           s_axi_awprot,
+  output                   s_axi_awready,
+  input                    s_axi_wvalid,
+  input   [31:0]           s_axi_wdata,
+  input   [ 3:0]           s_axi_wstrb,
+  output                   s_axi_wready,
+  output                   s_axi_bvalid,
+  output  [ 1:0]           s_axi_bresp,
+  input                    s_axi_bready,
+  input                    s_axi_arvalid,
+  input   [15:0]           s_axi_araddr,
+  input   [ 2:0]           s_axi_arprot,
+  output                   s_axi_arready,
+  output                   s_axi_rvalid,
+  output  [ 1:0]           s_axi_rresp,
+  output  [31:0]           s_axi_rdata,
+  input                    s_axi_rready
+);
+
+  // internal signals
+  wire           up_clk;
+  wire           up_rstn;
+  wire           up_rreq_s;
+  wire           up_wack_s;
+  wire           up_rack_s;
+  wire   [13:0]  up_raddr_s;
+  wire   [31:0]  up_rdata_s;
+  wire           up_wreq_s;
+  wire   [13:0]  up_waddr_s;
+  wire   [31:0]  up_wdata_s;
+
+  assign up_clk = s_axi_aclk;
+  assign up_rstn = s_axi_aresetn;
+
+  wire                    up_reset;
+  wire   [DATA_WIDTH-1:0] up_data;
+  wire                    up_data_written;
+  wire                    up_csi_b;
+  wire                    up_program_b;
+  wire                    up_cclk;
+  wire   [DATA_WIDTH-1:0] up_data_swapped;
+  wire   [DATA_WIDTH-1:0] data_sync;
+  wire                    rd_valid;
+  reg                     up_cclk_div;
+  reg                     up_init_b;
+  reg                     up_device_ready;
+  reg                     up_done;
+  reg                     prev_init_b;
+  reg    [$clog2(CLK_DIV)-1:0] counter = 0;
+
+  assign up_cclk = (CLK_DIV > 1) ? up_cclk_div : up_clk;
+  reg    up_cclk_delayed;
+
+  always @(posedge up_clk) begin
+    if (CLK_DIV > 1) begin
+      counter <= counter + 1'b1;
+      if (counter >= (CLK_DIV - 1))
+        counter <= 0;
+      up_cclk_div <= (counter < CLK_DIV / 2) ? 1'b1 : 1'b0;
+    end else begin
+      up_cclk_div <= 1'b0;
+    end
+    up_cclk_delayed <= up_cclk;
+  end
+
+  always @(posedge up_clk) begin
+    if (!up_rstn || !up_reset) begin
+      up_done <= 1'b0;
+      prev_init_b <= 1'b1;
+      up_init_b <= 1'b1;
+      up_device_ready <= 1'b0;
+    end else begin
+      up_done <= done;
+      up_init_b <= init_b;
+      prev_init_b <= up_init_b;
+    end
+
+    if (prev_init_b && !up_init_b) begin
+      up_device_ready <= 1'b1;
+    end
+  end
+
+  axi_selmap_regmap #(
+    .DATA_WIDTH (DATA_WIDTH)
+  ) i_regmap (
+    .up_rstn (up_rstn),
+    .up_clk (up_clk),
+    .up_wreq (up_wreq_s),
+    .up_waddr (up_waddr_s),
+    .up_wdata (up_wdata_s),
+    .up_wack (up_wack_s),
+    .up_rreq (up_rreq_s),
+    .up_raddr (up_raddr_s),
+    .up_rdata (up_rdata_s),
+    .up_rack (up_rack_s),
+    .device_ready (up_device_ready),
+    .done (up_done),
+    .reset (up_reset),
+    .data (up_data),
+    .data_written (up_data_written),
+    .csi_b (up_csi_b),
+    .program_b (up_program_b));
+
+  up_axi  #(
+    .AXI_ADDRESS_WIDTH (16)
+  ) i_up_axi (
+    .up_rstn (up_rstn),
+    .up_clk (up_clk),
+    .up_axi_awvalid (s_axi_awvalid),
+    .up_axi_awaddr (s_axi_awaddr),
+    .up_axi_awready (s_axi_awready),
+    .up_axi_wvalid (s_axi_wvalid),
+    .up_axi_wdata (s_axi_wdata),
+    .up_axi_wstrb (s_axi_wstrb),
+    .up_axi_wready (s_axi_wready),
+    .up_axi_bvalid (s_axi_bvalid),
+    .up_axi_bresp (s_axi_bresp),
+    .up_axi_bready (s_axi_bready),
+    .up_axi_arvalid (s_axi_arvalid),
+    .up_axi_araddr (s_axi_araddr),
+    .up_axi_arready (s_axi_arready),
+    .up_axi_rvalid (s_axi_rvalid),
+    .up_axi_rresp (s_axi_rresp),
+    .up_axi_rdata (s_axi_rdata),
+    .up_axi_rready (s_axi_rready),
+    .up_wreq (up_wreq_s),
+    .up_waddr (up_waddr_s),
+    .up_wdata (up_wdata_s),
+    .up_wack (up_wack_s),
+    .up_rreq (up_rreq_s),
+    .up_raddr (up_raddr_s),
+    .up_rdata (up_rdata_s),
+    .up_rack (up_rack_s));
+
+  assign rdwr_b    = 1'b0;
+  assign csi_b     = up_csi_b;
+  assign program_b = up_program_b;
+
+  /* Selmap bit mapping */
+  genvar i;
+  generate if (DATA_WIDTH >= 8) begin
+    for (i = 0; i < 8; i = i + 1) begin
+      assign up_data_swapped[7-i] = up_data[i];
+    end
+  end
+  endgenerate
+  generate if (DATA_WIDTH >= 16) begin
+    for (i = 0; i < 8; i = i + 1) begin
+      assign up_data_swapped[15-i] = up_data[8+i];
+    end
+  end
+  endgenerate
+  generate if (DATA_WIDTH == 32) begin
+    for (i = 0; i < 8; i = i + 1) begin
+      assign up_data_swapped[23-i] = up_data[16+i];
+      assign up_data_swapped[31-i] = up_data[24+i];
+    end
+  end
+  endgenerate
+
+  /*Add async_fifo in case of CLK_DIV*/
+  generate if (CLK_DIV > 1) begin
+    async_cdc_fifo #(
+      .DATA_WIDTH(DATA_WIDTH),
+      .CLK_DIV (CLK_DIV),
+      .FIFO_DEPTH(FIFO_DEPTH)
+    ) i_cdc_fifo (
+      .wr_clk (up_clk),
+      .rd_clk (up_clk),
+      .rstn (up_rstn),
+      .wr_en (up_data_written),
+      .wr_data (up_data_swapped),
+      .fifo_full (full_flag),
+      .rd_en (up_cclk),
+      .rd_data (data_sync),
+      .fifo_empty (empty_flag),
+      .rd_data_valid (rd_valid));
+  end
+  endgenerate
+
+  assign data = (CLK_DIV > 1) ? data_sync : up_data_swapped;
+  assign cclk = (CLK_DIV > 1) ? (up_cclk_delayed & rd_valid) : (up_cclk & up_data_written);
+endmodule

--- a/library/xilinx/axi_selmap/axi_selmap_ip.tcl
+++ b/library/xilinx/axi_selmap/axi_selmap_ip.tcl
@@ -1,0 +1,35 @@
+###############################################################################
+## Copyright (C) 2025 Analog Devices, Inc. All rights reserved.
+### SPDX short identifier: ADIBSD
+###############################################################################
+
+# ip
+source ../../../scripts/adi_env.tcl
+source $ad_hdl_dir/library/scripts/adi_ip_xilinx.tcl
+
+global VIVADO_IP_LIBRARY
+
+adi_ip_create axi_selmap
+adi_ip_files axi_selmap [list \
+  "$ad_hdl_dir/library/common/up_axi.v" \
+  "async_cdc_fifo.v" \
+  "axi_selmap_regmap.v" \
+  "axi_selmap.v"]
+
+adi_ip_properties axi_selmap
+
+set_property company_url {https://wiki.analog.com/resources/fpga/docs/axi_selmap} [ipx::current_core]
+
+adi_ip_add_core_dependencies [list \
+	analog.com:$VIVADO_IP_LIBRARY:util_cdc:1.0 \
+]
+
+set cc [ipx::current_core]
+
+set_property display_name "ADI AXI SelMap Interface" $cc
+set_property description  "ADI AXI SelMap Interface" $cc
+
+## Save the modifications
+
+ipx::create_xgui_files $cc
+ipx::save_core $cc

--- a/library/xilinx/axi_selmap/axi_selmap_regmap.v
+++ b/library/xilinx/axi_selmap/axi_selmap_regmap.v
@@ -1,0 +1,139 @@
+// ***************************************************************************
+// ***************************************************************************
+// Copyright (C) 2025 Analog Devices, Inc. All rights reserved.
+//
+// In this HDL repository, there are many different and unique modules, consisting
+// of various HDL (Verilog or VHDL) components. The individual modules are
+// developed independently, and may be accompanied by separate and unique license
+// terms.
+//
+// The user should read each of these license terms, and understand the
+// freedoms and responsibilities that he or she has by using this source/core.
+//
+// This core is distributed in the hope that it will be useful, but WITHOUT ANY
+// WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+// A PARTICULAR PURPOSE.
+//
+// Redistribution and use of source or resulting binaries, with or without modification
+// of this file, are permitted under one of the following two license terms:
+//
+//   1. The GNU General Public License version 2 as published by the
+//      Free Software Foundation, which can be found in the top level directory
+//      of this repository (LICENSE_GPL2), and also online at:
+//      <https://www.gnu.org/licenses/old-licenses/gpl-2.0.html>
+//
+// OR
+//
+//   2. An ADI specific BSD license, which can be found in the top level directory
+//      of this repository (LICENSE_ADIBSD), and also on-line at:
+//      https://github.com/analogdevicesinc/hdl/blob/main/LICENSE_ADIBSD
+//      This will allow to generate bit files and not release the source code,
+//      as long as it attaches to an ADI device.
+//
+// ***************************************************************************
+// ***************************************************************************
+`timescale 1ns/100ps
+
+module axi_selmap_regmap #(
+  parameter            DATA_WIDTH = 8,
+  parameter            CORE_MAGIC = 32'h73656C6D // selm
+) (
+  input                        device_ready,
+  input                        done,
+  output                       reset,
+
+  output      [DATA_WIDTH-1:0] data,
+  output                       data_written,
+  output                       csi_b,
+  output                       program_b,
+
+  // processor interface
+  input                        up_rstn,
+  input                        up_clk,
+  input                        up_wreq,
+  input       [13:0]           up_waddr,
+  input       [31:0]           up_wdata,
+  output reg                   up_wack,
+  input                        up_rreq,
+  input       [13:0]           up_raddr,
+  output reg  [31:0]           up_rdata,
+  output reg                   up_rack
+);
+
+  // internal registers
+
+  reg     [31:0]           up_scratch = 'd0;
+  reg                      up_reset = 1'b1;
+  reg     [DATA_WIDTH-1:0] up_data;
+  reg                      up_data_written;
+  reg                      up_csi_b;
+  reg                      up_program_b;
+  reg    [31:0]            up_byte_counter;
+
+  always @(posedge up_clk) begin
+    if (!up_rstn || !up_reset) begin
+      up_scratch <= 'd0;
+      up_reset <= 1'b1;
+      up_data <= 'd0;
+      up_data_written <= 1'b0;
+      up_csi_b <= 1'b1;
+      up_program_b <= 1'b1;
+      up_byte_counter <= 'd0;
+    end else begin
+      up_wack <= up_wreq;
+      up_data_written <= 1'b0;
+      if ((up_wreq == 1'b1) && (up_waddr == 14'h1)) begin
+        up_scratch <= up_wdata;
+      end
+      if ((up_wreq == 1'b1) && (up_waddr == 14'h2)) begin
+        up_reset <= up_wdata[0];
+      end
+      if ((up_wreq == 1'b1) && (up_waddr == 14'h3)) begin
+        up_program_b <= up_wdata[0];
+      end
+      if ((up_wreq == 1'b1) && (up_waddr == 14'h5)) begin
+        up_csi_b <= up_wdata[0];
+      end
+      if ((up_wreq == 1'b1) && (up_waddr == 14'h6)) begin
+        if (!up_data_written) begin
+          up_data <= up_wdata[DATA_WIDTH-1:0];
+          up_data_written <= 1'b1;
+          up_byte_counter <= up_byte_counter + 1'd1;
+        end
+      end
+    end
+  end
+
+  always @(posedge up_clk) begin
+    if (!up_rstn || !up_reset) begin
+      up_rack <= 'd0;
+      up_rdata <= 'd0;
+    end else begin
+      up_rack <= up_rreq;
+      if (up_rreq == 1'b1) begin
+        case (up_raddr)
+          14'h0: up_rdata <= CORE_MAGIC;
+          14'h1: up_rdata <= up_scratch;
+          14'h2: up_rdata <= up_reset;
+          14'h3: up_rdata <= up_program_b;
+          14'h4: up_rdata <= device_ready;
+          14'h5: up_rdata <= up_csi_b;
+          14'h6: up_rdata <= up_data;
+          14'h7: up_rdata <= up_byte_counter;
+          14'h8: up_rdata <= done;
+          default: up_rdata <= 0;
+         endcase
+      end else begin
+        up_rdata <= 32'd0;
+      end
+    end
+  end
+
+  assign reset = up_reset;
+
+  assign data = up_data;
+  assign data_written = up_data_written;
+  assign csi_b = up_csi_b;
+  assign program_b = up_program_b;
+
+endmodule

--- a/projects/scripts/adi_project_xilinx.tcl
+++ b/projects/scripts/adi_project_xilinx.tcl
@@ -561,9 +561,15 @@ proc adi_project_run {project_name} {
   if { [string match "*VIOLATED*" $timing_string] == 1 ||
        [string match "*Timing constraints are not met*" $timing_string] == 1} {
     write_hw_platform -fixed -force  -include_bit -file ${actual_project_name}.sdk/system_top_bad_timing.xsa
+    if {[info exists ::env(ADI_GENERATE_BIN)]} {
+      write_bitstream -bin_file ${actual_project_name}.sdk/system_top_bad_timing.bit
+    }
     return -code error [format "ERROR: Timing Constraints NOT met!"]
   } else {
     write_hw_platform -fixed -force  -include_bit -file ${actual_project_name}.sdk/system_top.xsa
+    if {[info exists ::env(ADI_GENERATE_BIN)]} {
+      write_bitstream -bin_file ${actual_project_name}.sdk/system_top.bit
+    }
   }
 }
 
@@ -708,4 +714,3 @@ proc adi_project_verify {project_name} {
     return -code error [format "ERROR: Timing Constraints NOT met!"]
   }
 }
-


### PR DESCRIPTION
## PR Description

This PR adds the selectmap IP for Xilinx boards and an environment variable that allows the .bin file to be generated during the build.

## PR Type
- [ ] Bug fix (change that fixes an issue)
- [x] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)
- [ ] Documentation

## PR Checklist
- [x] I have followed the code style guidelines
- [x] I have performed a self-review of changes
- [x] I have compiled all hdl projects and libraries affected by this PR
- [x] I have tested in hardware affected projects, at least on relevant boards
- [ ] I have commented my code, at least hard-to-understand parts
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe files, Copyright etc)
- [x] I have not introduced new Warnings/Critical Warnings on compilation
- [ ] I have added new hdl testbenches or updated existing ones
