### PR TITLE
VCU118 - Corundum: Updated scripts to solve critical warning related to system_top

### DIFF
--- a/projects/ad9081_fmca_ebz/vcu118/system_project.tcl
+++ b/projects/ad9081_fmca_ebz/vcu118/system_project.tcl
@@ -1,5 +1,5 @@
 ###############################################################################
-## Copyright (C) 2019-2025 Analog Devices, Inc. All rights reserved.
+## Copyright (C) 2019-2026 Analog Devices, Inc. All rights reserved.
 ### SPDX short identifier: ADIBSD
 ###############################################################################
 

--- a/projects/ad9082_fmca_ebz/vcu118/system_project.tcl
+++ b/projects/ad9082_fmca_ebz/vcu118/system_project.tcl
@@ -1,5 +1,5 @@
 ###############################################################################
-## Copyright (C) 2019-2025 Analog Devices, Inc. All rights reserved.
+## Copyright (C) 2019-2026 Analog Devices, Inc. All rights reserved.
 ### SPDX short identifier: ADIBSD
 ###############################################################################
 

--- a/projects/scripts/adi_project_xilinx.tcl
+++ b/projects/scripts/adi_project_xilinx.tcl
@@ -1,5 +1,5 @@
 ###############################################################################
-## Copyright (C) 2014-2023, 2025 Analog Devices, Inc. All rights reserved.
+## Copyright (C) 2014-2023, 2025-2026 Analog Devices, Inc. All rights reserved.
 ### SPDX short identifier: ADIBSD
 ###############################################################################
 


### PR DESCRIPTION
## PR Description

All projects are expected to have the same system top module named `system_top`.
Current Corundum network stack uses an alternative system top module name, which has a different name from system_top. Because of this, Vivado reports a critical warning.
The changes in this scripts don't affect existing projects, it adds an optional parameter to `adi_project_files`, which allows us to change the system_top module if needed.


## PR Type
- [x] Bug fix (change that fixes an issue)
- [x] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)
- [ ] Documentation

## PR Checklist
- [x] I have followed the code style guidelines
- [x] I have performed a self-review of changes
- [ ] I have compiled all hdl projects and libraries affected by this PR
- [ ] I have tested in hardware affected projects, at least on relevant boards
- [x] I have commented my code, at least hard-to-understand parts
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe files, Copyright etc)
- [x] I have not introduced new Warnings/Critical Warnings on compilation
- [ ] I have added new hdl testbenches or updated existing ones
