### PR TITLE
projects/ad9208_dual_ebz: Update READMEs with VADJ value

### DIFF
--- a/projects/ad9208_dual_ebz/README.md
+++ b/projects/ad9208_dual_ebz/README.md
@@ -1,8 +1,9 @@
 # AD9208-DUAL-EBZ HDL Project
 
-- Evaluation board product page: [EVAL-ADAD9208](https://www.analog.com/eval-ad9208)
+- Evaluation board product page: [EVAL-AD9208](https://www.analog.com/eval-ad9208)
 - System documentation: TO BE ADDED
 - HDL project documentation: http://analogdevicesinc.github.io/hdl/projects/ad9208_dual_ebz/index.html
+- Evaluation board VADJ range: 1.2V - 3.3V
 
 ## Supported parts
 

--- a/projects/ad9208_dual_ebz/vcu118/README.md
+++ b/projects/ad9208_dual_ebz/vcu118/README.md
@@ -1,4 +1,8 @@
+<!-- no_build_example, no_no_os -->
+
 # AD9208-DUAL-EBZ/VCU118 HDL Project
+
+- VADJ with which it was tested in hardware: 1.8V
 
 ## Building the project
 
@@ -11,7 +15,7 @@ All of the RX link modes can be found in the [AD9208 data sheet](https://www.ana
 
 If other configurations are desired, then the parameters from the HDL project (found in *common/ad9208_dual_ebz_bd.tcl*) need to be changed, as well as the Linux/no-OS project configurations.
 
-The available configuration:
+The fixed configuration:
 
 - JESD_MODE: link layer encoder mode used;
   - 8B10B - 8b10b link layer defined in JESD204B


### PR DESCRIPTION
## PR Description

Added the VADJ value in READMEs for AD9208-DUAL-EBZ.

## PR Type
- [ ] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)
- [x] Documentation

## PR Checklist
- [x] I have followed the code style guidelines
- [x] I have performed a self-review of changes
- [ ] I have compiled all hdl projects and libraries affected by this PR
- [ ] I have tested in hardware affected projects, at least on relevant boards
- [ ] I have commented my code, at least hard-to-understand parts
- [x] I have signed off all commits from this PR
- [x] I have updated the documentation (wiki pages, ReadMe files, Copyright etc)
- [ ] I have not introduced new Warnings/Critical Warnings on compilation
- [ ] I have added new hdl testbenches or updated existing ones
