### PR TITLE
library/util_axis_fifo_asym: fix behavior when tkeep=0

### DIFF
--- a/library/spi_engine/axi_spi_engine/axi_spi_engine.v
+++ b/library/spi_engine/axi_spi_engine/axi_spi_engine.v
@@ -137,7 +137,6 @@ module axi_spi_engine #(
   localparam PCORE_VERSION = 'h020000;
   localparam S_AXI = 0;
   localparam UP_FIFO = 1;
-  localparam max_num_of_reads = NUM_OF_SDIO-1;
 
   wire clk;
   wire rstn;
@@ -166,9 +165,7 @@ module axi_spi_engine #(
 
   wire [DATA_WIDTH-1:0] sdi_fifo_out_data;
   wire sdi_fifo_out_ready;
-  reg  find_next_valid_fifo_value;
   wire sdi_fifo_out_valid;
-  reg [3:0] sdi_out_counter;
 
   wire [7:0] sync_fifo_data;
   wire sync_fifo_valid;
@@ -529,7 +526,7 @@ module axi_spi_engine #(
     .s_axis_almost_full(sdi_fifo_almost_full),
     .m_axis_aclk(clk),
     .m_axis_aresetn(up_sw_resetn),
-    .m_axis_ready(sdi_fifo_out_ready || find_next_valid_fifo_value),
+    .m_axis_ready(sdi_fifo_out_ready),
     .m_axis_valid(sdi_fifo_out_valid),
     .m_axis_data(sdi_fifo_out_data),
     .m_axis_tlast(),
@@ -539,35 +536,16 @@ module axi_spi_engine #(
     .m_axis_almost_empty());
 
   assign sdi_fifo_out_ready = up_rreq_s == 1'b1 && up_raddr_s == 8'h3a;
-  assign sdi_output_read = (sdi_fifo_out_ready || find_next_valid_fifo_value) && sdi_fifo_out_valid;
+  assign sdi_output_read = sdi_fifo_out_ready && sdi_fifo_out_valid;
 
   always @(posedge clk) begin
     if (rstn == 1'b0) begin
       up_rack_ff <= 'd0;
     end else begin
-      if (sdi_fifo_out_ready || find_next_valid_fifo_value) begin
+      if (sdi_fifo_out_ready) begin
         up_rack_ff <= sdi_fifo_out_valid;
       end else begin
         up_rack_ff <= up_rreq_s;
-      end
-    end
-  end
-
-  //the current logic is considering that there is only one active lane in the set of lanes
-  always @(posedge clk) begin
-    if (!up_sw_resetn) begin
-      find_next_valid_fifo_value <= 1'b0;
-      sdi_out_counter <= 4'hf;
-    end else if (sdi_fifo_out_ready) begin
-      find_next_valid_fifo_value <= ~sdi_fifo_out_valid; //only in the next cycle it is possible to check if it is necessary a new read
-      sdi_out_counter <= sdi_fifo_out_valid ? 4'hf : 0;
-    end else begin
-      if (!sdi_fifo_out_valid && sdi_out_counter < max_num_of_reads) begin
-        find_next_valid_fifo_value <= 1'b1;
-        sdi_out_counter <= sdi_out_counter + 1'b1;
-      end else begin
-        find_next_valid_fifo_value <= 1'b0;
-        sdi_out_counter <= 4'hf;
       end
     end
   end

--- a/library/util_axis_fifo_asym/util_axis_fifo_asym.v
+++ b/library/util_axis_fifo_asym/util_axis_fifo_asym.v
@@ -221,8 +221,18 @@ module util_axis_fifo_asym #(
 
         if (TKEEP_EN) begin
 
-          assign s_axis_tlast_int_s[i] = (i==RATIO-1) ? ((|s_axis_tkeep[M_DATA_WIDTH/8*i+:M_DATA_WIDTH/8]) ? s_axis_tlast : 1'b0) :
-            (((|s_axis_tkeep[M_DATA_WIDTH/8*i+:M_DATA_WIDTH/8]) & (~(|s_axis_tkeep[M_DATA_WIDTH/8*(i+1)+:M_DATA_WIDTH/8]))) ? s_axis_tlast : 1'b0);
+          // tlast is asserted for the atomic fifo instances on the following conditions:
+          // - for the most significant instance, tlast is the input tlast if any of the tkeep bits for the instance is asserted (so we are not suppressing this transfer)
+          // - for the least significant instance, tlast is the input tlast if no tkeep bits are asserted for any instance (transfer is all null bytes)
+          // - for the other instances, we store the input tlast if all the following instances have tkeep=0 for all bits and no less significant instance has stored it
+          // thus, the tlast is stored on the most significant instance that has non-null bytes (meaning not all tkeep bits are 0), if there are any.
+          if (i==RATIO-1) begin
+            assign s_axis_tlast_int_s[i] = (|s_axis_tkeep[M_DATA_WIDTH/8*i+:M_DATA_WIDTH/8]) ? s_axis_tlast : 1'b0;
+          end else if (i==0) begin
+            assign s_axis_tlast_int_s[i] = (~|s_axis_tkeep[(S_DATA_WIDTH/8)-1:(M_DATA_WIDTH/8)]) ? s_axis_tlast : 1'b0;
+          end else begin
+            assign s_axis_tlast_int_s[i] = (~(|s_axis_tkeep[(S_DATA_WIDTH/8)-1:(M_DATA_WIDTH/8)*(i+1)]) && ~|s_axis_tlast_int_s[i-1:0]) ? s_axis_tlast : 1'b0;
+          end
 
         end else begin
 
@@ -284,7 +294,9 @@ module util_axis_fifo_asym #(
     if (RATIO_TYPE) begin : small_master
 
       for (i=0; i<RATIO; i=i+1) begin: gen_ready_small_master
-        assign m_axis_ready_int_s[i] = (m_axis_counter == i) ? m_axis_ready : 1'b0;
+        // When TKEEP_EN, we need to discard the data from the internal FIFOs for which tkeep=0.
+        // Thus we still need to assert m_axis_ready_int_s for that internal FIFO even without an actual AXI handshake.
+        assign m_axis_ready_int_s[i] = (m_axis_counter == i) ? (m_axis_ready ||  (TKEEP_EN && !(|m_axis_tkeep) && !m_axis_valid)) : 0;
       end
 
       assign m_axis_data = m_axis_data_int_s >> (m_axis_counter*A_WIDTH) ;
@@ -292,7 +304,17 @@ module util_axis_fifo_asym #(
 
       // VALID/EMPTY/ALMOST_EMPTY is driven by the current atomic instance
       assign m_axis_valid_int = m_axis_valid_int_s >> m_axis_counter;
-      assign m_axis_valid = m_axis_valid_int & (|m_axis_tkeep);
+
+      // When TLAST_EN=1, we still have to assert m_axis_valid when tlast is
+      // high even if all bytes are null due to tkeep. AXI-Streaming only allows
+      // us to suppress transfers with all tkeep bits deasserted if tlast is
+      // also deasserted.
+      if (TLAST_EN) begin
+        assign m_axis_valid = m_axis_valid_int & ((|m_axis_tkeep) || m_axis_tlast);
+      end else begin
+        assign m_axis_valid = m_axis_valid_int & (|m_axis_tkeep);
+      end
+
       assign m_axis_tlast = m_axis_tlast_int_s >> m_axis_counter;
 
       // the FIFO has the same level as the last atomic instance
@@ -385,7 +407,10 @@ module util_axis_fifo_asym #(
         if (!m_axis_aresetn) begin
           m_axis_counter <= 0;
         end else begin
-          if (m_axis_ready && m_axis_valid_int) begin
+          // When using tkeep, we might have an internally "valid" data beat without any actually valid bytes.
+          // This will result in m_axis_valid being actually low for the external world.
+          // In this case (tkeep is all 0), we need to increment the counter without waiting for m_axis_ready.
+          if ((m_axis_ready && m_axis_valid) || (TKEEP_EN && m_axis_valid_int && !(|m_axis_tkeep) && !m_axis_valid)) begin
             m_axis_counter <= m_axis_counter + 1'b1;
           end
         end


### PR DESCRIPTION
AXI Streaming doesn't allow for tvalid to depend on tready (AMBA AXI-Stream Protocol Specification, 2.2 Handshake signaling). 
The previous version of `util_axis_fifo_asym` relied on the downstream user asserting tready whenever there was data at the output that was invalid due to tkeep=0, even if tvalid was 0 in this case.

In #1808 this forced us to introduce extra logic on the `spi_engine` as a workaround. With this PR, we can skip that extra logic. If this is merged after #1808, we'll need to add a commit removing the workaround logic. 

This FIFO is used only in the `spi_engine` (after #1808 ) and `data_offload` IPs. I tried to make the fix so it only affects the `TKEEP_EN=1` case, which would only affect `spi_engine`. 



## PR Type
- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)
- [ ] Documentation

## PR Checklist
- [x] I have followed the code style guidelines
- [ ] I have performed a self-review of changes
- [ ] I have compiled all hdl projects and libraries affected by this PR
- [ ] I have tested in hardware affected projects, at least on relevant boards
- [x] I have commented my code, at least hard-to-understand parts
- [ ] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe files, Copyright etc)
- [x] I have not introduced new Warnings/Critical Warnings on compilation
- [x] I have added new hdl testbenches or updated existing ones
