### PR TITLE
.github/scripts/check_readme.sh: Fixed return status

### DIFF
--- a/.github/scripts/check_readme.sh
+++ b/.github/scripts/check_readme.sh
@@ -170,5 +170,5 @@ done
 
 if [ "$fail" -eq 1 ]; then
     echo "Something occurred! Check the output of the script."
-    exit 0
+    exit 1
 fi


### PR DESCRIPTION
## PR Description

Small fix. Returning 0 wouldn't signal the action flow to fail. Changed the return to 1.
GitHub action exit codes doc: https://docs.github.com/en/actions/how-tos/create-and-publish-actions/set-exit-codes#about-exit-codes

## PR Type
- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)
- [ ] Documentation

## PR Checklist
- [x] I have followed the code style guidelines
- [x] I have performed a self-review of changes
- [ ] I have compiled all hdl projects and libraries affected by this PR
- [ ] I have tested in hardware affected projects, at least on relevant boards
- [ ] I have commented my code, at least hard-to-understand parts
- [ ] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe files, Copyright etc)
- [ ] I have not introduced new Warnings/Critical Warnings on compilation
- [ ] I have added new hdl testbenches or updated existing ones
