### PR TITLE
jupiter/adrv9001: Enable DMA Scatter-Gather

### DIFF
--- a/projects/adrv9001/common/adrv9001_bd.tcl
+++ b/projects/adrv9001/common/adrv9001_bd.tcl
@@ -79,7 +79,9 @@ ad_ip_parameter axi_adrv9001_rx1_dma CONFIG.SYNC_TRANSFER_START 1
 ad_ip_parameter axi_adrv9001_rx1_dma CONFIG.AXI_SLICE_SRC 0
 ad_ip_parameter axi_adrv9001_rx1_dma CONFIG.AXI_SLICE_DEST 0
 ad_ip_parameter axi_adrv9001_rx1_dma CONFIG.DMA_2D_TRANSFER 0
+ad_ip_parameter axi_adrv9001_rx1_dma CONFIG.DMA_SG_TRANSFER 1
 ad_ip_parameter axi_adrv9001_rx1_dma CONFIG.DMA_DATA_WIDTH_SRC 64
+ad_ip_parameter axi_adrv9001_rx1_dma CONFIG.DMA_DATA_WIDTH_SG 64
 ad_ip_parameter axi_adrv9001_rx1_dma CONFIG.CACHE_COHERENT $CACHE_COHERENCY
 
 ad_ip_instance util_cpack2 util_adc_1_pack { \
@@ -97,7 +99,9 @@ ad_ip_parameter axi_adrv9001_rx2_dma CONFIG.SYNC_TRANSFER_START 1
 ad_ip_parameter axi_adrv9001_rx2_dma CONFIG.AXI_SLICE_SRC 0
 ad_ip_parameter axi_adrv9001_rx2_dma CONFIG.AXI_SLICE_DEST 0
 ad_ip_parameter axi_adrv9001_rx2_dma CONFIG.DMA_2D_TRANSFER 0
+ad_ip_parameter axi_adrv9001_rx2_dma CONFIG.DMA_SG_TRANSFER 1
 ad_ip_parameter axi_adrv9001_rx2_dma CONFIG.DMA_DATA_WIDTH_SRC 32
+ad_ip_parameter axi_adrv9001_rx2_dma CONFIG.DMA_DATA_WIDTH_SG 64
 ad_ip_parameter axi_adrv9001_rx2_dma CONFIG.CACHE_COHERENT $CACHE_COHERENCY
 
 ad_ip_instance util_cpack2 util_adc_2_pack { \
@@ -115,7 +119,9 @@ ad_ip_parameter axi_adrv9001_tx1_dma CONFIG.SYNC_TRANSFER_START 0
 ad_ip_parameter axi_adrv9001_tx1_dma CONFIG.AXI_SLICE_SRC 0
 ad_ip_parameter axi_adrv9001_tx1_dma CONFIG.AXI_SLICE_DEST 0
 ad_ip_parameter axi_adrv9001_tx1_dma CONFIG.DMA_2D_TRANSFER 0
+ad_ip_parameter axi_adrv9001_tx1_dma CONFIG.DMA_SG_TRANSFER 1
 ad_ip_parameter axi_adrv9001_tx1_dma CONFIG.DMA_DATA_WIDTH_DEST 64
+ad_ip_parameter axi_adrv9001_tx1_dma CONFIG.DMA_DATA_WIDTH_SG 64
 ad_ip_parameter axi_adrv9001_tx1_dma CONFIG.CACHE_COHERENT $CACHE_COHERENCY
 
 ad_ip_instance util_upack2 util_dac_1_upack { \
@@ -133,7 +139,9 @@ ad_ip_parameter axi_adrv9001_tx2_dma CONFIG.SYNC_TRANSFER_START 0
 ad_ip_parameter axi_adrv9001_tx2_dma CONFIG.AXI_SLICE_SRC 0
 ad_ip_parameter axi_adrv9001_tx2_dma CONFIG.AXI_SLICE_DEST 0
 ad_ip_parameter axi_adrv9001_tx2_dma CONFIG.DMA_2D_TRANSFER 0
+ad_ip_parameter axi_adrv9001_tx2_dma CONFIG.DMA_SG_TRANSFER 1
 ad_ip_parameter axi_adrv9001_tx2_dma CONFIG.DMA_DATA_WIDTH_DEST 32
+ad_ip_parameter axi_adrv9001_tx2_dma CONFIG.DMA_DATA_WIDTH_SG 64
 ad_ip_parameter axi_adrv9001_tx2_dma CONFIG.CACHE_COHERENT $CACHE_COHERENCY
 
 ad_ip_instance util_upack2 util_dac_2_upack { \
@@ -286,20 +294,34 @@ if {$CACHE_COHERENCY} {
   ad_mem_hpc0_interconnect $sys_cpu_clk sys_ps8/S_AXI_HPC0
   ad_mem_hpc0_interconnect $sys_cpu_clk axi_adrv9001_rx1_dma/m_dest_axi
   ad_mem_hpc0_interconnect $sys_cpu_clk axi_adrv9001_rx2_dma/m_dest_axi
-  ad_mem_hpc0_interconnect $sys_cpu_clk axi_adrv9001_tx1_dma/m_src_axi
-  ad_mem_hpc0_interconnect $sys_cpu_clk axi_adrv9001_tx2_dma/m_src_axi
+  ad_mem_hpc0_interconnect $sys_cpu_clk axi_adrv9001_rx1_dma/m_sg_axi
+  ad_mem_hpc0_interconnect $sys_cpu_clk axi_adrv9001_rx2_dma/m_sg_axi
+  ad_mem_hpc1_interconnect $sys_cpu_clk sys_ps8/S_AXI_HPC1
+  ad_mem_hpc1_interconnect $sys_cpu_clk axi_adrv9001_tx1_dma/m_src_axi
+  ad_mem_hpc1_interconnect $sys_cpu_clk axi_adrv9001_tx2_dma/m_src_axi
+  ad_mem_hpc1_interconnect $sys_cpu_clk axi_adrv9001_tx1_dma/m_sg_axi
+  ad_mem_hpc1_interconnect $sys_cpu_clk axi_adrv9001_tx2_dma/m_sg_axi
 } else {
   ad_mem_hp1_interconnect $sys_cpu_clk sys_ps7/S_AXI_HP1
   ad_mem_hp1_interconnect $sys_cpu_clk axi_adrv9001_rx1_dma/m_dest_axi
   ad_mem_hp1_interconnect $sys_cpu_clk axi_adrv9001_rx2_dma/m_dest_axi
-  ad_mem_hp1_interconnect $sys_cpu_clk axi_adrv9001_tx1_dma/m_src_axi
-  ad_mem_hp1_interconnect $sys_cpu_clk axi_adrv9001_tx2_dma/m_src_axi
+  ad_mem_hp1_interconnect $sys_cpu_clk axi_adrv9001_rx1_dma/m_sg_axi
+  ad_mem_hp1_interconnect $sys_cpu_clk axi_adrv9001_rx2_dma/m_sg_axi
+  ad_mem_hp2_interconnect $sys_cpu_clk sys_ps7/S_AXI_HP2
+  ad_mem_hp2_interconnect $sys_cpu_clk axi_adrv9001_tx1_dma/m_src_axi
+  ad_mem_hp2_interconnect $sys_cpu_clk axi_adrv9001_tx2_dma/m_src_axi
+  ad_mem_hp2_interconnect $sys_cpu_clk axi_adrv9001_tx1_dma/m_sg_axi
+  ad_mem_hp2_interconnect $sys_cpu_clk axi_adrv9001_tx2_dma/m_sg_axi
 }
 
 ad_connect $sys_cpu_resetn axi_adrv9001_rx1_dma/m_dest_axi_aresetn
 ad_connect $sys_cpu_resetn axi_adrv9001_rx2_dma/m_dest_axi_aresetn
 ad_connect $sys_cpu_resetn axi_adrv9001_tx1_dma/m_src_axi_aresetn
 ad_connect $sys_cpu_resetn axi_adrv9001_tx2_dma/m_src_axi_aresetn
+ad_connect $sys_cpu_resetn axi_adrv9001_rx1_dma/m_sg_axi_aresetn
+ad_connect $sys_cpu_resetn axi_adrv9001_rx2_dma/m_sg_axi_aresetn
+ad_connect $sys_cpu_resetn axi_adrv9001_tx1_dma/m_sg_axi_aresetn
+ad_connect $sys_cpu_resetn axi_adrv9001_tx2_dma/m_sg_axi_aresetn
 
 # interrupts
 

--- a/projects/jupiter_sdr/system_bd.tcl
+++ b/projects/jupiter_sdr/system_bd.tcl
@@ -326,8 +326,10 @@ ad_ip_parameter axi_adrv9001_rx1_dma CONFIG.CYCLIC 0
 ad_ip_parameter axi_adrv9001_rx1_dma CONFIG.SYNC_TRANSFER_START 1
 ad_ip_parameter axi_adrv9001_rx1_dma CONFIG.AXI_SLICE_SRC 0
 ad_ip_parameter axi_adrv9001_rx1_dma CONFIG.AXI_SLICE_DEST 0
+ad_ip_parameter axi_adrv9001_rx1_dma CONFIG.DMA_SG_TRANSFER 1
 ad_ip_parameter axi_adrv9001_rx1_dma CONFIG.DMA_2D_TRANSFER 0
 ad_ip_parameter axi_adrv9001_rx1_dma CONFIG.DMA_DATA_WIDTH_SRC 64
+ad_ip_parameter axi_adrv9001_rx1_dma CONFIG.DMA_DATA_WIDTH_SG 64
 ad_ip_parameter axi_adrv9001_rx1_dma CONFIG.CACHE_COHERENT 1
 ad_ip_parameter axi_adrv9001_rx1_dma CONFIG.AXI_AXCACHE 0b1111
 ad_ip_parameter axi_adrv9001_rx1_dma CONFIG.AXI_AXPROT 0b010
@@ -346,8 +348,10 @@ ad_ip_parameter axi_adrv9001_rx2_dma CONFIG.CYCLIC 0
 ad_ip_parameter axi_adrv9001_rx2_dma CONFIG.SYNC_TRANSFER_START 1
 ad_ip_parameter axi_adrv9001_rx2_dma CONFIG.AXI_SLICE_SRC 0
 ad_ip_parameter axi_adrv9001_rx2_dma CONFIG.AXI_SLICE_DEST 0
+ad_ip_parameter axi_adrv9001_rx2_dma CONFIG.DMA_SG_TRANSFER 1
 ad_ip_parameter axi_adrv9001_rx2_dma CONFIG.DMA_2D_TRANSFER 0
 ad_ip_parameter axi_adrv9001_rx2_dma CONFIG.DMA_DATA_WIDTH_SRC 64
+ad_ip_parameter axi_adrv9001_rx2_dma CONFIG.DMA_DATA_WIDTH_SG 64
 ad_ip_parameter axi_adrv9001_rx2_dma CONFIG.CACHE_COHERENT 1
 ad_ip_parameter axi_adrv9001_rx2_dma CONFIG.AXI_AXCACHE 0b1111
 ad_ip_parameter axi_adrv9001_rx2_dma CONFIG.AXI_AXPROT 0b010
@@ -366,8 +370,10 @@ ad_ip_parameter axi_adrv9001_tx1_dma CONFIG.CYCLIC 1
 ad_ip_parameter axi_adrv9001_tx1_dma CONFIG.SYNC_TRANSFER_START 0
 ad_ip_parameter axi_adrv9001_tx1_dma CONFIG.AXI_SLICE_SRC 0
 ad_ip_parameter axi_adrv9001_tx1_dma CONFIG.AXI_SLICE_DEST 0
+ad_ip_parameter axi_adrv9001_tx1_dma CONFIG.DMA_SG_TRANSFER 1
 ad_ip_parameter axi_adrv9001_tx1_dma CONFIG.DMA_2D_TRANSFER 0
 ad_ip_parameter axi_adrv9001_tx1_dma CONFIG.DMA_DATA_WIDTH_DEST 64
+ad_ip_parameter axi_adrv9001_tx1_dma CONFIG.DMA_DATA_WIDTH_SG 64
 ad_ip_parameter axi_adrv9001_tx1_dma CONFIG.CACHE_COHERENT 1
 ad_ip_parameter axi_adrv9001_tx1_dma CONFIG.AXI_AXCACHE 0b1111
 ad_ip_parameter axi_adrv9001_tx1_dma CONFIG.AXI_AXPROT 0b010
@@ -386,8 +392,10 @@ ad_ip_parameter axi_adrv9001_tx2_dma CONFIG.CYCLIC 1
 ad_ip_parameter axi_adrv9001_tx2_dma CONFIG.SYNC_TRANSFER_START 0
 ad_ip_parameter axi_adrv9001_tx2_dma CONFIG.AXI_SLICE_SRC 0
 ad_ip_parameter axi_adrv9001_tx2_dma CONFIG.AXI_SLICE_DEST 0
+ad_ip_parameter axi_adrv9001_tx2_dma CONFIG.DMA_SG_TRANSFER 1
 ad_ip_parameter axi_adrv9001_tx2_dma CONFIG.DMA_2D_TRANSFER 0
 ad_ip_parameter axi_adrv9001_tx2_dma CONFIG.DMA_DATA_WIDTH_DEST 32
+ad_ip_parameter axi_adrv9001_tx2_dma CONFIG.DMA_DATA_WIDTH_SG 64
 ad_ip_parameter axi_adrv9001_tx2_dma CONFIG.CACHE_COHERENT 1
 ad_ip_parameter axi_adrv9001_tx2_dma CONFIG.AXI_AXCACHE 0b1111
 ad_ip_parameter axi_adrv9001_tx2_dma CONFIG.AXI_AXPROT 0b010
@@ -624,16 +632,27 @@ ad_cpu_interconnect 0x44A60000  axi_adrv9001_tx2_dma
 ad_cpu_interconnect 0x45000000  axi_sysid_0
 ad_cpu_interconnect 0x44A70000  pl_sysmon
 
-ad_mem_hpc0_interconnect $sys_dma_clk sys_ps7/S_AXI_HPC0
+ad_mem_hpc0_interconnect $sys_dma_clk sys_ps8/S_AXI_HPC0
 ad_mem_hpc0_interconnect $sys_dma_clk axi_adrv9001_rx1_dma/m_dest_axi
 ad_mem_hpc0_interconnect $sys_dma_clk axi_adrv9001_rx2_dma/m_dest_axi
-ad_mem_hpc0_interconnect $sys_dma_clk axi_adrv9001_tx1_dma/m_src_axi
-ad_mem_hpc0_interconnect $sys_dma_clk axi_adrv9001_tx2_dma/m_src_axi
+ad_mem_hpc0_interconnect $sys_dma_clk axi_adrv9001_rx1_dma/m_sg_axi
+ad_mem_hpc0_interconnect $sys_dma_clk axi_adrv9001_rx2_dma/m_sg_axi
+
+ad_mem_hpc1_interconnect $sys_dma_clk sys_ps8/S_AXI_HPC1
+ad_mem_hpc1_interconnect $sys_dma_clk axi_adrv9001_tx1_dma/m_src_axi
+ad_mem_hpc1_interconnect $sys_dma_clk axi_adrv9001_tx2_dma/m_src_axi
+ad_mem_hpc1_interconnect $sys_dma_clk axi_adrv9001_tx1_dma/m_sg_axi
+ad_mem_hpc1_interconnect $sys_dma_clk axi_adrv9001_tx2_dma/m_sg_axi
 
 ad_connect $sys_dma_resetn axi_adrv9001_rx1_dma/m_dest_axi_aresetn
 ad_connect $sys_dma_resetn axi_adrv9001_rx2_dma/m_dest_axi_aresetn
 ad_connect $sys_dma_resetn axi_adrv9001_tx1_dma/m_src_axi_aresetn
 ad_connect $sys_dma_resetn axi_adrv9001_tx2_dma/m_src_axi_aresetn
+
+ad_connect $sys_dma_resetn axi_adrv9001_rx1_dma/m_sg_axi_aresetn
+ad_connect $sys_dma_resetn axi_adrv9001_rx2_dma/m_sg_axi_aresetn
+ad_connect $sys_dma_resetn axi_adrv9001_tx1_dma/m_sg_axi_aresetn
+ad_connect $sys_dma_resetn axi_adrv9001_tx2_dma/m_sg_axi_aresetn
 
 # interrupts
 ad_cpu_interrupt ps-13 mb-12 axi_adrv9001_rx1_dma/irq


### PR DESCRIPTION
## PR Description

This PR enables the DMA Scatter-Gather core and connections for jupiter_sdr and adrv9001 projects.

## PR Type
- [ ] Bug fix (change that fixes an issue)
- [x] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)
- [ ] Documentation

## PR Checklist
- [x] I have followed the code style guidelines
- [x] I have performed a self-review of changes
- [x] I have compiled all hdl projects and libraries affected by this PR
- [ ] I have tested in hardware affected projects, at least on relevant boards
- [ ] I have commented my code, at least hard-to-understand parts
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe files, Copyright etc)
- [ ] I have not introduced new Warnings/Critical Warnings on compilation
- [ ] I have added new hdl testbenches or updated existing ones
