### PR TITLE
ad_quadmxfe1_ebz: Use variable Data Offload size

### DIFF
--- a/projects/ad_quadmxfe1_ebz/vcu118/system_bd.tcl
+++ b/projects/ad_quadmxfe1_ebz/vcu118/system_bd.tcl
@@ -3,12 +3,10 @@
 ### SPDX short identifier: ADIBSD
 ###############################################################################
 
-## Offload attributes
-set adc_offload_type 0                   ; ## BRAM
-set adc_offload_size [expr 2*1024*1024]  ; ## 2 MB
-
-set dac_offload_type 0                   ; ## BRAM
-set dac_offload_size [expr 2*1024*1024]  ; ## 2 MB
+## ADC FIFO depth in samples per converter
+set adc_fifo_samples_per_converter [expr $ad_project_params(RX_KS_PER_CHANNEL)*1024]
+## DAC FIFO depth in samples per converter
+set dac_fifo_samples_per_converter [expr $ad_project_params(TX_KS_PER_CHANNEL)*1024]
 
 source $ad_hdl_dir/projects/common/vcu118/vcu118_system_bd.tcl
 source ../common/ad_quadmxfe1_ebz_bd.tcl


### PR DESCRIPTION
## PR Description

This PR updates the Data Offload instances in ad_quadmxfe1_ebz to use variable sizes, derived from the [RX/TX]_KS_PER_CHANNEL values.

## PR Type
- [ ] Bug fix (change that fixes an issue)
- [x] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)
- [ ] Documentation

## PR Checklist
- [x] I have followed the code style guidelines
- [x] I have performed a self-review of changes
- [x] I have compiled all hdl projects and libraries affected by this PR
- [ ] I have tested in hardware affected projects, at least on relevant boards
- [x] I have commented my code, at least hard-to-understand parts
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe files, Copyright etc)
- [x] I have not introduced new Warnings/Critical Warnings on compilation
- [ ] I have added new hdl testbenches or updated existing ones
