### PR TITLE
docs/regmap/adi_regmap_jesd_*.txt: update OCTETS_PER_FRAME bit width

### DIFF
--- a/docs/regmap/adi_regmap_jesd_rx.txt
+++ b/docs/regmap/adi_regmap_jesd_rx.txt
@@ -442,7 +442,7 @@ RO
 ENDFIELD
 
 FIELD
-[18:16] 0x00000000
+[23:16] 0x00000000
 OCTETS_PER_FRAME
 RW
 Number of octets per frame - 1 (F).

--- a/docs/regmap/adi_regmap_jesd_tx.txt
+++ b/docs/regmap/adi_regmap_jesd_tx.txt
@@ -407,7 +407,7 @@ RO
 ENDFIELD
 
 FIELD
-[18:16] 0x00000000
+[23:16] 0x00000000
 OCTETS_PER_FRAME
 RW
 Number of octets per frame - 1 (F).


### PR DESCRIPTION
OCTETS_PER_FRAME had already been updated to 8b, but this didn't match the regmap .txt

## PR Type
- [ ] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)
- [x] Documentation

## PR Checklist
- [x] I have followed the code style guidelines
- [x] I have performed a self-review of changes
- [ ] I have compiled all hdl projects and libraries affected by this PR
- [ ] I have tested in hardware affected projects, at least on relevant boards
- [ ] I have commented my code, at least hard-to-understand parts
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe files, Copyright etc)
- [ ] I have not introduced new Warnings/Critical Warnings on compilation
- [ ] I have added new hdl testbenches or updated existing ones
