### PR TITLE
daq3/kcu105: made FIFO smaller for timing closure

### DIFF
--- a/projects/daq3/kcu105/system_bd.tcl
+++ b/projects/daq3/kcu105/system_bd.tcl
@@ -3,13 +3,10 @@
 ### SPDX short identifier: ADIBSD
 ###############################################################################
 
-## FIFO depth is 4Mb - 250k samples
-set adc_fifo_address_width 16
+set adc_fifo_address_width 15
+set dac_fifo_address_width 14
 
-## FIFO depth is 4Mb - 250k samples
-set dac_fifo_address_width 15
-
-## NOTE: With this configuration the #36Kb BRAM utilization is at ~70%
+## NOTE: With this configuration the #36Kb BRAM utilization is at ~48%
 
 source $ad_hdl_dir/projects/common/kcu105/kcu105_system_bd.tcl
 source $ad_hdl_dir/projects/common/xilinx/adcfifo_bd.tcl


### PR DESCRIPTION
## PR Description

The project presented many failing endpoints for setup timing. The design has a deep FIFO with a large data width (128 bits) which consumes a lot of BRAM. Due to this high utilization, the net replication is high and the circuit is spread throughout the entire device. 88% of the timing budget is being consumed by path delays.

Different implementation strategies and physical optimization post PnR were tested but the critical path would not budge. By lowering the FIFO address width, timing closure was achieved.

| Timing | ADC Width | DAC Width | BRAM utilization |
| -- |  -- |  -- |  -- |
| FAIL | 16 | 15 | 78% |
| FAIL | 15 | 15 | 58% |
| PASS | 15 | 14 | 48% |
| PASS | 14 | 13 | 33% |

## PR Type
- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)
- [ ] Documentation

## PR Checklist
- [x] I have followed the code style guidelines
- [x] I have performed a self-review of changes
- [x] I have compiled all hdl projects and libraries affected by this PR
- [ ] I have tested in hardware affected projects, at least on relevant boards
- [x] I have commented my code, at least hard-to-understand parts
- [x] I have signed off all commits from this PR
- [x] I have updated the documentation (wiki pages, ReadMe files, Copyright etc)
- [x] I have not introduced new Warnings/Critical Warnings on compilation
- [ ] I have added new hdl testbenches or updated existing ones
