### PR TITLE
a5s0c,a5gt: remove vestiges

### DIFF
--- a/projects/scripts/adi_project_intel.tcl
+++ b/projects/scripts/adi_project_intel.tcl
@@ -1,5 +1,5 @@
 ###############################################################################
-## Copyright (C) 2017-2024 Analog Devices, Inc. All rights reserved.
+## Copyright (C) 2017-2025 Analog Devices, Inc. All rights reserved.
 ### SPDX short identifier: ADIBSD
 ###############################################################################
 
@@ -13,7 +13,7 @@ set device "none"
 # \param[parameter_list] - a list of global parameters (parameters of the
 # system_top module)
 #
-# Supported carrier names are: a10gx, a10soc, c5soc, de10nano, a5soc, a5gt.
+# Supported carrier names are: a10gx, a10soc, c5soc, de10nano, s10soc, fm87
 #
 proc adi_project {project_name {parameter_list {}}} {
 
@@ -73,18 +73,6 @@ proc adi_project {project_name {parameter_list {}}} {
   if [regexp "_de10nano" $project_name] {
     set family "Cyclone V"
     set device 5CSEBA6U23I7DK
-    set system_qip_file ${ad_project_dir}/system_bd/synthesis/system_bd.qip
-  }
-
-  if [regexp "_a5soc" $project_name] {
-    set family "Arria V"
-    set device 5ASTFD5K3F40I3ES
-    set system_qip_file ${ad_project_dir}/system_bd/synthesis/system_bd.qip
-  }
-
-  if [regexp "_a5gt" $project_name] {
-    set family "Arria V"
-    set device 5AGTFD7K3F40I3
     set system_qip_file ${ad_project_dir}/system_bd/synthesis/system_bd.qip
   }
 


### PR DESCRIPTION
## PR Description

Remove leftover references to unsupported carriers a5soc and a5gt

## PR Type
- [ ] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)
- [ ] Documentation

## PR Checklist
- [ ] I have followed the code style guidelines
- [x] I have performed a self-review of changes
- [ ] I have compiled all hdl projects and libraries affected by this PR
- [ ] I have tested in hardware affected projects, at least on relevant boards
- [ ] I have commented my code, at least hard-to-understand parts
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe files, Copyright etc)
- [ ] I have not introduced new Warnings/Critical Warnings on compilation
- [ ] I have added new hdl testbenches or updated existing ones
