### PR TITLE
projects/ad9081/x_band/ad9082/ad9209: Update READMEs with VADJ value

### DIFF
--- a/projects/ad9081_fmca_ebz/README.md
+++ b/projects/ad9081_fmca_ebz/README.md
@@ -3,6 +3,7 @@
 - Evaluation board product page: [EVAL-AD9081](https://www.analog.com/eval-ad9081)
 - System documentation: https://wiki.analog.com/resources/eval/user-guides/ad9081_fmca_ebz/quickstart
 - HDL project documentation: https://analogdevicesinc.github.io/hdl/projects/ad9081_fmca_ebz/index.html
+- Evaluation board VADJ range: 1.2V - 3.3V
 
 ## Supported parts
 

--- a/projects/ad9081_fmca_ebz/a10soc/README.md
+++ b/projects/ad9081_fmca_ebz/a10soc/README.md
@@ -1,4 +1,8 @@
+<!-- no_no_os -->
+
 # AD9081-FMCA-EBZ/A10SOC HDL Project
+
+- VADJ with which it was tested in hardware: 1.8V
 
 ## Building the project
 

--- a/projects/ad9081_fmca_ebz/fm87/README.md
+++ b/projects/ad9081_fmca_ebz/fm87/README.md
@@ -1,4 +1,8 @@
+<!-- no_dts, no_no_os -->
+
 # AD9081-FMCA-EBZ/FM87 HDL Project
+
+- VADJ with which it was tested in hardware: 1.2V
 
 ## Building the project
 

--- a/projects/ad9081_fmca_ebz/s10soc/README.md
+++ b/projects/ad9081_fmca_ebz/s10soc/README.md
@@ -1,4 +1,8 @@
+<!-- no_dts, no_no_os -->
+
 # AD9081-FMCA-EBZ/S10SOC HDL Project
+
+- VADJ with which it was tested in hardware: 1.8V
 
 ## Building the project
 

--- a/projects/ad9081_fmca_ebz/vck190/README.md
+++ b/projects/ad9081_fmca_ebz/vck190/README.md
@@ -1,4 +1,8 @@
+<!-- no_no_os -->
+
 # AD9081-FMCA-EBZ/VCK190 HDL Project
+
+- VADJ with which it was tested in hardware: 1.5V
 
 ## Building the project
 

--- a/projects/ad9081_fmca_ebz/vcu118/README.md
+++ b/projects/ad9081_fmca_ebz/vcu118/README.md
@@ -1,4 +1,8 @@
+<!-- no_no_os -->
+
 # AD9081-FMCA-EBZ/VCU118 HDL Project
+
+- VADJ with which it was tested in hardware: 1.8V
 
 ## Building the project
 

--- a/projects/ad9081_fmca_ebz/vpk180/README.md
+++ b/projects/ad9081_fmca_ebz/vpk180/README.md
@@ -1,4 +1,8 @@
+<!-- no_no_os -->
+
 # AD9081-FMCA-EBZ/VPK180 HDL Project
+
+- VADJ with which it was tested in hardware: 1.5V
 
 ## Building the project
 
@@ -15,7 +19,7 @@ All of the RX/TX link modes can be found in the [AD9081 data sheet](https://www.
 
 The overwritable parameters from the environment are:
 
-- JESD_MODE: link layer encoder mode used; 
+- JESD_MODE: link layer encoder mode used;
   - 8B10B - 8b10b link layer defined in JESD204B
   - 64B66B - 64b66b link layer defined in JESD204C
 - [RX/TX]_LANE_RATE: lane rate of the [RX/TX] link (RX: MxFE to FPGA/TX: FPGA to MxFE)

--- a/projects/ad9081_fmca_ebz/zc706/README.md
+++ b/projects/ad9081_fmca_ebz/zc706/README.md
@@ -1,4 +1,8 @@
+<!-- no_no_os -->
+
 # AD9081-FMCA-EBZ/ZC706 HDL Project
+
+- VADJ with which it was tested in hardware: 2.5V
 
 ## Building the project
 

--- a/projects/ad9081_fmca_ebz/zcu102/README.md
+++ b/projects/ad9081_fmca_ebz/zcu102/README.md
@@ -1,4 +1,8 @@
+<!-- no_no_os -->
+
 # AD9081-FMCA-EBZ/ZCU102 HDL Project
+
+- VADJ with which it was tested in hardware: 1.8V
 
 ## Building the project
 

--- a/projects/ad9081_fmca_ebz_x_band/README.md
+++ b/projects/ad9081_fmca_ebz_x_band/README.md
@@ -7,6 +7,7 @@
   - [ADXUD1AEBZ](https://wiki.analog.com/resources/eval/user-guides/xud1a)
 - System documentation: https://wiki.analog.com/resources/eval/developer-kits/x-band-dev-kit
 - HDL project documentation: https://analogdevicesinc.github.io/hdl/projects/ad9081_fmca_ebz_x_band/index.html
+- Evaluation board VADJ range: 1.2V - 3.3V (for the XUD custom break out board as well; PMODs are with 3.3V)
 
 ## Supported parts
 

--- a/projects/ad9081_fmca_ebz_x_band/zcu102/README.md
+++ b/projects/ad9081_fmca_ebz_x_band/zcu102/README.md
@@ -1,4 +1,8 @@
+<!-- no_no_os -->
+
 # AD9081-FMCA-EBZ-X-BAND/ZCU102 HDL Project
+
+- VADJ with which it was tested in hardware: 1.8V
 
 ## Building the project
 
@@ -17,7 +21,7 @@ If other configurations are desired, then the parameters from the HDL project (s
 
 The overwritable parameters from the environment:
 
-- JESD_MODE - link layer encoder mode used; 
+- JESD_MODE - link layer encoder mode used;
   - 8B10B - 8b10b link layer defined in JESD204B, uses ADI IP as Physical layer
   - 64B66B - 64b66b link layer defined in JESD204C, uses Xilinx IP as Physical layer
 - [RX/TX]_LANE_RATE - lane rate of the [RX/TX] link (RX: MxFE to FPGA/TX: FPGA to MxFE)
@@ -42,7 +46,22 @@ The overwritable parameters from the environment:
 This specific command is equivalent to running `make` only:
 
 ```
-make JESD_MODE=8B10B RX_LANE_RATE=10 TX_LANE_RATE=10 RX_JESD_M=8 RX_JESD_L=4 RX_JESD_S=1 TX_JESD_M=8 TX_JESD_L=4 TX_JESD_S=1 TDD_SUPPORT=1 SHARED_DEVCLK=1 TDD_CHANNEL_CNT=6 TDD_SYNC_WIDTH=0 TDD_SYNC_INT=0 TDD_SYNC_EXT=1 TDD_SYNC_EXT_CDC=1
+make JESD_MODE=8B10B \
+RX_LANE_RATE=10 \
+TX_LANE_RATE=10 \
+RX_JESD_M=8 \
+RX_JESD_L=4 \
+RX_JESD_S=1 \
+TX_JESD_M=8 \
+TX_JESD_L=4 \
+TX_JESD_S=1 \
+TDD_SUPPORT=1 \
+SHARED_DEVCLK=1 \
+TDD_CHANNEL_CNT=6 \
+TDD_SYNC_WIDTH=0 \
+TDD_SYNC_INT=0 \
+TDD_SYNC_EXT=1 \
+TDD_SYNC_EXT_CDC=1
 ```
 
 Corresponding device trees:

--- a/projects/ad9082_fmca_ebz/README.md
+++ b/projects/ad9082_fmca_ebz/README.md
@@ -3,6 +3,7 @@
 - Evaluation board product page: [EVAL-AD9082](https://www.analog.com/eval-ad9082)
 - System documentation: https://wiki.analog.com/resources/eval/user-guides/ad9081_fmca_ebz/quickstart
 - HDL project documentation: https://analogdevicesinc.github.io/hdl/projects/ad9081_fmca_ebz/index.html
+- Evaluation board VADJ range: 1.2V - 3.3V
 
 ## Supported parts
 

--- a/projects/ad9082_fmca_ebz/vck190/README.md
+++ b/projects/ad9082_fmca_ebz/vck190/README.md
@@ -1,4 +1,8 @@
+<!-- no_no_os -->
+
 # AD9082-FMCA-EBZ/VCK190 HDL Project
+
+- VADJ with which it was tested in hardware: 1.5V
 
 ## Building the project
 
@@ -15,7 +19,7 @@ All of the RX/TX link modes can be found in the [AD9082 data sheet](https://www.
 
 The overwritable parameters from the environment are:
 
-- JESD_MODE: link layer encoder mode used; 
+- JESD_MODE: link layer encoder mode used;
   - 8B10B - 8b10b link layer defined in JESD204B
   - 64B66B - 64b66b link layer defined in JESD204C
 - [RX/TX]_LANE_RATE: lane rate of the [RX/TX] link (RX: MxFE to FPGA/TX: FPGA to MxFE)

--- a/projects/ad9082_fmca_ebz/vcu118/README.md
+++ b/projects/ad9082_fmca_ebz/vcu118/README.md
@@ -1,4 +1,8 @@
+<!-- no_no_os -->
+
 # AD9082-FMCA-EBZ/VCU118 HDL Project
+
+- VADJ with which it was tested in hardware: 1.8V
 
 ## Building the project
 
@@ -15,7 +19,7 @@ All of the RX/TX link modes can be found in the [AD9082 data sheet](https://www.
 
 The overwritable parameters from the environment are:
 
-- JESD_MODE: link layer encoder mode used; 
+- JESD_MODE: link layer encoder mode used;
   - 8B10B - 8b10b link layer defined in JESD204B
   - 64B66B - 64b66b link layer defined in JESD204C
 - [RX/TX]_LANE_RATE: lane rate of the [RX/TX] link (RX: MxFE to FPGA/TX: FPGA to MxFE)

--- a/projects/ad9082_fmca_ebz/vpk180/README.md
+++ b/projects/ad9082_fmca_ebz/vpk180/README.md
@@ -1,4 +1,8 @@
+<!-- no_no_os -->
+
 # AD9082-FMCA-EBZ/VPK180 HDL Project
+
+- VADJ with which it was tested in hardware: 1.5V
 
 ## Building the project
 

--- a/projects/ad9082_fmca_ebz/zc706/README.md
+++ b/projects/ad9082_fmca_ebz/zc706/README.md
@@ -1,4 +1,8 @@
+<!-- no_no_os -->
+
 # AD9082-FMCA-EBZ/ZC706 HDL Project
+
+- VADJ with which it was tested in hardware: 2.5V
 
 ## Building the project
 

--- a/projects/ad9082_fmca_ebz/zcu102/README.md
+++ b/projects/ad9082_fmca_ebz/zcu102/README.md
@@ -1,4 +1,8 @@
+<!-- no_no_os -->
+
 # AD9082-FMCA-EBZ/ZCU102 HDL Project
+
+- VADJ with which it was tested in hardware: 1.8V
 
 ## Building the project
 

--- a/projects/ad9209_fmca_ebz/README.md
+++ b/projects/ad9209_fmca_ebz/README.md
@@ -5,6 +5,7 @@ The AD9081-FMCA-EBZ is used to evaluate the AD9209 (the RX side).
 - Evaluation board product page: [EVAL-AD9081](https://www.analog.com/eval-ad9081)
 - System documentation: TO BE ADDED
 - HDL project documentation: http://analogdevicesinc.github.io/hdl/projects/ad9209_fmca_ebz/index.html
+- Evaluation board VADJ range: 1.2V - 3.3V
 
 ## Supported parts
 

--- a/projects/ad9209_fmca_ebz/vck190/README.md
+++ b/projects/ad9209_fmca_ebz/vck190/README.md
@@ -1,4 +1,8 @@
+<!-- no_no_os -->
+
 # AD9209-FMCA-EBZ/VCK190 HDL Project
+
+- VADJ with which it was tested in hardware: 1.5V
 
 ## Building the project
 


### PR DESCRIPTION
## PR Description

Added the VADJ values and ranges for the AD9081/AD9081-FMCA-EBZ-X-BAND/AD9082/AD9209 projects.

## PR Type
- [ ] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)
- [x] Documentation

## PR Checklist
- [x] I have followed the code style guidelines
- [x] I have performed a self-review of changes
- [ ] I have compiled all hdl projects and libraries affected by this PR
- [ ] I have tested in hardware affected projects, at least on relevant boards
- [ ] I have commented my code, at least hard-to-understand parts
- [x] I have signed off all commits from this PR
- [x] I have updated the documentation (wiki pages, ReadMe files, Copyright etc)
- [ ] I have not introduced new Warnings/Critical Warnings on compilation
- [ ] I have added new hdl testbenches or updated existing ones
