### PR TITLE
a10soc, s10soc, fm87: move suppression of message 15714 to carrier tcl

### DIFF
--- a/projects/ad9081_fmca_ebz/a10soc/system_project.tcl
+++ b/projects/ad9081_fmca_ebz/a10soc/system_project.tcl
@@ -223,8 +223,6 @@ set_instance_assignment -name IO_STANDARD "1.8 V" -to spi1_sdio
 set_instance_assignment -name IO_STANDARD "1.8 V" -to txen[0]
 set_instance_assignment -name IO_STANDARD "1.8 V" -to txen[1]
 
-set_global_assignment -name MESSAGE_DISABLE 15714
-
 # set optimization to get a better timing closure
 set_global_assignment -name OPTIMIZATION_MODE "HIGH PERFORMANCE EFFORT"
 set_global_assignment -name PLACEMENT_EFFORT_MULTIPLIER 1.2

--- a/projects/ad9081_fmca_ebz/fm87/system_project.tcl
+++ b/projects/ad9081_fmca_ebz/fm87/system_project.tcl
@@ -259,8 +259,6 @@ set_instance_assignment -name IO_STANDARD "1.2 V" -to spi1_sdio
 set_instance_assignment -name IO_STANDARD "1.2 V" -to txen[0]
 set_instance_assignment -name IO_STANDARD "1.2 V" -to txen[1]
 
-set_global_assignment -name MESSAGE_DISABLE 15714
-
 # set optimization to get a better timing closure
 set_global_assignment -name OPTIMIZATION_MODE "Superior Performance"
 

--- a/projects/ad9081_fmca_ebz/s10soc/system_project.tcl
+++ b/projects/ad9081_fmca_ebz/s10soc/system_project.tcl
@@ -228,7 +228,6 @@ set_instance_assignment -name IO_STANDARD "1.8 V" -to agc2[1]
 set_instance_assignment -name IO_STANDARD "1.8 V" -to agc3[0]
 set_instance_assignment -name IO_STANDARD "1.8 V" -to agc3[1]
 
-set_global_assignment -name MESSAGE_DISABLE 15714
 set_global_assignment -name MESSAGE_DISABLE 24605
 
 # transceiver calibration clock

--- a/projects/common/a10soc/a10soc_system_assign.tcl
+++ b/projects/common/a10soc/a10soc_system_assign.tcl
@@ -1,5 +1,5 @@
 ###############################################################################
-## Copyright (C) 2016-2023 Analog Devices, Inc. All rights reserved.
+## Copyright (C) 2016-2023, 2025 Analog Devices, Inc. All rights reserved.
 ### SPDX short identifier: ADIBSD
 ###############################################################################
 
@@ -252,3 +252,5 @@ set_instance_assignment -name IO_STANDARD "1.8 V" -to hps_gpio[1]
 set_instance_assignment -name IO_STANDARD "1.8 V" -to hps_gpio[2]
 set_instance_assignment -name IO_STANDARD "1.8 V" -to hps_gpio[3]
 
+# Workaround for Quartus 25.1 incomplete IO assignment becoming a critical warning
+set_global_assignment -name MESSAGE_DISABLE 15714

--- a/projects/common/fm87/fm87_system_assign.tcl
+++ b/projects/common/fm87/fm87_system_assign.tcl
@@ -1,5 +1,5 @@
 ###############################################################################
-## Copyright (C) 2024 Analog Devices, Inc. All rights reserved.
+## Copyright (C) 2024-2025 Analog Devices, Inc. All rights reserved.
 ### SPDX short identifier: ADIBSD
 ###############################################################################
 
@@ -357,3 +357,6 @@ set_global_assignment -name PWRMGT_LINEAR_FORMAT_N "-12"
 set_global_assignment -name PWRMGT_TRANSLATED_VOLTAGE_VALUE_UNIT VOLTS
 
 set_global_assignment -name DEVICE_INITIALIZATION_CLOCK OSC_CLK_1_125MHz
+
+# Workaround for Quartus 25.1 incomplete IO assignment becoming a critical warning
+set_global_assignment -name MESSAGE_DISABLE 15714

--- a/projects/common/s10soc/s10soc_system_assign.tcl
+++ b/projects/common/s10soc/s10soc_system_assign.tcl
@@ -1,5 +1,5 @@
 ###############################################################################
-## Copyright (C) 2020-2024 Analog Devices, Inc. All rights reserved.
+## Copyright (C) 2020-2025 Analog Devices, Inc. All rights reserved.
 ### SPDX short identifier: ADIBSD
 ###############################################################################
 
@@ -371,3 +371,6 @@ set_global_assignment -name PWRMGT_VOLTAGE_OUTPUT_FORMAT "AUTO DISCOVERY"
 set_global_assignment -name PWRMGT_TRANSLATED_VOLTAGE_VALUE_UNIT VOLTS
 
 set_global_assignment -name DEVICE_INITIALIZATION_CLOCK OSC_CLK_1_125MHz
+
+# Workaround for Quartus 25.1 incomplete IO assignment becoming a critical warning
+set_global_assignment -name MESSAGE_DISABLE 15714

--- a/projects/daq2/a10soc/system_project.tcl
+++ b/projects/daq2/a10soc/system_project.tcl
@@ -134,8 +134,6 @@ set_instance_assignment -name IO_STANDARD "1.8 V" -to spi_clk
 set_instance_assignment -name IO_STANDARD "1.8 V" -to spi_sdio
 set_instance_assignment -name IO_STANDARD "1.8 V" -to spi_dir
 
-set_global_assignment -name MESSAGE_DISABLE 15714
-
 # set optimization to get a better timing closure
 set_global_assignment -name OPTIMIZATION_MODE "HIGH PERFORMANCE EFFORT"
 set_global_assignment -name PLACEMENT_EFFORT_MULTIPLIER 1.2


### PR DESCRIPTION
Quartus 25.1 has message 15714 ("Some pins have incomplete I/O assignments[...]") becoming a Critical Warning. This wasn't the case in previous versions and stops being the case for the next version. As a temporary workaround, just suppress this message.
We already had this suppressed for a few projects, but this PR moves it to be carrier-wide and cover more projects

Removes several Critical Warnings affecting a10soc, fm87 and s10soc projects that weren't previously covered.

## PR Type
- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)
- [ ] Documentation

## PR Checklist
- [x] I have followed the code style guidelines
- [x] I have performed a self-review of changes
- [ ] I have compiled all hdl projects and libraries affected by this PR
- [ ] I have tested in hardware affected projects, at least on relevant boards
- [x] I have commented my code, at least hard-to-understand parts
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe files, Copyright etc)
- [x] I have not introduced new Warnings/Critical Warnings on compilation
- [ ] I have added new hdl testbenches or updated existing ones
