### PR TITLE
projects: common: versal: Swap spi_io0_i with spi_io1_i

### DIFF
--- a/projects/common/vmk180/vmk180_system_bd.tcl
+++ b/projects/common/vmk180/vmk180_system_bd.tcl
@@ -177,8 +177,9 @@ ad_connect spi0_csn_sources/dout spi0_csn
 ad_connect  sys_cips/spi0_sck_o spi0_sclk
 ad_connect  sys_cips/spi0_sck_i GND
 ad_connect  sys_cips/spi0_io0_o spi0_mosi
-ad_connect  sys_cips/spi0_io0_i spi0_miso
-ad_connect  sys_cips/spi0_io1_i GND
+# Vivado 2025.1 bug: spi0_io0_i and spi0_io1_i are swapped
+ad_connect  sys_cips/spi0_io0_i GND
+ad_connect  sys_cips/spi0_io1_i spi0_miso
 ad_connect  sys_cips/spi0_ss_o  spi0_csn_sources/in0
 ad_connect  sys_cips/spi0_ss1_o spi0_csn_sources/in1
 ad_connect  sys_cips/spi0_ss2_o spi0_csn_sources/in2
@@ -191,8 +192,9 @@ ad_connect spi1_csn_sources/dout spi1_csn
 ad_connect  sys_cips/spi1_sck_o spi1_sclk
 ad_connect  sys_cips/spi1_sck_i GND
 ad_connect  sys_cips/spi1_io0_o spi1_mosi
-ad_connect  sys_cips/spi1_io0_i spi1_miso
-ad_connect  sys_cips/spi1_io1_i GND
+# Vivado 2025.1 bug: spi1_io0_i and spi1_io1_i are swapped
+ad_connect  sys_cips/spi1_io0_i GND
+ad_connect  sys_cips/spi1_io1_i spi1_miso
 ad_connect  sys_cips/spi1_ss_o  spi1_csn_sources/in0
 ad_connect  sys_cips/spi1_ss1_o spi1_csn_sources/in1
 ad_connect  sys_cips/spi1_ss2_o spi1_csn_sources/in2

--- a/projects/common/vpk180/vpk180_system_bd.tcl
+++ b/projects/common/vpk180/vpk180_system_bd.tcl
@@ -187,8 +187,9 @@ ad_connect spi0_csn_sources/dout spi0_csn
 ad_connect  sys_cips/spi0_sck_o spi0_sclk
 ad_connect  sys_cips/spi0_sck_i GND
 ad_connect  sys_cips/spi0_io0_o spi0_mosi
-ad_connect  sys_cips/spi0_io0_i spi0_miso
-ad_connect  sys_cips/spi0_io1_i GND
+# Vivado 2025.1 bug: spi0_io0_i and spi0_io1_i are swapped
+ad_connect  sys_cips/spi0_io0_i GND
+ad_connect  sys_cips/spi0_io1_i spi0_miso
 ad_connect  sys_cips/spi0_ss_o  spi0_csn_sources/in0
 ad_connect  sys_cips/spi0_ss1_o spi0_csn_sources/in1
 ad_connect  sys_cips/spi0_ss2_o spi0_csn_sources/in2
@@ -201,8 +202,9 @@ ad_connect spi1_csn_sources/dout spi1_csn
 ad_connect  sys_cips/spi1_sck_o spi1_sclk
 ad_connect  sys_cips/spi1_sck_i GND
 ad_connect  sys_cips/spi1_io0_o spi1_mosi
-ad_connect  sys_cips/spi1_io0_i spi1_miso
-ad_connect  sys_cips/spi1_io1_i GND
+# Vivado 2025.1 bug: spi1_io0_i and spi1_io1_i are swapped
+ad_connect  sys_cips/spi1_io0_i GND
+ad_connect  sys_cips/spi1_io1_i spi1_miso
 ad_connect  sys_cips/spi1_ss_o  spi1_csn_sources/in0
 ad_connect  sys_cips/spi1_ss1_o spi1_csn_sources/in1
 ad_connect  sys_cips/spi1_ss2_o spi1_csn_sources/in2


### PR DESCRIPTION
## PR Description

There is a known issue in Vivado 2024.1+, the MISO/MOSI lines are swapped in the PS.
The work-around is to swap the io0_i with io1_i

Tested on hardware with AD9084 and SPI started working after the swap.

https://adaptivesupport.amd.com/s/article/000037096?language=en_US

## PR Type
- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)
- [ ] Documentation

## PR Checklist
- [x] I have followed the code style guidelines
- [x] I have performed a self-review of changes
- [x] I have compiled all hdl projects and libraries affected by this PR
- [ ] I have tested in hardware affected projects, at least on relevant boards
- [ ] I have commented my code, at least hard-to-understand parts
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe files, Copyright etc)
- [ ] I have not introduced new Warnings/Critical Warnings on compilation
- [ ] I have added new hdl testbenches or updated existing ones
