### PR TITLE
project/ad4062: Resolve critical warnings

### DIFF
--- a/library/i3c_controller/i3c_controller_host_interface/i3c_controller_host_interface_ip.tcl
+++ b/library/i3c_controller/i3c_controller_host_interface/i3c_controller_host_interface_ip.tcl
@@ -97,6 +97,8 @@ adi_set_ports_dependency "offload_trigger" \
 
 set cc [ipx::current_core]
 
+ipx::associate_bus_interfaces -clock s_axi_aclk -reset reset_n $cc
+
 ## ID
 set_property -dict [list \
   "value_validation_type" "range_long" \

--- a/projects/ad4062_ardz/coraz7s/system_constr.xdc
+++ b/projects/ad4062_ardz/coraz7s/system_constr.xdc
@@ -11,14 +11,14 @@ set i3c_clk clk_fpga_0
 
 # Input data driven the peripherals toggles every 4 cycles max (PP) of the capture clock
 # gets registered by rx_reg
-set_multicycle_path -from [get_ports i3c_sda] -to [get_clocks $i3c_clk] -setup 4
-set_multicycle_path -from [get_ports i3c_sda] -to [get_clocks $i3c_clk] -hold 3
+set_multicycle_path -from [get_ports iic_ard_sda] -to [get_clocks $i3c_clk] -setup 4
+set_multicycle_path -from [get_ports iic_ard_sda] -to [get_clocks $i3c_clk] -hold 3
 
 # Output data toggles every 2 cycles max of the capture clock (PP)
-set_multicycle_path -from [get_clocks $i3c_clk] -to [get_ports i3c_sda] -setup 2
-set_multicycle_path -from [get_clocks $i3c_clk] -to [get_ports i3c_sda] -hold 1
-set_multicycle_path -from [get_clocks $i3c_clk] -to [get_ports i3c_scl] -setup 2
-set_multicycle_path -from [get_clocks $i3c_clk] -to [get_ports i3c_scl] -hold 1
+set_multicycle_path -from [get_clocks $i3c_clk] -to [get_ports iic_ard_sda] -setup 2
+set_multicycle_path -from [get_clocks $i3c_clk] -to [get_ports iic_ard_sda] -hold 1
+set_multicycle_path -from [get_clocks $i3c_clk] -to [get_ports iic_ard_scl] -setup 2
+set_multicycle_path -from [get_clocks $i3c_clk] -to [get_ports iic_ard_scl] -hold 1
 
 # Notes
 # tcr/tcf rising/fall time for SCL is 150e06 * 1 / fSCL, at fSCL = 12.5 MHz => 12ns, at fSCL = 6.25 MHz, 24ns.
@@ -29,11 +29,11 @@ set tsco_max   12;
 set tsco_min    8;
 set trc_dly_max 1;
 set trc_dly_min 0;
-set_input_delay  -clock $i3c_clk -max [expr $tsco_max + $trc_dly_max] [get_ports i3c_sda]
-set_input_delay  -clock $i3c_clk -min [expr $tsco_min + $trc_dly_min] [get_ports i3c_sda]
+set_input_delay  -clock $i3c_clk -max [expr $tsco_max + $trc_dly_max] [get_ports iic_ard_sda]
+set_input_delay  -clock $i3c_clk -min [expr $tsco_min + $trc_dly_min] [get_ports iic_ard_sda]
 set tsu         2;
 set thd         0;
-set_output_delay -clock $i3c_clk -max [expr $trc_dly_max + $tsu] [get_ports i3c_sda]
-set_output_delay -clock $i3c_clk -min [expr $trc_dly_min - $thd] [get_ports i3c_sda]
-set_output_delay -clock $i3c_clk -max [expr $trc_dly_max + $tsu] [get_ports i3c_scl]
-set_output_delay -clock $i3c_clk -min [expr $trc_dly_min - $thd] [get_ports i3c_scl]
+set_output_delay -clock $i3c_clk -max [expr $trc_dly_max + $tsu] [get_ports iic_ard_sda]
+set_output_delay -clock $i3c_clk -min [expr $trc_dly_min - $thd] [get_ports iic_ard_sda]
+set_output_delay -clock $i3c_clk -max [expr $trc_dly_max + $tsu] [get_ports iic_ard_scl]
+set_output_delay -clock $i3c_clk -min [expr $trc_dly_min - $thd] [get_ports iic_ard_scl]


### PR DESCRIPTION
## PR Description

The first was an oversight on the rename to match the common project, due to the overlay effort.
The second is due to vivado not inferring the clock that the reset is synchronous to, in this case, set it explicitly associate for the synchronous case.

## PR Type
- [ ] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)
- [ ] Documentation

## PR Checklist
- [ ] I have followed the code style guidelines
- [ ] I have performed a self-review of changes
- [ ] I have compiled all hdl projects and libraries affected by this PR
- [ ] I have tested in hardware affected projects, at least on relevant boards
- [ ] I have commented my code, at least hard-to-understand parts
- [ ] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe files, Copyright etc)
- [ ] I have not introduced new Warnings/Critical Warnings on compilation
- [ ] I have added new hdl testbenches or updated existing ones
