### PR TITLE
Fix FIFO ASYM HDL for Quartus

### DIFF
--- a/library/util_axis_fifo_asym/util_axis_fifo_asym.v
+++ b/library/util_axis_fifo_asym/util_axis_fifo_asym.v
@@ -108,7 +108,7 @@ module util_axis_fifo_asym #(
   // instantiate the FIFOs
   genvar i;
   generate
-    for (i=0; i<RATIO; i=i+1) begin
+    for (i=0; i<RATIO; i=i+1) begin: gen_fifo_instances
       util_axis_fifo #(
         .DATA_WIDTH (A_WIDTH),
         .ADDRESS_WIDTH (A_ADDRESS),
@@ -148,7 +148,7 @@ module util_axis_fifo_asym #(
 
     if (RATIO_TYPE) begin : big_slave
 
-      for (i=0; i<RATIO; i=i+1) begin
+      for (i=0; i<RATIO; i=i+1) begin: gen_tlast_big_slave
         assign s_axis_valid_int_s[i] = s_axis_valid & s_axis_ready;
 
         if (TKEEP_EN) begin
@@ -177,7 +177,7 @@ module util_axis_fifo_asym #(
 
       reg [RATIO-1:0] s_axis_valid_int_d = {RATIO{1'b0}};
 
-      for (i=0; i<RATIO; i=i+1) begin
+      for (i=0; i<RATIO; i=i+1) begin: gen_tlast_small_slave
         assign s_axis_data_int_s[A_WIDTH*i+:A_WIDTH] = s_axis_data;
         assign s_axis_tkeep_int_s[A_WIDTH/8*i+:A_WIDTH/8] = (s_axis_counter == i) ? s_axis_tkeep : {A_WIDTH/8{1'b0}};
         assign s_axis_tlast_int_s[i] = (s_axis_counter == i) ? s_axis_tlast : 1'b0;
@@ -215,7 +215,7 @@ module util_axis_fifo_asym #(
   generate
     if (RATIO_TYPE) begin : small_master
 
-      for (i=0; i<RATIO; i=i+1) begin
+      for (i=0; i<RATIO; i=i+1) begin: gen_ready_small_master
         assign m_axis_ready_int_s[i] = (m_axis_counter == i) ? m_axis_ready : 1'b0;
       end
 
@@ -236,11 +236,11 @@ module util_axis_fifo_asym #(
 
     end else begin : big_master
 
-      for (i=0; i<RATIO; i=i+1) begin
+      for (i=0; i<RATIO; i=i+1) begin: gen_ready_big_master
         assign m_axis_ready_int_s[i] = m_axis_ready & (&m_axis_valid_int_s);
       end
 
-      for (i=0; i<RATIO; i=i+1) begin
+      for (i=0; i<RATIO; i=i+1) begin: gen_tkeep_big_master
         assign m_axis_tkeep[i*A_WIDTH/8+:A_WIDTH/8] = ((m_axis_tlast_int_s[i:0] == 0) ||
                                                       (m_axis_tlast_int_s[i])) ?
                                                     m_axis_tkeep_int_s[i*A_WIDTH/8+:A_WIDTH/8] :


### PR DESCRIPTION
Fifo asym library is only being used by data_offload, which is not instantiated in quartus projects. However, future spi engine 2.0 will use it and it will break compilation.

Quartus demands a label for every for loop and this commit fixes it. No logic update was done in the HDL, so that is not going to change the current behavior of this library.

## PR Type
- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)
- [ ] Documentation

## PR Checklist
- [ ] I have followed the code style guidelines
- [x] I have performed a self-review of changes
- [ ] I have compiled all hdl projects and libraries affected by this PR
- [ ] I have tested in hardware affected projects, at least on relevant boards
- [ ] I have commented my code, at least hard-to-understand parts
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe files, Copyright etc)
- [x] I have not introduced new Warnings/Critical Warnings on compilation
- [ ] I have added new hdl testbenches or updated existing ones
