### PR TITLE
regmap: i3c_controller: Bump version to v1.0.0

### DIFF
--- a/docs/regmap/adi_regmap_i3c_controller.txt
+++ b/docs/regmap/adi_regmap_i3c_controller.txt
@@ -13,13 +13,13 @@ Version of the peripheral. Follows semantic versioning. Current version 0.01.00
 ENDREG
 
 FIELD
-[31:16] 0x00
+[31:16] 0x01
 VERSION_MAJOR
 RO
 ENDFIELD
 
 FIELD
-[15:8] 0x01
+[15:8] 0x00
 VERSION_MINOR
 RO
 ENDFIELD


### PR DESCRIPTION
## PR Description

To match 
```
  localparam [31:0] CORE_VERSION = {16'h0001,     /* MAJOR */
                                     8'h00,       /* MINOR */
                                     8'h00};      /* PATCH */
```
https://github.com/analogdevicesinc/hdl/blob/main/library/i3c_controller/i3c_controller_host_interface/i3c_controller_regmap.v#L127-L129

## PR Type
- [ ] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)
- [ ] Documentation

## PR Checklist
- [ ] I have followed the code style guidelines
- [ ] I have performed a self-review of changes
- [ ] I have compiled all hdl projects and libraries affected by this PR
- [ ] I have tested in hardware affected projects, at least on relevant boards
- [ ] I have commented my code, at least hard-to-understand parts
- [ ] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe files, Copyright etc)
- [ ] I have not introduced new Warnings/Critical Warnings on compilation
- [ ] I have added new hdl testbenches or updated existing ones
