### PR TITLE
projects: ad9081: intel: Suppress incomplete I/O assignments

### DIFF
--- a/projects/ad9081_fmca_ebz/a10soc/system_project.tcl
+++ b/projects/ad9081_fmca_ebz/a10soc/system_project.tcl
@@ -1,5 +1,5 @@
 ###############################################################################
-## Copyright (C) 2021-2024 Analog Devices, Inc. All rights reserved.
+## Copyright (C) 2021-2025 Analog Devices, Inc. All rights reserved.
 ### SPDX short identifier: ADIBSD
 ###############################################################################
 
@@ -222,6 +222,8 @@ set_instance_assignment -name IO_STANDARD "1.8 V" -to spi1_sclk
 set_instance_assignment -name IO_STANDARD "1.8 V" -to spi1_sdio
 set_instance_assignment -name IO_STANDARD "1.8 V" -to txen[0]
 set_instance_assignment -name IO_STANDARD "1.8 V" -to txen[1]
+
+set_global_assignment -name MESSAGE_DISABLE 15714
 
 # set optimization to get a better timing closure
 set_global_assignment -name OPTIMIZATION_MODE "HIGH PERFORMANCE EFFORT"

--- a/projects/ad9081_fmca_ebz/fm87/system_project.tcl
+++ b/projects/ad9081_fmca_ebz/fm87/system_project.tcl
@@ -1,5 +1,5 @@
 ###############################################################################
-## Copyright (C) 2024 Analog Devices, Inc. All rights reserved.
+## Copyright (C) 2024-2025 Analog Devices, Inc. All rights reserved.
 ### SPDX short identifier: ADIBSD
 ###############################################################################
 
@@ -227,6 +227,10 @@ set_instance_assignment -name IO_STANDARD "1.2 V" -to agc2[0]
 set_instance_assignment -name IO_STANDARD "1.2 V" -to agc2[1]
 set_instance_assignment -name IO_STANDARD "1.2 V" -to agc3[0]
 set_instance_assignment -name IO_STANDARD "1.2 V" -to agc3[1]
+set_instance_assignment -name IO_STANDARD "1.2 V" -to fpga_syncin_1_p
+set_instance_assignment -name IO_STANDARD "1.2 V" -to fpga_syncin_1_n
+set_instance_assignment -name IO_STANDARD "1.2 V" -to fpga_syncout_1_p
+set_instance_assignment -name IO_STANDARD "1.2 V" -to fpga_syncout_1_n
 set_instance_assignment -name IO_STANDARD "1.2 V" -to gpio[0]
 set_instance_assignment -name IO_STANDARD "1.2 V" -to gpio[1]
 set_instance_assignment -name IO_STANDARD "1.2 V" -to gpio[2]
@@ -254,6 +258,8 @@ set_instance_assignment -name IO_STANDARD "1.2 V" -to spi1_sclk
 set_instance_assignment -name IO_STANDARD "1.2 V" -to spi1_sdio
 set_instance_assignment -name IO_STANDARD "1.2 V" -to txen[0]
 set_instance_assignment -name IO_STANDARD "1.2 V" -to txen[1]
+
+set_global_assignment -name MESSAGE_DISABLE 15714
 
 # set optimization to get a better timing closure
 set_global_assignment -name OPTIMIZATION_MODE "Superior Performance"

--- a/projects/ad9081_fmca_ebz/s10soc/system_project.tcl
+++ b/projects/ad9081_fmca_ebz/s10soc/system_project.tcl
@@ -1,5 +1,5 @@
 ###############################################################################
-## Copyright (C) 2021-2024 Analog Devices, Inc. All rights reserved.
+## Copyright (C) 2021-2025 Analog Devices, Inc. All rights reserved.
 ### SPDX short identifier: ADIBSD
 ###############################################################################
 
@@ -227,6 +227,9 @@ set_instance_assignment -name IO_STANDARD "1.8 V" -to agc2[0]
 set_instance_assignment -name IO_STANDARD "1.8 V" -to agc2[1]
 set_instance_assignment -name IO_STANDARD "1.8 V" -to agc3[0]
 set_instance_assignment -name IO_STANDARD "1.8 V" -to agc3[1]
+
+set_global_assignment -name MESSAGE_DISABLE 15714
+set_global_assignment -name MESSAGE_DISABLE 24605
 
 # transceiver calibration clock
 set_global_assignment -name DEVICE_INITIALIZATION_CLOCK OSC_CLK_1_125MHZ

--- a/projects/daq2/a10soc/system_project.tcl
+++ b/projects/daq2/a10soc/system_project.tcl
@@ -134,6 +134,8 @@ set_instance_assignment -name IO_STANDARD "1.8 V" -to spi_clk
 set_instance_assignment -name IO_STANDARD "1.8 V" -to spi_sdio
 set_instance_assignment -name IO_STANDARD "1.8 V" -to spi_dir
 
+set_global_assignment -name MESSAGE_DISABLE 15714
+
 # set optimization to get a better timing closure
 set_global_assignment -name OPTIMIZATION_MODE "HIGH PERFORMANCE EFFORT"
 set_global_assignment -name PLACEMENT_EFFORT_MULTIPLIER 1.2


### PR DESCRIPTION
## PR Description

Should fix the failed builds on Jenkins.
There are no warnings when opening the I/O pin assignments report in Quartus so it's probably a bug in the latest release.

## PR Type
- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)
- [ ] Documentation

## PR Checklist
- [x] I have followed the code style guidelines
- [x] I have performed a self-review of changes
- [x] I have compiled all hdl projects and libraries affected by this PR
- [ ] I have tested in hardware affected projects, at least on relevant boards
- [ ] I have commented my code, at least hard-to-understand parts
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe files, Copyright etc)
- [ ] I have not introduced new Warnings/Critical Warnings on compilation
- [ ] I have added new hdl testbenches or updated existing ones
