### PR TITLE
.github/scripts/check_readme.sh: Added special project case

### DIFF
--- a/.github/scripts/README.md
+++ b/.github/scripts/README.md
@@ -32,7 +32,13 @@ This script ensures that all HDL project directories contain properly formatted 
 - **Board names** are uppercased and underscores are replaced with hyphens (e.g., `ad9081_fmca_ebz` → `AD9081-FMCA-EBZ`);
 - **Carrier names** are uppercased as-is (e.g., `de10nano` → `DE10NANO`), except for special carriers.
 
-#### 3. Special carrier exceptions
+#### 3. Special projects exceptions
+
+The following projects are allowed to use exceptions from the template in their project/README file:
+
+- `xcvr_wizard`
+
+#### 4. Special carrier exceptions
 
 The following carriers are allowed to use underscore in their README titles and are not flagged for title mismatches:
 
@@ -59,7 +65,7 @@ is_special_carrier() {
 }
 ```
 
-#### 4. Required sections
+#### 5. Required sections
 
 - **Main board README** MUST contain:
   - `Building the project`
@@ -80,7 +86,7 @@ Include these flags on the first line of the README.md file, as a MarkDown comme
 <!-- no_build_example, no_dts, no_no_os -->
 ```
 
-#### 5. Forbidden content
+#### 6. Forbidden content
 
 - Links to the following are not allowed:
   - `https://wiki.analog.com/resources/tools-software/linux-drivers-all`


### PR DESCRIPTION
## PR Description

In the previous implementation, the script would throw an error if the project missed a certain section in the roject/README.md file (e.g. No "Supported parts" section). To solve this issue and not introduce a new flag (the project/README.md files don't include any flags) this script was updated to include a function for 'special' projects (special = projects which can't respect the README.md files template). Also updated the. github/scripts/README.md file to reflect the changes. The workflows should not fail for these types of projects.

## PR Type
- [ ] Bug fix (change that fixes an issue)
- [x] New feature (change that adds new functionality)
- [x] Breaking change (has dependencies in other repos or will cause CI to fail)
- [ ] Documentation

## PR Checklist
- [x] I have followed the code style guidelines
- [x] I have performed a self-review of changes
- [ ] I have compiled all hdl projects and libraries affected by this PR
- [ ] I have tested in hardware affected projects, at least on relevant boards
- [x] I have commented my code, at least hard-to-understand parts
- [x] I have signed off all commits from this PR
- [x] I have updated the documentation (wiki pages, ReadMe files, Copyright etc)
- [ ] I have not introduced new Warnings/Critical Warnings on compilation
- [ ] I have added new hdl testbenches or updated existing ones
