### PR TITLE
library/axi_ad9361/xilinx: Fix frame delineation error check

### DIFF
--- a/library/axi_ad9361/xilinx/axi_ad9361_lvds_if.v
+++ b/library/axi_ad9361/xilinx/axi_ad9361_lvds_if.v
@@ -220,9 +220,9 @@ module axi_ad9361_lvds_if #(
   reg             rx_error_r2 = 'd0;
 
   always @(posedge l_clk) begin
-    rx_error_r1 <= ~((rx_frame_s == 4'b1100) || (rx_frame_s == 4'b0011));
-    rx_error_r2 <= ~((rx_frame_s == 4'b1111) || (rx_frame_s == 4'b1100) ||
-                     (rx_frame_s == 4'b0000) || (rx_frame_s == 4'b0011));
+    rx_error_r1 <= ~(({rx_frame_s, rx_frame} == 4'b1100) || ({rx_frame_s, rx_frame} == 4'b0011));
+    rx_error_r2 <= ~(({rx_frame_s, rx_frame} == 4'b1111) || ({rx_frame_s, rx_frame} == 4'b1100) ||
+                     ({rx_frame_s, rx_frame} == 4'b0000) || ({rx_frame_s, rx_frame} == 4'b0011));
   end
 
   always @(posedge l_clk) begin


### PR DESCRIPTION
The rx_error_r1 and rx_error_r2 checks were only using rx_frame_s (2 bits) instead of the concatenated {rx_frame_s, rx_frame} (4 bits) to properly validate frame alignment across consecutive clock cycles.

Signed-off-by: Emin Cetin eeminceetin@gmail.com

Warning - these changes have not been tested on the corresponding hardware / setup / boards!

## PR Description

The rx_error_r1 and rx_error_r2 checks were only using rx_frame_s (2 bits)
instead of the concatenated {rx_frame_s, rx_frame} (4 bits) to properly
validate frame alignment across consecutive clock cycles.

## PR Type
- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the code style guidelines
- [x] I have performed a self-review of changes
- [ ] I have compiled all hdl projects and libraries affected by this PR
- [ ] I have tested in hardware affected projects, at least on relevant boards
- [ ] I have commented my code, at least hard-to-understand parts
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe files, Copyright etc)
- [x] I have not introduced new Warnings/Critical Warnings on compilation
- [ ] I have added new hdl testbenches or updated existing ones

