### PR TITLE
docs: Fix documentation build warnings

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -6,7 +6,7 @@ from os import path
 
 repository = 'hdl'
 project = 'HDL'
-copyright = '2024, Analog Devices, Inc.'
+copyright = '2023-2025, Analog Devices, Inc.'
 author = 'Analog Devices, Inc.'
 version = '' # documentation version, will be printed on the cover page
 
@@ -26,7 +26,15 @@ source_suffix = '.rst'
 
 # -- External docs configuration ----------------------------------------------
 
-interref_repos = ['doctools', 'documentation', 'pyadi-iio']
+interref_repos = [
+        'adi-kuiper-gen',
+        'doctools',
+        'documentation',
+        'no-OS',
+        'precision-converters-firmware',
+        'pyadi-iio',
+        'scopy',
+]
 
 # -- Custom extensions configuration ------------------------------------------
 

--- a/docs/library/util_sigma_delta_spi/index.rst
+++ b/docs/library/util_sigma_delta_spi/index.rst
@@ -58,7 +58,7 @@ the ADC, or it can be connected to a HDL block, like the
 transaction to read the converted signal.
 
 The data ready condition is only detected if the chip-select signal (which is
-connected to the converter) has been asserted for **at least**``IDLE_TIMEOUT``
+connected to the converter) has been asserted for **at least** ``IDLE_TIMEOUT``
 clock cycles.
 
 The timeout is used to avoid spurious signal detection and the ``IDLE_TIMEOUT``

--- a/docs/user_guide/build_boot_bin.rst
+++ b/docs/user_guide/build_boot_bin.rst
@@ -58,8 +58,8 @@ The script can take 3 parameters:
 
    Keep in mind that **the u-boot is FPGA-specific**!
 
-   See the beginning of :external+documentation:ref:`kuiper sdcard` for
-   instructions on how to obtain the ADI Kuiper image.
+   See this :external+adi-kuiper-gen:ref:`tutorial <quick-start>` for
+   instructions on how to obtain the ADI Kuiper image and use it.
 
 If you didn't use ``make`` parameters when building the project, then
 the script can be saved in the **folder local to the project** (for
@@ -116,8 +116,8 @@ The script can take 4 parameters (the last one is optional):
 
    Keep in mind that **the u-boot is FPGA-specific**!
 
-   See the beginning of :external+documentation:ref:`kuiper sdcard` for
-   instructions on how to obtain the ADI Kuiper image.
+   See this :external+adi-kuiper-gen:ref:`tutorial <quick-start>` for
+   instructions on how to obtain the ADI Kuiper image and use it.
 
 If you didn't use ``make`` parameters when building the project, then
 the script can be saved in the **folder local to the project** (for
@@ -173,8 +173,8 @@ The script can take 4 parameters:
 
    Keep in mind that **the u-boot is FPGA-specific**!
 
-   See the beginning of :external+documentation:ref:`kuiper sdcard` for
-   instructions on how to obtain the ADI Kuiper image.
+   See this :external+adi-kuiper-gen:ref:`tutorial <quick-start>` for
+   instructions on how to obtain the ADI Kuiper image and use it.
 
 If you didn't use ``make`` parameters when building the project, then
 the script can be saved in the **folder local to the project** (for

--- a/docs/user_guide/build_hdl.rst
+++ b/docs/user_guide/build_hdl.rst
@@ -1105,9 +1105,9 @@ e.g. ``component.xml`` and ``.lock`` files.
 -------------------------------------------------------------------------------
 
 First, you have to write the SD card with the
-:external+documentation:doc:`ADI Kuiper image <linux/kuiper/index>`.
+:external+adi-kuiper-gen:doc:`ADI Kuiper image <index>`.
 Check this
-:external+documentation:ref:`tutorial <kuiper sdcard>`.
+:external+adi-kuiper-gen:ref:`tutorial <quick-start>`.
 
 Once you are done with that, you can go on with the following steps.
 


### PR DESCRIPTION
## PR Description

- Fixed links to the Kuiper documentation repository (it has changed from documentation/linux/kuiper to adi-kuiper-gen). https://github.com/analogdevicesinc/documentation/pull/56
- Added all the interref repositories
- Fixed warning in a library

## PR Type
- [ ] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)
- [x] Documentation

## PR Checklist
- [x] I have followed the code style guidelines
- [x] I have performed a self-review of changes
- [ ] I have compiled all hdl projects and libraries affected by this PR
- [ ] I have tested in hardware affected projects, at least on relevant boards
- [ ] I have commented my code, at least hard-to-understand parts
- [x] I have signed off all commits from this PR
- [x] I have updated the documentation (wiki pages, ReadMe files, Copyright etc)
- [x] I have not introduced new Warnings/Critical Warnings on compilation
- [ ] I have added new hdl testbenches or updated existing ones
