### PR TITLE
docs: AD7616/AD7606 documentation update

### DIFF
--- a/docs/projects/ad7606x_fmc/index.rst
+++ b/docs/projects/ad7606x_fmc/index.rst
@@ -289,7 +289,6 @@ spi_ad7606 **   12  56         88
 .. admonition:: Legend
    :class: note
 
-   - ``*`` instantiated only for INTF=0 (parallel interface)
    - ``**`` instantiated only for INTF=1 (serial interface)
 
 Building the HDL project

--- a/docs/projects/ad7616_sdz/index.rst
+++ b/docs/projects/ad7616_sdz/index.rst
@@ -239,13 +239,11 @@ Instance name   HDL Linux Zynq Actual Zynq
 =============== === ========== ===========
 axi_ad7616_dma  13  57         89
 spi_ad7616 **   12  56         88
-axi_ad7616 *    10  54         87
 =============== === ========== ===========
 
 .. admonition:: Legend
    :class: note
 
-   - ``*`` instantiated only for INTF=0 (parallel interface)
    - ``**`` instantiated only for INTF=1 (serial interface)
 
 Building the HDL project


### PR DESCRIPTION
## PR Description

Remove reference to the axi_ad7616 interrupt as it does not exist in the HDL design.
Update AD7606/AD7616 documentation.

## PR Type
- [ ] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)
- [x] Documentation

## PR Checklist
- [x] I have followed the code style guidelines
- [x] I have performed a self-review of changes
- [ ] I have compiled all hdl projects and libraries affected by this PR
- [ ] I have tested in hardware affected projects, at least on relevant boards
- [ ] I have commented my code, at least hard-to-understand parts
- [x] I have signed off all commits from this PR
- [x] I have updated the documentation (wiki pages, ReadMe files, Copyright etc)
- [x] I have not introduced new Warnings/Critical Warnings on compilation
- [ ] I have added new hdl testbenches or updated existing ones
