### PR TITLE
data_offload: Remove bypass_fifo instance when HAS_BYPASS=0

### DIFF
--- a/library/data_offload/data_offload.v
+++ b/library/data_offload/data_offload.v
@@ -235,7 +235,6 @@ module data_offload #(
                         (dst_bypass_s) ? data_bypass_s  : s_storage_axis_data;
   assign m_axis_last  = (dst_bypass_s) ? 1'b0           : s_storage_axis_last;
   assign m_axis_tkeep = (dst_bypass_s) ? {DST_DATA_WIDTH/8{1'b1}} : s_storage_axis_tkeep;
-
   assign s_axis_ready =  src_bypass_s ? ready_bypass_s : (wr_ready & m_storage_axis_ready);
 
   assign m_storage_axis_valid = s_axis_valid & wr_ready;
@@ -248,32 +247,38 @@ module data_offload #(
   // Bypass module instance -- the same FIFO, just a smaller depth
   // NOTE: Generating an overflow is making sense just in BYPASS mode, and
   // it's supported just with the FIFO interface
-  util_axis_fifo_asym #(
-    .S_DATA_WIDTH (SRC_DATA_WIDTH),
-    .ADDRESS_WIDTH (SRC_ADDR_WIDTH_BYPASS),
-    .M_DATA_WIDTH (DST_DATA_WIDTH),
-    .ASYNC_CLK (1)
-  ) i_bypass_fifo (
-    .m_axis_aclk (m_axis_aclk),
-    .m_axis_aresetn (dst_rstn),
-    .m_axis_ready (m_axis_ready),
-    .m_axis_valid (valid_bypass_s),
-    .m_axis_data  (data_bypass_s),
-    .m_axis_tlast (),
-    .m_axis_empty (),
-    .m_axis_almost_empty (),
-    .m_axis_tkeep (),
-    .m_axis_level (),
-    .s_axis_aclk  (s_axis_aclk),
-    .s_axis_aresetn (src_rstn),
-    .s_axis_ready (ready_bypass_s),
-    .s_axis_valid (s_axis_valid & src_bypass_s),
-    .s_axis_data  (s_axis_data),
-    .s_axis_tlast (),
-    .s_axis_full  (),
-    .s_axis_almost_full (),
-    .s_axis_tkeep (),
-    .s_axis_room ());
+  generate if (HAS_BYPASS) begin
+    util_axis_fifo_asym #(
+      .S_DATA_WIDTH (SRC_DATA_WIDTH),
+      .ADDRESS_WIDTH (SRC_ADDR_WIDTH_BYPASS),
+      .M_DATA_WIDTH (DST_DATA_WIDTH),
+      .ASYNC_CLK (1)
+    ) i_bypass_fifo (
+      .m_axis_aclk (m_axis_aclk),
+      .m_axis_aresetn (dst_rstn),
+      .m_axis_ready (m_axis_ready),
+      .m_axis_valid (valid_bypass_s),
+      .m_axis_data  (data_bypass_s),
+      .m_axis_tlast (),
+      .m_axis_empty (),
+      .m_axis_almost_empty (),
+      .m_axis_tkeep (),
+      .m_axis_level (),
+      .s_axis_aclk  (s_axis_aclk),
+      .s_axis_aresetn (src_rstn),
+      .s_axis_ready (ready_bypass_s),
+      .s_axis_valid (s_axis_valid & src_bypass_s),
+      .s_axis_data  (s_axis_data),
+      .s_axis_tlast (),
+      .s_axis_full  (),
+      .s_axis_almost_full (),
+      .s_axis_tkeep (),
+      .s_axis_room ());
+  end else begin
+      assign valid_bypass_s = 1'b0;
+      assign data_bypass_s = 'd0;
+      assign ready_bypass_s = 1'b0;
+  end endgenerate
 
   // register map
 


### PR DESCRIPTION
## PR Description

Remove the Data Offload Bypass FIFO when synthesis parameter HAS_BYPASS is set to value '0'. By default this parameter has value '1'. 

By removing the DO Bypass FIFO certain timing paths are optimized because there is not need to have this additional logic during design runtime!

## PR Type
- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)
- [ ] Documentation

## PR Checklist
- [x] I have followed the code style guidelines
- [x] I have performed a self-review of changes
- [x] I have compiled all hdl projects and libraries affected by this PR
- [x] I have tested in hardware affected projects, at least on relevant boards
- [ ] I have commented my code, at least hard-to-understand parts
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe files, Copyright etc)
- [x] I have not introduced new Warnings/Critical Warnings on compilation
- [ ] I have added new hdl testbenches or updated existing ones
