### PR TITLE
ad9082_vcu118: Updated Corundum pathing from absolute to relative

### DIFF
--- a/projects/ad9082_fmca_ebz/vcu118/Makefile
+++ b/projects/ad9082_fmca_ebz/vcu118/Makefile
@@ -14,7 +14,9 @@ M_DEPS += ../../common/vcu118/vcu118_system_constr.xdc
 M_DEPS += ../../common/vcu118/vcu118_system_bd.tcl
 M_DEPS += ../../ad9081_fmca_ebz/vcu118/timing_constr.xdc
 M_DEPS += ../../ad9081_fmca_ebz/vcu118/system_top.v
+M_DEPS += ../../ad9081_fmca_ebz/vcu118/system_top_corundum.v
 M_DEPS += ../../ad9081_fmca_ebz/vcu118/system_constr.xdc
+M_DEPS += ../../ad9081_fmca_ebz/vcu118/system_constr_corundum.xdc
 M_DEPS += ../../ad9081_fmca_ebz/vcu118/system_bd.tcl
 M_DEPS += ../../ad9081_fmca_ebz/common/ad9081_fmca_ebz_bd.tcl
 M_DEPS += ../../../library/xilinx/scripts/versal_xcvr_subsystem.tcl
@@ -54,19 +56,19 @@ ifeq ($(CORUNDUM), 1)
 
 	M_DEPS += ../../ad9081_fmca_ebz/vcu118/system_constr_corundum.xdc
 
-	M_DEPS += $(ADI_HDL_DIR)/library/corundum/scripts/corundum_vcu118_cfg.tcl
-	M_DEPS += $(ADI_HDL_DIR)/library/corundum/scripts/corundum.tcl
-	M_DEPS += $(ADI_HDL_DIR)/library/corundum/scripts/sync_reset.tcl
+	M_DEPS += ../../../library/corundum/scripts/corundum_vcu118_cfg.tcl
+	M_DEPS += ../../../library/corundum/scripts/corundum.tcl
+	M_DEPS += ../../../library/corundum/scripts/sync_reset.tcl
 
-	EXTERNAL_DEPS += $(ADI_HDL_DIR)/../corundum/fpga/common/syn/vivado/rb_drp.tcl
-	EXTERNAL_DEPS += $(ADI_HDL_DIR)/../corundum/fpga/common/syn/vivado/cmac_gty_wrapper.tcl
-	EXTERNAL_DEPS += $(ADI_HDL_DIR)/../corundum/fpga/common/syn/vivado/cmac_gty_ch_wrapper.tcl
-	EXTERNAL_DEPS += $(ADI_HDL_DIR)/../corundum/fpga/common/syn/vivado/mqnic_rb_clk_info.tcl
-	EXTERNAL_DEPS += $(ADI_HDL_DIR)/../corundum/fpga/common/syn/vivado/mqnic_ptp_clock.tcl
-	EXTERNAL_DEPS += $(ADI_HDL_DIR)/../corundum/fpga/common/syn/vivado/mqnic_port.tcl
-	EXTERNAL_DEPS += $(ADI_HDL_DIR)/../corundum/fpga/lib/eth/lib/axis/syn/vivado/axis_async_fifo.tcl
-	EXTERNAL_DEPS += $(ADI_HDL_DIR)/../corundum/fpga/lib/eth/syn/vivado/ptp_td_leaf.tcl
-	EXTERNAL_DEPS += $(ADI_HDL_DIR)/../corundum/fpga/lib/eth/syn/vivado/ptp_td_rel2tod.tcl
+	EXTERNAL_DEPS += ../../../../corundum/fpga/common/syn/vivado/rb_drp.tcl
+	EXTERNAL_DEPS += ../../../../corundum/fpga/common/syn/vivado/cmac_gty_wrapper.tcl
+	EXTERNAL_DEPS += ../../../../corundum/fpga/common/syn/vivado/cmac_gty_ch_wrapper.tcl
+	EXTERNAL_DEPS += ../../../../corundum/fpga/common/syn/vivado/mqnic_rb_clk_info.tcl
+	EXTERNAL_DEPS += ../../../../corundum/fpga/common/syn/vivado/mqnic_ptp_clock.tcl
+	EXTERNAL_DEPS += ../../../../corundum/fpga/common/syn/vivado/mqnic_port.tcl
+	EXTERNAL_DEPS += ../../../../corundum/fpga/lib/eth/lib/axis/syn/vivado/axis_async_fifo.tcl
+	EXTERNAL_DEPS += ../../../../corundum/fpga/lib/eth/syn/vivado/ptp_td_leaf.tcl
+	EXTERNAL_DEPS += ../../../../corundum/fpga/lib/eth/syn/vivado/ptp_td_rel2tod.tcl
 
 	LIB_DEPS += corundum/corundum_core
 	LIB_DEPS += corundum/ethernet/vcu118


### PR DESCRIPTION
## PR Description

Updated Corundum repository pathing from absolute to relative.
Since CI is not using the ADI_HDL_DIR option by default, it cannot find the absolute path to the Corundum repository, which should be located next to the HDL repository. This changes will still look for the same location, but it doesn't require the ADI_HDL_DIR variable to be exported.


## PR Type
- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)
- [ ] Documentation

## PR Checklist
- [x] I have followed the code style guidelines
- [x] I have performed a self-review of changes
- [x] I have compiled all hdl projects and libraries affected by this PR
- [ ] I have tested in hardware affected projects, at least on relevant boards
- [ ] I have commented my code, at least hard-to-understand parts
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe files, Copyright etc)
- [ ] I have not introduced new Warnings/Critical Warnings on compilation
- [ ] I have added new hdl testbenches or updated existing ones
