### PR TITLE
library/util_pack/: add labels to loops inside generate

### DIFF
--- a/library/util_pack/util_pack_common/pack_shell.v
+++ b/library/util_pack/util_pack_common/pack_shell.v
@@ -219,7 +219,7 @@ module pack_shell #(
 
         /* Copy the samples_enable to the first row to make addressing it easier */
         genvar j;
-        for (j = 0; j < NUM_OF_SAMPLES; j = j + 1) begin
+        for (j = 0; j < NUM_OF_SAMPLES; j = j + 1) begin: samples_enable_copy
           assign prefix_count_tmp[0][j] = ~samples_enable[j];
         end
 
@@ -231,8 +231,8 @@ module pack_shell #(
         * prefix_count_tmp[3] = '1 2 3 4 5 6 7 8'
         */
         genvar k;
-        for (j = 1; j < LOG2_NUM_OF_SAMPLES + 1; j = j + 1) begin
-          for (k = 0; k < NUM_OF_SAMPLES; k = k + 1) begin
+        for (j = 1; j < LOG2_NUM_OF_SAMPLES + 1; j = j + 1) begin: prefix_count_tmp_lines
+          for (k = 0; k < NUM_OF_SAMPLES; k = k + 1) begin: prefix_count_tmp_cols
             if (k < 2 ** (j-1)) begin
               assign prefix_count_tmp[j][k] = prefix_count_tmp[j-1][k];
             end else begin


### PR DESCRIPTION
Quartus requires that all blocks inside generate statements have a label. The lack of these block labels was causing some projects to fail to build.

https://www.intel.com/content/www/us/en/support/programmable/articles/000090348.html

## PR Type
- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)
- [ ] Documentation

## PR Checklist
- [ ] I have followed the code style guidelines
- [ ] I have performed a self-review of changes
- [ ] I have compiled all hdl projects and libraries affected by this PR
- [ ] I have tested in hardware affected projects, at least on relevant boards
- [ ] I have commented my code, at least hard-to-understand parts
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe files, Copyright etc)
- [ ] I have not introduced new Warnings/Critical Warnings on compilation
- [ ] I have added new hdl testbenches or updated existing ones
