### PR TITLE
adrv9009/kcu105: Fix timing

### DIFF
--- a/projects/adrv9009/kcu105/system_constr.xdc
+++ b/projects/adrv9009/kcu105/system_constr.xdc
@@ -97,3 +97,7 @@ set_case_analysis -quiet 0 [get_pins -quiet -hier *_channel/RXSYSCLKSEL[1]]
 set_case_analysis -quiet 1 [get_pins -quiet -hier *_channel/RXOUTCLKSEL[0]]
 set_case_analysis -quiet 1 [get_pins -quiet -hier *_channel/RXOUTCLKSEL[1]]
 set_case_analysis -quiet 0 [get_pins -quiet -hier *_channel/RXOUTCLKSEL[2]]
+
+# Hold time constraints for critical paths
+set_max_delay -datapath_only -from [get_clocks mmcm_clkout1] -to [get_clocks mmcm_clkout0] 5.0
+set_min_delay -from [get_clocks mmcm_clkout1] -to [get_clocks mmcm_clkout0] 1.0


### PR DESCRIPTION
## PR Description

Fix hold negative slack between two clock domains: mmcm_clkout0 (300 MHz) and mmcm_clkout1 (100 MHz)

## PR Type
- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)
- [ ] Documentation

## PR Checklist
- [x] I have followed the code style guidelines
- [x] I have performed a self-review of changes
- [x] I have compiled all hdl projects and libraries affected by this PR
- [x] I have tested in hardware affected projects, at least on relevant boards
- [x] I have commented my code, at least hard-to-understand parts
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe files, Copyright etc)
- [x] I have not introduced new Warnings/Critical Warnings on compilation
- [ ] I have added new hdl testbenches or updated existing ones
