### PR TITLE
projects/ad9081_vcu118: Fix timing and pathing

### DIFF
--- a/projects/ad9081_fmca_ebz/vcu118/Makefile
+++ b/projects/ad9081_fmca_ebz/vcu118/Makefile
@@ -51,19 +51,19 @@ ifeq ($(CORUNDUM), 1)
 
 	M_DEPS += system_constr_corundum.xdc
 
-	M_DEPS += $(ADI_HDL_DIR)/library/corundum/scripts/corundum_vcu118_cfg.tcl
-	M_DEPS += $(ADI_HDL_DIR)/library/corundum/scripts/corundum.tcl
-	M_DEPS += $(ADI_HDL_DIR)/library/corundum/scripts/sync_reset.tcl
+	M_DEPS += ../../../library/corundum/scripts/corundum_vcu118_cfg.tcl
+	M_DEPS += ../../../library/corundum/scripts/corundum.tcl
+	M_DEPS += ../../../library/corundum/scripts/sync_reset.tcl
 
-	EXTERNAL_DEPS += $(ADI_HDL_DIR)/../corundum/fpga/common/syn/vivado/rb_drp.tcl
-	EXTERNAL_DEPS += $(ADI_HDL_DIR)/../corundum/fpga/common/syn/vivado/cmac_gty_wrapper.tcl
-	EXTERNAL_DEPS += $(ADI_HDL_DIR)/../corundum/fpga/common/syn/vivado/cmac_gty_ch_wrapper.tcl
-	EXTERNAL_DEPS += $(ADI_HDL_DIR)/../corundum/fpga/common/syn/vivado/mqnic_rb_clk_info.tcl
-	EXTERNAL_DEPS += $(ADI_HDL_DIR)/../corundum/fpga/common/syn/vivado/mqnic_ptp_clock.tcl
-	EXTERNAL_DEPS += $(ADI_HDL_DIR)/../corundum/fpga/common/syn/vivado/mqnic_port.tcl
-	EXTERNAL_DEPS += $(ADI_HDL_DIR)/../corundum/fpga/lib/eth/lib/axis/syn/vivado/axis_async_fifo.tcl
-	EXTERNAL_DEPS += $(ADI_HDL_DIR)/../corundum/fpga/lib/eth/syn/vivado/ptp_td_leaf.tcl
-	EXTERNAL_DEPS += $(ADI_HDL_DIR)/../corundum/fpga/lib/eth/syn/vivado/ptp_td_rel2tod.tcl
+	EXTERNAL_DEPS += ../../../../corundum/fpga/common/syn/vivado/rb_drp.tcl
+	EXTERNAL_DEPS += ../../../../corundum/fpga/common/syn/vivado/cmac_gty_wrapper.tcl
+	EXTERNAL_DEPS += ../../../../corundum/fpga/common/syn/vivado/cmac_gty_ch_wrapper.tcl
+	EXTERNAL_DEPS += ../../../../corundum/fpga/common/syn/vivado/mqnic_rb_clk_info.tcl
+	EXTERNAL_DEPS += ../../../../corundum/fpga/common/syn/vivado/mqnic_ptp_clock.tcl
+	EXTERNAL_DEPS += ../../../../corundum/fpga/common/syn/vivado/mqnic_port.tcl
+	EXTERNAL_DEPS += ../../../../corundum/fpga/lib/eth/lib/axis/syn/vivado/axis_async_fifo.tcl
+	EXTERNAL_DEPS += ../../../../corundum/fpga/lib/eth/syn/vivado/ptp_td_leaf.tcl
+	EXTERNAL_DEPS += ../../../../corundum/fpga/lib/eth/syn/vivado/ptp_td_rel2tod.tcl
 
 	LIB_DEPS += corundum/corundum_core
 	LIB_DEPS += corundum/ethernet/vcu118

--- a/projects/ad9081_fmca_ebz/vcu118/system_bd.tcl
+++ b/projects/ad9081_fmca_ebz/vcu118/system_bd.tcl
@@ -144,9 +144,6 @@ if {$ad_project_params(JESD_MODE) == "64B66B"} {
 
 }
 
-ad_ip_parameter axi_ddr_cntrl CONFIG.C0_CLOCK_BOARD_INTERFACE default_250mhz_clk1
-ad_ip_parameter axi_ddr_cntrl CONFIG.C0_DDR4_BOARD_INTERFACE ddr4_sdram_c1_062
-
 if {$ad_project_params(CORUNDUM) == "1"} {
 
   source $ad_hdl_dir/library/corundum/scripts/corundum_vcu118_cfg.tcl


### PR DESCRIPTION
## PR Description

Updated makefile pathing for Corundum from using environment variable to relative pathing.
Fixed timing issue with the build.


## PR Type
- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)
- [ ] Documentation

## PR Checklist
- [x] I have followed the code style guidelines
- [x] I have performed a self-review of changes
- [x] I have compiled all hdl projects and libraries affected by this PR
- [ ] I have tested in hardware affected projects, at least on relevant boards
- [ ] I have commented my code, at least hard-to-understand parts
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe files, Copyright etc)
- [x] I have not introduced new Warnings/Critical Warnings on compilation
- [x] I have added new hdl testbenches or updated existing ones
