### PR TITLE
adrv9361z7035: Add VADJ values in README

### DIFF
--- a/projects/adrv9361z7035/README.md
+++ b/projects/adrv9361z7035/README.md
@@ -3,6 +3,7 @@
 - Evaluation board product page: [ADRV9361-Z7035](https://www.analog.com/adrv9361-z7035)
 - System documentation: https://wiki.analog.com/resources/eval/user-guides/adrv936x_rfsom
 - HDL project documentation: https://analogdevicesinc.github.io/hdl/projects/adrv9361z7035/index.html
+- Evaluation board VADJ range: 1.2V - 1.8V
 
 ## Supported parts
 

--- a/projects/adrv9361z7035/ccbob_cmos/README.md
+++ b/projects/adrv9361z7035/ccbob_cmos/README.md
@@ -1,7 +1,11 @@
+<!-- no_build_example, no_no_os -->
+
 # ADRV9361Z7035/CCBOB-CMOS HDL Project
 
 CCBOB_CMOS means [ADRV1CRR-BOB](https://www.analog.com/en/resources/evaluation-hardware-and-software/evaluation-boards-kits/adrv1crr-bob.html)
 to be used with CMOS version of the signals.
+
+- VADJ with which it was tested in hardware: 1.8V
 
 ## Building the project
 

--- a/projects/adrv9361z7035/ccbob_lvds/README.md
+++ b/projects/adrv9361z7035/ccbob_lvds/README.md
@@ -1,7 +1,11 @@
+<!-- no_build_example, no_no_os -->
+
 # ADRV9361Z7035/CCBOB-LVDS HDL Project
 
 CCBOB_LVDS means [ADRV1CRR-BOB](https://www.analog.com/en/resources/evaluation-hardware-and-software/evaluation-boards-kits/adrv1crr-bob.html)
 to be used with LVDS version of the signals.
+
+- VADJ with which it was tested in hardware: 1.8V
 
 ## Building the project
 

--- a/projects/adrv9361z7035/ccfmc_lvds/README.md
+++ b/projects/adrv9361z7035/ccfmc_lvds/README.md
@@ -1,7 +1,11 @@
+<!-- no_build_example, no_no_os -->
+
 # ADRV9361Z7035/CCFMC-LVDS HDL Project
 
 CCFMC_LVDS means [ADRV1CRR-FMC](https://www.analog.com/en/resources/evaluation-hardware-and-software/evaluation-boards-kits/adrv1crr-fmc.html)
 to be used with LVDS version of the signals.
+
+- VADJ with which it was tested in hardware: 1.8V
 
 ## Building the project
 


### PR DESCRIPTION
## PR Description

Add VADJ range & flags in README files for adrv9361z7035.

## PR Type
- [ ] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)
- [x] Documentation

## PR Checklist
- [x] I have followed the code style guidelines
- [x] I have performed a self-review of changes
- [ ] I have compiled all hdl projects and libraries affected by this PR
- [ ] I have tested in hardware affected projects, at least on relevant boards
- [ ] I have commented my code, at least hard-to-understand parts
- [x] I have signed off all commits from this PR
- [x] I have updated the documentation (wiki pages, ReadMe files, Copyright etc)
- [x] I have not introduced new Warnings/Critical Warnings on compilation
- [ ] I have added new hdl testbenches or updated existing ones
