### PR TITLE
scripts: backstage: Make library key shorted to fit 63 char

### DIFF
--- a/.github/scripts/gen_backstage_yaml.py
+++ b/.github/scripts/gen_backstage_yaml.py
@@ -206,10 +206,11 @@ def write_hdl_library_yaml(
     source_location = source_location_.format(org=args.org, repo=args.repo,
                                               tag=tag)
     key_ = key.replace('/', '-')
+    short_key_ = key[key.rfind('/')+1:]
     t: Dict = yaml_template()
     m = t['metadata']
     a = m['annotations']
-    m['name'] = f"hdl-library-{key_}"
+    m['name'] = f"hdl-library-{short_key_}"
     if tag != "main":
         t['spec']['subcomponentOf'] = m['name']
         m['name'] = m['name'] + '-' + tag
@@ -253,7 +254,7 @@ def write_hdl_library_yaml(
     if m['description'] is None:
         m['description'] = m['title']
 
-    file = path.join(dir_, f"library-{key_}-catalog-info.yaml")
+    file = path.join(dir_, f"library-{short_key_}-catalog-info.yaml")
     with open(file, 'w', encoding='utf-8') as f:
         yaml.dump(t, f, default_flow_style=False, sort_keys=False,
                   allow_unicode=True)


### PR DESCRIPTION
## PR Description

The length limit for the component is 63 characters, so

  hdl-library-i3c_controller-i3c_controller_host_interface-2023_r2

would cause errors.
Drop the path lib, just keep the right-most section instead

  hdl-library-i3c_controller_host_interface-2023_r2

To save some characters.

I need to remember the implications to the already existing content in the backstage branch.

## PR Type
- [ ] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)
- [ ] Documentation

## PR Checklist
- [ ] I have followed the code style guidelines
- [ ] I have performed a self-review of changes
- [ ] I have compiled all hdl projects and libraries affected by this PR
- [ ] I have tested in hardware affected projects, at least on relevant boards
- [ ] I have commented my code, at least hard-to-understand parts
- [ ] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe files, Copyright etc)
- [ ] I have not introduced new Warnings/Critical Warnings on compilation
- [ ] I have added new hdl testbenches or updated existing ones
