### PR TITLE
library/util_axis_fifo_asym: Fix room and level signals from FIFO ASYM

### DIFF
--- a/library/util_axis_fifo_asym/util_axis_fifo_asym.v
+++ b/library/util_axis_fifo_asym/util_axis_fifo_asym.v
@@ -94,6 +94,18 @@ module util_axis_fifo_asym #(
   reg [$clog2(RATIO)-1:0] s_axis_counter;
   reg [$clog2(RATIO)-1:0] m_axis_counter;
 
+  // FIFO level signals
+  reg                      s_axis_ready_d;
+  reg                      s_axis_valid_d;
+  reg  [              2:0] word_counter;
+  reg  [              2:0] num_of_words;
+  reg  [ADDRESS_WIDTH-1:0] s_input_level;
+  reg  [ADDRESS_WIDTH-1:0] s_input_room;
+  reg  [ADDRESS_WIDTH-1:0] s_input_level_next;
+  reg  [ADDRESS_WIDTH-1:0] s_input_room_next;
+  wire [ADDRESS_WIDTH-1:0] m_output_level;
+  wire                     sdi_output_read_sync;
+
   wire [RATIO-1:0] m_axis_ready_int_s;
   wire [RATIO-1:0] m_axis_valid_int_s;
   wire [RATIO*A_WIDTH-1:0] m_axis_data_int_s;
@@ -214,6 +226,46 @@ module util_axis_fifo_asym #(
   // write or slave logic
   generate
 
+    integer j;
+    always @(posedge s_axis_aclk) begin
+      if (!s_axis_aresetn) begin
+        num_of_words        <= 1;
+        s_axis_ready_d      <= 0;
+        s_axis_valid_d      <= 0;
+      end else begin
+        s_axis_ready_d      <= s_axis_ready;
+        s_axis_valid_d      <= s_axis_valid;
+        word_counter         = 0;
+        for (j = 0; j < RATIO; j = j + 1) begin
+          word_counter = word_counter + (|s_axis_tkeep[M_DATA_WIDTH/8*j+:M_DATA_WIDTH/8]);
+        end
+        num_of_words <= word_counter;
+      end
+    end
+
+    always @(posedge s_axis_aclk) begin
+      if (!s_axis_aresetn) begin
+        s_input_level <= 0;
+        s_input_room  <= {ADDRESS_WIDTH{1'b1}};
+      end else begin
+        s_input_room <= s_input_room_next;
+        s_input_level <= s_input_level_next;
+      end
+    end
+
+    always @(*) begin
+      s_input_level_next = s_input_level;
+      s_input_room_next  = s_input_room;
+      if (s_axis_ready_d && s_axis_valid_d) begin
+        s_input_level_next = s_input_level_next + num_of_words;
+        s_input_room_next  = s_input_room_next  - 1;
+      end
+      if (sdi_output_read_sync) begin
+        s_input_level_next = s_input_level_next - 1;
+        s_input_room_next  = s_input_room_next  + num_of_words;
+      end
+    end
+
     if (RATIO_TYPE) begin : big_slave
 
       for (i=0; i<RATIO; i=i+1) begin: gen_tlast_big_slave
@@ -278,12 +330,18 @@ module util_axis_fifo_asym #(
 
       // FULL/ALMOST_FULL is driven by the current atomic instance
       assign s_axis_almost_full = s_axis_almost_full_int_s >> s_axis_counter;
-
-      // the FIFO has the same room as the last atomic instance
-      // (NOTE: this is not the real room value, rather the value will be updated
-      // after every RATIO number of writes)
       assign s_axis_full = s_axis_full_int_s[RATIO-1];
-      assign s_axis_room = {s_axis_room_int_s[A_ADDRESS*(RATIO-1)+:A_ADDRESS], {$clog2(RATIO){1'b1}}};
+
+      // FIFO room behavior relies on the TKEEP_EN parameter
+      //    When TKEEP_EN == 0, the FIFO has the same room as
+      //    the last atomic instance multiplied by RATIO. The
+      //    value of the room is only updated every RATIO reads.
+      //    s_axis_room == {s_axis_room_int_s[A_ADDRESS*(RATIO-1)+:A_ADDRESS], {$clog2(RATIO){1'b1}}}
+      //
+      //    When TKEEP_EN == 1, it is using a counter whose decrement
+      //    relies on the tkeep.
+      //    s_axis_room == s_input_room
+      assign s_axis_room = (TKEEP_EN) ? s_input_room : {s_axis_room_int_s[A_ADDRESS*(RATIO-1)+:A_ADDRESS], {$clog2(RATIO){1'b1}}};
 
     end
 
@@ -300,7 +358,7 @@ module util_axis_fifo_asym #(
       end
 
       assign m_axis_data = m_axis_data_int_s >> (m_axis_counter*A_WIDTH) ;
-      assign m_axis_tkeep = m_axis_tkeep_int_s >> (m_axis_counter*A_WIDTH/8) ;
+      assign m_axis_tkeep = m_axis_tkeep_int_s >> (m_axis_counter*A_WIDTH/8); //m_axis_tkeep is always high when TKEEP_EN == 0
 
       // VALID/EMPTY/ALMOST_EMPTY is driven by the current atomic instance
       assign m_axis_valid_int = m_axis_valid_int_s >> m_axis_counter;
@@ -317,12 +375,28 @@ module util_axis_fifo_asym #(
 
       assign m_axis_tlast = m_axis_tlast_int_s >> m_axis_counter;
 
-      // the FIFO has the same level as the last atomic instance
-      // (NOTE: this is not the real level value, rather the value will be updated
-      // after every RATIO number of reads)
-      assign m_axis_level = {m_axis_level_int_s[A_ADDRESS-1:0], {$clog2(RATIO){1'b0}}};
+      // FIFO level behavior relies on the TKEEP_EN parameter
+      //    When TKEEP_EN == 0, the FIFO has the same level as
+      //    the last atomic instance multiplied by RATIO. The
+      //    value of the level is only updated every RATIO reads.
+      //    m_axis_level == {m_axis_level_int_s[A_ADDRESS-1:0], {$clog2(RATIO){1'b0}}}
+      //
+      //    When TKEEP_EN == 1, it is using a counter whose increment
+      //    relies on the tkeep.
+      //    m_axis_level == m_output_level
+      assign m_axis_level = (TKEEP_EN) ? m_output_level : {m_axis_level_int_s[A_ADDRESS-1:0], {$clog2(RATIO){1'b0}}};
       assign m_axis_almost_empty = m_axis_almost_empty_int_s[RATIO-1];
       assign m_axis_empty = m_axis_empty_int_s[RATIO-1];
+
+      sync_data #(
+        .NUM_OF_BITS  (ADDRESS_WIDTH),
+        .ASYNC_CLK    (ASYNC_CLK)
+      ) i_sdi_level_sync (
+        .in_clk   (s_axis_aclk),
+        .in_data  (s_input_level),
+        .out_clk  (m_axis_aclk),
+        .out_data (m_output_level)
+      );
 
     end else begin : big_master
 
@@ -333,14 +407,13 @@ module util_axis_fifo_asym #(
       for (i=0; i<RATIO; i=i+1) begin: gen_tkeep_big_master
         assign m_axis_tkeep[i*A_WIDTH/8+:A_WIDTH/8] = ((m_axis_tlast_int_s[i:0] == 0) ||
                                                       (m_axis_tlast_int_s[i])) ?
-                                                    m_axis_tkeep_int_s[i*A_WIDTH/8+:A_WIDTH/8] :
-                                                    {(A_WIDTH/8){1'b0}};
+                                                        m_axis_tkeep_int_s[i*A_WIDTH/8+:A_WIDTH/8] :
+                                                        {(A_WIDTH/8){1'b0}};
       end
 
       assign m_axis_data = m_axis_data_int_s;
       // if every instance has a valid data, the interface has valid data,
       // otherwise valid is asserted only if TLAST is asserted
-      // assign m_axis_valid_int = (|(m_axis_tlast_int_s & m_axis_valid_int_s)) ? |m_axis_valid_int_s : &m_axis_valid_int_s;
       if (TLAST_EN) begin
         assign m_axis_valid_int = (|(m_axis_tlast_int_s & m_axis_valid_int_s)) ? |m_axis_valid_int_s : &m_axis_valid_int_s;
       end else begin
@@ -358,12 +431,21 @@ module util_axis_fifo_asym #(
 
     end
 
+    sync_event #(
+      .NUM_OF_EVENTS (1),
+      .ASYNC_CLK (ASYNC_CLK)
+    ) i_sdi_output_read_sync (
+      .in_clk    (m_axis_aclk),
+      .in_event  (m_axis_ready & m_axis_valid),
+      .out_clk   (s_axis_aclk),
+      .out_event (sdi_output_read_sync));
+
   endgenerate
 
   generate
     if (RATIO == 1) begin
       initial begin
-        s_axis_counter = 1'b1;
+        s_axis_counter = 1'b1; //s_axis_counter == 1 is never executed in small_slave
       end
     end else if (RATIO > 1) begin
       if (RATIO_TYPE) begin

--- a/library/util_axis_fifo_asym/util_axis_fifo_asym.v
+++ b/library/util_axis_fifo_asym/util_axis_fifo_asym.v
@@ -417,8 +417,7 @@ module util_axis_fifo_asym #(
         .in_clk   (s_axis_aclk),
         .in_data  (s_input_level),
         .out_clk  (m_axis_aclk),
-        .out_data (m_output_level)
-      );
+        .out_data (m_output_level));
 
     end else begin : big_master
 

--- a/library/util_axis_fifo_asym/util_axis_fifo_asym.v
+++ b/library/util_axis_fifo_asym/util_axis_fifo_asym.v
@@ -97,8 +97,8 @@ module util_axis_fifo_asym #(
   // FIFO level signals
   reg                      s_axis_ready_d;
   reg                      s_axis_valid_d;
-  reg  [              2:0] word_counter;
-  reg  [              2:0] num_of_words;
+  reg  [$clog2(RATIO):0] word_counter;
+  reg  [$clog2(RATIO):0] num_of_words;
   reg  [ADDRESS_WIDTH-1:0] s_input_level;
   reg  [ADDRESS_WIDTH-1:0] s_input_room;
   reg  [ADDRESS_WIDTH-1:0] s_input_level_next;
@@ -226,33 +226,55 @@ module util_axis_fifo_asym #(
   // write or slave logic
   generate
 
-    integer j;
     always @(posedge s_axis_aclk) begin
       if (!s_axis_aresetn) begin
-        num_of_words        <= 1;
-        s_axis_ready_d      <= 0;
-        s_axis_valid_d      <= 0;
+        s_axis_ready_d <= 0;
+        s_axis_valid_d <= 0;
       end else begin
-        s_axis_ready_d      <= s_axis_ready;
-        s_axis_valid_d      <= s_axis_valid;
-        word_counter         = 0;
-        for (j = 0; j < RATIO; j = j + 1) begin
-          word_counter = word_counter + (|s_axis_tkeep[M_DATA_WIDTH/8*j+:M_DATA_WIDTH/8]);
+        s_axis_ready_d <= s_axis_ready;
+        s_axis_valid_d <= s_axis_valid;
+      end
+    end
+
+    if (RATIO_TYPE) begin : gen_word_counter
+      integer j;
+      always @(posedge s_axis_aclk) begin
+        if (!s_axis_aresetn) begin
+          num_of_words <= 1;
+        end else begin
+          word_counter = 0;
+          for (j = 0; j < RATIO; j = j + 1) begin
+            word_counter = word_counter + (|s_axis_tkeep[M_DATA_WIDTH/8*j+:M_DATA_WIDTH/8]);
+          end
+          num_of_words <= word_counter;
         end
-        num_of_words <= word_counter;
+      end
+    end else begin : gen_no_word_counter
+      always @(posedge s_axis_aclk) begin
+        if (!s_axis_aresetn) begin
+          num_of_words <= 1;
+        end
       end
     end
 
     always @(posedge s_axis_aclk) begin
       if (!s_axis_aresetn) begin
         s_input_level <= 0;
-        s_input_room  <= {ADDRESS_WIDTH{1'b1}};
+        s_input_room  <= RATIO * ({A_ADDRESS{1'b1}});
       end else begin
         s_input_room <= s_input_room_next;
         s_input_level <= s_input_level_next;
       end
     end
 
+    // s_input_level: used when slave is wider than master (RATIO_TYPE=1).
+    //   Increments by num_of_words on each wide input write (slave handshake),
+    //   decrements by 1 on each narrow output read (master handshake).
+    // s_input_room: used when slave is narrower than master (RATIO_TYPE=0).
+    //   Decrements by 1 on each narrow input write (slave handshake),
+    //   increments by RATIO on each wide output read (master handshake),
+    //   since one wide read drains all RATIO atomic FIFOs, freeing RATIO
+    //   narrow input slots.
     always @(*) begin
       s_input_level_next = s_input_level;
       s_input_room_next  = s_input_room;
@@ -262,7 +284,7 @@ module util_axis_fifo_asym #(
       end
       if (sdi_output_read_sync) begin
         s_input_level_next = s_input_level_next - 1;
-        s_input_room_next  = s_input_room_next  + num_of_words;
+        s_input_room_next  = s_input_room_next  + RATIO;
       end
     end
 
@@ -489,9 +511,12 @@ module util_axis_fifo_asym #(
         if (!m_axis_aresetn) begin
           m_axis_counter <= 0;
         end else begin
-          // When using tkeep, we might have an internally "valid" data beat without any actually valid bytes.
-          // This will result in m_axis_valid being actually low for the external world.
-          // In this case (tkeep is all 0), we need to increment the counter without waiting for m_axis_ready.
+          // Advance the master counter on two conditions:
+          // 1. Normal handshake: downstream accepted a valid beat (m_axis_ready && m_axis_valid).
+          // 2. Null-beat skip: the atomic FIFO has data (m_axis_valid_int) but all tkeep bits
+          //    are zero and the beat is not externally valid (!m_axis_valid). This second check
+          //    prevents skipping beats that carry tlast, which AXI-Stream requires to be
+          //    handshaked even when tkeep is fully deasserted.
           if ((m_axis_ready && m_axis_valid) || (TKEEP_EN && m_axis_valid_int && !(|m_axis_tkeep) && !m_axis_valid)) begin
             m_axis_counter <= m_axis_counter + 1'b1;
           end


### PR DESCRIPTION
ROOM and LEVEL signals are incorrect when there is an imbalance between the size of the input and output and TKEEP_EN == 1. This is fixed by inserting two counters, which are better for timing than performing a sum reduce ROOM and LEVEL of the internal symmetrical FIFOs.
This PR has to be merged after https://github.com/analogdevicesinc/hdl/pull/1914


## PR Type
- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)
- [ ] Documentation

## PR Checklist
- [x] I have followed the code style guidelines
- [x] I have performed a self-review of changes
- [x] I have compiled all hdl projects and libraries affected by this PR
- [ ] I have tested in hardware affected projects, at least on relevant boards
- [x] I have commented my code, at least hard-to-understand parts
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe files, Copyright etc)
- [x] I have not introduced new Warnings/Critical Warnings on compilation
- [ ] I have added new hdl testbenches or updated existing ones
