### PR TITLE
admx6001/vcu118: Fix timing violations

### DIFF
--- a/projects/admx6001_ebz/vcu118/system_constr.xdc
+++ b/projects/admx6001_ebz/vcu118/system_constr.xdc
@@ -150,8 +150,9 @@ create_clock -period 2.500 -name dco_clk      [get_ports dco_p]
 # Constraint SYSREFs
 # Assumption is that REFCLK and SYSREF have similar propagation delay,
 # and the SYSREF is a source synchronous Center-Aligned signal to REFCLK
-
-set_input_delay -clock [get_clocks global_clk_0] 1.600 [get_ports rx_sysref_*]
+set_input_delay -clock [get_clocks global_clk_0] \
+  [expr [get_property PERIOD [get_clocks global_clk_0]] / 2] \
+  [get_ports {rx_sysref_*}]
 
 ##by default IOB is TRUE and this register is not being driven by any IO element
 set_property IOB FALSE [get_cells -hierarchical -regexp {.*hmc7044_spi.*IO0_I_REG$}];
@@ -163,6 +164,8 @@ set_property IOB FALSE [get_cells -hierarchical -regexp {.*ltc2664_spi.*IO0_I_RE
 create_generated_clock -name adl5580_spi_clk -source [get_pins i_system_wrapper/system_i/adl5580_spi/ext_spi_clk] -divide_by 2 [get_pins i_system_wrapper/system_i/adl5580_spi/sck_o]
 create_generated_clock -name hmc7044_spi_clk -source [get_pins i_system_wrapper/system_i/hmc7044_spi/ext_spi_clk] -divide_by 2 [get_pins i_system_wrapper/system_i/hmc7044_spi/sck_o]
 
-# Set false path for the AD4080 sync GPIO
 
-set_false_path -through [get_nets i_system_wrapper/gpio_o[56]]
+
+# Set false path from AXI GPIO to AD9213 Data Offload as the GPIO is used only as a switch
+
+set_false_path -from [get_cells -hierarchical -filter {NAME =~ "*axi_gpio/U0/gpio_core_1/Dual.gpio2_Data_Out_reg*"}] -to [get_cells -hierarchical -filter {NAME =~ "*axi_ad9213_do*"}]

--- a/projects/admx6001_ebz/vcu118/system_project.tcl
+++ b/projects/admx6001_ebz/vcu118/system_project.tcl
@@ -16,8 +16,6 @@ adi_project_files admx6001_ebz_vcu118 [list \
   "system_constr.xdc" \
   "system_top.v" ]
 
-set_property PROCESSING_ORDER LATE [get_files system_constr.xdc]
-
 ## To improve timing in DDR4 MIG
 set_property strategy Performance_SpreadSLLs [get_runs impl_1]
 


### PR DESCRIPTION
## PR Description

The timing violation between the AXI_GPIO and DATA_OFFLOAD is solved by setting the false path as the gpio only acts as a switch. The JESD related timing violations are solved by removing the processing order command.

## PR Type
- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)
- [ ] Documentation

## PR Checklist
- [x] I have followed the code style guidelines
- [x] I have performed a self-review of changes
- [x] I have compiled all hdl projects and libraries affected by this PR
- [ ] I have tested in hardware affected projects, at least on relevant boards
- [ ] I have commented my code, at least hard-to-understand parts
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe files, Copyright etc)
- [x] I have not introduced new Warnings/Critical Warnings on compilation
- [ ] I have added new hdl testbenches or updated existing ones
