### PR TITLE
Update utility cores to inline hdl variants (Vivado 2024.2+)

### DIFF
--- a/library/axi_tdd/scripts/axi_tdd.tcl
+++ b/library/axi_tdd/scripts/axi_tdd.tcl
@@ -1,5 +1,5 @@
 ###############################################################################
-## Copyright (C) 2022-2023 Analog Devices, Inc. All rights reserved.
+## Copyright (C) 2022-2023, 2025 Analog Devices, Inc. All rights reserved.
 ### SPDX short identifier: ADIBSD
 ###############################################################################
 
@@ -42,7 +42,7 @@ proc ad_tdd_gen_create {ip_name
    ]
 
   for {set i 0} {$i < $num_of_channels} {incr i} {
-    ad_ip_instance xlslice "${ip_name}/tdd_ch_slice_${i}" [list \
+    ad_ip_instance ilslice "${ip_name}/tdd_ch_slice_${i}" [list \
       DIN_WIDTH $num_of_channels \
       DIN_FROM $i \
       DIN_TO $i \

--- a/library/jesd204/scripts/jesd204.tcl
+++ b/library/jesd204/scripts/jesd204.tcl
@@ -1,5 +1,5 @@
 ###############################################################################
-## Copyright (C) 2017-2022 Analog Devices, Inc. All rights reserved.
+## Copyright (C) 2017-2022, 2025 Analog Devices, Inc. All rights reserved.
 ### SPDX short identifier: ADIJESD204
 ###############################################################################
 
@@ -226,24 +226,24 @@ proc adi_tpl_jesd204_tx_create {ip_name num_of_lanes num_of_converters samples_p
       # Concatenation and slicer cores
       # xconcat limited to 32 input ports
       for {set i 0} {$i < $num_of_converters} {incr i 32} {
-      ad_ip_instance xlconcat "${ip_name}/data_concat[expr $i/32]" [list \
+      ad_ip_instance ilconcat "${ip_name}/data_concat[expr $i/32]" [list \
         NUM_PORTS [expr min(32,$num_of_converters-$i)] \
         ]
       }
       # main concat
       if {$num_of_converters > 32} {
-       ad_ip_instance xlconcat "${ip_name}/data_concat" [list \
+       ad_ip_instance ilconcat "${ip_name}/data_concat" [list \
         NUM_PORTS [expr int(ceil(double($num_of_converters)/32))] \
         ]
       }
 
       for {set i 0} {$i < $num_of_converters} {incr i} {
-        ad_ip_instance xlslice "${ip_name}/enable_slice_${i}" [list \
+        ad_ip_instance ilslice "${ip_name}/enable_slice_${i}" [list \
           DIN_WIDTH $num_of_converters \
           DIN_FROM $i \
           DIN_TO $i \
         ]
-        ad_ip_instance xlslice "${ip_name}/valid_slice_${i}" [list \
+        ad_ip_instance ilslice "${ip_name}/valid_slice_${i}" [list \
           DIN_WIDTH $num_of_converters \
           DIN_FROM $i \
           DIN_TO $i \
@@ -357,18 +357,18 @@ proc adi_tpl_jesd204_rx_create {ip_name num_of_lanes num_of_converters samples_p
     if {$num_of_converters > 1} {
       # Slicer cores
       for {set i 0} {$i < $num_of_converters} {incr i} {
-        ad_ip_instance xlslice ${ip_name}/data_slice_$i [list \
+        ad_ip_instance ilslice ${ip_name}/data_slice_$i [list \
           DIN_WIDTH [expr $dma_sample_width*$samples_per_channel*$num_of_converters] \
           DIN_FROM [expr $dma_sample_width*$samples_per_channel*($i+1)-1] \
           DIN_TO [expr $dma_sample_width*$samples_per_channel*$i] \
         ]
 
-        ad_ip_instance xlslice "${ip_name}/enable_slice_${i}" [list \
+        ad_ip_instance ilslice "${ip_name}/enable_slice_${i}" [list \
           DIN_WIDTH $num_of_converters \
           DIN_FROM $i \
           DIN_TO $i \
         ]
-        ad_ip_instance xlslice "${ip_name}/valid_slice_${i}" [list \
+        ad_ip_instance ilslice "${ip_name}/valid_slice_${i}" [list \
           DIN_WIDTH $num_of_converters \
           DIN_FROM $i \
           DIN_TO $i \
@@ -449,5 +449,3 @@ proc adi_jesd204_calc_tpl_width {link_datapath_width jesd_l jesd_m jesd_s jesd_n
   }
 
 }
-
-

--- a/projects/ad469x_evb/common/ad469x_bd.tcl
+++ b/projects/ad469x_evb/common/ad469x_bd.tcl
@@ -1,5 +1,5 @@
 ###############################################################################
-## Copyright (C) 2020-2024 Analog Devices, Inc. All rights reserved.
+## Copyright (C) 2020-2025 Analog Devices, Inc. All rights reserved.
 ### SPDX short identifier: ADIBSD
 ###############################################################################
 
@@ -84,11 +84,11 @@ ad_connect spi_clk $hier_spi_engine/spi_clk
 ad_connect $hier_spi_engine/m_spi ad469x_spi
 ad_connect axi_ad469x_dma/s_axis $hier_spi_engine/M_AXIS_SAMPLE
 
-ad_ip_instance util_vector_logic cnv_gate
+ad_ip_instance ilvector_logic cnv_gate
 ad_ip_parameter cnv_gate CONFIG.C_SIZE 1
 ad_ip_parameter cnv_gate CONFIG.C_OPERATION {and}
 
-ad_ip_instance util_vector_logic cnv_gate_gpio
+ad_ip_instance ilvector_logic cnv_gate_gpio
 ad_ip_parameter cnv_gate_gpio CONFIG.C_SIZE 1
 ad_ip_parameter cnv_gate_gpio CONFIG.C_OPERATION {or}
 

--- a/projects/ad738x_fmc/common/ad738x_bd.tcl
+++ b/projects/ad738x_fmc/common/ad738x_bd.tcl
@@ -1,5 +1,5 @@
 ###############################################################################
-## Copyright (C) 2019-2024 Analog Devices, Inc. All rights reserved.
+## Copyright (C) 2019-2025 Analog Devices, Inc. All rights reserved.
 ### SPDX short identifier: ADIBSD
 ###############################################################################
 
@@ -51,7 +51,7 @@ ad_ip_parameter spi_clkgen CONFIG.VCO_MUL 8
 ad_connect $sys_cpu_clk spi_clkgen/clk
 ad_connect spi_clk spi_clkgen/clk_0
 
-ad_ip_instance util_vector_logic cnv_gate
+ad_ip_instance ilvector_logic cnv_gate
 ad_ip_parameter cnv_gate CONFIG.C_SIZE 1
 ad_ip_parameter cnv_gate CONFIG.C_OPERATION {and}
 

--- a/projects/ad9081_fmca_ebz/common/ad9081_fmca_ebz_bd.tcl
+++ b/projects/ad9081_fmca_ebz/common/ad9081_fmca_ebz_bd.tcl
@@ -614,7 +614,7 @@ if {$INTF_CFG != "TX"} {
   ad_connect ext_sync_in rx_mxfe_tpl_core/adc_tpl_core/adc_sync_in
   if {$INTF_CFG == "RXTX"} {
     # Rx & Tx
-    ad_ip_instance util_vector_logic manual_sync_or [list \
+    ad_ip_instance ilvector_logic manual_sync_or [list \
       C_SIZE 1 \
       C_OPERATION {or} \
     ]
@@ -625,17 +625,17 @@ if {$INTF_CFG != "TX"} {
     ad_connect rx_mxfe_tpl_core/adc_tpl_core/adc_sync_manual_req_out rx_mxfe_tpl_core/adc_tpl_core/adc_sync_manual_req_in
   }
   # Reset pack cores
-  ad_ip_instance util_reduced_logic cpack_rst_logic
+  ad_ip_instance ilreduced_logic cpack_rst_logic
   ad_ip_parameter cpack_rst_logic config.c_operation {or}
   ad_ip_parameter cpack_rst_logic config.c_size {3}
 
-  ad_ip_instance util_vector_logic rx_do_rstout_logic
+  ad_ip_instance ilvector_logic rx_do_rstout_logic
   ad_ip_parameter rx_do_rstout_logic config.c_operation {not}
   ad_ip_parameter rx_do_rstout_logic config.c_size {1}
 
   ad_connect $adc_data_offload_name/s_axis_tready rx_do_rstout_logic/Op1
 
-  ad_ip_instance xlconcat cpack_reset_sources
+  ad_ip_instance ilconcat cpack_reset_sources
   ad_ip_parameter cpack_reset_sources config.num_ports {3}
   ad_connect rx_device_clk_rstgen/peripheral_reset cpack_reset_sources/in0
   ad_connect rx_mxfe_tpl_core/adc_tpl_core/adc_rst cpack_reset_sources/in1
@@ -657,11 +657,11 @@ if {$INTF_CFG != "RX"} {
     ad_connect tx_mxfe_tpl_core/dac_tpl_core/dac_sync_manual_req_out tx_mxfe_tpl_core/dac_tpl_core/dac_sync_manual_req_in
   }
   # Reset upack cores
-  ad_ip_instance util_reduced_logic upack_rst_logic
+  ad_ip_instance ilreduced_logic upack_rst_logic
   ad_ip_parameter upack_rst_logic config.c_operation {or}
   ad_ip_parameter upack_rst_logic config.c_size {2}
 
-  ad_ip_instance xlconcat upack_reset_sources
+  ad_ip_instance ilconcat upack_reset_sources
   ad_ip_parameter upack_reset_sources config.num_ports {2}
   ad_connect tx_device_clk_rstgen/peripheral_reset upack_reset_sources/in0
   ad_connect tx_mxfe_tpl_core/dac_tpl_core/dac_rst upack_reset_sources/in1

--- a/projects/ad9081_fmca_ebz/common/versal_transceiver.tcl
+++ b/projects/ad9081_fmca_ebz/common/versal_transceiver.tcl
@@ -1,5 +1,5 @@
 ###############################################################################
-## Copyright (C) 2021-2024 Analog Devices, Inc. All rights reserved.
+## Copyright (C) 2021-2025 Analog Devices, Inc. All rights reserved.
 ### SPDX short identifier: ADIBSD
 ###############################################################################
 
@@ -57,11 +57,11 @@ proc create_reset_logic {
   set max_lanes [expr max($rx_num_lanes, $tx_num_lanes)]
   set num_quads [expr int(ceil(1.0 * $max_lanes / 4))]
 
-  ad_ip_instance xlconcat ${ip_name}/concat_powergood [list \
+  ad_ip_instance ilconcat ${ip_name}/concat_powergood [list \
    NUM_PORTS $num_quads \
  ]
 
-  ad_ip_instance util_reduced_logic ${ip_name}/and_powergood [list \
+  ad_ip_instance ilreduced_logic ${ip_name}/and_powergood [list \
     C_SIZE $num_quads \
   ]
 
@@ -87,10 +87,10 @@ proc create_reset_logic {
       ad_connect ${ip_name}/${tx_bridge}/gt_ilo_reset ${ip_name}/gt_quad_base_${quad_index}/ch${ch_index}_iloreset
     }
   }
-  ad_ip_instance xlconcat ${ip_name}/xlconcat_iloresetdone [list \
+  ad_ip_instance ilconcat ${ip_name}/xlconcat_iloresetdone [list \
       NUM_PORTS ${rx_num_lanes} \
   ]
-  ad_ip_instance util_reduced_logic ${ip_name}/and_iloresetdone [list \
+  ad_ip_instance ilreduced_logic ${ip_name}/and_iloresetdone [list \
       C_SIZE ${rx_num_lanes} \
   ]
   for {set j 0} {$j < ${rx_num_lanes}} {incr j} {
@@ -101,10 +101,10 @@ proc create_reset_logic {
   ad_connect ${ip_name}/xlconcat_iloresetdone/dout ${ip_name}/and_iloresetdone/Op1
   ad_connect ${ip_name}/and_iloresetdone/Res ${ip_name}/${rx_bridge}/ilo_resetdone
   if {$asymmetric_mode} {
-    ad_ip_instance xlconcat ${ip_name}/xlconcat_iloresetdone_tx [list \
+    ad_ip_instance ilconcat ${ip_name}/xlconcat_iloresetdone_tx [list \
       NUM_PORTS ${tx_num_lanes} \
     ]
-    ad_ip_instance util_reduced_logic ${ip_name}/and_iloresetdone_tx [list \
+    ad_ip_instance ilreduced_logic ${ip_name}/and_iloresetdone_tx [list \
         C_SIZE ${tx_num_lanes} \
     ]
     for {set j 0} {$j < ${tx_num_lanes}} {incr j} {
@@ -122,10 +122,10 @@ proc create_reset_logic {
   }
 
   set num_cplllocks [expr 2 * ${num_quads}]
-  ad_ip_instance xlconcat ${ip_name}/concat_cplllock [list \
+  ad_ip_instance ilconcat ${ip_name}/concat_cplllock [list \
       NUM_PORTS ${num_cplllocks} \
   ]
-  ad_ip_instance util_reduced_logic ${ip_name}/and_cplllock [list \
+  ad_ip_instance ilreduced_logic ${ip_name}/and_cplllock [list \
       C_SIZE ${num_cplllocks} \
   ]
 
@@ -142,7 +142,7 @@ proc create_reset_logic {
     ad_connect ${ip_name}/and_cplllock/Res ${ip_name}/${tx_bridge}/gt_lcpll_lock
   }
 
-  ad_ip_instance xlconcat ${ip_name}/concat_phystatus [list \
+  ad_ip_instance ilconcat ${ip_name}/concat_phystatus [list \
     NUM_PORTS ${rx_num_lanes} \
   ]
   for {set j 0} {$j < ${rx_num_lanes}} {incr j} {
@@ -153,7 +153,7 @@ proc create_reset_logic {
   }
   ad_connect ${ip_name}/concat_phystatus/dout ${ip_name}/${rx_bridge}/ch_phystatus_in
   if {$asymmetric_mode} {
-    ad_ip_instance xlconcat ${ip_name}/concat_phystatus_tx [list \
+    ad_ip_instance ilconcat ${ip_name}/concat_phystatus_tx [list \
       NUM_PORTS ${rx_num_lanes} \
     ]
     for {set j 0} {$j < ${rx_num_lanes}} {incr j} {

--- a/projects/ad9081_fmca_ebz/vcu118/system_bd.tcl
+++ b/projects/ad9081_fmca_ebz/vcu118/system_bd.tcl
@@ -240,15 +240,15 @@ if {$ad_project_params(CORUNDUM) == "1"} {
     ad_connect corundum_hierarchy/input_axis_tdata util_corundum_cpack/packed_fifo_wr_data
     ad_connect corundum_hierarchy/input_axis_tready util_corundum_cpack/packed_fifo_wr_overflow
 
-    ad_ip_instance util_reduced_logic cpack_rst_logic_corundum
+    ad_ip_instance ilreduced_logic cpack_rst_logic_corundum
     ad_ip_parameter cpack_rst_logic_corundum config.c_operation {or}
     ad_ip_parameter cpack_rst_logic_corundum config.c_size {4}
 
-    ad_ip_instance util_vector_logic rx_do_rstout_logic_corundum
+    ad_ip_instance ilvector_logic rx_do_rstout_logic_corundum
     ad_ip_parameter rx_do_rstout_logic_corundum config.c_operation {not}
     ad_ip_parameter rx_do_rstout_logic_corundum config.c_size {1}
 
-    ad_ip_instance xlconcat cpack_reset_sources_corundum
+    ad_ip_instance ilconcat cpack_reset_sources_corundum
     ad_ip_parameter cpack_reset_sources_corundum config.num_ports {4}
 
     ad_connect corundum_hierarchy/input_axis_tready rx_do_rstout_logic_corundum/Op1
@@ -261,7 +261,7 @@ if {$ad_project_params(CORUNDUM) == "1"} {
     ad_connect cpack_reset_sources_corundum/dout cpack_rst_logic_corundum/op1
     ad_connect cpack_rst_logic_corundum/res util_corundum_cpack/reset
 
-    ad_ip_instance xlconcat input_enable_concat_corundum
+    ad_ip_instance ilconcat input_enable_concat_corundum
     ad_ip_parameter input_enable_concat_corundum config.num_ports $INPUT_CHANNELS
 
     for {set i 0} {$i<$INPUT_CHANNELS} {incr i} {
@@ -270,7 +270,7 @@ if {$ad_project_params(CORUNDUM) == "1"} {
 
     ad_connect input_enable_concat_corundum/dout corundum_hierarchy/input_enable
 
-    ad_ip_instance xlconcat output_enable_concat_corundum
+    ad_ip_instance ilconcat output_enable_concat_corundum
     ad_ip_parameter output_enable_concat_corundum config.num_ports $OUTPUT_CHANNELS
 
     for {set i 0} {$i<$OUTPUT_CHANNELS} {incr i} {

--- a/projects/ad_gmsl2eth_sl/common/ad_gmsl2eth_sl_bd.tcl
+++ b/projects/ad_gmsl2eth_sl/common/ad_gmsl2eth_sl_bd.tcl
@@ -534,7 +534,7 @@ assign_bd_address -offset 0xA000_0000 [get_bd_addr_segs \
   corundum_hierarchy/corundum_core/s_axil_ctrl/Reg
 ] -target_address_space sys_ps8/Data
 
-ad_ip_instance util_reduced_logic util_reduced_logic_0
+ad_ip_instance ilreduced_logic util_reduced_logic_0
 ad_ip_parameter util_reduced_logic_0 CONFIG.C_OPERATION {or}
 ad_ip_parameter util_reduced_logic_0 CONFIG.C_SIZE {8}
 

--- a/projects/ad_quadmxfe1_ebz/common/ad_quadmxfe1_ebz_bd.tcl
+++ b/projects/ad_quadmxfe1_ebz/common/ad_quadmxfe1_ebz_bd.tcl
@@ -226,11 +226,11 @@ ad_data_offload_create $adc_offload_name \
 ad_ip_parameter $adc_offload_name/i_data_offload CONFIG.SYNC_EXT_ADD_INTERNAL_CDC 0
 ad_connect $adc_offload_name/sync_ext GND
 
-ad_ip_instance util_vector_logic rx_do_rstout_logic
+ad_ip_instance ilvector_logic rx_do_rstout_logic
 ad_ip_parameter rx_do_rstout_logic config.c_operation {not}
 ad_ip_parameter rx_do_rstout_logic config.c_size {1}
 
-ad_ip_instance util_vector_logic cpack_reset_logic
+ad_ip_instance ilvector_logic cpack_reset_logic
 ad_ip_parameter cpack_reset_logic config.c_operation {or}
 ad_ip_parameter cpack_reset_logic config.c_size {1}
 
@@ -477,8 +477,8 @@ ad_connect  axi_mxfe_rx_jesd/rx_axi/device_reset jesd204_phy_125_126/rx_reset_gt
 #
 if {$ADI_PHY_SEL == 0} {
 # Rx Physical lanes to PHY
-ad_ip_instance xlconcat rx_concat_7_0_p [list NUM_PORTS {8}]
-ad_ip_instance xlconcat rx_concat_7_0_n [list NUM_PORTS {8}]
+ad_ip_instance ilconcat rx_concat_7_0_p [list NUM_PORTS {8}]
+ad_ip_instance ilconcat rx_concat_7_0_n [list NUM_PORTS {8}]
 
 ad_connect  rx_data_0_p rx_concat_7_0_p/In0
 ad_connect  rx_data_1_p rx_concat_7_0_p/In1
@@ -501,8 +501,8 @@ ad_connect  rx_data_7_n rx_concat_7_0_n/In7
 ad_connect  jesd204_phy_121_122/rxp_in rx_concat_7_0_p/dout
 ad_connect  jesd204_phy_121_122/rxn_in rx_concat_7_0_n/dout
 
-ad_ip_instance xlconcat rx_concat_15_8_p [list NUM_PORTS {8}]
-ad_ip_instance xlconcat rx_concat_15_8_n [list NUM_PORTS {8}]
+ad_ip_instance ilconcat rx_concat_15_8_p [list NUM_PORTS {8}]
+ad_ip_instance ilconcat rx_concat_15_8_n [list NUM_PORTS {8}]
 
 ad_connect  rx_data_8_p rx_concat_15_8_p/In0
 ad_connect  rx_data_9_p rx_concat_15_8_p/In1
@@ -611,13 +611,13 @@ if {$ADI_PHY_SEL == 0} {
 # Tx Physical lanes to PHY
 #
 for {set i 0} {$i < $MAX_TX_LANES} {incr i} {
-  ad_ip_instance xlslice txp_out_slice_$i [list \
+  ad_ip_instance ilslice txp_out_slice_$i [list \
     DIN_TO [expr $i % 8] \
     DIN_FROM [expr $i % 8] \
     DIN_WIDTH {8} \
     DOUT_WIDTH {1} \
   ]
-  ad_ip_instance xlslice txn_out_slice_$i [list \
+  ad_ip_instance ilslice txn_out_slice_$i [list \
     DIN_TO [expr $i % 8] \
     DIN_FROM [expr $i % 8] \
     DIN_WIDTH {8} \
@@ -749,4 +749,3 @@ ad_cpu_interrupt ps-12 mb-13 axi_mxfe_tx_dma/irq
 ad_cpu_interrupt ps-11 mb-14 axi_mxfe_rx_jesd/irq
 ad_cpu_interrupt ps-10 mb-15 axi_mxfe_tx_jesd/irq
 ad_cpu_interrupt ps-14 mb-8  axi_gpio_2/ip2intc_irpt
-

--- a/projects/adrv9009/common/adrv9009_bd.tcl
+++ b/projects/adrv9009/common/adrv9009_bd.tcl
@@ -338,7 +338,7 @@ ad_connect  adrv9009_tx_device_clk_rstgen/peripheral_reset util_adrv9009_tx_upac
 if {$TX_NUM_OF_CONVERTERS <= 2} {
   ad_connect  tx_fir_interpolator/valid_out_0  util_adrv9009_tx_upack/fifo_rd_en
 } else {
-  ad_ip_instance util_vector_logic logic_or [list \
+  ad_ip_instance ilvector_logic logic_or [list \
   C_OPERATION {or} \
   C_SIZE 1]
 

--- a/projects/adrv9009zu11eg/adrv2crr_fmcomms8/system_bd.tcl
+++ b/projects/adrv9009zu11eg/adrv2crr_fmcomms8/system_bd.tcl
@@ -1,5 +1,5 @@
 ###############################################################################
-## Copyright (C) 2020-2023 Analog Devices, Inc. All rights reserved.
+## Copyright (C) 2020-2023, 2025 Analog Devices, Inc. All rights reserved.
 ### SPDX short identifier: ADIBSD
 ###############################################################################
 
@@ -32,7 +32,7 @@ create_bd_port -dir I spi1_miso
 set_property -dict [list CONFIG.PSU__SPI1__PERIPHERAL__ENABLE {1} CONFIG.PSU__SPI1__PERIPHERAL__IO {EMIO}] [get_bd_cells sys_ps8]
 set_property -dict [list CONFIG.PSU__SPI1__GRP_SS1__ENABLE {1} CONFIG.PSU__SPI1__GRP_SS2__ENABLE {1}] [get_bd_cells sys_ps8]
 
-ad_ip_instance xlconcat spi1_csn_concat
+ad_ip_instance ilconcat spi1_csn_concat
 ad_ip_parameter spi1_csn_concat CONFIG.NUM_PORTS 3
 ad_connect  sys_ps8/emio_spi1_ss_o_n spi1_csn_concat/In0
 ad_connect  sys_ps8/emio_spi1_ss1_o_n spi1_csn_concat/In1

--- a/projects/adrv9009zu11eg/common/adrv2crr_fmc_bd.tcl
+++ b/projects/adrv9009zu11eg/common/adrv2crr_fmc_bd.tcl
@@ -80,7 +80,7 @@ ad_ip_parameter axi_fan_control_0 CONFIG.ID 1
 ad_ip_parameter axi_fan_control_0 CONFIG.PWM_FREQUENCY_HZ 1000
 ad_ip_parameter axi_fan_control_0 CONFIG.INTERNAL_SYSMONE 1
 
-ad_ip_instance xlconstant const_gnd_0
+ad_ip_instance ilconstant const_gnd_0
 ad_ip_parameter const_gnd_0 CONFIG.CONST_WIDTH {10}
 ad_ip_parameter const_gnd_0 CONFIG.CONST_VAL {0}
 

--- a/projects/adrv9009zu11eg/common/adrv9009zu11eg_bd.tcl
+++ b/projects/adrv9009zu11eg/common/adrv9009zu11eg_bd.tcl
@@ -170,7 +170,7 @@ ad_connect  gpio_t sys_ps8/emio_gpio_t
 
 # spi
 
-ad_ip_instance xlconcat spi0_csn_concat
+ad_ip_instance ilconcat spi0_csn_concat
 ad_ip_parameter spi0_csn_concat CONFIG.NUM_PORTS 3
 ad_connect  sys_ps8/emio_spi0_ss_o_n spi0_csn_concat/In0
 ad_connect  sys_ps8/emio_spi0_ss1_o_n spi0_csn_concat/In1
@@ -194,10 +194,10 @@ ad_connect  sys_cpu_clk rom_sys_0/clk
 
 # interrupts
 
-ad_ip_instance xlconcat sys_concat_intc_0
+ad_ip_instance ilconcat sys_concat_intc_0
 ad_ip_parameter sys_concat_intc_0 CONFIG.NUM_PORTS 8
 
-ad_ip_instance xlconcat sys_concat_intc_1
+ad_ip_instance ilconcat sys_concat_intc_1
 ad_ip_parameter sys_concat_intc_1 CONFIG.NUM_PORTS 8
 
 ad_connect  sys_concat_intc_0/dout sys_ps8/pl_ps_irq0

--- a/projects/adrv904x/common/adrv904x_bd.tcl
+++ b/projects/adrv904x/common/adrv904x_bd.tcl
@@ -235,12 +235,12 @@ ad_ip_parameter util_adrv904x_xcvr CONFIG.PPF0_CFG 0xF00
 ad_ip_parameter util_adrv904x_xcvr CONFIG.QPLL_CP 0xFF
 ad_ip_parameter util_adrv904x_xcvr CONFIG.QPLL_CP_G3 0xF
 ad_ip_parameter util_adrv904x_xcvr CONFIG.QPLL_LPF 0x31D
-ad_ip_parameter util_adrv904x_xcvr CONFIG.RXDFE_KH_CFG2 {0x2631} 
-ad_ip_parameter util_adrv904x_xcvr CONFIG.RXDFE_KH_CFG3 {0x411C} 
-ad_ip_parameter util_adrv904x_xcvr CONFIG.RX_WIDEMODE_CDR {"01"} 
-ad_ip_parameter util_adrv904x_xcvr CONFIG.RX_XMODE_SEL {"0"} 
-ad_ip_parameter util_adrv904x_xcvr CONFIG.TXPI_CFG0 {0x0000} 
-ad_ip_parameter util_adrv904x_xcvr CONFIG.TXPI_CFG1 {0x0000} 
+ad_ip_parameter util_adrv904x_xcvr CONFIG.RXDFE_KH_CFG2 {0x2631}
+ad_ip_parameter util_adrv904x_xcvr CONFIG.RXDFE_KH_CFG3 {0x411C}
+ad_ip_parameter util_adrv904x_xcvr CONFIG.RX_WIDEMODE_CDR {"01"}
+ad_ip_parameter util_adrv904x_xcvr CONFIG.RX_XMODE_SEL {"0"}
+ad_ip_parameter util_adrv904x_xcvr CONFIG.TXPI_CFG0 {0x0000}
+ad_ip_parameter util_adrv904x_xcvr CONFIG.TXPI_CFG1 {0x0000}
 
 # xcvr interfaces
 
@@ -335,7 +335,7 @@ create_bd_port -dir I ext_sync_in
 ad_ip_parameter rx_adrv904x_tpl_core/adc_tpl_core CONFIG.EXT_SYNC 1
 ad_connect ext_sync_in rx_adrv904x_tpl_core/adc_tpl_core/adc_sync_in
 
-ad_ip_instance util_vector_logic manual_sync_or [list \
+ad_ip_instance ilvector_logic manual_sync_or [list \
     C_SIZE 1 \
     C_OPERATION {or} \
 ]

--- a/projects/adrv9361z7035/common/adrv9361z7035_bd.tcl
+++ b/projects/adrv9361z7035/common/adrv9361z7035_bd.tcl
@@ -1,5 +1,5 @@
 ###############################################################################
-## Copyright (C) 2016-2024 Analog Devices, Inc. All rights reserved.
+## Copyright (C) 2016-2025 Analog Devices, Inc. All rights reserved.
 ### SPDX short identifier: ADIBSD
 ###############################################################################
 
@@ -100,13 +100,13 @@ ad_ip_instance axi_iic axi_iic_main
 ad_ip_parameter axi_iic_main CONFIG.USE_BOARD_FLOW true
 ad_ip_parameter axi_iic_main CONFIG.IIC_BOARD_INTERFACE Custom
 
-ad_ip_instance xlconcat sys_concat_intc
+ad_ip_instance ilconcat sys_concat_intc
 ad_ip_parameter sys_concat_intc CONFIG.NUM_PORTS 16
 
 ad_ip_instance proc_sys_reset sys_rstgen
 ad_ip_parameter sys_rstgen CONFIG.C_EXT_RST_WIDTH 1
 
-ad_ip_instance util_vector_logic sys_logic_inv
+ad_ip_instance ilvector_logic sys_logic_inv
 ad_ip_parameter sys_logic_inv CONFIG.C_SIZE 1
 ad_ip_parameter sys_logic_inv CONFIG.C_OPERATION not
 
@@ -226,12 +226,12 @@ ad_connect gps_pps axi_ad9361/gps_pps
 # interface clock divider to generate sampling clock
 # interface runs at 4x in 2r2t mode, and 2x in 1r1t mode
 
-ad_ip_instance xlconcat util_ad9361_divclk_sel_concat
+ad_ip_instance ilconcat util_ad9361_divclk_sel_concat
 ad_ip_parameter util_ad9361_divclk_sel_concat CONFIG.NUM_PORTS 2
 ad_connect axi_ad9361/adc_r1_mode util_ad9361_divclk_sel_concat/In0
 ad_connect axi_ad9361/dac_r1_mode util_ad9361_divclk_sel_concat/In1
 
-ad_ip_instance util_reduced_logic util_ad9361_divclk_sel
+ad_ip_instance ilreduced_logic util_ad9361_divclk_sel
 ad_ip_parameter util_ad9361_divclk_sel CONFIG.C_SIZE 2
 ad_connect util_ad9361_divclk_sel_concat/dout util_ad9361_divclk_sel/Op1
 
@@ -473,5 +473,3 @@ proc cfg_ad9361_interface {cmos_or_lvds} {
   }
 
 }
-
-

--- a/projects/adrv9364z7020/common/adrv9364z7020_bd.tcl
+++ b/projects/adrv9364z7020/common/adrv9364z7020_bd.tcl
@@ -1,5 +1,5 @@
 ###############################################################################
-## Copyright (C) 2016-2024 Analog Devices, Inc. All rights reserved.
+## Copyright (C) 2016-2025 Analog Devices, Inc. All rights reserved.
 ### SPDX short identifier: ADIBSD
 ###############################################################################
 
@@ -100,13 +100,13 @@ ad_ip_instance axi_iic axi_iic_main
 ad_ip_parameter axi_iic_main CONFIG.USE_BOARD_FLOW true
 ad_ip_parameter axi_iic_main CONFIG.IIC_BOARD_INTERFACE Custom
 
-ad_ip_instance xlconcat sys_concat_intc
+ad_ip_instance ilconcat sys_concat_intc
 ad_ip_parameter sys_concat_intc CONFIG.NUM_PORTS 16
 
 ad_ip_instance proc_sys_reset sys_rstgen
 ad_ip_parameter sys_rstgen CONFIG.C_EXT_RST_WIDTH 1
 
-ad_ip_instance util_vector_logic sys_logic_inv
+ad_ip_instance ilvector_logic sys_logic_inv
 ad_ip_parameter sys_logic_inv CONFIG.C_SIZE 1
 ad_ip_parameter sys_logic_inv CONFIG.C_OPERATION not
 
@@ -226,12 +226,12 @@ ad_connect gps_pps axi_ad9361/gps_pps
 # interface clock divider to generate sampling clock
 # interface runs at 4x in 2r2t mode, and 2x in 1r1t mode
 
-ad_ip_instance xlconcat util_ad9361_divclk_sel_concat
+ad_ip_instance ilconcat util_ad9361_divclk_sel_concat
 ad_ip_parameter util_ad9361_divclk_sel_concat CONFIG.NUM_PORTS 2
 ad_connect axi_ad9361/adc_r1_mode util_ad9361_divclk_sel_concat/In0
 ad_connect axi_ad9361/dac_r1_mode util_ad9361_divclk_sel_concat/In1
 
-ad_ip_instance util_reduced_logic util_ad9361_divclk_sel
+ad_ip_instance ilreduced_logic util_ad9361_divclk_sel
 ad_ip_parameter util_ad9361_divclk_sel CONFIG.C_SIZE 2
 ad_connect util_ad9361_divclk_sel_concat/dout util_ad9361_divclk_sel/Op1
 
@@ -473,5 +473,3 @@ proc cfg_ad9361_interface {cmos_or_lvds} {
   }
 
 }
-
-

--- a/projects/adrv9371x/common/adrv9371x_bd.tcl
+++ b/projects/adrv9371x/common/adrv9371x_bd.tcl
@@ -284,7 +284,7 @@ for {set i 0} {$i < $TX_NUM_OF_CONVERTERS} {incr i} {
 if {$TX_NUM_OF_CONVERTERS <= 2} {
   ad_connect  tx_fir_interpolator/valid_out_0  util_ad9371_tx_upack/fifo_rd_en
 } else {
-  ad_ip_instance util_vector_logic logic_or [list \
+  ad_ip_instance ilvector_logic logic_or [list \
     C_OPERATION {or} \
     C_SIZE 1]
 

--- a/projects/cn0363/common/cn0363_bd.tcl
+++ b/projects/cn0363/common/cn0363_bd.tcl
@@ -1,5 +1,5 @@
 ###############################################################################
-## Copyright (C) 2016-2024 Analog Devices, Inc. All rights reserved.
+## Copyright (C) 2016-2025 Analog Devices, Inc. All rights reserved.
 ### SPDX short identifier: ADIBSD
 ###############################################################################
 
@@ -73,7 +73,7 @@ ad_connect util_sigma_delta_spi/data_ready $hier_spi_engine/trigger
 ad_connect util_sigma_delta_spi/m_spi spi
 
 ad_ip_instance c_counter_binary phase_gen
-ad_ip_instance xlslice phase_slice
+ad_ip_instance ilslice phase_slice
 create_bd_port -dir O excitation
 
 set excitation_freq 1020
@@ -148,7 +148,7 @@ current_bd_instance /processing
 	ad_ip_parameter lpf	CONFIG.Has_ARESETn true
 	ad_ip_parameter lpf	CONFIG.Reset_Data_Vector false
 
-  ad_ip_instance util_vector_logic overflow_or
+  ad_ip_instance ilvector_logic overflow_or
 	ad_ip_parameter overflow_or	CONFIG.C_SIZE 1
 	ad_ip_parameter overflow_or	CONFIG.C_OPERATION or
 

--- a/projects/cn0585/common/cn0585_bd.tcl
+++ b/projects/cn0585/common/cn0585_bd.tcl
@@ -1,5 +1,5 @@
 ###############################################################################
-## Copyright (C) 2022-2024 Analog Devices, Inc. All rights reserved.
+## Copyright (C) 2022-2025 Analog Devices, Inc. All rights reserved.
 ### SPDX short identifier: ADIBSD
 ###############################################################################
 
@@ -108,7 +108,7 @@ ad_ip_parameter axi_pwm_gen CONFIG.PULSE_3_WIDTH 1
 
 # constant 1
 
-create_bd_cell -type ip -vlnv xilinx.com:ip:xlconstant:1.1 const_vcc_1
+create_bd_cell -type inline_hdl -vlnv xilinx.com:inline_hdl:ilconstant const_vcc_1
 
 # sys_rstgen
 

--- a/projects/common/ac701/ac701_system_bd.tcl
+++ b/projects/common/ac701/ac701_system_bd.tcl
@@ -131,7 +131,7 @@ ad_connect  sys_cpu_clk                 rom_sys_0/clk
 ad_ip_instance axi_intc axi_intc
 ad_ip_parameter axi_intc CONFIG.C_HAS_FAST 0
 
-ad_ip_instance xlconcat sys_concat_intc
+ad_ip_instance ilconcat sys_concat_intc
 ad_ip_parameter sys_concat_intc CONFIG.NUM_PORTS 16
 
 # connections
@@ -284,5 +284,3 @@ create_bd_addr_seg -range 0x2000 -offset 0x0 [get_bd_addr_spaces sys_mb/Data] \
   [get_bd_addr_segs sys_dlmb_cntlr/SLMB/Mem] SEG_dlmb_cntlr
 create_bd_addr_seg -range 0x2000 -offset 0x0 [get_bd_addr_spaces sys_mb/Instruction] \
   [get_bd_addr_segs sys_ilmb_cntlr/SLMB/Mem] SEG_ilmb_cntlr
-
-

--- a/projects/common/coraz7s/coraz7s_system_bd.tcl
+++ b/projects/common/coraz7s/coraz7s_system_bd.tcl
@@ -54,7 +54,7 @@ ad_ip_parameter sys_ps7 CONFIG.PCW_SPI0_SPI0_IO EMIO
 ad_ip_parameter sys_ps7 CONFIG.PCW_SPI1_PERIPHERAL_ENABLE 1
 ad_ip_parameter sys_ps7 CONFIG.PCW_SPI1_SPI1_IO EMIO
 
-ad_ip_instance xlconcat sys_concat_intc
+ad_ip_instance ilconcat sys_concat_intc
 ad_ip_parameter sys_concat_intc CONFIG.NUM_PORTS 16
 
 ad_ip_instance proc_sys_reset sys_rstgen

--- a/projects/common/kcu105/kcu105_system_bd.tcl
+++ b/projects/common/kcu105/kcu105_system_bd.tcl
@@ -127,7 +127,7 @@ ad_ip_parameter axi_gpio CONFIG.C_INTERRUPT_PRESENT 1
 ad_ip_instance axi_intc axi_intc
 ad_ip_parameter axi_intc CONFIG.C_HAS_FAST 0
 
-ad_ip_instance xlconcat sys_concat_intc
+ad_ip_instance ilconcat sys_concat_intc
 ad_ip_parameter sys_concat_intc CONFIG.NUM_PORTS 16
 
 # ddr4
@@ -278,5 +278,3 @@ create_bd_addr_seg -range 0x20000 -offset 0x0 [get_bd_addr_spaces sys_mb/Data] \
   [get_bd_addr_segs sys_dlmb_cntlr/SLMB/Mem] SEG_dlmb_cntlr
 create_bd_addr_seg -range 0x20000 -offset 0x0 [get_bd_addr_spaces sys_mb/Instruction] \
   [get_bd_addr_segs sys_ilmb_cntlr/SLMB/Mem] SEG_ilmb_cntlr
-
-

--- a/projects/common/kv260/kv260_system_bd.tcl
+++ b/projects/common/kv260/kv260_system_bd.tcl
@@ -102,7 +102,7 @@ ad_connect  gpio_t sys_ps8/emio_gpio_t
 
 # spi
 
-ad_ip_instance xlconcat spi0_csn_concat
+ad_ip_instance ilconcat spi0_csn_concat
 ad_ip_parameter spi0_csn_concat CONFIG.NUM_PORTS 3
 ad_connect  sys_ps8/emio_spi0_ss_o_n spi0_csn_concat/In0
 ad_connect  sys_ps8/emio_spi0_ss1_o_n spi0_csn_concat/In1
@@ -115,10 +115,10 @@ ad_connect  sys_ps8/emio_spi0_ss_i_n VCC
 ad_connect  sys_ps8/emio_spi0_sclk_i GND
 ad_connect  sys_ps8/emio_spi0_s_i GND
 
-ad_ip_instance xlconcat sys_concat_intc_0
+ad_ip_instance ilconcat sys_concat_intc_0
 ad_ip_parameter sys_concat_intc_0 CONFIG.NUM_PORTS 8
 
-ad_ip_instance xlconcat sys_concat_intc_1
+ad_ip_instance ilconcat sys_concat_intc_1
 ad_ip_parameter sys_concat_intc_1 CONFIG.NUM_PORTS 8
 
 ad_connect  sys_concat_intc_0/dout sys_ps8/pl_ps_irq0

--- a/projects/common/microzed/microzed_system_bd.tcl
+++ b/projects/common/microzed/microzed_system_bd.tcl
@@ -53,7 +53,7 @@ ad_ip_parameter sys_ps7 CONFIG.PCW_USE_FABRIC_INTERRUPT 1
 ad_ip_parameter sys_ps7 CONFIG.PCW_IRQ_F2P_INTR 1
 ad_ip_parameter sys_ps7 CONFIG.PCW_IRQ_F2P_MODE REVERSE
 
-ad_ip_instance xlconcat sys_concat_intc
+ad_ip_instance ilconcat sys_concat_intc
 ad_ip_parameter sys_concat_intc CONFIG.NUM_PORTS 16
 
 ad_ip_instance proc_sys_reset sys_rstgen

--- a/projects/common/vc709/vc709_system_bd.tcl
+++ b/projects/common/vc709/vc709_system_bd.tcl
@@ -102,7 +102,7 @@ ad_ip_parameter axi_gpio CONFIG.C_INTERRUPT_PRESENT 1
 ad_ip_instance axi_intc axi_intc
 ad_ip_parameter axi_intc CONFIG.C_HAS_FAST 0
 
-ad_ip_instance xlconcat sys_concat_intc
+ad_ip_instance ilconcat sys_concat_intc
 ad_ip_parameter sys_concat_intc CONFIG.NUM_PORTS 16
 
 # linear flash

--- a/projects/common/vcu118/vcu118_system_bd.tcl
+++ b/projects/common/vcu118/vcu118_system_bd.tcl
@@ -139,7 +139,7 @@ ad_ip_parameter axi_gpio CONFIG.C_INTERRUPT_PRESENT 1
 ad_ip_instance axi_intc axi_intc
 ad_ip_parameter axi_intc CONFIG.C_HAS_FAST 0
 
-ad_ip_instance xlconcat sys_concat_intc
+ad_ip_instance ilconcat sys_concat_intc
 ad_ip_parameter sys_concat_intc CONFIG.NUM_PORTS 17
 
 # ddr4
@@ -304,4 +304,3 @@ create_bd_addr_seg -range 0x80000 -offset 0x0 [get_bd_addr_spaces sys_mb/Data] \
   [get_bd_addr_segs sys_dlmb_cntlr/SLMB/Mem] SEG_dlmb_cntlr
 create_bd_addr_seg -range 0x80000 -offset 0x0 [get_bd_addr_spaces sys_mb/Instruction] \
   [get_bd_addr_segs sys_ilmb_cntlr/SLMB/Mem] SEG_ilmb_cntlr
-

--- a/projects/common/vmk180/vmk180_system_bd.tcl
+++ b/projects/common/vmk180/vmk180_system_bd.tcl
@@ -170,7 +170,7 @@ set sys_dma_resetn        [get_bd_nets sys_350m_resetn]
 
 #
 
-ad_ip_instance xlconcat spi0_csn_sources
+ad_ip_instance ilconcat spi0_csn_sources
 ad_ip_parameter spi0_csn_sources config.num_ports {3}
 ad_connect spi0_csn_sources/dout spi0_csn
 
@@ -185,7 +185,7 @@ ad_connect  sys_cips/spi0_ss1_o spi0_csn_sources/in1
 ad_connect  sys_cips/spi0_ss2_o spi0_csn_sources/in2
 ad_connect  sys_cips/spi0_ss_i  VCC
 
-ad_ip_instance xlconcat spi1_csn_sources
+ad_ip_instance ilconcat spi1_csn_sources
 ad_ip_parameter spi1_csn_sources config.num_ports {3}
 ad_connect spi1_csn_sources/dout spi1_csn
 
@@ -212,4 +212,3 @@ ad_connect  sys_cpu_clk                 rom_sys_0/clk
 ad_cpu_interconnect 0x45000000 axi_sysid_0
 
 # interrupts
-

--- a/projects/common/vpk180/vpk180_system_bd.tcl
+++ b/projects/common/vpk180/vpk180_system_bd.tcl
@@ -180,7 +180,7 @@ set sys_dma_resetn        [get_bd_nets sys_350m_resetn]
 
 # spi
 
-ad_ip_instance xlconcat spi0_csn_sources
+ad_ip_instance ilconcat spi0_csn_sources
 ad_ip_parameter spi0_csn_sources config.num_ports {3}
 ad_connect spi0_csn_sources/dout spi0_csn
 
@@ -195,7 +195,7 @@ ad_connect  sys_cips/spi0_ss1_o spi0_csn_sources/in1
 ad_connect  sys_cips/spi0_ss2_o spi0_csn_sources/in2
 ad_connect  sys_cips/spi0_ss_i  VCC
 
-ad_ip_instance xlconcat spi1_csn_sources
+ad_ip_instance ilconcat spi1_csn_sources
 ad_ip_parameter spi1_csn_sources config.num_ports {3}
 ad_connect spi1_csn_sources/dout spi1_csn
 

--- a/projects/common/xilinx/adi_fir_filter_bd.tcl
+++ b/projects/common/xilinx/adi_fir_filter_bd.tcl
@@ -1,5 +1,5 @@
 ###############################################################################
-## Copyright (C) 2019-2023 Analog Devices, Inc. All rights reserved.
+## Copyright (C) 2019-2023, 2025 Analog Devices, Inc. All rights reserved.
 ### SPDX short identifier: ADIBSD
 ###############################################################################
 
@@ -180,7 +180,7 @@ proc ad_add_interpolation_filter {name filter_rate n_chan parallel_paths \
     create_bd_pin -dir I -from [expr 16*$parallel_paths-1] -to 0 $name/data_in_$i
     create_bd_pin -dir O -from [expr 16*$parallel_paths-1] -to 0 $name/data_out_$i
 
-    ad_ip_instance util_vector_logic $name/logic_and_$i [list \
+    ad_ip_instance ilvector_logic $name/logic_and_$i [list \
       C_SIZE 1]
 
     create_bd_cell -type module -reference ad_bus_mux $name/out_mux_$i
@@ -207,4 +207,3 @@ proc ad_add_interpolation_filter {name filter_rate n_chan parallel_paths \
     ad_connect  $name/cdc_sync_active/out_bits  $name/out_mux_${i}/select_path
   }
 }
-

--- a/projects/common/zc702/zc702_system_bd.tcl
+++ b/projects/common/zc702/zc702_system_bd.tcl
@@ -72,7 +72,7 @@ ad_ip_instance axi_iic axi_iic_main
 ad_ip_parameter axi_iic_main CONFIG.USE_BOARD_FLOW true
 ad_ip_parameter axi_iic_main CONFIG.IIC_BOARD_INTERFACE IIC_MAIN
 
-ad_ip_instance xlconcat sys_concat_intc
+ad_ip_instance ilconcat sys_concat_intc
 ad_ip_parameter sys_concat_intc CONFIG.NUM_PORTS 16
 
 ad_ip_instance proc_sys_reset sys_rstgen

--- a/projects/common/zc706/zc706_system_bd.tcl
+++ b/projects/common/zc706/zc706_system_bd.tcl
@@ -74,7 +74,7 @@ ad_ip_instance axi_iic axi_iic_main
 ad_ip_parameter axi_iic_main CONFIG.USE_BOARD_FLOW true
 ad_ip_parameter axi_iic_main CONFIG.IIC_BOARD_INTERFACE Custom
 
-ad_ip_instance xlconcat sys_concat_intc
+ad_ip_instance ilconcat sys_concat_intc
 ad_ip_parameter sys_concat_intc CONFIG.NUM_PORTS 16
 
 ad_ip_instance proc_sys_reset sys_rstgen
@@ -237,4 +237,3 @@ ad_cpu_interconnect 0x70e00000 axi_hdmi_core
 ad_cpu_interconnect 0x75c00000 axi_spdif_tx_core
 ad_mem_hp0_interconnect sys_cpu_clk sys_ps7/S_AXI_HP0
 ad_mem_hp0_interconnect sys_cpu_clk axi_hdmi_dma/m_src_axi
-

--- a/projects/common/zcu102/zcu102_system_bd.tcl
+++ b/projects/common/zcu102/zcu102_system_bd.tcl
@@ -109,7 +109,7 @@ ad_connect  gpio_t sys_ps8/emio_gpio_t
 
 # spi
 
-ad_ip_instance xlconcat spi0_csn_concat
+ad_ip_instance ilconcat spi0_csn_concat
 ad_ip_parameter spi0_csn_concat CONFIG.NUM_PORTS 3
 ad_connect  sys_ps8/emio_spi0_ss_o_n spi0_csn_concat/In0
 ad_connect  sys_ps8/emio_spi0_ss1_o_n spi0_csn_concat/In1
@@ -122,7 +122,7 @@ ad_connect  sys_ps8/emio_spi0_ss_i_n VCC
 ad_connect  sys_ps8/emio_spi0_sclk_i GND
 ad_connect  sys_ps8/emio_spi0_s_i GND
 
-ad_ip_instance xlconcat spi1_csn_concat
+ad_ip_instance ilconcat spi1_csn_concat
 ad_ip_parameter spi1_csn_concat CONFIG.NUM_PORTS 3
 ad_connect  sys_ps8/emio_spi1_ss_o_n spi1_csn_concat/In0
 ad_connect  sys_ps8/emio_spi1_ss1_o_n spi1_csn_concat/In1
@@ -145,12 +145,12 @@ ad_connect  axi_sysid_0/sys_rom_data   	rom_sys_0/rom_data
 ad_connect  sys_cpu_clk                 rom_sys_0/clk
 
 ad_cpu_interconnect 0x45000000 axi_sysid_0
-# interrupts	
+# interrupts
 
-ad_ip_instance xlconcat sys_concat_intc_0
+ad_ip_instance ilconcat sys_concat_intc_0
 ad_ip_parameter sys_concat_intc_0 CONFIG.NUM_PORTS 8
 
-ad_ip_instance xlconcat sys_concat_intc_1
+ad_ip_instance ilconcat sys_concat_intc_1
 ad_ip_parameter sys_concat_intc_1 CONFIG.NUM_PORTS 8
 
 ad_connect  sys_concat_intc_0/dout sys_ps8/pl_ps_irq0
@@ -172,4 +172,3 @@ ad_connect  sys_concat_intc_0/In3 GND
 ad_connect  sys_concat_intc_0/In2 GND
 ad_connect  sys_concat_intc_0/In1 GND
 ad_connect  sys_concat_intc_0/In0 GND
-

--- a/projects/common/zed/zed_system_bd.tcl
+++ b/projects/common/zed/zed_system_bd.tcl
@@ -93,7 +93,7 @@ ad_ip_parameter axi_iic_main CONFIG.IIC_BOARD_INTERFACE Custom
 
 ad_ip_instance util_i2c_mixer sys_i2c_mixer
 
-ad_ip_instance xlconcat sys_concat_intc
+ad_ip_instance ilconcat sys_concat_intc
 ad_ip_parameter sys_concat_intc CONFIG.NUM_PORTS 16
 
 ad_ip_instance proc_sys_reset sys_rstgen
@@ -101,7 +101,7 @@ ad_ip_parameter sys_rstgen CONFIG.C_EXT_RST_WIDTH 1
 ad_ip_instance proc_sys_reset sys_200m_rstgen
 ad_ip_parameter sys_200m_rstgen CONFIG.C_EXT_RST_WIDTH 1
 
-ad_ip_instance util_vector_logic sys_logic_inv
+ad_ip_instance ilvector_logic sys_logic_inv
 ad_ip_parameter sys_logic_inv CONFIG.C_SIZE 1
 ad_ip_parameter sys_logic_inv CONFIG.C_OPERATION not
 

--- a/projects/fmcomms2/common/fmcomms2_bd.tcl
+++ b/projects/fmcomms2/common/fmcomms2_bd.tcl
@@ -70,12 +70,12 @@ ad_connect tdd_sync_i util_ad9361_tdd_sync/sync_in
 # interface clock divider to generate sampling clock
 # interface runs at 4x in 2r2t mode, and 2x in 1r1t mode
 
-ad_ip_instance xlconcat util_ad9361_divclk_sel_concat
+ad_ip_instance ilconcat util_ad9361_divclk_sel_concat
 ad_ip_parameter util_ad9361_divclk_sel_concat CONFIG.NUM_PORTS 2
 ad_connect axi_ad9361/adc_r1_mode util_ad9361_divclk_sel_concat/In0
 ad_connect axi_ad9361/dac_r1_mode util_ad9361_divclk_sel_concat/In1
 
-ad_ip_instance util_reduced_logic util_ad9361_divclk_sel
+ad_ip_instance ilreduced_logic util_ad9361_divclk_sel
 ad_ip_parameter util_ad9361_divclk_sel CONFIG.C_SIZE 2
 ad_connect util_ad9361_divclk_sel_concat/dout util_ad9361_divclk_sel/Op1
 
@@ -242,4 +242,3 @@ if {$CACHE_COHERENCY} {
 
 ad_cpu_interrupt ps-13 mb-12 axi_ad9361_adc_dma/irq
 ad_cpu_interrupt ps-12 mb-13 axi_ad9361_dac_dma/irq
-

--- a/projects/fmcomms5/common/fmcomms5_bd.tcl
+++ b/projects/fmcomms5/common/fmcomms5_bd.tcl
@@ -104,14 +104,14 @@ ad_connect axi_ad9361_1/tdd_sync GND
 # interface clock divider to generate sampling clock
 # interface runs at 4x in 2r2t mode, and 2x in 1r1t mode
 
-ad_ip_instance xlconcat util_ad9361_divclk_sel_concat
+ad_ip_instance ilconcat util_ad9361_divclk_sel_concat
 ad_ip_parameter util_ad9361_divclk_sel_concat CONFIG.NUM_PORTS 4
 ad_connect axi_ad9361_0/adc_r1_mode util_ad9361_divclk_sel_concat/In0
 ad_connect axi_ad9361_0/dac_r1_mode util_ad9361_divclk_sel_concat/In1
 ad_connect axi_ad9361_1/adc_r1_mode util_ad9361_divclk_sel_concat/In2
 ad_connect axi_ad9361_1/dac_r1_mode util_ad9361_divclk_sel_concat/In3
 
-ad_ip_instance util_reduced_logic util_ad9361_divclk_sel
+ad_ip_instance ilreduced_logic util_ad9361_divclk_sel
 ad_ip_parameter util_ad9361_divclk_sel CONFIG.C_SIZE 4
 ad_connect util_ad9361_divclk_sel_concat/dout util_ad9361_divclk_sel/Op1
 

--- a/projects/jupiter_sdr/system_bd.tcl
+++ b/projects/jupiter_sdr/system_bd.tcl
@@ -199,9 +199,9 @@ ad_connect  sys_cpu_clk rom_sys_0/clk
 
 # interrupts
 
-ad_ip_instance xlconcat sys_concat_intc_0
+ad_ip_instance ilconcat sys_concat_intc_0
 ad_ip_parameter sys_concat_intc_0 CONFIG.NUM_PORTS 8
-ad_ip_instance xlconcat sys_concat_intc_1
+ad_ip_instance ilconcat sys_concat_intc_1
 ad_ip_parameter sys_concat_intc_1 CONFIG.NUM_PORTS 8
 
 ad_connect  sys_concat_intc_0/dout sys_ps8/pl_ps_irq0

--- a/projects/m2k/system_bd.tcl
+++ b/projects/m2k/system_bd.tcl
@@ -137,7 +137,7 @@ ad_ip_parameter sys_ps7 CONFIG.PCW_UIPARAM_DDR_FREQ_MHZ {500.0}
 
 ad_ip_instance axi_iic axi_iic_main
 
-ad_ip_instance xlconcat sys_concat_intc
+ad_ip_instance ilconcat sys_concat_intc
 ad_ip_parameter sys_concat_intc CONFIG.NUM_PORTS 16
 
 ad_ip_instance proc_sys_reset sys_rstgen
@@ -229,7 +229,7 @@ ad_ip_parameter bram_adc CONFIG.Write_Width_B 32
 ad_ip_parameter bram_adc CONFIG.Read_Width_B 32
 ad_ip_parameter bram_adc CONFIG.Write_Depth_A 8192
 
-create_bd_cell -type ip -vlnv xilinx.com:ip:xlconcat:2.1 ad9963_adc_concat
+create_bd_cell -type inline_hdl -vlnv xilinx.com:inline_hdl:ilconcat ad9963_adc_concat
 
 ad_ip_instance axi_dmac ad9963_adc_dmac
 ad_ip_parameter ad9963_adc_dmac CONFIG.DMA_DATA_WIDTH_SRC 32

--- a/projects/pluto/system_bd.tcl
+++ b/projects/pluto/system_bd.tcl
@@ -1,5 +1,5 @@
 ###############################################################################
-## Copyright (C) 2014-2024 Analog Devices, Inc. All rights reserved.
+## Copyright (C) 2014-2025 Analog Devices, Inc. All rights reserved.
 ### SPDX short identifier: ADIBSD
 ###############################################################################
 
@@ -94,7 +94,7 @@ ad_ip_parameter sys_ps7 CONFIG.PCW_UIPARAM_DDR_DQS_TO_CLK_DELAY_1 0.050
 ad_ip_parameter sys_ps7 CONFIG.PCW_UIPARAM_DDR_BOARD_DELAY0 0.241
 ad_ip_parameter sys_ps7 CONFIG.PCW_UIPARAM_DDR_BOARD_DELAY1 0.240
 
-ad_ip_instance xlconcat sys_concat_intc
+ad_ip_instance ilconcat sys_concat_intc
 ad_ip_parameter sys_concat_intc CONFIG.NUM_PORTS 16
 
 ad_ip_instance proc_sys_reset sys_rstgen
@@ -212,7 +212,7 @@ ad_ip_parameter axi_ad9361_dac_dma CONFIG.DMA_DATA_WIDTH_DEST 64
 
 ad_add_interpolation_filter "tx_fir_interpolator" 8 2 1 {61.44} {7.68} \
                              "$ad_hdl_dir/library/util_fir_int/coefile_int.coe"
-ad_ip_instance xlslice interp_slice
+ad_ip_instance ilslice interp_slice
 ad_ip_instance util_upack2 tx_upack
 
 ad_ip_instance axi_dmac axi_ad9361_adc_dma
@@ -227,7 +227,7 @@ ad_ip_parameter axi_ad9361_adc_dma CONFIG.DMA_DATA_WIDTH_SRC 64
 
 ad_add_decimation_filter "rx_fir_decimator" 8 2 1 {61.44} {61.44} \
                          "$ad_hdl_dir/library/util_fir_int/coefile_int.coe"
-ad_ip_instance xlslice decim_slice
+ad_ip_instance ilslice decim_slice
 ad_ip_instance util_cpack2 cpack
 
 # connections
@@ -298,7 +298,7 @@ ad_connect axi_ad9361/dac_data_q1 tx_upack/fifo_rd_data_3
 
 ad_connect tx_upack/s_axis  axi_ad9361_dac_dma/m_axis
 
-ad_ip_instance util_vector_logic logic_or [list \
+ad_ip_instance ilvector_logic logic_or [list \
   C_OPERATION {or} \
   C_SIZE 1]
 
@@ -332,7 +332,7 @@ ad_tdd_gen_create axi_tdd_0 $TDD_CHANNEL_CNT \
                             $TDD_SYNC_EXT \
                             $TDD_SYNC_EXT_CDC
 
-ad_ip_instance util_vector_logic logic_inv [list \
+ad_ip_instance ilvector_logic logic_inv [list \
   C_OPERATION {not} \
   C_SIZE 1]
 
@@ -380,4 +380,3 @@ ad_connect sys_cpu_resetn axi_ad9361_dac_dma/m_src_axi_aresetn
 ad_cpu_interrupt ps-13 mb-13 axi_ad9361_adc_dma/irq
 ad_cpu_interrupt ps-12 mb-12 axi_ad9361_dac_dma/irq
 ad_cpu_interrupt ps-11 mb-11 axi_spi/ip2intc_irpt
-

--- a/projects/scripts/adi_board.tcl
+++ b/projects/scripts/adi_board.tcl
@@ -1,5 +1,5 @@
 ###############################################################################
-## Copyright (C) 2014-2023 Analog Devices, Inc. All rights reserved.
+## Copyright (C) 2014-2023, 2025 Analog Devices, Inc. All rights reserved.
 ### SPDX short identifier: ADIBSD
 ###############################################################################
 
@@ -23,7 +23,7 @@ set xcvr_instance NONE
 
 set use_smartconnect 1
 
-## Add an instance of an IP to the block design.
+## Add an instance of an IP or inline_hdl to the block design.
 #
 # \param[i_ip] - name of the IP
 # \param[i_name] - name of the instance
@@ -31,9 +31,13 @@ set use_smartconnect 1
 # pairs
 #
 proc ad_ip_instance {i_ip i_name {i_params {}}} {
-
-  set cell [create_bd_cell -type ip -vlnv [get_ipdefs -all -filter "VLNV =~ *:${i_ip}:* && \
-    design_tool_contexts =~ *IPI* && UPGRADE_VERSIONS == \"\""] ${i_name}]
+  set ip_type ip
+  set ip_def [get_ipdefs -all -filter "VLNV =~ *:${i_ip}:* && \
+    design_tool_contexts =~ *IPI* && UPGRADE_VERSIONS == \"\""]
+  if {[string match "*inline_hdl*" $ip_def]} {
+    set ip_type inline_hdl
+  }
+  set cell [create_bd_cell -type ${ip_type} -vlnv ${ip_def} ${i_name}]
   if {$i_params != {}} {
     set config {}
     # Add CONFIG. prefix to all config options
@@ -119,7 +123,7 @@ proc ad_connect_int_get_const {name width} {
   set cell [get_bd_cells -quiet $cell_name]
   if {$cell eq ""} {
     # Create new constant source
-    ad_ip_instance xlconstant $cell_name
+    ad_ip_instance ilconstant $cell_name
     set cell [get_bd_cells -quiet $cell_name]
     set_property CONFIG.CONST_WIDTH $width $cell
     set_property CONFIG.CONST_VAL $value $cell


### PR DESCRIPTION
## PR Description

With Vivado 2024.2, Xilinx introduced new utility IPs variants called "inline_hdl" that are now recommended and should lead to faster build times.

The old variants are supposedly being removed in the 2026 Vivado release.


## PR Type
- [ ] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)
- [ ] Documentation

## PR Checklist
- [x] I have followed the code style guidelines
- [x] I have performed a self-review of changes
- [ ] I have compiled all hdl projects and libraries affected by this PR
- [ ] I have tested in hardware affected projects, at least on relevant boards
- [ ] I have commented my code, at least hard-to-understand parts
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe files, Copyright etc)
- [x] I have not introduced new Warnings/Critical Warnings on compilation
- [ ] I have added new hdl testbenches or updated existing ones
