### PR TITLE
ad4134_fmc: Fix constraints & update README

### DIFF
--- a/projects/ad4134_fmc/README.md
+++ b/projects/ad4134_fmc/README.md
@@ -3,6 +3,7 @@
 - Evaluation board product page: [EVAL-AD4134](https://www.analog.com/eval-ad4134)
 - System documentation: https://wiki.analog.com/resources/eval/user-guides/ad4134/hdl
 - HDL project documentation: https://analogdevicesinc.github.io/hdl/projects/ad4134_fmc/index.html
+- Evaluation board VADJ: 1.8V
 
 ## Supported parts
 

--- a/projects/ad4134_fmc/zed/Makefile
+++ b/projects/ad4134_fmc/zed/Makefile
@@ -8,7 +8,6 @@ PROJECT_NAME := ad4134_fmc_zed
 
 M_DEPS += ../common/ad4134_bd.tcl
 M_DEPS += ../../scripts/adi_pd.tcl
-M_DEPS += ../../common/zed/zed_system_constr.xdc
 M_DEPS += ../../common/zed/zed_system_bd.tcl
 M_DEPS += ../../../library/spi_engine/scripts/spi_engine.tcl
 M_DEPS += ../../../library/common/ad_iobuf.v

--- a/projects/ad4134_fmc/zed/README.md
+++ b/projects/ad4134_fmc/zed/README.md
@@ -1,4 +1,8 @@
+<!-- no_build_example, no_no_os -->
+
 # AD4134-FMC/ZED HDL Project
+
+- VADJ with which it was tested in hardware: 1.8V
 
 ## Building the project
 

--- a/projects/ad4134_fmc/zed/system_constr.xdc
+++ b/projects/ad4134_fmc/zed/system_constr.xdc
@@ -1,36 +1,130 @@
 ###############################################################################
-## Copyright (C) 2023 Analog Devices, Inc. All rights reserved.
+## Copyright (C) 2023, 2025  Analog Devices, Inc. All rights reserved.
 ### SPDX short identifier: ADIBSD
 ###############################################################################
 
 # ad4134 SPI configuration interface
-set_property -dict {PACKAGE_PIN N22 IOSTANDARD LVCMOS25} [get_ports ad4134_spi_sdi];         ## FMC_LPC_LA03_P
-set_property -dict {PACKAGE_PIN M22 IOSTANDARD LVCMOS25} [get_ports ad4134_spi_sdo];         ## FMC_LPC_LA04_N
-set_property -dict {PACKAGE_PIN N19 IOSTANDARD LVCMOS25} [get_ports ad4134_spi_sclk];        ## FMC_LPC_LA01_P_CC
-set_property -dict {PACKAGE_PIN J18 IOSTANDARD LVCMOS25} [get_ports ad4134_spi_cs] ;         ## FMC_LPC_LA05_P
+set_property -dict {PACKAGE_PIN N22 IOSTANDARD LVCMOS18} [get_ports ad4134_spi_sdi];         ## FMC_LPC_LA03_P
+set_property -dict {PACKAGE_PIN M22 IOSTANDARD LVCMOS18} [get_ports ad4134_spi_sdo];         ## FMC_LPC_LA04_N
+set_property -dict {PACKAGE_PIN N19 IOSTANDARD LVCMOS18} [get_ports ad4134_spi_sclk];        ## FMC_LPC_LA01_P_CC
+set_property -dict {PACKAGE_PIN J18 IOSTANDARD LVCMOS18} [get_ports ad4134_spi_cs] ;         ## FMC_LPC_LA05_P
 
 # ad4134 data interface
 
-set_property -dict {PACKAGE_PIN L18 IOSTANDARD LVCMOS25 IOB TRUE} [get_ports ad4134_dclk];   ## FMC_LPC_CLK0_M2C_P
-set_property -dict {PACKAGE_PIN M20 IOSTANDARD LVCMOS25 IOB TRUE} [get_ports ad4134_din[0]]; ## FMC_LPC_LA00_N_CC
-set_property -dict {PACKAGE_PIN L22 IOSTANDARD LVCMOS25 IOB TRUE} [get_ports ad4134_din[1]]; ## FMC_LPC_LA06_N
-set_property -dict {PACKAGE_PIN P17 IOSTANDARD LVCMOS25 IOB TRUE} [get_ports ad4134_din[2]]; ## FMC_LPC_LA02_P
-set_property -dict {PACKAGE_PIN P18 IOSTANDARD LVCMOS25 IOB TRUE} [get_ports ad4134_din[3]]; ## FMC_LPC_LA02_N
-set_property -dict {PACKAGE_PIN M19 IOSTANDARD LVCMOS25} [get_ports ad4134_odr];             ## FMC_LPC_LA00_P_CC
+set_property -dict {PACKAGE_PIN L18 IOSTANDARD LVCMOS18 IOB TRUE} [get_ports ad4134_dclk];   ## FMC_LPC_CLK0_M2C_P
+set_property -dict {PACKAGE_PIN M20 IOSTANDARD LVCMOS18 IOB TRUE} [get_ports ad4134_din[0]]; ## FMC_LPC_LA00_N_CC
+set_property -dict {PACKAGE_PIN L22 IOSTANDARD LVCMOS18 IOB TRUE} [get_ports ad4134_din[1]]; ## FMC_LPC_LA06_N
+set_property -dict {PACKAGE_PIN P17 IOSTANDARD LVCMOS18 IOB TRUE} [get_ports ad4134_din[2]]; ## FMC_LPC_LA02_P
+set_property -dict {PACKAGE_PIN P18 IOSTANDARD LVCMOS18 IOB TRUE} [get_ports ad4134_din[3]]; ## FMC_LPC_LA02_N
+set_property -dict {PACKAGE_PIN M19 IOSTANDARD LVCMOS18} [get_ports ad4134_odr];             ## FMC_LPC_LA00_P_CC
 
 # ad4134 GPIO lines
 
-set_property -dict {PACKAGE_PIN J20 IOSTANDARD LVCMOS25} [get_ports ad4134_resetn];          ## FMC_LPC_LA16_P
-set_property -dict {PACKAGE_PIN T16 IOSTANDARD LVCMOS25} [get_ports ad4134_pdn];             ## FMC_LPC_LA07_P
-set_property -dict {PACKAGE_PIN M21 IOSTANDARD LVCMOS25} [get_ports ad4134_mode];            ## FMC_LPC_LA04_P
-set_property -dict {PACKAGE_PIN R19 IOSTANDARD LVCMOS25} [get_ports ad4134_gpio0];           ## FMC_LPC_LA10_P
-set_property -dict {PACKAGE_PIN T19 IOSTANDARD LVCMOS25} [get_ports ad4134_gpio1];           ## FMC_LPC_LA10_N
-set_property -dict {PACKAGE_PIN N17 IOSTANDARD LVCMOS25} [get_ports ad4134_gpio2];           ## FMC_LPC_LA11_P
-set_property -dict {PACKAGE_PIN N18 IOSTANDARD LVCMOS25} [get_ports ad4134_gpio3];           ## FMC_LPC_LA11_N
-set_property -dict {PACKAGE_PIN P20 IOSTANDARD LVCMOS25} [get_ports ad4134_gpio4];           ## FMC_LPC_LA12_P
-set_property -dict {PACKAGE_PIN P21 IOSTANDARD LVCMOS25} [get_ports ad4134_gpio5];           ## FMC_LPC_LA12_N
-set_property -dict {PACKAGE_PIN L17 IOSTANDARD LVCMOS25} [get_ports ad4134_gpio6];           ## FMC_LPC_LA13_P
-set_property -dict {PACKAGE_PIN M17 IOSTANDARD LVCMOS25} [get_ports ad4134_gpio7];           ## FMC_LPC_LA13_N
-set_property -dict {PACKAGE_PIN L21 IOSTANDARD LVCMOS25} [get_ports ad4134_pinbspi];         ## FMC_LPC_LA06_P
-set_property -dict {PACKAGE_PIN K19 IOSTANDARD LVCMOS25} [get_ports ad4134_dclkio];          ## FMC_LPC_LA14_P
-set_property -dict {PACKAGE_PIN K20 IOSTANDARD LVCMOS25} [get_ports ad4134_dclk_mode];       ## FMC_LPC_LA14_N
+set_property -dict {PACKAGE_PIN J20 IOSTANDARD LVCMOS18} [get_ports ad4134_resetn];          ## FMC_LPC_LA16_P
+set_property -dict {PACKAGE_PIN T16 IOSTANDARD LVCMOS18} [get_ports ad4134_pdn];             ## FMC_LPC_LA07_P
+set_property -dict {PACKAGE_PIN M21 IOSTANDARD LVCMOS18} [get_ports ad4134_mode];            ## FMC_LPC_LA04_P
+set_property -dict {PACKAGE_PIN R19 IOSTANDARD LVCMOS18} [get_ports ad4134_gpio0];           ## FMC_LPC_LA10_P
+set_property -dict {PACKAGE_PIN T19 IOSTANDARD LVCMOS18} [get_ports ad4134_gpio1];           ## FMC_LPC_LA10_N
+set_property -dict {PACKAGE_PIN N17 IOSTANDARD LVCMOS18} [get_ports ad4134_gpio2];           ## FMC_LPC_LA11_P
+set_property -dict {PACKAGE_PIN N18 IOSTANDARD LVCMOS18} [get_ports ad4134_gpio3];           ## FMC_LPC_LA11_N
+set_property -dict {PACKAGE_PIN P20 IOSTANDARD LVCMOS18} [get_ports ad4134_gpio4];           ## FMC_LPC_LA12_P
+set_property -dict {PACKAGE_PIN P21 IOSTANDARD LVCMOS18} [get_ports ad4134_gpio5];           ## FMC_LPC_LA12_N
+set_property -dict {PACKAGE_PIN L17 IOSTANDARD LVCMOS18} [get_ports ad4134_gpio6];           ## FMC_LPC_LA13_P
+set_property -dict {PACKAGE_PIN M17 IOSTANDARD LVCMOS18} [get_ports ad4134_gpio7];           ## FMC_LPC_LA13_N
+set_property -dict {PACKAGE_PIN L21 IOSTANDARD LVCMOS18} [get_ports ad4134_pinbspi];         ## FMC_LPC_LA06_P
+set_property -dict {PACKAGE_PIN K19 IOSTANDARD LVCMOS18} [get_ports ad4134_dclkio];          ## FMC_LPC_LA14_P
+set_property -dict {PACKAGE_PIN K20 IOSTANDARD LVCMOS18} [get_ports ad4134_dclk_mode];       ## FMC_LPC_LA14_N
+
+# Zedboard common xdc
+# set IOSTANDARD according to VADJ 1.8V
+
+# hdmi
+
+set_property  -dict {PACKAGE_PIN  W18   IOSTANDARD LVCMOS33}           [get_ports hdmi_out_clk]
+set_property  -dict {PACKAGE_PIN  W17   IOSTANDARD LVCMOS33  IOB TRUE} [get_ports hdmi_vsync]
+set_property  -dict {PACKAGE_PIN  V17   IOSTANDARD LVCMOS33  IOB TRUE} [get_ports hdmi_hsync]
+set_property  -dict {PACKAGE_PIN  U16   IOSTANDARD LVCMOS33  IOB TRUE} [get_ports hdmi_data_e]
+set_property  -dict {PACKAGE_PIN  Y13   IOSTANDARD LVCMOS33  IOB TRUE} [get_ports hdmi_data[0]]
+set_property  -dict {PACKAGE_PIN  AA13  IOSTANDARD LVCMOS33  IOB TRUE} [get_ports hdmi_data[1]]
+set_property  -dict {PACKAGE_PIN  AA14  IOSTANDARD LVCMOS33  IOB TRUE} [get_ports hdmi_data[2]]
+set_property  -dict {PACKAGE_PIN  Y14   IOSTANDARD LVCMOS33  IOB TRUE} [get_ports hdmi_data[3]]
+set_property  -dict {PACKAGE_PIN  AB15  IOSTANDARD LVCMOS33  IOB TRUE} [get_ports hdmi_data[4]]
+set_property  -dict {PACKAGE_PIN  AB16  IOSTANDARD LVCMOS33  IOB TRUE} [get_ports hdmi_data[5]]
+set_property  -dict {PACKAGE_PIN  AA16  IOSTANDARD LVCMOS33  IOB TRUE} [get_ports hdmi_data[6]]
+set_property  -dict {PACKAGE_PIN  AB17  IOSTANDARD LVCMOS33  IOB TRUE} [get_ports hdmi_data[7]]
+set_property  -dict {PACKAGE_PIN  AA17  IOSTANDARD LVCMOS33  IOB TRUE} [get_ports hdmi_data[8]]
+set_property  -dict {PACKAGE_PIN  Y15   IOSTANDARD LVCMOS33  IOB TRUE} [get_ports hdmi_data[9]]
+set_property  -dict {PACKAGE_PIN  W13   IOSTANDARD LVCMOS33  IOB TRUE} [get_ports hdmi_data[10]]
+set_property  -dict {PACKAGE_PIN  W15   IOSTANDARD LVCMOS33  IOB TRUE} [get_ports hdmi_data[11]]
+set_property  -dict {PACKAGE_PIN  V15   IOSTANDARD LVCMOS33  IOB TRUE} [get_ports hdmi_data[12]]
+set_property  -dict {PACKAGE_PIN  U17   IOSTANDARD LVCMOS33  IOB TRUE} [get_ports hdmi_data[13]]
+set_property  -dict {PACKAGE_PIN  V14   IOSTANDARD LVCMOS33  IOB TRUE} [get_ports hdmi_data[14]]
+set_property  -dict {PACKAGE_PIN  V13   IOSTANDARD LVCMOS33  IOB TRUE} [get_ports hdmi_data[15]]
+
+# spdif
+
+set_property  -dict {PACKAGE_PIN  U15   IOSTANDARD LVCMOS33} [get_ports spdif]
+
+# i2s
+
+set_property  -dict {PACKAGE_PIN  AB2   IOSTANDARD LVCMOS33} [get_ports i2s_mclk]
+set_property  -dict {PACKAGE_PIN  AA6   IOSTANDARD LVCMOS33} [get_ports i2s_bclk]
+set_property  -dict {PACKAGE_PIN  Y6    IOSTANDARD LVCMOS33} [get_ports i2s_lrclk]
+set_property  -dict {PACKAGE_PIN  Y8    IOSTANDARD LVCMOS33} [get_ports i2s_sdata_out]
+set_property  -dict {PACKAGE_PIN  AA7   IOSTANDARD LVCMOS33} [get_ports i2s_sdata_in]
+
+# iic
+
+set_property  -dict {PACKAGE_PIN  R7    IOSTANDARD LVCMOS33} [get_ports iic_scl]
+set_property  -dict {PACKAGE_PIN  U7    IOSTANDARD LVCMOS33} [get_ports iic_sda]
+set_property  -dict {PACKAGE_PIN  AA18  IOSTANDARD LVCMOS33 PULLTYPE PULLUP} [get_ports iic_mux_scl[1]]
+set_property  -dict {PACKAGE_PIN  Y16   IOSTANDARD LVCMOS33 PULLTYPE PULLUP} [get_ports iic_mux_sda[1]]
+set_property  -dict {PACKAGE_PIN  AB4   IOSTANDARD LVCMOS33 PULLTYPE PULLUP} [get_ports iic_mux_scl[0]]
+set_property  -dict {PACKAGE_PIN  AB5   IOSTANDARD LVCMOS33 PULLTYPE PULLUP} [get_ports iic_mux_sda[0]]
+
+# otg
+
+set_property  -dict {PACKAGE_PIN  L16   IOSTANDARD LVCMOS18} [get_ports otg_vbusoc]
+
+# gpio (switches, leds and such)
+
+set_property  -dict {PACKAGE_PIN  P16   IOSTANDARD LVCMOS18} [get_ports gpio_bd[0]]       ; ## BTNC
+set_property  -dict {PACKAGE_PIN  R16   IOSTANDARD LVCMOS18} [get_ports gpio_bd[1]]       ; ## BTND
+set_property  -dict {PACKAGE_PIN  N15   IOSTANDARD LVCMOS18} [get_ports gpio_bd[2]]       ; ## BTNL
+set_property  -dict {PACKAGE_PIN  R18   IOSTANDARD LVCMOS18} [get_ports gpio_bd[3]]       ; ## BTNR
+set_property  -dict {PACKAGE_PIN  T18   IOSTANDARD LVCMOS18} [get_ports gpio_bd[4]]       ; ## BTNU
+set_property  -dict {PACKAGE_PIN  U10   IOSTANDARD LVCMOS33} [get_ports gpio_bd[5]]       ; ## OLED-DC
+set_property  -dict {PACKAGE_PIN  U9    IOSTANDARD LVCMOS33} [get_ports gpio_bd[6]]       ; ## OLED-RES
+set_property  -dict {PACKAGE_PIN  AB12  IOSTANDARD LVCMOS33} [get_ports gpio_bd[7]]       ; ## OLED-SCLK
+set_property  -dict {PACKAGE_PIN  AA12  IOSTANDARD LVCMOS33} [get_ports gpio_bd[8]]       ; ## OLED-SDIN
+set_property  -dict {PACKAGE_PIN  U11   IOSTANDARD LVCMOS33} [get_ports gpio_bd[9]]       ; ## OLED-VBAT
+set_property  -dict {PACKAGE_PIN  U12   IOSTANDARD LVCMOS33} [get_ports gpio_bd[10]]      ; ## OLED-VDD
+
+set_property  -dict {PACKAGE_PIN  F22   IOSTANDARD LVCMOS18} [get_ports gpio_bd[11]]      ; ## SW0
+set_property  -dict {PACKAGE_PIN  G22   IOSTANDARD LVCMOS18} [get_ports gpio_bd[12]]      ; ## SW1
+set_property  -dict {PACKAGE_PIN  H22   IOSTANDARD LVCMOS18} [get_ports gpio_bd[13]]      ; ## SW2
+set_property  -dict {PACKAGE_PIN  F21   IOSTANDARD LVCMOS18} [get_ports gpio_bd[14]]      ; ## SW3
+set_property  -dict {PACKAGE_PIN  H19   IOSTANDARD LVCMOS18} [get_ports gpio_bd[15]]      ; ## SW4
+set_property  -dict {PACKAGE_PIN  H18   IOSTANDARD LVCMOS18} [get_ports gpio_bd[16]]      ; ## SW5
+set_property  -dict {PACKAGE_PIN  H17   IOSTANDARD LVCMOS18} [get_ports gpio_bd[17]]      ; ## SW6
+set_property  -dict {PACKAGE_PIN  M15   IOSTANDARD LVCMOS18} [get_ports gpio_bd[18]]      ; ## SW7
+
+set_property  -dict {PACKAGE_PIN  T22   IOSTANDARD LVCMOS33} [get_ports gpio_bd[19]]      ; ## LD0
+set_property  -dict {PACKAGE_PIN  T21   IOSTANDARD LVCMOS33} [get_ports gpio_bd[20]]      ; ## LD1
+set_property  -dict {PACKAGE_PIN  U22   IOSTANDARD LVCMOS33} [get_ports gpio_bd[21]]      ; ## LD2
+set_property  -dict {PACKAGE_PIN  U21   IOSTANDARD LVCMOS33} [get_ports gpio_bd[22]]      ; ## LD3
+set_property  -dict {PACKAGE_PIN  V22   IOSTANDARD LVCMOS33} [get_ports gpio_bd[23]]      ; ## LD4
+set_property  -dict {PACKAGE_PIN  W22   IOSTANDARD LVCMOS33} [get_ports gpio_bd[24]]      ; ## LD5
+set_property  -dict {PACKAGE_PIN  U19   IOSTANDARD LVCMOS33} [get_ports gpio_bd[25]]      ; ## LD6
+set_property  -dict {PACKAGE_PIN  U14   IOSTANDARD LVCMOS33} [get_ports gpio_bd[26]]      ; ## LD7
+
+set_property  -dict {PACKAGE_PIN  H15   IOSTANDARD LVCMOS18} [get_ports gpio_bd[27]]      ; ## XADC-GIO0
+set_property  -dict {PACKAGE_PIN  R15   IOSTANDARD LVCMOS18} [get_ports gpio_bd[28]]      ; ## XADC-GIO1
+set_property  -dict {PACKAGE_PIN  K15   IOSTANDARD LVCMOS18} [get_ports gpio_bd[29]]      ; ## XADC-GIO2
+set_property  -dict {PACKAGE_PIN  J15   IOSTANDARD LVCMOS18} [get_ports gpio_bd[30]]      ; ## XADC-GIO3
+
+set_property  -dict {PACKAGE_PIN  G17   IOSTANDARD LVCMOS18} [get_ports gpio_bd[31]]      ; ## OTG-RESETN
+
+# Define SPI clock
+create_clock -name spi0_clk      -period 40   [get_pins -hier */EMIOSPI0SCLKO]
+create_clock -name spi1_clk      -period 40   [get_pins -hier */EMIOSPI1SCLKO]

--- a/projects/ad4134_fmc/zed/system_project.tcl
+++ b/projects/ad4134_fmc/zed/system_project.tcl
@@ -1,5 +1,5 @@
 ###############################################################################
-## Copyright (C) 2023 Analog Devices, Inc. All rights reserved.
+## Copyright (C) 2023, 2025 Analog Devices, Inc. All rights reserved.
 ### SPDX short identifier: ADIBSD
 ###############################################################################
 
@@ -12,7 +12,6 @@ adi_project ad4134_fmc_zed
 adi_project_files ad4134_fmc_zed [list \
     "$ad_hdl_dir/library/common/ad_iobuf.v" \
     "system_top.v" \
-    "system_constr.xdc" \
-    "$ad_hdl_dir/projects/common/zed/zed_system_constr.xdc"]
+    "system_constr.xdc"]
 
 adi_project_run ad4134_fmc_zed


### PR DESCRIPTION
## PR Description

The VADJ value for the ad4134_fmc is 1.8V (according to the IOVDD value). Fixed the constraints file to reflect the changes from the LVCMOS25 to LVCMOS18 IOSTANDARD. Also added the zed common xdc file contents and set the VADJ to 1.8V.

Updated the README files to contain de VADJ value.

## PR Type
- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)
- [x] Documentation

## PR Checklist
- [x] I have followed the code style guidelines
- [x] I have performed a self-review of changes
- [x] I have compiled all hdl projects and libraries affected by this PR
- [ ] I have tested in hardware affected projects, at least on relevant boards
- [x] I have commented my code, at least hard-to-understand parts
- [x] I have signed off all commits from this PR
- [x] I have updated the documentation (wiki pages, ReadMe files, Copyright etc)
- [x] I have not introduced new Warnings/Critical Warnings on compilation
- [ ] I have added new hdl testbenches or updated existing ones
