### PR TITLE
projects/ad488x: Fix Critical Warning

### DIFF
--- a/projects/ad488x_fmc_evb/zed/system_project.tcl
+++ b/projects/ad488x_fmc_evb/zed/system_project.tcl
@@ -14,6 +14,5 @@ adi_project_files ad488x_fmc_evb_zed [list \
   "system_constr.xdc" \
   "system_top.v" ]
 
-set_property PROCESSING_ORDER LATE [get_files system_constr.xdc]
 
 adi_project_run ad488x_fmc_evb_zed


### PR DESCRIPTION


## PR Description

Fixed the CRITICAL WARNING: [Common 17-55] 'get_property' expects at least one object

## PR Type
- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)
- [ ] Documentation

## PR Checklist
- [x] I have followed the code style guidelines
- [x] I have performed a self-review of changes
- [x] I have compiled all hdl projects and libraries affected by this PR
- [ ] I have tested in hardware affected projects, at least on relevant boards
- [ ] I have commented my code, at least hard-to-understand parts
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe files, Copyright etc)
- [x] I have not introduced new Warnings/Critical Warnings on compilation
- [ ] I have added new hdl testbenches or updated existing ones
