### PR TITLE
projects/ad719x_ardz/coraz7s: Fix missing I2C connections

### DIFF
--- a/projects/ad719x_asdz/coraz7s/system_top_ardz.v
+++ b/projects/ad719x_asdz/coraz7s/system_top_ardz.v
@@ -1,6 +1,6 @@
 // ***************************************************************************
 // ***************************************************************************
-// Copyright (C) 2022-2024 Analog Devices, Inc. All rights reserved.
+// Copyright (C) 2022-2025 Analog Devices, Inc. All rights reserved.
 //
 // In this HDL repository, there are many different and unique modules, consisting
 // of various HDL (Verilog or VHDL) components. The individual modules are
@@ -62,6 +62,9 @@ module system_top (
 
   inout   [ 1:0]  btn,
   inout   [ 5:0]  led,
+
+  inout           iic_ard_scl,
+  inout           iic_ard_sda,
 
   // ad7190 spi pins
 
@@ -159,6 +162,8 @@ module system_top (
     .spi1_csn_i (1'b1),
     .spi1_sdi_i (1'b0),
     .spi1_sdo_i (1'b0),
-    .spi1_sdo_o ());
+    .spi1_sdo_o (),
+    .iic_ard_scl_io (iic_ard_scl),
+    .iic_ard_sda_io (iic_ard_sda));
 
 endmodule


### PR DESCRIPTION
## PR Description

This PR adds the missing I2C signals in system_top_ardz.v for ARDZPMODN1:
- Introduces I2C inout ports: iic_ard_scl, iic_ard_sda
- Connects the signals in the module instantiation:
    .iic_ard_scl_io(iic_ard_scl),
    .iic_ard_sda_io(iic_ard_sda)
- Fixes build failure when running make ARDZ_PMOD_N=1


## PR Type
- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)
- [ ] Documentation

## PR Checklist
- [x] I have followed the code style guidelines
- [x] I have performed a self-review of changes
- [ ] I have compiled all hdl projects and libraries affected by this PR
- [ ] I have tested in hardware affected projects, at least on relevant boards
- [ ] I have commented my code, at least hard-to-understand parts
- [x] I have signed off all commits from this PR
- [x] I have updated the documentation (wiki pages, ReadMe files, Copyright etc)
- [x] I have not introduced new Warnings/Critical Warnings on compilation
- [ ] I have added new hdl testbenches or updated existing ones
