### PR TITLE
cn0506: zcu102: Update to the latest ZynqMP's GMII Enets' design

### DIFF
--- a/projects/cn0506/zcu102/system_bd.tcl
+++ b/projects/cn0506/zcu102/system_bd.tcl
@@ -1,5 +1,5 @@
 ###############################################################################
-## Copyright (C) 2022-2023 Analog Devices, Inc. All rights reserved.
+## Copyright (C) 2022-2023, 2025 Analog Devices, Inc. All rights reserved.
 ### SPDX short identifier: ADIBSD
 ###############################################################################
 
@@ -28,6 +28,8 @@ set INTF_CFG [get_env_param INTF_CFG RGMII]
 switch $INTF_CFG {
   MII {
     source ../common/mii_bd.tcl
+    create_bd_port -dir O -from 2 -to 0 emio_enet0_speed_mode
+    create_bd_port -dir O -from 2 -to 0 emio_enet1_speed_mode
 
     set_property -dict [list \
       CONFIG.PSU__ENET0__GRP_MDIO__ENABLE {1} \
@@ -43,6 +45,9 @@ switch $INTF_CFG {
     make_bd_intf_pins_external  [get_bd_intf_pins sys_ps8/MDIO_ENET0]
     make_bd_intf_pins_external  [get_bd_intf_pins sys_ps8/GMII_ENET1]
     make_bd_intf_pins_external  [get_bd_intf_pins sys_ps8/MDIO_ENET1]
+
+    ad_connect sys_ps8/emio_enet0_speed_mode emio_enet0_speed_mode
+    ad_connect sys_ps8/emio_enet1_speed_mode emio_enet1_speed_mode
   }
   RGMII {
     source ../common/rgmii_bd.tcl

--- a/projects/cn0506/zcu102/system_top_mii.v
+++ b/projects/cn0506/zcu102/system_top_mii.v
@@ -1,6 +1,6 @@
 // ***************************************************************************
 // ***************************************************************************
-// Copyright (C) 2014-2023 Analog Devices, Inc. All rights reserved.
+// Copyright (C) 2014-2023, 2025 Analog Devices, Inc. All rights reserved.
 //
 // In this HDL repository, there are many different and unique modules, consisting
 // of various HDL (Verilog or VHDL) components. The individual modules are
@@ -158,7 +158,7 @@ module system_top (
     .GMII_ENET0_0_tx_en(mii_tx_en_a),
     .GMII_ENET0_0_tx_er(),
     .GMII_ENET0_0_txd({mii_txd_extra_a,mii_txd_a}),
-    .GMII_ENET0_0_speed_mode(speed_mode_a_s),
+    .emio_enet0_speed_mode(speed_mode_a_s),
     .MDIO_ENET0_0_mdc(mdc_fmc_a),
     .MDIO_ENET0_0_mdio_io(mdio_fmc_a),
 
@@ -172,7 +172,7 @@ module system_top (
     .GMII_ENET1_0_tx_en(mii_tx_en_b),
     .GMII_ENET1_0_tx_er(),
     .GMII_ENET1_0_txd({mii_txd_extra_b,mii_txd_b}),
-    .GMII_ENET1_0_speed_mode(speed_mode_b_s),
+    .emio_enet1_speed_mode(speed_mode_b_s),
     .MDIO_ENET1_0_mdc(mdc_fmc_b),
     .MDIO_ENET1_0_mdio_io(mdio_fmc_b));
 


### PR DESCRIPTION
## PR Description

cn0506: zcu102: Update to the latest ZynqMP's GMII Enets' design
The latest variant of ZynqMP IP (in 2025 version of Vivado suite) exposes the speed_mode ports as individual ones, different from the previous integration into GMII interface.

## PR Type
- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)
- [ ] Documentation

## PR Checklist
- [x] I have followed the code style guidelines
- [x] I have performed a self-review of changes
- [ ] I have compiled all hdl projects and libraries affected by this PR
- [ ] I have tested in hardware affected projects, at least on relevant boards
- [ ] I have commented my code, at least hard-to-understand parts
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe files, Copyright etc)
- [ ] I have not introduced new Warnings/Critical Warnings on compilation
- [ ] I have added new hdl testbenches or updated existing ones
