### PR TITLE
projects/ad9082: Updated project to support the Corundum network stack

### DIFF
--- a/projects/ad9081_fmca_ebz/vcu118/system_bd.tcl
+++ b/projects/ad9081_fmca_ebz/vcu118/system_bd.tcl
@@ -144,9 +144,6 @@ if {$ad_project_params(JESD_MODE) == "64B66B"} {
 
 }
 
-ad_ip_parameter axi_ddr_cntrl CONFIG.C0_CLOCK_BOARD_INTERFACE default_250mhz_clk1
-ad_ip_parameter axi_ddr_cntrl CONFIG.C0_DDR4_BOARD_INTERFACE ddr4_sdram_c1_062
-
 if {$ad_project_params(CORUNDUM) == "1"} {
 
   source $ad_hdl_dir/library/corundum/scripts/corundum_vcu118_cfg.tcl

--- a/projects/ad9082_fmca_ebz/vcu118/Makefile
+++ b/projects/ad9082_fmca_ebz/vcu118/Makefile
@@ -1,5 +1,5 @@
 ####################################################################################
-## Copyright (c) 2018 - 2023 Analog Devices, Inc.
+## Copyright (c) 2018 - 2025 Analog Devices, Inc.
 ### SPDX short identifier: BSD-1-Clause
 ## Auto-generated, do not modify!
 ####################################################################################
@@ -45,5 +45,31 @@ LIB_DEPS += util_pack/util_cpack2
 LIB_DEPS += util_pack/util_upack2
 LIB_DEPS += xilinx/axi_adxcvr
 LIB_DEPS += xilinx/util_adxcvr
+
+CORUNDUM ?= 0
+
+ifeq ($(CORUNDUM), 1)
+	export BOARD := VCU118
+	export CPU := MB
+
+	M_DEPS += ../../ad9081_fmca_ebz/vcu118/system_constr_corundum.xdc
+
+	M_DEPS += $(ADI_HDL_DIR)/library/corundum/scripts/corundum_vcu118_cfg.tcl
+	M_DEPS += $(ADI_HDL_DIR)/library/corundum/scripts/corundum.tcl
+	M_DEPS += $(ADI_HDL_DIR)/library/corundum/scripts/sync_reset.tcl
+
+	EXTERNAL_DEPS += $(ADI_HDL_DIR)/../corundum/fpga/common/syn/vivado/rb_drp.tcl
+	EXTERNAL_DEPS += $(ADI_HDL_DIR)/../corundum/fpga/common/syn/vivado/cmac_gty_wrapper.tcl
+	EXTERNAL_DEPS += $(ADI_HDL_DIR)/../corundum/fpga/common/syn/vivado/cmac_gty_ch_wrapper.tcl
+	EXTERNAL_DEPS += $(ADI_HDL_DIR)/../corundum/fpga/common/syn/vivado/mqnic_rb_clk_info.tcl
+	EXTERNAL_DEPS += $(ADI_HDL_DIR)/../corundum/fpga/common/syn/vivado/mqnic_ptp_clock.tcl
+	EXTERNAL_DEPS += $(ADI_HDL_DIR)/../corundum/fpga/common/syn/vivado/mqnic_port.tcl
+	EXTERNAL_DEPS += $(ADI_HDL_DIR)/../corundum/fpga/lib/eth/lib/axis/syn/vivado/axis_async_fifo.tcl
+	EXTERNAL_DEPS += $(ADI_HDL_DIR)/../corundum/fpga/lib/eth/syn/vivado/ptp_td_leaf.tcl
+	EXTERNAL_DEPS += $(ADI_HDL_DIR)/../corundum/fpga/lib/eth/syn/vivado/ptp_td_rel2tod.tcl
+
+	LIB_DEPS += corundum/corundum_core
+	LIB_DEPS += corundum/ethernet/vcu118
+endif
 
 include ../../scripts/project-xilinx.mk

--- a/projects/ad9082_fmca_ebz/vcu118/system_project.tcl
+++ b/projects/ad9082_fmca_ebz/vcu118/system_project.tcl
@@ -1,5 +1,5 @@
 ###############################################################################
-## Copyright (C) 2019-2024 Analog Devices, Inc. All rights reserved.
+## Copyright (C) 2019-2025 Analog Devices, Inc. All rights reserved.
 ### SPDX short identifier: ADIBSD
 ###############################################################################
 
@@ -49,15 +49,42 @@ adi_project ad9082_fmca_ebz_vcu118 0 [list \
   TX_NUM_LINKS [get_env_param TX_NUM_LINKS            1 ] \
   RX_KS_PER_CHANNEL [get_env_param RX_KS_PER_CHANNEL 64 ] \
   TX_KS_PER_CHANNEL [get_env_param TX_KS_PER_CHANNEL 64 ] \
+  CORUNDUM          [get_env_param CORUNDUM           0 ] \
 ]
 
 adi_project_files ad9082_fmca_ebz_vcu118 [list \
-  "../../ad9081_fmca_ebz/vcu118/system_top.v" \
   "../../ad9081_fmca_ebz/vcu118/system_constr.xdc"\
   "../../ad9081_fmca_ebz/vcu118/timing_constr.xdc"\
   "../../../library/common/ad_3w_spi.v"\
   "$ad_hdl_dir/library/common/ad_iobuf.v" \
-  "$ad_hdl_dir/projects/common/vcu118/vcu118_system_constr.xdc" ]
+  "$ad_hdl_dir/projects/common/vcu118/vcu118_system_constr.xdc" \
+]
+
+if {[get_env_param CORUNDUM 0] == 1} {
+  adi_project_files ad9082_fmca_ebz_vcu118 [list \
+    "../../ad9081_fmca_ebz/vcu118/system_constr_corundum.xdc" \
+    "../../ad9081_fmca_ebz/vcu118/system_top_corundum.v" \
+    "$ad_hdl_dir/../corundum/fpga/mqnic/VCU118/fpga_100g/boot.xdc" \
+    "$ad_hdl_dir/../corundum/fpga/mqnic/VCU118/fpga_100g/rtl/sync_signal.v" \
+  ]
+
+  add_files -fileset constrs_1 -norecurse [list \
+    "$ad_hdl_dir/../corundum/fpga/common/syn/vivado/rb_drp.tcl" \
+    "$ad_hdl_dir/library/corundum/scripts/sync_reset.tcl" \
+    "$ad_hdl_dir/../corundum/fpga/common/syn/vivado/cmac_gty_wrapper.tcl" \
+    "$ad_hdl_dir/../corundum/fpga/common/syn/vivado/cmac_gty_ch_wrapper.tcl" \
+    "$ad_hdl_dir/../corundum/fpga/common/syn/vivado/mqnic_rb_clk_info.tcl" \
+    "$ad_hdl_dir/../corundum/fpga/common/syn/vivado/mqnic_ptp_clock.tcl" \
+    "$ad_hdl_dir/../corundum/fpga/common/syn/vivado/mqnic_port.tcl" \
+    "$ad_hdl_dir/../corundum/fpga/lib/eth/lib/axis/syn/vivado/axis_async_fifo.tcl" \
+    "$ad_hdl_dir/../corundum/fpga/lib/eth/syn/vivado/ptp_td_leaf.tcl" \
+    "$ad_hdl_dir/../corundum/fpga/lib/eth/syn/vivado/ptp_td_rel2tod.tcl" \
+  ]
+} else {
+  adi_project_files ad9082_fmca_ebz_vcu118 [list \
+    "../../ad9081_fmca_ebz/vcu118/system_top.v" \
+  ]
+}
 
 # Avoid critical warning in OOC mode from the clock definitions
 # since at that stage the submodules are not stiched together yet
@@ -65,6 +92,6 @@ if {$ADI_USE_OOC_SYNTHESIS == 1} {
   set_property used_in_synthesis false [get_files timing_constr.xdc]
 }
 
-set_property strategy Performance_ExtraTimingOpt [get_runs impl_1]
+set_property strategy Congestion_SpreadLogic_high [get_runs impl_1]
 
 adi_project_run ad9082_fmca_ebz_vcu118


### PR DESCRIPTION
## PR Description

Since the AD9081 and the AD9082 have the same block design, when the Corundum network stack was added to the AD9081 project files, the AD9082 was left as is, and broke the build.
This PR is fixing the project by adding the Corundum system to it.


## PR Type
- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)
- [ ] Documentation

## PR Checklist
- [x] I have followed the code style guidelines
- [x] I have performed a self-review of changes
- [x] I have compiled all hdl projects and libraries affected by this PR
- [ ] I have tested in hardware affected projects, at least on relevant boards
- [ ] I have commented my code, at least hard-to-understand parts
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe files, Copyright etc)
- [x] I have not introduced new Warnings/Critical Warnings on compilation
- [ ] I have added new hdl testbenches or updated existing ones
