### PR TITLE
docs: projects: Remove export-filename paths from the diagrams

### DIFF
--- a/docs/library/axi_ad35xxr/detailed_architecture.svg
+++ b/docs/library/axi_ad35xxr/detailed_architecture.svg
@@ -10,7 +10,7 @@
    id="svg36"
    sodipodi:docname="detailed_architecture.svg"
    inkscape:version="1.3.2 (091e20e, 2023-11-25, custom)"
-   inkscape:export-filename="detailed_architecture.png"
+
    inkscape:export-xdpi="300"
    inkscape:export-ydpi="300"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"

--- a/docs/library/axi_ad9144/block_diagram.svg
+++ b/docs/library/axi_ad9144/block_diagram.svg
@@ -16,7 +16,7 @@
    version="1.1"
    inkscape:version="0.91 r13725"
    sodipodi:docname="adc_lvds.svg"
-   inkscape:export-filename="D:\Git\ghdl\docs\block_diagrams\axi_ad9265\axi_ad9265.png"
+
    inkscape:export-xdpi="400"
    inkscape:export-ydpi="400">
   <defs

--- a/docs/library/axi_ad9265/block_diagram.svg
+++ b/docs/library/axi_ad9265/block_diagram.svg
@@ -16,7 +16,7 @@
    version="1.1"
    inkscape:version="0.91 r13725"
    sodipodi:docname="adc_lvds.svg"
-   inkscape:export-filename="D:\Git\ghdl\docs\block_diagrams\axi_ad9265\axi_ad9265.png"
+
    inkscape:export-xdpi="400"
    inkscape:export-ydpi="400">
   <defs

--- a/docs/library/axi_ad9265/detailed_architecture.svg
+++ b/docs/library/axi_ad9265/detailed_architecture.svg
@@ -16,7 +16,7 @@
    version="1.1"
    inkscape:version="0.91 r13725"
    sodipodi:docname="axi_ad9265_4.svg"
-   inkscape:export-filename="D:\Git\ghdl\docs\block_diagrams\axi_ad9265\axi_ad9265.png"
+
    inkscape:export-xdpi="400"
    inkscape:export-ydpi="400"
    style="shape-rendering:crispEdges">

--- a/docs/library/axi_ad9467/block_diagram.svg
+++ b/docs/library/axi_ad9467/block_diagram.svg
@@ -16,7 +16,7 @@
    version="1.1"
    inkscape:version="0.91 r13725"
    sodipodi:docname="adc_lvds.svg"
-   inkscape:export-filename="D:\Git\ghdl\docs\block_diagrams\axi_ad9265\axi_ad9265.png"
+
    inkscape:export-xdpi="400"
    inkscape:export-ydpi="400">
   <defs

--- a/docs/library/axi_ad9467/detailed_architecture.svg
+++ b/docs/library/axi_ad9467/detailed_architecture.svg
@@ -15,7 +15,7 @@
    version="1.1"
    inkscape:version="0.91 r13725"
    sodipodi:docname="axi_ad9467.svg"
-   inkscape:export-filename="D:\Git\ghdl\docs\block_diagrams\axi_ad9265\axi_ad9265.png"
+
    inkscape:export-xdpi="400"
    inkscape:export-ydpi="400"
    style="shape-rendering:crispEdges"

--- a/docs/library/axi_ad9643/adc_lvds.svg
+++ b/docs/library/axi_ad9643/adc_lvds.svg
@@ -16,7 +16,7 @@
    version="1.1"
    inkscape:version="0.91 r13725"
    sodipodi:docname="adc_lvds.svg"
-   inkscape:export-filename="D:\Git\ghdl\docs\block_diagrams\axi_ad9265\axi_ad9265.png"
+
    inkscape:export-xdpi="400"
    inkscape:export-ydpi="400">
   <defs

--- a/docs/library/axi_ad9643/axi_ad9643_block_diagram.svg
+++ b/docs/library/axi_ad9643/axi_ad9643_block_diagram.svg
@@ -15,7 +15,7 @@
    version="1.1"
    inkscape:version="0.91 r13725"
    sodipodi:docname="axi_ad9643.svg"
-   inkscape:export-filename="D:\Git\ghdl\docs\block_diagrams\axi_ad9265\axi_ad9265.png"
+
    inkscape:export-xdpi="400"
    inkscape:export-ydpi="400"
    style="shape-rendering:crispEdges"

--- a/docs/library/axi_ad9671/block_diagram.svg
+++ b/docs/library/axi_ad9671/block_diagram.svg
@@ -15,7 +15,7 @@
    version="1.1"
    inkscape:version="0.91 r13725"
    sodipodi:docname="adc_jesd.svg"
-   inkscape:export-filename="D:\Git\ghdl\docs\block_diagrams\axi_ad9265\axi_ad9265.png"
+
    inkscape:export-xdpi="400"
    inkscape:export-ydpi="400"
    viewBox="0 0 425 350"

--- a/docs/library/axi_ad9671/detailed_architecture.svg
+++ b/docs/library/axi_ad9671/detailed_architecture.svg
@@ -8,7 +8,7 @@
    version="1.1"
    inkscape:version="1.1.1 (3bf5ae0d25, 2021-09-20)"
    sodipodi:docname="detailed_architecture.svg"
-   inkscape:export-filename="D:\Git\ghdl\docs\block_diagrams\axi_ad9265\axi_ad9265.png"
+
    inkscape:export-xdpi="400"
    inkscape:export-ydpi="400"
    style="shape-rendering:crispEdges"

--- a/docs/library/jesd204/ad_ip_jesd204_tpl_dac/ad_ip_jesd204_transport_dac.svg
+++ b/docs/library/jesd204/ad_ip_jesd204_tpl_dac/ad_ip_jesd204_transport_dac.svg
@@ -9,7 +9,7 @@
    id="svg4828"
    inkscape:version="1.3.2 (091e20e, 2023-11-25, custom)"
    sodipodi:docname="ad_ip_jesd204_transport_dac.svg"
-   inkscape:export-filename="/home/lars/ad_ip_jesd204_transport_dac.png"
+
    inkscape:export-xdpi="90"
    inkscape:export-ydpi="90"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"

--- a/docs/library/jesd204/axi_jesd204_rx/jesd204c_rx_emb_state_machine.svg
+++ b/docs/library/jesd204/axi_jesd204_rx/jesd204c_rx_emb_state_machine.svg
@@ -136,7 +136,7 @@
   <circle
      inkscape:export-ydpi="90.034584"
      inkscape:export-xdpi="90.034584"
-     inkscape:export-filename="/home/lars/text14934.png"
+
      style="fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:3.51027;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
      id="circle1075"
      cx="189.02844"
@@ -145,7 +145,7 @@
   <path
      inkscape:export-ydpi="90.034584"
      inkscape:export-xdpi="90.034584"
-     inkscape:export-filename="/home/lars/text14934.png"
+
      inkscape:connector-curvature="0"
      inkscape:original-d="m 113,-163.63782 29,46"
      inkscape:path-effect="#path-effect1079"
@@ -156,7 +156,7 @@
   <text
      inkscape:export-ydpi="90.034584"
      inkscape:export-xdpi="90.034584"
-     inkscape:export-filename="/home/lars/text14934.png"
+
      id="text1085"
      y="76.974976"
      x="154.6398"
@@ -185,7 +185,7 @@
   <circle
      inkscape:export-ydpi="90.034584"
      inkscape:export-xdpi="90.034584"
-     inkscape:export-filename="/home/lars/text14934.png"
+
      id="circle1087"
      style="fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:3.51027;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
      cx="189.02844"
@@ -194,7 +194,7 @@
   <text
      inkscape:export-ydpi="90.034584"
      inkscape:export-xdpi="90.034584"
-     inkscape:export-filename="/home/lars/text14934.png"
+
      id="text1093"
      y="157.89743"
      x="163.96887"
@@ -213,7 +213,7 @@
   <g
      id="g1103"
      transform="matrix(0.87756872,0,0,0.87756872,150.84093,293.63815)"
-     inkscape:export-filename="/home/lars/text14934.png"
+
      inkscape:export-xdpi="90.034584"
      inkscape:export-ydpi="90.034584">
     <circle
@@ -254,7 +254,7 @@
      x="315.49448"
      y="214.25241"
      id="text1109"
-     inkscape:export-filename="/home/lars/text14934.png"
+
      inkscape:export-xdpi="90.034584"
      inkscape:export-ydpi="90.034584"><tspan
        sodipodi:role="line"
@@ -265,7 +265,7 @@
   <g
      inkscape:export-ydpi="90.034584"
      inkscape:export-xdpi="90.034584"
-     inkscape:export-filename="/home/lars/text14934.png"
+
      transform="matrix(0.87756872,0,0,0.87756872,-135.18355,293.63815)"
      id="g1119">
     <circle
@@ -303,7 +303,7 @@
   <text
      inkscape:export-ydpi="90.034584"
      inkscape:export-xdpi="90.034584"
-     inkscape:export-filename="/home/lars/text14934.png"
+
      id="text1127"
      y="415.92331"
      x="152.49796"
@@ -338,7 +338,7 @@
   <text
      inkscape:export-ydpi="90.034584"
      inkscape:export-xdpi="90.034584"
-     inkscape:export-filename="/home/lars/text14934.png"
+
      id="text1139"
      y="303.03339"
      x="157.80576"
@@ -360,7 +360,7 @@
      x="50.12146"
      y="20.480965"
      id="text1145"
-     inkscape:export-filename="/home/lars/text14934.png"
+
      inkscape:export-xdpi="90.034584"
      inkscape:export-ydpi="90.034584"><tspan
        sodipodi:role="line"
@@ -376,7 +376,7 @@
   <text
      inkscape:export-ydpi="90.034584"
      inkscape:export-xdpi="90.034584"
-     inkscape:export-filename="/home/lars/text14934.png"
+
      id="text1127-4"
      y="239.94699"
      x="67.197937"

--- a/docs/library/jesd204/axi_jesd204_rx/jesd204c_rx_state_machine.svg
+++ b/docs/library/jesd204/axi_jesd204_rx/jesd204c_rx_state_machine.svg
@@ -188,7 +188,7 @@
      cx="138.61261"
      inkscape:export-ydpi="90.034584"
      inkscape:export-xdpi="90.034584"
-     inkscape:export-filename="/home/lars/text14934.png"
+
      style="fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:2.86593;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
      id="circle975" />
   <circle
@@ -255,7 +255,7 @@
   <path
      inkscape:export-ydpi="90.034584"
      inkscape:export-xdpi="90.034584"
-     inkscape:export-filename="/home/lars/text14934.png"
+
      inkscape:connector-curvature="0"
      inkscape:original-d="m 113,-163.63782 29,46"
      inkscape:path-effect="#path-effect1007"
@@ -266,7 +266,7 @@
   <text
      inkscape:export-ydpi="90.034584"
      inkscape:export-xdpi="90.034584"
-     inkscape:export-filename="/home/lars/text14934.png"
+
      id="text1011"
      y="46.344978"
      x="106.73944"
@@ -280,7 +280,7 @@
   <text
      inkscape:export-ydpi="90.034584"
      inkscape:export-xdpi="90.034584"
-     inkscape:export-filename="/home/lars/text14934.png"
+
      xml:space="preserve"
      style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:9px;line-height:0%;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.716483"
      x="111.66547"
@@ -302,13 +302,13 @@
      cx="138.61261"
      inkscape:export-ydpi="90.034584"
      inkscape:export-xdpi="90.034584"
-     inkscape:export-filename="/home/lars/text14934.png"
+
      id="circle1019"
      style="fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:2.86593;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
   <text
      inkscape:export-ydpi="90.034584"
      inkscape:export-xdpi="90.034584"
-     inkscape:export-filename="/home/lars/text14934.png"
+
      id="text1023"
      y="113.41203"
      x="110.99359"
@@ -322,7 +322,7 @@
   <path
      inkscape:export-ydpi="90.034584"
      inkscape:export-xdpi="90.034584"
-     inkscape:export-filename="/home/lars/text14934.png"
+
      sodipodi:nodetypes="cc"
      style="fill:none;stroke:#000000;stroke-width:4;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#TriangleOutS)"
      d="m 181.43857,10.36218 -1,49"
@@ -387,7 +387,7 @@
   <text
      inkscape:export-ydpi="90.034584"
      inkscape:export-xdpi="90.034584"
-     inkscape:export-filename="/home/lars/text14934.png"
+
      id="text1073"
      y="23.065567"
      x="60.889709"
@@ -404,7 +404,7 @@
      x="305.72617"
      style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:9px;line-height:0%;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.716483"
      xml:space="preserve"
-     inkscape:export-filename="/home/lars/text14934.png"
+
      inkscape:export-xdpi="90.034584"
      inkscape:export-ydpi="90.034584"><tspan
        id="tspan1194"
@@ -423,7 +423,7 @@
      x="294.75754"
      style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:9px;line-height:0%;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.716483"
      xml:space="preserve"
-     inkscape:export-filename="/home/lars/text14934.png"
+
      inkscape:export-xdpi="90.034584"
      inkscape:export-ydpi="90.034584"><tspan
        id="tspan1200"
@@ -444,7 +444,7 @@
   <text
      inkscape:export-ydpi="90.034584"
      inkscape:export-xdpi="90.034584"
-     inkscape:export-filename="/home/lars/text14934.png"
+
      xml:space="preserve"
      style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:9px;line-height:0%;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.716483"
      x="271.71906"
@@ -463,7 +463,7 @@
   <text
      inkscape:export-ydpi="90.034584"
      inkscape:export-xdpi="90.034584"
-     inkscape:export-filename="/home/lars/text14934.png"
+
      xml:space="preserve"
      style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:9px;line-height:0%;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.716483"
      x="266.9472"

--- a/docs/library/jesd204/axi_jesd204_tx/jesd204_tx_state_machine.svg
+++ b/docs/library/jesd204/axi_jesd204_tx/jesd204_tx_state_machine.svg
@@ -188,7 +188,7 @@
   <circle
      id="path14924"
      style="fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:2.3584;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-     inkscape:export-filename="/home/lars/text14934.png"
+
      inkscape:export-xdpi="90.034584"
      inkscape:export-ydpi="90.034584"
      cx="118.48425"
@@ -197,7 +197,7 @@
   <g
      id="g13932"
      transform="matrix(0.58959955,0,0,0.58959955,-6.7971306,124.18974)"
-     inkscape:export-filename="/home/lars/text14934.png"
+
      inkscape:export-xdpi="90.034584"
      inkscape:export-ydpi="90.034584">
     <circle
@@ -221,7 +221,7 @@
   <g
      id="g13937"
      transform="matrix(0.58959955,0,0,0.58959955,94.127509,188.17136)"
-     inkscape:export-filename="/home/lars/text14934.png"
+
      inkscape:export-xdpi="90.034584"
      inkscape:export-ydpi="90.034584">
     <circle
@@ -246,7 +246,7 @@
   <g
      transform="matrix(0.58959955,0,0,0.58959955,-9.9567306,259.20804)"
      id="g13945"
-     inkscape:export-filename="/home/lars/text14934.png"
+
      inkscape:export-xdpi="90.034584"
      inkscape:export-ydpi="90.034584">
     <circle
@@ -276,7 +276,7 @@
      inkscape:original-d="m 236.49811,147.56657 65.68436,42.64349"
      inkscape:connector-curvature="0"
      sodipodi:nodetypes="cc"
-     inkscape:export-filename="/home/lars/text14934.png"
+
      inkscape:export-xdpi="90.034584"
      inkscape:export-ydpi="90.034584"
      transform="matrix(0.58959955,0,0,0.58959955,12.070049,97.657762)" />
@@ -287,7 +287,7 @@
      inkscape:path-effect="#path-effect13959"
      inkscape:original-d="m 181.46425,183.36218 -1,108"
      inkscape:connector-curvature="0"
-     inkscape:export-filename="/home/lars/text14934.png"
+
      inkscape:export-xdpi="90.034584"
      inkscape:export-ydpi="90.034584"
      transform="matrix(0.58959955,0,0,0.58959955,12.070049,97.657762)" />
@@ -299,7 +299,7 @@
      inkscape:original-d="M 305.34597,270.71575 242,335.36218"
      inkscape:connector-curvature="0"
      sodipodi:nodetypes="cc"
-     inkscape:export-filename="/home/lars/text14934.png"
+
      inkscape:export-xdpi="90.034584"
      inkscape:export-ydpi="90.034584"
      transform="matrix(0.58959955,0,0,0.58959955,12.070049,97.657762)" />
@@ -310,7 +310,7 @@
      inkscape:path-effect="#path-effect14667"
      inkscape:original-d="m 113,-163.63782 29,46"
      inkscape:connector-curvature="0"
-     inkscape:export-filename="/home/lars/text14934.png"
+
      inkscape:export-xdpi="90.034584"
      inkscape:export-ydpi="90.034584"
      transform="matrix(0.58959955,0,0,0.58959955,12.070049,97.657762)" />
@@ -320,7 +320,7 @@
      x="92.255554"
      y="13.558571"
      id="text14851"
-     inkscape:export-filename="/home/lars/text14934.png"
+
      inkscape:export-xdpi="90.034584"
      inkscape:export-ydpi="90.034584"><tspan
        sodipodi:role="line"
@@ -334,7 +334,7 @@
      x="173.72125"
      y="168.63443"
      id="text14855"
-     inkscape:export-filename="/home/lars/text14934.png"
+
      inkscape:export-xdpi="90.034584"
      inkscape:export-ydpi="90.034584"><tspan
        sodipodi:role="line"
@@ -358,7 +358,7 @@
      x="112.27863"
      style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:11px;line-height:0%;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.5896"
      xml:space="preserve"
-     inkscape:export-filename="/home/lars/text14934.png"
+
      inkscape:export-xdpi="90.034584"
      inkscape:export-ydpi="90.034584"><tspan
        style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:11px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:end;text-anchor:end;stroke-width:0.5896"
@@ -384,7 +384,7 @@
   <circle
      style="fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:2.3584;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
      id="path14894"
-     inkscape:export-filename="/home/lars/text14934.png"
+
      inkscape:export-xdpi="90.034584"
      inkscape:export-ydpi="90.034584"
      cx="118.48425"
@@ -396,7 +396,7 @@
      x="100.47314"
      y="68.748596"
      id="text14896"
-     inkscape:export-filename="/home/lars/text14934.png"
+
      inkscape:export-xdpi="90.034584"
      inkscape:export-ydpi="90.034584"><tspan
        sodipodi:role="line"
@@ -412,7 +412,7 @@
      d="m 181.43857,10.36218 -1,49"
      style="fill:none;stroke:#000000;stroke-width:4;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#TriangleOutS)"
      sodipodi:nodetypes="cc"
-     inkscape:export-filename="/home/lars/text14934.png"
+
      inkscape:export-xdpi="90.034584"
      inkscape:export-ydpi="90.034584"
      transform="matrix(0.58959955,0,0,0.58959955,12.070049,97.657762)" />
@@ -422,7 +422,7 @@
      x="122.91473"
      y="115.0728"
      id="text14930"
-     inkscape:export-filename="/home/lars/text14934.png"
+
      inkscape:export-xdpi="90.034584"
      inkscape:export-ydpi="90.034584"><tspan
        sodipodi:role="line"

--- a/docs/library/jesd204/generic_jesd_bds/generic_jesd_paths.svg
+++ b/docs/library/jesd204/generic_jesd_bds/generic_jesd_paths.svg
@@ -2881,7 +2881,7 @@
       <g
          transform="translate(-3.6098747,1.9368189)"
          id="g7177"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/g7219.png"
+
          inkscape:export-xdpi="180"
          inkscape:export-ydpi="180">
         <g
@@ -3115,13 +3115,13 @@
     <g
        id="g13582"
        transform="translate(131.56285,-380.53334)"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/generic_Tx_JESD_path.png"
+
        inkscape:export-xdpi="180"
        inkscape:export-ydpi="180" />
     <g
        inkscape:export-ydpi="180"
        inkscape:export-xdpi="180"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/F8_Tx_JESD_path.png"
+
        id="g3351-2"
        transform="matrix(0.65068191,0,0,0.7092071,1190.2609,633.93676)"
        style="stroke-width:1.47207212">
@@ -3132,7 +3132,7 @@
          height="188.78664"
          x="563.84381"
          y="-1322.8033"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/generic_Rx_JESD_path.png"
+
          inkscape:export-xdpi="180"
          inkscape:export-ydpi="180" />
       <rect
@@ -3142,13 +3142,13 @@
          height="188.12085"
          x="-160.22995"
          y="-1322.1254"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/generic_Rx_JESD_path.png"
+
          inkscape:export-xdpi="180"
          inkscape:export-ydpi="180" />
       <g
          id="g13642-3"
          transform="matrix(1.5368492,0,0,1.4100254,-194.18504,-1604.0853)"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/generic_Rx_JESD_path.png"
+
          inkscape:export-xdpi="180"
          inkscape:export-ydpi="180">
         <rect
@@ -3183,7 +3183,7 @@
       <g
          id="g13654-8"
          transform="matrix(1.5368492,0,0,1.4100254,-36.087064,-1583.9421)"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/generic_Rx_JESD_path.png"
+
          inkscape:export-xdpi="180"
          inkscape:export-ydpi="180">
         <rect
@@ -3213,7 +3213,7 @@
       <g
          transform="matrix(1.5368492,0,0,1.4100254,172.62881,-1584.4407)"
          id="g13668-1"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/generic_Rx_JESD_path.png"
+
          inkscape:export-xdpi="180"
          inkscape:export-ydpi="180">
         <rect
@@ -3244,13 +3244,13 @@
          style="fill:none;stroke:#000000;stroke-width:1.47207px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:url(#Arrow1Mend-9)"
          d="m 250.05361,-1337.1213 c 0,43.6342 0,43.6342 0,43.6342"
          id="path13686-2"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/generic_Rx_JESD_path.png"
+
          inkscape:export-xdpi="180"
          inkscape:export-ydpi="180" />
       <text
          inkscape:export-ydpi="180"
          inkscape:export-xdpi="180"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/generic_Rx_JESD_path.png"
+
          xml:space="preserve"
          style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:17.6649px;line-height:0%;font-family:sans-serif;-inkscape-font-specification:Sans;text-indent:0;text-align:center;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-anchor:middle;display:inline;overflow:visible;visibility:visible;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.47207;marker:none;enable-background:accumulate"
          x="435.28268"
@@ -3266,20 +3266,20 @@
          style="fill:none;stroke:#000000;stroke-width:1.47207px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
          d="m 451.07061,-1209.2653 9.9895,-14.8052"
          id="path13708-2"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/generic_Rx_JESD_path.png"
+
          inkscape:export-xdpi="180"
          inkscape:export-ydpi="180" />
       <path
          inkscape:export-ydpi="180"
          inkscape:export-xdpi="180"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Tx_JESD_path.png"
+
          style="fill:none;stroke:#000000;stroke-width:1.47207px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
          d="m 246.46091,-1208.2078 9.9895,-14.8052"
          id="use13710-8" />
       <text
          inkscape:export-ydpi="180"
          inkscape:export-xdpi="180"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/generic_Rx_JESD_path.png"
+
          xml:space="preserve"
          style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:17.6649px;line-height:0%;font-family:sans-serif;-inkscape-font-specification:Sans;text-indent:0;text-align:center;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-anchor:middle;display:inline;overflow:visible;visibility:visible;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.47207;marker:none;enable-background:accumulate"
          x="239.15988"
@@ -3294,7 +3294,7 @@
       <g
          inkscape:export-ydpi="180"
          inkscape:export-xdpi="180"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/generic_Tx_JESD_path.png"
+
          transform="matrix(1.5368492,0,0,1.4100254,-353.17121,-781.45195)"
          id="use13732-7">
         <ellipse
@@ -3325,7 +3325,7 @@
       <g
          inkscape:export-ydpi="180"
          inkscape:export-xdpi="180"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/generic_Tx_JESD_path.png"
+
          transform="matrix(1.5368492,0,0,1.4100254,-152.61235,-781.45195)"
          id="use13734-8">
         <ellipse
@@ -3356,7 +3356,7 @@
       <path
          inkscape:export-ydpi="180"
          inkscape:export-xdpi="180"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/generic_Rx_JESD_path.png"
+
          id="path13736-1"
          d="m 656.48551,-1337.1213 c 0,43.6342 0,43.6342 0,43.6342"
          style="fill:none;stroke:#000000;stroke-width:1.47207px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:url(#Arrow1Mend-9)" />
@@ -3366,7 +3366,7 @@
          x="628.461"
          style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:17.6649px;line-height:0%;font-family:sans-serif;-inkscape-font-specification:Sans;text-indent:0;text-align:center;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-anchor:middle;display:inline;overflow:visible;visibility:visible;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.47207;marker:none;enable-background:accumulate"
          xml:space="preserve"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/generic_Rx_JESD_path.png"
+
          inkscape:export-xdpi="180"
          inkscape:export-ydpi="180"
          transform="scale(1.044004,0.95785074)"><tspan
@@ -3378,14 +3378,14 @@
       <path
          inkscape:export-ydpi="180"
          inkscape:export-xdpi="180"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/generic_Rx_JESD_path.png"
+
          id="path13742-6"
          d="m 24.389486,-1337.1213 c 0,43.6342 0,43.6342 0,43.6342"
          style="fill:none;stroke:#000000;stroke-width:1.47207px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:url(#Arrow1Mend-9)" />
       <text
          inkscape:export-ydpi="180"
          inkscape:export-xdpi="180"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/generic_Rx_JESD_path.png"
+
          xml:space="preserve"
          style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:17.6649px;line-height:0%;font-family:sans-serif;-inkscape-font-specification:Sans;text-indent:0;text-align:center;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-anchor:middle;display:inline;overflow:visible;visibility:visible;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.47207;marker:none;enable-background:accumulate"
          x="27.07913"
@@ -3400,7 +3400,7 @@
       <text
          inkscape:export-ydpi="180"
          inkscape:export-xdpi="180"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/generic_Rx_JESD_path.png"
+
          xml:space="preserve"
          style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:17.6649px;line-height:0%;font-family:sans-serif;-inkscape-font-specification:Sans;text-indent:0;text-align:center;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-anchor:middle;display:inline;overflow:visible;visibility:visible;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.47207;marker:none;enable-background:accumulate"
          x="239.41245"
@@ -3415,7 +3415,7 @@
       <g
          transform="matrix(1.5368492,0,0,1.4100254,-558.34055,-780.04192)"
          id="g13760-5"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/generic_Rx_JESD_path.png"
+
          inkscape:export-xdpi="180"
          inkscape:export-ydpi="180">
         <ellipse
@@ -3447,13 +3447,13 @@
          id="path13768-6"
          d="m -17.390834,-1283.727 h 69.61794"
          style="fill:none;stroke:#000000;stroke-width:1.47207px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-start:url(#Arrow1Lstart-5);marker-end:none"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/generic_Rx_JESD_path.png"
+
          inkscape:export-xdpi="180"
          inkscape:export-ydpi="180" />
       <g
          inkscape:export-ydpi="180"
          inkscape:export-xdpi="180"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/generic_Tx_JESD_path.png"
+
          id="use13774-5"
          transform="matrix(1.5368492,0,0,1.4100254,-785.63475,-785.76705)">
         <ellipse
@@ -3484,14 +3484,14 @@
       <path
          inkscape:export-ydpi="180"
          inkscape:export-xdpi="180"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Tx_JESD_path.png"
+
          style="fill:none;stroke:#000000;stroke-width:1.47207px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
          d="m 17.300316,-1209.2653 9.98952,-14.8053"
          id="use13776-3" />
       <text
          inkscape:export-ydpi="180"
          inkscape:export-xdpi="180"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/generic_Rx_JESD_path.png"
+
          xml:space="preserve"
          style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:17.6649px;line-height:0%;font-family:sans-serif;-inkscape-font-specification:Sans;text-indent:0;text-align:center;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-anchor:middle;display:inline;overflow:visible;visibility:visible;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.47207;marker:none;enable-background:accumulate"
          x="3.0668011"
@@ -3509,7 +3509,7 @@
          x="93.481903"
          style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:17.6649px;line-height:0%;font-family:sans-serif;-inkscape-font-specification:Sans;text-indent:0;text-align:center;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-anchor:middle;display:inline;overflow:visible;visibility:visible;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.47207;marker:none;enable-background:accumulate"
          xml:space="preserve"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/generic_Rx_JESD_path.png"
+
          inkscape:export-xdpi="180"
          inkscape:export-ydpi="180"
          transform="scale(1.044004,0.95785074)"><tspan
@@ -3524,7 +3524,7 @@
          x="629.93304"
          style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:17.6649px;line-height:0%;font-family:sans-serif;-inkscape-font-specification:Sans;text-indent:0;text-align:center;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-anchor:middle;display:inline;overflow:visible;visibility:visible;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.47207;marker:none;enable-background:accumulate"
          xml:space="preserve"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/generic_Rx_JESD_path.png"
+
          inkscape:export-xdpi="180"
          inkscape:export-ydpi="180"
          transform="scale(1.044004,0.95785074)"><tspan
@@ -3537,13 +3537,13 @@
          id="path13790-2"
          d="m 654.28661,-1209.2653 9.9895,-14.8052"
          style="fill:none;stroke:#000000;stroke-width:1.47207px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/generic_Rx_JESD_path.png"
+
          inkscape:export-xdpi="180"
          inkscape:export-ydpi="180" />
       <use
          inkscape:export-ydpi="180"
          inkscape:export-xdpi="180"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/generic_Rx_JESD_path.png"
+
          height="1488.189"
          width="2104.7244"
          transform="translate(0.76843417,45.12081)"
@@ -3554,7 +3554,7 @@
       <use
          inkscape:export-ydpi="180"
          inkscape:export-xdpi="180"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/generic_Rx_JESD_path.png"
+
          height="1488.189"
          width="2104.7244"
          transform="translate(4.1678104e-6,67.681217)"
@@ -3565,7 +3565,7 @@
       <use
          inkscape:export-ydpi="180"
          inkscape:export-xdpi="180"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/generic_Rx_JESD_path.png"
+
          x="0"
          y="0"
          xlink:href="#path15771-9"
@@ -3576,7 +3576,7 @@
       <use
          inkscape:export-ydpi="180"
          inkscape:export-xdpi="180"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/generic_Rx_JESD_path.png"
+
          x="0"
          y="0"
          xlink:href="#path15771-9"
@@ -3587,7 +3587,7 @@
       <use
          inkscape:export-ydpi="180"
          inkscape:export-xdpi="180"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/generic_Rx_JESD_path.png"
+
          height="1488.189"
          width="2104.7244"
          transform="matrix(0.85420883,0,0,1,224.42201,-2.8502955e-6)"
@@ -3598,7 +3598,7 @@
       <use
          inkscape:export-ydpi="180"
          inkscape:export-xdpi="180"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/generic_Rx_JESD_path.png"
+
          height="1488.189"
          width="2104.7244"
          transform="matrix(0.84169996,0,0,1,434.38129,42.62821)"
@@ -3609,7 +3609,7 @@
       <use
          inkscape:export-ydpi="180"
          inkscape:export-xdpi="180"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/generic_Rx_JESD_path.png"
+
          height="1488.189"
          width="2104.7244"
          transform="matrix(0.84169996,0,0,1,433.73451,65.188616)"
@@ -3620,7 +3620,7 @@
       <use
          inkscape:export-ydpi="180"
          inkscape:export-xdpi="180"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/generic_Rx_JESD_path.png"
+
          x="0"
          y="0"
          xlink:href="#path15771-9"
@@ -3631,7 +3631,7 @@
       <use
          inkscape:export-ydpi="180"
          inkscape:export-xdpi="180"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/generic_Rx_JESD_path.png"
+
          x="0"
          y="0"
          xlink:href="#path13768-6"
@@ -3642,7 +3642,7 @@
       <use
          inkscape:export-ydpi="180"
          inkscape:export-xdpi="180"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/generic_Rx_JESD_path.png"
+
          x="0"
          y="0"
          xlink:href="#path13768-6"
@@ -3653,7 +3653,7 @@
       <use
          inkscape:export-ydpi="180"
          inkscape:export-xdpi="180"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/generic_Rx_JESD_path.png"
+
          height="1488.189"
          width="2104.7244"
          transform="matrix(0.85420883,0,0,1,640.63441,-2.4926031)"
@@ -3664,7 +3664,7 @@
       <path
          inkscape:export-ydpi="180"
          inkscape:export-xdpi="180"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/generic_Rx_JESD_path.png"
+
          style="fill:none;stroke:#000000;stroke-width:1.47207px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-start:url(#Arrow1Lstart-5);marker-end:none"
          d="m -17.390834,-1283.727 h 69.61794"
          id="path15769-3" />
@@ -3672,7 +3672,7 @@
          id="path15771-9"
          d="m -17.390834,-1283.727 h 69.61794"
          style="fill:none;stroke:#000000;stroke-width:1.47207px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-start:url(#Arrow1Lstart-5);marker-end:none"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/generic_Rx_JESD_path.png"
+
          inkscape:export-xdpi="180"
          inkscape:export-ydpi="180" />
       <text
@@ -3693,7 +3693,7 @@
          x="582.16217"
          style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:15.7022px;line-height:0%;font-family:Sans;-inkscape-font-specification:'Sans, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-indent:0;text-align:center;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-anchor:middle;display:inline;overflow:visible;visibility:visible;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.47207;marker:none;enable-background:accumulate"
          xml:space="preserve"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/generic_Tx_JESD_path.png"
+
          inkscape:export-xdpi="180"
          inkscape:export-ydpi="180"
          transform="scale(1.044004,0.95785074)"><tspan
@@ -3708,7 +3708,7 @@
          x="392.6705"
          style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:15.7022px;line-height:0%;font-family:Sans;-inkscape-font-specification:'Sans, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-indent:0;text-align:center;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-anchor:middle;display:inline;overflow:visible;visibility:visible;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.47207;marker:none;enable-background:accumulate"
          xml:space="preserve"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/generic_Tx_JESD_path.png"
+
          inkscape:export-xdpi="180"
          inkscape:export-ydpi="180"
          transform="scale(1.044004,0.95785074)"><tspan
@@ -3742,7 +3742,7 @@
       <rect
          inkscape:export-ydpi="180"
          inkscape:export-xdpi="180"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Rx_JESD_path.png"
+
          y="-793.87909"
          x="548.20795"
          height="199.75406"
@@ -3752,7 +3752,7 @@
       <rect
          inkscape:export-ydpi="180"
          inkscape:export-xdpi="180"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Rx_JESD_path.png"
+
          y="-794.1983"
          x="-32.315475"
          height="200.08531"
@@ -3762,7 +3762,7 @@
       <g
          inkscape:export-ydpi="180"
          inkscape:export-xdpi="180"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Rx_JESD_path.png"
+
          transform="matrix(0.79145132,0,0,0.72613921,-194.18738,-861.90088)"
          id="g15777-2">
         <rect
@@ -3787,7 +3787,7 @@
       <g
          inkscape:export-ydpi="180"
          inkscape:export-xdpi="180"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Rx_JESD_path.png"
+
          transform="matrix(0.79145132,0,0,0.72613921,-194.18738,-861.10469)"
          id="g15785-4">
         <rect
@@ -3812,7 +3812,7 @@
       <g
          inkscape:export-ydpi="180"
          inkscape:export-xdpi="180"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Rx_JESD_path.png"
+
          transform="matrix(0.79145132,0,0,0.72613921,-194.18738,-860.30852)"
          id="g15793-3">
         <rect
@@ -3837,7 +3837,7 @@
       <g
          inkscape:export-ydpi="180"
          inkscape:export-xdpi="180"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Rx_JESD_path.png"
+
          transform="matrix(1.5368492,0,0,1.4100254,-150.72728,-966.70639)"
          id="g15801-1">
         <rect
@@ -3862,7 +3862,7 @@
       <text
          inkscape:export-ydpi="180"
          inkscape:export-xdpi="180"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Rx_JESD_path.png"
+
          xml:space="preserve"
          style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:17.6649px;line-height:0%;font-family:sans-serif;-inkscape-font-specification:Sans;text-indent:0;text-align:center;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-anchor:middle;display:inline;overflow:visible;visibility:visible;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2.167;marker:none;enable-background:accumulate"
          x="-127.1509"
@@ -3877,7 +3877,7 @@
       <text
          inkscape:export-ydpi="180"
          inkscape:export-xdpi="180"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Rx_JESD_path.png"
+
          xml:space="preserve"
          style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:17.6649px;line-height:0%;font-family:sans-serif;-inkscape-font-specification:Sans;text-indent:0;text-align:center;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-anchor:middle;display:inline;overflow:visible;visibility:visible;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2.167;marker:none;enable-background:accumulate"
          x="-85.873619"
@@ -3892,7 +3892,7 @@
       <g
          inkscape:export-ydpi="180"
          inkscape:export-xdpi="180"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Rx_JESD_path.png"
+
          transform="matrix(1.5368492,0,0,1.4100254,-209.82083,-1064.1937)"
          id="g15817-9">
         <rect
@@ -3927,7 +3927,7 @@
       <g
          inkscape:export-ydpi="180"
          inkscape:export-xdpi="180"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Rx_JESD_path.png"
+
          transform="matrix(1.5368492,0,0,1.4100254,-51.722838,-1044.0505)"
          id="g15829-5">
         <rect
@@ -3957,7 +3957,7 @@
       <text
          inkscape:export-ydpi="180"
          inkscape:export-xdpi="180"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Rx_JESD_path.png"
+
          xml:space="preserve"
          style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:17.6649px;line-height:0%;font-family:sans-serif;-inkscape-font-specification:Sans;text-indent:0;text-align:center;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-anchor:middle;display:inline;overflow:visible;visibility:visible;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.47207;marker:none;enable-background:accumulate"
          x="221.49155"
@@ -3972,7 +3972,7 @@
       <g
          inkscape:export-ydpi="180"
          inkscape:export-xdpi="180"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Rx_JESD_path.png"
+
          id="g15843-4"
          transform="matrix(1.5368492,0,0,1.4100254,156.99293,-1044.549)">
         <rect
@@ -4002,7 +4002,7 @@
       <text
          inkscape:export-ydpi="180"
          inkscape:export-xdpi="180"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Rx_JESD_path.png"
+
          xml:space="preserve"
          style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:17.6649px;line-height:0%;font-family:sans-serif;-inkscape-font-specification:Sans;text-indent:0;text-align:center;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-anchor:middle;display:inline;overflow:visible;visibility:visible;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2.167;marker:none;enable-background:accumulate"
          x="3.5508189"
@@ -4017,7 +4017,7 @@
       <path
          inkscape:export-ydpi="180"
          inkscape:export-xdpi="180"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/F8_Tx_JESD_path.png"
+
          id="use15865-0"
          d="m 164.67893,-596.19526 7.6842,-14.10025 7.6843,14.10025 z"
          style="fill:none;stroke:#000000;stroke-width:1.47207px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
@@ -4025,7 +4025,7 @@
       <g
          id="g15871-6"
          transform="matrix(0.79145132,0,0,0.72613921,84.508852,-959.69659)"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Rx_JESD_path.png"
+
          inkscape:export-xdpi="180"
          inkscape:export-ydpi="180">
         <rect
@@ -4050,7 +4050,7 @@
       <g
          id="g15879-9"
          transform="matrix(0.79145132,0,0,0.72613921,84.508852,-958.90039)"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Rx_JESD_path.png"
+
          inkscape:export-xdpi="180"
          inkscape:export-ydpi="180">
         <rect
@@ -4075,7 +4075,7 @@
       <g
          id="g15887-6"
          transform="matrix(0.79145132,0,0,0.72613921,84.508852,-958.10419)"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Rx_JESD_path.png"
+
          inkscape:export-xdpi="180"
          inkscape:export-ydpi="180">
         <rect
@@ -4100,7 +4100,7 @@
       <g
          id="g15895-1"
          transform="matrix(1.5368492,0,0,1.4100254,127.96913,-1064.5021)"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Rx_JESD_path.png"
+
          inkscape:export-xdpi="180"
          inkscape:export-ydpi="180">
         <rect
@@ -4125,7 +4125,7 @@
       <g
          inkscape:export-ydpi="180"
          inkscape:export-xdpi="180"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Rx_JESD_path.png"
+
          transform="matrix(0.79145132,0,0,0.72613921,139.60993,-959.50959)"
          id="g15903-6">
         <rect
@@ -4150,7 +4150,7 @@
       <g
          inkscape:export-ydpi="180"
          inkscape:export-xdpi="180"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Rx_JESD_path.png"
+
          transform="matrix(0.79145132,0,0,0.72613921,139.60993,-958.71349)"
          id="g15911-8">
         <rect
@@ -4175,7 +4175,7 @@
       <g
          inkscape:export-ydpi="180"
          inkscape:export-xdpi="180"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Rx_JESD_path.png"
+
          transform="matrix(0.79145132,0,0,0.72613921,139.60993,-957.91729)"
          id="g15919-3">
         <rect
@@ -4200,7 +4200,7 @@
       <g
          inkscape:export-ydpi="180"
          inkscape:export-xdpi="180"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Rx_JESD_path.png"
+
          transform="matrix(1.5368492,0,0,1.4100254,183.07023,-1064.3152)"
          id="g15927-4">
         <rect
@@ -4225,7 +4225,7 @@
       <g
          id="g15935-3"
          transform="matrix(0.79145132,0,0,0.72613921,-194.18738,-779.49692)"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Rx_JESD_path.png"
+
          inkscape:export-xdpi="180"
          inkscape:export-ydpi="180">
         <rect
@@ -4250,7 +4250,7 @@
       <g
          id="g15943-4"
          transform="matrix(0.79145132,0,0,0.72613921,-194.18738,-778.70074)"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Rx_JESD_path.png"
+
          inkscape:export-xdpi="180"
          inkscape:export-ydpi="180">
         <rect
@@ -4275,7 +4275,7 @@
       <g
          id="g15951-7"
          transform="matrix(0.79145132,0,0,0.72613921,-194.18738,-777.90456)"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Rx_JESD_path.png"
+
          inkscape:export-xdpi="180"
          inkscape:export-ydpi="180">
         <rect
@@ -4300,7 +4300,7 @@
       <g
          id="g15959-6"
          transform="matrix(1.5368492,0,0,1.4100254,-150.72728,-884.30247)"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Rx_JESD_path.png"
+
          inkscape:export-xdpi="180"
          inkscape:export-ydpi="180">
         <rect
@@ -4325,21 +4325,21 @@
       <path
          inkscape:export-ydpi="180"
          inkscape:export-xdpi="180"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Rx_JESD_path.png"
+
          style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:none;stroke:#37abc8;stroke-width:4.69978;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:4.69978, 4.69978;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:new"
          d="m 176.68613,-908.12274 c 0,103.80253 0,103.80253 0,103.80253"
          id="path15967-5" />
       <path
          inkscape:export-ydpi="180"
          inkscape:export-xdpi="180"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Rx_JESD_path.png"
+
          id="path15969-7"
          d="m 291.51073,-909.19182 c 0,103.12064 0,103.12064 0,103.12064"
          style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:none;stroke:#37abc8;stroke-width:4.69978;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:4.69978, 4.69978;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:new" />
       <text
          inkscape:export-ydpi="180"
          inkscape:export-xdpi="180"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Rx_JESD_path.png"
+
          transform="scale(0.89159784,1.1215819)"
          id="text15971-5"
          y="-829.38177"
@@ -4357,7 +4357,7 @@
          x="137.85147"
          style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:17.6649px;line-height:0%;font-family:sans-serif;-inkscape-font-specification:Sans;text-indent:0;text-align:center;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-anchor:middle;display:inline;overflow:visible;visibility:visible;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2.167;marker:none;enable-background:accumulate"
          xml:space="preserve"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Rx_JESD_path.png"
+
          inkscape:export-xdpi="180"
          inkscape:export-ydpi="180"
          transform="scale(1.044004,0.95785074)"><tspan
@@ -4369,7 +4369,7 @@
       <text
          inkscape:export-ydpi="180"
          inkscape:export-xdpi="180"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Rx_JESD_path.png"
+
          xml:space="preserve"
          style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:17.6649px;line-height:0%;font-family:sans-serif;-inkscape-font-specification:Sans;text-indent:0;text-align:center;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-anchor:middle;display:inline;overflow:visible;visibility:visible;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2.167;marker:none;enable-background:accumulate"
          x="137.8367"
@@ -4387,7 +4387,7 @@
          x="137.8367"
          style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:17.6649px;line-height:0%;font-family:sans-serif;-inkscape-font-specification:Sans;text-indent:0;text-align:center;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-anchor:middle;display:inline;overflow:visible;visibility:visible;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2.167;marker:none;enable-background:accumulate"
          xml:space="preserve"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Rx_JESD_path.png"
+
          inkscape:export-xdpi="180"
          inkscape:export-ydpi="180"
          transform="scale(1.044004,0.95785074)"><tspan
@@ -4399,7 +4399,7 @@
       <text
          inkscape:export-ydpi="180"
          inkscape:export-xdpi="180"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Rx_JESD_path.png"
+
          xml:space="preserve"
          style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:17.6649px;line-height:0%;font-family:sans-serif;-inkscape-font-specification:Sans;text-indent:0;text-align:center;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-anchor:middle;display:inline;overflow:visible;visibility:visible;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2.167;marker:none;enable-background:accumulate"
          x="137.8367"
@@ -4414,7 +4414,7 @@
       <text
          inkscape:export-ydpi="180"
          inkscape:export-xdpi="180"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Rx_JESD_path.png"
+
          xml:space="preserve"
          style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:17.6649px;line-height:0%;font-family:sans-serif;-inkscape-font-specification:Sans;text-indent:0;text-align:center;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-anchor:middle;display:inline;overflow:visible;visibility:visible;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2.167;marker:none;enable-background:accumulate"
          x="198.94247"
@@ -4437,7 +4437,7 @@
          x="197.83847"
          style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:17.6649px;line-height:0%;font-family:sans-serif;-inkscape-font-specification:Sans;text-indent:0;text-align:center;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-anchor:middle;display:inline;overflow:visible;visibility:visible;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2.167;marker:none;enable-background:accumulate"
          xml:space="preserve"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Rx_JESD_path.png"
+
          inkscape:export-xdpi="180"
          inkscape:export-ydpi="180"
          transform="scale(1.044004,0.95785074)"><tspan
@@ -4449,7 +4449,7 @@
       <text
          inkscape:export-ydpi="180"
          inkscape:export-xdpi="180"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Rx_JESD_path.png"
+
          xml:space="preserve"
          style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:17.6649px;line-height:0%;font-family:sans-serif;-inkscape-font-specification:Sans;text-indent:0;text-align:center;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-anchor:middle;display:inline;overflow:visible;visibility:visible;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2.167;marker:none;enable-background:accumulate"
          x="83.384865"
@@ -4467,7 +4467,7 @@
          x="248.99301"
          style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:17.6649px;line-height:0%;font-family:sans-serif;-inkscape-font-specification:Sans;text-indent:0;text-align:center;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-anchor:middle;display:inline;overflow:visible;visibility:visible;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2.167;marker:none;enable-background:accumulate"
          xml:space="preserve"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Rx_JESD_path.png"
+
          inkscape:export-xdpi="180"
          inkscape:export-ydpi="180"
          transform="scale(1.044004,0.95785074)"><tspan
@@ -4484,7 +4484,7 @@
       <path
          inkscape:export-ydpi="180"
          inkscape:export-xdpi="180"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Rx_JESD_path.png"
+
          id="path16011-9"
          d="m 234.41773,-797.22967 c 0,43.63424 0,43.63424 0,43.63424"
          style="fill:none;stroke:#000000;stroke-width:1.47207px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:url(#Arrow1Mend-09)" />
@@ -4494,7 +4494,7 @@
          x="417.36154"
          style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:17.6649px;line-height:0%;font-family:sans-serif;-inkscape-font-specification:Sans;text-indent:0;text-align:center;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-anchor:middle;display:inline;overflow:visible;visibility:visible;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.47207;marker:none;enable-background:accumulate"
          xml:space="preserve"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Rx_JESD_path.png"
+
          inkscape:export-xdpi="180"
          inkscape:export-ydpi="180"
          transform="scale(1.044004,0.95785074)"><tspan
@@ -4506,112 +4506,112 @@
       <path
          inkscape:export-ydpi="180"
          inkscape:export-xdpi="180"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Rx_JESD_path.png"
+
          style="fill:none;stroke:#000000;stroke-width:1.47207px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:url(#Arrow2Lend-8-88)"
          d="m 33.832482,-715.19247 h -54.61209"
          id="path16019-8" />
       <path
          inkscape:export-ydpi="180"
          inkscape:export-xdpi="180"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Rx_JESD_path.png"
+
          id="path16021-2"
          d="m 252.13343,-743.83532 h -58.8599"
          style="fill:none;stroke:#000000;stroke-width:1.47207px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:url(#Arrow2Lend-8-88)" />
       <path
          inkscape:export-ydpi="180"
          inkscape:export-xdpi="180"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Tx_JESD_path.png"
+
          style="fill:none;stroke:#000000;stroke-width:1.47207px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#Arrow2Lend-8-88)"
          d="m 252.13343,-677.03372 h -58.8599"
          id="use16023-6" />
       <path
          inkscape:export-ydpi="180"
          inkscape:export-xdpi="180"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Tx_JESD_path.png"
+
          style="fill:none;stroke:#000000;stroke-width:1.47207px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#Arrow2Lend-8-88)"
          d="m 252.13343,-699.30096 h -58.8599"
          id="use16025-6" />
       <path
          inkscape:export-ydpi="180"
          inkscape:export-xdpi="180"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Tx_JESD_path.png"
+
          style="fill:none;stroke:#000000;stroke-width:1.47207px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#Arrow2Lend-8-88)"
          d="m 252.13343,-721.56811 h -58.8599"
          id="use16027-0" />
       <path
          inkscape:export-ydpi="180"
          inkscape:export-xdpi="180"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Rx_JESD_path.png"
+
          style="fill:none;stroke:#000000;stroke-width:1.47207px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:url(#Arrow2Lend-8-88)"
          d="m 461.32623,-743.83532 h -58.8599"
          id="path16029-3" />
       <path
          inkscape:export-ydpi="180"
          inkscape:export-xdpi="180"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Tx_JESD_path.png"
+
          style="fill:none;stroke:#000000;stroke-width:1.47207px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:url(#Arrow2Lend-8-88)"
          d="m 461.32623,-677.03372 h -58.8599"
          id="use16031-8" />
       <path
          inkscape:export-ydpi="180"
          inkscape:export-xdpi="180"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Tx_JESD_path.png"
+
          style="fill:none;stroke:#000000;stroke-width:1.47207px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#Arrow2Lend-8-88)"
          d="m 461.32623,-699.30096 h -58.8599"
          id="use16033-0" />
       <path
          inkscape:export-ydpi="180"
          inkscape:export-xdpi="180"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Tx_JESD_path.png"
+
          style="fill:none;stroke:#000000;stroke-width:1.47207px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#Arrow2Lend-8-88)"
          d="m 461.32643,-721.56811 h -58.86"
          id="use16035-1" />
       <path
          inkscape:export-ydpi="180"
          inkscape:export-xdpi="180"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Tx_JESD_path.png"
+
          style="fill:none;stroke:#000000;stroke-width:1.25681px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:url(#Arrow2Lend-8-88)"
          d="m 652.76403,-677.03372 h -42.9042"
          id="use16037-2" />
       <path
          inkscape:export-ydpi="180"
          inkscape:export-xdpi="180"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Tx_JESD_path.png"
+
          style="fill:none;stroke:#000000;stroke-width:1.25681px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#Arrow2Lend-8-88)"
          d="m 652.76403,-699.30096 h -42.9042"
          id="use16039-5" />
       <path
          inkscape:export-ydpi="180"
          inkscape:export-xdpi="180"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Tx_JESD_path.png"
+
          style="fill:none;stroke:#000000;stroke-width:1.25681px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#Arrow2Lend-8-88)"
          d="m 652.76403,-721.56811 h -42.9042"
          id="use16041-0" />
       <path
          inkscape:export-ydpi="180"
          inkscape:export-xdpi="180"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Rx_JESD_path.png"
+
          style="fill:none;stroke:#000000;stroke-width:1.47207px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
          d="m 9.0690723,-707.26108 9.9895197,-14.80527"
          id="path16043-9" />
       <path
          inkscape:export-ydpi="180"
          inkscape:export-xdpi="180"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Rx_JESD_path.png"
+
          id="path16045-4"
          d="m 432.36113,-669.37363 9.9895,-14.80527"
          style="fill:none;stroke:#000000;stroke-width:1.47207px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
       <path
          inkscape:export-ydpi="180"
          inkscape:export-xdpi="180"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Tx_JESD_path.png"
+
          style="fill:none;stroke:#000000;stroke-width:1.47207px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
          d="m 226.59883,-669.37362 9.9895,-14.80527"
          id="use16047-7" />
       <path
          inkscape:export-ydpi="180"
          inkscape:export-xdpi="180"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Tx_JESD_path.png"
+
          style="fill:none;stroke:#000000;stroke-width:1.25681px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#Arrow2Lend-8-88)"
          d="m 653.57913,-746.24483 h -42.9042"
          id="use16049-8" />
@@ -4621,7 +4621,7 @@
          x="13.960121"
          style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:17.6649px;line-height:0%;font-family:sans-serif;-inkscape-font-specification:Sans;text-indent:0;text-align:center;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-anchor:middle;display:inline;overflow:visible;visibility:visible;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2.167;marker:none;enable-background:accumulate"
          xml:space="preserve"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Rx_JESD_path.png"
+
          inkscape:export-xdpi="180"
          inkscape:export-ydpi="180"
          transform="scale(1.044004,0.95785074)"><tspan
@@ -4648,7 +4648,7 @@
          x="565.26611"
          style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:15.7022px;line-height:0%;font-family:Sans;-inkscape-font-specification:'Sans, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-indent:0;text-align:center;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-anchor:middle;display:inline;overflow:visible;visibility:visible;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.47207;marker:none;enable-background:accumulate"
          xml:space="preserve"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/generic_Tx_JESD_path.png"
+
          inkscape:export-xdpi="180"
          inkscape:export-ydpi="180"
          transform="scale(1.044004,0.95785074)"><tspan
@@ -4663,7 +4663,7 @@
          x="375.77451"
          style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:15.7022px;line-height:0%;font-family:Sans;-inkscape-font-specification:'Sans, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-indent:0;text-align:center;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-anchor:middle;display:inline;overflow:visible;visibility:visible;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.47207;marker:none;enable-background:accumulate"
          xml:space="preserve"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/generic_Tx_JESD_path.png"
+
          inkscape:export-xdpi="180"
          inkscape:export-ydpi="180"
          transform="scale(1.044004,0.95785074)"><tspan
@@ -4675,7 +4675,7 @@
       <rect
          inkscape:export-ydpi="180"
          inkscape:export-xdpi="180"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/generic_Tx_JESD_path.png"
+
          y="-1319.4731"
          x="-775.78052"
          height="188.78664"
@@ -4685,7 +4685,7 @@
       <rect
          inkscape:export-ydpi="180"
          inkscape:export-xdpi="180"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/generic_Tx_JESD_path.png"
+
          y="-1318.795"
          x="-1481.4122"
          height="188.12085"
@@ -4736,7 +4736,7 @@
       <g
          inkscape:export-ydpi="180"
          inkscape:export-xdpi="180"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/generic_Tx_JESD_path.png"
+
          transform="matrix(1.5368492,0,0,1.4100254,-1375.7113,-1580.6118)"
          id="g12820">
         <rect
@@ -4766,7 +4766,7 @@
       <text
          inkscape:export-ydpi="180"
          inkscape:export-xdpi="180"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/generic_Tx_JESD_path.png"
+
          xml:space="preserve"
          style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:17.6649px;line-height:0%;font-family:sans-serif;-inkscape-font-specification:Sans;text-indent:0;text-align:center;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-anchor:middle;display:inline;overflow:visible;visibility:visible;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.47207;marker:none;enable-background:accumulate"
          x="-1058.4685"
@@ -4781,7 +4781,7 @@
       <g
          inkscape:export-ydpi="180"
          inkscape:export-xdpi="180"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/generic_Tx_JESD_path.png"
+
          id="g12834"
          transform="matrix(1.5368492,0,0,1.4100254,-1166.9955,-1581.1104)">
         <rect
@@ -4811,7 +4811,7 @@
       <path
          inkscape:export-ydpi="180"
          inkscape:export-xdpi="180"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/generic_Tx_JESD_path.png"
+
          id="path13002"
          d="m -1104.9392,-1333.7911 c 0,43.6343 0,43.6343 0,43.6343"
          style="fill:none;stroke:#000000;stroke-width:1.47207px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:url(#Arrow1Mend-06)" />
@@ -4821,7 +4821,7 @@
          x="-859.65417"
          style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:17.6649px;line-height:0%;font-family:sans-serif;-inkscape-font-specification:Sans;text-indent:0;text-align:center;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-anchor:middle;display:inline;overflow:visible;visibility:visible;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.47207;marker:none;enable-background:accumulate"
          xml:space="preserve"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/generic_Tx_JESD_path.png"
+
          inkscape:export-xdpi="180"
          inkscape:export-ydpi="180"
          transform="scale(1.044004,0.95785074)"><tspan
@@ -4833,98 +4833,98 @@
       <path
          inkscape:export-ydpi="180"
          inkscape:export-xdpi="180"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/generic_Tx_JESD_path.png"
+
          id="path13012"
          d="m -1131.9876,-1280.3967 h 58.8599"
          style="fill:none;stroke:#000000;stroke-width:1.47207px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:url(#Arrow2Lend-8-89)" />
       <path
          inkscape:export-ydpi="180"
          inkscape:export-xdpi="180"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Tx_JESD_path.png"
+
          style="fill:none;stroke:#000000;stroke-width:1.47207px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:url(#Arrow2Lend-8-89)"
          d="m -1131.9876,-1213.5951 h 58.8599"
          id="use13014" />
       <path
          inkscape:export-ydpi="180"
          inkscape:export-xdpi="180"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Tx_JESD_path.png"
+
          style="fill:none;stroke:#000000;stroke-width:1.47207px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#Arrow2Lend-8-89)"
          d="m -1131.9876,-1235.8624 h 58.8599"
          id="use13016" />
       <path
          inkscape:export-ydpi="180"
          inkscape:export-xdpi="180"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/generic_Tx_JESD_path.png"
+
          style="fill:none;stroke:#000000;stroke-width:1.47207px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:url(#Arrow2Lend-8-89)"
          d="m -922.79474,-1280.3967 h 58.86"
          id="path13020" />
       <path
          inkscape:export-ydpi="180"
          inkscape:export-xdpi="180"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Tx_JESD_path.png"
+
          style="fill:none;stroke:#000000;stroke-width:1.47207px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:url(#Arrow2Lend-8-89)"
          d="m -922.79474,-1213.5951 h 58.86"
          id="use13022" />
       <path
          inkscape:export-ydpi="180"
          inkscape:export-xdpi="180"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Tx_JESD_path.png"
+
          style="fill:none;stroke:#000000;stroke-width:1.47207px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#Arrow2Lend-8-89)"
          d="m -922.79474,-1235.8624 h 58.86"
          id="use13024" />
       <path
          inkscape:export-ydpi="180"
          inkscape:export-xdpi="180"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Tx_JESD_path.png"
+
          style="fill:none;stroke:#000000;stroke-width:1.25681px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:url(#Arrow2Lend-8-89)"
          d="m -714.14514,-1213.5951 h 42.9041"
          id="use13030" />
       <path
          inkscape:export-ydpi="180"
          inkscape:export-xdpi="180"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Tx_JESD_path.png"
+
          style="fill:none;stroke:#000000;stroke-width:1.25681px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#Arrow2Lend-8-89)"
          d="m -714.14514,-1235.8624 h 42.9041"
          id="use13032" />
       <path
          inkscape:export-ydpi="180"
          inkscape:export-xdpi="180"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/generic_Tx_JESD_path.png"
+
          id="path13038"
          d="m -903.92224,-1205.935 9.9896,-14.8053"
          style="fill:none;stroke:#000000;stroke-width:1.47207px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
       <path
          inkscape:export-ydpi="180"
          inkscape:export-xdpi="180"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Tx_JESD_path.png"
+
          style="fill:none;stroke:#000000;stroke-width:1.47207px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
          d="m -1115.8319,-1205.935 9.9896,-14.8053"
          id="use13040" />
       <path
          inkscape:export-ydpi="180"
          inkscape:export-xdpi="180"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/generic_Tx_JESD_path.png"
+
          style="fill:none;stroke:#000000;stroke-width:1.47207px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:url(#Arrow2Lend-8-89)"
          d="m -1131.9876,-1280.3967 h 58.8599"
          id="path13042" />
       <path
          inkscape:export-ydpi="180"
          inkscape:export-xdpi="180"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Tx_JESD_path.png"
+
          style="fill:none;stroke:#000000;stroke-width:1.47207px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:url(#Arrow2Lend-8-89)"
          d="m -1131.9876,-1213.5951 h 58.8599"
          id="use13044" />
       <path
          inkscape:export-ydpi="180"
          inkscape:export-xdpi="180"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Tx_JESD_path.png"
+
          style="fill:none;stroke:#000000;stroke-width:1.47207px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#Arrow2Lend-8-89)"
          d="m -1131.9876,-1235.8624 h 58.8599"
          id="use13046" />
       <path
          inkscape:export-ydpi="180"
          inkscape:export-xdpi="180"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Tx_JESD_path.png"
+
          style="fill:none;stroke:#000000;stroke-width:1.25681px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#Arrow2Lend-8-89)"
          d="m -714.91364,-1280.3374 h 42.9042"
          id="use13052" />
@@ -4934,7 +4934,7 @@
          x="-1055.7769"
          style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:17.6649px;line-height:0%;font-family:sans-serif;-inkscape-font-specification:Sans;text-indent:0;text-align:center;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-anchor:middle;display:inline;overflow:visible;visibility:visible;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.47207;marker:none;enable-background:accumulate"
          xml:space="preserve"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/generic_Tx_JESD_path.png"
+
          inkscape:export-xdpi="180"
          inkscape:export-ydpi="180"
          transform="scale(1.044004,0.95785074)"><tspan
@@ -4946,7 +4946,7 @@
       <g
          inkscape:export-ydpi="180"
          inkscape:export-xdpi="180"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/generic_Tx_JESD_path.png"
+
          transform="matrix(1.5368492,0,0,1.4100254,-1913.3333,-776.71165)"
          id="g13484">
         <ellipse
@@ -4977,7 +4977,7 @@
       <use
          inkscape:export-ydpi="180"
          inkscape:export-xdpi="180"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/generic_Tx_JESD_path.png"
+
          height="1488.189"
          width="1052.3622"
          transform="translate(208.24303,-1.4100363)"
@@ -4988,7 +4988,7 @@
       <use
          inkscape:export-ydpi="180"
          inkscape:export-xdpi="180"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/generic_Tx_JESD_path.png"
+
          height="1488.189"
          width="1052.3622"
          transform="translate(194.41139)"
@@ -5000,13 +5000,13 @@
          style="fill:none;stroke:#000000;stroke-width:1.47207px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:url(#Arrow1Mend-06)"
          d="m -698.50724,-1333.7911 c 0,43.6343 0,43.6343 0,43.6343"
          id="path13493"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/generic_Tx_JESD_path.png"
+
          inkscape:export-xdpi="180"
          inkscape:export-ydpi="180" />
       <text
          inkscape:export-ydpi="180"
          inkscape:export-xdpi="180"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/generic_Tx_JESD_path.png"
+
          xml:space="preserve"
          style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:17.6649px;line-height:0%;font-family:sans-serif;-inkscape-font-specification:Sans;text-indent:0;text-align:center;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-anchor:middle;display:inline;overflow:visible;visibility:visible;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.47207;marker:none;enable-background:accumulate"
          x="-666.47571"
@@ -5022,7 +5022,7 @@
          style="fill:none;stroke:#000000;stroke-width:1.47207px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:url(#Arrow1Mend-06)"
          d="m -1324.4559,-1333.7911 c 0,43.6343 0,43.6343 0,43.6343"
          id="path13499"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/generic_Tx_JESD_path.png"
+
          inkscape:export-xdpi="180"
          inkscape:export-ydpi="180" />
       <text
@@ -5031,7 +5031,7 @@
          x="-1264.9136"
          style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:17.6649px;line-height:0%;font-family:sans-serif;-inkscape-font-specification:Sans;text-indent:0;text-align:center;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-anchor:middle;display:inline;overflow:visible;visibility:visible;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.47207;marker:none;enable-background:accumulate"
          xml:space="preserve"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/generic_Tx_JESD_path.png"
+
          inkscape:export-xdpi="180"
          inkscape:export-ydpi="180"
          transform="scale(1.044004,0.95785074)"><tspan
@@ -5046,7 +5046,7 @@
          x="-1058.4685"
          style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:17.6649px;line-height:0%;font-family:sans-serif;-inkscape-font-specification:Sans;text-indent:0;text-align:center;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-anchor:middle;display:inline;overflow:visible;visibility:visible;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.47207;marker:none;enable-background:accumulate"
          xml:space="preserve"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/generic_Tx_JESD_path.png"
+
          inkscape:export-xdpi="180"
          inkscape:export-ydpi="180"
          transform="scale(1.044004,0.95785074)"><tspan
@@ -5058,35 +5058,35 @@
       <path
          inkscape:export-ydpi="180"
          inkscape:export-xdpi="180"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Tx_JESD_path.png"
+
          style="fill:none;stroke:#000000;stroke-width:1.47207px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
          d="m -1115.8319,-1205.935 9.9896,-14.8053"
          id="use13513" />
       <path
          inkscape:export-ydpi="180"
          inkscape:export-xdpi="180"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/generic_Tx_JESD_path.png"
+
          id="path13515"
          d="m -1131.9876,-1280.3967 h 58.8599"
          style="fill:none;stroke:#000000;stroke-width:1.47207px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:url(#Arrow2Lend-8-89)" />
       <path
          inkscape:export-ydpi="180"
          inkscape:export-xdpi="180"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Tx_JESD_path.png"
+
          style="fill:none;stroke:#000000;stroke-width:1.47207px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:url(#Arrow2Lend-8-89)"
          d="m -1131.9876,-1213.5951 h 58.8599"
          id="use13517" />
       <path
          inkscape:export-ydpi="180"
          inkscape:export-xdpi="180"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Tx_JESD_path.png"
+
          style="fill:none;stroke:#000000;stroke-width:1.47207px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#Arrow2Lend-8-89)"
          d="m -1131.9876,-1235.8624 h 58.8599"
          id="use13519" />
       <g
          inkscape:export-ydpi="180"
          inkscape:export-xdpi="180"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/generic_Tx_JESD_path.png"
+
          id="g13521"
          transform="matrix(1.5368492,0,0,1.4100254,-1913.3333,-776.71165)">
         <ellipse
@@ -5117,28 +5117,28 @@
       <path
          inkscape:export-ydpi="180"
          inkscape:export-xdpi="180"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/generic_Tx_JESD_path.png"
+
          style="fill:none;stroke:#000000;stroke-width:1.47207px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:url(#Arrow2Lend-8-89)"
          d="m -1349.3309,-1280.3967 h 58.8599"
          id="path13529" />
       <path
          inkscape:export-ydpi="180"
          inkscape:export-xdpi="180"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Tx_JESD_path.png"
+
          style="fill:none;stroke:#000000;stroke-width:1.47207px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:url(#Arrow2Lend-8-89)"
          d="m -1349.3309,-1213.5951 h 58.8599"
          id="use13531" />
       <path
          inkscape:export-ydpi="180"
          inkscape:export-xdpi="180"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Tx_JESD_path.png"
+
          style="fill:none;stroke:#000000;stroke-width:1.47207px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#Arrow2Lend-8-89)"
          d="m -1349.3309,-1235.8624 h 58.8599"
          id="use13533" />
       <use
          inkscape:export-ydpi="180"
          inkscape:export-xdpi="180"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/generic_Tx_JESD_path.png"
+
          height="1488.189"
          width="1052.3622"
          transform="translate(-221.14679)"
@@ -5149,7 +5149,7 @@
       <use
          inkscape:export-ydpi="180"
          inkscape:export-xdpi="180"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/generic_Tx_JESD_path.png"
+
          height="1488.189"
          width="1052.3622"
          transform="translate(-215.71326)"
@@ -5163,7 +5163,7 @@
          x="-1280.0934"
          style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:17.6649px;line-height:0%;font-family:sans-serif;-inkscape-font-specification:Sans;text-indent:0;text-align:center;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-anchor:middle;display:inline;overflow:visible;visibility:visible;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.47207;marker:none;enable-background:accumulate"
          xml:space="preserve"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/generic_Tx_JESD_path.png"
+
          inkscape:export-xdpi="180"
          inkscape:export-ydpi="180"
          transform="scale(1.044004,0.95785074)"><tspan
@@ -5175,7 +5175,7 @@
       <text
          inkscape:export-ydpi="180"
          inkscape:export-xdpi="180"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/generic_Tx_JESD_path.png"
+
          xml:space="preserve"
          style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:17.6649px;line-height:0%;font-family:sans-serif;-inkscape-font-specification:Sans;text-indent:0;text-align:center;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-anchor:middle;display:inline;overflow:visible;visibility:visible;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.47207;marker:none;enable-background:accumulate"
          x="-1191.1504"
@@ -5190,7 +5190,7 @@
       <text
          inkscape:export-ydpi="180"
          inkscape:export-xdpi="180"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/generic_Tx_JESD_path.png"
+
          xml:space="preserve"
          style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:17.6649px;line-height:0%;font-family:sans-serif;-inkscape-font-specification:Sans;text-indent:0;text-align:center;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-anchor:middle;display:inline;overflow:visible;visibility:visible;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.47207;marker:none;enable-background:accumulate"
          x="-665.00366"
@@ -5205,7 +5205,7 @@
       <path
          inkscape:export-ydpi="180"
          inkscape:export-xdpi="180"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/generic_Tx_JESD_path.png"
+
          style="fill:none;stroke:#000000;stroke-width:1.47207px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
          d="m -700.70624,-1205.935 9.9896,-14.8053"
          id="path13580" />
@@ -5215,7 +5215,7 @@
          x="-700.34473"
          style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:15.7022px;line-height:0%;font-family:Sans;-inkscape-font-specification:'Sans, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-indent:0;text-align:center;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-anchor:middle;display:inline;overflow:visible;visibility:visible;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.47207;marker:none;enable-background:accumulate"
          xml:space="preserve"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/generic_Tx_JESD_path.png"
+
          inkscape:export-xdpi="180"
          inkscape:export-ydpi="180"
          transform="scale(1.044004,0.95785074)"><tspan
@@ -5230,7 +5230,7 @@
          x="-889.8363"
          style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:15.7022px;line-height:0%;font-family:Sans;-inkscape-font-specification:'Sans, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-indent:0;text-align:center;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-anchor:middle;display:inline;overflow:visible;visibility:visible;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.47207;marker:none;enable-background:accumulate"
          xml:space="preserve"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/generic_Tx_JESD_path.png"
+
          inkscape:export-xdpi="180"
          inkscape:export-ydpi="180"
          transform="scale(1.044004,0.95785074)"><tspan
@@ -5268,7 +5268,7 @@
          height="199.75406"
          x="-805.42151"
          y="-866.16687"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Tx_JESD_path.png"
+
          inkscape:export-xdpi="180"
          inkscape:export-ydpi="180" />
       <rect
@@ -5278,13 +5278,13 @@
          height="200.08531"
          x="-1385.9449"
          y="-866.48608"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Tx_JESD_path.png"
+
          inkscape:export-xdpi="180"
          inkscape:export-ydpi="180" />
       <g
          id="g9025"
          transform="matrix(0.79145132,0,0,0.72613921,-1547.817,-934.18868)"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Tx_JESD_path.png"
+
          inkscape:export-xdpi="180"
          inkscape:export-ydpi="180">
         <rect
@@ -5309,7 +5309,7 @@
       <g
          id="g9033"
          transform="matrix(0.79145132,0,0,0.72613921,-1547.817,-933.3925)"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Tx_JESD_path.png"
+
          inkscape:export-xdpi="180"
          inkscape:export-ydpi="180">
         <rect
@@ -5334,7 +5334,7 @@
       <g
          id="g9041"
          transform="matrix(0.79145132,0,0,0.72613921,-1547.817,-932.59633)"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Tx_JESD_path.png"
+
          inkscape:export-xdpi="180"
          inkscape:export-ydpi="180">
         <rect
@@ -5359,7 +5359,7 @@
       <g
          id="g9049"
          transform="matrix(1.5368492,0,0,1.4100254,-1504.3567,-1038.9942)"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Tx_JESD_path.png"
+
          inkscape:export-xdpi="180"
          inkscape:export-ydpi="180">
         <rect
@@ -5387,7 +5387,7 @@
          x="-1423.726"
          style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:17.6649px;line-height:0%;font-family:sans-serif;-inkscape-font-specification:Sans;text-indent:0;text-align:center;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-anchor:middle;display:inline;overflow:visible;visibility:visible;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2.167;marker:none;enable-background:accumulate"
          xml:space="preserve"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Tx_JESD_path.png"
+
          inkscape:export-xdpi="180"
          inkscape:export-ydpi="180"
          transform="scale(1.044004,0.95785074)"><tspan
@@ -5402,7 +5402,7 @@
          x="-1382.4486"
          style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:17.6649px;line-height:0%;font-family:sans-serif;-inkscape-font-specification:Sans;text-indent:0;text-align:center;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-anchor:middle;display:inline;overflow:visible;visibility:visible;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2.167;marker:none;enable-background:accumulate"
          xml:space="preserve"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Tx_JESD_path.png"
+
          inkscape:export-xdpi="180"
          inkscape:export-ydpi="180"
          transform="scale(1.044004,0.95785074)"><tspan
@@ -5414,7 +5414,7 @@
       <g
          id="g9065"
          transform="matrix(1.5368492,0,0,1.4100254,-1563.4504,-1136.4815)"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Tx_JESD_path.png"
+
          inkscape:export-xdpi="180"
          inkscape:export-ydpi="180">
         <rect
@@ -5449,7 +5449,7 @@
       <g
          id="g9089"
          transform="matrix(1.5368492,0,0,1.4100254,-1405.3523,-1116.3382)"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Tx_JESD_path.png"
+
          inkscape:export-xdpi="180"
          inkscape:export-ydpi="180">
         <rect
@@ -5482,7 +5482,7 @@
          x="-1086.8601"
          style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:17.6649px;line-height:0%;font-family:sans-serif;-inkscape-font-specification:Sans;text-indent:0;text-align:center;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-anchor:middle;display:inline;overflow:visible;visibility:visible;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.47207;marker:none;enable-background:accumulate"
          xml:space="preserve"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Tx_JESD_path.png"
+
          inkscape:export-xdpi="180"
          inkscape:export-ydpi="180"
          transform="scale(1.044004,0.95785074)"><tspan
@@ -5494,7 +5494,7 @@
       <g
          transform="matrix(1.5368492,0,0,1.4100254,-1196.6365,-1116.8368)"
          id="g9111"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Tx_JESD_path.png"
+
          inkscape:export-xdpi="180"
          inkscape:export-ydpi="180">
         <rect
@@ -5527,7 +5527,7 @@
          x="-1293.0242"
          style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:17.6649px;line-height:0%;font-family:sans-serif;-inkscape-font-specification:Sans;text-indent:0;text-align:center;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-anchor:middle;display:inline;overflow:visible;visibility:visible;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2.167;marker:none;enable-background:accumulate"
          xml:space="preserve"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Tx_JESD_path.png"
+
          inkscape:export-xdpi="180"
          inkscape:export-ydpi="180"
          transform="scale(1.044004,0.95785074)"><tspan
@@ -5539,7 +5539,7 @@
       <path
          inkscape:export-ydpi="180"
          inkscape:export-xdpi="180"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/F8_Tx_JESD_path.png"
+
          id="use9159"
          d="m -1188.9506,-668.48307 7.6843,-14.10025 7.6842,14.10025 z"
          style="fill:none;stroke:#000000;stroke-width:1.47207px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
@@ -5547,7 +5547,7 @@
       <g
          inkscape:export-ydpi="180"
          inkscape:export-xdpi="180"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Tx_JESD_path.png"
+
          transform="matrix(0.79145132,0,0,0.72613921,-1287.5629,-1031.9844)"
          id="g9209">
         <rect
@@ -5572,7 +5572,7 @@
       <g
          inkscape:export-ydpi="180"
          inkscape:export-xdpi="180"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Tx_JESD_path.png"
+
          transform="matrix(0.79145132,0,0,0.72613921,-1287.5629,-1031.1882)"
          id="g9217">
         <rect
@@ -5597,7 +5597,7 @@
       <g
          inkscape:export-ydpi="180"
          inkscape:export-xdpi="180"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Tx_JESD_path.png"
+
          transform="matrix(0.79145132,0,0,0.72613921,-1287.5629,-1030.392)"
          id="g9225">
         <rect
@@ -5622,7 +5622,7 @@
       <g
          inkscape:export-ydpi="180"
          inkscape:export-xdpi="180"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Tx_JESD_path.png"
+
          transform="matrix(1.5368492,0,0,1.4100254,-1244.1026,-1136.79)"
          id="g9233">
         <rect
@@ -5647,7 +5647,7 @@
       <g
          id="g9241"
          transform="matrix(0.79145132,0,0,0.72613921,-1232.4617,-1031.7974)"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Tx_JESD_path.png"
+
          inkscape:export-xdpi="180"
          inkscape:export-ydpi="180">
         <rect
@@ -5672,7 +5672,7 @@
       <g
          id="g9249"
          transform="matrix(0.79145132,0,0,0.72613921,-1232.4617,-1031.0012)"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Tx_JESD_path.png"
+
          inkscape:export-xdpi="180"
          inkscape:export-ydpi="180">
         <rect
@@ -5697,7 +5697,7 @@
       <g
          id="g9257"
          transform="matrix(0.79145132,0,0,0.72613921,-1232.4617,-1030.2051)"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Tx_JESD_path.png"
+
          inkscape:export-xdpi="180"
          inkscape:export-ydpi="180">
         <rect
@@ -5722,7 +5722,7 @@
       <g
          id="g9265"
          transform="matrix(1.5368492,0,0,1.4100254,-1189.0015,-1136.603)"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Tx_JESD_path.png"
+
          inkscape:export-xdpi="180"
          inkscape:export-ydpi="180">
         <rect
@@ -5747,7 +5747,7 @@
       <g
          inkscape:export-ydpi="180"
          inkscape:export-xdpi="180"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Tx_JESD_path.png"
+
          transform="matrix(0.79145132,0,0,0.72613921,-1547.817,-851.78473)"
          id="g9273">
         <rect
@@ -5772,7 +5772,7 @@
       <g
          inkscape:export-ydpi="180"
          inkscape:export-xdpi="180"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Tx_JESD_path.png"
+
          transform="matrix(0.79145132,0,0,0.72613921,-1547.817,-850.98854)"
          id="g9281">
         <rect
@@ -5797,7 +5797,7 @@
       <g
          inkscape:export-ydpi="180"
          inkscape:export-xdpi="180"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Tx_JESD_path.png"
+
          transform="matrix(0.79145132,0,0,0.72613921,-1547.817,-850.19237)"
          id="g9289">
         <rect
@@ -5822,7 +5822,7 @@
       <g
          inkscape:export-ydpi="180"
          inkscape:export-xdpi="180"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Tx_JESD_path.png"
+
          transform="matrix(1.5368492,0,0,1.4100254,-1504.3567,-956.59032)"
          id="g9297">
         <rect
@@ -5848,14 +5848,14 @@
          id="path9305"
          d="m -1195.3856,-980.41052 c 0,103.80251 0,103.80251 0,103.80251"
          style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:none;stroke:#37abc8;stroke-width:4.69978;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:4.69978, 4.69978;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:new"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Tx_JESD_path.png"
+
          inkscape:export-xdpi="180"
          inkscape:export-ydpi="180" />
       <path
          style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:none;stroke:#37abc8;stroke-width:4.69978;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:4.69978, 4.69978;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:new"
          d="m -1080.561,-981.47962 c 0,103.12064 0,103.12064 0,103.12064"
          id="path9307"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Tx_JESD_path.png"
+
          inkscape:export-xdpi="180"
          inkscape:export-ydpi="180" />
       <text
@@ -5865,7 +5865,7 @@
          y="-892.64966"
          id="text9309"
          transform="scale(0.89159784,1.1215819)"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Tx_JESD_path.png"
+
          inkscape:export-xdpi="180"
          inkscape:export-ydpi="180"><tspan
            style="font-size:15.7022px;line-height:1.25;stroke-width:2.167"
@@ -5876,7 +5876,7 @@
       <text
          inkscape:export-ydpi="180"
          inkscape:export-xdpi="180"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Tx_JESD_path.png"
+
          xml:space="preserve"
          style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:17.6649px;line-height:0%;font-family:sans-serif;-inkscape-font-specification:Sans;text-indent:0;text-align:center;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-anchor:middle;display:inline;overflow:visible;visibility:visible;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2.167;marker:none;enable-background:accumulate"
          x="-1176.3884"
@@ -5894,7 +5894,7 @@
          x="-1176.4032"
          style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:17.6649px;line-height:0%;font-family:sans-serif;-inkscape-font-specification:Sans;text-indent:0;text-align:center;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-anchor:middle;display:inline;overflow:visible;visibility:visible;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2.167;marker:none;enable-background:accumulate"
          xml:space="preserve"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Tx_JESD_path.png"
+
          inkscape:export-xdpi="180"
          inkscape:export-ydpi="180"
          transform="scale(1.044004,0.95785074)"><tspan
@@ -5906,7 +5906,7 @@
       <text
          inkscape:export-ydpi="180"
          inkscape:export-xdpi="180"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Tx_JESD_path.png"
+
          xml:space="preserve"
          style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:17.6649px;line-height:0%;font-family:sans-serif;-inkscape-font-specification:Sans;text-indent:0;text-align:center;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-anchor:middle;display:inline;overflow:visible;visibility:visible;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2.167;marker:none;enable-background:accumulate"
          x="-1176.4032"
@@ -5924,7 +5924,7 @@
          x="-1176.4032"
          style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:17.6649px;line-height:0%;font-family:sans-serif;-inkscape-font-specification:Sans;text-indent:0;text-align:center;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-anchor:middle;display:inline;overflow:visible;visibility:visible;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2.167;marker:none;enable-background:accumulate"
          xml:space="preserve"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Tx_JESD_path.png"
+
          inkscape:export-xdpi="180"
          inkscape:export-ydpi="180"
          transform="scale(1.044004,0.95785074)"><tspan
@@ -5939,7 +5939,7 @@
          x="-1115.2974"
          style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:17.6649px;line-height:0%;font-family:sans-serif;-inkscape-font-specification:Sans;text-indent:0;text-align:center;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-anchor:middle;display:inline;overflow:visible;visibility:visible;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2.167;marker:none;enable-background:accumulate"
          xml:space="preserve"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Tx_JESD_path.png"
+
          inkscape:export-xdpi="180"
          inkscape:export-ydpi="180"
          transform="scale(1.044004,0.95785074)"><tspan
@@ -5956,7 +5956,7 @@
       <text
          inkscape:export-ydpi="180"
          inkscape:export-xdpi="180"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Tx_JESD_path.png"
+
          xml:space="preserve"
          style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:17.6649px;line-height:0%;font-family:sans-serif;-inkscape-font-specification:Sans;text-indent:0;text-align:center;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-anchor:middle;display:inline;overflow:visible;visibility:visible;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2.167;marker:none;enable-background:accumulate"
          x="-1091.4504"
@@ -5974,7 +5974,7 @@
          x="-1230.8551"
          style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:17.6649px;line-height:0%;font-family:sans-serif;-inkscape-font-specification:Sans;text-indent:0;text-align:center;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-anchor:middle;display:inline;overflow:visible;visibility:visible;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2.167;marker:none;enable-background:accumulate"
          xml:space="preserve"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Tx_JESD_path.png"
+
          inkscape:export-xdpi="180"
          inkscape:export-ydpi="180"
          transform="scale(1.044004,0.95785074)"><tspan
@@ -5986,7 +5986,7 @@
       <text
          inkscape:export-ydpi="180"
          inkscape:export-xdpi="180"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Tx_JESD_path.png"
+
          xml:space="preserve"
          style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:17.6649px;line-height:0%;font-family:sans-serif;-inkscape-font-specification:Sans;text-indent:0;text-align:center;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-anchor:middle;display:inline;overflow:visible;visibility:visible;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2.167;marker:none;enable-background:accumulate"
          x="-1065.2469"
@@ -6007,13 +6007,13 @@
          style="fill:none;stroke:#000000;stroke-width:1.47207px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:url(#Arrow1Mend-08)"
          d="m -1134.5802,-869.51747 c 0,43.63423 0,43.63423 0,43.63423"
          id="path9374"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Tx_JESD_path.png"
+
          inkscape:export-xdpi="180"
          inkscape:export-ydpi="180" />
       <text
          inkscape:export-ydpi="180"
          inkscape:export-xdpi="180"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Tx_JESD_path.png"
+
          xml:space="preserve"
          style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:17.6649px;line-height:0%;font-family:sans-serif;-inkscape-font-specification:Sans;text-indent:0;text-align:center;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-anchor:middle;display:inline;overflow:visible;visibility:visible;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.47207;marker:none;enable-background:accumulate"
          x="-888.04584"
@@ -6028,21 +6028,21 @@
       <path
          inkscape:export-ydpi="180"
          inkscape:export-xdpi="180"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Tx_JESD_path.png"
+
          id="path11137"
          d="m -1375.6816,-787.48028 h 54.612"
          style="fill:none;stroke:#000000;stroke-width:1.47207px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:url(#Arrow2Lend-8-6)" />
       <path
          inkscape:export-ydpi="180"
          inkscape:export-xdpi="180"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Tx_JESD_path.png"
+
          style="fill:none;stroke:#000000;stroke-width:1.47207px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:url(#Arrow2Lend-8-6)"
          d="m -1161.6287,-816.12313 h 58.86"
          id="path11551" />
       <use
          inkscape:export-ydpi="180"
          inkscape:export-xdpi="180"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Tx_JESD_path.png"
+
          style="stroke-width:0.2;stroke-miterlimit:4;stroke-dasharray:none"
          height="1488.189"
          width="1052.3622"
@@ -6054,7 +6054,7 @@
       <use
          inkscape:export-ydpi="180"
          inkscape:export-xdpi="180"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Tx_JESD_path.png"
+
          height="1488.189"
          width="1052.3622"
          transform="translate(3.7309678e-5,-22.267238)"
@@ -6065,7 +6065,7 @@
       <use
          inkscape:export-ydpi="180"
          inkscape:export-xdpi="180"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Tx_JESD_path.png"
+
          height="1488.189"
          width="1052.3622"
          transform="translate(-6.2690322e-5,-22.267148)"
@@ -6076,14 +6076,14 @@
       <path
          inkscape:export-ydpi="180"
          inkscape:export-xdpi="180"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Tx_JESD_path.png"
+
          id="path11559"
          d="m -952.43575,-816.12313 h 58.85997"
          style="fill:none;stroke:#000000;stroke-width:1.47207px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:url(#Arrow2Lend-8-6)" />
       <use
          inkscape:export-ydpi="180"
          inkscape:export-xdpi="180"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Tx_JESD_path.png"
+
          x="0"
          y="0"
          xlink:href="#path11551"
@@ -6094,7 +6094,7 @@
       <use
          inkscape:export-ydpi="180"
          inkscape:export-xdpi="180"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Tx_JESD_path.png"
+
          x="0"
          y="0"
          xlink:href="#use11553"
@@ -6105,7 +6105,7 @@
       <use
          inkscape:export-ydpi="180"
          inkscape:export-xdpi="180"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Tx_JESD_path.png"
+
          x="0"
          y="0"
          xlink:href="#use11555"
@@ -6116,7 +6116,7 @@
       <use
          inkscape:export-ydpi="180"
          inkscape:export-xdpi="180"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Tx_JESD_path.png"
+
          height="1488.189"
          width="1052.3622"
          transform="matrix(0.72891965,0,0,1,102.94779,66.801602)"
@@ -6127,7 +6127,7 @@
       <use
          inkscape:export-ydpi="180"
          inkscape:export-xdpi="180"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Tx_JESD_path.png"
+
          height="1488.189"
          width="1052.3622"
          transform="matrix(0.72891965,0,0,1,102.94779,-22.267238)"
@@ -6138,7 +6138,7 @@
       <use
          inkscape:export-ydpi="180"
          inkscape:export-xdpi="180"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Tx_JESD_path.png"
+
          height="1488.189"
          width="1052.3622"
          transform="matrix(0.72891965,0,0,1,102.94778,-22.267148)"
@@ -6149,21 +6149,21 @@
       <path
          inkscape:export-ydpi="180"
          inkscape:export-xdpi="180"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Tx_JESD_path.png"
+
          id="path11713"
          d="m -1366.0763,-779.54889 9.9895,-14.80526"
          style="fill:none;stroke:#000000;stroke-width:1.47207px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
       <path
          inkscape:export-ydpi="180"
          inkscape:export-xdpi="180"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Tx_JESD_path.png"
+
          style="fill:none;stroke:#000000;stroke-width:1.47207px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
          d="m -933.56318,-741.66144 9.98952,-14.80526"
          id="use11719" />
       <use
          inkscape:export-ydpi="180"
          inkscape:export-xdpi="180"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Tx_JESD_path.png"
+
          height="1488.189"
          width="1052.3622"
          transform="translate(-211.90966)"
@@ -6174,7 +6174,7 @@
       <use
          inkscape:export-ydpi="180"
          inkscape:export-xdpi="180"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Tx_JESD_path.png"
+
          x="0"
          y="0"
          xlink:href="#use11555"
@@ -6185,7 +6185,7 @@
       <text
          inkscape:export-ydpi="180"
          inkscape:export-xdpi="180"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Tx_JESD_path.png"
+
          xml:space="preserve"
          style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:17.6649px;line-height:0%;font-family:sans-serif;-inkscape-font-specification:Sans;text-indent:0;text-align:center;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-anchor:middle;display:inline;overflow:visible;visibility:visible;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2.167;marker:none;enable-background:accumulate"
          x="-1282.615"
@@ -6215,7 +6215,7 @@
          x="-731.25513"
          style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:15.7022px;line-height:0%;font-family:Sans;-inkscape-font-specification:'Sans, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-indent:0;text-align:center;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-anchor:middle;display:inline;overflow:visible;visibility:visible;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.47207;marker:none;enable-background:accumulate"
          xml:space="preserve"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/generic_Tx_JESD_path.png"
+
          inkscape:export-xdpi="180"
          inkscape:export-ydpi="180"
          transform="scale(1.044004,0.95785074)"><tspan
@@ -6230,7 +6230,7 @@
          x="-920.74677"
          style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:15.7022px;line-height:0%;font-family:Sans;-inkscape-font-specification:'Sans, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-indent:0;text-align:center;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-anchor:middle;display:inline;overflow:visible;visibility:visible;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.47207;marker:none;enable-background:accumulate"
          xml:space="preserve"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/generic_Tx_JESD_path.png"
+
          inkscape:export-xdpi="180"
          inkscape:export-ydpi="180"
          transform="scale(1.044004,0.95785074)"><tspan
@@ -6246,7 +6246,7 @@
          height="199.75406"
          x="-815.30188"
          y="-378.22861"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Tx_JESD_path.png"
+
          inkscape:export-xdpi="180"
          inkscape:export-ydpi="180" />
       <rect
@@ -6256,13 +6256,13 @@
          height="200.08531"
          x="-1395.8251"
          y="-378.54794"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Tx_JESD_path.png"
+
          inkscape:export-xdpi="180"
          inkscape:export-ydpi="180" />
       <g
          id="g9025-6"
          transform="matrix(0.79145132,0,0,0.72613921,-1557.6974,-446.2505)"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Tx_JESD_path.png"
+
          inkscape:export-xdpi="180"
          inkscape:export-ydpi="180">
         <rect
@@ -6288,7 +6288,7 @@
          style="fill:#6699cc;fill-opacity:1"
          id="g9033-2"
          transform="matrix(0.79145132,0,0,0.72613921,-1557.6974,-445.4544)"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Tx_JESD_path.png"
+
          inkscape:export-xdpi="180"
          inkscape:export-ydpi="180">
         <rect
@@ -6313,7 +6313,7 @@
       <g
          id="g9041-3"
          transform="matrix(0.79145132,0,0,0.72613921,-1557.6974,-444.65816)"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Tx_JESD_path.png"
+
          inkscape:export-xdpi="180"
          inkscape:export-ydpi="180">
         <rect
@@ -6339,7 +6339,7 @@
          style="fill:#6699cc;fill-opacity:1"
          id="g9049-2"
          transform="matrix(1.5368492,0,0,1.4100254,-1514.2371,-551.05614)"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Tx_JESD_path.png"
+
          inkscape:export-xdpi="180"
          inkscape:export-ydpi="180">
         <rect
@@ -6367,7 +6367,7 @@
          x="-1433.1899"
          style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:17.6649px;line-height:0%;font-family:sans-serif;-inkscape-font-specification:Sans;text-indent:0;text-align:center;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-anchor:middle;display:inline;overflow:visible;visibility:visible;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2.167;marker:none;enable-background:accumulate"
          xml:space="preserve"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Tx_JESD_path.png"
+
          inkscape:export-xdpi="180"
          inkscape:export-ydpi="180"
          transform="scale(1.044004,0.95785074)"><tspan
@@ -6382,7 +6382,7 @@
          x="-1391.9126"
          style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:17.6649px;line-height:0%;font-family:sans-serif;-inkscape-font-specification:Sans;text-indent:0;text-align:center;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-anchor:middle;display:inline;overflow:visible;visibility:visible;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2.167;marker:none;enable-background:accumulate"
          xml:space="preserve"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Tx_JESD_path.png"
+
          inkscape:export-xdpi="180"
          inkscape:export-ydpi="180"
          transform="scale(1.044004,0.95785074)"><tspan
@@ -6394,7 +6394,7 @@
       <g
          id="g9065-2"
          transform="matrix(1.5368492,0,0,1.4100254,-1573.3308,-648.54332)"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Tx_JESD_path.png"
+
          inkscape:export-xdpi="180"
          inkscape:export-ydpi="180">
         <rect
@@ -6429,7 +6429,7 @@
       <g
          id="g9089-2"
          transform="matrix(1.5368492,0,0,1.4100254,-1415.2327,-628.40012)"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Tx_JESD_path.png"
+
          inkscape:export-xdpi="180"
          inkscape:export-ydpi="180">
         <rect
@@ -6462,7 +6462,7 @@
          x="-1096.3245"
          style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:17.6649px;line-height:0%;font-family:sans-serif;-inkscape-font-specification:Sans;text-indent:0;text-align:center;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-anchor:middle;display:inline;overflow:visible;visibility:visible;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.47207;marker:none;enable-background:accumulate"
          xml:space="preserve"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Tx_JESD_path.png"
+
          inkscape:export-xdpi="180"
          inkscape:export-ydpi="180"
          transform="scale(1.044004,0.95785074)"><tspan
@@ -6474,7 +6474,7 @@
       <g
          transform="matrix(1.5368492,0,0,1.4100254,-1206.5169,-628.89871)"
          id="g9111-2"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Tx_JESD_path.png"
+
          inkscape:export-xdpi="180"
          inkscape:export-ydpi="180">
         <rect
@@ -6507,7 +6507,7 @@
          x="-1302.4882"
          style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:17.6649px;line-height:0%;font-family:sans-serif;-inkscape-font-specification:Sans;text-indent:0;text-align:center;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-anchor:middle;display:inline;overflow:visible;visibility:visible;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2.167;marker:none;enable-background:accumulate"
          xml:space="preserve"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Tx_JESD_path.png"
+
          inkscape:export-xdpi="180"
          inkscape:export-ydpi="180"
          transform="scale(1.044004,0.95785074)"><tspan
@@ -6519,7 +6519,7 @@
       <path
          inkscape:export-ydpi="180"
          inkscape:export-xdpi="180"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/F8_Tx_JESD_path.png"
+
          id="use9159-3"
          d="m -1198.8309,-180.54491 7.6842,-14.10025 7.6843,14.10025 z"
          style="fill:none;stroke:#000000;stroke-width:1.47207px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
@@ -6527,7 +6527,7 @@
       <g
          inkscape:export-ydpi="180"
          inkscape:export-xdpi="180"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Tx_JESD_path.png"
+
          transform="matrix(0.79145132,0,0,0.72613921,-1297.4434,-544.0462)"
          id="g9209-0">
         <rect
@@ -6552,7 +6552,7 @@
       <g
          inkscape:export-ydpi="180"
          inkscape:export-xdpi="180"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Tx_JESD_path.png"
+
          transform="matrix(0.79145132,0,0,0.72613921,-1297.4434,-543.2501)"
          id="g9217-0">
         <rect
@@ -6577,7 +6577,7 @@
       <g
          inkscape:export-ydpi="180"
          inkscape:export-xdpi="180"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Tx_JESD_path.png"
+
          transform="matrix(0.79145132,0,0,0.72613921,-1297.4434,-542.45386)"
          id="g9225-5">
         <rect
@@ -6602,7 +6602,7 @@
       <g
          inkscape:export-ydpi="180"
          inkscape:export-xdpi="180"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Tx_JESD_path.png"
+
          transform="matrix(1.5368492,0,0,1.4100254,-1253.9831,-648.85184)"
          id="g9233-5">
         <rect
@@ -6627,7 +6627,7 @@
       <g
          id="g9241-7"
          transform="matrix(0.79145132,0,0,0.72613921,-1242.3421,-543.85937)"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Tx_JESD_path.png"
+
          inkscape:export-xdpi="180"
          inkscape:export-ydpi="180">
         <rect
@@ -6652,7 +6652,7 @@
       <g
          id="g9249-5"
          transform="matrix(0.79145132,0,0,0.72613921,-1242.3421,-543.06313)"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Tx_JESD_path.png"
+
          inkscape:export-xdpi="180"
          inkscape:export-ydpi="180">
         <rect
@@ -6677,7 +6677,7 @@
       <g
          id="g9257-4"
          transform="matrix(0.79145132,0,0,0.72613921,-1242.3421,-542.26689)"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Tx_JESD_path.png"
+
          inkscape:export-xdpi="180"
          inkscape:export-ydpi="180">
         <rect
@@ -6702,7 +6702,7 @@
       <g
          id="g9265-8"
          transform="matrix(1.5368492,0,0,1.4100254,-1198.882,-648.66487)"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Tx_JESD_path.png"
+
          inkscape:export-xdpi="180"
          inkscape:export-ydpi="180">
         <rect
@@ -6728,7 +6728,7 @@
          style="fill:#aaccee;fill-opacity:1"
          inkscape:export-ydpi="180"
          inkscape:export-xdpi="180"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Tx_JESD_path.png"
+
          transform="matrix(0.79145132,0,0,0.72613921,-1557.6974,-363.84665)"
          id="g9273-4">
         <rect
@@ -6753,7 +6753,7 @@
       <g
          inkscape:export-ydpi="180"
          inkscape:export-xdpi="180"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Tx_JESD_path.png"
+
          transform="matrix(0.79145132,0,0,0.72613921,-1557.6974,-363.0504)"
          id="g9281-9">
         <rect
@@ -6778,7 +6778,7 @@
       <g
          inkscape:export-ydpi="180"
          inkscape:export-xdpi="180"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Tx_JESD_path.png"
+
          transform="matrix(0.79145132,0,0,0.72613921,-1557.6974,-362.2543)"
          id="g9289-8">
         <rect
@@ -6803,7 +6803,7 @@
       <g
          inkscape:export-ydpi="180"
          inkscape:export-xdpi="180"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Tx_JESD_path.png"
+
          transform="matrix(1.5368492,0,0,1.4100254,-1514.2371,-468.65214)"
          id="g9297-6">
         <rect
@@ -6829,7 +6829,7 @@
          id="path9305-0"
          d="m -1205.2661,-492.47241 c 0,103.80255 0,103.80255 0,103.80255"
          style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:none;stroke:#37abc8;stroke-width:4.69978;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:4.69978, 4.69978;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:new"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Tx_JESD_path.png"
+
          inkscape:export-xdpi="180"
          inkscape:export-ydpi="180"
          inkscape:connector-curvature="0" />
@@ -6837,7 +6837,7 @@
          style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:none;stroke:#37abc8;stroke-width:4.69978;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:4.69978, 4.69978;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:new"
          d="m -1090.4415,-493.54149 c 0,103.12066 0,103.12066 0,103.12066"
          id="path9307-4"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Tx_JESD_path.png"
+
          inkscape:export-xdpi="180"
          inkscape:export-ydpi="180"
          inkscape:connector-curvature="0" />
@@ -6848,7 +6848,7 @@
          y="-458.78946"
          id="text9309-8"
          transform="scale(0.89159784,1.1215819)"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Tx_JESD_path.png"
+
          inkscape:export-xdpi="180"
          inkscape:export-ydpi="180"><tspan
            style="font-size:15.7022px;line-height:1.25;stroke-width:2.167"
@@ -6859,7 +6859,7 @@
       <text
          inkscape:export-ydpi="180"
          inkscape:export-xdpi="180"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Tx_JESD_path.png"
+
          xml:space="preserve"
          style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:17.6649px;line-height:0%;font-family:sans-serif;-inkscape-font-specification:Sans;text-indent:0;text-align:center;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-anchor:middle;display:inline;overflow:visible;visibility:visible;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2.167;marker:none;enable-background:accumulate"
          x="-1185.8527"
@@ -6877,7 +6877,7 @@
          x="-1185.8672"
          style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:17.6649px;line-height:0%;font-family:sans-serif;-inkscape-font-specification:Sans;text-indent:0;text-align:center;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-anchor:middle;display:inline;overflow:visible;visibility:visible;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2.167;marker:none;enable-background:accumulate"
          xml:space="preserve"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Tx_JESD_path.png"
+
          inkscape:export-xdpi="180"
          inkscape:export-ydpi="180"
          transform="scale(1.044004,0.95785074)"><tspan
@@ -6889,7 +6889,7 @@
       <text
          inkscape:export-ydpi="180"
          inkscape:export-xdpi="180"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Tx_JESD_path.png"
+
          xml:space="preserve"
          style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:17.6649px;line-height:0%;font-family:sans-serif;-inkscape-font-specification:Sans;text-indent:0;text-align:center;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-anchor:middle;display:inline;overflow:visible;visibility:visible;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2.167;marker:none;enable-background:accumulate"
          x="-1185.8672"
@@ -6907,7 +6907,7 @@
          x="-1185.8672"
          style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:17.6649px;line-height:0%;font-family:sans-serif;-inkscape-font-specification:Sans;text-indent:0;text-align:center;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-anchor:middle;display:inline;overflow:visible;visibility:visible;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2.167;marker:none;enable-background:accumulate"
          xml:space="preserve"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Tx_JESD_path.png"
+
          inkscape:export-xdpi="180"
          inkscape:export-ydpi="180"
          transform="scale(1.044004,0.95785074)"><tspan
@@ -6922,7 +6922,7 @@
          x="-1124.7616"
          style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:17.6649px;line-height:0%;font-family:sans-serif;-inkscape-font-specification:Sans;text-indent:0;text-align:center;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-anchor:middle;display:inline;overflow:visible;visibility:visible;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2.167;marker:none;enable-background:accumulate"
          xml:space="preserve"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Tx_JESD_path.png"
+
          inkscape:export-xdpi="180"
          inkscape:export-ydpi="180"
          transform="scale(1.044004,0.95785074)"><tspan
@@ -6939,7 +6939,7 @@
       <text
          inkscape:export-ydpi="180"
          inkscape:export-xdpi="180"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Tx_JESD_path.png"
+
          xml:space="preserve"
          style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:17.6649px;line-height:0%;font-family:sans-serif;-inkscape-font-specification:Sans;text-indent:0;text-align:center;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-anchor:middle;display:inline;overflow:visible;visibility:visible;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2.167;marker:none;enable-background:accumulate"
          x="-1111.145"
@@ -6957,7 +6957,7 @@
          x="-1240.3192"
          style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:17.6649px;line-height:0%;font-family:sans-serif;-inkscape-font-specification:Sans;text-indent:0;text-align:center;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-anchor:middle;display:inline;overflow:visible;visibility:visible;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2.167;marker:none;enable-background:accumulate"
          xml:space="preserve"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Tx_JESD_path.png"
+
          inkscape:export-xdpi="180"
          inkscape:export-ydpi="180"
          transform="scale(1.044004,0.95785074)"><tspan
@@ -6969,7 +6969,7 @@
       <text
          inkscape:export-ydpi="180"
          inkscape:export-xdpi="180"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Tx_JESD_path.png"
+
          xml:space="preserve"
          style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:17.6649px;line-height:0%;font-family:sans-serif;-inkscape-font-specification:Sans;text-indent:0;text-align:center;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-anchor:middle;display:inline;overflow:visible;visibility:visible;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2.167;marker:none;enable-background:accumulate"
          x="-1074.7112"
@@ -6990,14 +6990,14 @@
          style="fill:none;stroke:#000000;stroke-width:1.47207px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:url(#Arrow1Mend-7-2)"
          d="m -1144.4606,-381.57941 c 0,43.63423 0,43.63423 0,43.63423"
          id="path9374-7"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Tx_JESD_path.png"
+
          inkscape:export-xdpi="180"
          inkscape:export-ydpi="180"
          inkscape:connector-curvature="0" />
       <text
          inkscape:export-ydpi="180"
          inkscape:export-xdpi="180"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Tx_JESD_path.png"
+
          xml:space="preserve"
          style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:17.6649px;line-height:0%;font-family:sans-serif;-inkscape-font-specification:Sans;text-indent:0;text-align:center;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-anchor:middle;display:inline;overflow:visible;visibility:visible;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.47207;marker:none;enable-background:accumulate"
          x="-897.50989"
@@ -7012,7 +7012,7 @@
       <path
          inkscape:export-ydpi="180"
          inkscape:export-xdpi="180"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Tx_JESD_path.png"
+
          id="path11137-5"
          d="m -1385.562,-299.54216 h 54.612"
          style="fill:none;stroke:#000000;stroke-width:1.47207px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:url(#Arrow2Lend-8-3-5)"
@@ -7020,7 +7020,7 @@
       <path
          inkscape:export-ydpi="180"
          inkscape:export-xdpi="180"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Tx_JESD_path.png"
+
          style="fill:none;stroke:#000000;stroke-width:1.47207px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:url(#Arrow2Lend-8-3-5)"
          d="m -1171.509,-328.18499 h 58.8599"
          id="path11551-9"
@@ -7028,7 +7028,7 @@
       <use
          inkscape:export-ydpi="180"
          inkscape:export-xdpi="180"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Tx_JESD_path.png"
+
          style="stroke-width:0.2;stroke-miterlimit:4;stroke-dasharray:none"
          height="1488.189"
          width="1052.3622"
@@ -7040,7 +7040,7 @@
       <use
          inkscape:export-ydpi="180"
          inkscape:export-xdpi="180"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Tx_JESD_path.png"
+
          height="1488.189"
          width="1052.3622"
          transform="translate(2.35891e-5,-22.267204)"
@@ -7051,7 +7051,7 @@
       <use
          inkscape:export-ydpi="180"
          inkscape:export-xdpi="180"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Tx_JESD_path.png"
+
          height="1488.189"
          width="1052.3622"
          transform="translate(2.35891e-5,-22.267204)"
@@ -7062,7 +7062,7 @@
       <path
          inkscape:export-ydpi="180"
          inkscape:export-xdpi="180"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Tx_JESD_path.png"
+
          id="path11559-7"
          d="m -962.31627,-328.18499 h 58.86"
          style="fill:none;stroke:#000000;stroke-width:1.47207px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:url(#Arrow2Lend-8-3-5)"
@@ -7070,7 +7070,7 @@
       <use
          inkscape:export-ydpi="180"
          inkscape:export-xdpi="180"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Tx_JESD_path.png"
+
          x="0"
          y="0"
          xlink:href="#path11551-9"
@@ -7081,7 +7081,7 @@
       <use
          inkscape:export-ydpi="180"
          inkscape:export-xdpi="180"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Tx_JESD_path.png"
+
          x="0"
          y="0"
          xlink:href="#use11553-7"
@@ -7092,7 +7092,7 @@
       <use
          inkscape:export-ydpi="180"
          inkscape:export-xdpi="180"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Tx_JESD_path.png"
+
          x="0"
          y="0"
          xlink:href="#use11555-7"
@@ -7103,7 +7103,7 @@
       <use
          inkscape:export-ydpi="180"
          inkscape:export-xdpi="180"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Tx_JESD_path.png"
+
          height="1488.189"
          width="1052.3622"
          transform="matrix(0.72891965,0,0,1,100.26944,66.801556)"
@@ -7114,7 +7114,7 @@
       <use
          inkscape:export-ydpi="180"
          inkscape:export-xdpi="180"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Tx_JESD_path.png"
+
          height="1488.189"
          width="1052.3622"
          transform="matrix(0.72891965,0,0,1,100.26944,-22.267204)"
@@ -7125,7 +7125,7 @@
       <use
          inkscape:export-ydpi="180"
          inkscape:export-xdpi="180"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Tx_JESD_path.png"
+
          height="1488.189"
          width="1052.3622"
          transform="matrix(0.72891965,0,0,1,100.26944,-22.267204)"
@@ -7136,7 +7136,7 @@
       <path
          inkscape:export-ydpi="180"
          inkscape:export-xdpi="180"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Tx_JESD_path.png"
+
          id="path11713-4"
          d="m -1375.9567,-291.61076 9.9896,-14.80527"
          style="fill:none;stroke:#000000;stroke-width:1.47207px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
@@ -7144,7 +7144,7 @@
       <path
          inkscape:export-ydpi="180"
          inkscape:export-xdpi="180"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Tx_JESD_path.png"
+
          style="fill:none;stroke:#000000;stroke-width:1.47207px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
          d="m -943.44357,-253.72338 9.9895,-14.80527"
          id="use11719-8"
@@ -7152,7 +7152,7 @@
       <use
          inkscape:export-ydpi="180"
          inkscape:export-xdpi="180"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Tx_JESD_path.png"
+
          height="1488.189"
          width="1052.3622"
          transform="translate(-211.90966,5.6401182e-5)"
@@ -7163,7 +7163,7 @@
       <use
          inkscape:export-ydpi="180"
          inkscape:export-xdpi="180"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Tx_JESD_path.png"
+
          x="0"
          y="0"
          xlink:href="#use11555-7"
@@ -7174,7 +7174,7 @@
       <text
          inkscape:export-ydpi="180"
          inkscape:export-xdpi="180"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Tx_JESD_path.png"
+
          xml:space="preserve"
          style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:17.6649px;line-height:0%;font-family:sans-serif;-inkscape-font-specification:Sans;text-indent:0;text-align:center;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-anchor:middle;display:inline;overflow:visible;visibility:visible;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2.167;marker:none;enable-background:accumulate"
          x="-1292.0791"
@@ -7189,7 +7189,7 @@
       <text
          inkscape:export-ydpi="180"
          inkscape:export-xdpi="180"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Tx_JESD_path.png"
+
          xml:space="preserve"
          style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:17.6649px;line-height:0.95;font-family:sans-serif;-inkscape-font-specification:Sans;text-indent:0;text-align:center;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-anchor:middle;display:inline;overflow:visible;visibility:visible;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2.167;marker:none;enable-background:accumulate"
          x="-1420.8448"
@@ -7209,7 +7209,7 @@
          x="-1418.9476"
          style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:17.6649px;line-height:0.95;font-family:sans-serif;-inkscape-font-specification:Sans;text-indent:0;text-align:center;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-anchor:middle;display:inline;overflow:visible;visibility:visible;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2.167;marker:none;enable-background:accumulate"
          xml:space="preserve"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Tx_JESD_path.png"
+
          inkscape:export-xdpi="180"
          inkscape:export-ydpi="180"
          transform="scale(1.044004,0.95785074)"><tspan
@@ -7238,7 +7238,7 @@
          x="-740.21521"
          style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:15.7022px;line-height:0%;font-family:Sans;-inkscape-font-specification:'Sans, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-indent:0;text-align:center;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-anchor:middle;display:inline;overflow:visible;visibility:visible;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.47207;marker:none;enable-background:accumulate"
          xml:space="preserve"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/generic_Tx_JESD_path.png"
+
          inkscape:export-xdpi="180"
          inkscape:export-ydpi="180"
          transform="scale(1.044004,0.95785074)"><tspan
@@ -7253,7 +7253,7 @@
          x="-929.70679"
          style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:15.7022px;line-height:0%;font-family:Sans;-inkscape-font-specification:'Sans, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-indent:0;text-align:center;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-anchor:middle;display:inline;overflow:visible;visibility:visible;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.47207;marker:none;enable-background:accumulate"
          xml:space="preserve"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/generic_Tx_JESD_path.png"
+
          inkscape:export-xdpi="180"
          inkscape:export-ydpi="180"
          transform="scale(1.044004,0.95785074)"><tspan
@@ -7265,7 +7265,7 @@
       <rect
          inkscape:export-ydpi="180"
          inkscape:export-xdpi="180"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/F8_Tx_JESD_path.png"
+
          y="146.94865"
          x="-112.98798"
          height="200.91966"
@@ -7275,7 +7275,7 @@
       <rect
          inkscape:export-ydpi="180"
          inkscape:export-xdpi="180"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/F8_Tx_JESD_path.png"
+
          y="148.11427"
          x="601.36456"
          height="199.75406"
@@ -7285,7 +7285,7 @@
       <rect
          inkscape:export-ydpi="180"
          inkscape:export-xdpi="180"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/F8_Tx_JESD_path.png"
+
          y="147.79515"
          x="260.60916"
          height="200.08531"
@@ -7295,7 +7295,7 @@
       <g
          inkscape:export-ydpi="180"
          inkscape:export-xdpi="180"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/F8_Tx_JESD_path.png"
+
          transform="matrix(0.79145132,0,0,0.72613921,-292.93812,100.07625)"
          id="g3019-0">
         <rect
@@ -7320,7 +7320,7 @@
       <g
          inkscape:export-ydpi="180"
          inkscape:export-xdpi="180"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/F8_Tx_JESD_path.png"
+
          transform="matrix(0.79145132,0,0,0.72613921,-292.93812,112.1527)"
          id="g3024-3">
         <rect
@@ -7345,7 +7345,7 @@
       <g
          inkscape:export-ydpi="180"
          inkscape:export-xdpi="180"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/F8_Tx_JESD_path.png"
+
          transform="matrix(0.79145132,0,0,0.72613921,-292.93812,124.229)"
          id="g3029-74">
         <rect
@@ -7370,7 +7370,7 @@
       <g
          inkscape:export-ydpi="180"
          inkscape:export-xdpi="180"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/F8_Tx_JESD_path.png"
+
          transform="matrix(1.5368492,0,0,1.4100254,-249.47791,29.111367)"
          id="g7286-0">
         <rect
@@ -7395,7 +7395,7 @@
       <text
          inkscape:export-ydpi="180"
          inkscape:export-xdpi="180"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/F8_Tx_JESD_path.png"
+
          xml:space="preserve"
          style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:17.6649px;line-height:0%;font-family:sans-serif;-inkscape-font-specification:Sans;text-indent:0;text-align:center;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-anchor:middle;display:inline;overflow:visible;visibility:visible;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2.167;marker:none;enable-background:accumulate"
          x="-216.02272"
@@ -7410,7 +7410,7 @@
       <text
          inkscape:export-ydpi="180"
          inkscape:export-xdpi="180"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/F8_Tx_JESD_path.png"
+
          xml:space="preserve"
          style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:17.6649px;line-height:0%;font-family:sans-serif;-inkscape-font-specification:Sans;text-indent:0;text-align:center;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-anchor:middle;display:inline;overflow:visible;visibility:visible;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2.167;marker:none;enable-background:accumulate"
          x="-166.49214"
@@ -7425,7 +7425,7 @@
       <g
          inkscape:export-ydpi="180"
          inkscape:export-xdpi="180"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/F8_Tx_JESD_path.png"
+
          transform="matrix(1.5368492,0,0,1.4100254,-259.35801,-1.3409539)"
          id="g7155-8">
         <g
@@ -7542,7 +7542,7 @@
       <g
          inkscape:export-ydpi="180"
          inkscape:export-xdpi="180"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/F8_Tx_JESD_path.png"
+
          id="g6810-1"
          transform="matrix(0.77100887,0,0,0.70738371,181.48564,25.455737)">
         <rect
@@ -7567,7 +7567,7 @@
       <g
          inkscape:export-ydpi="180"
          inkscape:export-xdpi="180"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/F8_Tx_JESD_path.png"
+
          id="g6818-0"
          transform="matrix(0.77100887,0,0,0.70738371,233.55164,6.1624961)">
         <rect
@@ -7592,7 +7592,7 @@
       <g
          inkscape:export-ydpi="180"
          inkscape:export-xdpi="180"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/F8_Tx_JESD_path.png"
+
          id="g6826-5"
          transform="matrix(0.77100887,0,0,0.70738371,293.46324,-13.130744)">
         <rect
@@ -7617,7 +7617,7 @@
       <g
          inkscape:export-ydpi="180"
          inkscape:export-xdpi="180"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/F8_Tx_JESD_path.png"
+
          id="g6834-0"
          transform="matrix(0.77100887,0,0,0.70738371,345.83999,-32.423974)">
         <rect
@@ -7642,7 +7642,7 @@
       <g
          inkscape:export-ydpi="180"
          inkscape:export-xdpi="180"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/F8_Tx_JESD_path.png"
+
          transform="matrix(1.5368492,0,0,1.4100254,-298.87697,-122.2003)"
          id="g3416-6">
         <rect
@@ -7677,7 +7677,7 @@
       <g
          inkscape:export-ydpi="180"
          inkscape:export-xdpi="180"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/F8_Tx_JESD_path.png"
+
          transform="matrix(1.5368492,0,0,1.4100254,77.651035,-102.05709)"
          id="g3367-6">
         <rect
@@ -7707,7 +7707,7 @@
       <text
          inkscape:export-ydpi="180"
          inkscape:export-xdpi="180"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/F8_Tx_JESD_path.png"
+
          id="text3385-6"
          y="282.98206"
          x="134.8532"
@@ -7722,7 +7722,7 @@
       <g
          inkscape:export-ydpi="180"
          inkscape:export-xdpi="180"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/F8_Tx_JESD_path.png"
+
          id="g3393-1"
          transform="matrix(1.5368492,0,0,1.4100254,224.27706,-102.05709)">
         <rect
@@ -7752,7 +7752,7 @@
       <text
          inkscape:export-ydpi="180"
          inkscape:export-xdpi="180"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/F8_Tx_JESD_path.png"
+
          id="text3407-4"
          y="278.77609"
          x="475.08011"
@@ -7767,7 +7767,7 @@
       <text
          inkscape:export-ydpi="180"
          inkscape:export-xdpi="180"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/F8_Tx_JESD_path.png"
+
          xml:space="preserve"
          style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:17.6649px;line-height:0%;font-family:sans-serif;-inkscape-font-specification:Sans;text-indent:0;text-align:center;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-anchor:middle;display:inline;overflow:visible;visibility:visible;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.47207;marker:none;enable-background:accumulate"
          x="-82.792656"
@@ -7782,7 +7782,7 @@
       <text
          inkscape:export-ydpi="180"
          inkscape:export-xdpi="180"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/F8_Tx_JESD_path.png"
+
          transform="scale(0.94856303,1.0542262)"
          id="text6100-4-6"
          y="325.09647"
@@ -7797,7 +7797,7 @@
       <text
          inkscape:export-ydpi="180"
          inkscape:export-xdpi="180"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/F8_Tx_JESD_path.png"
+
          transform="scale(0.92004082,1.0869083)"
          id="text6100-3"
          y="314.14673"
@@ -7812,7 +7812,7 @@
       <text
          inkscape:export-ydpi="180"
          inkscape:export-xdpi="180"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/F8_Tx_JESD_path.png"
+
          transform="scale(0.98024992,1.020148)"
          id="text6100-0-9"
          y="332.54031"
@@ -7827,7 +7827,7 @@
       <path
          inkscape:export-ydpi="180"
          inkscape:export-xdpi="180"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/F8_Tx_JESD_path.png"
+
          id="path6616-3"
          d="m 137.60015,120.83476 c 0,60.29173 0,60.29173 0,60.29173"
          style="fill:none;stroke:#000000;stroke-width:1.47207px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:url(#Arrow1Mend-1-5)"
@@ -7835,7 +7835,7 @@
       <path
          inkscape:export-ydpi="180"
          inkscape:export-xdpi="180"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/F8_Tx_JESD_path.png"
+
          style="fill:none;stroke:#000000;stroke-width:1.47207px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:url(#Arrow1Mend-1-5)"
          d="m 317.76283,122.4912 c 0,60.29173 0,60.29173 0,60.29173"
          id="path6842-5"
@@ -7843,7 +7843,7 @@
       <path
          inkscape:export-ydpi="180"
          inkscape:export-xdpi="180"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/F8_Tx_JESD_path.png"
+
          style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:none;stroke:#37abc8;stroke-width:4.69978;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:4.69978, 4.69978;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:new"
          d="m 273.17222,59.520767 c 0,60.291723 0,60.291723 0,60.291723"
          id="path6844-3"
@@ -7851,7 +7851,7 @@
       <path
          inkscape:export-ydpi="180"
          inkscape:export-xdpi="180"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/F8_Tx_JESD_path.png"
+
          id="path7055-0"
          d="m 381.84944,59.520767 c 0,60.291723 0,60.291723 0,60.291723"
          style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:none;stroke:#37abc8;stroke-width:4.69978;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:4.69978, 4.69978;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:new"
@@ -7859,7 +7859,7 @@
       <path
          inkscape:export-ydpi="180"
          inkscape:export-xdpi="180"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/F8_Tx_JESD_path.png"
+
          style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:none;stroke:#37abc8;stroke-width:4.69978;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:4.69978, 4.69978;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:new"
          d="m 493.81982,59.520767 c 0,60.291723 0,60.291723 0,60.291723"
          id="path7057-0"
@@ -7867,7 +7867,7 @@
       <path
          inkscape:export-ydpi="180"
          inkscape:export-xdpi="180"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/F8_Tx_JESD_path.png"
+
          id="path7059-3"
          d="m 31.667435,59.520767 c 0,60.291723 0,60.291723 0,60.291723"
          style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:none;stroke:#000080;stroke-width:4.72512;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:4.72512, 4.72512;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:new"
@@ -7875,7 +7875,7 @@
       <path
          inkscape:export-ydpi="180"
          inkscape:export-xdpi="180"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/F8_Tx_JESD_path.png"
+
          style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:none;stroke:#000080;stroke-width:4.72512;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:4.72512, 4.72512;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:new"
          d="m 245.72855,60.527927 c 0,60.291733 0,60.291733 0,60.291733"
          id="path7061-6"
@@ -7883,7 +7883,7 @@
       <text
          inkscape:export-ydpi="180"
          inkscape:export-xdpi="180"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/F8_Tx_JESD_path.png"
+
          xml:space="preserve"
          style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:17.6649px;line-height:0%;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;letter-spacing:0px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-anchor:start;display:inline;overflow:visible;visibility:visible;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2.167;marker:none;enable-background:new"
          x="95.822723"
@@ -7898,7 +7898,7 @@
       <text
          inkscape:export-ydpi="180"
          inkscape:export-xdpi="180"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/F8_Tx_JESD_path.png"
+
          transform="scale(0.89159784,1.1215819)"
          id="text7088-2"
          y="56.399757"
@@ -7913,7 +7913,7 @@
       <text
          inkscape:export-ydpi="180"
          inkscape:export-xdpi="180"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/F8_Tx_JESD_path.png"
+
          xml:space="preserve"
          style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:17.6649px;line-height:0%;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;letter-spacing:0px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-anchor:start;display:inline;overflow:visible;visibility:visible;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2.167;marker:none;enable-background:new"
          x="433.80344"
@@ -7928,7 +7928,7 @@
       <path
          inkscape:export-ydpi="180"
          inkscape:export-xdpi="180"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/F8_Tx_JESD_path.png"
+
          id="path7297-6"
          d="m -15.132235,345.13999 7.6842397,-14.10025 7.68425001,14.10025 z"
          style="fill:none;stroke:#000000;stroke-width:1.47207px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
@@ -7936,7 +7936,7 @@
       <use
          inkscape:export-ydpi="180"
          inkscape:export-xdpi="180"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/F8_Tx_JESD_path.png"
+
          height="1052.3622"
          width="744.09448"
          transform="translate(308.93059,0.15426112)"
@@ -7947,7 +7947,7 @@
       <path
          inkscape:export-ydpi="180"
          inkscape:export-xdpi="180"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/F8_Tx_JESD_path.png"
+
          id="path7331-5"
          d="M 391.79055,369.93868 H 301.3877 v -24.93636"
          style="fill:none;stroke:#000000;stroke-width:1.47207px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
@@ -7955,7 +7955,7 @@
       <path
          inkscape:export-ydpi="180"
          inkscape:export-xdpi="180"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/F8_Tx_JESD_path.png"
+
          style="fill:none;stroke:#000000;stroke-width:1.47207px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
          d="M 709.67659,444.38291 H -7.6508553 V 345.8564"
          id="path7333-0"
@@ -7963,7 +7963,7 @@
       <path
          inkscape:export-ydpi="180"
          inkscape:export-xdpi="180"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/F8_Tx_JESD_path.png"
+
          style="fill:none;stroke:#000000;stroke-width:1.47207px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
          d="M 388.79584,370.02847 H 592.76217 V 293.53636"
          id="path7349-6"
@@ -7971,7 +7971,7 @@
       <path
          inkscape:export-ydpi="180"
          inkscape:export-xdpi="180"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/F8_Tx_JESD_path.png"
+
          style="fill:none;stroke:#000000;stroke-width:1.47207px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:url(#Arrow2Lend-8-7-8)"
          d="M -54.396735,192.59785 H -136.96442"
          id="path12437-0"
@@ -7979,14 +7979,14 @@
       <path
          inkscape:export-ydpi="180"
          inkscape:export-xdpi="180"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Tx_JESD_path.png"
+
          id="use12472-7"
          d="m 126.88539,242.88333 9.98952,-14.80527"
          style="fill:none;stroke:#000000;stroke-width:1.47207px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
       <use
          inkscape:export-ydpi="180"
          inkscape:export-xdpi="180"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/F8_Tx_JESD_path.png"
+
          height="1488.189"
          width="1052.3622"
          transform="translate(-218.97343,40.380027)"
@@ -7997,7 +7997,7 @@
       <use
          inkscape:export-ydpi="180"
          inkscape:export-xdpi="180"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/F8_Tx_JESD_path.png"
+
          height="1488.189"
          width="1052.3622"
          transform="translate(575.26932,-41.377189)"
@@ -8008,7 +8008,7 @@
       <path
          inkscape:export-ydpi="180"
          inkscape:export-xdpi="180"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/F8_Tx_JESD_path.png"
+
          id="path12480-6"
          d="M 174.61516,235.96902 H 102.9906"
          style="fill:none;stroke:#000000;stroke-width:1.47207px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:url(#Arrow2Lend-8-7-8)"
@@ -8016,7 +8016,7 @@
       <path
          inkscape:export-ydpi="180"
          inkscape:export-xdpi="180"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/F8_Tx_JESD_path.png"
+
          id="path12484-6"
          d="M 528.67494,234.97197 H 456.02639"
          style="fill:none;stroke:#000000;stroke-width:1.47207px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:url(#Arrow2Lend-8-7-8)"
@@ -8024,7 +8024,7 @@
       <path
          inkscape:export-ydpi="180"
          inkscape:export-xdpi="180"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/F8_Tx_JESD_path.png"
+
          style="fill:none;stroke:#000000;stroke-width:1.47207px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:url(#Arrow2Lend-8-7-8)"
          d="M 714.07151,234.97197 H 678.80313"
          id="path12486-7"
@@ -8032,7 +8032,7 @@
       <path
          inkscape:export-ydpi="180"
          inkscape:export-xdpi="180"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/F8_Tx_JESD_path.png"
+
          id="path12488-6"
          d="M -54.396735,221.01336 H -136.96442"
          style="fill:none;stroke:#000000;stroke-width:1.47207px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:url(#Arrow2Lend-8-7-8)"
@@ -8040,7 +8040,7 @@
       <path
          inkscape:export-ydpi="180"
          inkscape:export-xdpi="180"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/F8_Tx_JESD_path.png"
+
          style="fill:none;stroke:#000000;stroke-width:1.47207px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:url(#Arrow2Lend-8-7-8)"
          d="M -54.396735,249.42905 H -136.96442"
          id="path12490-2"
@@ -8048,7 +8048,7 @@
       <path
          inkscape:export-ydpi="180"
          inkscape:export-xdpi="180"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/F8_Tx_JESD_path.png"
+
          id="path12492-5"
          d="M -54.396735,277.84464 H -136.96442"
          style="fill:none;stroke:#000000;stroke-width:1.47207px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:url(#Arrow2Lend-8-7-8)"
@@ -8056,7 +8056,7 @@
       <text
          inkscape:export-ydpi="180"
          inkscape:export-xdpi="180"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/F8_Tx_JESD_path.png"
+
          xml:space="preserve"
          style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:17.6649px;line-height:0%;font-family:sans-serif;-inkscape-font-specification:Sans;text-indent:0;text-align:center;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-anchor:middle;display:inline;overflow:visible;visibility:visible;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2.167;marker:none;enable-background:accumulate"
          x="-64.099014"
@@ -8075,7 +8075,7 @@
          y="411.52896"
          id="text2242-8"
          transform="scale(0.94856303,1.0542262)"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/F8_Tx_JESD_path.png"
+
          inkscape:export-xdpi="180"
          inkscape:export-ydpi="180"><tspan
            sodipodi:role="line"
@@ -8086,7 +8086,7 @@
       <g
          inkscape:export-ydpi="180"
          inkscape:export-xdpi="180"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/F8_Tx_JESD_path.png"
+
          id="g3351-2-2"
          transform="translate(9.1152446,-6.0604539)"
          style="stroke-width:1.47207">
@@ -8117,7 +8117,7 @@
       <path
          inkscape:export-ydpi="180"
          inkscape:export-xdpi="180"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/F8_Tx_JESD_path.png"
+
          style="fill:none;stroke:#000000;stroke-width:1.47207px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
          d="M 708.73619,405.73609 H 210.63429 V 291.66942"
          id="path7333-5-7"
@@ -8125,7 +8125,7 @@
       <text
          inkscape:export-ydpi="180"
          inkscape:export-xdpi="180"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/F8_Tx_JESD_path.png"
+
          transform="scale(0.94856303,1.0542262)"
          id="text2950-1"
          y="376.26456"
@@ -8159,7 +8159,7 @@
       <rect
          inkscape:export-ydpi="180"
          inkscape:export-xdpi="180"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/F8_Tx_JESD_path.png"
+
          y="147.45024"
          x="-1495.2523"
          height="200.91966"
@@ -8169,7 +8169,7 @@
       <rect
          inkscape:export-ydpi="180"
          inkscape:export-xdpi="180"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/F8_Tx_JESD_path.png"
+
          y="148.61584"
          x="-780.89984"
          height="199.75406"
@@ -8179,7 +8179,7 @@
       <rect
          inkscape:export-ydpi="180"
          inkscape:export-xdpi="180"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/F8_Tx_JESD_path.png"
+
          y="148.29674"
          x="-1121.6553"
          height="200.08531"
@@ -8189,7 +8189,7 @@
       <g
          inkscape:export-ydpi="180"
          inkscape:export-xdpi="180"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/F8_Tx_JESD_path.png"
+
          transform="matrix(0.79145132,0,0,0.72613921,-1675.2025,100.57787)"
          id="g3019">
         <rect
@@ -8214,7 +8214,7 @@
       <g
          inkscape:export-ydpi="180"
          inkscape:export-xdpi="180"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/F8_Tx_JESD_path.png"
+
          transform="matrix(0.79145132,0,0,0.72613921,-1675.2025,112.65426)"
          id="g3024">
         <rect
@@ -8239,7 +8239,7 @@
       <g
          inkscape:export-ydpi="180"
          inkscape:export-xdpi="180"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/F8_Tx_JESD_path.png"
+
          transform="matrix(0.79145132,0,0,0.72613921,-1675.2025,124.73063)"
          id="g3029">
         <rect
@@ -8264,7 +8264,7 @@
       <g
          inkscape:export-ydpi="180"
          inkscape:export-xdpi="180"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/F8_Tx_JESD_path.png"
+
          transform="matrix(1.5368492,0,0,1.4100254,-1631.7423,29.612925)"
          id="g7286">
         <rect
@@ -8289,7 +8289,7 @@
       <text
          inkscape:export-ydpi="180"
          inkscape:export-xdpi="180"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/F8_Tx_JESD_path.png"
+
          xml:space="preserve"
          style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:17.6649px;line-height:0%;font-family:sans-serif;-inkscape-font-specification:Sans;text-indent:0;text-align:center;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-anchor:middle;display:inline;overflow:visible;visibility:visible;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2.167;marker:none;enable-background:accumulate"
          x="-1540.0256"
@@ -8304,7 +8304,7 @@
       <text
          inkscape:export-ydpi="180"
          inkscape:export-xdpi="180"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/F8_Tx_JESD_path.png"
+
          xml:space="preserve"
          style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:17.6649px;line-height:0%;font-family:sans-serif;-inkscape-font-specification:Sans;text-indent:0;text-align:center;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-anchor:middle;display:inline;overflow:visible;visibility:visible;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2.167;marker:none;enable-background:accumulate"
          x="-1490.4951"
@@ -8319,7 +8319,7 @@
       <g
          inkscape:export-ydpi="180"
          inkscape:export-xdpi="180"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/F8_Tx_JESD_path.png"
+
          transform="matrix(1.5368492,0,0,1.4100254,-1641.6224,-0.83938472)"
          id="g7155">
         <g
@@ -8436,7 +8436,7 @@
       <g
          inkscape:export-ydpi="180"
          inkscape:export-xdpi="180"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/F8_Tx_JESD_path.png"
+
          id="g6810"
          transform="matrix(0.77100887,0,0,0.70738371,-1200.7787,25.957375)">
         <rect
@@ -8461,7 +8461,7 @@
       <g
          inkscape:export-ydpi="180"
          inkscape:export-xdpi="180"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/F8_Tx_JESD_path.png"
+
          id="g6818"
          transform="matrix(0.77100887,0,0,0.70738371,-1148.7127,6.6641153)">
         <rect
@@ -8486,7 +8486,7 @@
       <g
          inkscape:export-ydpi="180"
          inkscape:export-xdpi="180"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/F8_Tx_JESD_path.png"
+
          id="g6826"
          transform="matrix(0.77100887,0,0,0.70738371,-1088.8012,-12.629155)">
         <rect
@@ -8511,7 +8511,7 @@
       <g
          inkscape:export-ydpi="180"
          inkscape:export-xdpi="180"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/F8_Tx_JESD_path.png"
+
          id="g6834"
          transform="matrix(0.77100887,0,0,0.70738371,-1036.4245,-31.922445)">
         <rect
@@ -8536,7 +8536,7 @@
       <g
          inkscape:export-ydpi="180"
          inkscape:export-xdpi="180"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/F8_Tx_JESD_path.png"
+
          transform="matrix(1.5368492,0,0,1.4100254,-1681.1413,-121.6987)"
          id="g3416">
         <rect
@@ -8571,7 +8571,7 @@
       <g
          inkscape:export-ydpi="180"
          inkscape:export-xdpi="180"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/F8_Tx_JESD_path.png"
+
          transform="matrix(1.5368492,0,0,1.4100254,-1304.6133,-101.55549)"
          id="g3367">
         <rect
@@ -8601,7 +8601,7 @@
       <text
          inkscape:export-ydpi="180"
          inkscape:export-xdpi="180"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/F8_Tx_JESD_path.png"
+
          id="text3385"
          y="283.50568"
          x="-1189.1499"
@@ -8616,7 +8616,7 @@
       <g
          inkscape:export-ydpi="180"
          inkscape:export-xdpi="180"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/F8_Tx_JESD_path.png"
+
          id="g3393"
          transform="matrix(1.5368492,0,0,1.4100254,-1157.9874,-101.55549)">
         <rect
@@ -8646,7 +8646,7 @@
       <text
          inkscape:export-ydpi="180"
          inkscape:export-xdpi="180"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/F8_Tx_JESD_path.png"
+
          id="text3407"
          y="279.29971"
          x="-848.92291"
@@ -8661,7 +8661,7 @@
       <text
          inkscape:export-ydpi="180"
          inkscape:export-xdpi="180"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/F8_Tx_JESD_path.png"
+
          xml:space="preserve"
          style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:17.6649px;line-height:0%;font-family:sans-serif;-inkscape-font-specification:Sans;text-indent:0;text-align:center;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-anchor:middle;display:inline;overflow:visible;visibility:visible;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.47207;marker:none;enable-background:accumulate"
          x="-1406.7957"
@@ -8676,7 +8676,7 @@
       <text
          inkscape:export-ydpi="180"
          inkscape:export-xdpi="180"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/F8_Tx_JESD_path.png"
+
          transform="scale(0.94856302,1.0542262)"
          id="text6100-4"
          y="325.57227"
@@ -8691,7 +8691,7 @@
       <text
          inkscape:export-ydpi="180"
          inkscape:export-xdpi="180"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/F8_Tx_JESD_path.png"
+
          transform="scale(0.92004083,1.0869083)"
          id="text6100"
          y="314.60828"
@@ -8706,7 +8706,7 @@
       <text
          inkscape:export-ydpi="180"
          inkscape:export-xdpi="180"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/F8_Tx_JESD_path.png"
+
          transform="scale(0.98024992,1.020148)"
          id="text6100-0"
          y="333.03204"
@@ -8721,7 +8721,7 @@
       <path
          inkscape:export-ydpi="180"
          inkscape:export-xdpi="180"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/F8_Tx_JESD_path.png"
+
          id="path6616"
          d="m -1244.6642,121.33636 c 0,60.29173 0,60.29173 0,60.29173"
          style="fill:none;stroke:#000000;stroke-width:1.47207px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:url(#Arrow1Mend-3)"
@@ -8729,7 +8729,7 @@
       <path
          inkscape:export-ydpi="180"
          inkscape:export-xdpi="180"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/F8_Tx_JESD_path.png"
+
          style="fill:none;stroke:#000000;stroke-width:1.47207px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:url(#Arrow1Mend-3)"
          d="m -1064.5015,122.99281 c 0,60.29172 0,60.29172 0,60.29172"
          id="path6842"
@@ -8737,7 +8737,7 @@
       <path
          inkscape:export-ydpi="180"
          inkscape:export-xdpi="180"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/F8_Tx_JESD_path.png"
+
          style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:none;stroke:#37abc8;stroke-width:4.69978;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:4.69978, 4.69978;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:new"
          d="m -1109.0921,60.022365 c 0,60.291735 0,60.291735 0,60.291735"
          id="path6844"
@@ -8745,7 +8745,7 @@
       <path
          inkscape:export-ydpi="180"
          inkscape:export-xdpi="180"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/F8_Tx_JESD_path.png"
+
          id="path7055"
          d="m -1000.4149,60.022365 c 0,60.291735 0,60.291735 0,60.291735"
          style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:none;stroke:#37abc8;stroke-width:4.69978;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:4.69978, 4.69978;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:new"
@@ -8753,7 +8753,7 @@
       <path
          inkscape:export-ydpi="180"
          inkscape:export-xdpi="180"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/F8_Tx_JESD_path.png"
+
          style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:none;stroke:#37abc8;stroke-width:4.69978;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:4.69978, 4.69978;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:new"
          d="m -888.44451,60.022365 c 0,60.291735 0,60.291735 0,60.291735"
          id="path7057"
@@ -8761,7 +8761,7 @@
       <path
          inkscape:export-ydpi="180"
          inkscape:export-xdpi="180"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/F8_Tx_JESD_path.png"
+
          id="path7059"
          d="m -1350.597,60.022365 c 0,60.291735 0,60.291735 0,60.291735"
          style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:none;stroke:#000080;stroke-width:4.72512;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:4.72512, 4.72512;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:new"
@@ -8769,7 +8769,7 @@
       <path
          inkscape:export-ydpi="180"
          inkscape:export-xdpi="180"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/F8_Tx_JESD_path.png"
+
          style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:none;stroke:#000080;stroke-width:4.72512;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:4.72512, 4.72512;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:new"
          d="m -1136.5359,61.029535 c 0,60.291725 0,60.291725 0,60.291725"
          id="path7061"
@@ -8777,7 +8777,7 @@
       <text
          inkscape:export-ydpi="180"
          inkscape:export-xdpi="180"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/F8_Tx_JESD_path.png"
+
          xml:space="preserve"
          style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:17.6649px;line-height:0%;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;letter-spacing:0px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-anchor:start;display:inline;overflow:visible;visibility:visible;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2.167;marker:none;enable-background:new"
          x="-1454.5"
@@ -8792,7 +8792,7 @@
       <text
          inkscape:export-ydpi="180"
          inkscape:export-xdpi="180"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/F8_Tx_JESD_path.png"
+
          transform="scale(0.89159783,1.1215819)"
          id="text7088"
          y="56.84697"
@@ -8807,7 +8807,7 @@
       <text
          inkscape:export-ydpi="180"
          inkscape:export-xdpi="180"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/F8_Tx_JESD_path.png"
+
          xml:space="preserve"
          style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:17.6649px;line-height:0%;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;letter-spacing:0px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-anchor:start;display:inline;overflow:visible;visibility:visible;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2.167;marker:none;enable-background:new"
          x="-1116.5192"
@@ -8822,7 +8822,7 @@
       <path
          inkscape:export-ydpi="180"
          inkscape:export-xdpi="180"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/F8_Tx_JESD_path.png"
+
          id="path7297"
          d="m -1397.3966,345.64159 7.6843,-14.10025 7.6842,14.10025 z"
          style="fill:none;stroke:#000000;stroke-width:1.47207px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
@@ -8830,7 +8830,7 @@
       <use
          inkscape:export-ydpi="180"
          inkscape:export-xdpi="180"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/F8_Tx_JESD_path.png"
+
          height="1052.3622"
          width="744.09448"
          transform="translate(308.93065,0.15421472)"
@@ -8841,7 +8841,7 @@
       <path
          inkscape:export-ydpi="180"
          inkscape:export-xdpi="180"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/F8_Tx_JESD_path.png"
+
          id="path7331"
          d="m -990.47381,370.44027 h -90.40279 v -24.93635"
          style="fill:none;stroke:#000000;stroke-width:1.47207px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
@@ -8849,7 +8849,7 @@
       <path
          inkscape:export-ydpi="180"
          inkscape:export-xdpi="180"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/F8_Tx_JESD_path.png"
+
          style="fill:none;stroke:#000000;stroke-width:1.47207px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
          d="M -672.58781,444.88451 H -1389.9152 V 346.358"
          id="path7333"
@@ -8857,7 +8857,7 @@
       <path
          inkscape:export-ydpi="180"
          inkscape:export-xdpi="180"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/F8_Tx_JESD_path.png"
+
          style="fill:none;stroke:#000000;stroke-width:1.47207px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
          d="m -993.46851,370.53006 h 203.9663 v -76.4921"
          id="path7349"
@@ -8865,7 +8865,7 @@
       <path
          inkscape:export-ydpi="180"
          inkscape:export-xdpi="180"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/F8_Tx_JESD_path.png"
+
          style="fill:none;stroke:#000000;stroke-width:1.47207px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:url(#Arrow2Lend-8-5)"
          d="m -1512.5136,193.09945 h 73.4861"
          id="path12437"
@@ -8873,14 +8873,14 @@
       <path
          inkscape:export-ydpi="180"
          inkscape:export-xdpi="180"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Tx_JESD_path.png"
+
          id="use12472"
          d="m -1255.3791,243.38487 9.9895,-14.80526"
          style="fill:none;stroke:#000000;stroke-width:1.47207px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
       <use
          inkscape:export-ydpi="180"
          inkscape:export-xdpi="180"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/F8_Tx_JESD_path.png"
+
          height="1488.189"
          width="1052.3622"
          transform="translate(-218.97337,40.380055)"
@@ -8891,7 +8891,7 @@
       <use
          inkscape:export-ydpi="180"
          inkscape:export-xdpi="180"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/F8_Tx_JESD_path.png"
+
          height="1488.189"
          width="1052.3622"
          transform="translate(575.26941,-41.377115)"
@@ -8902,7 +8902,7 @@
       <path
          inkscape:export-ydpi="180"
          inkscape:export-xdpi="180"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/F8_Tx_JESD_path.png"
+
          id="path12480"
          d="m -1281.3147,236.47062 h 71.6246"
          style="fill:none;stroke:#000000;stroke-width:1.47207px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:url(#Arrow2Lend-8-5)"
@@ -8910,7 +8910,7 @@
       <path
          inkscape:export-ydpi="180"
          inkscape:export-xdpi="180"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/F8_Tx_JESD_path.png"
+
          id="path12484"
          d="m -928.27901,235.47357 h 72.6486"
          style="fill:none;stroke:#000000;stroke-width:1.47207px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:url(#Arrow2Lend-8-5)"
@@ -8918,7 +8918,7 @@
       <path
          inkscape:export-ydpi="180"
          inkscape:export-xdpi="180"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/F8_Tx_JESD_path.png"
+
          style="fill:none;stroke:#000000;stroke-width:1.47207px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:url(#Arrow2Lend-8-5)"
          d="m -705.50211,235.47357 h 35.2684"
          id="path12486"
@@ -8926,7 +8926,7 @@
       <path
          inkscape:export-ydpi="180"
          inkscape:export-xdpi="180"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/F8_Tx_JESD_path.png"
+
          id="path12488"
          d="m -1512.5136,221.51496 h 73.4861"
          style="fill:none;stroke:#000000;stroke-width:1.47207px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:url(#Arrow2Lend-8-5)"
@@ -8934,7 +8934,7 @@
       <path
          inkscape:export-ydpi="180"
          inkscape:export-xdpi="180"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/F8_Tx_JESD_path.png"
+
          style="fill:none;stroke:#000000;stroke-width:1.47207px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:url(#Arrow2Lend-8-5)"
          d="m -1512.5136,249.93065 h 73.4861"
          id="path12490"
@@ -8942,7 +8942,7 @@
       <path
          inkscape:export-ydpi="180"
          inkscape:export-xdpi="180"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/F8_Tx_JESD_path.png"
+
          id="path12492"
          d="m -1512.5136,278.34624 h 73.4861"
          style="fill:none;stroke:#000000;stroke-width:1.47207px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:url(#Arrow2Lend-8-5)"
@@ -8950,7 +8950,7 @@
       <text
          inkscape:export-ydpi="180"
          inkscape:export-xdpi="180"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/F8_Tx_JESD_path.png"
+
          xml:space="preserve"
          style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:17.6649px;line-height:0%;font-family:sans-serif;-inkscape-font-specification:Sans;text-indent:0;text-align:center;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-anchor:middle;display:inline;overflow:visible;visibility:visible;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2.167;marker:none;enable-background:accumulate"
          x="-1388.1021"
@@ -8969,7 +8969,7 @@
          y="412.00476"
          id="text2242"
          transform="scale(0.94856302,1.0542262)"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/F8_Tx_JESD_path.png"
+
          inkscape:export-xdpi="180"
          inkscape:export-ydpi="180"><tspan
            sodipodi:role="line"
@@ -8980,7 +8980,7 @@
       <g
          inkscape:export-ydpi="180"
          inkscape:export-xdpi="180"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/F8_Tx_JESD_path.png"
+
          id="g3351"
          transform="translate(-1373.1492,-5.5588347)"
          style="stroke-width:1.47207">
@@ -9011,7 +9011,7 @@
       <path
          inkscape:export-ydpi="180"
          inkscape:export-xdpi="180"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/F8_Tx_JESD_path.png"
+
          style="fill:none;stroke:#000000;stroke-width:1.47207px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
          d="M -673.52821,406.23769 H -1171.6301 V 292.17102"
          id="path7333-5"
@@ -9019,7 +9019,7 @@
       <text
          inkscape:export-ydpi="180"
          inkscape:export-xdpi="180"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/F8_Tx_JESD_path.png"
+
          transform="scale(0.94856302,1.0542262)"
          id="text2950"
          y="376.74036"

--- a/docs/library/jesd204/generic_jesd_bds/jesd204_generic_rx_f8.svg
+++ b/docs/library/jesd204/generic_jesd_bds/jesd204_generic_rx_f8.svg
@@ -2285,13 +2285,13 @@
     <g
        id="g13582"
        transform="translate(131.56285,-380.53334)"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/generic_Tx_JESD_path.png"
+
        inkscape:export-xdpi="180"
        inkscape:export-ydpi="180" />
     <rect
        inkscape:export-ydpi="180"
        inkscape:export-xdpi="180"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/F8_Tx_JESD_path.png"
+
        y="742.4519"
        x="1110.8105"
        height="142.49365"
@@ -2301,7 +2301,7 @@
     <rect
        inkscape:export-ydpi="180"
        inkscape:export-xdpi="180"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/F8_Tx_JESD_path.png"
+
        y="743.27856"
        x="1575.6268"
        height="141.66699"
@@ -2311,7 +2311,7 @@
     <rect
        inkscape:export-ydpi="180"
        inkscape:export-xdpi="180"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/F8_Tx_JESD_path.png"
+
        y="743.05225"
        x="1353.9034"
        height="141.90192"
@@ -2321,7 +2321,7 @@
     <g
        inkscape:export-ydpi="180"
        inkscape:export-xdpi="180"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/F8_Tx_JESD_path.png"
+
        transform="matrix(0.51498307,0,0,0.51498307,993.72023,709.20966)"
        id="g3019-0">
       <rect
@@ -2346,7 +2346,7 @@
     <g
        inkscape:export-ydpi="180"
        inkscape:export-xdpi="180"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/F8_Tx_JESD_path.png"
+
        transform="matrix(0.51498307,0,0,0.51498307,993.72023,717.77436)"
        id="g3024-3">
       <rect
@@ -2371,7 +2371,7 @@
     <g
        inkscape:export-ydpi="180"
        inkscape:export-xdpi="180"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/F8_Tx_JESD_path.png"
+
        transform="matrix(0.51498307,0,0,0.51498307,993.72023,726.33896)"
        id="g3029-74">
       <rect
@@ -2396,7 +2396,7 @@
     <g
        inkscape:export-ydpi="180"
        inkscape:export-xdpi="180"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/F8_Tx_JESD_path.png"
+
        transform="translate(1021.999,658.88086)"
        id="g7286-0">
       <rect
@@ -2421,7 +2421,7 @@
     <text
        inkscape:export-ydpi="180"
        inkscape:export-xdpi="180"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/F8_Tx_JESD_path.png"
+
        xml:space="preserve"
        style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0%;font-family:sans-serif;-inkscape-font-specification:Sans;text-indent:0;text-align:center;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-anchor:middle;display:inline;overflow:visible;visibility:visible;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;marker:none;enable-background:accumulate"
        x="1037.5824"
@@ -2435,7 +2435,7 @@
     <text
        inkscape:export-ydpi="180"
        inkscape:export-xdpi="180"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/F8_Tx_JESD_path.png"
+
        xml:space="preserve"
        style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0%;font-family:sans-serif;-inkscape-font-specification:Sans;text-indent:0;text-align:center;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-anchor:middle;display:inline;overflow:visible;visibility:visible;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;marker:none;enable-background:accumulate"
        x="1071.2292"
@@ -2449,7 +2449,7 @@
     <g
        inkscape:export-ydpi="180"
        inkscape:export-xdpi="180"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/F8_Tx_JESD_path.png"
+
        transform="translate(1015.5702,637.28386)"
        id="g7155-8">
       <g
@@ -2566,7 +2566,7 @@
     <g
        inkscape:export-ydpi="180"
        inkscape:export-xdpi="180"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/F8_Tx_JESD_path.png"
+
        id="g6810-1"
        transform="matrix(0.50168154,0,0,0.50168154,1302.4192,656.28826)">
       <rect
@@ -2591,7 +2591,7 @@
     <g
        inkscape:export-ydpi="180"
        inkscape:export-xdpi="180"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/F8_Tx_JESD_path.png"
+
        id="g6818-0"
        transform="matrix(0.50168154,0,0,0.50168154,1336.2976,642.60536)">
       <rect
@@ -2616,7 +2616,7 @@
     <g
        inkscape:export-ydpi="180"
        inkscape:export-xdpi="180"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/F8_Tx_JESD_path.png"
+
        id="g6826-5"
        transform="matrix(0.50168154,0,0,0.50168154,1375.281,628.92246)">
       <rect
@@ -2641,7 +2641,7 @@
     <g
        inkscape:export-ydpi="180"
        inkscape:export-xdpi="180"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/F8_Tx_JESD_path.png"
+
        id="g6834-0"
        transform="matrix(0.50168154,0,0,0.50168154,1409.3616,615.23956)">
       <rect
@@ -2666,7 +2666,7 @@
     <g
        inkscape:export-ydpi="180"
        inkscape:export-xdpi="180"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/F8_Tx_JESD_path.png"
+
        transform="translate(989.85593,551.56955)"
        id="g3416-6">
       <rect
@@ -2701,7 +2701,7 @@
     <g
        inkscape:export-ydpi="180"
        inkscape:export-xdpi="180"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/F8_Tx_JESD_path.png"
+
        transform="translate(1234.8559,565.85526)"
        id="g3367-6">
       <rect
@@ -2731,7 +2731,7 @@
     <text
        inkscape:export-ydpi="180"
        inkscape:export-xdpi="180"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/F8_Tx_JESD_path.png"
+
        id="text3385-6"
        y="830.46869"
        x="1275.9375"
@@ -2745,7 +2745,7 @@
     <g
        inkscape:export-ydpi="180"
        inkscape:export-xdpi="180"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/F8_Tx_JESD_path.png"
+
        id="g3393-1"
        transform="translate(1330.2628,565.85526)">
       <rect
@@ -2775,7 +2775,7 @@
     <text
        inkscape:export-ydpi="180"
        inkscape:export-xdpi="180"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/F8_Tx_JESD_path.png"
+
        id="text3407-4"
        y="827.61151"
        x="1507.0586"
@@ -2789,7 +2789,7 @@
     <text
        inkscape:export-ydpi="180"
        inkscape:export-xdpi="180"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/F8_Tx_JESD_path.png"
+
        xml:space="preserve"
        style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0%;font-family:sans-serif;-inkscape-font-specification:Sans;text-indent:0;text-align:center;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-anchor:middle;display:inline;overflow:visible;visibility:visible;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
        x="1128.0875"
@@ -2803,7 +2803,7 @@
     <text
        inkscape:export-ydpi="180"
        inkscape:export-xdpi="180"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/F8_Tx_JESD_path.png"
+
        transform="scale(0.90858178,1.1006164)"
        id="text6100-4-6"
        y="800.73132"
@@ -2818,7 +2818,7 @@
     <text
        inkscape:export-ydpi="180"
        inkscape:export-xdpi="180"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/F8_Tx_JESD_path.png"
+
        transform="scale(0.88126178,1.1347366)"
        id="text6100-3"
        y="775.85645"
@@ -2833,7 +2833,7 @@
     <text
        inkscape:export-ydpi="180"
        inkscape:export-xdpi="180"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/F8_Tx_JESD_path.png"
+
        transform="scale(0.9389331,1.0650386)"
        id="text6100-0-9"
        y="825.1593"
@@ -2848,7 +2848,7 @@
     <path
        inkscape:export-ydpi="180"
        inkscape:export-xdpi="180"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/F8_Tx_JESD_path.png"
+
        id="path6616-3"
        d="m 1273.8637,723.93174 c 0,42.75932 0,42.75932 0,42.75932"
        style="fill:none;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:url(#Arrow1Mend-1)"
@@ -2856,7 +2856,7 @@
     <path
        inkscape:export-ydpi="180"
        inkscape:export-xdpi="180"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/F8_Tx_JESD_path.png"
+
        style="fill:none;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:url(#Arrow1Mend-1)"
        d="m 1391.0923,725.1065 c 0,42.75932 0,42.75932 0,42.75932"
        id="path6842-5"
@@ -2864,7 +2864,7 @@
     <path
        inkscape:export-ydpi="180"
        inkscape:export-xdpi="180"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/F8_Tx_JESD_path.png"
+
        style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:none;stroke:#37abc8;stroke-width:3.19263;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:3.19263, 3.19263;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:new"
        d="m 1362.078,680.44742 c 0,42.75932 0,42.75932 0,42.75932"
        id="path6844-3"
@@ -2872,7 +2872,7 @@
     <path
        inkscape:export-ydpi="180"
        inkscape:export-xdpi="180"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/F8_Tx_JESD_path.png"
+
        id="path7055-0"
        d="m 1432.7923,680.44742 c 0,42.75932 0,42.75932 0,42.75932"
        style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:none;stroke:#37abc8;stroke-width:3.19263;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:3.19263, 3.19263;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:new"
@@ -2880,7 +2880,7 @@
     <path
        inkscape:export-ydpi="180"
        inkscape:export-xdpi="180"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/F8_Tx_JESD_path.png"
+
        style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:none;stroke:#37abc8;stroke-width:3.19263;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:3.19263, 3.19263;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:new"
        d="m 1505.6494,680.44742 c 0,42.75932 0,42.75932 0,42.75932"
        id="path7057-0"
@@ -2888,7 +2888,7 @@
     <path
        inkscape:export-ydpi="180"
        inkscape:export-xdpi="180"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/F8_Tx_JESD_path.png"
+
        id="path7059-3"
        d="m 1204.9352,680.44742 c 0,42.75932 0,42.75932 0,42.75932"
        style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:none;stroke:#000080;stroke-width:3.20984;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:3.20984, 3.20984;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:new"
@@ -2896,7 +2896,7 @@
     <path
        inkscape:export-ydpi="180"
        inkscape:export-xdpi="180"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/F8_Tx_JESD_path.png"
+
        style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:none;stroke:#000080;stroke-width:3.20984;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:3.20984, 3.20984;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:new"
        d="m 1344.2209,681.16171 c 0,42.75932 0,42.75932 0,42.75932"
        id="path7061-6"
@@ -2904,7 +2904,7 @@
     <text
        inkscape:export-ydpi="180"
        inkscape:export-xdpi="180"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/F8_Tx_JESD_path.png"
+
        xml:space="preserve"
        style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0%;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;letter-spacing:0px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-anchor:start;display:inline;overflow:visible;visibility:visible;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;marker:none;enable-background:new"
        x="1451.8682"
@@ -2919,7 +2919,7 @@
     <text
        inkscape:export-ydpi="180"
        inkscape:export-xdpi="180"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/F8_Tx_JESD_path.png"
+
        transform="scale(0.85401764,1.170936)"
        id="text7088-2"
        y="583.37701"
@@ -2934,7 +2934,7 @@
     <text
        inkscape:export-ydpi="180"
        inkscape:export-xdpi="180"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/F8_Tx_JESD_path.png"
+
        xml:space="preserve"
        style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0%;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;letter-spacing:0px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-anchor:start;display:inline;overflow:visible;visibility:visible;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;marker:none;enable-background:new"
        x="1681.4634"
@@ -2949,7 +2949,7 @@
     <path
        inkscape:export-ydpi="180"
        inkscape:export-xdpi="180"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/F8_Tx_JESD_path.png"
+
        id="path7297-6"
        d="m 1174.4835,883.0106 5,-10 5,10 z"
        style="fill:none;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
@@ -2957,7 +2957,7 @@
     <use
        inkscape:export-ydpi="180"
        inkscape:export-xdpi="180"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/F8_Tx_JESD_path.png"
+
        height="1052.3622"
        width="744.09448"
        transform="translate(201.01558,0.10940217)"
@@ -2968,7 +2968,7 @@
     <path
        inkscape:export-ydpi="180"
        inkscape:export-xdpi="180"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/F8_Tx_JESD_path.png"
+
        id="path7331-5"
        d="m 1439.2608,900.598 h -58.8235 v -17.68504"
        style="fill:none;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
@@ -2976,7 +2976,7 @@
     <path
        inkscape:export-ydpi="180"
        inkscape:export-xdpi="180"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/F8_Tx_JESD_path.png"
+
        style="fill:none;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
        d="m 1646.1035,953.39438 h -466.752 v -69.8757"
        id="path7333-0"
@@ -2984,7 +2984,7 @@
     <path
        inkscape:export-ydpi="180"
        inkscape:export-xdpi="180"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/F8_Tx_JESD_path.png"
+
        style="fill:none;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
        d="m 1437.3122,900.66168 h 132.7172 v -54.24874"
        id="path7349-6"
@@ -2992,7 +2992,7 @@
     <path
        inkscape:export-ydpi="180"
        inkscape:export-xdpi="180"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/F8_Tx_JESD_path.png"
+
        style="fill:none;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:url(#Arrow2Lend-8-7)"
        d="m 1148.9348,774.82663 h -53.7253"
        id="path12437-0"
@@ -3000,14 +3000,14 @@
     <path
        inkscape:export-ydpi="180"
        inkscape:export-xdpi="180"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Tx_JESD_path.png"
+
        id="use12472-7"
        d="m 1266.8918,810.48945 6.5,-10.5"
        style="fill:none;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     <use
        inkscape:export-ydpi="180"
        inkscape:export-xdpi="180"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/F8_Tx_JESD_path.png"
+
        height="1488.189"
        width="1052.3622"
        transform="translate(-142.48202,28.637802)"
@@ -3018,7 +3018,7 @@
     <use
        inkscape:export-ydpi="180"
        inkscape:export-xdpi="180"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/F8_Tx_JESD_path.png"
+
        height="1488.189"
        width="1052.3622"
        transform="translate(374.31738,-29.344998)"
@@ -3029,7 +3029,7 @@
     <path
        inkscape:export-ydpi="180"
        inkscape:export-xdpi="180"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/F8_Tx_JESD_path.png"
+
        id="path12480-6"
        d="m 1297.9487,805.58577 h -46.6048"
        style="fill:none;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:url(#Arrow2Lend-8-7)"
@@ -3037,7 +3037,7 @@
     <path
        inkscape:export-ydpi="180"
        inkscape:export-xdpi="180"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/F8_Tx_JESD_path.png"
+
        id="path12484-6"
        d="m 1528.329,804.87866 h -47.2711"
        style="fill:none;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:url(#Arrow2Lend-8-7)"
@@ -3045,7 +3045,7 @@
     <path
        inkscape:export-ydpi="180"
        inkscape:export-xdpi="180"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/F8_Tx_JESD_path.png"
+
        style="fill:none;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:url(#Arrow2Lend-8-7)"
        d="m 1648.9632,804.87866 h -22.9485"
        id="path12486-7"
@@ -3053,7 +3053,7 @@
     <path
        inkscape:export-ydpi="180"
        inkscape:export-xdpi="180"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/F8_Tx_JESD_path.png"
+
        id="path12488-6"
        d="m 1148.9348,794.97911 h -53.7253"
        style="fill:none;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:url(#Arrow2Lend-8-7)"
@@ -3061,7 +3061,7 @@
     <path
        inkscape:export-ydpi="180"
        inkscape:export-xdpi="180"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/F8_Tx_JESD_path.png"
+
        style="fill:none;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:url(#Arrow2Lend-8-7)"
        d="m 1148.9348,815.13172 h -53.7253"
        id="path12490-2"
@@ -3069,7 +3069,7 @@
     <path
        inkscape:export-ydpi="180"
        inkscape:export-xdpi="180"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/F8_Tx_JESD_path.png"
+
        id="path12492-5"
        d="m 1148.9348,835.28426 h -53.7253"
        style="fill:none;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:url(#Arrow2Lend-8-7)"
@@ -3077,7 +3077,7 @@
     <text
        inkscape:export-ydpi="180"
        inkscape:export-xdpi="180"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/F8_Tx_JESD_path.png"
+
        xml:space="preserve"
        style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0%;font-family:sans-serif;-inkscape-font-specification:Sans;text-indent:0;text-align:center;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-anchor:middle;display:inline;overflow:visible;visibility:visible;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;marker:none;enable-background:accumulate"
        x="1140.7864"
@@ -3095,7 +3095,7 @@
        y="859.44617"
        id="text2242-8"
        transform="scale(0.90858178,1.1006164)"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/F8_Tx_JESD_path.png"
+
        inkscape:export-xdpi="180"
        inkscape:export-ydpi="180"><tspan
          sodipodi:role="line"
@@ -3106,7 +3106,7 @@
     <g
        inkscape:export-ydpi="180"
        inkscape:export-xdpi="180"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/F8_Tx_JESD_path.png"
+
        id="g3351-2"
        transform="matrix(0.65068191,0,0,0.7092071,1190.2609,633.93676)"
        style="stroke-width:1.47207">
@@ -3137,7 +3137,7 @@
     <path
        inkscape:export-ydpi="180"
        inkscape:export-xdpi="180"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/F8_Tx_JESD_path.png"
+
        style="fill:none;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
        d="M 1645.4916,925.98578 H 1321.3857 V 845.08889"
        id="path7333-5-7"
@@ -3145,7 +3145,7 @@
     <text
        inkscape:export-ydpi="180"
        inkscape:export-xdpi="180"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/F8_Tx_JESD_path.png"
+
        transform="scale(0.90858178,1.1006164)"
        id="text2950-1"
        y="835.49054"

--- a/docs/library/jesd204/generic_jesd_bds/jesd204_generic_rx_path.svg
+++ b/docs/library/jesd204/generic_jesd_bds/jesd204_generic_rx_path.svg
@@ -1123,7 +1123,7 @@
     <g
        id="g13582"
        transform="translate(131.56285,-380.53334)"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/generic_Tx_JESD_path.png"
+
        inkscape:export-xdpi="180"
        inkscape:export-ydpi="180" />
     <rect
@@ -1133,7 +1133,7 @@
        height="133.88882"
        x="1517.0769"
        y="-325.29602"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/generic_Rx_JESD_path.png"
+
        inkscape:export-xdpi="180"
        inkscape:export-ydpi="180" />
     <rect
@@ -1143,13 +1143,13 @@
        height="133.41664"
        x="1045.9352"
        y="-324.81519"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/generic_Rx_JESD_path.png"
+
        inkscape:export-xdpi="180"
        inkscape:export-ydpi="180" />
     <g
        id="g13642"
        transform="translate(1023.8412,-524.78312)"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/generic_Rx_JESD_path.png"
+
        inkscape:export-xdpi="180"
        inkscape:export-ydpi="180">
       <rect
@@ -1184,7 +1184,7 @@
     <g
        id="g13654"
        transform="translate(1126.7127,-510.49742)"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/generic_Rx_JESD_path.png"
+
        inkscape:export-xdpi="180"
        inkscape:export-ydpi="180">
       <rect
@@ -1214,7 +1214,7 @@
     <g
        transform="translate(1262.5204,-510.85102)"
        id="g13668"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/generic_Rx_JESD_path.png"
+
        inkscape:export-xdpi="180"
        inkscape:export-ydpi="180">
       <rect
@@ -1245,13 +1245,13 @@
        style="fill:none;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:url(#Arrow1Mend)"
        d="m 1312.8993,-335.45038 c 0,30.94571 0,30.94571 0,30.94571"
        id="path13686"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/generic_Rx_JESD_path.png"
+
        inkscape:export-xdpi="180"
        inkscape:export-ydpi="180" />
     <text
        inkscape:export-ydpi="180"
        inkscape:export-xdpi="180"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/generic_Rx_JESD_path.png"
+
        xml:space="preserve"
        style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0%;font-family:sans-serif;-inkscape-font-specification:Sans;text-indent:0;text-align:center;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-anchor:middle;display:inline;overflow:visible;visibility:visible;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
        x="1445.8877"
@@ -1266,20 +1266,20 @@
        style="fill:none;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
        d="m 1443.6974,-244.77397 6.5,-10.5"
        id="path13708"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/generic_Rx_JESD_path.png"
+
        inkscape:export-xdpi="180"
        inkscape:export-ydpi="180" />
     <path
        inkscape:export-ydpi="180"
        inkscape:export-xdpi="180"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Tx_JESD_path.png"
+
        style="fill:none;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
        d="m 1310.5616,-244.02399 6.5,-10.5"
        id="use13710" />
     <text
        inkscape:export-ydpi="180"
        inkscape:export-xdpi="180"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/generic_Rx_JESD_path.png"
+
        xml:space="preserve"
        style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0%;font-family:sans-serif;-inkscape-font-specification:Sans;text-indent:0;text-align:center;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-anchor:middle;display:inline;overflow:visible;visibility:visible;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
        x="1312.6587"
@@ -1293,7 +1293,7 @@
     <g
        inkscape:export-ydpi="180"
        inkscape:export-xdpi="180"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/generic_Tx_JESD_path.png"
+
        transform="translate(920.39177,58.63425)"
        id="use13732">
       <ellipse
@@ -1324,7 +1324,7 @@
     <g
        inkscape:export-ydpi="180"
        inkscape:export-xdpi="180"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/generic_Tx_JESD_path.png"
+
        transform="translate(1050.8918,58.63425)"
        id="use13734">
       <ellipse
@@ -1355,7 +1355,7 @@
     <path
        inkscape:export-ydpi="180"
        inkscape:export-xdpi="180"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/generic_Rx_JESD_path.png"
+
        id="path13736"
        d="m 1577.3572,-335.45038 c 0,30.94571 0,30.94571 0,30.94571"
        style="fill:none;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:url(#Arrow1Mend)" />
@@ -1365,7 +1365,7 @@
        x="1577.1166"
        style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0%;font-family:sans-serif;-inkscape-font-specification:Sans;text-indent:0;text-align:center;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-anchor:middle;display:inline;overflow:visible;visibility:visible;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
        xml:space="preserve"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/generic_Rx_JESD_path.png"
+
        inkscape:export-xdpi="180"
        inkscape:export-ydpi="180"><tspan
          style="font-size:13px;line-height:1.25;font-family:sans-serif"
@@ -1376,14 +1376,14 @@
     <path
        inkscape:export-ydpi="180"
        inkscape:export-xdpi="180"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/generic_Rx_JESD_path.png"
+
        id="path13742"
        d="m 1166.0637,-335.45038 c 0,30.94571 0,30.94571 0,30.94571"
        style="fill:none;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:url(#Arrow1Mend)" />
     <text
        inkscape:export-ydpi="180"
        inkscape:export-xdpi="180"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/generic_Rx_JESD_path.png"
+
        xml:space="preserve"
        style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0%;font-family:sans-serif;-inkscape-font-specification:Sans;text-indent:0;text-align:center;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-anchor:middle;display:inline;overflow:visible;visibility:visible;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
        x="1168.5891"
@@ -1397,7 +1397,7 @@
     <text
        inkscape:export-ydpi="180"
        inkscape:export-xdpi="180"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/generic_Rx_JESD_path.png"
+
        xml:space="preserve"
        style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0%;font-family:sans-serif;-inkscape-font-specification:Sans;text-indent:0;text-align:center;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-anchor:middle;display:inline;overflow:visible;visibility:visible;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
        x="1312.8302"
@@ -1411,7 +1411,7 @@
     <g
        transform="translate(786.89179,59.634253)"
        id="g13760"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/generic_Rx_JESD_path.png"
+
        inkscape:export-xdpi="180"
        inkscape:export-ydpi="180">
       <ellipse
@@ -1443,13 +1443,13 @@
        id="path13768"
        d="m 1138.878,-297.58273 h 45.2991"
        style="fill:none;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-start:url(#Arrow1Lstart);marker-end:none"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/generic_Rx_JESD_path.png"
+
        inkscape:export-xdpi="180"
        inkscape:export-ydpi="180" />
     <g
        inkscape:export-ydpi="180"
        inkscape:export-xdpi="180"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/generic_Tx_JESD_path.png"
+
        id="use13774"
        transform="translate(638.99556,55.573947)">
       <ellipse
@@ -1480,14 +1480,14 @@
     <path
        inkscape:export-ydpi="180"
        inkscape:export-xdpi="180"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Tx_JESD_path.png"
+
        style="fill:none;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
        d="m 1161.4509,-244.77399 6.5,-10.5"
        id="use13776" />
     <text
        inkscape:export-ydpi="180"
        inkscape:export-xdpi="180"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/generic_Rx_JESD_path.png"
+
        xml:space="preserve"
        style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0%;font-family:sans-serif;-inkscape-font-specification:Sans;text-indent:0;text-align:center;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-anchor:middle;display:inline;overflow:visible;visibility:visible;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
        x="1152.2772"
@@ -1504,7 +1504,7 @@
        x="1213.6975"
        style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0%;font-family:sans-serif;-inkscape-font-specification:Sans;text-indent:0;text-align:center;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-anchor:middle;display:inline;overflow:visible;visibility:visible;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
        xml:space="preserve"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/generic_Rx_JESD_path.png"
+
        inkscape:export-xdpi="180"
        inkscape:export-ydpi="180"><tspan
          style="font-size:13px;line-height:1.25;font-family:sans-serif"
@@ -1518,7 +1518,7 @@
        x="1578.1166"
        style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0%;font-family:sans-serif;-inkscape-font-specification:Sans;text-indent:0;text-align:center;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-anchor:middle;display:inline;overflow:visible;visibility:visible;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
        xml:space="preserve"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/generic_Rx_JESD_path.png"
+
        inkscape:export-xdpi="180"
        inkscape:export-ydpi="180"><tspan
          style="font-size:13px;line-height:1.25;font-family:sans-serif"
@@ -1530,13 +1530,13 @@
        id="path13790"
        d="m 1575.9264,-244.77397 6.5,-10.5"
        style="fill:none;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/generic_Rx_JESD_path.png"
+
        inkscape:export-xdpi="180"
        inkscape:export-ydpi="180" />
     <use
        inkscape:export-ydpi="180"
        inkscape:export-xdpi="180"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/generic_Rx_JESD_path.png"
+
        height="1488.189"
        width="2104.7244"
        transform="translate(0.5,32)"
@@ -1547,7 +1547,7 @@
     <use
        inkscape:export-ydpi="180"
        inkscape:export-xdpi="180"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/generic_Rx_JESD_path.png"
+
        height="1488.189"
        width="2104.7244"
        transform="translate(0,48)"
@@ -1558,7 +1558,7 @@
     <use
        inkscape:export-ydpi="180"
        inkscape:export-xdpi="180"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/generic_Rx_JESD_path.png"
+
        x="0"
        y="0"
        xlink:href="#path15771"
@@ -1569,7 +1569,7 @@
     <use
        inkscape:export-ydpi="180"
        inkscape:export-xdpi="180"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/generic_Rx_JESD_path.png"
+
        x="0"
        y="0"
        xlink:href="#path15771"
@@ -1580,7 +1580,7 @@
     <use
        inkscape:export-ydpi="180"
        inkscape:export-xdpi="180"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/generic_Rx_JESD_path.png"
+
        height="1488.189"
        width="2104.7244"
        transform="matrix(0.85420883,0,0,1,313.71546,0)"
@@ -1591,7 +1591,7 @@
     <use
        inkscape:export-ydpi="180"
        inkscape:export-xdpi="180"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/generic_Rx_JESD_path.png"
+
        height="1488.189"
        width="2104.7244"
        transform="matrix(0.84169995,0,0,1,464.7198,30.232233)"
@@ -1602,7 +1602,7 @@
     <use
        inkscape:export-ydpi="180"
        inkscape:export-xdpi="180"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/generic_Rx_JESD_path.png"
+
        height="1488.189"
        width="2104.7244"
        transform="matrix(0.84169995,0,0,1,464.29895,46.232233)"
@@ -1613,7 +1613,7 @@
     <use
        inkscape:export-ydpi="180"
        inkscape:export-xdpi="180"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/generic_Rx_JESD_path.png"
+
        x="0"
        y="0"
        xlink:href="#path15771"
@@ -1624,7 +1624,7 @@
     <use
        inkscape:export-ydpi="180"
        inkscape:export-xdpi="180"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/generic_Rx_JESD_path.png"
+
        x="0"
        y="0"
        xlink:href="#path13768"
@@ -1635,7 +1635,7 @@
     <use
        inkscape:export-ydpi="180"
        inkscape:export-xdpi="180"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/generic_Rx_JESD_path.png"
+
        x="0"
        y="0"
        xlink:href="#path13768"
@@ -1646,7 +1646,7 @@
     <use
        inkscape:export-ydpi="180"
        inkscape:export-xdpi="180"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/generic_Rx_JESD_path.png"
+
        height="1488.189"
        width="2104.7244"
        transform="matrix(0.85420883,0,0,1,584.53735,-1.7677669)"
@@ -1657,7 +1657,7 @@
     <path
        inkscape:export-ydpi="180"
        inkscape:export-xdpi="180"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/generic_Rx_JESD_path.png"
+
        style="fill:none;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-start:url(#Arrow1Lstart);marker-end:none"
        d="m 1138.878,-297.58273 h 45.2991"
        id="path15769" />
@@ -1665,13 +1665,13 @@
        id="path15771"
        d="m 1138.878,-297.58273 h 45.2991"
        style="fill:none;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-start:url(#Arrow1Lstart);marker-end:none"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/generic_Rx_JESD_path.png"
+
        inkscape:export-xdpi="180"
        inkscape:export-ydpi="180" />
     <g
        inkscape:export-ydpi="180"
        inkscape:export-xdpi="180"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/F8_Tx_JESD_path.png"
+
        id="g3351-2"
        transform="matrix(0.65068191,0,0,0.7092071,1440.7377,492.69043)"
        style="stroke-width:1.47207">
@@ -1693,7 +1693,7 @@
          x="154.46059"
          style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:15.7022px;line-height:0%;font-family:Sans;-inkscape-font-specification:'Sans, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-indent:0;text-align:center;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-anchor:middle;display:inline;overflow:visible;visibility:visible;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.47207;marker:none;enable-background:accumulate"
          xml:space="preserve"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/generic_Tx_JESD_path.png"
+
          inkscape:export-xdpi="180"
          inkscape:export-ydpi="180"
          transform="scale(1.044004,0.95785074)"><tspan
@@ -1708,7 +1708,7 @@
          x="-35.031052"
          style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:15.7022px;line-height:0%;font-family:Sans;-inkscape-font-specification:'Sans, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-indent:0;text-align:center;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-anchor:middle;display:inline;overflow:visible;visibility:visible;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.47207;marker:none;enable-background:accumulate"
          xml:space="preserve"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/generic_Tx_JESD_path.png"
+
          inkscape:export-xdpi="180"
          inkscape:export-ydpi="180"
          transform="scale(1.044004,0.95785074)"><tspan

--- a/docs/library/jesd204/generic_jesd_bds/jesd204_generic_rx_path_ex1.svg
+++ b/docs/library/jesd204/generic_jesd_bds/jesd204_generic_rx_path_ex1.svg
@@ -1122,13 +1122,13 @@
     <g
        id="g13582"
        transform="translate(131.56285,-380.53334)"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/generic_Tx_JESD_path.png"
+
        inkscape:export-xdpi="180"
        inkscape:export-ydpi="180" />
     <rect
        inkscape:export-ydpi="180"
        inkscape:export-xdpi="180"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Rx_JESD_path.png"
+
        y="19.545294"
        x="1528.7152"
        height="141.66699"
@@ -1138,7 +1138,7 @@
     <rect
        inkscape:export-ydpi="180"
        inkscape:export-xdpi="180"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Rx_JESD_path.png"
+
        y="19.318914"
        x="1150.9791"
        height="141.90192"
@@ -1148,7 +1148,7 @@
     <g
        inkscape:export-ydpi="180"
        inkscape:export-xdpi="180"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Rx_JESD_path.png"
+
        transform="matrix(0.51498307,0,0,0.51498307,1045.652,-28.696247)"
        id="g15777">
       <rect
@@ -1173,7 +1173,7 @@
     <g
        inkscape:export-ydpi="180"
        inkscape:export-xdpi="180"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Rx_JESD_path.png"
+
        transform="matrix(0.51498307,0,0,0.51498307,1045.652,-28.131587)"
        id="g15785">
       <rect
@@ -1198,7 +1198,7 @@
     <g
        inkscape:export-ydpi="180"
        inkscape:export-xdpi="180"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Rx_JESD_path.png"
+
        transform="matrix(0.51498307,0,0,0.51498307,1045.652,-27.566937)"
        id="g15793">
       <rect
@@ -1223,7 +1223,7 @@
     <g
        inkscape:export-ydpi="180"
        inkscape:export-xdpi="180"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Rx_JESD_path.png"
+
        transform="translate(1073.9307,-103.02509)"
        id="g15801">
       <rect
@@ -1248,7 +1248,7 @@
     <text
        inkscape:export-ydpi="180"
        inkscape:export-xdpi="180"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Rx_JESD_path.png"
+
        xml:space="preserve"
        style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0%;font-family:sans-serif;-inkscape-font-specification:Sans;text-indent:0;text-align:center;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-anchor:middle;display:inline;overflow:visible;visibility:visible;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;marker:none;enable-background:accumulate"
        x="1085.6307"
@@ -1262,7 +1262,7 @@
     <text
        inkscape:export-ydpi="180"
        inkscape:export-xdpi="180"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Rx_JESD_path.png"
+
        xml:space="preserve"
        style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0%;font-family:sans-serif;-inkscape-font-specification:Sans;text-indent:0;text-align:center;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-anchor:middle;display:inline;overflow:visible;visibility:visible;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;marker:none;enable-background:accumulate"
        x="1113.671"
@@ -1276,7 +1276,7 @@
     <g
        inkscape:export-ydpi="180"
        inkscape:export-xdpi="180"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Rx_JESD_path.png"
+
        transform="translate(1035.4796,-172.16372)"
        id="g15817">
       <rect
@@ -1311,7 +1311,7 @@
     <g
        inkscape:export-ydpi="180"
        inkscape:export-xdpi="180"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Rx_JESD_path.png"
+
        transform="translate(1138.3511,-157.87801)"
        id="g15829">
       <rect
@@ -1341,7 +1341,7 @@
     <text
        inkscape:export-ydpi="180"
        inkscape:export-xdpi="180"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Rx_JESD_path.png"
+
        xml:space="preserve"
        style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0%;font-family:sans-serif;-inkscape-font-specification:Sans;text-indent:0;text-align:center;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-anchor:middle;display:inline;overflow:visible;visibility:visible;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
        x="1322.4686"
@@ -1355,7 +1355,7 @@
     <g
        inkscape:export-ydpi="180"
        inkscape:export-xdpi="180"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Rx_JESD_path.png"
+
        id="g15843"
        transform="translate(1274.1587,-158.23156)">
       <rect
@@ -1385,7 +1385,7 @@
     <text
        inkscape:export-ydpi="180"
        inkscape:export-xdpi="180"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Rx_JESD_path.png"
+
        xml:space="preserve"
        style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0%;font-family:sans-serif;-inkscape-font-specification:Sans;text-indent:0;text-align:center;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-anchor:middle;display:inline;overflow:visible;visibility:visible;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;marker:none;enable-background:accumulate"
        x="1174.4183"
@@ -1399,7 +1399,7 @@
     <path
        inkscape:export-ydpi="180"
        inkscape:export-xdpi="180"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/F8_Tx_JESD_path.png"
+
        id="use15865"
        d="m 1279.1598,159.74406 5,-10 5,10 z"
        style="fill:none;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
@@ -1407,7 +1407,7 @@
     <g
        id="g15871"
        transform="matrix(0.51498307,0,0,0.51498307,1226.9946,-98.053647)"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Rx_JESD_path.png"
+
        inkscape:export-xdpi="180"
        inkscape:export-ydpi="180">
       <rect
@@ -1432,7 +1432,7 @@
     <g
        id="g15879"
        transform="matrix(0.51498307,0,0,0.51498307,1226.9946,-97.488987)"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Rx_JESD_path.png"
+
        inkscape:export-xdpi="180"
        inkscape:export-ydpi="180">
       <rect
@@ -1457,7 +1457,7 @@
     <g
        id="g15887"
        transform="matrix(0.51498307,0,0,0.51498307,1226.9946,-96.924337)"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Rx_JESD_path.png"
+
        inkscape:export-xdpi="180"
        inkscape:export-ydpi="180">
       <rect
@@ -1482,7 +1482,7 @@
     <g
        id="g15895"
        transform="translate(1255.2734,-172.38249)"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Rx_JESD_path.png"
+
        inkscape:export-xdpi="180"
        inkscape:export-ydpi="180">
       <rect
@@ -1507,7 +1507,7 @@
     <g
        inkscape:export-ydpi="180"
        inkscape:export-xdpi="180"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Rx_JESD_path.png"
+
        transform="matrix(0.51498307,0,0,0.51498307,1262.8479,-97.921067)"
        id="g15903">
       <rect
@@ -1532,7 +1532,7 @@
     <g
        inkscape:export-ydpi="180"
        inkscape:export-xdpi="180"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Rx_JESD_path.png"
+
        transform="matrix(0.51498307,0,0,0.51498307,1262.8479,-97.356407)"
        id="g15911">
       <rect
@@ -1557,7 +1557,7 @@
     <g
        inkscape:export-ydpi="180"
        inkscape:export-xdpi="180"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Rx_JESD_path.png"
+
        transform="matrix(0.51498307,0,0,0.51498307,1262.8479,-96.791747)"
        id="g15919">
       <rect
@@ -1582,7 +1582,7 @@
     <g
        inkscape:export-ydpi="180"
        inkscape:export-xdpi="180"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Rx_JESD_path.png"
+
        transform="translate(1291.1267,-172.24991)"
        id="g15927">
       <rect
@@ -1607,7 +1607,7 @@
     <g
        id="g15935"
        transform="matrix(0.51498307,0,0,0.51498307,1045.652,29.745223)"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Rx_JESD_path.png"
+
        inkscape:export-xdpi="180"
        inkscape:export-ydpi="180">
       <rect
@@ -1632,7 +1632,7 @@
     <g
        id="g15943"
        transform="matrix(0.51498307,0,0,0.51498307,1045.652,30.309883)"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Rx_JESD_path.png"
+
        inkscape:export-xdpi="180"
        inkscape:export-ydpi="180">
       <rect
@@ -1657,7 +1657,7 @@
     <g
        id="g15951"
        transform="matrix(0.51498307,0,0,0.51498307,1045.652,30.874533)"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Rx_JESD_path.png"
+
        inkscape:export-xdpi="180"
        inkscape:export-ydpi="180">
       <rect
@@ -1682,7 +1682,7 @@
     <g
        id="g15959"
        transform="translate(1073.9307,-44.583617)"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Rx_JESD_path.png"
+
        inkscape:export-xdpi="180"
        inkscape:export-ydpi="180">
       <rect
@@ -1707,21 +1707,21 @@
     <path
        inkscape:export-ydpi="180"
        inkscape:export-xdpi="180"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Rx_JESD_path.png"
+
        style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:none;stroke:#37abc8;stroke-width:3.19263;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:3.19263, 3.19263;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:new"
        d="m 1286.9727,-61.477117 c 0,73.61749 0,73.61749 0,73.61749"
        id="path15967" />
     <path
        inkscape:export-ydpi="180"
        inkscape:export-xdpi="180"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Rx_JESD_path.png"
+
        id="path15969"
        d="m 1361.687,-62.235317 c 0,73.13389 0,73.13389 0,73.13389"
        style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:none;stroke:#37abc8;stroke-width:3.19263;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:3.19263, 3.19263;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:new" />
     <text
        inkscape:export-ydpi="180"
        inkscape:export-xdpi="180"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Rx_JESD_path.png"
+
        transform="scale(0.85401764,1.170936)"
        id="text15971"
        y="-65.886101"
@@ -1739,7 +1739,7 @@
        x="1265.6508"
        style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0%;font-family:sans-serif;-inkscape-font-specification:Sans;text-indent:0;text-align:center;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-anchor:middle;display:inline;overflow:visible;visibility:visible;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;marker:none;enable-background:accumulate"
        xml:space="preserve"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Rx_JESD_path.png"
+
        inkscape:export-xdpi="180"
        inkscape:export-ydpi="180"><tspan
          style="font-size:10.2997px;line-height:1.25;font-family:sans-serif"
@@ -1750,7 +1750,7 @@
     <text
        inkscape:export-ydpi="180"
        inkscape:export-xdpi="180"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Rx_JESD_path.png"
+
        xml:space="preserve"
        style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0%;font-family:sans-serif;-inkscape-font-specification:Sans;text-indent:0;text-align:center;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-anchor:middle;display:inline;overflow:visible;visibility:visible;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;marker:none;enable-background:accumulate"
        x="1265.6406"
@@ -1767,7 +1767,7 @@
        x="1265.6406"
        style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0%;font-family:sans-serif;-inkscape-font-specification:Sans;text-indent:0;text-align:center;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-anchor:middle;display:inline;overflow:visible;visibility:visible;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;marker:none;enable-background:accumulate"
        xml:space="preserve"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Rx_JESD_path.png"
+
        inkscape:export-xdpi="180"
        inkscape:export-ydpi="180"><tspan
          style="font-size:10.2997px;line-height:1.25;font-family:sans-serif"
@@ -1778,7 +1778,7 @@
     <text
        inkscape:export-ydpi="180"
        inkscape:export-xdpi="180"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Rx_JESD_path.png"
+
        xml:space="preserve"
        style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0%;font-family:sans-serif;-inkscape-font-specification:Sans;text-indent:0;text-align:center;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-anchor:middle;display:inline;overflow:visible;visibility:visible;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;marker:none;enable-background:accumulate"
        x="1265.6406"
@@ -1792,7 +1792,7 @@
     <text
        inkscape:export-ydpi="180"
        inkscape:export-xdpi="180"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Rx_JESD_path.png"
+
        xml:space="preserve"
        style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0%;font-family:sans-serif;-inkscape-font-specification:Sans;text-indent:0;text-align:center;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-anchor:middle;display:inline;overflow:visible;visibility:visible;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;marker:none;enable-background:accumulate"
        x="1307.1508"
@@ -1814,7 +1814,7 @@
        x="1306.4008"
        style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0%;font-family:sans-serif;-inkscape-font-specification:Sans;text-indent:0;text-align:center;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-anchor:middle;display:inline;overflow:visible;visibility:visible;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;marker:none;enable-background:accumulate"
        xml:space="preserve"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Rx_JESD_path.png"
+
        inkscape:export-xdpi="180"
        inkscape:export-ydpi="180"><tspan
          style="font-size:10.2997px;line-height:1.25;font-family:sans-serif"
@@ -1825,7 +1825,7 @@
     <text
        inkscape:export-ydpi="180"
        inkscape:export-xdpi="180"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Rx_JESD_path.png"
+
        xml:space="preserve"
        style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0%;font-family:sans-serif;-inkscape-font-specification:Sans;text-indent:0;text-align:center;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-anchor:middle;display:inline;overflow:visible;visibility:visible;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;marker:none;enable-background:accumulate"
        x="1228.6508"
@@ -1842,7 +1842,7 @@
        x="1341.1508"
        style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0%;font-family:sans-serif;-inkscape-font-specification:Sans;text-indent:0;text-align:center;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-anchor:middle;display:inline;overflow:visible;visibility:visible;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;marker:none;enable-background:accumulate"
        xml:space="preserve"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Rx_JESD_path.png"
+
        inkscape:export-xdpi="180"
        inkscape:export-ydpi="180"><tspan
          style="font-size:10.2997px;line-height:1.25;font-family:sans-serif"
@@ -1858,7 +1858,7 @@
     <path
        inkscape:export-ydpi="180"
        inkscape:export-xdpi="180"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Rx_JESD_path.png"
+
        id="path16011"
        d="m 1324.5376,17.169033 c 0,30.94571 0,30.94571 0,30.94571"
        style="fill:none;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:url(#Arrow1Mend)" />
@@ -1868,7 +1868,7 @@
        x="1455.526"
        style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0%;font-family:sans-serif;-inkscape-font-specification:Sans;text-indent:0;text-align:center;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-anchor:middle;display:inline;overflow:visible;visibility:visible;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
        xml:space="preserve"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Rx_JESD_path.png"
+
        inkscape:export-xdpi="180"
        inkscape:export-ydpi="180"><tspan
          style="font-size:13px;line-height:1.25;font-family:sans-serif"
@@ -1879,112 +1879,112 @@
     <path
        inkscape:export-ydpi="180"
        inkscape:export-xdpi="180"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Rx_JESD_path.png"
+
        style="fill:none;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:url(#Arrow2Lend-8)"
        d="m 1194.0204,75.350393 h -35.5351"
        id="path16019" />
     <path
        inkscape:export-ydpi="180"
        inkscape:export-xdpi="180"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Rx_JESD_path.png"
+
        id="path16021"
        d="m 1336.0649,55.036683 h -38.2991"
        style="fill:none;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:url(#Arrow2Lend-8)" />
     <path
        inkscape:export-ydpi="180"
        inkscape:export-xdpi="180"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Tx_JESD_path.png"
+
        style="fill:none;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#Arrow2Lend-8)"
        d="m 1336.0649,102.41285 h -38.2991"
        id="use16023" />
     <path
        inkscape:export-ydpi="180"
        inkscape:export-xdpi="180"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Tx_JESD_path.png"
+
        style="fill:none;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#Arrow2Lend-8)"
        d="m 1336.0649,86.620767 h -38.2991"
        id="use16025" />
     <path
        inkscape:export-ydpi="180"
        inkscape:export-xdpi="180"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Tx_JESD_path.png"
+
        style="fill:none;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#Arrow2Lend-8)"
        d="m 1336.0649,70.828744 h -38.2991"
        id="use16027" />
     <path
        inkscape:export-ydpi="180"
        inkscape:export-xdpi="180"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Rx_JESD_path.png"
+
        style="fill:none;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:url(#Arrow2Lend-8)"
        d="m 1472.1829,55.036683 h -38.2991"
        id="path16029" />
     <path
        inkscape:export-ydpi="180"
        inkscape:export-xdpi="180"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Tx_JESD_path.png"
+
        style="fill:none;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:url(#Arrow2Lend-8)"
        d="m 1472.1829,102.41285 h -38.2991"
        id="use16031" />
     <path
        inkscape:export-ydpi="180"
        inkscape:export-xdpi="180"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Tx_JESD_path.png"
+
        style="fill:none;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#Arrow2Lend-8)"
        d="m 1472.1829,86.620767 h -38.2991"
        id="use16033" />
     <path
        inkscape:export-ydpi="180"
        inkscape:export-xdpi="180"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Tx_JESD_path.png"
+
        style="fill:none;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#Arrow2Lend-8)"
        d="m 1472.183,70.828744 h -38.2991"
        id="use16035" />
     <path
        inkscape:export-ydpi="180"
        inkscape:export-xdpi="180"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Tx_JESD_path.png"
+
        style="fill:none;stroke:#000000;stroke-width:0.853768px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:url(#Arrow2Lend-8)"
        d="m 1596.748,102.41285 h -27.917"
        id="use16037" />
     <path
        inkscape:export-ydpi="180"
        inkscape:export-xdpi="180"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Tx_JESD_path.png"
+
        style="fill:none;stroke:#000000;stroke-width:0.853768px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#Arrow2Lend-8)"
        d="m 1596.748,86.620767 h -27.917"
        id="use16039" />
     <path
        inkscape:export-ydpi="180"
        inkscape:export-xdpi="180"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Tx_JESD_path.png"
+
        style="fill:none;stroke:#000000;stroke-width:0.853768px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#Arrow2Lend-8)"
        d="m 1596.748,70.828744 h -27.917"
        id="use16041" />
     <path
        inkscape:export-ydpi="180"
        inkscape:export-xdpi="180"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Rx_JESD_path.png"
+
        style="fill:none;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
        d="m 1177.9073,80.975393 6.5,-10.5"
        id="path16043" />
     <path
        inkscape:export-ydpi="180"
        inkscape:export-xdpi="180"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Rx_JESD_path.png"
+
        id="path16045"
        d="m 1453.3358,107.84544 6.5,-10.5"
        style="fill:none;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     <path
        inkscape:export-ydpi="180"
        inkscape:export-xdpi="180"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Tx_JESD_path.png"
+
        style="fill:none;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
        d="m 1319.45,107.84545 6.5,-10.500003"
        id="use16047" />
     <path
        inkscape:export-ydpi="180"
        inkscape:export-xdpi="180"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Tx_JESD_path.png"
+
        style="fill:none;stroke:#000000;stroke-width:0.853768px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#Arrow2Lend-8)"
        d="m 1597.2784,53.327844 h -27.917"
        id="use16049" />
@@ -1994,7 +1994,7 @@
        x="1181.4895"
        style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0%;font-family:sans-serif;-inkscape-font-specification:Sans;text-indent:0;text-align:center;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-anchor:middle;display:inline;overflow:visible;visibility:visible;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;marker:none;enable-background:accumulate"
        xml:space="preserve"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Rx_JESD_path.png"
+
        inkscape:export-xdpi="180"
        inkscape:export-ydpi="180"><tspan
          style="font-size:13px;line-height:1.25;font-family:sans-serif"
@@ -2005,7 +2005,7 @@
     <g
        inkscape:export-ydpi="180"
        inkscape:export-xdpi="180"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/F8_Tx_JESD_path.png"
+
        id="g3351-2"
        transform="matrix(0.65068191,0,0,0.7092071,1190.2609,633.93676)"
        style="stroke-width:1.47207" />
@@ -2026,7 +2026,7 @@
        x="1555.9996"
        style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:10.6667px;line-height:0%;font-family:Sans;-inkscape-font-specification:'Sans, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-indent:0;text-align:center;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-anchor:middle;display:inline;overflow:visible;visibility:visible;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.999999;marker:none;enable-background:accumulate"
        xml:space="preserve"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/generic_Tx_JESD_path.png"
+
        inkscape:export-xdpi="180"
        inkscape:export-ydpi="180"><tspan
          style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:10.6667px;line-height:1.25;font-family:Sans;-inkscape-font-specification:'Sans, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;stroke-width:0.999999"
@@ -2040,7 +2040,7 @@
        x="1427.2753"
        style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:10.6667px;line-height:0%;font-family:Sans;-inkscape-font-specification:'Sans, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-indent:0;text-align:center;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-anchor:middle;display:inline;overflow:visible;visibility:visible;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.999999;marker:none;enable-background:accumulate"
        xml:space="preserve"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/generic_Tx_JESD_path.png"
+
        inkscape:export-xdpi="180"
        inkscape:export-ydpi="180"><tspan
          style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:10.6667px;line-height:1.25;font-family:Sans;-inkscape-font-specification:'Sans, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;stroke-width:0.999999"

--- a/docs/library/jesd204/generic_jesd_bds/jesd204_generic_tx_f8.svg
+++ b/docs/library/jesd204/generic_jesd_bds/jesd204_generic_tx_f8.svg
@@ -2285,7 +2285,7 @@
     <rect
        inkscape:export-ydpi="180"
        inkscape:export-xdpi="180"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/F8_Tx_JESD_path.png"
+
        y="738.17981"
        x="178.95473"
        height="142.49365"
@@ -2295,7 +2295,7 @@
     <rect
        inkscape:export-ydpi="180"
        inkscape:export-xdpi="180"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/F8_Tx_JESD_path.png"
+
        y="739.00647"
        x="643.77094"
        height="141.66699"
@@ -2305,7 +2305,7 @@
     <rect
        inkscape:export-ydpi="180"
        inkscape:export-xdpi="180"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/F8_Tx_JESD_path.png"
+
        y="738.78015"
        x="422.04755"
        height="141.90192"
@@ -2315,7 +2315,7 @@
     <g
        inkscape:export-ydpi="180"
        inkscape:export-xdpi="180"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/F8_Tx_JESD_path.png"
+
        transform="matrix(0.51498307,0,0,0.51498307,61.864334,704.9376)"
        id="g3019">
       <rect
@@ -2340,7 +2340,7 @@
     <g
        inkscape:export-ydpi="180"
        inkscape:export-xdpi="180"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/F8_Tx_JESD_path.png"
+
        transform="matrix(0.51498307,0,0,0.51498307,61.864334,713.50226)"
        id="g3024">
       <rect
@@ -2365,7 +2365,7 @@
     <g
        inkscape:export-ydpi="180"
        inkscape:export-xdpi="180"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/F8_Tx_JESD_path.png"
+
        transform="matrix(0.51498307,0,0,0.51498307,61.864334,722.06691)"
        id="g3029">
       <rect
@@ -2390,7 +2390,7 @@
     <g
        inkscape:export-ydpi="180"
        inkscape:export-xdpi="180"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/F8_Tx_JESD_path.png"
+
        transform="translate(90.143124,654.60876)"
        id="g7286">
       <rect
@@ -2415,7 +2415,7 @@
     <text
        inkscape:export-ydpi="180"
        inkscape:export-xdpi="180"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/F8_Tx_JESD_path.png"
+
        xml:space="preserve"
        style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0%;font-family:sans-serif;-inkscape-font-specification:Sans;text-indent:0;text-align:center;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-anchor:middle;display:inline;overflow:visible;visibility:visible;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;marker:none;enable-background:accumulate"
        x="105.72659"
@@ -2429,7 +2429,7 @@
     <text
        inkscape:export-ydpi="180"
        inkscape:export-xdpi="180"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/F8_Tx_JESD_path.png"
+
        xml:space="preserve"
        style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0%;font-family:sans-serif;-inkscape-font-specification:Sans;text-indent:0;text-align:center;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-anchor:middle;display:inline;overflow:visible;visibility:visible;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;marker:none;enable-background:accumulate"
        x="139.37346"
@@ -2443,7 +2443,7 @@
     <g
        inkscape:export-ydpi="180"
        inkscape:export-xdpi="180"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/F8_Tx_JESD_path.png"
+
        transform="translate(83.714354,633.01177)"
        id="g7155">
       <g
@@ -2560,7 +2560,7 @@
     <g
        inkscape:export-ydpi="180"
        inkscape:export-xdpi="180"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/F8_Tx_JESD_path.png"
+
        id="g6810"
        transform="matrix(0.50168154,0,0,0.50168154,370.56336,652.01622)">
       <rect
@@ -2585,7 +2585,7 @@
     <g
        inkscape:export-ydpi="180"
        inkscape:export-xdpi="180"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/F8_Tx_JESD_path.png"
+
        id="g6818"
        transform="matrix(0.50168154,0,0,0.50168154,404.44174,638.3333)">
       <rect
@@ -2610,7 +2610,7 @@
     <g
        inkscape:export-ydpi="180"
        inkscape:export-xdpi="180"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/F8_Tx_JESD_path.png"
+
        id="g6826"
        transform="matrix(0.50168154,0,0,0.50168154,443.42508,624.65038)">
       <rect
@@ -2635,7 +2635,7 @@
     <g
        inkscape:export-ydpi="180"
        inkscape:export-xdpi="180"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/F8_Tx_JESD_path.png"
+
        id="g6834"
        transform="matrix(0.50168154,0,0,0.50168154,477.50569,610.96744)">
       <rect
@@ -2660,7 +2660,7 @@
     <g
        inkscape:export-ydpi="180"
        inkscape:export-xdpi="180"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/F8_Tx_JESD_path.png"
+
        transform="translate(58.000064,547.29748)"
        id="g3416">
       <rect
@@ -2695,7 +2695,7 @@
     <g
        inkscape:export-ydpi="180"
        inkscape:export-xdpi="180"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/F8_Tx_JESD_path.png"
+
        transform="translate(303.00006,561.58319)"
        id="g3367">
       <rect
@@ -2725,7 +2725,7 @@
     <text
        inkscape:export-ydpi="180"
        inkscape:export-xdpi="180"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/F8_Tx_JESD_path.png"
+
        id="text3385"
        y="826.19659"
        x="344.0816"
@@ -2739,7 +2739,7 @@
     <g
        inkscape:export-ydpi="180"
        inkscape:export-xdpi="180"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/F8_Tx_JESD_path.png"
+
        id="g3393"
        transform="translate(398.4069,561.58319)">
       <rect
@@ -2769,7 +2769,7 @@
     <text
        inkscape:export-ydpi="180"
        inkscape:export-xdpi="180"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/F8_Tx_JESD_path.png"
+
        id="text3407"
        y="823.33942"
        x="575.2027"
@@ -2783,7 +2783,7 @@
     <text
        inkscape:export-ydpi="180"
        inkscape:export-xdpi="180"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/F8_Tx_JESD_path.png"
+
        xml:space="preserve"
        style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0%;font-family:sans-serif;-inkscape-font-specification:Sans;text-indent:0;text-align:center;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-anchor:middle;display:inline;overflow:visible;visibility:visible;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
        x="196.23164"
@@ -2797,7 +2797,7 @@
     <text
        inkscape:export-ydpi="180"
        inkscape:export-xdpi="180"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/F8_Tx_JESD_path.png"
+
        transform="scale(0.90858178,1.1006164)"
        id="text6100-4"
        y="796.84979"
@@ -2812,7 +2812,7 @@
     <text
        inkscape:export-ydpi="180"
        inkscape:export-xdpi="180"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/F8_Tx_JESD_path.png"
+
        transform="scale(0.88126178,1.1347366)"
        id="text6100"
        y="772.09167"
@@ -2827,7 +2827,7 @@
     <text
        inkscape:export-ydpi="180"
        inkscape:export-xdpi="180"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/F8_Tx_JESD_path.png"
+
        transform="scale(0.9389331,1.0650386)"
        id="text6100-0"
        y="821.14813"
@@ -2842,7 +2842,7 @@
     <path
        inkscape:export-ydpi="180"
        inkscape:export-xdpi="180"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/F8_Tx_JESD_path.png"
+
        id="path6616"
        d="m 342.00786,719.65967 c 0,42.75932 0,42.75932 0,42.75932"
        style="fill:none;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:url(#Arrow1Mend)"
@@ -2850,7 +2850,7 @@
     <path
        inkscape:export-ydpi="180"
        inkscape:export-xdpi="180"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/F8_Tx_JESD_path.png"
+
        style="fill:none;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:url(#Arrow1Mend)"
        d="m 459.23647,720.83443 c 0,42.75932 0,42.75932 0,42.75932"
        id="path6842"
@@ -2858,7 +2858,7 @@
     <path
        inkscape:export-ydpi="180"
        inkscape:export-xdpi="180"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/F8_Tx_JESD_path.png"
+
        style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:none;stroke:#37abc8;stroke-width:3.19263;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:3.19263, 3.19263;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:new"
        d="m 430.22214,676.17535 c 0,42.75932 0,42.75932 0,42.75932"
        id="path6844"
@@ -2866,7 +2866,7 @@
     <path
        inkscape:export-ydpi="180"
        inkscape:export-xdpi="180"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/F8_Tx_JESD_path.png"
+
        id="path7055"
        d="m 500.93643,676.17535 c 0,42.75932 0,42.75932 0,42.75932"
        style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:none;stroke:#37abc8;stroke-width:3.19263;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:3.19263, 3.19263;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:new"
@@ -2874,7 +2874,7 @@
     <path
        inkscape:export-ydpi="180"
        inkscape:export-xdpi="180"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/F8_Tx_JESD_path.png"
+
        style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:none;stroke:#37abc8;stroke-width:3.19263;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:3.19263, 3.19263;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:new"
        d="m 573.79357,676.17535 c 0,42.75932 0,42.75932 0,42.75932"
        id="path7057"
@@ -2882,7 +2882,7 @@
     <path
        inkscape:export-ydpi="180"
        inkscape:export-xdpi="180"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/F8_Tx_JESD_path.png"
+
        id="path7059"
        d="m 273.07928,676.17535 c 0,42.75932 0,42.75932 0,42.75932"
        style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:none;stroke:#000080;stroke-width:3.20984;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:3.20984, 3.20984;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:new"
@@ -2890,7 +2890,7 @@
     <path
        inkscape:export-ydpi="180"
        inkscape:export-xdpi="180"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/F8_Tx_JESD_path.png"
+
        style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:none;stroke:#000080;stroke-width:3.20984;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:3.20984, 3.20984;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:new"
        d="m 412.365,676.88964 c 0,42.75932 0,42.75932 0,42.75932"
        id="path7061"
@@ -2898,7 +2898,7 @@
     <text
        inkscape:export-ydpi="180"
        inkscape:export-xdpi="180"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/F8_Tx_JESD_path.png"
+
        xml:space="preserve"
        style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0%;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;letter-spacing:0px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-anchor:start;display:inline;overflow:visible;visibility:visible;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;marker:none;enable-background:new"
        x="360.72455"
@@ -2913,7 +2913,7 @@
     <text
        inkscape:export-ydpi="180"
        inkscape:export-xdpi="180"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/F8_Tx_JESD_path.png"
+
        transform="scale(0.85401764,1.170936)"
        id="text7088"
        y="579.72858"
@@ -2928,7 +2928,7 @@
     <text
        inkscape:export-ydpi="180"
        inkscape:export-xdpi="180"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/F8_Tx_JESD_path.png"
+
        xml:space="preserve"
        style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0%;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;letter-spacing:0px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-anchor:start;display:inline;overflow:visible;visibility:visible;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;marker:none;enable-background:new"
        x="590.31989"
@@ -2943,7 +2943,7 @@
     <path
        inkscape:export-ydpi="180"
        inkscape:export-xdpi="180"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/F8_Tx_JESD_path.png"
+
        id="path7297"
        d="m 242.62766,878.73853 5,-10 5,10 z"
        style="fill:none;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
@@ -2951,7 +2951,7 @@
     <use
        inkscape:export-ydpi="180"
        inkscape:export-xdpi="180"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/F8_Tx_JESD_path.png"
+
        height="1052.3622"
        width="744.09448"
        transform="translate(201.01562,0.10937058)"
@@ -2962,7 +2962,7 @@
     <path
        inkscape:export-ydpi="180"
        inkscape:export-xdpi="180"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/F8_Tx_JESD_path.png"
+
        id="path7331"
        d="M 507.40493,896.32593 H 448.58147 V 878.64089"
        style="fill:none;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
@@ -2970,7 +2970,7 @@
     <path
        inkscape:export-ydpi="180"
        inkscape:export-xdpi="180"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/F8_Tx_JESD_path.png"
+
        style="fill:none;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
        d="M 714.2476,949.12231 H 247.49567 v -69.8757"
        id="path7333"
@@ -2978,7 +2978,7 @@
     <path
        inkscape:export-ydpi="180"
        inkscape:export-xdpi="180"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/F8_Tx_JESD_path.png"
+
        style="fill:none;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
        d="m 505.45636,896.38961 h 132.7172 v -54.24874"
        id="path7349"
@@ -2986,7 +2986,7 @@
     <path
        inkscape:export-ydpi="180"
        inkscape:export-xdpi="180"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/F8_Tx_JESD_path.png"
+
        style="fill:none;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:url(#Arrow2Lend-8)"
        d="m 167.7231,770.55456 h 47.81609"
        id="path12437"
@@ -2994,14 +2994,14 @@
     <path
        inkscape:export-ydpi="180"
        inkscape:export-xdpi="180"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Tx_JESD_path.png"
+
        id="use12472"
        d="m 335.03588,806.21734 6.5,-10.5"
        style="fill:none;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     <use
        inkscape:export-ydpi="180"
        inkscape:export-xdpi="180"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/F8_Tx_JESD_path.png"
+
        height="1488.189"
        width="1052.3622"
        transform="translate(-142.48202,28.637821)"
@@ -3012,7 +3012,7 @@
     <use
        inkscape:export-ydpi="180"
        inkscape:export-xdpi="180"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/F8_Tx_JESD_path.png"
+
        height="1488.189"
        width="1052.3622"
        transform="translate(374.31735,-29.344939)"
@@ -3023,7 +3023,7 @@
     <path
        inkscape:export-ydpi="180"
        inkscape:export-xdpi="180"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/F8_Tx_JESD_path.png"
+
        id="path12480"
        d="m 318.16001,801.3137 h 46.60483"
        style="fill:none;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:url(#Arrow2Lend-8)"
@@ -3031,7 +3031,7 @@
     <path
        inkscape:export-ydpi="180"
        inkscape:export-xdpi="180"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/F8_Tx_JESD_path.png"
+
        id="path12484"
        d="m 547.874,800.60659 h 47.27115"
        style="fill:none;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:url(#Arrow2Lend-8)"
@@ -3039,7 +3039,7 @@
     <path
        inkscape:export-ydpi="180"
        inkscape:export-xdpi="180"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/F8_Tx_JESD_path.png"
+
        style="fill:none;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:url(#Arrow2Lend-8)"
        d="m 692.83087,800.60659 h 22.9485"
        id="path12486"
@@ -3047,7 +3047,7 @@
     <path
        inkscape:export-ydpi="180"
        inkscape:export-xdpi="180"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/F8_Tx_JESD_path.png"
+
        id="path12488"
        d="m 167.7231,790.70704 h 47.81609"
        style="fill:none;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:url(#Arrow2Lend-8)"
@@ -3055,7 +3055,7 @@
     <path
        inkscape:export-ydpi="180"
        inkscape:export-xdpi="180"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/F8_Tx_JESD_path.png"
+
        style="fill:none;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:url(#Arrow2Lend-8)"
        d="m 167.7231,810.85965 h 47.81609"
        id="path12490"
@@ -3063,7 +3063,7 @@
     <path
        inkscape:export-ydpi="180"
        inkscape:export-xdpi="180"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/F8_Tx_JESD_path.png"
+
        id="path12492"
        d="m 167.7231,831.01219 h 47.81609"
        style="fill:none;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:url(#Arrow2Lend-8)"
@@ -3071,7 +3071,7 @@
     <text
        inkscape:export-ydpi="180"
        inkscape:export-xdpi="180"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/F8_Tx_JESD_path.png"
+
        xml:space="preserve"
        style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0%;font-family:sans-serif;-inkscape-font-specification:Sans;text-indent:0;text-align:center;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-anchor:middle;display:inline;overflow:visible;visibility:visible;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;marker:none;enable-background:accumulate"
        x="208.93053"
@@ -3085,7 +3085,7 @@
     <g
        id="g13582"
        transform="translate(131.56285,-380.53334)"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/generic_Tx_JESD_path.png"
+
        inkscape:export-xdpi="180"
        inkscape:export-ydpi="180" />
     <text
@@ -3095,7 +3095,7 @@
        y="855.56464"
        id="text2242"
        transform="scale(0.90858178,1.1006164)"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/F8_Tx_JESD_path.png"
+
        inkscape:export-xdpi="180"
        inkscape:export-ydpi="180"><tspan
          sodipodi:role="line"
@@ -3106,7 +3106,7 @@
     <g
        inkscape:export-ydpi="180"
        inkscape:export-xdpi="180"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/F8_Tx_JESD_path.png"
+
        id="g3351"
        transform="matrix(0.65068191,0,0,0.7092071,258.40502,629.6647)"
        style="stroke-width:1.47207">
@@ -3137,7 +3137,7 @@
     <path
        inkscape:export-ydpi="180"
        inkscape:export-xdpi="180"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/F8_Tx_JESD_path.png"
+
        style="fill:none;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
        d="M 713.6357,921.71371 H 389.52981 v -80.89689"
        id="path7333-5"
@@ -3145,7 +3145,7 @@
     <text
        inkscape:export-ydpi="180"
        inkscape:export-xdpi="180"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/F8_Tx_JESD_path.png"
+
        transform="scale(0.90858178,1.1006164)"
        id="text2950"
        y="831.60901"

--- a/docs/library/jesd204/generic_jesd_bds/jesd204_generic_tx_path.svg
+++ b/docs/library/jesd204/generic_jesd_bds/jesd204_generic_tx_path.svg
@@ -1123,7 +1123,7 @@
     <rect
        inkscape:export-ydpi="180"
        inkscape:export-xdpi="180"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/generic_Tx_JESD_path.png"
+
        y="-325.29602"
        x="617.63702"
        height="133.88882"
@@ -1133,7 +1133,7 @@
     <rect
        inkscape:export-ydpi="180"
        inkscape:export-xdpi="180"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/generic_Tx_JESD_path.png"
+
        y="-324.81519"
        x="158.49532"
        height="133.41664"
@@ -1182,7 +1182,7 @@
     <g
        inkscape:export-ydpi="180"
        inkscape:export-xdpi="180"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/generic_Tx_JESD_path.png"
+
        transform="translate(227.27292,-510.49742)"
        id="g12820">
       <rect
@@ -1212,7 +1212,7 @@
     <text
        inkscape:export-ydpi="180"
        inkscape:export-xdpi="180"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/generic_Tx_JESD_path.png"
+
        xml:space="preserve"
        style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0%;font-family:sans-serif;-inkscape-font-specification:Sans;text-indent:0;text-align:center;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-anchor:middle;display:inline;overflow:visible;visibility:visible;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
        x="403.39038"
@@ -1226,7 +1226,7 @@
     <g
        inkscape:export-ydpi="180"
        inkscape:export-xdpi="180"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/generic_Tx_JESD_path.png"
+
        id="g12834"
        transform="translate(363.08053,-510.85102)">
       <rect
@@ -1256,7 +1256,7 @@
     <path
        inkscape:export-ydpi="180"
        inkscape:export-xdpi="180"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/generic_Tx_JESD_path.png"
+
        id="path13002"
        d="m 403.45944,-335.45038 c 0,30.94571 0,30.94571 0,30.94571"
        style="fill:none;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:url(#Arrow1Mend)" />
@@ -1266,7 +1266,7 @@
        x="538.44781"
        style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0%;font-family:sans-serif;-inkscape-font-specification:Sans;text-indent:0;text-align:center;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-anchor:middle;display:inline;overflow:visible;visibility:visible;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
        xml:space="preserve"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/generic_Tx_JESD_path.png"
+
        inkscape:export-xdpi="180"
        inkscape:export-ydpi="180"><tspan
          style="font-size:13px;line-height:1.25;font-family:sans-serif"
@@ -1277,98 +1277,98 @@
     <path
        inkscape:export-ydpi="180"
        inkscape:export-xdpi="180"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/generic_Tx_JESD_path.png"
+
        id="path13012"
        d="m 385.8595,-297.58273 h 38.29912"
        style="fill:none;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:url(#Arrow2Lend-8)" />
     <path
        inkscape:export-ydpi="180"
        inkscape:export-xdpi="180"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Tx_JESD_path.png"
+
        style="fill:none;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:url(#Arrow2Lend-8)"
        d="m 385.8595,-250.20655 h 38.29912"
        id="use13014" />
     <path
        inkscape:export-ydpi="180"
        inkscape:export-xdpi="180"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Tx_JESD_path.png"
+
        style="fill:none;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#Arrow2Lend-8)"
        d="m 385.8595,-265.99868 h 38.29912"
        id="use13016" />
     <path
        inkscape:export-ydpi="180"
        inkscape:export-xdpi="180"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/generic_Tx_JESD_path.png"
+
        style="fill:none;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:url(#Arrow2Lend-8)"
        d="m 521.97755,-297.58273 h 38.29912"
        id="path13020" />
     <path
        inkscape:export-ydpi="180"
        inkscape:export-xdpi="180"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Tx_JESD_path.png"
+
        style="fill:none;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:url(#Arrow2Lend-8)"
        d="m 521.97756,-250.20655 h 38.29912"
        id="use13022" />
     <path
        inkscape:export-ydpi="180"
        inkscape:export-xdpi="180"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Tx_JESD_path.png"
+
        style="fill:none;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#Arrow2Lend-8)"
        d="m 521.97756,-265.99868 h 38.29912"
        id="use13024" />
     <path
        inkscape:export-ydpi="180"
        inkscape:export-xdpi="180"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Tx_JESD_path.png"
+
        style="fill:none;stroke:#000000;stroke-width:0.853768px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:url(#Arrow2Lend-8)"
        d="m 657.74206,-250.20655 h 27.91698"
        id="use13030" />
     <path
        inkscape:export-ydpi="180"
        inkscape:export-xdpi="180"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Tx_JESD_path.png"
+
        style="fill:none;stroke:#000000;stroke-width:0.853768px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#Arrow2Lend-8)"
        d="m 657.74206,-265.99868 h 27.91698"
        id="use13032" />
     <path
        inkscape:export-ydpi="180"
        inkscape:export-xdpi="180"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/generic_Tx_JESD_path.png"
+
        id="path13038"
        d="m 534.25759,-244.77397 6.5,-10.5"
        style="fill:none;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     <path
        inkscape:export-ydpi="180"
        inkscape:export-xdpi="180"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Tx_JESD_path.png"
+
        style="fill:none;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
        d="m 396.37177,-244.77399 6.5,-10.5"
        id="use13040" />
     <path
        inkscape:export-ydpi="180"
        inkscape:export-xdpi="180"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/generic_Tx_JESD_path.png"
+
        style="fill:none;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:url(#Arrow2Lend-8)"
        d="m 385.8595,-297.58273 h 38.29912"
        id="path13042" />
     <path
        inkscape:export-ydpi="180"
        inkscape:export-xdpi="180"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Tx_JESD_path.png"
+
        style="fill:none;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:url(#Arrow2Lend-8)"
        d="m 385.8595,-250.20655 h 38.29912"
        id="use13044" />
     <path
        inkscape:export-ydpi="180"
        inkscape:export-xdpi="180"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Tx_JESD_path.png"
+
        style="fill:none;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#Arrow2Lend-8)"
        d="m 385.8595,-265.99868 h 38.29912"
        id="use13046" />
     <path
        inkscape:export-ydpi="180"
        inkscape:export-xdpi="180"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Tx_JESD_path.png"
+
        style="fill:none;stroke:#000000;stroke-width:0.853768px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#Arrow2Lend-8)"
        d="m 657.24205,-297.54066 h 27.91698"
        id="use13052" />
@@ -1378,7 +1378,7 @@
        x="405.21881"
        style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0%;font-family:sans-serif;-inkscape-font-specification:Sans;text-indent:0;text-align:center;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-anchor:middle;display:inline;overflow:visible;visibility:visible;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
        xml:space="preserve"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/generic_Tx_JESD_path.png"
+
        inkscape:export-xdpi="180"
        inkscape:export-ydpi="180"><tspan
          style="font-size:13px;line-height:1.25;font-family:sans-serif"
@@ -1389,7 +1389,7 @@
     <g
        inkscape:export-ydpi="180"
        inkscape:export-xdpi="180"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/generic_Tx_JESD_path.png"
+
        transform="translate(-122.54803,59.634253)"
        id="g13484">
       <ellipse
@@ -1420,7 +1420,7 @@
     <use
        inkscape:export-ydpi="180"
        inkscape:export-xdpi="180"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/generic_Tx_JESD_path.png"
+
        height="1488.189"
        width="1052.3622"
        transform="translate(135.5,-1.000003)"
@@ -1431,7 +1431,7 @@
     <use
        inkscape:export-ydpi="180"
        inkscape:export-xdpi="180"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/generic_Tx_JESD_path.png"
+
        height="1488.189"
        width="1052.3622"
        transform="translate(126.5)"
@@ -1443,13 +1443,13 @@
        style="fill:none;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:url(#Arrow1Mend)"
        d="m 667.91738,-335.45038 c 0,30.94571 0,30.94571 0,30.94571"
        id="path13493"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/generic_Tx_JESD_path.png"
+
        inkscape:export-xdpi="180"
        inkscape:export-ydpi="180" />
     <text
        inkscape:export-ydpi="180"
        inkscape:export-xdpi="180"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/generic_Tx_JESD_path.png"
+
        xml:space="preserve"
        style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0%;font-family:sans-serif;-inkscape-font-specification:Sans;text-indent:0;text-align:center;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-anchor:middle;display:inline;overflow:visible;visibility:visible;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
        x="669.67676"
@@ -1464,7 +1464,7 @@
        style="fill:none;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:url(#Arrow1Mend)"
        d="m 260.62387,-335.45038 c 0,30.94571 0,30.94571 0,30.94571"
        id="path13499"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/generic_Tx_JESD_path.png"
+
        inkscape:export-xdpi="180"
        inkscape:export-ydpi="180" />
     <text
@@ -1473,7 +1473,7 @@
        x="263.14926"
        style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0%;font-family:sans-serif;-inkscape-font-specification:Sans;text-indent:0;text-align:center;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-anchor:middle;display:inline;overflow:visible;visibility:visible;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
        xml:space="preserve"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/generic_Tx_JESD_path.png"
+
        inkscape:export-xdpi="180"
        inkscape:export-ydpi="180"><tspan
          style="font-size:13px;line-height:1.25;font-family:sans-serif"
@@ -1487,7 +1487,7 @@
        x="403.39038"
        style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0%;font-family:sans-serif;-inkscape-font-specification:Sans;text-indent:0;text-align:center;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-anchor:middle;display:inline;overflow:visible;visibility:visible;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
        xml:space="preserve"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/generic_Tx_JESD_path.png"
+
        inkscape:export-xdpi="180"
        inkscape:export-ydpi="180"><tspan
          style="font-size:13px;line-height:1.25;font-family:sans-serif"
@@ -1498,35 +1498,35 @@
     <path
        inkscape:export-ydpi="180"
        inkscape:export-xdpi="180"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Tx_JESD_path.png"
+
        style="fill:none;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
        d="m 396.37177,-244.77399 6.5,-10.5"
        id="use13513" />
     <path
        inkscape:export-ydpi="180"
        inkscape:export-xdpi="180"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/generic_Tx_JESD_path.png"
+
        id="path13515"
        d="m 385.8595,-297.58273 h 38.29912"
        style="fill:none;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:url(#Arrow2Lend-8)" />
     <path
        inkscape:export-ydpi="180"
        inkscape:export-xdpi="180"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Tx_JESD_path.png"
+
        style="fill:none;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:url(#Arrow2Lend-8)"
        d="m 385.8595,-250.20655 h 38.29912"
        id="use13517" />
     <path
        inkscape:export-ydpi="180"
        inkscape:export-xdpi="180"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Tx_JESD_path.png"
+
        style="fill:none;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#Arrow2Lend-8)"
        d="m 385.8595,-265.99868 h 38.29912"
        id="use13519" />
     <g
        inkscape:export-ydpi="180"
        inkscape:export-xdpi="180"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/generic_Tx_JESD_path.png"
+
        id="g13521"
        transform="translate(-122.54803,59.634253)">
       <ellipse
@@ -1557,28 +1557,28 @@
     <path
        inkscape:export-ydpi="180"
        inkscape:export-xdpi="180"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/generic_Tx_JESD_path.png"
+
        style="fill:none;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:url(#Arrow2Lend-8)"
        d="m 244.43814,-297.58273 h 38.29912"
        id="path13529" />
     <path
        inkscape:export-ydpi="180"
        inkscape:export-xdpi="180"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Tx_JESD_path.png"
+
        style="fill:none;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:url(#Arrow2Lend-8)"
        d="m 244.43814,-250.20655 h 38.29912"
        id="use13531" />
     <path
        inkscape:export-ydpi="180"
        inkscape:export-xdpi="180"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Tx_JESD_path.png"
+
        style="fill:none;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#Arrow2Lend-8)"
        d="m 244.43814,-265.99868 h 38.29912"
        id="use13533" />
     <use
        inkscape:export-ydpi="180"
        inkscape:export-xdpi="180"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/generic_Tx_JESD_path.png"
+
        height="1488.189"
        width="1052.3622"
        transform="translate(-143.89623)"
@@ -1589,7 +1589,7 @@
     <use
        inkscape:export-ydpi="180"
        inkscape:export-xdpi="180"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/generic_Tx_JESD_path.png"
+
        height="1488.189"
        width="1052.3622"
        transform="translate(-140.3607)"
@@ -1603,7 +1603,7 @@
        x="252.83736"
        style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0%;font-family:sans-serif;-inkscape-font-specification:Sans;text-indent:0;text-align:center;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-anchor:middle;display:inline;overflow:visible;visibility:visible;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
        xml:space="preserve"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/generic_Tx_JESD_path.png"
+
        inkscape:export-xdpi="180"
        inkscape:export-ydpi="180"><tspan
          style="font-size:13px;line-height:1.25;font-family:sans-serif"
@@ -1614,7 +1614,7 @@
     <text
        inkscape:export-ydpi="180"
        inkscape:export-xdpi="180"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/generic_Tx_JESD_path.png"
+
        xml:space="preserve"
        style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0%;font-family:sans-serif;-inkscape-font-specification:Sans;text-indent:0;text-align:center;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-anchor:middle;display:inline;overflow:visible;visibility:visible;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
        x="313.25766"
@@ -1628,7 +1628,7 @@
     <text
        inkscape:export-ydpi="180"
        inkscape:export-xdpi="180"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/generic_Tx_JESD_path.png"
+
        xml:space="preserve"
        style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0%;font-family:sans-serif;-inkscape-font-specification:Sans;text-indent:0;text-align:center;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-anchor:middle;display:inline;overflow:visible;visibility:visible;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
        x="670.67676"
@@ -1642,20 +1642,20 @@
     <path
        inkscape:export-ydpi="180"
        inkscape:export-xdpi="180"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/generic_Tx_JESD_path.png"
+
        style="fill:none;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
        d="m 666.48656,-244.77397 6.5,-10.5"
        id="path13580" />
     <g
        id="g13582"
        transform="translate(131.56285,-380.53334)"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/generic_Tx_JESD_path.png"
+
        inkscape:export-xdpi="180"
        inkscape:export-ydpi="180" />
     <g
        inkscape:export-ydpi="180"
        inkscape:export-xdpi="180"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/F8_Tx_JESD_path.png"
+
        id="g3351-2"
        transform="matrix(0.65068191,0,0,0.7092071,1190.2609,633.93676)"
        style="stroke-width:1.47207" />
@@ -1665,7 +1665,7 @@
        x="646.66907"
        style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:10.6667px;line-height:0%;font-family:Sans;-inkscape-font-specification:'Sans, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-indent:0;text-align:center;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-anchor:middle;display:inline;overflow:visible;visibility:visible;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
        xml:space="preserve"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/generic_Tx_JESD_path.png"
+
        inkscape:export-xdpi="180"
        inkscape:export-ydpi="180"><tspan
          style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:10.6667px;line-height:1.25;font-family:Sans;-inkscape-font-specification:'Sans, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal"
@@ -1679,7 +1679,7 @@
        x="517.94464"
        style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:10.6667px;line-height:0%;font-family:Sans;-inkscape-font-specification:'Sans, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-indent:0;text-align:center;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-anchor:middle;display:inline;overflow:visible;visibility:visible;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
        xml:space="preserve"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/generic_Tx_JESD_path.png"
+
        inkscape:export-xdpi="180"
        inkscape:export-ydpi="180"><tspan
          style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:10.6667px;line-height:1.25;font-family:Sans;-inkscape-font-specification:'Sans, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal"

--- a/docs/library/jesd204/generic_jesd_bds/jesd204_generic_tx_path_ex1.svg
+++ b/docs/library/jesd204/generic_jesd_bds/jesd204_generic_tx_path_ex1.svg
@@ -1127,7 +1127,7 @@
        height="141.66699"
        x="638.71527"
        y="25.545294"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Tx_JESD_path.png"
+
        inkscape:export-xdpi="180"
        inkscape:export-ydpi="180" />
     <rect
@@ -1137,13 +1137,13 @@
        height="141.90192"
        x="260.97916"
        y="25.318914"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Tx_JESD_path.png"
+
        inkscape:export-xdpi="180"
        inkscape:export-ydpi="180" />
     <g
        id="g9025"
        transform="matrix(0.51498307,0,0,0.51498307,155.65196,-22.696247)"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Tx_JESD_path.png"
+
        inkscape:export-xdpi="180"
        inkscape:export-ydpi="180">
       <rect
@@ -1168,7 +1168,7 @@
     <g
        id="g9033"
        transform="matrix(0.51498307,0,0,0.51498307,155.65196,-22.131587)"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Tx_JESD_path.png"
+
        inkscape:export-xdpi="180"
        inkscape:export-ydpi="180">
       <rect
@@ -1193,7 +1193,7 @@
     <g
        id="g9041"
        transform="matrix(0.51498307,0,0,0.51498307,155.65196,-21.566937)"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Tx_JESD_path.png"
+
        inkscape:export-xdpi="180"
        inkscape:export-ydpi="180">
       <rect
@@ -1218,7 +1218,7 @@
     <g
        id="g9049"
        transform="translate(183.93075,-97.025087)"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Tx_JESD_path.png"
+
        inkscape:export-xdpi="180"
        inkscape:export-ydpi="180">
       <rect
@@ -1246,7 +1246,7 @@
        x="195.63078"
        style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0%;font-family:sans-serif;-inkscape-font-specification:Sans;text-indent:0;text-align:center;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-anchor:middle;display:inline;overflow:visible;visibility:visible;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;marker:none;enable-background:accumulate"
        xml:space="preserve"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Tx_JESD_path.png"
+
        inkscape:export-xdpi="180"
        inkscape:export-ydpi="180"><tspan
          style="font-size:10.2997px;line-height:1.25;font-family:sans-serif"
@@ -1260,7 +1260,7 @@
        x="223.67104"
        style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0%;font-family:sans-serif;-inkscape-font-specification:Sans;text-indent:0;text-align:center;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-anchor:middle;display:inline;overflow:visible;visibility:visible;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;marker:none;enable-background:accumulate"
        xml:space="preserve"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Tx_JESD_path.png"
+
        inkscape:export-xdpi="180"
        inkscape:export-ydpi="180"><tspan
          style="font-size:10.2997px;line-height:1.25;font-family:sans-serif"
@@ -1271,7 +1271,7 @@
     <g
        id="g9065"
        transform="translate(145.47959,-166.16372)"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Tx_JESD_path.png"
+
        inkscape:export-xdpi="180"
        inkscape:export-ydpi="180">
       <rect
@@ -1306,7 +1306,7 @@
     <g
        id="g9089"
        transform="translate(248.35113,-151.87801)"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Tx_JESD_path.png"
+
        inkscape:export-xdpi="180"
        inkscape:export-ydpi="180">
       <rect
@@ -1339,7 +1339,7 @@
        x="424.46863"
        style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0%;font-family:sans-serif;-inkscape-font-specification:Sans;text-indent:0;text-align:center;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-anchor:middle;display:inline;overflow:visible;visibility:visible;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
        xml:space="preserve"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Tx_JESD_path.png"
+
        inkscape:export-xdpi="180"
        inkscape:export-ydpi="180"><tspan
          style="font-size:13px;line-height:1.25;font-family:sans-serif"
@@ -1350,7 +1350,7 @@
     <g
        transform="translate(384.15874,-152.23156)"
        id="g9111"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Tx_JESD_path.png"
+
        inkscape:export-xdpi="180"
        inkscape:export-ydpi="180">
       <rect
@@ -1383,7 +1383,7 @@
        x="284.41837"
        style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0%;font-family:sans-serif;-inkscape-font-specification:Sans;text-indent:0;text-align:center;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-anchor:middle;display:inline;overflow:visible;visibility:visible;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;marker:none;enable-background:accumulate"
        xml:space="preserve"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Tx_JESD_path.png"
+
        inkscape:export-xdpi="180"
        inkscape:export-ydpi="180"><tspan
          style="font-size:13px;line-height:1.25;font-family:sans-serif"
@@ -1394,7 +1394,7 @@
     <path
        inkscape:export-ydpi="180"
        inkscape:export-xdpi="180"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/F8_Tx_JESD_path.png"
+
        id="use9159"
        d="m 389.15983,165.74406 5,-10 5,10 z"
        style="fill:none;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
@@ -1402,7 +1402,7 @@
     <g
        inkscape:export-ydpi="180"
        inkscape:export-xdpi="180"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Tx_JESD_path.png"
+
        transform="matrix(0.51498307,0,0,0.51498307,324.99459,-92.053647)"
        id="g9209">
       <rect
@@ -1427,7 +1427,7 @@
     <g
        inkscape:export-ydpi="180"
        inkscape:export-xdpi="180"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Tx_JESD_path.png"
+
        transform="matrix(0.51498307,0,0,0.51498307,324.99459,-91.488987)"
        id="g9217">
       <rect
@@ -1452,7 +1452,7 @@
     <g
        inkscape:export-ydpi="180"
        inkscape:export-xdpi="180"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Tx_JESD_path.png"
+
        transform="matrix(0.51498307,0,0,0.51498307,324.99459,-90.924337)"
        id="g9225">
       <rect
@@ -1477,7 +1477,7 @@
     <g
        inkscape:export-ydpi="180"
        inkscape:export-xdpi="180"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Tx_JESD_path.png"
+
        transform="translate(353.27338,-166.38249)"
        id="g9233">
       <rect
@@ -1502,7 +1502,7 @@
     <g
        id="g9241"
        transform="matrix(0.51498307,0,0,0.51498307,360.84791,-91.921067)"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Tx_JESD_path.png"
+
        inkscape:export-xdpi="180"
        inkscape:export-ydpi="180">
       <rect
@@ -1527,7 +1527,7 @@
     <g
        id="g9249"
        transform="matrix(0.51498307,0,0,0.51498307,360.84791,-91.356407)"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Tx_JESD_path.png"
+
        inkscape:export-xdpi="180"
        inkscape:export-ydpi="180">
       <rect
@@ -1552,7 +1552,7 @@
     <g
        id="g9257"
        transform="matrix(0.51498307,0,0,0.51498307,360.84791,-90.791747)"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Tx_JESD_path.png"
+
        inkscape:export-xdpi="180"
        inkscape:export-ydpi="180">
       <rect
@@ -1577,7 +1577,7 @@
     <g
        id="g9265"
        transform="translate(389.1267,-166.24991)"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Tx_JESD_path.png"
+
        inkscape:export-xdpi="180"
        inkscape:export-ydpi="180">
       <rect
@@ -1602,7 +1602,7 @@
     <g
        inkscape:export-ydpi="180"
        inkscape:export-xdpi="180"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Tx_JESD_path.png"
+
        transform="matrix(0.51498307,0,0,0.51498307,155.65196,35.745223)"
        id="g9273">
       <rect
@@ -1627,7 +1627,7 @@
     <g
        inkscape:export-ydpi="180"
        inkscape:export-xdpi="180"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Tx_JESD_path.png"
+
        transform="matrix(0.51498307,0,0,0.51498307,155.65196,36.309883)"
        id="g9281">
       <rect
@@ -1652,7 +1652,7 @@
     <g
        inkscape:export-ydpi="180"
        inkscape:export-xdpi="180"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Tx_JESD_path.png"
+
        transform="matrix(0.51498307,0,0,0.51498307,155.65196,36.874533)"
        id="g9289">
       <rect
@@ -1677,7 +1677,7 @@
     <g
        inkscape:export-ydpi="180"
        inkscape:export-xdpi="180"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Tx_JESD_path.png"
+
        transform="translate(183.93075,-38.583617)"
        id="g9297">
       <rect
@@ -1703,14 +1703,14 @@
        id="path9305"
        d="m 384.9727,-55.477117 c 0,73.61749 0,73.61749 0,73.61749"
        style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:none;stroke:#37abc8;stroke-width:3.19263;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:3.19263, 3.19263;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:new"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Tx_JESD_path.png"
+
        inkscape:export-xdpi="180"
        inkscape:export-ydpi="180" />
     <path
        style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:none;stroke:#37abc8;stroke-width:3.19263;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:3.19263, 3.19263;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:new"
        d="m 459.68699,-56.235317 c 0,73.13389 0,73.13389 0,73.13389"
        id="path9307"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Tx_JESD_path.png"
+
        inkscape:export-xdpi="180"
        inkscape:export-ydpi="180" />
     <text
@@ -1720,7 +1720,7 @@
        y="-59.957813"
        id="text9309"
        transform="scale(0.85401764,1.170936)"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Tx_JESD_path.png"
+
        inkscape:export-xdpi="180"
        inkscape:export-ydpi="180"><tspan
          style="font-size:10.6667px;line-height:1.25"
@@ -1731,7 +1731,7 @@
     <text
        inkscape:export-ydpi="180"
        inkscape:export-xdpi="180"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Tx_JESD_path.png"
+
        xml:space="preserve"
        style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0%;font-family:sans-serif;-inkscape-font-specification:Sans;text-indent:0;text-align:center;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-anchor:middle;display:inline;overflow:visible;visibility:visible;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;marker:none;enable-background:accumulate"
        x="363.65076"
@@ -1748,7 +1748,7 @@
        x="363.64069"
        style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0%;font-family:sans-serif;-inkscape-font-specification:Sans;text-indent:0;text-align:center;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-anchor:middle;display:inline;overflow:visible;visibility:visible;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;marker:none;enable-background:accumulate"
        xml:space="preserve"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Tx_JESD_path.png"
+
        inkscape:export-xdpi="180"
        inkscape:export-ydpi="180"><tspan
          style="font-size:10.2997px;line-height:1.25;font-family:sans-serif"
@@ -1759,7 +1759,7 @@
     <text
        inkscape:export-ydpi="180"
        inkscape:export-xdpi="180"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Tx_JESD_path.png"
+
        xml:space="preserve"
        style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0%;font-family:sans-serif;-inkscape-font-specification:Sans;text-indent:0;text-align:center;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-anchor:middle;display:inline;overflow:visible;visibility:visible;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;marker:none;enable-background:accumulate"
        x="363.64069"
@@ -1776,7 +1776,7 @@
        x="363.64069"
        style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0%;font-family:sans-serif;-inkscape-font-specification:Sans;text-indent:0;text-align:center;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-anchor:middle;display:inline;overflow:visible;visibility:visible;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;marker:none;enable-background:accumulate"
        xml:space="preserve"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Tx_JESD_path.png"
+
        inkscape:export-xdpi="180"
        inkscape:export-ydpi="180"><tspan
          style="font-size:10.2997px;line-height:1.25;font-family:sans-serif"
@@ -1790,7 +1790,7 @@
        x="405.15076"
        style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0%;font-family:sans-serif;-inkscape-font-specification:Sans;text-indent:0;text-align:center;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-anchor:middle;display:inline;overflow:visible;visibility:visible;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;marker:none;enable-background:accumulate"
        xml:space="preserve"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Tx_JESD_path.png"
+
        inkscape:export-xdpi="180"
        inkscape:export-ydpi="180"><tspan
          style="font-size:10.2997px;line-height:1.25;font-family:sans-serif"
@@ -1806,7 +1806,7 @@
     <text
        inkscape:export-ydpi="180"
        inkscape:export-xdpi="180"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Tx_JESD_path.png"
+
        xml:space="preserve"
        style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0%;font-family:sans-serif;-inkscape-font-specification:Sans;text-indent:0;text-align:center;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-anchor:middle;display:inline;overflow:visible;visibility:visible;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;marker:none;enable-background:accumulate"
        x="421.35031"
@@ -1823,7 +1823,7 @@
        x="326.65076"
        style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0%;font-family:sans-serif;-inkscape-font-specification:Sans;text-indent:0;text-align:center;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-anchor:middle;display:inline;overflow:visible;visibility:visible;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;marker:none;enable-background:accumulate"
        xml:space="preserve"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Tx_JESD_path.png"
+
        inkscape:export-xdpi="180"
        inkscape:export-ydpi="180"><tspan
          style="font-size:10.2997px;line-height:1.25;font-family:sans-serif"
@@ -1834,7 +1834,7 @@
     <text
        inkscape:export-ydpi="180"
        inkscape:export-xdpi="180"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Tx_JESD_path.png"
+
        xml:space="preserve"
        style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0%;font-family:sans-serif;-inkscape-font-specification:Sans;text-indent:0;text-align:center;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-anchor:middle;display:inline;overflow:visible;visibility:visible;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;marker:none;enable-background:accumulate"
        x="439.15076"
@@ -1854,13 +1854,13 @@
        style="fill:none;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:url(#Arrow1Mend)"
        d="m 424.53765,23.169033 c 0,30.94571 0,30.94571 0,30.94571"
        id="path9374"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Tx_JESD_path.png"
+
        inkscape:export-xdpi="180"
        inkscape:export-ydpi="180" />
     <text
        inkscape:export-ydpi="180"
        inkscape:export-xdpi="180"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Tx_JESD_path.png"
+
        xml:space="preserve"
        style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0%;font-family:sans-serif;-inkscape-font-specification:Sans;text-indent:0;text-align:center;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-anchor:middle;display:inline;overflow:visible;visibility:visible;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
        x="559.52606"
@@ -1874,21 +1874,21 @@
     <path
        inkscape:export-ydpi="180"
        inkscape:export-xdpi="180"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Tx_JESD_path.png"
+
        id="path11137"
        d="m 267.6573,81.350393 h 35.5351"
        style="fill:none;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:url(#Arrow2Lend-8)" />
     <path
        inkscape:export-ydpi="180"
        inkscape:export-xdpi="180"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Tx_JESD_path.png"
+
        style="fill:none;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:url(#Arrow2Lend-8)"
        d="m 406.93771,61.036683 h 38.29912"
        id="path11551" />
     <use
        inkscape:export-ydpi="180"
        inkscape:export-xdpi="180"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Tx_JESD_path.png"
+
        style="stroke-width:0.2;stroke-miterlimit:4;stroke-dasharray:none"
        height="1488.189"
        width="1052.3622"
@@ -1900,7 +1900,7 @@
     <use
        inkscape:export-ydpi="180"
        inkscape:export-xdpi="180"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Tx_JESD_path.png"
+
        height="1488.189"
        width="1052.3622"
        transform="translate(1.9040634e-6,-15.792083)"
@@ -1911,7 +1911,7 @@
     <use
        inkscape:export-ydpi="180"
        inkscape:export-xdpi="180"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Tx_JESD_path.png"
+
        height="1488.189"
        width="1052.3622"
        transform="translate(-8.0959366e-6,-15.792023)"
@@ -1922,14 +1922,14 @@
     <path
        inkscape:export-ydpi="180"
        inkscape:export-xdpi="180"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Tx_JESD_path.png"
+
        id="path11559"
        d="m 543.05576,61.036683 h 38.29912"
        style="fill:none;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:url(#Arrow2Lend-8)" />
     <use
        inkscape:export-ydpi="180"
        inkscape:export-xdpi="180"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Tx_JESD_path.png"
+
        x="0"
        y="0"
        xlink:href="#path11551"
@@ -1940,7 +1940,7 @@
     <use
        inkscape:export-ydpi="180"
        inkscape:export-xdpi="180"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Tx_JESD_path.png"
+
        x="0"
        y="0"
        xlink:href="#use11553"
@@ -1951,7 +1951,7 @@
     <use
        inkscape:export-ydpi="180"
        inkscape:export-xdpi="180"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Tx_JESD_path.png"
+
        x="0"
        y="0"
        xlink:href="#use11555"
@@ -1962,7 +1962,7 @@
     <use
        inkscape:export-ydpi="180"
        inkscape:export-xdpi="180"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Tx_JESD_path.png"
+
        height="1488.189"
        width="1052.3622"
        transform="matrix(0.72891965,0,0,1,382.19538,47.376167)"
@@ -1973,7 +1973,7 @@
     <use
        inkscape:export-ydpi="180"
        inkscape:export-xdpi="180"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Tx_JESD_path.png"
+
        height="1488.189"
        width="1052.3622"
        transform="matrix(0.72891965,0,0,1,382.19538,-15.792083)"
@@ -1984,7 +1984,7 @@
     <use
        inkscape:export-ydpi="180"
        inkscape:export-xdpi="180"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Tx_JESD_path.png"
+
        height="1488.189"
        width="1052.3622"
        transform="matrix(0.72891965,0,0,1,382.19537,-15.792023)"
@@ -1995,21 +1995,21 @@
     <path
        inkscape:export-ydpi="180"
        inkscape:export-xdpi="180"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Tx_JESD_path.png"
+
        id="path11713"
        d="m 273.9073,86.975393 6.5,-10.5"
        style="fill:none;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     <path
        inkscape:export-ydpi="180"
        inkscape:export-xdpi="180"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Tx_JESD_path.png"
+
        style="fill:none;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
        d="m 555.3358,113.84544 6.5,-10.5"
        id="use11719" />
     <use
        inkscape:export-ydpi="180"
        inkscape:export-xdpi="180"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Tx_JESD_path.png"
+
        height="1488.189"
        width="1052.3622"
        transform="translate(-137.88582)"
@@ -2020,7 +2020,7 @@
     <use
        inkscape:export-ydpi="180"
        inkscape:export-xdpi="180"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Tx_JESD_path.png"
+
        x="0"
        y="0"
        xlink:href="#use11555"
@@ -2031,7 +2031,7 @@
     <text
        inkscape:export-ydpi="180"
        inkscape:export-xdpi="180"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Tx_JESD_path.png"
+
        xml:space="preserve"
        style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0%;font-family:sans-serif;-inkscape-font-specification:Sans;text-indent:0;text-align:center;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-anchor:middle;display:inline;overflow:visible;visibility:visible;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;marker:none;enable-background:accumulate"
        x="291.48947"
@@ -2045,13 +2045,13 @@
     <g
        id="g13582"
        transform="translate(131.56285,-380.53334)"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/generic_Tx_JESD_path.png"
+
        inkscape:export-xdpi="180"
        inkscape:export-ydpi="180" />
     <g
        inkscape:export-ydpi="180"
        inkscape:export-xdpi="180"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/F8_Tx_JESD_path.png"
+
        id="g3351-2"
        transform="matrix(0.65068191,0,0,0.7092071,1190.2609,633.93676)"
        style="stroke-width:1.47207" />
@@ -2072,7 +2072,7 @@
        x="666.03625"
        style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:10.6667px;line-height:0%;font-family:Sans;-inkscape-font-specification:'Sans, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-indent:0;text-align:center;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-anchor:middle;display:inline;overflow:visible;visibility:visible;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
        xml:space="preserve"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/generic_Tx_JESD_path.png"
+
        inkscape:export-xdpi="180"
        inkscape:export-ydpi="180"><tspan
          style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:10.6667px;line-height:1.25;font-family:Sans;-inkscape-font-specification:'Sans, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal"
@@ -2086,7 +2086,7 @@
        x="537.31183"
        style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:10.6667px;line-height:0%;font-family:Sans;-inkscape-font-specification:'Sans, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-indent:0;text-align:center;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-anchor:middle;display:inline;overflow:visible;visibility:visible;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
        xml:space="preserve"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/generic_Tx_JESD_path.png"
+
        inkscape:export-xdpi="180"
        inkscape:export-ydpi="180"><tspan
          style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:10.6667px;line-height:1.25;font-family:Sans;-inkscape-font-specification:'Sans, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal"

--- a/docs/library/jesd204/generic_jesd_bds/jesd204_generic_tx_path_ex2.svg
+++ b/docs/library/jesd204/generic_jesd_bds/jesd204_generic_tx_path_ex2.svg
@@ -1123,7 +1123,7 @@
     <g
        id="g13582"
        transform="translate(131.56285,-380.53334)"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/generic_Tx_JESD_path.png"
+
        inkscape:export-xdpi="180"
        inkscape:export-ydpi="180" />
     <rect
@@ -1133,7 +1133,7 @@
        height="141.66699"
        x="648.07983"
        y="325.89532"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Tx_JESD_path.png"
+
        inkscape:export-xdpi="180"
        inkscape:export-ydpi="180" />
     <rect
@@ -1143,13 +1143,13 @@
        height="141.90192"
        x="270.34375"
        y="325.66882"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Tx_JESD_path.png"
+
        inkscape:export-xdpi="180"
        inkscape:export-ydpi="180" />
     <g
        id="g9025-6"
        transform="matrix(0.51498307,0,0,0.51498307,165.0164,277.65369)"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Tx_JESD_path.png"
+
        inkscape:export-xdpi="180"
        inkscape:export-ydpi="180">
       <rect
@@ -1175,7 +1175,7 @@
        style="fill:#6699cc;fill-opacity:1"
        id="g9033-2"
        transform="matrix(0.51498307,0,0,0.51498307,165.0164,278.21829)"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Tx_JESD_path.png"
+
        inkscape:export-xdpi="180"
        inkscape:export-ydpi="180">
       <rect
@@ -1200,7 +1200,7 @@
     <g
        id="g9041-3"
        transform="matrix(0.51498307,0,0,0.51498307,165.0164,278.78299)"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Tx_JESD_path.png"
+
        inkscape:export-xdpi="180"
        inkscape:export-ydpi="180">
       <rect
@@ -1226,7 +1226,7 @@
        style="fill:#6699cc;fill-opacity:1"
        id="g9049-2"
        transform="translate(193.2952,203.32479)"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Tx_JESD_path.png"
+
        inkscape:export-xdpi="180"
        inkscape:export-ydpi="180">
       <rect
@@ -1254,7 +1254,7 @@
        x="204.9953"
        style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0%;font-family:sans-serif;-inkscape-font-specification:Sans;text-indent:0;text-align:center;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-anchor:middle;display:inline;overflow:visible;visibility:visible;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;marker:none;enable-background:accumulate"
        xml:space="preserve"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Tx_JESD_path.png"
+
        inkscape:export-xdpi="180"
        inkscape:export-ydpi="180"><tspan
          style="font-size:10.2997px;line-height:1.25;font-family:sans-serif"
@@ -1268,7 +1268,7 @@
        x="233.03564"
        style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0%;font-family:sans-serif;-inkscape-font-specification:Sans;text-indent:0;text-align:center;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-anchor:middle;display:inline;overflow:visible;visibility:visible;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;marker:none;enable-background:accumulate"
        xml:space="preserve"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Tx_JESD_path.png"
+
        inkscape:export-xdpi="180"
        inkscape:export-ydpi="180"><tspan
          style="font-size:10.2997px;line-height:1.25;font-family:sans-serif"
@@ -1279,7 +1279,7 @@
     <g
        id="g9065-2"
        transform="translate(154.844,134.18619)"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Tx_JESD_path.png"
+
        inkscape:export-xdpi="180"
        inkscape:export-ydpi="180">
       <rect
@@ -1314,7 +1314,7 @@
     <g
        id="g9089-2"
        transform="translate(257.7156,148.47189)"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Tx_JESD_path.png"
+
        inkscape:export-xdpi="180"
        inkscape:export-ydpi="180">
       <rect
@@ -1347,7 +1347,7 @@
        x="433.83289"
        style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0%;font-family:sans-serif;-inkscape-font-specification:Sans;text-indent:0;text-align:center;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-anchor:middle;display:inline;overflow:visible;visibility:visible;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
        xml:space="preserve"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Tx_JESD_path.png"
+
        inkscape:export-xdpi="180"
        inkscape:export-ydpi="180"><tspan
          style="font-size:13px;line-height:1.25;font-family:sans-serif"
@@ -1358,7 +1358,7 @@
     <g
        transform="translate(393.52318,148.11829)"
        id="g9111-2"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Tx_JESD_path.png"
+
        inkscape:export-xdpi="180"
        inkscape:export-ydpi="180">
       <rect
@@ -1391,7 +1391,7 @@
        x="293.7829"
        style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0%;font-family:sans-serif;-inkscape-font-specification:Sans;text-indent:0;text-align:center;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-anchor:middle;display:inline;overflow:visible;visibility:visible;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;marker:none;enable-background:accumulate"
        xml:space="preserve"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Tx_JESD_path.png"
+
        inkscape:export-xdpi="180"
        inkscape:export-ydpi="180"><tspan
          style="font-size:13px;line-height:1.25;font-family:sans-serif"
@@ -1402,7 +1402,7 @@
     <path
        inkscape:export-ydpi="180"
        inkscape:export-xdpi="180"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/F8_Tx_JESD_path.png"
+
        id="use9159-3"
        d="m 398.52431,466.09398 5,-10 5,10 z"
        style="fill:none;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
@@ -1410,7 +1410,7 @@
     <g
        inkscape:export-ydpi="180"
        inkscape:export-xdpi="180"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Tx_JESD_path.png"
+
        transform="matrix(0.51498307,0,0,0.51498307,334.35898,208.29629)"
        id="g9209-0">
       <rect
@@ -1435,7 +1435,7 @@
     <g
        inkscape:export-ydpi="180"
        inkscape:export-xdpi="180"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Tx_JESD_path.png"
+
        transform="matrix(0.51498307,0,0,0.51498307,334.35898,208.86089)"
        id="g9217-0">
       <rect
@@ -1460,7 +1460,7 @@
     <g
        inkscape:export-ydpi="180"
        inkscape:export-xdpi="180"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Tx_JESD_path.png"
+
        transform="matrix(0.51498307,0,0,0.51498307,334.35898,209.42559)"
        id="g9225-5">
       <rect
@@ -1485,7 +1485,7 @@
     <g
        inkscape:export-ydpi="180"
        inkscape:export-xdpi="180"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Tx_JESD_path.png"
+
        transform="translate(362.63778,133.96739)"
        id="g9233-5">
       <rect
@@ -1510,7 +1510,7 @@
     <g
        id="g9241-7"
        transform="matrix(0.51498307,0,0,0.51498307,370.21238,208.42879)"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Tx_JESD_path.png"
+
        inkscape:export-xdpi="180"
        inkscape:export-ydpi="180">
       <rect
@@ -1535,7 +1535,7 @@
     <g
        id="g9249-5"
        transform="matrix(0.51498307,0,0,0.51498307,370.21238,208.99349)"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Tx_JESD_path.png"
+
        inkscape:export-xdpi="180"
        inkscape:export-ydpi="180">
       <rect
@@ -1560,7 +1560,7 @@
     <g
        id="g9257-4"
        transform="matrix(0.51498307,0,0,0.51498307,370.21238,209.55819)"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Tx_JESD_path.png"
+
        inkscape:export-xdpi="180"
        inkscape:export-ydpi="180">
       <rect
@@ -1585,7 +1585,7 @@
     <g
        id="g9265-8"
        transform="translate(398.49108,134.09999)"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Tx_JESD_path.png"
+
        inkscape:export-xdpi="180"
        inkscape:export-ydpi="180">
       <rect
@@ -1611,7 +1611,7 @@
        style="fill:#aaccee;fill-opacity:1"
        inkscape:export-ydpi="180"
        inkscape:export-xdpi="180"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Tx_JESD_path.png"
+
        transform="matrix(0.51498307,0,0,0.51498307,165.0164,336.09509)"
        id="g9273-4">
       <rect
@@ -1636,7 +1636,7 @@
     <g
        inkscape:export-ydpi="180"
        inkscape:export-xdpi="180"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Tx_JESD_path.png"
+
        transform="matrix(0.51498307,0,0,0.51498307,165.0164,336.65979)"
        id="g9281-9">
       <rect
@@ -1661,7 +1661,7 @@
     <g
        inkscape:export-ydpi="180"
        inkscape:export-xdpi="180"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Tx_JESD_path.png"
+
        transform="matrix(0.51498307,0,0,0.51498307,165.0164,337.22439)"
        id="g9289-8">
       <rect
@@ -1686,7 +1686,7 @@
     <g
        inkscape:export-ydpi="180"
        inkscape:export-xdpi="180"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Tx_JESD_path.png"
+
        transform="translate(193.2952,261.76629)"
        id="g9297-6">
       <rect
@@ -1712,7 +1712,7 @@
        id="path9305-0"
        d="m 394.33708,244.87279 c 0,73.6175 0,73.6175 0,73.6175"
        style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:none;stroke:#37abc8;stroke-width:3.19263;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:3.19263, 3.19263;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:new"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Tx_JESD_path.png"
+
        inkscape:export-xdpi="180"
        inkscape:export-ydpi="180"
        inkscape:connector-curvature="0" />
@@ -1720,7 +1720,7 @@
        style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:none;stroke:#37abc8;stroke-width:3.19263;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:3.19263, 3.19263;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:new"
        d="m 469.05138,244.11459 c 0,73.1339 0,73.1339 0,73.1339"
        id="path9307-4"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Tx_JESD_path.png"
+
        inkscape:export-xdpi="180"
        inkscape:export-ydpi="180"
        inkscape:connector-curvature="0" />
@@ -1731,7 +1731,7 @@
        y="195.74171"
        id="text9309-8"
        transform="scale(0.85401764,1.170936)"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Tx_JESD_path.png"
+
        inkscape:export-xdpi="180"
        inkscape:export-ydpi="180"><tspan
          style="font-size:10.6667px;line-height:1.25"
@@ -1742,7 +1742,7 @@
     <text
        inkscape:export-ydpi="180"
        inkscape:export-xdpi="180"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Tx_JESD_path.png"
+
        xml:space="preserve"
        style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0%;font-family:sans-serif;-inkscape-font-specification:Sans;text-indent:0;text-align:center;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-anchor:middle;display:inline;overflow:visible;visibility:visible;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;marker:none;enable-background:accumulate"
        x="373.01514"
@@ -1759,7 +1759,7 @@
        x="373.00525"
        style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0%;font-family:sans-serif;-inkscape-font-specification:Sans;text-indent:0;text-align:center;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-anchor:middle;display:inline;overflow:visible;visibility:visible;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;marker:none;enable-background:accumulate"
        xml:space="preserve"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Tx_JESD_path.png"
+
        inkscape:export-xdpi="180"
        inkscape:export-ydpi="180"><tspan
          style="font-size:10.2997px;line-height:1.25;font-family:sans-serif"
@@ -1770,7 +1770,7 @@
     <text
        inkscape:export-ydpi="180"
        inkscape:export-xdpi="180"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Tx_JESD_path.png"
+
        xml:space="preserve"
        style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0%;font-family:sans-serif;-inkscape-font-specification:Sans;text-indent:0;text-align:center;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-anchor:middle;display:inline;overflow:visible;visibility:visible;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;marker:none;enable-background:accumulate"
        x="373.00525"
@@ -1787,7 +1787,7 @@
        x="373.00525"
        style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0%;font-family:sans-serif;-inkscape-font-specification:Sans;text-indent:0;text-align:center;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-anchor:middle;display:inline;overflow:visible;visibility:visible;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;marker:none;enable-background:accumulate"
        xml:space="preserve"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Tx_JESD_path.png"
+
        inkscape:export-xdpi="180"
        inkscape:export-ydpi="180"><tspan
          style="font-size:10.2997px;line-height:1.25;font-family:sans-serif"
@@ -1801,7 +1801,7 @@
        x="414.51514"
        style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0%;font-family:sans-serif;-inkscape-font-specification:Sans;text-indent:0;text-align:center;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-anchor:middle;display:inline;overflow:visible;visibility:visible;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;marker:none;enable-background:accumulate"
        xml:space="preserve"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Tx_JESD_path.png"
+
        inkscape:export-xdpi="180"
        inkscape:export-ydpi="180"><tspan
          style="font-size:10.2997px;line-height:1.25;font-family:sans-serif"
@@ -1817,7 +1817,7 @@
     <text
        inkscape:export-ydpi="180"
        inkscape:export-xdpi="180"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Tx_JESD_path.png"
+
        xml:space="preserve"
        style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0%;font-family:sans-serif;-inkscape-font-specification:Sans;text-indent:0;text-align:center;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-anchor:middle;display:inline;overflow:visible;visibility:visible;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;marker:none;enable-background:accumulate"
        x="423.76514"
@@ -1834,7 +1834,7 @@
        x="336.0152"
        style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0%;font-family:sans-serif;-inkscape-font-specification:Sans;text-indent:0;text-align:center;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-anchor:middle;display:inline;overflow:visible;visibility:visible;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;marker:none;enable-background:accumulate"
        xml:space="preserve"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Tx_JESD_path.png"
+
        inkscape:export-xdpi="180"
        inkscape:export-ydpi="180"><tspan
          style="font-size:10.2997px;line-height:1.25;font-family:sans-serif"
@@ -1845,7 +1845,7 @@
     <text
        inkscape:export-ydpi="180"
        inkscape:export-xdpi="180"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Tx_JESD_path.png"
+
        xml:space="preserve"
        style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0%;font-family:sans-serif;-inkscape-font-specification:Sans;text-indent:0;text-align:center;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-anchor:middle;display:inline;overflow:visible;visibility:visible;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;marker:none;enable-background:accumulate"
        x="448.51514"
@@ -1865,14 +1865,14 @@
        style="fill:none;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:url(#Arrow1Mend-7)"
        d="m 433.90208,323.51889 c 0,30.9457 0,30.9457 0,30.9457"
        id="path9374-7"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Tx_JESD_path.png"
+
        inkscape:export-xdpi="180"
        inkscape:export-ydpi="180"
        inkscape:connector-curvature="0" />
     <text
        inkscape:export-ydpi="180"
        inkscape:export-xdpi="180"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Tx_JESD_path.png"
+
        xml:space="preserve"
        style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0%;font-family:sans-serif;-inkscape-font-specification:Sans;text-indent:0;text-align:center;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-anchor:middle;display:inline;overflow:visible;visibility:visible;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
        x="568.8905"
@@ -1886,7 +1886,7 @@
     <path
        inkscape:export-ydpi="180"
        inkscape:export-xdpi="180"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Tx_JESD_path.png"
+
        id="path11137-5"
        d="m 277.0218,381.70029 h 35.535"
        style="fill:none;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:url(#Arrow2Lend-8-3)"
@@ -1894,7 +1894,7 @@
     <path
        inkscape:export-ydpi="180"
        inkscape:export-xdpi="180"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Tx_JESD_path.png"
+
        style="fill:none;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:url(#Arrow2Lend-8-3)"
        d="m 416.30218,361.38659 h 38.2991"
        id="path11551-9"
@@ -1902,7 +1902,7 @@
     <use
        inkscape:export-ydpi="180"
        inkscape:export-xdpi="180"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Tx_JESD_path.png"
+
        style="stroke-width:0.2;stroke-miterlimit:4;stroke-dasharray:none"
        height="1488.189"
        width="1052.3622"
@@ -1914,7 +1914,7 @@
     <use
        inkscape:export-ydpi="180"
        inkscape:export-xdpi="180"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Tx_JESD_path.png"
+
        height="1488.189"
        width="1052.3622"
        transform="translate(8.8801643e-6,-15.79206)"
@@ -1925,7 +1925,7 @@
     <use
        inkscape:export-ydpi="180"
        inkscape:export-xdpi="180"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Tx_JESD_path.png"
+
        height="1488.189"
        width="1052.3622"
        transform="translate(-1.1198358e-6,-15.79206)"
@@ -1936,7 +1936,7 @@
     <path
        inkscape:export-ydpi="180"
        inkscape:export-xdpi="180"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Tx_JESD_path.png"
+
        id="path11559-7"
        d="m 552.42018,361.38659 h 38.2991"
        style="fill:none;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:url(#Arrow2Lend-8-3)"
@@ -1944,7 +1944,7 @@
     <use
        inkscape:export-ydpi="180"
        inkscape:export-xdpi="180"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Tx_JESD_path.png"
+
        x="0"
        y="0"
        xlink:href="#path11551-9"
@@ -1955,7 +1955,7 @@
     <use
        inkscape:export-ydpi="180"
        inkscape:export-xdpi="180"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Tx_JESD_path.png"
+
        x="0"
        y="0"
        xlink:href="#use11553-7"
@@ -1966,7 +1966,7 @@
     <use
        inkscape:export-ydpi="180"
        inkscape:export-xdpi="180"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Tx_JESD_path.png"
+
        x="0"
        y="0"
        xlink:href="#use11555-7"
@@ -1977,7 +1977,7 @@
     <use
        inkscape:export-ydpi="180"
        inkscape:export-xdpi="180"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Tx_JESD_path.png"
+
        height="1488.189"
        width="1052.3622"
        transform="matrix(0.72891965,0,0,1,384.73392,47.376141)"
@@ -1988,7 +1988,7 @@
     <use
        inkscape:export-ydpi="180"
        inkscape:export-xdpi="180"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Tx_JESD_path.png"
+
        height="1488.189"
        width="1052.3622"
        transform="matrix(0.72891965,0,0,1,384.73392,-15.79206)"
@@ -1999,7 +1999,7 @@
     <use
        inkscape:export-ydpi="180"
        inkscape:export-xdpi="180"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Tx_JESD_path.png"
+
        height="1488.189"
        width="1052.3622"
        transform="matrix(0.72891965,0,0,1,384.73392,-15.79206)"
@@ -2010,7 +2010,7 @@
     <path
        inkscape:export-ydpi="180"
        inkscape:export-xdpi="180"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Tx_JESD_path.png"
+
        id="path11713-4"
        d="m 283.2718,387.32529 6.5,-10.5"
        style="fill:none;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
@@ -2018,7 +2018,7 @@
     <path
        inkscape:export-ydpi="180"
        inkscape:export-xdpi="180"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Tx_JESD_path.png"
+
        style="fill:none;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
        d="m 564.70028,414.19529 6.5,-10.5"
        id="use11719-8"
@@ -2026,7 +2026,7 @@
     <use
        inkscape:export-ydpi="180"
        inkscape:export-xdpi="180"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Tx_JESD_path.png"
+
        height="1488.189"
        width="1052.3622"
        transform="translate(-137.88582,4.1854836e-5)"
@@ -2037,7 +2037,7 @@
     <use
        inkscape:export-ydpi="180"
        inkscape:export-xdpi="180"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Tx_JESD_path.png"
+
        x="0"
        y="0"
        xlink:href="#use11555-7"
@@ -2048,7 +2048,7 @@
     <text
        inkscape:export-ydpi="180"
        inkscape:export-xdpi="180"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Tx_JESD_path.png"
+
        xml:space="preserve"
        style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0%;font-family:sans-serif;-inkscape-font-specification:Sans;text-indent:0;text-align:center;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-anchor:middle;display:inline;overflow:visible;visibility:visible;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;marker:none;enable-background:accumulate"
        x="300.85394"
@@ -2062,7 +2062,7 @@
     <text
        inkscape:export-ydpi="180"
        inkscape:export-xdpi="180"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Tx_JESD_path.png"
+
        xml:space="preserve"
        style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0.95;font-family:sans-serif;-inkscape-font-specification:Sans;text-indent:0;text-align:center;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-anchor:middle;display:inline;overflow:visible;visibility:visible;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;marker:none;enable-background:accumulate"
        x="213.38153"
@@ -2081,7 +2081,7 @@
        x="214.67035"
        style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0.95;font-family:sans-serif;-inkscape-font-specification:Sans;text-indent:0;text-align:center;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-anchor:middle;display:inline;overflow:visible;visibility:visible;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;marker:none;enable-background:accumulate"
        xml:space="preserve"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/sample_Tx_JESD_path.png"
+
        inkscape:export-xdpi="180"
        inkscape:export-ydpi="180"><tspan
          style="font-size:10.2997px;line-height:0.95;font-family:sans-serif"
@@ -2094,7 +2094,7 @@
     <g
        inkscape:export-ydpi="180"
        inkscape:export-xdpi="180"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/F8_Tx_JESD_path.png"
+
        id="g3351-2"
        transform="matrix(0.65068191,0,0,0.7092071,1359.7565,589.99346)"
        style="stroke-width:1.47207">
@@ -2116,7 +2116,7 @@
          x="-1006.9171"
          style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:15.7022px;line-height:0%;font-family:Sans;-inkscape-font-specification:'Sans, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-indent:0;text-align:center;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-anchor:middle;display:inline;overflow:visible;visibility:visible;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.47207;marker:none;enable-background:accumulate"
          xml:space="preserve"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/generic_Tx_JESD_path.png"
+
          inkscape:export-xdpi="180"
          inkscape:export-ydpi="180"
          transform="scale(1.044004,0.95785074)"><tspan
@@ -2131,7 +2131,7 @@
          x="-1196.4087"
          style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:15.7022px;line-height:0%;font-family:Sans;-inkscape-font-specification:'Sans, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-indent:0;text-align:center;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-anchor:middle;display:inline;overflow:visible;visibility:visible;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.47207;marker:none;enable-background:accumulate"
          xml:space="preserve"
-         inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/generic_Tx_JESD_path.png"
+
          inkscape:export-xdpi="180"
          inkscape:export-ydpi="180"
          transform="scale(1.044004,0.95785074)"><tspan

--- a/docs/library/jesd204/jesd204_chain.svg
+++ b/docs/library/jesd204/jesd204_chain.svg
@@ -8,7 +8,7 @@
    version="1.1"
    inkscape:version="1.1.1 (3bf5ae0d25, 2021-09-20)"
    sodipodi:docname="jesd204b_chain.svg"
-   inkscape:export-filename="/home/lars/graphics/jesd/jesd204b_chain.png"
+
    inkscape:export-xdpi="90"
    inkscape:export-ydpi="90"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
@@ -400,7 +400,7 @@
          width="160.714"
          id="rect4728-6"
          style="fill:url(#linearGradient429436);fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:6;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-         inkscape:export-filename="/home/lars/jesd204_chain.png"
+
          inkscape:export-xdpi="90"
          inkscape:export-ydpi="90" />
       <text
@@ -409,7 +409,7 @@
          x="108.40558"
          style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0%;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none"
          xml:space="preserve"
-         inkscape:export-filename="/home/lars/jesd204_chain.png"
+
          inkscape:export-xdpi="90"
          inkscape:export-ydpi="90"><tspan
            style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:20px;line-height:1.25;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans Bold';text-align:center;text-anchor:middle"
@@ -430,7 +430,7 @@
        width="520.26929"
        id="rect3761"
        style="fill:url(#linearGradient429418);fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:7.81077;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-       inkscape:export-filename="/home/lars/jesd204_chain.png"
+
        inkscape:export-xdpi="90"
        inkscape:export-ydpi="90" />
     <text
@@ -439,7 +439,7 @@
        x="230.18436"
        y="253.28296"
        id="text3769"
-       inkscape:export-filename="/home/lars/jesd204_chain.png"
+
        inkscape:export-xdpi="90"
        inkscape:export-ydpi="90"><tspan
          sodipodi:role="line"
@@ -452,7 +452,7 @@
       <g
          id="g3809"
          transform="translate(-86.630188,247.84483)"
-         inkscape:export-filename="/home/lars/jesd204_chain.png"
+
          inkscape:export-xdpi="90"
          inkscape:export-ydpi="90">
         <rect
@@ -497,7 +497,7 @@
        id="path3815"
        inkscape:connector-curvature="0"
        sodipodi:nodetypes="cc"
-       inkscape:export-filename="/home/lars/jesd204_chain.png"
+
        inkscape:export-xdpi="90"
        inkscape:export-ydpi="90" />
     <path
@@ -506,7 +506,7 @@
        id="path4447"
        d="m 323.53236,406.63558 h 22.22335"
        style="fill:none;stroke:#000000;stroke-width:5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#TriangleOutS)"
-       inkscape:export-filename="/home/lars/jesd204_chain.png"
+
        inkscape:export-xdpi="90"
        inkscape:export-ydpi="90" />
     <path
@@ -515,7 +515,7 @@
        id="path4449"
        inkscape:connector-curvature="0"
        sodipodi:nodetypes="cc"
-       inkscape:export-filename="/home/lars/jesd204_chain.png"
+
        inkscape:export-xdpi="90"
        inkscape:export-ydpi="90" />
     <path
@@ -524,7 +524,7 @@
        id="path4475"
        d="m 578.37223,406.63558 h 22.92624"
        style="fill:none;stroke:#000000;stroke-width:5.10756;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#TriangleOutS)"
-       inkscape:export-filename="/home/lars/jesd204_chain.png"
+
        inkscape:export-xdpi="90"
        inkscape:export-ydpi="90" />
     <path
@@ -533,7 +533,7 @@
        id="path4477"
        inkscape:connector-curvature="0"
        sodipodi:nodetypes="cccc"
-       inkscape:export-filename="/home/lars/jesd204_chain.png"
+
        inkscape:export-xdpi="90"
        inkscape:export-ydpi="90" />
     <text
@@ -542,7 +542,7 @@
        x="160.89287"
        y="477.36523"
        id="text4663"
-       inkscape:export-filename="/home/lars/jesd204_chain.png"
+
        inkscape:export-xdpi="90"
        inkscape:export-ydpi="90"><tspan
          sodipodi:role="line"
@@ -607,7 +607,7 @@
     <g
        id="g4712"
        transform="translate(-60.64466,314)"
-       inkscape:export-filename="/home/lars/jesd204_chain.png"
+
        inkscape:export-xdpi="90"
        inkscape:export-ydpi="90">
       <rect
@@ -637,7 +637,7 @@
     <g
        transform="translate(-251.82746,314)"
        id="g4718"
-       inkscape:export-filename="/home/lars/jesd204_chain.png"
+
        inkscape:export-xdpi="90"
        inkscape:export-ydpi="90">
       <rect
@@ -671,7 +671,7 @@
        height="255.08521"
        x="224.56088"
        y="-121.83542"
-       inkscape:export-filename="/home/lars/jesd204_chain.png"
+
        inkscape:export-xdpi="90"
        inkscape:export-ydpi="90" />
     <text
@@ -680,7 +680,7 @@
        x="395.70901"
        style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0%;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none"
        xml:space="preserve"
-       inkscape:export-filename="/home/lars/jesd204_chain.png"
+
        inkscape:export-xdpi="90"
        inkscape:export-ydpi="90"><tspan
          style="font-size:15px;line-height:1.25"
@@ -699,7 +699,7 @@
        x="395.01273"
        style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0%;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none"
        xml:space="preserve"
-       inkscape:export-filename="/home/lars/jesd204_chain.png"
+
        inkscape:export-xdpi="90"
        inkscape:export-ydpi="90"><tspan
          style="font-size:15px;line-height:1.25"
@@ -713,7 +713,7 @@
        x="230.18436"
        style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0%;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none"
        xml:space="preserve"
-       inkscape:export-filename="/home/lars/jesd204_chain.png"
+
        inkscape:export-xdpi="90"
        inkscape:export-ydpi="90"><tspan
          style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:30px;line-height:1.25;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans Bold'"
@@ -727,7 +727,7 @@
       <g
          transform="translate(-86.630188,-202.97248)"
          id="g4742"
-         inkscape:export-filename="/home/lars/jesd204_chain.png"
+
          inkscape:export-xdpi="90"
          inkscape:export-ydpi="90">
         <rect
@@ -772,7 +772,7 @@
        id="path4772"
        d="M 238.75584,65.818274 H 199.21827"
        style="fill:none;stroke:#000000;stroke-width:4.75649;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#TriangleOutS)"
-       inkscape:export-filename="/home/lars/jesd204_chain.png"
+
        inkscape:export-xdpi="90"
        inkscape:export-ydpi="90" />
     <path
@@ -781,7 +781,7 @@
        id="path4774"
        inkscape:connector-curvature="0"
        sodipodi:nodetypes="cc"
-       inkscape:export-filename="/home/lars/jesd204_chain.png"
+
        inkscape:export-xdpi="90"
        inkscape:export-ydpi="90" />
     <path
@@ -790,13 +790,13 @@
        id="path4776"
        d="M 465.69199,65.818274 H 444.29372"
        style="fill:none;stroke:#000000;stroke-width:4.93442;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#TriangleOutS)"
-       inkscape:export-filename="/home/lars/jesd204_chain.png"
+
        inkscape:export-xdpi="90"
        inkscape:export-ydpi="90" />
     <g
        transform="translate(20.369715,-209.30566)"
        id="g4778"
-       inkscape:export-filename="/home/lars/jesd204_chain.png"
+
        inkscape:export-xdpi="90"
        inkscape:export-ydpi="90">
       <rect
@@ -829,7 +829,7 @@
        id="path4788"
        inkscape:connector-curvature="0"
        sodipodi:nodetypes="cc"
-       inkscape:export-filename="/home/lars/jesd204_chain.png"
+
        inkscape:export-xdpi="90"
        inkscape:export-ydpi="90" />
     <path
@@ -838,7 +838,7 @@
        id="path4790"
        d="m 364.64286,105.64676 v 13.38941 H 159.28571 v -14.13651"
        style="fill:none;stroke:#000000;stroke-width:3;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-start:url(#TriangleInS);marker-end:none"
-       inkscape:export-filename="/home/lars/jesd204_chain.png"
+
        inkscape:export-xdpi="90"
        inkscape:export-ydpi="90" />
     <text
@@ -847,7 +847,7 @@
        x="158.75002"
        style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0%;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none"
        xml:space="preserve"
-       inkscape:export-filename="/home/lars/jesd204_chain.png"
+
        inkscape:export-xdpi="90"
        inkscape:export-ydpi="90"><tspan
          style="font-size:15px;line-height:1.25"
@@ -861,7 +861,7 @@
        x="6.4285736"
        y="-139.78067"
        id="text5168"
-       inkscape:export-filename="/home/lars/jesd204_chain.png"
+
        inkscape:export-xdpi="90"
        inkscape:export-ydpi="90"><tspan
          sodipodi:role="line"
@@ -875,7 +875,7 @@
        x="6.4285736"
        style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0%;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none"
        xml:space="preserve"
-       inkscape:export-filename="/home/lars/jesd204_chain.png"
+
        inkscape:export-xdpi="90"
        inkscape:export-ydpi="90"><tspan
          y="210.50504"
@@ -893,7 +893,7 @@
          width="160.714"
          id="rect4728"
          style="fill:url(#linearGradient429436);fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:6;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-         inkscape:export-filename="/home/lars/jesd204_chain.png"
+
          inkscape:export-xdpi="90"
          inkscape:export-ydpi="90" />
       <text
@@ -902,7 +902,7 @@
          x="108.40597"
          style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0%;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none"
          xml:space="preserve"
-         inkscape:export-filename="/home/lars/jesd204_chain.png"
+
          inkscape:export-xdpi="90"
          inkscape:export-ydpi="90"><tspan
            style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:20px;line-height:1.25;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans Bold';text-align:center;text-anchor:middle"
@@ -918,7 +918,7 @@
       <g
          id="g961"
          transform="matrix(0.66767832,0,0,0.66767832,268.62497,179.08152)"
-         inkscape:export-filename="/home/lars/jesd204_chain.png"
+
          inkscape:export-xdpi="90"
          inkscape:export-ydpi="90">
         <path
@@ -940,7 +940,7 @@
       <g
          transform="translate(-99.959503,-202.97248)"
          id="g4752"
-         inkscape:export-filename="/home/lars/jesd204_chain.png"
+
          inkscape:export-xdpi="90"
          inkscape:export-ydpi="90">
         <rect
@@ -970,7 +970,7 @@
       <g
          id="g973"
          transform="matrix(0.66767832,0,0,0.66767832,516.48212,179.08152)"
-         inkscape:export-filename="/home/lars/jesd204_chain.png"
+
          inkscape:export-xdpi="90"
          inkscape:export-ydpi="90">
         <path
@@ -992,7 +992,7 @@
       <g
          transform="translate(-98.977814,-202.97247)"
          id="g4762"
-         inkscape:export-filename="/home/lars/jesd204_chain.png"
+
          inkscape:export-xdpi="90"
          inkscape:export-ydpi="90">
         <rect
@@ -1022,7 +1022,7 @@
       <g
          transform="matrix(0.66767832,0,0,0.66767832,654.53011,179.08152)"
          id="g979"
-         inkscape:export-filename="/home/lars/jesd204_chain.png"
+
          inkscape:export-xdpi="90"
          inkscape:export-ydpi="90">
         <path
@@ -1047,7 +1047,7 @@
          height="74.285721"
          x="28.571428"
          y="369.49274"
-         inkscape:export-filename="/home/lars/jesd204_chain.png"
+
          inkscape:export-xdpi="90"
          inkscape:export-ydpi="90" />
       <text
@@ -1056,7 +1056,7 @@
          x="108.82589"
          y="401.02036"
          id="text2987"
-         inkscape:export-filename="/home/lars/jesd204_chain.png"
+
          inkscape:export-xdpi="90"
          inkscape:export-ydpi="90"><tspan
            sodipodi:role="line"
@@ -1072,7 +1072,7 @@
       <g
          transform="matrix(0.66767832,0,0,0.66767832,268.62497,630.32627)"
          id="g985"
-         inkscape:export-filename="/home/lars/jesd204_chain.png"
+
          inkscape:export-xdpi="90"
          inkscape:export-ydpi="90">
         <path
@@ -1093,7 +1093,7 @@
       <g
          id="g3803"
          transform="translate(-99.959503,247.84483)"
-         inkscape:export-filename="/home/lars/jesd204_chain.png"
+
          inkscape:export-xdpi="90"
          inkscape:export-ydpi="90">
         <rect
@@ -1123,7 +1123,7 @@
       <g
          transform="matrix(0.66767832,0,0,0.66767832,516.48212,630.32627)"
          id="g997"
-         inkscape:export-filename="/home/lars/jesd204_chain.png"
+
          inkscape:export-xdpi="90"
          inkscape:export-ydpi="90">
         <path
@@ -1144,7 +1144,7 @@
       <g
          id="g3797"
          transform="translate(-98.977814,247.84483)"
-         inkscape:export-filename="/home/lars/jesd204_chain.png"
+
          inkscape:export-xdpi="90"
          inkscape:export-ydpi="90">
         <rect
@@ -1174,7 +1174,7 @@
       <g
          id="g1003"
          transform="matrix(0.66767832,0,0,0.66767832,654.53011,630.32627)"
-         inkscape:export-filename="/home/lars/jesd204_chain.png"
+
          inkscape:export-xdpi="90"
          inkscape:export-ydpi="90">
         <path
@@ -1206,7 +1206,7 @@
     <g
        transform="translate(20.369341,-95.169953)"
        id="g4778-2"
-       inkscape:export-filename="/home/lars/jesd204_chain.png"
+
        inkscape:export-xdpi="90"
        inkscape:export-ydpi="90">
       <rect
@@ -1266,7 +1266,7 @@
          width="160.714"
          id="rect4728-6-1"
          style="fill:url(#linearGradient429436);fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:6;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-         inkscape:export-filename="/home/lars/jesd204_chain.png"
+
          inkscape:export-xdpi="90"
          inkscape:export-ydpi="90" />
       <text
@@ -1275,7 +1275,7 @@
          x="108.40558"
          style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0%;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none"
          xml:space="preserve"
-         inkscape:export-filename="/home/lars/jesd204_chain.png"
+
          inkscape:export-xdpi="90"
          inkscape:export-ydpi="90"><tspan
            style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:20px;line-height:1.25;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans Bold';text-align:center;text-anchor:middle"
@@ -1295,7 +1295,7 @@
        x="395.70911"
        style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0%;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none"
        xml:space="preserve"
-       inkscape:export-filename="/home/lars/jesd204_chain.png"
+
        inkscape:export-xdpi="90"
        inkscape:export-ydpi="90"><tspan
          style="font-size:15px;line-height:1.25"
@@ -1314,7 +1314,7 @@
        x="395.01282"
        style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0%;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none"
        xml:space="preserve"
-       inkscape:export-filename="/home/lars/jesd204_chain.png"
+
        inkscape:export-xdpi="90"
        inkscape:export-ydpi="90"><tspan
          style="font-size:15px;line-height:1.25"
@@ -1325,7 +1325,7 @@
     <g
        transform="translate(20.369714,131.23785)"
        id="g4778-7"
-       inkscape:export-filename="/home/lars/jesd204_chain.png"
+
        inkscape:export-xdpi="90"
        inkscape:export-ydpi="90">
       <rect
@@ -1355,7 +1355,7 @@
     <g
        transform="translate(20.36934,245.37356)"
        id="g4778-2-9"
-       inkscape:export-filename="/home/lars/jesd204_chain.png"
+
        inkscape:export-xdpi="90"
        inkscape:export-ydpi="90">
       <rect

--- a/docs/library/jesd204/jesd204_layers.svg
+++ b/docs/library/jesd204/jesd204_layers.svg
@@ -335,13 +335,13 @@
     <g
        id="g4113"
        transform="translate(330.86155,229.12232)"
-       inkscape:export-filename="/home/lars/jesd204_layers.png"
+
        inkscape:export-xdpi="279.61734"
        inkscape:export-ydpi="279.61734">
       <g
          inkscape:export-ydpi="279.61734"
          inkscape:export-xdpi="279.61734"
-         inkscape:export-filename="/home/lars/jesd204_layers.png"
+
          transform="translate(0,3.6707682)"
          id="g3776">
         <rect
@@ -366,7 +366,7 @@
       <text
          inkscape:export-ydpi="279.61734"
          inkscape:export-xdpi="279.61734"
-         inkscape:export-filename="/home/lars/jesd204_layers.png"
+
          id="text3813"
          y="284.85709"
          x="222.83656"
@@ -391,13 +391,13 @@
     <g
        id="g4123"
        transform="translate(330.86155,223.91444)"
-       inkscape:export-filename="/home/lars/jesd204_layers.png"
+
        inkscape:export-xdpi="279.61734"
        inkscape:export-ydpi="279.61734">
       <g
          inkscape:export-ydpi="279.61734"
          inkscape:export-xdpi="279.61734"
-         inkscape:export-filename="/home/lars/jesd204_layers.png"
+
          transform="translate(-18.804688,4.3784506)"
          id="g3771">
         <rect
@@ -422,7 +422,7 @@
       <text
          inkscape:export-ydpi="279.61734"
          inkscape:export-xdpi="279.61734"
-         inkscape:export-filename="/home/lars/jesd204_layers.png"
+
          id="text3817"
          y="236.57187"
          x="222.76625"
@@ -441,7 +441,7 @@
     </g>
     <g
        id="g4135"
-       inkscape:export-filename="/home/lars/jesd204_layers.png"
+
        inkscape:export-xdpi="279.61734"
        inkscape:export-ydpi="279.61734"
        transform="translate(330.86155,218.70657)">
@@ -466,7 +466,7 @@
       <text
          inkscape:export-ydpi="279.61734"
          inkscape:export-xdpi="279.61734"
-         inkscape:export-filename="/home/lars/jesd204_layers.png"
+
          xml:space="preserve"
          style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.8px;line-height:0%;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1.06667"
          x="223.50824"
@@ -496,14 +496,14 @@
          id="tspan7747">layer per octet</tspan></text>
     <g
        id="g4103"
-       inkscape:export-filename="/home/lars/jesd204_layers.png"
+
        inkscape:export-xdpi="279.61734"
        inkscape:export-ydpi="279.61734"
        transform="translate(330.86155,218.70657)">
       <g
          inkscape:export-ydpi="279.61734"
          inkscape:export-xdpi="279.61734"
-         inkscape:export-filename="/home/lars/jesd204_layers.png"
+
          transform="translate(-15.125001,15.623693)"
          id="g3781">
         <rect
@@ -528,7 +528,7 @@
       <text
          inkscape:export-ydpi="279.61734"
          inkscape:export-xdpi="279.61734"
-         inkscape:export-filename="/home/lars/jesd204_layers.png"
+
          id="text3837"
          y="358.76605"
          x="222.76625"

--- a/docs/projects/ad35xxr_evb/ad35xxr_evb_zed_block_diagram.svg
+++ b/docs/projects/ad35xxr_evb/ad35xxr_evb_zed_block_diagram.svg
@@ -9,7 +9,7 @@
    id="svg29591"
    inkscape:version="1.3.2 (091e20e, 2023-11-25, custom)"
    sodipodi:docname="ad35xxr_evb_zed_block_diagram.svg"
-   inkscape:export-filename="ad35xxr_evb_zed_block_diagram.png"
+
    inkscape:export-xdpi="96"
    inkscape:export-ydpi="96"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
@@ -847,7 +847,7 @@
        height="116.72887"
        x="45.85265"
        y="42.423283"
-       inkscape:export-filename="C:\workspace\ad\ghdl\docs\block_diagrams\cn0577\cn0577_block_diagram.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36" />
     <path
@@ -856,7 +856,7 @@
        id="path4518"
        d="M 133.57232,45.349186 V 40.279672"
        style="display:inline;fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:0.396875;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-start:url(#TriangleInM);marker-end:url(#TriangleOutM);shape-rendering:crispEdges;enable-background:new"
-       inkscape:export-filename="C:\workspace\ad\ghdl\docs\block_diagrams\cn0577\cn0577_block_diagram.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36" />
     <path
@@ -865,7 +865,7 @@
        id="path4518-5"
        d="M 140.48242,45.347446 V 40.304278"
        style="display:inline;fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:0.396875;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-start:url(#TriangleInM-7);marker-end:url(#TriangleOutM-2);shape-rendering:crispEdges;enable-background:new"
-       inkscape:export-filename="C:\workspace\ad\ghdl\docs\block_diagrams\cn0577\cn0577_block_diagram.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36" />
     <path
@@ -874,7 +874,7 @@
        id="path4518-5-9"
        d="M 147.39251,45.34172 V 40.272264"
        style="display:inline;fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:0.396875;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-start:url(#TriangleInM-7-1);marker-end:url(#TriangleOutM-2-8);shape-rendering:crispEdges;enable-background:new"
-       inkscape:export-filename="C:\workspace\ad\ghdl\docs\block_diagrams\cn0577\cn0577_block_diagram.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36" />
     <rect
@@ -885,7 +885,7 @@
        height="19.844805"
        x="-164.83311"
        y="46.539265"
-       inkscape:export-filename="C:\workspace\ad\ghdl\docs\block_diagrams\cn0577\cn0577_block_diagram.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36" />
     <path
@@ -893,7 +893,7 @@
        d="M 157.54764,46.715505 V 66.42975"
        id="path4179"
        inkscape:connector-curvature="0"
-       inkscape:export-filename="C:\workspace\ad\ghdl\docs\block_diagrams\cn0577\cn0577_block_diagram.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36" />
     <path
@@ -901,7 +901,7 @@
        d="M 150.76627,46.715505 V 66.42975"
        id="path4179-9"
        inkscape:connector-curvature="0"
-       inkscape:export-filename="C:\workspace\ad\ghdl\docs\block_diagrams\cn0577\cn0577_block_diagram.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36" />
     <path
@@ -909,7 +909,7 @@
        d="M 123.64077,46.715505 V 66.42975"
        id="path4179-0"
        inkscape:connector-curvature="0"
-       inkscape:export-filename="C:\workspace\ad\ghdl\docs\block_diagrams\cn0577\cn0577_block_diagram.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36" />
     <path
@@ -917,7 +917,7 @@
        d="M 130.42215,46.715505 V 66.42975"
        id="path4179-4"
        inkscape:connector-curvature="0"
-       inkscape:export-filename="C:\workspace\ad\ghdl\docs\block_diagrams\cn0577\cn0577_block_diagram.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36" />
     <path
@@ -925,7 +925,7 @@
        d="M 137.20352,46.715505 V 66.42975"
        id="path4179-7"
        inkscape:connector-curvature="0"
-       inkscape:export-filename="C:\workspace\ad\ghdl\docs\block_diagrams\cn0577\cn0577_block_diagram.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36" />
     <path
@@ -933,7 +933,7 @@
        d="M 143.98489,46.715505 V 66.42975"
        id="path4179-41"
        inkscape:connector-curvature="0"
-       inkscape:export-filename="C:\workspace\ad\ghdl\docs\block_diagrams\cn0577\cn0577_block_diagram.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36" />
     <path
@@ -941,7 +941,7 @@
        d="M 116.8594,46.715505 V 66.42975"
        id="path4179-0-3"
        inkscape:connector-curvature="0"
-       inkscape:export-filename="C:\workspace\ad\ghdl\docs\block_diagrams\cn0577\cn0577_block_diagram.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36" />
     <text
@@ -951,7 +951,7 @@
        x="-62.18874"
        style="font-style:normal;font-weight:normal;font-size:3.175px;line-height:0%;font-family:Arial;letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;shape-rendering:crispEdges"
        xml:space="preserve"
-       inkscape:export-filename="C:\workspace\ad\ghdl\docs\block_diagrams\cn0577\cn0577_block_diagram.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36"><tspan
          style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:2.97656px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial Bold';stroke-width:0.264583px"
@@ -966,7 +966,7 @@
        x="-60.271706"
        style="font-style:normal;font-weight:normal;font-size:3.175px;line-height:0%;font-family:Arial;letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;shape-rendering:crispEdges"
        xml:space="preserve"
-       inkscape:export-filename="C:\workspace\ad\ghdl\docs\block_diagrams\cn0577\cn0577_block_diagram.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36"><tspan
          style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:2.97656px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial Bold';stroke-width:0.264583px"
@@ -981,7 +981,7 @@
        x="-60.204849"
        style="font-style:normal;font-weight:normal;font-size:3.175px;line-height:0%;font-family:Arial;letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;shape-rendering:crispEdges"
        xml:space="preserve"
-       inkscape:export-filename="C:\workspace\ad\ghdl\docs\block_diagrams\cn0577\cn0577_block_diagram.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36"><tspan
          style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:2.97656px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial Bold';stroke-width:0.264583px"
@@ -996,7 +996,7 @@
        x="-58.415714"
        style="font-style:normal;font-weight:normal;font-size:3.175px;line-height:0%;font-family:Arial;letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;shape-rendering:crispEdges"
        xml:space="preserve"
-       inkscape:export-filename="C:\workspace\ad\ghdl\docs\block_diagrams\cn0577\cn0577_block_diagram.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36"><tspan
          style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:2.97656px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial Bold';stroke-width:0.264583px"
@@ -1011,7 +1011,7 @@
        x="-58.398273"
        style="font-style:normal;font-weight:normal;font-size:3.175px;line-height:0%;font-family:Arial;letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;shape-rendering:crispEdges"
        xml:space="preserve"
-       inkscape:export-filename="C:\workspace\ad\ghdl\docs\block_diagrams\cn0577\cn0577_block_diagram.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36"><tspan
          style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:2.97656px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial Bold';stroke-width:0.264583px"
@@ -1028,7 +1028,7 @@
        x="-63.036072"
        style="font-style:normal;font-weight:normal;font-size:3.175px;line-height:0%;font-family:Arial;letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;shape-rendering:crispEdges"
        xml:space="preserve"
-       inkscape:export-filename="C:\workspace\ad\ghdl\docs\block_diagrams\cn0577\cn0577_block_diagram.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36"><tspan
          style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:2.97656px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial Bold';stroke-width:0.264583px"
@@ -1055,7 +1055,7 @@
        x="-60.131454"
        style="font-style:normal;font-weight:normal;font-size:3.175px;line-height:0%;font-family:Arial;letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;shape-rendering:crispEdges"
        xml:space="preserve"
-       inkscape:export-filename="C:\workspace\ad\ghdl\docs\block_diagrams\cn0577\cn0577_block_diagram.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36"><tspan
          style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:2.97656px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial Bold';stroke-width:0.264583px"
@@ -1072,7 +1072,7 @@
        y="36.366516"
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36"
-       inkscape:export-filename="C:\workspace\ad\ghdl\docs\block_diagrams\cn0577\cn0577_block_diagram.png" />
+ />
     <text
        xml:space="preserve"
        style="font-style:normal;font-weight:normal;font-size:3.175px;line-height:0%;font-family:Arial;letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;shape-rendering:crispEdges;enable-background:new"
@@ -1081,7 +1081,7 @@
        id="text4595"
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36"
-       inkscape:export-filename="C:\workspace\ad\ghdl\docs\block_diagrams\cn0577\cn0577_block_diagram.png"><tspan
+><tspan
          style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:3.30729px;line-height:1.25;font-family:Arial;-inkscape-font-specification:Arial;stroke-width:0.264583px"
          sodipodi:role="line"
          id="tspan4597"
@@ -1096,7 +1096,7 @@
        y="83.339706"
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36"
-       inkscape:export-filename="C:\workspace\ad\ghdl\docs\block_diagrams\cn0577\cn0577_block_diagram.png" />
+ />
     <text
        xml:space="preserve"
        style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:3.88056px;line-height:0%;font-family:Arial;-inkscape-font-specification:'Arial, Bold';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;shape-rendering:crispEdges;enable-background:new"
@@ -1106,7 +1106,7 @@
        transform="rotate(-90)"
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36"
-       inkscape:export-filename="C:\workspace\ad\ghdl\docs\block_diagrams\cn0577\cn0577_block_diagram.png"><tspan
+><tspan
          sodipodi:role="line"
          id="tspan4491"
          x="-134.61133"
@@ -1120,7 +1120,7 @@
        id="text4482"
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36"
-       inkscape:export-filename="C:\workspace\ad\ghdl\docs\block_diagrams\cn0577\cn0577_block_diagram.png"><tspan
+><tspan
          sodipodi:role="line"
          x="179.62912"
          y="57.091106"
@@ -1135,7 +1135,7 @@
        y="69.942032"
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36"
-       inkscape:export-filename="C:\workspace\ad\ghdl\docs\block_diagrams\cn0577\cn0577_block_diagram.png" />
+ />
     <rect
        style="display:inline;vector-effect:none;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.459227;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:0;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;shape-rendering:crispEdges;enable-background:new"
        id="rect4488"
@@ -1145,7 +1145,7 @@
        y="76.277794"
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36"
-       inkscape:export-filename="C:\workspace\ad\ghdl\docs\block_diagrams\cn0577\cn0577_block_diagram.png" />
+ />
     <text
        xml:space="preserve"
        style="font-style:normal;font-weight:normal;font-size:3.175px;line-height:0%;font-family:Arial;letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;shape-rendering:crispEdges;enable-background:new"
@@ -1155,7 +1155,7 @@
        transform="rotate(-90)"
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36"
-       inkscape:export-filename="C:\workspace\ad\ghdl\docs\block_diagrams\cn0577\cn0577_block_diagram.png"><tspan
+><tspan
          sodipodi:role="line"
          id="tspan4493"
          x="-129.60384"
@@ -1170,7 +1170,7 @@
        y="69.953239"
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36"
-       inkscape:export-filename="C:\workspace\ad\ghdl\docs\block_diagrams\cn0577\cn0577_block_diagram.png" />
+ />
     <rect
        y="73.397713"
        x="72.880264"
@@ -1180,7 +1180,7 @@
        style="display:inline;vector-effect:none;fill:#d2e6eb;fill-opacity:1;fill-rule:nonzero;stroke:#0f3296;stroke-width:0.225601;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;shape-rendering:crispEdges;enable-background:new"
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36"
-       inkscape:export-filename="C:\workspace\ad\ghdl\docs\block_diagrams\cn0577\cn0577_block_diagram.png" />
+ />
     <text
        transform="rotate(-90)"
        id="text5788"
@@ -1190,7 +1190,7 @@
        xml:space="preserve"
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36"
-       inkscape:export-filename="C:\workspace\ad\ghdl\docs\block_diagrams\cn0577\cn0577_block_diagram.png"><tspan
+><tspan
          style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:4.63021px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial Bold';fill:#28170b;stroke:none;stroke-width:0.264583px;stroke-opacity:1"
          y="79.038582"
          x="-114.37154"
@@ -1203,7 +1203,7 @@
        x="69.524628"
        style="font-style:normal;font-weight:normal;font-size:3.175px;line-height:0%;font-family:Arial;letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;shape-rendering:crispEdges;enable-background:new"
        xml:space="preserve"
-       inkscape:export-filename="C:\workspace\ad\ghdl\docs\block_diagrams\cn0577\cn0577_block_diagram.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36"><tspan
          style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:3.96875px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial Bold';stroke-width:0.264583px"
@@ -1542,7 +1542,7 @@
        y="112.51494"
        id="text2401-61-1-54-8"
        transform="scale(1.0162353,0.98402408)"
-       inkscape:export-filename="C:\workspace\ad\ghdl\docs\block_diagrams\cn0577\cn0577_block_diagram.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36"><tspan
          sodipodi:role="line"
@@ -1557,7 +1557,7 @@
        y="113.11918"
        id="text2401-61-1-54-8-3"
        transform="scale(1.0162353,0.98402408)"
-       inkscape:export-filename="C:\workspace\ad\ghdl\docs\block_diagrams\cn0577\cn0577_block_diagram.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36"><tspan
          sodipodi:role="line"

--- a/docs/projects/ad4080_fmc_evb/ad4080_fmc_evb_zed_block_diagram.svg
+++ b/docs/projects/ad4080_fmc_evb/ad4080_fmc_evb_zed_block_diagram.svg
@@ -624,7 +624,7 @@
        y="69.981445"
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36"
-       inkscape:export-filename="C:\workspace\ad\ghdl\docs\block_diagrams\cn0577\cn0577_block_diagram.png" />
+ />
     <rect
        style="display:inline;fill:none;fill-opacity:1;stroke:#3f4b55;stroke-width:0.436;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:0.436,1.308;stroke-dashoffset:0;stroke-opacity:1;shape-rendering:crispEdges;enable-background:new"
        id="rect6078"
@@ -634,7 +634,7 @@
        y="78.586243"
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36"
-       inkscape:export-filename="C:\workspace\ad\ghdl\docs\block_diagrams\cn0577\cn0577_block_diagram.png" />
+ />
     <rect
        style="fill:#fefdfe;fill-opacity:1;fill-rule:evenodd;stroke:#071414;stroke-width:0.4;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:75.5906;stroke-opacity:1"
        id="rect46745"
@@ -649,7 +649,7 @@
        height="116.72887"
        x="45.85265"
        y="42.423283"
-       inkscape:export-filename="C:\workspace\ad\ghdl\docs\block_diagrams\cn0577\cn0577_block_diagram.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36" />
     <path
@@ -658,7 +658,7 @@
        id="path4518"
        d="M 133.57232,45.349186 V 40.279672"
        style="display:inline;fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:0.396875;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-start:url(#TriangleInM);marker-end:url(#TriangleOutM);shape-rendering:crispEdges;enable-background:new"
-       inkscape:export-filename="C:\workspace\ad\ghdl\docs\block_diagrams\cn0577\cn0577_block_diagram.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36" />
     <path
@@ -667,7 +667,7 @@
        id="path4518-5"
        d="M 140.48242,45.347446 V 40.304278"
        style="display:inline;fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:0.396875;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-start:url(#TriangleInM-7);marker-end:url(#TriangleOutM-2);shape-rendering:crispEdges;enable-background:new"
-       inkscape:export-filename="C:\workspace\ad\ghdl\docs\block_diagrams\cn0577\cn0577_block_diagram.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36" />
     <path
@@ -676,7 +676,7 @@
        id="path4518-5-9"
        d="M 147.39251,45.34172 V 40.272264"
        style="display:inline;fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:0.396875;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-start:url(#TriangleInM-7-1);marker-end:url(#TriangleOutM-2-8);shape-rendering:crispEdges;enable-background:new"
-       inkscape:export-filename="C:\workspace\ad\ghdl\docs\block_diagrams\cn0577\cn0577_block_diagram.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36" />
     <rect
@@ -687,7 +687,7 @@
        height="19.844805"
        x="-164.83311"
        y="46.539265"
-       inkscape:export-filename="C:\workspace\ad\ghdl\docs\block_diagrams\cn0577\cn0577_block_diagram.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36" />
     <path
@@ -695,7 +695,7 @@
        d="M 157.54764,46.715505 V 66.42975"
        id="path4179"
        inkscape:connector-curvature="0"
-       inkscape:export-filename="C:\workspace\ad\ghdl\docs\block_diagrams\cn0577\cn0577_block_diagram.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36" />
     <path
@@ -703,7 +703,7 @@
        d="M 150.76627,46.715505 V 66.42975"
        id="path4179-9"
        inkscape:connector-curvature="0"
-       inkscape:export-filename="C:\workspace\ad\ghdl\docs\block_diagrams\cn0577\cn0577_block_diagram.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36" />
     <path
@@ -711,7 +711,7 @@
        d="M 123.64077,46.715505 V 66.42975"
        id="path4179-0"
        inkscape:connector-curvature="0"
-       inkscape:export-filename="C:\workspace\ad\ghdl\docs\block_diagrams\cn0577\cn0577_block_diagram.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36" />
     <path
@@ -719,7 +719,7 @@
        d="M 130.42215,46.715505 V 66.42975"
        id="path4179-4"
        inkscape:connector-curvature="0"
-       inkscape:export-filename="C:\workspace\ad\ghdl\docs\block_diagrams\cn0577\cn0577_block_diagram.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36" />
     <path
@@ -727,7 +727,7 @@
        d="M 137.20352,46.715505 V 66.42975"
        id="path4179-7"
        inkscape:connector-curvature="0"
-       inkscape:export-filename="C:\workspace\ad\ghdl\docs\block_diagrams\cn0577\cn0577_block_diagram.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36" />
     <path
@@ -735,7 +735,7 @@
        d="M 143.98489,46.715505 V 66.42975"
        id="path4179-41"
        inkscape:connector-curvature="0"
-       inkscape:export-filename="C:\workspace\ad\ghdl\docs\block_diagrams\cn0577\cn0577_block_diagram.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36" />
     <path
@@ -743,7 +743,7 @@
        d="M 116.8594,46.715505 V 66.42975"
        id="path4179-0-3"
        inkscape:connector-curvature="0"
-       inkscape:export-filename="C:\workspace\ad\ghdl\docs\block_diagrams\cn0577\cn0577_block_diagram.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36" />
     <text
@@ -753,7 +753,7 @@
        x="-62.18874"
        style="font-style:normal;font-weight:normal;font-size:3.175px;line-height:0%;font-family:Arial;letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;shape-rendering:crispEdges"
        xml:space="preserve"
-       inkscape:export-filename="C:\workspace\ad\ghdl\docs\block_diagrams\cn0577\cn0577_block_diagram.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36"><tspan
          style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:2.97656px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial Bold';stroke-width:0.264583px"
@@ -768,7 +768,7 @@
        x="-60.271706"
        style="font-style:normal;font-weight:normal;font-size:3.175px;line-height:0%;font-family:Arial;letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;shape-rendering:crispEdges"
        xml:space="preserve"
-       inkscape:export-filename="C:\workspace\ad\ghdl\docs\block_diagrams\cn0577\cn0577_block_diagram.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36"><tspan
          style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:2.97656px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial Bold';stroke-width:0.264583px"
@@ -783,7 +783,7 @@
        x="-60.204849"
        style="font-style:normal;font-weight:normal;font-size:3.175px;line-height:0%;font-family:Arial;letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;shape-rendering:crispEdges"
        xml:space="preserve"
-       inkscape:export-filename="C:\workspace\ad\ghdl\docs\block_diagrams\cn0577\cn0577_block_diagram.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36"><tspan
          style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:2.97656px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial Bold';stroke-width:0.264583px"
@@ -798,7 +798,7 @@
        x="-58.415714"
        style="font-style:normal;font-weight:normal;font-size:3.175px;line-height:0%;font-family:Arial;letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;shape-rendering:crispEdges"
        xml:space="preserve"
-       inkscape:export-filename="C:\workspace\ad\ghdl\docs\block_diagrams\cn0577\cn0577_block_diagram.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36"><tspan
          style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:2.97656px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial Bold';stroke-width:0.264583px"
@@ -813,7 +813,7 @@
        x="-58.398273"
        style="font-style:normal;font-weight:normal;font-size:3.175px;line-height:0%;font-family:Arial;letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;shape-rendering:crispEdges"
        xml:space="preserve"
-       inkscape:export-filename="C:\workspace\ad\ghdl\docs\block_diagrams\cn0577\cn0577_block_diagram.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36"><tspan
          style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:2.97656px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial Bold';stroke-width:0.264583px"
@@ -830,7 +830,7 @@
        x="-63.036072"
        style="font-style:normal;font-weight:normal;font-size:3.175px;line-height:0%;font-family:Arial;letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;shape-rendering:crispEdges"
        xml:space="preserve"
-       inkscape:export-filename="C:\workspace\ad\ghdl\docs\block_diagrams\cn0577\cn0577_block_diagram.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36"><tspan
          style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:2.97656px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial Bold';stroke-width:0.264583px"
@@ -857,7 +857,7 @@
        x="-60.131454"
        style="font-style:normal;font-weight:normal;font-size:3.175px;line-height:0%;font-family:Arial;letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;shape-rendering:crispEdges"
        xml:space="preserve"
-       inkscape:export-filename="C:\workspace\ad\ghdl\docs\block_diagrams\cn0577\cn0577_block_diagram.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36"><tspan
          style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:2.97656px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial Bold';stroke-width:0.264583px"
@@ -874,7 +874,7 @@
        y="36.366516"
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36"
-       inkscape:export-filename="C:\workspace\ad\ghdl\docs\block_diagrams\cn0577\cn0577_block_diagram.png" />
+ />
     <text
        xml:space="preserve"
        style="font-style:normal;font-weight:normal;font-size:3.175px;line-height:0%;font-family:Arial;letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;shape-rendering:crispEdges;enable-background:new"
@@ -883,7 +883,7 @@
        id="text4595"
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36"
-       inkscape:export-filename="C:\workspace\ad\ghdl\docs\block_diagrams\cn0577\cn0577_block_diagram.png"><tspan
+><tspan
          style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:3.30729px;line-height:1.25;font-family:Arial;-inkscape-font-specification:Arial;stroke-width:0.264583px"
          sodipodi:role="line"
          id="tspan4597"
@@ -898,7 +898,7 @@
        y="85.137817"
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36"
-       inkscape:export-filename="C:\workspace\ad\ghdl\docs\block_diagrams\cn0577\cn0577_block_diagram.png" />
+ />
     <text
        xml:space="preserve"
        style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:3.88056px;line-height:0%;font-family:Arial;-inkscape-font-specification:'Arial, Bold';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;shape-rendering:crispEdges;enable-background:new"
@@ -908,7 +908,7 @@
        transform="rotate(-90)"
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36"
-       inkscape:export-filename="C:\workspace\ad\ghdl\docs\block_diagrams\cn0577\cn0577_block_diagram.png"><tspan
+><tspan
          sodipodi:role="line"
          id="tspan4491"
          x="-136.32645"
@@ -922,7 +922,7 @@
        id="text4482"
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36"
-       inkscape:export-filename="C:\workspace\ad\ghdl\docs\block_diagrams\cn0577\cn0577_block_diagram.png"><tspan
+><tspan
          sodipodi:role="line"
          x="179.62912"
          y="57.091106"
@@ -937,7 +937,7 @@
        y="65.548294"
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36"
-       inkscape:export-filename="C:\workspace\ad\ghdl\docs\block_diagrams\cn0577\cn0577_block_diagram.png" />
+ />
     <text
        xml:space="preserve"
        style="font-style:normal;font-weight:normal;font-size:3.175px;line-height:0%;font-family:Arial;letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;shape-rendering:crispEdges;enable-background:new"
@@ -947,7 +947,7 @@
        transform="rotate(-90)"
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36"
-       inkscape:export-filename="C:\workspace\ad\ghdl\docs\block_diagrams\cn0577\cn0577_block_diagram.png"><tspan
+><tspan
          sodipodi:role="line"
          id="tspan4493"
          x="-136.48291"
@@ -962,7 +962,7 @@
        y="69.953239"
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36"
-       inkscape:export-filename="C:\workspace\ad\ghdl\docs\block_diagrams\cn0577\cn0577_block_diagram.png" />
+ />
     <rect
        y="73.397713"
        x="72.880264"
@@ -972,7 +972,7 @@
        style="display:inline;vector-effect:none;fill:#ffcccc;fill-opacity:1;fill-rule:nonzero;stroke:#a01414;stroke-width:0.225601;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;shape-rendering:crispEdges;enable-background:new"
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36"
-       inkscape:export-filename="C:\workspace\ad\ghdl\docs\block_diagrams\cn0577\cn0577_block_diagram.png" />
+ />
     <text
        transform="rotate(-90)"
        id="text5788"
@@ -982,7 +982,7 @@
        xml:space="preserve"
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36"
-       inkscape:export-filename="C:\workspace\ad\ghdl\docs\block_diagrams\cn0577\cn0577_block_diagram.png"><tspan
+><tspan
          style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:4.63021px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial Bold';fill:#28170b;stroke:none;stroke-width:0.264583px;stroke-opacity:1"
          y="79.038582"
          x="-114.37154"
@@ -995,7 +995,7 @@
        x="69.524628"
        style="font-style:normal;font-weight:normal;font-size:3.175px;line-height:0%;font-family:Arial;letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;shape-rendering:crispEdges;enable-background:new"
        xml:space="preserve"
-       inkscape:export-filename="C:\workspace\ad\ghdl\docs\block_diagrams\cn0577\cn0577_block_diagram.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36"><tspan
          style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:3.96875px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial Bold';stroke-width:0.264583px"
@@ -1007,7 +1007,7 @@
        id="g5654"
        style="display:inline;fill:#a01414;fill-opacity:1;stroke:#a01414;stroke-width:0.91193;stroke-opacity:1;shape-rendering:crispEdges;enable-background:new"
        transform="matrix(0.32827811,0,0,0.26434798,19.943177,-34.962379)"
-       inkscape:export-filename="C:\workspace\ad\ghdl\docs\block_diagrams\cn0577\cn0577_block_diagram.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36">
       <path
@@ -1021,7 +1021,7 @@
        id="g5654-3"
        style="display:inline;fill:#a01414;fill-opacity:1;stroke:#a01414;stroke-width:0.57429;stroke-opacity:1;shape-rendering:crispEdges;enable-background:new"
        transform="matrix(0.80784318,0,0,0.27086297,-22.589664,-39.068558)"
-       inkscape:export-filename="C:\workspace\ad\ghdl\docs\block_diagrams\cn0577\cn0577_block_diagram.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36">
       <path
@@ -1122,7 +1122,7 @@
        style="display:inline;shape-rendering:crispEdges;enable-background:new"
        id="ddr"
        transform="matrix(0.37593397,0,0,0.37593391,-17.27073,-132.78758)"
-       inkscape:export-filename="C:\workspace\ad\ghdl\docs\block_diagrams\cn0577\cn0577_block_diagram.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36">
       <rect
@@ -1231,7 +1231,7 @@
        style="display:inline;shape-rendering:crispEdges;enable-background:new"
        id="g8892"
        transform="matrix(0.26458333,0,0,0.26458333,40.080594,-84.382617)"
-       inkscape:export-filename="C:\workspace\ad\ghdl\docs\block_diagrams\cn0577\cn0577_block_diagram.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36">
       <rect
@@ -1341,7 +1341,7 @@
        id="uart"
        transform="matrix(0,-0.10973853,0.10973855,0,102.98407,90.423989)"
        style="display:inline;stroke-width:2.41103;stroke-miterlimit:4;stroke-dasharray:none;shape-rendering:crispEdges;enable-background:new"
-       inkscape:export-filename="C:\workspace\ad\ghdl\docs\block_diagrams\cn0577\cn0577_block_diagram.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36">
       <rect
@@ -1441,7 +1441,7 @@
        y="112.67403"
        id="text2401-61-1-54-8"
        transform="scale(1.0162353,0.98402408)"
-       inkscape:export-filename="C:\workspace\ad\ghdl\docs\block_diagrams\cn0577\cn0577_block_diagram.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36"><tspan
          sodipodi:role="line"
@@ -1456,7 +1456,7 @@
        y="111.75716"
        id="text2401-61-1-54-8-3"
        transform="scale(1.0162353,0.98402408)"
-       inkscape:export-filename="C:\workspace\ad\ghdl\docs\block_diagrams\cn0577\cn0577_block_diagram.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36"><tspan
          sodipodi:role="line"

--- a/docs/projects/ad488x_fmc_evb/ad488x_fmc_evb_zed_block_diagram.svg
+++ b/docs/projects/ad488x_fmc_evb/ad488x_fmc_evb_zed_block_diagram.svg
@@ -862,7 +862,7 @@
        height="177.24677"
        x="4.3267717"
        y="5.0751486"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD4880\AD44880_BLOCK_DIAGRAM.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36" />
     <rect
@@ -872,7 +872,7 @@
        height="170.50319"
        x="8.4500179"
        y="10.807824"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD4880\AD44880_BLOCK_DIAGRAM.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36" />
     <path
@@ -881,7 +881,7 @@
        id="path4518"
        d="M 133.92972,32.483769 V 27.414255"
        style="display:inline;fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:0.396875;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-start:url(#TriangleInM);marker-end:url(#TriangleOutM);shape-rendering:crispEdges;enable-background:new"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD4880\AD44880_BLOCK_DIAGRAM.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36" />
     <path
@@ -890,7 +890,7 @@
        id="path4518-5"
        d="M 140.83982,32.482029 V 27.438861"
        style="display:inline;fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:0.396875;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-start:url(#TriangleInM-7);marker-end:url(#TriangleOutM-2);shape-rendering:crispEdges;enable-background:new"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD4880\AD44880_BLOCK_DIAGRAM.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36" />
     <path
@@ -899,7 +899,7 @@
        id="path4518-5-9"
        d="M 147.74991,32.476303 V 27.406847"
        style="display:inline;fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:0.396875;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-start:url(#TriangleInM-7-1);marker-end:url(#TriangleOutM-2-8);shape-rendering:crispEdges;enable-background:new"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD4880\AD44880_BLOCK_DIAGRAM.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36" />
     <rect
@@ -910,7 +910,7 @@
        height="19.844805"
        x="-165.19052"
        y="33.673855"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD4880\AD44880_BLOCK_DIAGRAM.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36" />
     <path
@@ -918,7 +918,7 @@
        d="m 157.90504,33.850088 v 19.71424"
        id="path4179"
        inkscape:connector-curvature="0"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD4880\AD44880_BLOCK_DIAGRAM.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36" />
     <path
@@ -926,7 +926,7 @@
        d="m 151.12367,33.850088 v 19.71424"
        id="path4179-9"
        inkscape:connector-curvature="0"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD4880\AD44880_BLOCK_DIAGRAM.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36" />
     <path
@@ -934,7 +934,7 @@
        d="m 123.99817,33.850088 v 19.71424"
        id="path4179-0"
        inkscape:connector-curvature="0"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD4880\AD44880_BLOCK_DIAGRAM.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36" />
     <path
@@ -942,7 +942,7 @@
        d="m 130.77955,33.850088 v 19.71424"
        id="path4179-4"
        inkscape:connector-curvature="0"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD4880\AD44880_BLOCK_DIAGRAM.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36" />
     <path
@@ -950,7 +950,7 @@
        d="m 137.56092,33.850088 v 19.71424"
        id="path4179-7"
        inkscape:connector-curvature="0"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD4880\AD44880_BLOCK_DIAGRAM.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36" />
     <path
@@ -958,7 +958,7 @@
        d="m 144.34229,33.850088 v 19.71424"
        id="path4179-41"
        inkscape:connector-curvature="0"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD4880\AD44880_BLOCK_DIAGRAM.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36" />
     <path
@@ -966,7 +966,7 @@
        d="m 117.2168,33.850088 v 19.71424"
        id="path4179-0-3"
        inkscape:connector-curvature="0"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD4880\AD44880_BLOCK_DIAGRAM.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36" />
     <text
@@ -976,7 +976,7 @@
        x="-49.41568"
        style="font-style:normal;font-weight:normal;font-size:3.175px;line-height:0%;font-family:Arial;letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;shape-rendering:crispEdges"
        xml:space="preserve"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD4880\AD44880_BLOCK_DIAGRAM.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36"><tspan
          style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:2.97656px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial Bold';stroke-width:0.264583px"
@@ -991,7 +991,7 @@
        x="-47.498642"
        style="font-style:normal;font-weight:normal;font-size:3.175px;line-height:0%;font-family:Arial;letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;shape-rendering:crispEdges"
        xml:space="preserve"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD4880\AD44880_BLOCK_DIAGRAM.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36"><tspan
          style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:2.97656px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial Bold';stroke-width:0.264583px"
@@ -1006,7 +1006,7 @@
        x="-47.431786"
        style="font-style:normal;font-weight:normal;font-size:3.175px;line-height:0%;font-family:Arial;letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;shape-rendering:crispEdges"
        xml:space="preserve"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD4880\AD44880_BLOCK_DIAGRAM.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36"><tspan
          style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:2.97656px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial Bold';stroke-width:0.264583px"
@@ -1021,7 +1021,7 @@
        x="-45.642647"
        style="font-style:normal;font-weight:normal;font-size:3.175px;line-height:0%;font-family:Arial;letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;shape-rendering:crispEdges"
        xml:space="preserve"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD4880\AD44880_BLOCK_DIAGRAM.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36"><tspan
          style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:2.97656px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial Bold';stroke-width:0.264583px"
@@ -1036,7 +1036,7 @@
        x="-45.625206"
        style="font-style:normal;font-weight:normal;font-size:3.175px;line-height:0%;font-family:Arial;letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;shape-rendering:crispEdges"
        xml:space="preserve"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD4880\AD44880_BLOCK_DIAGRAM.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36"><tspan
          style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:2.97656px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial Bold';stroke-width:0.264583px"
@@ -1053,7 +1053,7 @@
        x="-50.263016"
        style="font-style:normal;font-weight:normal;font-size:3.175px;line-height:0%;font-family:Arial;letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;shape-rendering:crispEdges"
        xml:space="preserve"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD4880\AD44880_BLOCK_DIAGRAM.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36"><tspan
          style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:2.97656px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial Bold';stroke-width:0.264583px"
@@ -1068,7 +1068,7 @@
        x="82.596695"
        style="font-style:normal;font-weight:normal;font-size:3.175px;line-height:0%;font-family:Arial;letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;shape-rendering:crispEdges"
        xml:space="preserve"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD4880\AD44880_BLOCK_DIAGRAM.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36"><tspan
          y="27.874945"
@@ -1083,7 +1083,7 @@
        x="-47.358391"
        style="font-style:normal;font-weight:normal;font-size:3.175px;line-height:0%;font-family:Arial;letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;shape-rendering:crispEdges"
        xml:space="preserve"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD4880\AD44880_BLOCK_DIAGRAM.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36"><tspan
          style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:2.97656px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial Bold';stroke-width:0.264583px"
@@ -1100,7 +1100,7 @@
        y="23.501108"
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD4880\AD44880_BLOCK_DIAGRAM.png" />
+ />
     <text
        xml:space="preserve"
        style="font-style:normal;font-weight:normal;font-size:3.175px;line-height:0%;font-family:Arial;letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;shape-rendering:crispEdges;enable-background:new"
@@ -1109,7 +1109,7 @@
        id="text4595"
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD4880\AD44880_BLOCK_DIAGRAM.png"><tspan
+><tspan
          style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:3.30729px;line-height:1.25;font-family:Arial;-inkscape-font-specification:Arial;stroke-width:0.264583px"
          sodipodi:role="line"
          id="tspan4597"
@@ -1124,7 +1124,7 @@
        y="75.585739"
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD4880\AD44880_BLOCK_DIAGRAM.png" />
+ />
     <text
        xml:space="preserve"
        style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:3.88056px;line-height:0%;font-family:Arial;-inkscape-font-specification:'Arial, Bold';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;shape-rendering:crispEdges;enable-background:new"
@@ -1134,7 +1134,7 @@
        transform="rotate(-90)"
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD4880\AD44880_BLOCK_DIAGRAM.png"><tspan
+><tspan
          sodipodi:role="line"
          id="tspan4491"
          x="-145.71025"
@@ -1148,7 +1148,7 @@
        id="text4482"
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD4880\AD44880_BLOCK_DIAGRAM.png"><tspan
+><tspan
          sodipodi:role="line"
          x="179.98653"
          y="44.225689"
@@ -1163,7 +1163,7 @@
        y="59.58049"
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD4880\AD44880_BLOCK_DIAGRAM.png" />
+ />
     <rect
        style="display:inline;vector-effect:none;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.459227;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:0;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;shape-rendering:crispEdges;enable-background:new"
        id="rect4488"
@@ -1173,7 +1173,7 @@
        y="61.679832"
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD4880\AD44880_BLOCK_DIAGRAM.png" />
+ />
     <text
        xml:space="preserve"
        style="font-style:normal;font-weight:normal;font-size:3.175px;line-height:0%;font-family:Arial;letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;shape-rendering:crispEdges;enable-background:new"
@@ -1183,7 +1183,7 @@
        transform="rotate(-90)"
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD4880\AD44880_BLOCK_DIAGRAM.png"><tspan
+><tspan
          sodipodi:role="line"
          id="tspan4493"
          x="-125.37051"
@@ -1198,7 +1198,7 @@
        y="60.050694"
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD4880\AD44880_BLOCK_DIAGRAM.png" />
+ />
     <rect
        y="73.144989"
        x="36.993958"
@@ -1208,7 +1208,7 @@
        style="display:inline;vector-effect:none;fill:#ffcccc;fill-opacity:1;fill-rule:nonzero;stroke:#a01414;stroke-width:0.225601;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;shape-rendering:crispEdges;enable-background:new"
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD4880\AD44880_BLOCK_DIAGRAM.png" />
+ />
     <rect
        y="80.504799"
        x="62.293724"
@@ -1218,7 +1218,7 @@
        style="display:inline;vector-effect:none;fill:#ffcccc;fill-opacity:1;fill-rule:nonzero;stroke:#a01414;stroke-width:0.225601;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;shape-rendering:crispEdges;enable-background:new"
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD4880\AD44880_BLOCK_DIAGRAM.png" />
+ />
     <text
        transform="rotate(-90)"
        id="text5788"
@@ -1228,7 +1228,7 @@
        xml:space="preserve"
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD4880\AD44880_BLOCK_DIAGRAM.png"><tspan
+><tspan
          style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:4.63021px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial Bold';fill:#28170b;stroke:none;stroke-width:0.264583px;stroke-opacity:1"
          y="43.225876"
          x="-125.85468"
@@ -1243,7 +1243,7 @@
        xml:space="preserve"
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD4880\AD44880_BLOCK_DIAGRAM.png"><tspan
+><tspan
          style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:4.63021px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial Bold';fill:#28170b;stroke:none;stroke-width:0.264583px;stroke-opacity:1"
          y="124.14346"
          x="71.168358"
@@ -1256,7 +1256,7 @@
        x="69.884613"
        style="font-style:normal;font-weight:normal;font-size:3.175px;line-height:0%;font-family:Arial;letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;shape-rendering:crispEdges;enable-background:new"
        xml:space="preserve"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD4880\AD44880_BLOCK_DIAGRAM.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36"><tspan
          style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:3.96875px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial Bold';stroke-width:0.264583px"
@@ -1268,7 +1268,7 @@
        id="g5654"
        style="display:inline;fill:#a01414;fill-opacity:1;stroke:#a01414;stroke-width:0.91193;stroke-opacity:1;shape-rendering:crispEdges;enable-background:new"
        transform="matrix(0.32827811,0,0,0.26434798,-19.695839,-24.135676)"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD4880\AD44880_BLOCK_DIAGRAM.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36">
       <path
@@ -1282,7 +1282,7 @@
        id="g5654-3"
        style="display:inline;fill:#a01414;fill-opacity:1;stroke:#a01414;stroke-width:0.74793;stroke-opacity:1;shape-rendering:crispEdges;enable-background:new"
        transform="matrix(0.4762859,0,0,0.27086297,-15.602972,-27.890617)"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD4880\AD44880_BLOCK_DIAGRAM.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36">
       <path
@@ -1296,7 +1296,7 @@
        id="g5654-2"
        style="display:inline;fill:#a01414;fill-opacity:1;stroke:#a01414;stroke-opacity:1;shape-rendering:crispEdges;enable-background:new"
        transform="matrix(0.46245287,0,0,0.26458333,24.934835,-101.65513)"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD4880\AD44880_BLOCK_DIAGRAM.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36" />
     <text
@@ -1305,7 +1305,7 @@
        x="112.0732"
        style="font-style:normal;font-weight:normal;font-size:3.175px;line-height:0%;font-family:Arial;letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;shape-rendering:crispEdges;enable-background:new"
        xml:space="preserve"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD4880\AD44880_BLOCK_DIAGRAM.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36"><tspan
          id="tspan11370-7-5"
@@ -1319,7 +1319,7 @@
        id="path1206"
        d="M 198.39343,82.075765 H 160.98307"
        style="fill:none;stroke:#000000;stroke-width:0.529167;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#marker1216);shape-rendering:crispEdges"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD4880\AD44880_BLOCK_DIAGRAM.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36" />
     <path
@@ -1328,7 +1328,7 @@
        id="path1206-9"
        d="M 198.66335,87.208081 H 161.25301"
        style="display:inline;fill:none;stroke:#000000;stroke-width:0.529167;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#marker1216-9);shape-rendering:crispEdges;enable-background:new"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD4880\AD44880_BLOCK_DIAGRAM.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36" />
     <text
@@ -1338,7 +1338,7 @@
        style="font-style:normal;font-weight:normal;font-size:4.42089px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583;shape-rendering:crispEdges"
        xml:space="preserve"
        transform="scale(1.0443046,0.95757502)"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD4880\AD44880_BLOCK_DIAGRAM.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36"><tspan
          style="font-size:3.68407px;stroke-width:0.264583"
@@ -1353,7 +1353,7 @@
        style="font-style:normal;font-weight:normal;font-size:4.42089px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583;shape-rendering:crispEdges"
        xml:space="preserve"
        transform="scale(1.0443046,0.95757502)"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD4880\AD44880_BLOCK_DIAGRAM.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36"><tspan
          style="font-size:3.68407px;stroke-width:0.264583"
@@ -1367,7 +1367,7 @@
        id="path1206-5"
        d="M 198.38955,97.429305 H 160.9792"
        style="fill:none;stroke:#000000;stroke-width:0.529167;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#marker1216-4);shape-rendering:crispEdges"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD4880\AD44880_BLOCK_DIAGRAM.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36" />
     <path
@@ -1376,7 +1376,7 @@
        id="path1206-9-1"
        d="M 198.65947,102.5616 H 161.24913"
        style="display:inline;fill:none;stroke:#000000;stroke-width:0.529167;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#marker1216-9-6);shape-rendering:crispEdges;enable-background:new"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD4880\AD44880_BLOCK_DIAGRAM.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36" />
     <text
@@ -1386,7 +1386,7 @@
        style="font-style:normal;font-weight:normal;font-size:4.42089px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583;shape-rendering:crispEdges"
        xml:space="preserve"
        transform="scale(1.0443046,0.95757502)"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD4880\AD44880_BLOCK_DIAGRAM.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36"><tspan
          style="font-size:3.68407px;stroke-width:0.264583"
@@ -1401,7 +1401,7 @@
        style="font-style:normal;font-weight:normal;font-size:4.42089px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583;shape-rendering:crispEdges"
        xml:space="preserve"
        transform="scale(1.0443046,0.95757502)"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD4880\AD44880_BLOCK_DIAGRAM.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36"><tspan
          style="font-size:3.68407px;stroke-width:0.264583"
@@ -1413,7 +1413,7 @@
        style="display:inline;shape-rendering:crispEdges;enable-background:new"
        id="ddr"
        transform="matrix(0.37593397,0,0,0.37593391,-16.913329,-145.6534)"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD4880\AD44880_BLOCK_DIAGRAM.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36">
       <rect
@@ -1522,7 +1522,7 @@
        style="display:inline;shape-rendering:crispEdges;enable-background:new"
        id="g8892"
        transform="matrix(0.26458333,0,0,0.26458333,40.437995,-97.248346)"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD4880\AD44880_BLOCK_DIAGRAM.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36">
       <rect
@@ -1632,7 +1632,7 @@
        id="uart"
        transform="matrix(0,-0.10973853,0.10973855,0,103.34147,77.55856)"
        style="display:inline;stroke-width:2.41103;stroke-miterlimit:4;stroke-dasharray:none;shape-rendering:crispEdges;enable-background:new"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD4880\AD44880_BLOCK_DIAGRAM.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36">
       <rect
@@ -1732,7 +1732,7 @@
        y="123.67651"
        id="text2401-61-1-54-8"
        transform="scale(1.0162353,0.98402408)"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD4880\AD44880_BLOCK_DIAGRAM.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36"><tspan
          sodipodi:role="line"
@@ -1747,7 +1747,7 @@
        y="123.2982"
        id="text2401-61-1-54-8-3"
        transform="scale(1.0162353,0.98402408)"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD4880\AD44880_BLOCK_DIAGRAM.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36"><tspan
          sodipodi:role="line"
@@ -1762,7 +1762,7 @@
        height="13.626906"
        x="130.64497"
        y="82.556091"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD4880\AD44880_BLOCK_DIAGRAM.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36" />
     <rect
@@ -1772,7 +1772,7 @@
        height="3.6373949"
        x="129.91284"
        y="112.3062"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD4880\AD44880_BLOCK_DIAGRAM.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36" />
     <rect
@@ -1782,7 +1782,7 @@
        height="6.8542814"
        x="145.87386"
        y="88.030754"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD4880\AD44880_BLOCK_DIAGRAM.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36" />
     <rect
@@ -1792,7 +1792,7 @@
        height="8.1842365"
        x="130.64609"
        y="98.350143"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD4880\AD44880_BLOCK_DIAGRAM.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36" />
     <text
@@ -1800,7 +1800,7 @@
        transform="matrix(0.0954441,0,0,0.07735464,98.299642,56.475776)"
        id="text4758"
        style="font-size:14px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial, Normal';white-space:pre;shape-inside:url(#rect4760);stroke-width:3.07925"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD4880\AD44880_BLOCK_DIAGRAM.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36"><tspan
          x="505.75977"
@@ -1813,7 +1813,7 @@
        height="6.8542814"
        x="131.9803"
        y="87.959953"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD4880\AD44880_BLOCK_DIAGRAM.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36" />
     <text
@@ -1821,7 +1821,7 @@
        transform="matrix(0.0954441,0,0,0.07735464,86.183747,56.515798)"
        id="text4758-5"
        style="font-size:14px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial, Normal';white-space:pre;shape-inside:url(#rect4760-6);stroke-width:3.07925"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD4880\AD44880_BLOCK_DIAGRAM.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36"><tspan
          x="505.75977"
@@ -1834,7 +1834,7 @@
        y="91.234436"
        id="text21502"
        transform="scale(1.065612,0.93842788)"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD4880\AD44880_BLOCK_DIAGRAM.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36"><tspan
          sodipodi:role="line"
@@ -1847,7 +1847,7 @@
        transform="matrix(0.08783843,0,0,0.07735464,105.62205,65.57295)"
        id="text24668"
        style="font-size:16px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial, Normal';white-space:pre;shape-inside:url(#rect24670);stroke-width:3.2098"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD4880\AD44880_BLOCK_DIAGRAM.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36"><tspan
          x="298.9668"
@@ -1860,7 +1860,7 @@
        height="8.1842365"
        x="144.4581"
        y="98.276237"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD4880\AD44880_BLOCK_DIAGRAM.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36" />
     <text
@@ -1868,7 +1868,7 @@
        transform="matrix(0.08783843,0,0,0.07735464,119.43405,65.499062)"
        id="text24668-1"
        style="font-size:16px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial, Normal';white-space:pre;shape-inside:url(#rect24670-6);stroke-width:3.2098"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD4880\AD44880_BLOCK_DIAGRAM.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36"><tspan
          x="298.9668"
@@ -1881,7 +1881,7 @@
        y="122.28669"
        id="text41823"
        transform="scale(1.065612,0.93842788)"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD4880\AD44880_BLOCK_DIAGRAM.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36"><tspan
          sodipodi:role="line"
@@ -1893,14 +1893,14 @@
        style="fill:#a01414;fill-opacity:1;stroke:#a01414;stroke-width:0.6;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:20;stroke-opacity:1;marker-start:url(#TriangleInM-3);marker-end:url(#marker51146)"
        d="m 151.02244,107.78375 c 0,3.28676 0,3.16036 0,3.16036"
        id="path42520-2"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD4880\AD44880_BLOCK_DIAGRAM.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36" />
     <path
        style="fill:#a01414;fill-opacity:1;stroke:#a01414;stroke-width:0.6;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:20;stroke-opacity:1;marker-start:url(#TriangleInM-0);marker-end:url(#marker51146-9)"
        d="m 136.25134,107.80489 c 0,3.28677 0,3.16036 0,3.16036"
        id="path42520-2-7"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD4880\AD44880_BLOCK_DIAGRAM.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36" />
     <rect
@@ -1910,7 +1910,7 @@
        height="39.648827"
        x="126.81845"
        y="77.625374"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD4880\AD44880_BLOCK_DIAGRAM.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36" />
     <text
@@ -1920,7 +1920,7 @@
        y="85.926407"
        id="text49535"
        transform="scale(1.065612,0.93842788)"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD4880\AD44880_BLOCK_DIAGRAM.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36"><tspan
          sodipodi:role="line"
@@ -1934,7 +1934,7 @@
        x="13.360975"
        y="175.72833"
        id="text41772"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD4880\AD44880_BLOCK_DIAGRAM.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36"><tspan
          sodipodi:role="line"
@@ -1948,7 +1948,7 @@
        x="44.984196"
        y="175.84045"
        id="text41772-4"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD4880\AD44880_BLOCK_DIAGRAM.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36"><tspan
          sodipodi:role="line"
@@ -1962,7 +1962,7 @@
        id="path1206-6"
        d="M 198.38955,108.86611 H 160.9792"
        style="fill:none;stroke:#000000;stroke-width:0.529167;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#marker1216-71);shape-rendering:crispEdges"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD4880\AD44880_BLOCK_DIAGRAM.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36" />
     <path
@@ -1971,7 +1971,7 @@
        id="path1206-9-12"
        d="M 198.65949,113.99842 H 161.24913"
        style="display:inline;fill:none;stroke:#000000;stroke-width:0.529167;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#marker1216-9-9);shape-rendering:crispEdges;enable-background:new"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD4880\AD44880_BLOCK_DIAGRAM.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36" />
     <text
@@ -1981,7 +1981,7 @@
        style="font-style:normal;font-weight:normal;font-size:4.42089px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583;shape-rendering:crispEdges"
        xml:space="preserve"
        transform="scale(1.0443046,0.95757502)"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD4880\AD44880_BLOCK_DIAGRAM.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36"><tspan
          style="font-size:3.68407px;stroke-width:0.264583"
@@ -1996,7 +1996,7 @@
        style="font-style:normal;font-weight:normal;font-size:4.42089px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583;shape-rendering:crispEdges"
        xml:space="preserve"
        transform="scale(1.0443046,0.95757502)"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD4880\AD44880_BLOCK_DIAGRAM.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36"><tspan
          style="font-size:3.68407px;stroke-width:0.264583"
@@ -2010,7 +2010,7 @@
        id="path1206-1"
        d="M 198.36871,125.98561 H 160.95835"
        style="fill:none;stroke:#000000;stroke-width:0.529167;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#marker1216-3);shape-rendering:crispEdges"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD4880\AD44880_BLOCK_DIAGRAM.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36" />
     <path
@@ -2019,7 +2019,7 @@
        id="path1206-9-4"
        d="M 198.63863,131.11793 H 161.22829"
        style="display:inline;fill:none;stroke:#000000;stroke-width:0.529167;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#marker1216-9-94);shape-rendering:crispEdges;enable-background:new"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD4880\AD44880_BLOCK_DIAGRAM.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36" />
     <path
@@ -2028,7 +2028,7 @@
        id="path1206-9-4-6"
        d="M 126.37654,90.791427 H 98.322673"
        style="display:inline;fill:none;stroke:#000000;stroke-width:0.529167;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#marker1216-9-94-1);shape-rendering:crispEdges;enable-background:new"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD4880\AD44880_BLOCK_DIAGRAM.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36" />
     <path
@@ -2037,7 +2037,7 @@
        id="path1206-9-4-6-7"
        d="M 126.53083,96.341941 H 98.47697"
        style="display:inline;fill:none;stroke:#000000;stroke-width:0.529167;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#marker1216-9-94-1-4);shape-rendering:crispEdges;enable-background:new"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD4880\AD44880_BLOCK_DIAGRAM.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36" />
     <text
@@ -2046,7 +2046,7 @@
        x="106.28091"
        y="95.303329"
        id="text59898-5-01"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD4880\AD44880_BLOCK_DIAGRAM.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36"><tspan
          sodipodi:role="line"
@@ -2060,7 +2060,7 @@
        x="104.98835"
        y="100.12487"
        id="text59898-5-01-1"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD4880\AD44880_BLOCK_DIAGRAM.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36"><tspan
          sodipodi:role="line"
@@ -2074,7 +2074,7 @@
        id="path1206-9-4-6-7-00"
        d="M 126.70953,101.22769 H 98.655671"
        style="display:inline;fill:none;stroke:#000000;stroke-width:0.529167;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#marker1216-9-94-1-4-5);shape-rendering:crispEdges;enable-background:new"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD4880\AD44880_BLOCK_DIAGRAM.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36" />
     <text
@@ -2083,7 +2083,7 @@
        x="104.98835"
        y="141.01016"
        id="text59898-5-01-1-2"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD4880\AD44880_BLOCK_DIAGRAM.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36"><tspan
          sodipodi:role="line"
@@ -2097,7 +2097,7 @@
        id="path1206-9-4-6-7-00-2"
        d="M 126.29964,142.11298 H 98.245776"
        style="display:inline;fill:none;stroke:#000000;stroke-width:0.529167;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#marker1216-9-94-1-4-5-7);shape-rendering:crispEdges;enable-background:new"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD4880\AD44880_BLOCK_DIAGRAM.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36" />
     <path
@@ -2106,7 +2106,7 @@
        id="path1206-9-4-6-7-0"
        d="M 126.17343,137.14647 H 98.119572"
        style="display:inline;fill:none;stroke:#000000;stroke-width:0.529167;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#marker1216-9-94-1-4-0);shape-rendering:crispEdges;enable-background:new"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD4880\AD44880_BLOCK_DIAGRAM.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36" />
     <text
@@ -2116,7 +2116,7 @@
        style="font-style:normal;font-weight:normal;font-size:4.42089px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583;shape-rendering:crispEdges"
        xml:space="preserve"
        transform="scale(1.0443046,0.95757502)"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD4880\AD44880_BLOCK_DIAGRAM.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36"><tspan
          style="font-size:3.68407px;stroke-width:0.264583"
@@ -2131,7 +2131,7 @@
        style="font-style:normal;font-weight:normal;font-size:4.42089px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583;shape-rendering:crispEdges"
        xml:space="preserve"
        transform="scale(1.0443046,0.95757502)"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD4880\AD44880_BLOCK_DIAGRAM.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36"><tspan
          style="font-size:3.68407px;stroke-width:0.264583"
@@ -2145,7 +2145,7 @@
        id="path1206-5-9"
        d="M 198.36483,141.3392 H 160.95448"
        style="fill:none;stroke:#000000;stroke-width:0.529167;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#marker1216-4-8);shape-rendering:crispEdges"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD4880\AD44880_BLOCK_DIAGRAM.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36" />
     <path
@@ -2154,7 +2154,7 @@
        id="path1206-9-1-5"
        d="M 198.63475,146.47151 H 161.22441"
        style="display:inline;fill:none;stroke:#000000;stroke-width:0.529167;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#marker1216-9-6-2);shape-rendering:crispEdges;enable-background:new"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD4880\AD44880_BLOCK_DIAGRAM.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36" />
     <text
@@ -2164,7 +2164,7 @@
        style="font-style:normal;font-weight:normal;font-size:4.42089px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583;shape-rendering:crispEdges"
        xml:space="preserve"
        transform="scale(1.0443046,0.95757502)"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD4880\AD44880_BLOCK_DIAGRAM.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36"><tspan
          style="font-size:3.68407px;stroke-width:0.264583"
@@ -2179,7 +2179,7 @@
        style="font-style:normal;font-weight:normal;font-size:4.42089px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583;shape-rendering:crispEdges"
        xml:space="preserve"
        transform="scale(1.0443046,0.95757502)"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD4880\AD44880_BLOCK_DIAGRAM.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36"><tspan
          style="font-size:3.68407px;stroke-width:0.264583"
@@ -2194,7 +2194,7 @@
        height="13.626906"
        x="130.62025"
        y="126.46612"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD4880\AD44880_BLOCK_DIAGRAM.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36" />
     <rect
@@ -2204,7 +2204,7 @@
        height="3.6373949"
        x="129.88814"
        y="156.21626"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD4880\AD44880_BLOCK_DIAGRAM.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36" />
     <rect
@@ -2214,7 +2214,7 @@
        height="6.8542814"
        x="145.84914"
        y="131.94081"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD4880\AD44880_BLOCK_DIAGRAM.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36" />
     <rect
@@ -2224,7 +2224,7 @@
        height="8.1842365"
        x="130.62137"
        y="142.26019"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD4880\AD44880_BLOCK_DIAGRAM.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36" />
     <text
@@ -2232,7 +2232,7 @@
        transform="matrix(0.0954441,0,0,0.07735464,98.274922,100.38562)"
        id="text4758-2"
        style="font-size:14px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial, Normal';white-space:pre;shape-inside:url(#rect4760-7);stroke-width:3.07925"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD4880\AD44880_BLOCK_DIAGRAM.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36"><tspan
          x="505.75977"
@@ -2245,7 +2245,7 @@
        height="6.8542814"
        x="131.95558"
        y="131.87001"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD4880\AD44880_BLOCK_DIAGRAM.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36" />
     <text
@@ -2253,7 +2253,7 @@
        transform="matrix(0.0954441,0,0,0.07735464,86.159027,100.42564)"
        id="text4758-5-5"
        style="font-size:14px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial, Normal';white-space:pre;shape-inside:url(#rect4760-6-7);stroke-width:3.07925"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD4880\AD44880_BLOCK_DIAGRAM.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36"><tspan
          x="505.75977"
@@ -2266,7 +2266,7 @@
        y="138.02536"
        id="text21502-6"
        transform="scale(1.065612,0.93842788)"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD4880\AD44880_BLOCK_DIAGRAM.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36"><tspan
          sodipodi:role="line"
@@ -2279,7 +2279,7 @@
        transform="matrix(0.08783843,0,0,0.07735464,105.59733,109.48279)"
        id="text24668-7"
        style="font-size:16px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial, Normal';white-space:pre;shape-inside:url(#rect24670-7);stroke-width:3.2098"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD4880\AD44880_BLOCK_DIAGRAM.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36"><tspan
          x="298.9668"
@@ -2292,7 +2292,7 @@
        height="8.1842365"
        x="144.43338"
        y="142.18631"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD4880\AD44880_BLOCK_DIAGRAM.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36" />
     <text
@@ -2300,7 +2300,7 @@
        transform="matrix(0.08783843,0,0,0.07735464,119.40933,109.4089)"
        id="text24668-1-9"
        style="font-size:16px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial, Normal';white-space:pre;shape-inside:url(#rect24670-6-6);stroke-width:3.2098"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD4880\AD44880_BLOCK_DIAGRAM.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36"><tspan
          x="298.9668"
@@ -2313,7 +2313,7 @@
        y="169.07762"
        id="text41823-3"
        transform="scale(1.065612,0.93842788)"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD4880\AD44880_BLOCK_DIAGRAM.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36"><tspan
          sodipodi:role="line"
@@ -2325,14 +2325,14 @@
        style="fill:#a01414;fill-opacity:1;stroke:#a01414;stroke-width:0.6;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:20;stroke-opacity:1;marker-start:url(#TriangleInM-3-8);marker-end:url(#marker51146-5)"
        d="m 150.99772,151.69366 c 0,3.28676 0,3.16036 0,3.16036"
        id="path42520-2-1"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD4880\AD44880_BLOCK_DIAGRAM.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36" />
     <path
        style="fill:#a01414;fill-opacity:1;stroke:#a01414;stroke-width:0.6;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:20;stroke-opacity:1;marker-start:url(#TriangleInM-0-1);marker-end:url(#marker51146-9-0)"
        d="m 136.22662,151.7148 c 0,3.28677 0,3.16036 0,3.16036"
        id="path42520-2-7-1"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD4880\AD44880_BLOCK_DIAGRAM.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36" />
     <rect
@@ -2342,7 +2342,7 @@
        height="39.648827"
        x="126.79372"
        y="121.53537"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD4880\AD44880_BLOCK_DIAGRAM.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36" />
     <text
@@ -2352,7 +2352,7 @@
        y="132.71733"
        id="text49535-5"
        transform="scale(1.065612,0.93842788)"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD4880\AD44880_BLOCK_DIAGRAM.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36"><tspan
          sodipodi:role="line"
@@ -2366,7 +2366,7 @@
        id="path1206-6-8"
        d="M 198.36483,152.77602 H 160.95448"
        style="fill:none;stroke:#000000;stroke-width:0.529167;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#marker1216-71-1);shape-rendering:crispEdges"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD4880\AD44880_BLOCK_DIAGRAM.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36" />
     <path
@@ -2375,7 +2375,7 @@
        id="path1206-9-12-9"
        d="M 198.63477,157.90833 H 161.22441"
        style="display:inline;fill:none;stroke:#000000;stroke-width:0.529167;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#marker1216-9-9-1);shape-rendering:crispEdges;enable-background:new"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD4880\AD44880_BLOCK_DIAGRAM.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36" />
     <text
@@ -2385,7 +2385,7 @@
        style="font-style:normal;font-weight:normal;font-size:4.42089px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583;shape-rendering:crispEdges"
        xml:space="preserve"
        transform="scale(1.0443046,0.95757502)"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD4880\AD44880_BLOCK_DIAGRAM.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36"><tspan
          style="font-size:3.68407px;stroke-width:0.264583"
@@ -2400,7 +2400,7 @@
        style="font-style:normal;font-weight:normal;font-size:4.42089px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583;shape-rendering:crispEdges"
        xml:space="preserve"
        transform="scale(1.0443046,0.95757502)"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD4880\AD44880_BLOCK_DIAGRAM.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36"><tspan
          style="font-size:3.68407px;stroke-width:0.264583"
@@ -2413,7 +2413,7 @@
        d="m 161.96028,55.891378 -0.0814,13.444073 34.3415,-0.07082 v 0 0"
        id="path54607"
        sodipodi:nodetypes="ccccc"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD4880\AD44880_BLOCK_DIAGRAM.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36" />
     <text
@@ -2422,7 +2422,7 @@
        x="164.46185"
        y="67.427681"
        id="text59898"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD4880\AD44880_BLOCK_DIAGRAM.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36"><tspan
          sodipodi:role="line"
@@ -2436,7 +2436,7 @@
        x="103.10733"
        y="89.593117"
        id="text59898-5"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD4880\AD44880_BLOCK_DIAGRAM.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36"><tspan
          sodipodi:role="line"
@@ -2450,7 +2450,7 @@
        x="103.10733"
        y="136.14142"
        id="text59898-5-0"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD4880\AD44880_BLOCK_DIAGRAM.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36"><tspan
          sodipodi:role="line"

--- a/docs/projects/ad7405_fmc/ad7405_zed_cmos_diagram.svg
+++ b/docs/projects/ad7405_fmc/ad7405_zed_cmos_diagram.svg
@@ -413,7 +413,7 @@
        height="137.58115"
        x="35.198463"
        y="50.647671"
-       inkscape:export-filename="C:\workspace\ad\ghdl\docs\block_diagrams\cn0577\cn0577_block_diagram.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36" />
     <path
@@ -422,7 +422,7 @@
        id="path4518"
        d="M 122.91397,53.569407 V 48.499893"
        style="display:inline;fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:0.396875;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-start:url(#TriangleInM);marker-end:url(#TriangleOutM);shape-rendering:crispEdges;enable-background:new"
-       inkscape:export-filename="C:\workspace\ad\ghdl\docs\block_diagrams\cn0577\cn0577_block_diagram.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36" />
     <path
@@ -431,7 +431,7 @@
        id="path4518-5"
        d="M 129.82407,53.567667 V 48.524499"
        style="display:inline;fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:0.396875;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-start:url(#TriangleInM-7);marker-end:url(#TriangleOutM-2);shape-rendering:crispEdges;enable-background:new"
-       inkscape:export-filename="C:\workspace\ad\ghdl\docs\block_diagrams\cn0577\cn0577_block_diagram.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36" />
     <path
@@ -440,7 +440,7 @@
        id="path4518-5-9"
        d="M 136.73416,53.561941 V 48.492485"
        style="display:inline;fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:0.396875;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-start:url(#TriangleInM-7-1);marker-end:url(#TriangleOutM-2-8);shape-rendering:crispEdges;enable-background:new"
-       inkscape:export-filename="C:\workspace\ad\ghdl\docs\block_diagrams\cn0577\cn0577_block_diagram.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36" />
     <rect
@@ -451,7 +451,7 @@
        height="19.844805"
        x="-154.17477"
        y="54.759487"
-       inkscape:export-filename="C:\workspace\ad\ghdl\docs\block_diagrams\cn0577\cn0577_block_diagram.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36" />
     <path
@@ -459,7 +459,7 @@
        d="M 146.88929,54.935726 V 74.649971"
        id="path4179"
        inkscape:connector-curvature="0"
-       inkscape:export-filename="C:\workspace\ad\ghdl\docs\block_diagrams\cn0577\cn0577_block_diagram.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36" />
     <path
@@ -467,7 +467,7 @@
        d="M 140.10792,54.935726 V 74.649971"
        id="path4179-9"
        inkscape:connector-curvature="0"
-       inkscape:export-filename="C:\workspace\ad\ghdl\docs\block_diagrams\cn0577\cn0577_block_diagram.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36" />
     <path
@@ -475,7 +475,7 @@
        d="M 112.98242,54.935726 V 74.649971"
        id="path4179-0"
        inkscape:connector-curvature="0"
-       inkscape:export-filename="C:\workspace\ad\ghdl\docs\block_diagrams\cn0577\cn0577_block_diagram.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36" />
     <path
@@ -483,7 +483,7 @@
        d="M 119.7638,54.935726 V 74.649971"
        id="path4179-4"
        inkscape:connector-curvature="0"
-       inkscape:export-filename="C:\workspace\ad\ghdl\docs\block_diagrams\cn0577\cn0577_block_diagram.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36" />
     <path
@@ -491,7 +491,7 @@
        d="M 126.54517,54.935726 V 74.649971"
        id="path4179-7"
        inkscape:connector-curvature="0"
-       inkscape:export-filename="C:\workspace\ad\ghdl\docs\block_diagrams\cn0577\cn0577_block_diagram.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36" />
     <path
@@ -499,7 +499,7 @@
        d="M 133.32654,54.935726 V 74.649971"
        id="path4179-41"
        inkscape:connector-curvature="0"
-       inkscape:export-filename="C:\workspace\ad\ghdl\docs\block_diagrams\cn0577\cn0577_block_diagram.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36" />
     <path
@@ -507,7 +507,7 @@
        d="M 106.20105,54.935726 V 74.649971"
        id="path4179-0-3"
        inkscape:connector-curvature="0"
-       inkscape:export-filename="C:\workspace\ad\ghdl\docs\block_diagrams\cn0577\cn0577_block_diagram.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36" />
     <text
@@ -517,7 +517,7 @@
        x="-70.350021"
        style="font-style:normal;font-weight:normal;font-size:3.175px;line-height:0%;font-family:Arial;letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;shape-rendering:crispEdges"
        xml:space="preserve"
-       inkscape:export-filename="C:\workspace\ad\ghdl\docs\block_diagrams\cn0577\cn0577_block_diagram.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36"><tspan
          style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:2.97656px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial Bold';stroke-width:0.264583px"
@@ -532,7 +532,7 @@
        x="-68.432983"
        style="font-style:normal;font-weight:normal;font-size:3.175px;line-height:0%;font-family:Arial;letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;shape-rendering:crispEdges"
        xml:space="preserve"
-       inkscape:export-filename="C:\workspace\ad\ghdl\docs\block_diagrams\cn0577\cn0577_block_diagram.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36"><tspan
          style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:2.97656px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial Bold';stroke-width:0.264583px"
@@ -547,7 +547,7 @@
        x="-68.366127"
        style="font-style:normal;font-weight:normal;font-size:3.175px;line-height:0%;font-family:Arial;letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;shape-rendering:crispEdges"
        xml:space="preserve"
-       inkscape:export-filename="C:\workspace\ad\ghdl\docs\block_diagrams\cn0577\cn0577_block_diagram.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36"><tspan
          style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:2.97656px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial Bold';stroke-width:0.264583px"
@@ -562,7 +562,7 @@
        x="-66.576996"
        style="font-style:normal;font-weight:normal;font-size:3.175px;line-height:0%;font-family:Arial;letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;shape-rendering:crispEdges"
        xml:space="preserve"
-       inkscape:export-filename="C:\workspace\ad\ghdl\docs\block_diagrams\cn0577\cn0577_block_diagram.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36"><tspan
          style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:2.97656px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial Bold';stroke-width:0.264583px"
@@ -577,7 +577,7 @@
        x="-66.559555"
        style="font-style:normal;font-weight:normal;font-size:3.175px;line-height:0%;font-family:Arial;letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;shape-rendering:crispEdges"
        xml:space="preserve"
-       inkscape:export-filename="C:\workspace\ad\ghdl\docs\block_diagrams\cn0577\cn0577_block_diagram.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36"><tspan
          style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:2.97656px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial Bold';stroke-width:0.264583px"
@@ -594,7 +594,7 @@
        x="-71.19735"
        style="font-style:normal;font-weight:normal;font-size:3.175px;line-height:0%;font-family:Arial;letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;shape-rendering:crispEdges"
        xml:space="preserve"
-       inkscape:export-filename="C:\workspace\ad\ghdl\docs\block_diagrams\cn0577\cn0577_block_diagram.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36"><tspan
          style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:2.97656px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial Bold';stroke-width:0.264583px"
@@ -621,7 +621,7 @@
        x="-68.292732"
        style="font-style:normal;font-weight:normal;font-size:3.175px;line-height:0%;font-family:Arial;letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;shape-rendering:crispEdges"
        xml:space="preserve"
-       inkscape:export-filename="C:\workspace\ad\ghdl\docs\block_diagrams\cn0577\cn0577_block_diagram.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36"><tspan
          style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:2.97656px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial Bold';stroke-width:0.264583px"
@@ -638,7 +638,7 @@
        y="44.586739"
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36"
-       inkscape:export-filename="C:\workspace\ad\ghdl\docs\block_diagrams\cn0577\cn0577_block_diagram.png" />
+ />
     <text
        xml:space="preserve"
        style="font-style:normal;font-weight:normal;font-size:3.175px;line-height:0%;font-family:Arial;letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;shape-rendering:crispEdges;enable-background:new"
@@ -647,7 +647,7 @@
        id="text4595"
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36"
-       inkscape:export-filename="C:\workspace\ad\ghdl\docs\block_diagrams\cn0577\cn0577_block_diagram.png"><tspan
+><tspan
          style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:3.30729px;line-height:1.25;font-family:Arial;-inkscape-font-specification:Arial;stroke-width:0.264583px"
          sodipodi:role="line"
          id="tspan4597"
@@ -662,7 +662,7 @@
        y="96.811897"
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36"
-       inkscape:export-filename="C:\workspace\ad\ghdl\docs\block_diagrams\cn0577\cn0577_block_diagram.png" />
+ />
     <text
        xml:space="preserve"
        style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:3.88056px;line-height:0%;font-family:Arial;-inkscape-font-specification:'Arial, Bold';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;shape-rendering:crispEdges;enable-background:new"
@@ -672,7 +672,7 @@
        transform="rotate(-90)"
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36"
-       inkscape:export-filename="C:\workspace\ad\ghdl\docs\block_diagrams\cn0577\cn0577_block_diagram.png"><tspan
+><tspan
          sodipodi:role="line"
          id="tspan4491"
          x="-148.08353"
@@ -686,7 +686,7 @@
        id="text4482"
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36"
-       inkscape:export-filename="C:\workspace\ad\ghdl\docs\block_diagrams\cn0577\cn0577_block_diagram.png"><tspan
+><tspan
          sodipodi:role="line"
          x="168.97078"
          y="65.311325"
@@ -701,7 +701,7 @@
        y="78.169144"
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36"
-       inkscape:export-filename="C:\workspace\ad\ghdl\docs\block_diagrams\cn0577\cn0577_block_diagram.png" />
+ />
     <rect
        style="display:inline;vector-effect:none;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.459227;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:0;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;shape-rendering:crispEdges;enable-background:new"
        id="rect4488"
@@ -711,7 +711,7 @@
        y="92.270683"
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36"
-       inkscape:export-filename="C:\workspace\ad\ghdl\docs\block_diagrams\cn0577\cn0577_block_diagram.png" />
+ />
     <text
        xml:space="preserve"
        style="font-style:normal;font-weight:normal;font-size:3.175px;line-height:0%;font-family:Arial;letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;shape-rendering:crispEdges;enable-background:new"
@@ -721,7 +721,7 @@
        transform="rotate(-90)"
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36"
-       inkscape:export-filename="C:\workspace\ad\ghdl\docs\block_diagrams\cn0577\cn0577_block_diagram.png"><tspan
+><tspan
          sodipodi:role="line"
          id="tspan4493"
          x="-156.85475"
@@ -736,7 +736,7 @@
        y="78.173462"
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36"
-       inkscape:export-filename="C:\workspace\ad\ghdl\docs\block_diagrams\cn0577\cn0577_block_diagram.png" />
+ />
     <rect
        y="86.869904"
        x="62.221916"
@@ -746,7 +746,7 @@
        style="display:inline;vector-effect:none;fill:#ffcccc;fill-opacity:1;fill-rule:nonzero;stroke:#a01414;stroke-width:0.225601;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;shape-rendering:crispEdges;enable-background:new"
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36"
-       inkscape:export-filename="C:\workspace\ad\ghdl\docs\block_diagrams\cn0577\cn0577_block_diagram.png" />
+ />
     <text
        transform="rotate(-90)"
        id="text5788"
@@ -756,7 +756,7 @@
        xml:space="preserve"
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36"
-       inkscape:export-filename="C:\workspace\ad\ghdl\docs\block_diagrams\cn0577\cn0577_block_diagram.png"><tspan
+><tspan
          style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:4.63021px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial Bold';fill:#28170b;stroke:none;stroke-width:0.264583px;stroke-opacity:1"
          y="68.558937"
          x="-127.59537"
@@ -769,7 +769,7 @@
        x="58.789307"
        style="font-style:normal;font-weight:normal;font-size:3.175px;line-height:0%;font-family:Arial;letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;shape-rendering:crispEdges;enable-background:new"
        xml:space="preserve"
-       inkscape:export-filename="C:\workspace\ad\ghdl\docs\block_diagrams\cn0577\cn0577_block_diagram.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36"><tspan
          style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:3.96875px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial Bold';stroke-width:0.264583px"
@@ -781,7 +781,7 @@
        id="g5654"
        style="display:inline;fill:#a01414;fill-opacity:1;stroke:#a01414;stroke-width:0.91193;stroke-opacity:1;shape-rendering:crispEdges;enable-background:new"
        transform="matrix(0.32827811,0,0,0.26434798,9.284829,-20.986822)"
-       inkscape:export-filename="C:\workspace\ad\ghdl\docs\block_diagrams\cn0577\cn0577_block_diagram.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36">
       <path
@@ -795,7 +795,7 @@
        id="g5654-3"
        style="display:inline;fill:#a01414;fill-opacity:1;stroke:#a01414;stroke-width:0.57429;stroke-opacity:1;shape-rendering:crispEdges;enable-background:new"
        transform="matrix(0.80784318,0,0,0.27086297,-32.868931,-24.545517)"
-       inkscape:export-filename="C:\workspace\ad\ghdl\docs\block_diagrams\cn0577\cn0577_block_diagram.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36">
       <path
@@ -859,7 +859,7 @@
        style="display:inline;shape-rendering:crispEdges;enable-background:new"
        id="ddr"
        transform="matrix(0.37593397,0,0,0.37593391,-27.929078,-124.56736)"
-       inkscape:export-filename="C:\workspace\ad\ghdl\docs\block_diagrams\cn0577\cn0577_block_diagram.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36">
       <rect
@@ -968,7 +968,7 @@
        style="display:inline;shape-rendering:crispEdges;enable-background:new"
        id="g8892"
        transform="matrix(0.26458333,0,0,0.26458333,29.422246,-76.162396)"
-       inkscape:export-filename="C:\workspace\ad\ghdl\docs\block_diagrams\cn0577\cn0577_block_diagram.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36">
       <rect
@@ -1078,7 +1078,7 @@
        id="uart"
        transform="matrix(0,-0.10973853,0.10973855,0,92.325722,98.64421)"
        style="display:inline;stroke-width:2.41103;stroke-miterlimit:4;stroke-dasharray:none;shape-rendering:crispEdges;enable-background:new"
-       inkscape:export-filename="C:\workspace\ad\ghdl\docs\block_diagrams\cn0577\cn0577_block_diagram.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36">
       <rect
@@ -1178,7 +1178,7 @@
        y="126.80623"
        id="text2401-61-1-54-8"
        transform="scale(1.0162353,0.98402408)"
-       inkscape:export-filename="C:\workspace\ad\ghdl\docs\block_diagrams\cn0577\cn0577_block_diagram.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36"><tspan
          sodipodi:role="line"
@@ -1193,7 +1193,7 @@
        y="126.45621"
        id="text2401-61-1-54-8-3"
        transform="scale(1.0162353,0.98402408)"
-       inkscape:export-filename="C:\workspace\ad\ghdl\docs\block_diagrams\cn0577\cn0577_block_diagram.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36"><tspan
          sodipodi:role="line"

--- a/docs/projects/ad7405_fmc/ad7405_zed_lvds_diagram.svg
+++ b/docs/projects/ad7405_fmc/ad7405_zed_lvds_diagram.svg
@@ -389,7 +389,7 @@
        height="148.45645"
        x="35.194302"
        y="50.643509"
-       inkscape:export-filename="C:\workspace\ad\ghdl\docs\block_diagrams\cn0577\cn0577_block_diagram.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36" />
     <path
@@ -398,7 +398,7 @@
        id="path4518"
        d="M 122.91397,53.569407 V 48.499893"
        style="display:inline;fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:0.396875;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-start:url(#TriangleInM);marker-end:url(#TriangleOutM);shape-rendering:crispEdges;enable-background:new"
-       inkscape:export-filename="C:\workspace\ad\ghdl\docs\block_diagrams\cn0577\cn0577_block_diagram.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36" />
     <path
@@ -407,7 +407,7 @@
        id="path4518-5"
        d="M 129.82407,53.567667 V 48.524499"
        style="display:inline;fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:0.396875;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-start:url(#TriangleInM-7);marker-end:url(#TriangleOutM-2);shape-rendering:crispEdges;enable-background:new"
-       inkscape:export-filename="C:\workspace\ad\ghdl\docs\block_diagrams\cn0577\cn0577_block_diagram.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36" />
     <path
@@ -416,7 +416,7 @@
        id="path4518-5-9"
        d="M 136.73416,53.561941 V 48.492485"
        style="display:inline;fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:0.396875;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-start:url(#TriangleInM-7-1);marker-end:url(#TriangleOutM-2-8);shape-rendering:crispEdges;enable-background:new"
-       inkscape:export-filename="C:\workspace\ad\ghdl\docs\block_diagrams\cn0577\cn0577_block_diagram.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36" />
     <rect
@@ -427,7 +427,7 @@
        height="19.844805"
        x="-154.17477"
        y="54.759487"
-       inkscape:export-filename="C:\workspace\ad\ghdl\docs\block_diagrams\cn0577\cn0577_block_diagram.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36" />
     <path
@@ -435,7 +435,7 @@
        d="M 146.88929,54.935726 V 74.649971"
        id="path4179"
        inkscape:connector-curvature="0"
-       inkscape:export-filename="C:\workspace\ad\ghdl\docs\block_diagrams\cn0577\cn0577_block_diagram.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36" />
     <path
@@ -443,7 +443,7 @@
        d="M 140.10792,54.935726 V 74.649971"
        id="path4179-9"
        inkscape:connector-curvature="0"
-       inkscape:export-filename="C:\workspace\ad\ghdl\docs\block_diagrams\cn0577\cn0577_block_diagram.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36" />
     <path
@@ -451,7 +451,7 @@
        d="M 112.98242,54.935726 V 74.649971"
        id="path4179-0"
        inkscape:connector-curvature="0"
-       inkscape:export-filename="C:\workspace\ad\ghdl\docs\block_diagrams\cn0577\cn0577_block_diagram.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36" />
     <path
@@ -459,7 +459,7 @@
        d="M 119.7638,54.935726 V 74.649971"
        id="path4179-4"
        inkscape:connector-curvature="0"
-       inkscape:export-filename="C:\workspace\ad\ghdl\docs\block_diagrams\cn0577\cn0577_block_diagram.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36" />
     <path
@@ -467,7 +467,7 @@
        d="M 126.54517,54.935726 V 74.649971"
        id="path4179-7"
        inkscape:connector-curvature="0"
-       inkscape:export-filename="C:\workspace\ad\ghdl\docs\block_diagrams\cn0577\cn0577_block_diagram.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36" />
     <path
@@ -475,7 +475,7 @@
        d="M 133.32654,54.935726 V 74.649971"
        id="path4179-41"
        inkscape:connector-curvature="0"
-       inkscape:export-filename="C:\workspace\ad\ghdl\docs\block_diagrams\cn0577\cn0577_block_diagram.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36" />
     <path
@@ -483,7 +483,7 @@
        d="M 106.20105,54.935726 V 74.649971"
        id="path4179-0-3"
        inkscape:connector-curvature="0"
-       inkscape:export-filename="C:\workspace\ad\ghdl\docs\block_diagrams\cn0577\cn0577_block_diagram.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36" />
     <text
@@ -493,7 +493,7 @@
        x="-70.350021"
        style="font-style:normal;font-weight:normal;font-size:3.175px;line-height:0%;font-family:Arial;letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;shape-rendering:crispEdges"
        xml:space="preserve"
-       inkscape:export-filename="C:\workspace\ad\ghdl\docs\block_diagrams\cn0577\cn0577_block_diagram.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36"><tspan
          style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:2.97656px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial Bold';stroke-width:0.264583px"
@@ -508,7 +508,7 @@
        x="-68.432983"
        style="font-style:normal;font-weight:normal;font-size:3.175px;line-height:0%;font-family:Arial;letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;shape-rendering:crispEdges"
        xml:space="preserve"
-       inkscape:export-filename="C:\workspace\ad\ghdl\docs\block_diagrams\cn0577\cn0577_block_diagram.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36"><tspan
          style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:2.97656px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial Bold';stroke-width:0.264583px"
@@ -523,7 +523,7 @@
        x="-68.366127"
        style="font-style:normal;font-weight:normal;font-size:3.175px;line-height:0%;font-family:Arial;letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;shape-rendering:crispEdges"
        xml:space="preserve"
-       inkscape:export-filename="C:\workspace\ad\ghdl\docs\block_diagrams\cn0577\cn0577_block_diagram.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36"><tspan
          style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:2.97656px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial Bold';stroke-width:0.264583px"
@@ -538,7 +538,7 @@
        x="-66.576996"
        style="font-style:normal;font-weight:normal;font-size:3.175px;line-height:0%;font-family:Arial;letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;shape-rendering:crispEdges"
        xml:space="preserve"
-       inkscape:export-filename="C:\workspace\ad\ghdl\docs\block_diagrams\cn0577\cn0577_block_diagram.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36"><tspan
          style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:2.97656px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial Bold';stroke-width:0.264583px"
@@ -553,7 +553,7 @@
        x="-66.559555"
        style="font-style:normal;font-weight:normal;font-size:3.175px;line-height:0%;font-family:Arial;letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;shape-rendering:crispEdges"
        xml:space="preserve"
-       inkscape:export-filename="C:\workspace\ad\ghdl\docs\block_diagrams\cn0577\cn0577_block_diagram.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36"><tspan
          style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:2.97656px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial Bold';stroke-width:0.264583px"
@@ -570,7 +570,7 @@
        x="-71.19735"
        style="font-style:normal;font-weight:normal;font-size:3.175px;line-height:0%;font-family:Arial;letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;shape-rendering:crispEdges"
        xml:space="preserve"
-       inkscape:export-filename="C:\workspace\ad\ghdl\docs\block_diagrams\cn0577\cn0577_block_diagram.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36"><tspan
          style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:2.97656px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial Bold';stroke-width:0.264583px"
@@ -597,7 +597,7 @@
        x="-68.292732"
        style="font-style:normal;font-weight:normal;font-size:3.175px;line-height:0%;font-family:Arial;letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;shape-rendering:crispEdges"
        xml:space="preserve"
-       inkscape:export-filename="C:\workspace\ad\ghdl\docs\block_diagrams\cn0577\cn0577_block_diagram.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36"><tspan
          style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:2.97656px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial Bold';stroke-width:0.264583px"
@@ -614,7 +614,7 @@
        y="44.586739"
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36"
-       inkscape:export-filename="C:\workspace\ad\ghdl\docs\block_diagrams\cn0577\cn0577_block_diagram.png" />
+ />
     <text
        xml:space="preserve"
        style="font-style:normal;font-weight:normal;font-size:3.175px;line-height:0%;font-family:Arial;letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;shape-rendering:crispEdges;enable-background:new"
@@ -623,7 +623,7 @@
        id="text4595"
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36"
-       inkscape:export-filename="C:\workspace\ad\ghdl\docs\block_diagrams\cn0577\cn0577_block_diagram.png"><tspan
+><tspan
          style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:3.30729px;line-height:1.25;font-family:Arial;-inkscape-font-specification:Arial;stroke-width:0.264583px"
          sodipodi:role="line"
          id="tspan4597"
@@ -638,7 +638,7 @@
        y="96.811897"
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36"
-       inkscape:export-filename="C:\workspace\ad\ghdl\docs\block_diagrams\cn0577\cn0577_block_diagram.png" />
+ />
     <text
        xml:space="preserve"
        style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:3.88056px;line-height:0%;font-family:Arial;-inkscape-font-specification:'Arial, Bold';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;shape-rendering:crispEdges;enable-background:new"
@@ -648,7 +648,7 @@
        transform="rotate(-90)"
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36"
-       inkscape:export-filename="C:\workspace\ad\ghdl\docs\block_diagrams\cn0577\cn0577_block_diagram.png"><tspan
+><tspan
          sodipodi:role="line"
          id="tspan4491"
          x="-148.08353"
@@ -662,7 +662,7 @@
        id="text4482"
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36"
-       inkscape:export-filename="C:\workspace\ad\ghdl\docs\block_diagrams\cn0577\cn0577_block_diagram.png"><tspan
+><tspan
          sodipodi:role="line"
          x="168.97078"
          y="65.311325"
@@ -677,7 +677,7 @@
        y="78.162254"
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36"
-       inkscape:export-filename="C:\workspace\ad\ghdl\docs\block_diagrams\cn0577\cn0577_block_diagram.png" />
+ />
     <rect
        style="display:inline;vector-effect:none;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.459227;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:0;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;shape-rendering:crispEdges;enable-background:new"
        id="rect4488"
@@ -687,7 +687,7 @@
        y="92.270683"
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36"
-       inkscape:export-filename="C:\workspace\ad\ghdl\docs\block_diagrams\cn0577\cn0577_block_diagram.png" />
+ />
     <text
        xml:space="preserve"
        style="font-style:normal;font-weight:normal;font-size:3.175px;line-height:0%;font-family:Arial;letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;shape-rendering:crispEdges;enable-background:new"
@@ -697,7 +697,7 @@
        transform="rotate(-90)"
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36"
-       inkscape:export-filename="C:\workspace\ad\ghdl\docs\block_diagrams\cn0577\cn0577_block_diagram.png"><tspan
+><tspan
          sodipodi:role="line"
          id="tspan4493"
          x="-156.85475"
@@ -712,7 +712,7 @@
        y="78.173462"
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36"
-       inkscape:export-filename="C:\workspace\ad\ghdl\docs\block_diagrams\cn0577\cn0577_block_diagram.png" />
+ />
     <rect
        y="86.869904"
        x="62.221916"
@@ -722,7 +722,7 @@
        style="display:inline;vector-effect:none;fill:#ffcccc;fill-opacity:1;fill-rule:nonzero;stroke:#a01414;stroke-width:0.225601;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;shape-rendering:crispEdges;enable-background:new"
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36"
-       inkscape:export-filename="C:\workspace\ad\ghdl\docs\block_diagrams\cn0577\cn0577_block_diagram.png" />
+ />
     <text
        transform="rotate(-90)"
        id="text5788"
@@ -732,7 +732,7 @@
        xml:space="preserve"
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36"
-       inkscape:export-filename="C:\workspace\ad\ghdl\docs\block_diagrams\cn0577\cn0577_block_diagram.png"><tspan
+><tspan
          style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:4.63021px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial Bold';fill:#28170b;stroke:none;stroke-width:0.264583px;stroke-opacity:1"
          y="68.558937"
          x="-127.59537"
@@ -745,7 +745,7 @@
        x="58.789307"
        style="font-style:normal;font-weight:normal;font-size:3.175px;line-height:0%;font-family:Arial;letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;shape-rendering:crispEdges;enable-background:new"
        xml:space="preserve"
-       inkscape:export-filename="C:\workspace\ad\ghdl\docs\block_diagrams\cn0577\cn0577_block_diagram.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36"><tspan
          style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:3.96875px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial Bold';stroke-width:0.264583px"
@@ -757,7 +757,7 @@
        id="g5654"
        style="display:inline;fill:#a01414;fill-opacity:1;stroke:#a01414;stroke-width:0.91193;stroke-opacity:1;shape-rendering:crispEdges;enable-background:new"
        transform="matrix(0.32827811,0,0,0.26434798,9.284829,-20.986822)"
-       inkscape:export-filename="C:\workspace\ad\ghdl\docs\block_diagrams\cn0577\cn0577_block_diagram.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36">
       <path
@@ -771,7 +771,7 @@
        id="g5654-3"
        style="display:inline;fill:#a01414;fill-opacity:1;stroke:#a01414;stroke-width:0.57429;stroke-opacity:1;shape-rendering:crispEdges;enable-background:new"
        transform="matrix(0.80784318,0,0,0.27086297,-32.868931,-24.545517)"
-       inkscape:export-filename="C:\workspace\ad\ghdl\docs\block_diagrams\cn0577\cn0577_block_diagram.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36">
       <path
@@ -854,7 +854,7 @@
        style="display:inline;shape-rendering:crispEdges;enable-background:new"
        id="ddr"
        transform="matrix(0.37593397,0,0,0.37593391,-27.929078,-124.56736)"
-       inkscape:export-filename="C:\workspace\ad\ghdl\docs\block_diagrams\cn0577\cn0577_block_diagram.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36">
       <rect
@@ -963,7 +963,7 @@
        style="display:inline;shape-rendering:crispEdges;enable-background:new"
        id="g8892"
        transform="matrix(0.26458333,0,0,0.26458333,29.422246,-76.162396)"
-       inkscape:export-filename="C:\workspace\ad\ghdl\docs\block_diagrams\cn0577\cn0577_block_diagram.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36">
       <rect
@@ -1073,7 +1073,7 @@
        id="uart"
        transform="matrix(0,-0.10973853,0.10973855,0,92.325722,98.64421)"
        style="display:inline;stroke-width:2.41103;stroke-miterlimit:4;stroke-dasharray:none;shape-rendering:crispEdges;enable-background:new"
-       inkscape:export-filename="C:\workspace\ad\ghdl\docs\block_diagrams\cn0577\cn0577_block_diagram.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36">
       <rect
@@ -1173,7 +1173,7 @@
        y="126.80623"
        id="text2401-61-1-54-8"
        transform="scale(1.0162353,0.98402408)"
-       inkscape:export-filename="C:\workspace\ad\ghdl\docs\block_diagrams\cn0577\cn0577_block_diagram.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36"><tspan
          sodipodi:role="line"
@@ -1188,7 +1188,7 @@
        y="126.45621"
        id="text2401-61-1-54-8-3"
        transform="scale(1.0162353,0.98402408)"
-       inkscape:export-filename="C:\workspace\ad\ghdl\docs\block_diagrams\cn0577\cn0577_block_diagram.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36"><tspan
          sodipodi:role="line"

--- a/docs/projects/ad777x_fmcz/ad777x_hdl_block_diagram.svg
+++ b/docs/projects/ad777x_fmcz/ad777x_hdl_block_diagram.svg
@@ -397,7 +397,7 @@
        id="flowRoot33657"
        style="font-style:normal;font-weight:normal;font-size:40px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.0168229;stroke-miterlimit:4;stroke-dasharray:0.0336457, 0.0336457;stroke-dashoffset:0"
        transform="matrix(0.30527839,0,0,0.35359713,-232.3735,-114.27306)"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD7768\AD7768_BLOCK_DIAGRAM.png"
+
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96"><flowRegion
          id="flowRegion33659"
@@ -416,7 +416,7 @@
        x="192.51585"
        y="192.08813"
        id="text3992-4"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD7768\AD7768_BLOCK_DIAGRAM.png"
+
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96"
        transform="scale(1.0247942,0.97580567)"><tspan
@@ -432,7 +432,7 @@
        y="54.682735"
        id="text3996"
        transform="scale(0.92916675,1.0762331)"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD7768\AD7768_BLOCK_DIAGRAM.png"
+
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96"><tspan
          sodipodi:role="line"
@@ -447,7 +447,7 @@
        y="-22.507824"
        id="text3104"
        transform="scale(0.92916675,1.0762331)"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD7768\AD7768_BLOCK_DIAGRAM.png"
+
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96" />
     <text
@@ -536,7 +536,7 @@
        y="71.028183"
        id="text4598"
        transform="matrix(0,-1.1726554,0.85276546,0,0,0)"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD7768\AD7768_BLOCK_DIAGRAM_new.png"
+
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96"><tspan
          sodipodi:role="line"
@@ -549,7 +549,7 @@
        xml:space="preserve"
        id="flowRoot5982"
        style="font-style:normal;font-weight:normal;line-height:0.01%;font-family:Arial;letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.328079px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;shape-rendering:crispEdges;enable-background:new"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD7768\AD7768_BLOCK_DIAGRAM_new.png"
+
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96"><flowRegion
          id="flowRegion5984"
@@ -569,7 +569,7 @@
        height="313.56332"
        x="-184.40785"
        y="-25.298443"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD7768\AD7768_BLOCK_DIAGRAM_new.png"
+
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96" />
     <text
@@ -579,7 +579,7 @@
        y="-14.942104"
        id="text4576-5"
        transform="matrix(0,-1.0919481,0.91579442,0,0,0)"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD7768\AD7768_BLOCK_DIAGRAM_new.png"
+
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96"><tspan
          sodipodi:role="line"
@@ -594,7 +594,7 @@
        y="69.694801"
        id="text4598-2"
        transform="matrix(0,-1.1726554,0.85276546,0,0,0)"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD7768\AD7768_BLOCK_DIAGRAM_new.png"
+
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96"><tspan
          sodipodi:role="line"
@@ -607,7 +607,7 @@
        xml:space="preserve"
        id="flowRoot5982-0"
        style="font-style:normal;font-weight:normal;line-height:0.01%;font-family:Arial;letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.328079px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;shape-rendering:crispEdges;enable-background:new"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD7768\AD7768_BLOCK_DIAGRAM_new.png"
+
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96"><flowRegion
          id="flowRegion5984-3"
@@ -624,7 +624,7 @@
        transform="matrix(0.83810432,0,0,0.79804018,-173.7657,-329.78055)"
        style="display:inline;stroke-width:0.328079;shape-rendering:crispEdges;enable-background:new"
        id="g6613"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD7768\AD7768_BLOCK_DIAGRAM_new.png"
+
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96">
       <rect
@@ -654,7 +654,7 @@
        height="118.6965"
        x="-4.2286062"
        y="119.17262"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD7768\AD7768_BLOCK_DIAGRAM_new.png"
+
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96" />
     <rect
@@ -664,7 +664,7 @@
        height="118.69216"
        x="1.0630604"
        y="116.70972"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD7768\AD7768_BLOCK_DIAGRAM_new.png"
+
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96" />
     <text
@@ -673,7 +673,7 @@
        x="82.402588"
        y="140.8287"
        id="text4964"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD7768\AD7768_BLOCK_DIAGRAM_new.png"
+
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96"
        transform="scale(1.0247942,0.97580567)"><tspan
@@ -693,7 +693,7 @@
        x="63.720039"
        y="112.19315"
        id="text5138"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD7768\AD7768_BLOCK_DIAGRAM_new.png"
+
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96"
        transform="scale(1.0247942,0.97580567)"><tspan
@@ -708,7 +708,7 @@
        id="path5555"
        d="m 198.44156,186.53307 v -4.94517 h 18.26909 c 0,0 -2.4e-4,-4.41458 0,-6.57757 1e-4,-2.16302 0,-6.57762 0,-6.57762 h -18.26917 v -4.94512 l -12.276,11.52274 z"
        style="display:inline;fill:#c8c8c8;fill-opacity:1;fill-rule:evenodd;stroke:#a01414;stroke-width:0.268311;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;shape-rendering:crispEdges;enable-background:new"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD7768\AD7768_BLOCK_DIAGRAM_new.png"
+
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96" />
     <path
@@ -717,7 +717,7 @@
        id="path5553"
        inkscape:connector-curvature="0"
        sodipodi:nodetypes="cccsccccc"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD7768\AD7768_BLOCK_DIAGRAM_new.png"
+
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96" />
     <rect
@@ -727,7 +727,7 @@
        width="22.982616"
        id="rect5679"
        style="display:inline;fill:#ffcccc;fill-opacity:1;fill-rule:nonzero;stroke:#a01414;stroke-width:0.536625;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;shape-rendering:crispEdges;enable-background:new"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD7768\AD7768_BLOCK_DIAGRAM_new.png"
+
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96" />
     <text
@@ -737,7 +737,7 @@
        y="-41.183083"
        id="text5771"
        transform="matrix(0,-0.97580567,1.0247942,0,0,0)"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD7768\AD7768_BLOCK_DIAGRAM_new.png"
+
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96"><tspan
          sodipodi:role="line"
@@ -752,7 +752,7 @@
        height="220.34608"
        x="-162.97861"
        y="60.04932"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD7768\AD7768_BLOCK_DIAGRAM_new.png"
+
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96" />
     <rect
@@ -762,7 +762,7 @@
        height="153.34886"
        x="-178.85361"
        y="92.582672"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD7768\AD7768_BLOCK_DIAGRAM_new.png"
+
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96" />
     <text
@@ -772,7 +772,7 @@
        y="-158.91817"
        id="text4489"
        transform="matrix(0,-0.97515083,1.0254824,0,0,0)"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD7768\AD7768_BLOCK_DIAGRAM_new.png"
+
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96"><tspan
          sodipodi:role="line"
@@ -784,7 +784,7 @@
        style="display:inline;stroke-width:0.328079;shape-rendering:crispEdges;enable-background:new"
        id="ddr"
        transform="matrix(1.1908229,0,0,1.1338977,-396.3709,-551.46501)"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD7768\AD7768_BLOCK_DIAGRAM_new.png"
+
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96">
       <rect
@@ -893,7 +893,7 @@
        style="display:inline;stroke-width:0.328079;shape-rendering:crispEdges;enable-background:new"
        id="g8892"
        transform="matrix(0.83810432,0,0,0.79804018,-216.37886,-407.0613)"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD7768\AD7768_BLOCK_DIAGRAM_new.png"
+
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96">
       <rect
@@ -1003,7 +1003,7 @@
        id="uart"
        transform="matrix(0,-0.33099504,0.34761207,0,-16.285282,120.19295)"
        style="display:inline;stroke-width:0.79101;stroke-miterlimit:4;stroke-dasharray:none;shape-rendering:crispEdges;enable-background:new"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD7768\AD7768_BLOCK_DIAGRAM_new.png"
+
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96">
       <rect
@@ -1101,7 +1101,7 @@
        style="display:inline;stroke-width:0.328079;shape-rendering:crispEdges;enable-background:new"
        id="g4600"
        transform="matrix(0.83810432,0,0,0.79804018,-189.60493,-396.42627)"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD7768\AD7768_BLOCK_DIAGRAM_new.png"
+
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96">
       <rect
@@ -1128,7 +1128,7 @@
        xml:space="preserve"
        id="flowRoot3911"
        style="font-style:normal;font-weight:normal;line-height:0.01%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.328079px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;shape-rendering:crispEdges;enable-background:new"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD7768\AD7768_BLOCK_DIAGRAM_new.png"
+
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96"><flowRegion
          id="flowRegion3913"
@@ -1145,7 +1145,7 @@
        id="g5654-0"
        style="display:inline;fill:#a01414;fill-opacity:1;stroke:#a01414;stroke-width:0.458074;stroke-opacity:1;shape-rendering:crispEdges;enable-background:new"
        transform="matrix(1.3377069,0,0,0.70423597,-326.93153,-215.72374)"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD7768\AD7768_BLOCK_DIAGRAM_new.png"
+
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96">
       <path
@@ -1161,7 +1161,7 @@
        x="-137.08852"
        y="176.8913"
        id="text3992-5-0"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD7768\AD7768_BLOCK_DIAGRAM_new.png"
+
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96"
        transform="scale(1.0247942,0.97580567)"><tspan
@@ -1174,7 +1174,7 @@
        id="g5654-0-0"
        style="display:inline;fill:#a01414;fill-opacity:1;stroke:#a01414;stroke-width:0.460246;stroke-opacity:1;shape-rendering:crispEdges;enable-background:new"
        transform="matrix(1.1693499,0,0,0.79804018,-242.22784,-269.54777)"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD7768\AD7768_BLOCK_DIAGRAM_new.png"
+
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96">
       <path
@@ -1355,14 +1355,14 @@
        height="219.34015"
        x="-99.478607"
        y="61.055248"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD7768\AD7768_BLOCK_DIAGRAM_new.png"
+
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96" />
     <g
        id="g5654-7-6"
        style="display:inline;fill:#a01414;fill-opacity:1;stroke:#080a02;stroke-width:0.284098;stroke-opacity:1;shape-rendering:crispEdges;enable-background:new"
        transform="matrix(1.1176788,0,0,0.79804018,-182.43618,-291.93318)"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD7768\AD7768_BLOCK_DIAGRAM_new.png"
+
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96">
       <path
@@ -1381,7 +1381,7 @@
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96"
        transform="scale(0.92621941,1.0796578)"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD7768\AD7768_BLOCK_DIAGRAM_new.png"><tspan
+><tspan
          sodipodi:role="line"
          id="tspan6098-9"
          x="-172.3903"
@@ -1395,7 +1395,7 @@
        id="text6100-6-9"
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD7768\AD7768_BLOCK_DIAGRAM_new.png"
+
        transform="scale(1.0247942,0.97580567)"><tspan
          sodipodi:role="line"
          id="tspan6098-9-4"
@@ -1406,7 +1406,7 @@
        id="g6577"
        style="display:inline;stroke-width:0.343136;shape-rendering:crispEdges;enable-background:new"
        transform="matrix(0.76616699,0,0,0.79804018,-144.47686,-321.88456)"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD7768\AD7768_BLOCK_DIAGRAM_new.png"
+
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96">
       <path
@@ -1565,7 +1565,7 @@
        x="113.17983"
        y="200.88734"
        id="text4574"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD7768\AD7768_BLOCK_DIAGRAM_new.png"
+
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96"
        transform="scale(1.0247942,0.97580567)"><tspan
@@ -1600,7 +1600,7 @@
        d="M 21.144596,12.83227 H -148.14732"
        id="path4305-3"
        inkscape:connector-curvature="0"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD7768\AD7768_BLOCK_DIAGRAM_new.png"
+
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96" />
     <text
@@ -1610,7 +1610,7 @@
        y="8.2840433"
        id="text4307-4"
        transform="scale(1.0489055,0.95337473)"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD7768\AD7768_BLOCK_DIAGRAM_new.png"
+
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96"><tspan
          sodipodi:role="line"
@@ -1625,7 +1625,7 @@
        y="28.656128"
        id="text4311-0"
        transform="scale(1.0489055,0.95337473)"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD7768\AD7768_BLOCK_DIAGRAM_new.png"
+
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96"><tspan
          sodipodi:role="line"
@@ -1642,7 +1642,7 @@
        style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:16.9333px;line-height:0%;font-family:Arial;-inkscape-font-specification:'Arial, Bold';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:0.858696;stroke:none;stroke-width:0.302525px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;shape-rendering:crispEdges;enable-background:new"
        xml:space="preserve"
        transform="scale(1.0564806,0.94653891)"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD7768\AD7768_BLOCK_DIAGRAM_new.png"><tspan
+><tspan
          sodipodi:role="line"
          id="tspan9"
          x="221.34094"
@@ -1654,7 +1654,7 @@
        height="155.49106"
        x="-120.45817"
        y="95.732155"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD7768\AD7768_BLOCK_DIAGRAM_new.png"
+
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96" />
     <text
@@ -1664,7 +1664,7 @@
        y="-98.570908"
        id="text5775-9"
        transform="matrix(0,-0.97580567,1.0247942,0,0,0)"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD7768\AD7768_BLOCK_DIAGRAM_new.png"
+
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96"><tspan
          sodipodi:role="line"
@@ -1679,7 +1679,7 @@
        y="410.08487"
        id="text10629-4"
        transform="matrix(0,-1.2780579,0.78243716,0,0,0)"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD7768\AD7768_BLOCK_DIAGRAM_new.png"
+
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96"><tspan
          sodipodi:role="line"
@@ -1694,7 +1694,7 @@
        y="402.18237"
        id="text10629-4-5-5"
        transform="matrix(0,-1.2780579,0.78243716,0,0,0)"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD7768\AD7768_BLOCK_DIAGRAM_new.png"
+
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96"><tspan
          sodipodi:role="line"
@@ -1711,7 +1711,7 @@
        stroke="none"
        pointer-events="all"
        id="rect1827"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD7768\AD7768_BLOCK_DIAGRAM_new.png"
+
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96"
        style="display:inline;stroke-width:0.264583" />
@@ -1724,7 +1724,7 @@
        stroke="none"
        pointer-events="all"
        id="rect1835"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD7768\AD7768_BLOCK_DIAGRAM_new.png"
+
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96"
        style="display:inline;stroke-width:0.264583" />
@@ -1735,7 +1735,7 @@
        height="158.92726"
        x="-9.5202732"
        y="94.743645"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD7768\AD7768_BLOCK_DIAGRAM_new.png"
+
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96">
       <title
@@ -1745,7 +1745,7 @@
        id="g5654-7-6-2"
        style="display:inline;opacity:0.98718;fill:#a01414;fill-opacity:1;stroke:#000000;stroke-width:0.481182;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;shape-rendering:crispEdges;enable-background:new"
        transform="matrix(1.1130219,0,0,0.79804018,-181.78185,-241.79772)"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD7768\AD7768_BLOCK_DIAGRAM_new.png"
+
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96">
       <path
@@ -1772,7 +1772,7 @@
        x="-25.719864"
        y="202.55939"
        id="text3992"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD7768\AD7768_BLOCK_DIAGRAM_new.png"
+
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96"
        transform="scale(1.0247942,0.97580567)"><tspan
@@ -1787,7 +1787,7 @@
        x="-80.391624"
        y="173.98314"
        id="text3992-5"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD7768\AD7768_BLOCK_DIAGRAM_new.png"
+
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96"
        transform="scale(1.0247942,0.97580567)"><tspan
@@ -1802,7 +1802,7 @@
        x="-29.188549"
        y="176.67244"
        id="text3992-2"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD7768\AD7768_BLOCK_DIAGRAM_new.png"
+
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96"
        transform="scale(1.0247942,0.97580567)"><tspan
@@ -1817,7 +1817,7 @@
        x="-25.302835"
        y="150.82263"
        id="text3992-6"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD7768\AD7768_BLOCK_DIAGRAM_new.png"
+
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96"
        transform="scale(1.0247942,0.97580567)"><tspan
@@ -1868,7 +1868,7 @@
        style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:16.9333px;line-height:0%;font-family:Arial;-inkscape-font-specification:'Arial, Bold';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:0.858696;stroke:none;stroke-width:0.302525px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;shape-rendering:crispEdges;enable-background:new"
        xml:space="preserve"
        transform="scale(1.0564806,0.94653891)"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD7768\AD7768_BLOCK_DIAGRAM_new.png"><tspan
+><tspan
          sodipodi:role="line"
          id="tspan3"
          x="208.31343"

--- a/docs/projects/ad9081_fmca_ebz/ad9081_clock_scheme_vcu118.svg
+++ b/docs/projects/ad9081_fmca_ebz/ad9081_clock_scheme_vcu118.svg
@@ -9,7 +9,7 @@
    id="svg1993"
    inkscape:version="1.1.1 (3bf5ae0d25, 2021-09-20)"
    sodipodi:docname="ad9081_clock_scheme_vcu118.svg"
-   inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png"
+
    inkscape:export-xdpi="96"
    inkscape:export-ydpi="96"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
@@ -1778,7 +1778,7 @@
     <g
        inkscape:export-ydpi="180"
        inkscape:export-xdpi="180"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/generic_Tx_JESD_path.png"
+
        id="use13535"
        transform="matrix(0.26458333,0,0,0.26458333,-176.3204,566.91768)">
       <ellipse
@@ -1809,7 +1809,7 @@
     <g
        inkscape:export-ydpi="180"
        inkscape:export-xdpi="180"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/generic_Tx_JESD_path.png"
+
        id="use13535-0"
        transform="matrix(0.26458333,0,0,0.26458333,-176.3204,566.91768)">
       <ellipse
@@ -1846,7 +1846,7 @@
        height="65.040627"
        x="-138.40842"
        y="-98.80117"
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png" />
+ />
     <text
        inkscape:export-ydpi="96"
        inkscape:export-xdpi="96"
@@ -1856,7 +1856,7 @@
        y="-124.55183"
        id="text17738"
        transform="rotate(-90)"
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png"><tspan
+><tspan
          sodipodi:role="line"
          id="tspan17736"
          x="47.822815"
@@ -1867,7 +1867,7 @@
        transform="matrix(2.1625098,0,0,1.2566551,-168.792,-60.660761)"
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96"
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png">
+>
       <rect
          inkscape:export-ydpi="96"
          inkscape:export-xdpi="96"
@@ -1897,7 +1897,7 @@
        transform="matrix(1.2496492,0,0,1.2567868,-160.65535,-60.656733)"
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96"
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png">
+>
       <rect
          inkscape:export-ydpi="96"
          inkscape:export-xdpi="96"
@@ -1930,7 +1930,7 @@
        x="2.7943225"
        style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.82222px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.465361;shape-rendering:crispEdges;enable-background:new"
        xml:space="preserve"
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png"><tspan
+><tspan
          style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.82222px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;stroke-width:0.465361"
          y="-47.640606"
          x="2.7943225"
@@ -1944,7 +1944,7 @@
        x="2.7943225"
        style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.82222px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.465361;shape-rendering:crispEdges;enable-background:new"
        xml:space="preserve"
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png"><tspan
+><tspan
          style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.82222px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;stroke-width:0.465361"
          y="-60.269089"
          x="2.7943225"
@@ -1958,7 +1958,7 @@
        x="2.9114556"
        style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.82222px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.465361;shape-rendering:crispEdges;enable-background:new"
        xml:space="preserve"
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png"><tspan
+><tspan
          style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.82222px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;stroke-width:0.465361"
          y="-72.170578"
          x="2.9114556"
@@ -1972,7 +1972,7 @@
        x="2.7948086"
        style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.82222px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.465361;shape-rendering:crispEdges;enable-background:new"
        xml:space="preserve"
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png"><tspan
+><tspan
          style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.82222px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;stroke-width:0.465361"
          y="-83.232765"
          x="2.7948086"
@@ -1986,7 +1986,7 @@
        x="-28.494009"
        y="-50.942856"
        id="text27307"
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png"><tspan
+><tspan
          id="tspan27305"
          sodipodi:role="line"
          x="-28.494009"
@@ -1999,7 +1999,7 @@
        style="fill:none;stroke:#000000;stroke-width:0.410516px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:url(#marker28903)"
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96"
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png" />
+ />
     <text
        id="text28157"
        y="-85.97847"
@@ -2008,7 +2008,7 @@
        xml:space="preserve"
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96"
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png"><tspan
+><tspan
          style="stroke-width:0.465361"
          y="-85.97847"
          x="-115.58714"
@@ -2021,7 +2021,7 @@
        style="fill:none;stroke:#000000;stroke-width:0.411158px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:url(#marker28185)"
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96"
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png" />
+ />
     <text
        inkscape:export-ydpi="96"
        inkscape:export-xdpi="96"
@@ -2030,7 +2030,7 @@
        x="-115.58714"
        y="-50.005211"
        id="text28465"
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png"><tspan
+><tspan
          id="tspan28463"
          sodipodi:role="line"
          x="-115.58714"
@@ -2044,7 +2044,7 @@
        x="-115.58714"
        y="-74.056854"
        id="text28859"
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png"><tspan
+><tspan
          id="tspan28857"
          sodipodi:role="line"
          x="-115.58714"
@@ -2058,7 +2058,7 @@
        xml:space="preserve"
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96"
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png"><tspan
+><tspan
          style="stroke-width:0.465361"
          y="-110.6318"
          x="77.98333"
@@ -2072,7 +2072,7 @@
        x="-76.376122"
        y="-110.63258"
        id="text35792"
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png"><tspan
+><tspan
          id="tspan35790"
          sodipodi:role="line"
          x="-76.376122"
@@ -2083,7 +2083,7 @@
        transform="matrix(1.7588032,0,0,1.7588431,-179.53915,-47.148835)"
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96"
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png">
+>
       <path
          inkscape:connector-curvature="0"
          id="path35971"
@@ -2107,7 +2107,7 @@
        style="fill:none;stroke:#000000;stroke-width:0.515172px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:url(#marker36002)"
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96"
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png" />
+ />
     <text
        id="text35998"
        y="-88.170174"
@@ -2116,7 +2116,7 @@
        xml:space="preserve"
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96"
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png"><tspan
+><tspan
          style="stroke-width:0.465357"
          y="-88.170174"
          x="74.090523"
@@ -2129,7 +2129,7 @@
        inkscape:connector-curvature="0"
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96"
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png" />
+ />
     <text
        inkscape:export-ydpi="96"
        inkscape:export-xdpi="96"
@@ -2138,7 +2138,7 @@
        x="74.090523"
        y="-82.949844"
        id="text37206"
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png"><tspan
+><tspan
          id="tspan37204"
          sodipodi:role="line"
          x="74.090523"
@@ -2151,7 +2151,7 @@
        style="fill:none;stroke:#000000;stroke-width:0.441;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:url(#marker36002-0);stroke-miterlimit:4;stroke-dasharray:none"
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96"
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png" />
+ />
     <text
        id="text35998-56"
        y="-52.107357"
@@ -2160,7 +2160,7 @@
        xml:space="preserve"
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96"
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png"><tspan
+><tspan
          style="stroke-width:0.465362"
          y="-52.107357"
          x="74.492821"
@@ -2173,7 +2173,7 @@
        inkscape:connector-curvature="0"
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96"
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png" />
+ />
     <text
        inkscape:export-ydpi="96"
        inkscape:export-xdpi="96"
@@ -2182,7 +2182,7 @@
        x="74.492821"
        y="-46.887035"
        id="text37206-7"
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png"><tspan
+><tspan
          id="tspan37204-5"
          sodipodi:role="line"
          x="74.492821"
@@ -2537,14 +2537,14 @@
        x="-28.802086"
        style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.96383px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.465361;shape-rendering:crispEdges;enable-background:new"
        xml:space="preserve"
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png"><tspan
+><tspan
          style="stroke-width:0.465361"
          y="-74.573807"
          x="-28.802086"
          sodipodi:role="line"
          id="tspan6705-1">CLKIN6</tspan></text>
     <path
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png"
+
        inkscape:export-ydpi="96"
        inkscape:export-xdpi="96"
        style="fill:none;stroke:#000000;stroke-width:0.409876px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:url(#marker5160)"
@@ -2552,7 +2552,7 @@
        id="path5148"
        inkscape:connector-curvature="0" />
     <text
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png"
+
        id="text5152"
        y="-62.253029"
        x="-115.58833"
@@ -2566,7 +2566,7 @@
          sodipodi:role="line"
          id="tspan5150">CLKOUT8 </tspan></text>
     <text
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png"
+
        xml:space="preserve"
        style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.96383px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.465361;shape-rendering:crispEdges;enable-background:new"
        x="-28.491961"
@@ -2587,7 +2587,7 @@
        x="-85.494698"
        y="-50.942856"
        id="text28465-9"
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png"><tspan
+><tspan
          id="tspan28463-0"
          sodipodi:role="line"
          x="-85.494698"
@@ -2601,7 +2601,7 @@
        x="-85.493851"
        y="-63.198586"
        id="text28465-9-2"
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png"><tspan
+><tspan
          id="tspan28463-0-5"
          sodipodi:role="line"
          x="-85.493851"
@@ -2615,7 +2615,7 @@
        x="-85.493858"
        y="-75.186859"
        id="text28465-9-2-0"
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png"><tspan
+><tspan
          id="tspan28463-0-5-8"
          sodipodi:role="line"
          x="-85.493858"
@@ -2629,7 +2629,7 @@
        x="-85.700775"
        y="-85.88752"
        id="text28465-9-2-0-3"
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png"><tspan
+><tspan
          id="tspan28463-0-5-8-0"
          sodipodi:role="line"
          x="-85.700775"
@@ -2643,7 +2643,7 @@
        x="-41.306274"
        style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.13475px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.465361;shape-rendering:crispEdges;enable-background:new"
        xml:space="preserve"
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png"><tspan
+><tspan
          style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.13475px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;stroke-width:0.465361"
          y="-85.887955"
          x="-41.306274"
@@ -2657,7 +2657,7 @@
        x="1.9883882"
        y="-108.39421"
        id="text17738-3"
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png"><tspan
+><tspan
          sodipodi:role="line"
          id="tspan17736-1"
          x="1.9883882"
@@ -2670,7 +2670,7 @@
        style="fill:none;stroke:#000000;stroke-width:0.411158px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:url(#marker28185-1)"
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96"
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png" />
+ />
     <path
        inkscape:connector-curvature="0"
        id="path28181-9"
@@ -2678,7 +2678,7 @@
        style="fill:none;stroke:#000000;stroke-width:0.422447px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:url(#marker28185-5)"
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96"
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png" />
+ />
     <text
        inkscape:export-ydpi="96"
        inkscape:export-xdpi="96"
@@ -2687,7 +2687,7 @@
        x="20.980427"
        y="-74.856567"
        id="text28465-9-2-0-5"
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png"><tspan
+><tspan
          id="tspan28463-0-5-8-02"
          sodipodi:role="line"
          x="20.980427"
@@ -2701,7 +2701,7 @@
        x="20.773348"
        y="-85.657051"
        id="text28465-9-2-0-3-9"
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png"><tspan
+><tspan
          id="tspan28463-0-5-8-0-7"
          sodipodi:role="line"
          x="20.773348"
@@ -2714,7 +2714,7 @@
        style="fill:none;stroke:#000000;stroke-width:0.290653px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:url(#marker28185-1-3)"
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96"
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png" />
+ />
     <text
        id="text35998-5"
        y="-74.065689"
@@ -2723,7 +2723,7 @@
        xml:space="preserve"
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96"
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png"><tspan
+><tspan
          style="stroke-width:0.465362"
          y="-74.065689"
          x="72.872177"
@@ -2736,7 +2736,7 @@
        style="fill:none;stroke:#000000;stroke-width:0.421626px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:url(#marker28185-5-7)"
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96"
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png" />
+ />
     <text
        inkscape:export-ydpi="96"
        inkscape:export-xdpi="96"
@@ -2745,7 +2745,7 @@
        x="21.359823"
        y="-63.096565"
        id="text28465-9-2-0-5-7"
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png"><tspan
+><tspan
          id="tspan28463-0-5-8-02-8"
          sodipodi:role="line"
          x="21.359823"
@@ -2759,7 +2759,7 @@
        xml:space="preserve"
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96"
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png"><tspan
+><tspan
          style="stroke-width:0.465362"
          y="-62.305798"
          x="73.251556"
@@ -2772,7 +2772,7 @@
        style="fill:none;stroke:#000000;stroke-width:0.292805px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:url(#marker28185-5-2)"
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96"
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png" />
+ />
     <text
        inkscape:export-ydpi="96"
        inkscape:export-xdpi="96"
@@ -2781,7 +2781,7 @@
        x="21.348658"
        y="-50.817795"
        id="text28465-9-2-0-5-3"
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png"><tspan
+><tspan
          id="tspan28463-0-5-8-02-2"
          sodipodi:role="line"
          x="21.348658"
@@ -2795,7 +2795,7 @@
        x="-11.454544"
        style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.82222px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#808080;fill-opacity:1;stroke:none;stroke-width:0.465361;shape-rendering:crispEdges;enable-background:new"
        xml:space="preserve"
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png"><tspan
+><tspan
          style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.82222px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;fill:#808080;stroke-width:0.465361"
          y="-80.226624"
          x="-11.454544"
@@ -2809,7 +2809,7 @@
        x="13.716972"
        style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.82222px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#808080;fill-opacity:1;stroke:none;stroke-width:0.465361;shape-rendering:crispEdges;enable-background:new"
        xml:space="preserve"
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png"><tspan
+><tspan
          style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.82222px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;fill:#808080;stroke-width:0.465361"
          y="-80.226334"
          x="13.716972"
@@ -2823,7 +2823,7 @@
        x="-11.165821"
        style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.82222px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#808080;fill-opacity:1;stroke:none;stroke-width:0.465361;shape-rendering:crispEdges;enable-background:new"
        xml:space="preserve"
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png"><tspan
+><tspan
          style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.82222px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;fill:#808080;stroke-width:0.465361"
          y="-69.014023"
          x="-11.165821"
@@ -2837,7 +2837,7 @@
        x="-11.109966"
        style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.82222px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#808080;fill-opacity:1;stroke:none;stroke-width:0.465361;shape-rendering:crispEdges;enable-background:new"
        xml:space="preserve"
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png"><tspan
+><tspan
          style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.82222px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;fill:#808080;stroke-width:0.465361"
          y="-57.166176"
          x="-11.109966"
@@ -2851,7 +2851,7 @@
        x="-10.791643"
        style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.82222px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#808080;fill-opacity:1;stroke:none;stroke-width:0.465361;shape-rendering:crispEdges;enable-background:new"
        xml:space="preserve"
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png"><tspan
+><tspan
          style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.82222px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;fill:#808080;stroke-width:0.465361"
          y="-44.844334"
          x="-10.791643"
@@ -2865,7 +2865,7 @@
        x="13.716515"
        style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.82222px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#808080;fill-opacity:1;stroke:none;stroke-width:0.465361;shape-rendering:crispEdges;enable-background:new"
        xml:space="preserve"
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png"><tspan
+><tspan
          style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.82222px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;fill:#808080;stroke-width:0.465361"
          y="-69.014023"
          x="13.716515"
@@ -2879,7 +2879,7 @@
        x="13.716515"
        style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.82222px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#808080;fill-opacity:1;stroke:none;stroke-width:0.465361;shape-rendering:crispEdges;enable-background:new"
        xml:space="preserve"
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png"><tspan
+><tspan
          style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.82222px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;fill:#808080;stroke-width:0.465361"
          y="-57.166332"
          x="13.716515"
@@ -2893,7 +2893,7 @@
        x="13.716515"
        style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.82222px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#808080;fill-opacity:1;stroke:none;stroke-width:0.465361;shape-rendering:crispEdges;enable-background:new"
        xml:space="preserve"
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png"><tspan
+><tspan
          style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.82222px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;fill:#808080;stroke-width:0.465361"
          y="-44.844334"
          x="13.716515"
@@ -2907,7 +2907,7 @@
        x="-97.24575"
        style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.82222px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#808080;fill-opacity:1;stroke:none;stroke-width:0.465361;shape-rendering:crispEdges;enable-background:new"
        xml:space="preserve"
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png"><tspan
+><tspan
          style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.82222px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;stroke-width:0.465361;fill:#808080"
          y="45.110058"
          x="-97.24575"
@@ -2921,7 +2921,7 @@
        x="-89.762207"
        style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.82222px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#808080;fill-opacity:1;stroke:none;stroke-width:0.465361;shape-rendering:crispEdges;enable-background:new"
        xml:space="preserve"
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png"><tspan
+><tspan
          style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.82222px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;stroke-width:0.465361;fill:#808080"
          y="77.757027"
          x="-89.762207"

--- a/docs/projects/ad9081_fmca_ebz/ad9081_clock_scheme_zcu102.svg
+++ b/docs/projects/ad9081_fmca_ebz/ad9081_clock_scheme_zcu102.svg
@@ -9,7 +9,7 @@
    id="svg1993"
    inkscape:version="1.1.1 (3bf5ae0d25, 2021-09-20)"
    sodipodi:docname="ad9081_clock_scheme_zcu102.svg"
-   inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png"
+
    inkscape:export-xdpi="96"
    inkscape:export-ydpi="96"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
@@ -1795,7 +1795,7 @@
     <g
        inkscape:export-ydpi="180"
        inkscape:export-xdpi="180"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/generic_Tx_JESD_path.png"
+
        id="use13535"
        transform="matrix(0.26458333,0,0,0.26458333,-176.3204,566.91768)">
       <ellipse
@@ -1826,7 +1826,7 @@
     <g
        inkscape:export-ydpi="180"
        inkscape:export-xdpi="180"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/generic_Tx_JESD_path.png"
+
        id="use13535-0"
        transform="matrix(0.26458333,0,0,0.26458333,-176.3204,566.91768)">
       <ellipse
@@ -1863,7 +1863,7 @@
        height="65.040627"
        x="-138.78259"
        y="-96.181931"
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png" />
+ />
     <text
        inkscape:export-ydpi="96"
        inkscape:export-xdpi="96"
@@ -1873,7 +1873,7 @@
        y="-124.926"
        id="text17738"
        transform="rotate(-90)"
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png"><tspan
+><tspan
          sodipodi:role="line"
          id="tspan17736"
          x="45.203575"
@@ -1884,7 +1884,7 @@
        transform="matrix(2.1625098,0,0,1.2566551,-169.16618,-58.04152)"
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96"
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png">
+>
       <rect
          inkscape:export-ydpi="96"
          inkscape:export-xdpi="96"
@@ -1914,7 +1914,7 @@
        transform="matrix(1.2496492,0,0,1.2567868,-161.02953,-58.037492)"
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96"
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png">
+>
       <rect
          inkscape:export-ydpi="96"
          inkscape:export-xdpi="96"
@@ -1947,7 +1947,7 @@
        x="2.4201453"
        style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.82222px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.465361;shape-rendering:crispEdges;enable-background:new"
        xml:space="preserve"
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png"><tspan
+><tspan
          style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.82222px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;stroke-width:0.465361"
          y="-45.021366"
          x="2.4201453"
@@ -1961,7 +1961,7 @@
        x="2.4201453"
        style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.82222px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.465361;shape-rendering:crispEdges;enable-background:new"
        xml:space="preserve"
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png"><tspan
+><tspan
          style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.82222px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;stroke-width:0.465361"
          y="-57.649849"
          x="2.4201453"
@@ -1975,7 +1975,7 @@
        x="2.5372784"
        style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.82222px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.465361;shape-rendering:crispEdges;enable-background:new"
        xml:space="preserve"
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png"><tspan
+><tspan
          style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.82222px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;stroke-width:0.465361"
          y="-69.551338"
          x="2.5372784"
@@ -1989,7 +1989,7 @@
        x="2.4206314"
        style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.82222px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.465361;shape-rendering:crispEdges;enable-background:new"
        xml:space="preserve"
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png"><tspan
+><tspan
          style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.82222px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;stroke-width:0.465361"
          y="-80.613525"
          x="2.4206314"
@@ -2003,7 +2003,7 @@
        x="-28.868187"
        y="-48.323616"
        id="text27307"
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png"><tspan
+><tspan
          id="tspan27305"
          sodipodi:role="line"
          x="-28.868187"
@@ -2016,7 +2016,7 @@
        style="fill:none;stroke:#000000;stroke-width:0.410516px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:url(#marker28903)"
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96"
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png" />
+ />
     <text
        id="text28157"
        y="-83.35923"
@@ -2025,7 +2025,7 @@
        xml:space="preserve"
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96"
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png"><tspan
+><tspan
          style="stroke-width:0.465361"
          y="-83.35923"
          x="-115.96132"
@@ -2038,7 +2038,7 @@
        style="fill:none;stroke:#000000;stroke-width:0.411158px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:url(#marker28185)"
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96"
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png" />
+ />
     <text
        inkscape:export-ydpi="96"
        inkscape:export-xdpi="96"
@@ -2047,7 +2047,7 @@
        x="-115.96132"
        y="-47.385971"
        id="text28465"
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png"><tspan
+><tspan
          id="tspan28463"
          sodipodi:role="line"
          x="-115.96132"
@@ -2061,7 +2061,7 @@
        x="-115.96132"
        y="-71.437614"
        id="text28859"
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png"><tspan
+><tspan
          id="tspan28857"
          sodipodi:role="line"
          x="-115.96132"
@@ -2075,7 +2075,7 @@
        xml:space="preserve"
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96"
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png"><tspan
+><tspan
          style="stroke-width:0.465361"
          y="-108.01256"
          x="77.609154"
@@ -2089,7 +2089,7 @@
        x="-76.750298"
        y="-108.01334"
        id="text35792"
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png"><tspan
+><tspan
          id="tspan35790"
          sodipodi:role="line"
          x="-76.750298"
@@ -2103,7 +2103,7 @@
        xml:space="preserve"
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96"
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png"><tspan
+><tspan
          style="stroke-width:0.465357"
          y="-83.038155"
          x="73.716347"
@@ -2116,7 +2116,7 @@
        style="fill:none;stroke:#000000;stroke-width:0.441;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#marker36002-0)"
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96"
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png" />
+ />
     <text
        id="text35998-56"
        y="-50.688122"
@@ -2125,7 +2125,7 @@
        xml:space="preserve"
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96"
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png"><tspan
+><tspan
          style="stroke-width:0.465362"
          y="-50.688122"
          x="74.118645"
@@ -2138,7 +2138,7 @@
        inkscape:connector-curvature="0"
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96"
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png" />
+ />
     <text
        inkscape:export-ydpi="96"
        inkscape:export-xdpi="96"
@@ -2147,7 +2147,7 @@
        x="74.118645"
        y="-43.26812"
        id="text37206-7"
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png"><tspan
+><tspan
          id="tspan37204-5"
          sodipodi:role="line"
          x="74.118645"
@@ -2161,14 +2161,14 @@
        x="-29.176264"
        style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.96383px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.465361;shape-rendering:crispEdges;enable-background:new"
        xml:space="preserve"
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png"><tspan
+><tspan
          style="stroke-width:0.465361"
          y="-71.954567"
          x="-29.176264"
          sodipodi:role="line"
          id="tspan6705-1">CLKIN6</tspan></text>
     <path
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png"
+
        inkscape:export-ydpi="96"
        inkscape:export-xdpi="96"
        style="fill:none;stroke:#000000;stroke-width:0.409876px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:url(#marker5160)"
@@ -2176,7 +2176,7 @@
        id="path5148"
        inkscape:connector-curvature="0" />
     <text
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png"
+
        id="text5152"
        y="-59.633789"
        x="-115.96251"
@@ -2190,7 +2190,7 @@
          sodipodi:role="line"
          id="tspan5150">CLKOUT10 </tspan></text>
     <text
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png"
+
        xml:space="preserve"
        style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.96383px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.465361;shape-rendering:crispEdges;enable-background:new"
        x="-28.866138"
@@ -2211,7 +2211,7 @@
        x="-85.868874"
        y="-48.323616"
        id="text28465-9"
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png"><tspan
+><tspan
          id="tspan28463-0"
          sodipodi:role="line"
          x="-85.868874"
@@ -2225,7 +2225,7 @@
        x="-85.868027"
        y="-60.579346"
        id="text28465-9-2"
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png"><tspan
+><tspan
          id="tspan28463-0-5"
          sodipodi:role="line"
          x="-85.868027"
@@ -2239,7 +2239,7 @@
        x="-85.868034"
        y="-72.567619"
        id="text28465-9-2-0"
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png"><tspan
+><tspan
          id="tspan28463-0-5-8"
          sodipodi:role="line"
          x="-85.868034"
@@ -2253,7 +2253,7 @@
        x="-86.074951"
        y="-83.26828"
        id="text28465-9-2-0-3"
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png"><tspan
+><tspan
          id="tspan28463-0-5-8-0"
          sodipodi:role="line"
          x="-86.074951"
@@ -2267,7 +2267,7 @@
        x="-41.68045"
        style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.13475px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.465361;shape-rendering:crispEdges;enable-background:new"
        xml:space="preserve"
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png"><tspan
+><tspan
          style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.13475px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;stroke-width:0.465361"
          y="-83.268715"
          x="-41.68045"
@@ -2281,7 +2281,7 @@
        x="1.6142108"
        y="-105.77497"
        id="text17738-3"
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png"><tspan
+><tspan
          sodipodi:role="line"
          id="tspan17736-1"
          x="1.6142108"
@@ -2294,7 +2294,7 @@
        style="fill:none;stroke:#000000;stroke-width:0.411158px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:url(#marker28185-1)"
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96"
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png" />
+ />
     <path
        inkscape:connector-curvature="0"
        id="path28181-9"
@@ -2302,7 +2302,7 @@
        style="fill:none;stroke:#000000;stroke-width:0.422447px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:url(#marker28185-5)"
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96"
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png" />
+ />
     <path
        inkscape:connector-curvature="0"
        id="path28181-9-10"
@@ -2310,7 +2310,7 @@
        style="fill:none;stroke:#000000;stroke-width:0.442;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96"
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png" />
+ />
     <path
        inkscape:connector-curvature="0"
        id="path28181-9-10-1"
@@ -2318,7 +2318,7 @@
        style="fill:none;stroke:#000000;stroke-width:0.308077;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#marker5160)"
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96"
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png" />
+ />
     <path
        inkscape:connector-curvature="0"
        id="path28181-9-10-18"
@@ -2326,7 +2326,7 @@
        style="fill:none;stroke:#000000;stroke-width:0.4;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96"
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png" />
+ />
     <path
        inkscape:connector-curvature="0"
        id="path28181-9-10-1-7"
@@ -2334,7 +2334,7 @@
        style="fill:none;stroke:#000000;stroke-width:0.19;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#marker5160-1)"
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96"
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png" />
+ />
     <text
        inkscape:export-ydpi="96"
        inkscape:export-xdpi="96"
@@ -2343,7 +2343,7 @@
        x="20.606249"
        y="-72.237328"
        id="text28465-9-2-0-5"
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png"><tspan
+><tspan
          id="tspan28463-0-5-8-02"
          sodipodi:role="line"
          x="20.606249"
@@ -2357,7 +2357,7 @@
        x="20.39917"
        y="-83.037811"
        id="text28465-9-2-0-3-9"
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png"><tspan
+><tspan
          id="tspan28463-0-5-8-0-7"
          sodipodi:role="line"
          x="20.39917"
@@ -2370,7 +2370,7 @@
        style="fill:none;stroke:#000000;stroke-width:0.421608px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:url(#marker28185-1-3)"
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96"
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png" />
+ />
     <text
        id="text35998-5"
        y="-71.446449"
@@ -2379,7 +2379,7 @@
        xml:space="preserve"
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96"
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png"><tspan
+><tspan
          style="stroke-width:0.465362"
          y="-71.446449"
          x="72.498001"
@@ -2392,7 +2392,7 @@
        style="fill:none;stroke:#000000;stroke-width:0.283984px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:url(#marker28185-5-7)"
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96"
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png" />
+ />
     <path
        inkscape:connector-curvature="0"
        id="path28181-9-1-2"
@@ -2400,7 +2400,7 @@
        style="fill:none;stroke:#000000;stroke-width:0.291881px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:url(#marker28185-5-7-1)"
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96"
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png" />
+ />
     <text
        inkscape:export-ydpi="96"
        inkscape:export-xdpi="96"
@@ -2409,7 +2409,7 @@
        x="20.985645"
        y="-60.477325"
        id="text28465-9-2-0-5-7"
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png"><tspan
+><tspan
          id="tspan28463-0-5-8-02-8"
          sodipodi:role="line"
          x="20.985645"
@@ -2423,7 +2423,7 @@
        xml:space="preserve"
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96"
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png"><tspan
+><tspan
          style="stroke-width:0.465362"
          y="-61.686356"
          x="72.87738"
@@ -2436,7 +2436,7 @@
        style="fill:none;stroke:#000000;stroke-width:0.292805px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:url(#marker28185-5-2)"
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96"
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png" />
+ />
     <text
        inkscape:export-ydpi="96"
        inkscape:export-xdpi="96"
@@ -2445,7 +2445,7 @@
        x="20.97448"
        y="-48.198555"
        id="text28465-9-2-0-5-3"
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png"><tspan
+><tspan
          id="tspan28463-0-5-8-02-2"
          sodipodi:role="line"
          x="20.97448"
@@ -2459,7 +2459,7 @@
        x="-11.828721"
        style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.82222px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#808080;fill-opacity:1;stroke:none;stroke-width:0.465361;shape-rendering:crispEdges;enable-background:new"
        xml:space="preserve"
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png"><tspan
+><tspan
          style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.82222px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;fill:#808080;stroke-width:0.465361"
          y="-77.607384"
          x="-11.828721"
@@ -2473,7 +2473,7 @@
        x="13.342795"
        style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.82222px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#808080;fill-opacity:1;stroke:none;stroke-width:0.465361;shape-rendering:crispEdges;enable-background:new"
        xml:space="preserve"
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png"><tspan
+><tspan
          style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.82222px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;fill:#808080;stroke-width:0.465361"
          y="-77.607094"
          x="13.342795"
@@ -2487,7 +2487,7 @@
        x="-11.539998"
        style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.82222px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#808080;fill-opacity:1;stroke:none;stroke-width:0.465361;shape-rendering:crispEdges;enable-background:new"
        xml:space="preserve"
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png"><tspan
+><tspan
          style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.82222px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;fill:#808080;stroke-width:0.465361"
          y="-66.394783"
          x="-11.539998"
@@ -2501,7 +2501,7 @@
        x="-11.484143"
        style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.82222px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#808080;fill-opacity:1;stroke:none;stroke-width:0.465361;shape-rendering:crispEdges;enable-background:new"
        xml:space="preserve"
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png"><tspan
+><tspan
          style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.82222px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;fill:#808080;stroke-width:0.465361"
          y="-54.546936"
          x="-11.484143"
@@ -2515,7 +2515,7 @@
        x="-11.16582"
        style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.82222px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#808080;fill-opacity:1;stroke:none;stroke-width:0.465361;shape-rendering:crispEdges;enable-background:new"
        xml:space="preserve"
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png"><tspan
+><tspan
          style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.82222px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;fill:#808080;stroke-width:0.465361"
          y="-42.225094"
          x="-11.16582"
@@ -2529,7 +2529,7 @@
        x="13.342338"
        style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.82222px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#808080;fill-opacity:1;stroke:none;stroke-width:0.465361;shape-rendering:crispEdges;enable-background:new"
        xml:space="preserve"
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png"><tspan
+><tspan
          style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.82222px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;fill:#808080;stroke-width:0.465361"
          y="-66.394783"
          x="13.342338"
@@ -2543,7 +2543,7 @@
        x="13.342338"
        style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.82222px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#808080;fill-opacity:1;stroke:none;stroke-width:0.465361;shape-rendering:crispEdges;enable-background:new"
        xml:space="preserve"
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png"><tspan
+><tspan
          style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.82222px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;fill:#808080;stroke-width:0.465361"
          y="-54.547092"
          x="13.342338"
@@ -2557,7 +2557,7 @@
        x="13.342338"
        style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.82222px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#808080;fill-opacity:1;stroke:none;stroke-width:0.465361;shape-rendering:crispEdges;enable-background:new"
        xml:space="preserve"
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png"><tspan
+><tspan
          style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.82222px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;fill:#808080;stroke-width:0.465361"
          y="-42.225094"
          x="13.342338"
@@ -2579,7 +2579,7 @@
        xml:space="preserve"
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96"
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png"><tspan
+><tspan
          style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.82222px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;stroke-width:0.465;stroke-miterlimit:4;stroke-dasharray:none"
          y="-51.425182"
          x="40.959858"
@@ -2593,7 +2593,7 @@
        xml:space="preserve"
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96"
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png"><tspan
+><tspan
          style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.82222px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;stroke-width:0.465362"
          y="-57.128944"
          x="63.742271"
@@ -2607,7 +2607,7 @@
        xml:space="preserve"
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96"
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png"><tspan
+><tspan
          style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.82222px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;stroke-width:0.465362"
          y="-61.902473"
          x="63.687141"

--- a/docs/projects/ad9083_evb/ad9083_evb_a10soc_block_diagram.svg
+++ b/docs/projects/ad9083_evb/ad9083_evb_a10soc_block_diagram.svg
@@ -8,7 +8,7 @@
    id="svg1993"
    inkscape:version="1.2.1 (9c6d41e410, 2022-07-14)"
    sodipodi:docname="ad9083_evb_a10soc_block_diagram.svg"
-   inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png"
+
    inkscape:export-xdpi="96"
    inkscape:export-ydpi="96"
    viewBox="0 0 789.71869 492.67099"

--- a/docs/projects/ad9083_evb/ad9083_evb_zcu102_block_diagram.svg
+++ b/docs/projects/ad9083_evb/ad9083_evb_zcu102_block_diagram.svg
@@ -9,7 +9,7 @@
    id="svg1993"
    inkscape:version="1.2.1 (9c6d41e410, 2022-07-14)"
    sodipodi:docname="ad9083_evb_zcu102_block_diagram.svg"
-   inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png"
+
    inkscape:export-xdpi="96"
    inkscape:export-ydpi="96"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"

--- a/docs/projects/ad9084_ebz/ad9084_clock_scheme_vcu118.svg
+++ b/docs/projects/ad9084_ebz/ad9084_clock_scheme_vcu118.svg
@@ -9,7 +9,7 @@
    id="svg1993"
    inkscape:version="1.2.2 (732a01da63, 2022-12-09)"
    sodipodi:docname="ad9084_clock_scheme_vcu118.svg"
-   inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png"
+
    inkscape:export-xdpi="96"
    inkscape:export-ydpi="96"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
@@ -1858,7 +1858,7 @@
     <g
        inkscape:export-ydpi="180"
        inkscape:export-xdpi="180"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/generic_Tx_JESD_path.png"
+
        id="use13535"
        transform="matrix(0.26458333,0,0,0.26458333,-176.3204,566.91768)">
       <ellipse
@@ -1889,7 +1889,7 @@
     <g
        inkscape:export-ydpi="180"
        inkscape:export-xdpi="180"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/generic_Tx_JESD_path.png"
+
        id="use13535-0"
        transform="matrix(0.26458333,0,0,0.26458333,-176.3204,566.91768)">
       <ellipse
@@ -1926,7 +1926,7 @@
        height="76.217216"
        x="-138.38405"
        y="-98.77681"
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png" />
+ />
     <text
        inkscape:export-ydpi="96"
        inkscape:export-xdpi="96"
@@ -1936,7 +1936,7 @@
        y="-124.55183"
        id="text17738"
        transform="rotate(-90)"
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png"><tspan
+><tspan
          sodipodi:role="line"
          id="tspan17736"
          x="44.647812"
@@ -1947,7 +1947,7 @@
        transform="matrix(2.1609131,0,0,1.378867,-168.57366,-56.933613)"
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96"
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png">
+>
       <rect
          inkscape:export-ydpi="96"
          inkscape:export-xdpi="96"
@@ -1977,7 +1977,7 @@
        transform="matrix(1.2472163,0,0,1.5085381,-160.32266,-52.982574)"
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96"
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png">
+>
       <rect
          inkscape:export-ydpi="96"
          inkscape:export-xdpi="96"
@@ -2010,7 +2010,7 @@
        x="3.3555884"
        style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.82222px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.465361;shape-rendering:crispEdges;enable-background:new"
        xml:space="preserve"
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png"><tspan
+><tspan
          style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.82222px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;stroke-width:0.465361"
          y="-28.931742"
          x="3.3555884"
@@ -2024,7 +2024,7 @@
        x="2.7943225"
        style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.82222px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.465361;shape-rendering:crispEdges;enable-background:new"
        xml:space="preserve"
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png"><tspan
+><tspan
          style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.82222px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;stroke-width:0.465361"
          y="-60.269089"
          x="2.7943225"
@@ -2038,7 +2038,7 @@
        x="2.9114556"
        style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.82222px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.465361;shape-rendering:crispEdges;enable-background:new"
        xml:space="preserve"
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png"><tspan
+><tspan
          style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.82222px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;stroke-width:0.465361"
          y="-72.170578"
          x="2.9114556"
@@ -2052,7 +2052,7 @@
        x="2.7948086"
        style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.82222px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.465361;shape-rendering:crispEdges;enable-background:new"
        xml:space="preserve"
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png"><tspan
+><tspan
          style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.82222px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;stroke-width:0.465361"
          y="-83.232765"
          x="2.7948086"
@@ -2066,7 +2066,7 @@
        x="-33.56649"
        y="-31.485634"
        id="text27307"
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png"><tspan
+><tspan
          id="tspan27305"
          sodipodi:role="line"
          x="-33.56649"
@@ -2079,7 +2079,7 @@
        style="fill:none;stroke:#000000;stroke-width:0.410516px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:url(#marker28903)"
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96"
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png" />
+ />
     <text
        id="text28157"
        y="-82.164703"
@@ -2088,7 +2088,7 @@
        xml:space="preserve"
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96"
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png"><tspan
+><tspan
          style="stroke-width:0.465361"
          y="-82.164703"
          x="-115.21296"
@@ -2101,7 +2101,7 @@
        style="fill:none;stroke:#000000;stroke-width:0.411158px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:url(#marker28185)"
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96"
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png" />
+ />
     <text
        inkscape:export-ydpi="96"
        inkscape:export-xdpi="96"
@@ -2110,7 +2110,7 @@
        x="-112.02307"
        y="-27.379637"
        id="text28465"
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png"><tspan
+><tspan
          id="tspan28463"
          sodipodi:role="line"
          x="-112.02307"
@@ -2124,7 +2124,7 @@
        x="-112.29704"
        y="-71.404366"
        id="text28859"
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png"><tspan
+><tspan
          id="tspan28857"
          sodipodi:role="line"
          x="-112.29704"
@@ -2138,7 +2138,7 @@
        xml:space="preserve"
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96"
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png"><tspan
+><tspan
          style="stroke-width:0.465361"
          y="-110.6318"
          x="77.98333"
@@ -2152,7 +2152,7 @@
        x="-76.376122"
        y="-110.63258"
        id="text35792"
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png"><tspan
+><tspan
          id="tspan35790"
          sodipodi:role="line"
          x="-76.376122"
@@ -2163,7 +2163,7 @@
        transform="matrix(1.7588032,0,0,1.7588431,-185.32009,-46.8956)"
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96"
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png">
+>
       <path
          inkscape:connector-curvature="0"
          id="path35971"
@@ -2187,7 +2187,7 @@
        style="fill:none;stroke:#000000;stroke-width:0.551051px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:url(#marker36002)"
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96"
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png" />
+ />
     <text
        id="text35998"
        y="-87.508713"
@@ -2196,7 +2196,7 @@
        xml:space="preserve"
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96"
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png"><tspan
+><tspan
          style="stroke-width:0.465357"
          y="-87.508713"
          x="67.938957"
@@ -2209,7 +2209,7 @@
        inkscape:connector-curvature="0"
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96"
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png" />
+ />
     <text
        inkscape:export-ydpi="96"
        inkscape:export-xdpi="96"
@@ -2218,7 +2218,7 @@
        x="66.616043"
        y="-82.089951"
        id="text37206"
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png"><tspan
+><tspan
          id="tspan37204"
          sodipodi:role="line"
          x="66.616043"
@@ -2231,7 +2231,7 @@
        style="fill:none;stroke:#000000;stroke-width:0.441;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#marker36002-0)"
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96"
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png" />
+ />
     <text
        id="text35998-56"
        y="-33.024311"
@@ -2240,7 +2240,7 @@
        xml:space="preserve"
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96"
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png"><tspan
+><tspan
          style="stroke-width:0.465362"
          y="-33.024311"
          x="74.866997"
@@ -2253,7 +2253,7 @@
        inkscape:connector-curvature="0"
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96"
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png" />
+ />
     <text
        inkscape:export-ydpi="96"
        inkscape:export-xdpi="96"
@@ -2262,7 +2262,7 @@
        x="74.866997"
        y="-27.803991"
        id="text37206-7"
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png"><tspan
+><tspan
          id="tspan37204-5"
          sodipodi:role="line"
          x="74.866997"
@@ -2729,14 +2729,14 @@
        x="-41.545208"
        style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.96383px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.465361;shape-rendering:crispEdges;enable-background:new"
        xml:space="preserve"
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png"><tspan
+><tspan
          style="stroke-width:0.465361"
          y="-74.947983"
          x="-41.545208"
          sodipodi:role="line"
          id="tspan6705-1">    clk_m2c[1]</tspan></text>
     <path
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png"
+
        inkscape:export-ydpi="96"
        inkscape:export-xdpi="96"
        style="fill:none;stroke:#000000;stroke-width:0.409876px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:url(#marker5160)"
@@ -2744,7 +2744,7 @@
        id="path5148"
        inkscape:connector-curvature="0" />
     <text
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png"
+
        id="text5152"
        y="-59.420109"
        x="-112.22739"
@@ -2765,14 +2765,14 @@
        x="-115.34203"
        y="-49.709904"
        id="text28859-6"
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png"><tspan
+><tspan
          id="tspan28857-9"
          sodipodi:role="line"
          x="-115.34203"
          y="-49.709904"
          style="stroke-width:0.465361">CLKOUT11 </tspan></text>
     <text
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png"
+
        id="text5152-4"
        y="-38.351109"
        x="-115.24306"
@@ -2786,7 +2786,7 @@
          sodipodi:role="line"
          id="tspan5150-1">CLKOUT12 </tspan></text>
     <text
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png"
+
        xml:space="preserve"
        style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.96383px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.465361;shape-rendering:crispEdges;enable-background:new"
        x="-34.499886"
@@ -2807,7 +2807,7 @@
        x="-87.552673"
        y="-30.830824"
        id="text28465-9"
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png"><tspan
+><tspan
          id="tspan28463-0"
          sodipodi:role="line"
          x="-87.552673"
@@ -2821,7 +2821,7 @@
        x="-87.551826"
        y="-62.917953"
        id="text28465-9-2"
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png"><tspan
+><tspan
          id="tspan28463-0-5"
          sodipodi:role="line"
          x="-87.551826"
@@ -2835,7 +2835,7 @@
        x="-87.45829"
        y="-74.812683"
        id="text28465-9-2-0"
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png"><tspan
+><tspan
          id="tspan28463-0-5-8"
          sodipodi:role="line"
          x="-87.45829"
@@ -2849,7 +2849,7 @@
        x="-87.384575"
        y="-85.700432"
        id="text28465-9-2-0-3"
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png"><tspan
+><tspan
          id="tspan28463-0-5-8-0"
          sodipodi:role="line"
          x="-87.384575"
@@ -2863,7 +2863,7 @@
        x="0.0040132329"
        y="-107.86504"
        id="text17738-3"
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png"><tspan
+><tspan
          sodipodi:role="line"
          id="tspan17736-1"
          x="0.0040132329"
@@ -2876,7 +2876,7 @@
        style="fill:none;stroke:#000000;stroke-width:0.411158px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:url(#marker28185-1)"
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96"
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png" />
+ />
     <path
        inkscape:connector-curvature="0"
        id="path28181-9"
@@ -2884,7 +2884,7 @@
        style="fill:none;stroke:#000000;stroke-width:0.422447px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:url(#marker28185-5)"
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96"
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png" />
+ />
     <text
        inkscape:export-ydpi="96"
        inkscape:export-xdpi="96"
@@ -2893,7 +2893,7 @@
        x="20.980427"
        y="-74.856567"
        id="text28465-9-2-0-5"
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png"><tspan
+><tspan
          id="tspan28463-0-5-8-02"
          sodipodi:role="line"
          x="20.980427"
@@ -2907,7 +2907,7 @@
        x="20.773348"
        y="-85.657051"
        id="text28465-9-2-0-3-9"
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png"><tspan
+><tspan
          id="tspan28463-0-5-8-0-7"
          sodipodi:role="line"
          x="20.773348"
@@ -2920,7 +2920,7 @@
        style="fill:none;stroke:#000000;stroke-width:0.269555px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:url(#marker28185-1-3)"
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96"
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png" />
+ />
     <text
        id="text35998-5"
        y="-74.065689"
@@ -2929,7 +2929,7 @@
        xml:space="preserve"
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96"
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png"><tspan
+><tspan
          style="stroke-width:0.465362"
          y="-74.065689"
          x="63.876335"
@@ -2942,7 +2942,7 @@
        style="fill:none;stroke:#000000;stroke-width:0.421626px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:url(#marker28185-5-7)"
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96"
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png" />
+ />
     <text
        inkscape:export-ydpi="96"
        inkscape:export-xdpi="96"
@@ -2951,7 +2951,7 @@
        x="21.359823"
        y="-63.096565"
        id="text28465-9-2-0-5-7"
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png"><tspan
+><tspan
          id="tspan28463-0-5-8-02-8"
          sodipodi:role="line"
          x="21.359823"
@@ -2965,7 +2965,7 @@
        xml:space="preserve"
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96"
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png"><tspan
+><tspan
          style="stroke-width:0.465362"
          y="-62.305798"
          x="64.255714"
@@ -2978,7 +2978,7 @@
        style="fill:none;stroke:#000000;stroke-width:0.292805px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:url(#marker28185-5-2)"
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96"
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png" />
+ />
     <text
        inkscape:export-ydpi="96"
        inkscape:export-xdpi="96"
@@ -2987,7 +2987,7 @@
        x="21.722836"
        y="-31.734751"
        id="text28465-9-2-0-5-3"
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png"><tspan
+><tspan
          id="tspan28463-0-5-8-02-2"
          sodipodi:role="line"
          x="21.722836"
@@ -3001,7 +3001,7 @@
        x="-11.454544"
        style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.82222px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#808080;fill-opacity:1;stroke:none;stroke-width:0.465361;shape-rendering:crispEdges;enable-background:new"
        xml:space="preserve"
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png"><tspan
+><tspan
          style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.82222px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;fill:#808080;stroke-width:0.465361"
          y="-80.226624"
          x="-11.454544"
@@ -3015,7 +3015,7 @@
        x="13.716972"
        style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.82222px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#808080;fill-opacity:1;stroke:none;stroke-width:0.465361;shape-rendering:crispEdges;enable-background:new"
        xml:space="preserve"
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png"><tspan
+><tspan
          style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.82222px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;fill:#808080;stroke-width:0.465361"
          y="-80.226334"
          x="13.716972"
@@ -3029,7 +3029,7 @@
        x="-11.165821"
        style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.82222px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#808080;fill-opacity:1;stroke:none;stroke-width:0.465361;shape-rendering:crispEdges;enable-background:new"
        xml:space="preserve"
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png"><tspan
+><tspan
          style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.82222px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;fill:#808080;stroke-width:0.465361"
          y="-69.014023"
          x="-11.165821"
@@ -3043,7 +3043,7 @@
        x="-11.109966"
        style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.82222px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#808080;fill-opacity:1;stroke:none;stroke-width:0.465361;shape-rendering:crispEdges;enable-background:new"
        xml:space="preserve"
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png"><tspan
+><tspan
          style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.82222px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;fill:#808080;stroke-width:0.465361"
          y="-57.166176"
          x="-11.109966"
@@ -3057,7 +3057,7 @@
        x="-10.043288"
        style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.82222px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#808080;fill-opacity:1;stroke:none;stroke-width:0.465361;shape-rendering:crispEdges;enable-background:new"
        xml:space="preserve"
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png"><tspan
+><tspan
          style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.82222px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;fill:#808080;stroke-width:0.465361"
          y="-24.63876"
          x="-10.043288"
@@ -3071,7 +3071,7 @@
        x="13.716515"
        style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.82222px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#808080;fill-opacity:1;stroke:none;stroke-width:0.465361;shape-rendering:crispEdges;enable-background:new"
        xml:space="preserve"
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png"><tspan
+><tspan
          style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.82222px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;fill:#808080;stroke-width:0.465361"
          y="-69.014023"
          x="13.716515"
@@ -3085,7 +3085,7 @@
        x="13.716515"
        style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.82222px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#808080;fill-opacity:1;stroke:none;stroke-width:0.465361;shape-rendering:crispEdges;enable-background:new"
        xml:space="preserve"
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png"><tspan
+><tspan
          style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.82222px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;fill:#808080;stroke-width:0.465361"
          y="-57.166332"
          x="13.716515"
@@ -3099,7 +3099,7 @@
        x="14.090692"
        style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.82222px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#808080;fill-opacity:1;stroke:none;stroke-width:0.465361;shape-rendering:crispEdges;enable-background:new"
        xml:space="preserve"
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png"><tspan
+><tspan
          style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.82222px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;fill:#808080;stroke-width:0.465361"
          y="-25.76129"
          x="14.090692"
@@ -3113,7 +3113,7 @@
        x="-97.24575"
        style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.82222px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#808080;fill-opacity:1;stroke:none;stroke-width:0.465361;shape-rendering:crispEdges;enable-background:new"
        xml:space="preserve"
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png"><tspan
+><tspan
          style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.82222px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;stroke-width:0.465361;fill:#808080"
          y="45.110058"
          x="-97.24575"
@@ -3127,7 +3127,7 @@
        x="-89.762207"
        style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.82222px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#808080;fill-opacity:1;stroke:none;stroke-width:0.465361;shape-rendering:crispEdges;enable-background:new"
        xml:space="preserve"
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png"><tspan
+><tspan
          style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.82222px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;stroke-width:0.465361;fill:#808080"
          y="77.757027"
          x="-89.762207"
@@ -3145,7 +3145,7 @@
        x="2.7843564"
        style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.82222px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.465361;shape-rendering:crispEdges;enable-background:new"
        xml:space="preserve"
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png"><tspan
+><tspan
          style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.82222px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;stroke-width:0.465361"
          y="-38.890041"
          x="2.7843564"
@@ -3159,7 +3159,7 @@
        x="2.9014885"
        style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.82222px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.465361;shape-rendering:crispEdges;enable-background:new"
        xml:space="preserve"
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png"><tspan
+><tspan
          style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.82222px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;stroke-width:0.465361"
          y="-50.262363"
          x="2.9014885"
@@ -3172,7 +3172,7 @@
        style="fill:none;stroke:#000000;stroke-width:0.411158px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:url(#marker28185-6)"
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96"
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png" />
+ />
     <text
        inkscape:export-ydpi="96"
        inkscape:export-xdpi="96"
@@ -3181,14 +3181,14 @@
        x="-34.103725"
        style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.96383px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.465361;shape-rendering:crispEdges;enable-background:new"
        xml:space="preserve"
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png"><tspan
+><tspan
          style="stroke-width:0.465361"
          y="-52.665592"
          x="-34.103725"
          sodipodi:role="line"
          id="tspan6705-1-4">ref_clk[1]</tspan></text>
     <path
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png"
+
        inkscape:export-ydpi="96"
        inkscape:export-xdpi="96"
        style="fill:none;stroke:#000000;stroke-width:0.409876px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:url(#marker5160-0)"
@@ -3196,7 +3196,7 @@
        id="path5148-9"
        inkscape:connector-curvature="0" />
     <text
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png"
+
        xml:space="preserve"
        style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.96383px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.465361;shape-rendering:crispEdges;enable-background:new"
        x="-34.322765"
@@ -3217,7 +3217,7 @@
        x="-87.655342"
        y="-42.038727"
        id="text28465-9-2-2"
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png"><tspan
+><tspan
          id="tspan28463-0-5-4"
          sodipodi:role="line"
          x="-87.655342"
@@ -3231,7 +3231,7 @@
        x="-87.468262"
        y="-52.998013"
        id="text28465-9-2-0-9"
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png"><tspan
+><tspan
          id="tspan28463-0-5-8-6"
          sodipodi:role="line"
          x="-87.468262"
@@ -3244,7 +3244,7 @@
        style="fill:none;stroke:#000000;stroke-width:0.422447px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:url(#marker28185-5-6)"
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96"
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png" />
+ />
     <text
        inkscape:export-ydpi="96"
        inkscape:export-xdpi="96"
@@ -3253,7 +3253,7 @@
        x="20.970459"
        y="-52.948353"
        id="text28465-9-2-0-5-0"
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png"><tspan
+><tspan
          id="tspan28463-0-5-8-02-6"
          sodipodi:role="line"
          x="20.970459"
@@ -3267,7 +3267,7 @@
        xml:space="preserve"
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96"
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png"><tspan
+><tspan
          style="stroke-width:0.465362"
          y="-52.157475"
          x="64.293732"
@@ -3280,7 +3280,7 @@
        style="fill:none;stroke:#000000;stroke-width:0.421626px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:url(#marker28185-5-7-4)"
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96"
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png" />
+ />
     <text
        inkscape:export-ydpi="96"
        inkscape:export-xdpi="96"
@@ -3289,7 +3289,7 @@
        x="21.349855"
        y="-41.717518"
        id="text28465-9-2-0-5-7-9"
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png"><tspan
+><tspan
          id="tspan28463-0-5-8-02-8-1"
          sodipodi:role="line"
          x="21.349855"
@@ -3303,7 +3303,7 @@
        xml:space="preserve"
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96"
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png"><tspan
+><tspan
          style="stroke-width:0.465362"
          y="-40.210495"
          x="64.079742"
@@ -3317,7 +3317,7 @@
        x="-11.17579"
        style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.82222px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#808080;fill-opacity:1;stroke:none;stroke-width:0.465361;shape-rendering:crispEdges;enable-background:new"
        xml:space="preserve"
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png"><tspan
+><tspan
          style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.82222px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;fill:#808080;stroke-width:0.465361"
          y="-47.105808"
          x="-11.17579"
@@ -3331,7 +3331,7 @@
        x="-11.119935"
        style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.82222px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#808080;fill-opacity:1;stroke:none;stroke-width:0.465361;shape-rendering:crispEdges;enable-background:new"
        xml:space="preserve"
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png"><tspan
+><tspan
          style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.82222px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;fill:#808080;stroke-width:0.465361"
          y="-35.787128"
          x="-11.119935"
@@ -3345,7 +3345,7 @@
        x="13.706548"
        style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.82222px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#808080;fill-opacity:1;stroke:none;stroke-width:0.465361;shape-rendering:crispEdges;enable-background:new"
        xml:space="preserve"
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png"><tspan
+><tspan
          style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.82222px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;fill:#808080;stroke-width:0.465361"
          y="-47.105808"
          x="13.706548"
@@ -3359,14 +3359,14 @@
        x="13.706548"
        style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.82222px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#808080;fill-opacity:1;stroke:none;stroke-width:0.465361;shape-rendering:crispEdges;enable-background:new"
        xml:space="preserve"
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png"><tspan
+><tspan
          style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.82222px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;fill:#808080;stroke-width:0.465361"
          y="-35.258118"
          x="13.706548"
          sodipodi:role="line"
          id="tspan6705-1-3-9-4-4-3-3">MGTREFCLK1P_122</tspan></text>
     <text
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png"
+
        xml:space="preserve"
        style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.96383px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.465361;shape-rendering:crispEdges;enable-background:new"
        x="-34.657074"

--- a/docs/projects/ad9208_dual_ebz/ad9208_dual_ebz_block_diagram.svg
+++ b/docs/projects/ad9208_dual_ebz/ad9208_dual_ebz_block_diagram.svg
@@ -9,7 +9,7 @@
    id="svg1993"
    inkscape:version="1.1.1 (3bf5ae0d25, 2021-09-20)"
    sodipodi:docname="ad9208_dual_ebz_block_diagram.svg"
-   inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png"
+
    inkscape:export-xdpi="96"
    inkscape:export-ydpi="96"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
@@ -1731,7 +1731,7 @@
     <g
        inkscape:export-ydpi="180"
        inkscape:export-xdpi="180"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/generic_Tx_JESD_path.png"
+
        id="use13535"
        transform="matrix(0.26458333,0,0,0.26458333,-176.3204,566.91768)">
       <ellipse
@@ -1762,7 +1762,7 @@
     <g
        inkscape:export-ydpi="180"
        inkscape:export-xdpi="180"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/generic_Tx_JESD_path.png"
+
        id="use13535-0"
        transform="matrix(0.26458333,0,0,0.26458333,-176.3204,566.91768)">
       <ellipse

--- a/docs/projects/ad9208_dual_ebz/ad9208_dual_ebz_clock_scheme.svg
+++ b/docs/projects/ad9208_dual_ebz/ad9208_dual_ebz_clock_scheme.svg
@@ -9,7 +9,7 @@
    id="svg1993"
    inkscape:version="1.1.1 (3bf5ae0d25, 2021-09-20)"
    sodipodi:docname="ad9208_dual_ebz_clock_scheme.svg.2025_01_21_16_55_27.0.svg"
-   inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png"
+
    inkscape:export-xdpi="96"
    inkscape:export-ydpi="96"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
@@ -1418,7 +1418,7 @@
        height="81.25708"
        x="-24.758972"
        y="-180.47188"
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png" />
+ />
     <text
        inkscape:export-ydpi="96"
        inkscape:export-xdpi="96"
@@ -1427,7 +1427,7 @@
        x="116.41038"
        style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.82222px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.465361;shape-rendering:crispEdges;enable-background:new"
        xml:space="preserve"
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png"><tspan
+><tspan
          style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.82222px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;stroke-width:0.465361"
          y="-105.3662"
          x="116.41038"
@@ -1441,7 +1441,7 @@
        x="116.41038"
        style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.82222px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.465361;shape-rendering:crispEdges;enable-background:new"
        xml:space="preserve"
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png"><tspan
+><tspan
          style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.82222px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;stroke-width:0.465361"
          y="-117.99466"
          x="116.41038"
@@ -1455,7 +1455,7 @@
        x="85.122047"
        y="-108.66843"
        id="text27307-8-6"
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png"><tspan
+><tspan
          id="tspan27305-1-7"
          sodipodi:role="line"
          x="85.122047"
@@ -1468,7 +1468,7 @@
        style="fill:none;stroke:#000000;stroke-width:0.410516px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:url(#marker28903-3-7)"
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96"
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png" />
+ />
     <text
        inkscape:export-ydpi="96"
        inkscape:export-xdpi="96"
@@ -1477,7 +1477,7 @@
        x="-1.9710755"
        y="-107.73078"
        id="text28465-4-9"
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png"><tspan
+><tspan
          id="tspan28463-8-3"
          sodipodi:role="line"
          x="-1.9710755"
@@ -1491,14 +1491,14 @@
        xml:space="preserve"
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96"
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png"><tspan
+><tspan
          style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.23333px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;stroke-width:0.465362"
          y="-107.1871"
          x="187.43306"
          sodipodi:role="line"
          id="tspan35996-3-5">glbl_clk_1</tspan></text>
     <path
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png"
+
        inkscape:export-ydpi="96"
        inkscape:export-xdpi="96"
        style="fill:none;stroke:#000000;stroke-width:0.409876px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:url(#marker5160-4)"
@@ -1506,7 +1506,7 @@
        id="path5148-5"
        inkscape:connector-curvature="0" />
     <text
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png"
+
        id="text5152-0"
        y="-119.9786"
        x="-1.9722657"
@@ -1520,7 +1520,7 @@
          sodipodi:role="line"
          id="tspan5150-4">CLKOUT6 </tspan></text>
     <text
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png"
+
        xml:space="preserve"
        style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.465361;shape-rendering:crispEdges;enable-background:new"
        x="85.124092"
@@ -1541,7 +1541,7 @@
        x="28.121363"
        y="-108.66843"
        id="text28465-9-27"
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png"><tspan
+><tspan
          id="tspan28463-0-2"
          sodipodi:role="line"
          x="28.121363"
@@ -1555,7 +1555,7 @@
        x="28.12221"
        y="-120.92416"
        id="text28465-9-2-2"
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png"><tspan
+><tspan
          id="tspan28463-0-5-9"
          sodipodi:role="line"
          x="28.12221"
@@ -1569,7 +1569,7 @@
        x="134.97589"
        y="-120.82214"
        id="text28465-9-2-0-5-7-3"
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png"><tspan
+><tspan
          id="tspan28463-0-5-8-02-8-7"
          sodipodi:role="line"
          x="134.97589"
@@ -1582,7 +1582,7 @@
        style="fill:none;stroke:#000000;stroke-width:0.421626px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:url(#marker28185-5-7-6)"
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96"
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png" />
+ />
     <text
        id="text35998-5-3-2"
        y="-120.03138"
@@ -1591,7 +1591,7 @@
        xml:space="preserve"
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96"
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png"><tspan
+><tspan
          style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.23333px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;stroke-width:0.465362"
          y="-120.03138"
          x="187.43306"
@@ -1605,7 +1605,7 @@
        x="134.96472"
        y="-108.54337"
        id="text28465-9-2-0-5-3-5"
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png"><tspan
+><tspan
          id="tspan28463-0-5-8-02-2-7"
          sodipodi:role="line"
          x="134.96472"
@@ -1620,7 +1620,7 @@
        y="-10.937139"
        id="text17738-5"
        transform="rotate(-90)"
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png"><tspan
+><tspan
          sodipodi:role="line"
          id="tspan17736-9"
          x="121.64798"
@@ -1631,7 +1631,7 @@
        transform="matrix(2.1573193,0,0,1.5693704,-54.467524,-132.80155)"
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96"
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png">
+>
       <rect
          inkscape:export-ydpi="96"
          inkscape:export-xdpi="96"
@@ -1661,7 +1661,7 @@
        transform="matrix(1.2466588,0,0,1.5685493,-46.631744,-132.82666)"
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96"
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png">
+>
       <rect
          inkscape:export-ydpi="96"
          inkscape:export-xdpi="96"
@@ -1689,7 +1689,7 @@
        x="116.40886"
        style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.82222px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.465361;shape-rendering:crispEdges;enable-background:new"
        xml:space="preserve"
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png"><tspan
+><tspan
          style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.82222px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;stroke-width:0.465361"
          y="-118.26345"
          x="116.40886"
@@ -1703,7 +1703,7 @@
        x="116.40886"
        style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.82222px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.465361;shape-rendering:crispEdges;enable-background:new"
        xml:space="preserve"
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png"><tspan
+><tspan
          style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.82222px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;stroke-width:0.465361"
          y="-105.73872"
          x="116.40886"
@@ -1717,7 +1717,7 @@
        x="127.33257"
        style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.82222px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#808080;fill-opacity:1;stroke:none;stroke-width:0.465361;shape-rendering:crispEdges;enable-background:new"
        xml:space="preserve"
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png"><tspan
+><tspan
          style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.82222px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;fill:#808080;stroke-width:0.465361"
          y="-114.89191"
          x="127.33257"
@@ -1731,7 +1731,7 @@
        x="127.33257"
        style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.82222px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#808080;fill-opacity:1;stroke:none;stroke-width:0.465361;shape-rendering:crispEdges;enable-background:new"
        xml:space="preserve"
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png"><tspan
+><tspan
          style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.82222px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;fill:#808080;stroke-width:0.465361"
          y="-102.56992"
          x="127.33257"
@@ -1745,7 +1745,7 @@
        x="116.40901"
        style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.82222px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.465361;shape-rendering:crispEdges;enable-background:new"
        xml:space="preserve"
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png"><tspan
+><tspan
          style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.82222px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;stroke-width:0.465361"
          y="-129.34608"
          x="116.40901"
@@ -1759,7 +1759,7 @@
        x="116.40901"
        style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.82222px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.465361;shape-rendering:crispEdges;enable-background:new"
        xml:space="preserve"
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png"><tspan
+><tspan
          style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.82222px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;stroke-width:0.465361"
          y="-141.97456"
          x="116.40901"
@@ -1773,7 +1773,7 @@
        x="116.52615"
        style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.82222px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.465361;shape-rendering:crispEdges;enable-background:new"
        xml:space="preserve"
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png"><tspan
+><tspan
          style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.82222px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;stroke-width:0.465361"
          y="-153.87605"
          x="116.52615"
@@ -1787,7 +1787,7 @@
        x="116.4095"
        style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.82222px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.465361;shape-rendering:crispEdges;enable-background:new"
        xml:space="preserve"
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png"><tspan
+><tspan
          style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.82222px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;stroke-width:0.465361"
          y="-164.93823"
          x="116.4095"
@@ -1801,7 +1801,7 @@
        x="85.120682"
        y="-132.64833"
        id="text27307-8"
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png"><tspan
+><tspan
          id="tspan27305-1"
          sodipodi:role="line"
          x="85.120682"
@@ -1814,7 +1814,7 @@
        style="fill:none;stroke:#000000;stroke-width:0.410516px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:url(#marker28903-3)"
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96"
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png" />
+ />
     <text
        id="text28157-7"
        y="-167.68394"
@@ -1823,7 +1823,7 @@
        xml:space="preserve"
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96"
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png"><tspan
+><tspan
          style="stroke-width:0.465361"
          y="-167.68394"
          x="-1.9724545"
@@ -1836,7 +1836,7 @@
        style="fill:none;stroke:#000000;stroke-width:0.411158px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:url(#marker28185-3)"
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96"
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png" />
+ />
     <text
        inkscape:export-ydpi="96"
        inkscape:export-xdpi="96"
@@ -1845,7 +1845,7 @@
        x="-1.9724545"
        y="-131.71068"
        id="text28465-4"
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png"><tspan
+><tspan
          id="tspan28463-8"
          sodipodi:role="line"
          x="-1.9724545"
@@ -1859,7 +1859,7 @@
        x="-1.9724545"
        y="-155.76233"
        id="text28859-4"
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png"><tspan
+><tspan
          id="tspan28857-3"
          sodipodi:role="line"
          x="-1.9724545"
@@ -1873,7 +1873,7 @@
        xml:space="preserve"
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96"
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png"><tspan
+><tspan
          style="stroke-width:0.465361"
          y="-191.27895"
          x="191.59802"
@@ -1887,7 +1887,7 @@
        x="37.238567"
        y="-191.27974"
        id="text35792-5"
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png"><tspan
+><tspan
          id="tspan35790-8"
          sodipodi:role="line"
          x="37.238567"
@@ -1901,14 +1901,14 @@
        x="74.425148"
        style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.465361;shape-rendering:crispEdges;enable-background:new"
        xml:space="preserve"
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png"><tspan
+><tspan
          style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;stroke-width:0.465361"
          y="-156.27928"
          x="74.425148"
          sodipodi:role="line"
          id="tspan6705-1">FMC_GBTCLK2</tspan></text>
     <path
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png"
+
        inkscape:export-ydpi="96"
        inkscape:export-xdpi="96"
        style="fill:none;stroke:#000000;stroke-width:0.409876px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:url(#marker5160)"
@@ -1916,7 +1916,7 @@
        id="path5148"
        inkscape:connector-curvature="0" />
     <text
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png"
+
        id="text5152"
        y="-143.9585"
        x="-1.9736447"
@@ -1930,7 +1930,7 @@
          sodipodi:role="line"
          id="tspan5150">CLKOUT10 </tspan></text>
     <text
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png"
+
        xml:space="preserve"
        style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.465361;shape-rendering:crispEdges;enable-background:new"
        x="85.122726"
@@ -1951,7 +1951,7 @@
        x="28.119991"
        y="-132.64833"
        id="text28465-9"
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png"><tspan
+><tspan
          id="tspan28463-0"
          sodipodi:role="line"
          x="28.119991"
@@ -1965,7 +1965,7 @@
        x="28.120838"
        y="-144.90405"
        id="text28465-9-2"
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png"><tspan
+><tspan
          id="tspan28463-0-5"
          sodipodi:role="line"
          x="28.120838"
@@ -1979,7 +1979,7 @@
        x="28.120831"
        y="-156.89233"
        id="text28465-9-2-0"
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png"><tspan
+><tspan
          id="tspan28463-0-5-8"
          sodipodi:role="line"
          x="28.120831"
@@ -1993,7 +1993,7 @@
        x="27.913914"
        y="-167.59299"
        id="text28465-9-2-0-3"
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png"><tspan
+><tspan
          id="tspan28463-0-5-8-0"
          sodipodi:role="line"
          x="27.913914"
@@ -2007,7 +2007,7 @@
        x="74.425087"
        style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.465361;shape-rendering:crispEdges;enable-background:new"
        xml:space="preserve"
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png"><tspan
+><tspan
          style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;stroke-width:0.465361"
          y="-167.59343"
          x="74.425087"
@@ -2021,7 +2021,7 @@
        x="115.60308"
        y="-190.09969"
        id="text17738-3"
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png"><tspan
+><tspan
          sodipodi:role="line"
          id="tspan17736-1"
          x="115.60308"
@@ -2034,7 +2034,7 @@
        style="fill:none;stroke:#000000;stroke-width:0.411158px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:url(#marker28185-1)"
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96"
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png" />
+ />
     <path
        inkscape:connector-curvature="0"
        id="path28181-9"
@@ -2042,7 +2042,7 @@
        style="fill:none;stroke:#000000;stroke-width:0.422447px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:url(#marker28185-5)"
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96"
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png" />
+ />
     <text
        inkscape:export-ydpi="96"
        inkscape:export-xdpi="96"
@@ -2051,7 +2051,7 @@
        x="134.59512"
        y="-156.56204"
        id="text28465-9-2-0-5"
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png"><tspan
+><tspan
          id="tspan28463-0-5-8-02"
          sodipodi:role="line"
          x="134.59512"
@@ -2065,7 +2065,7 @@
        x="134.38803"
        y="-167.36252"
        id="text28465-9-2-0-3-9"
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png"><tspan
+><tspan
          id="tspan28463-0-5-8-0-7"
          sodipodi:role="line"
          x="134.38803"
@@ -2079,7 +2079,7 @@
        xml:space="preserve"
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96"
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png"><tspan
+><tspan
          style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.23333px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;stroke-width:0.465362"
          y="-155.77116"
          x="187.43306"
@@ -2092,7 +2092,7 @@
        style="fill:none;stroke:#000000;stroke-width:0.289679px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:url(#marker28185-5-7)"
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96"
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png" />
+ />
     <text
        inkscape:export-ydpi="96"
        inkscape:export-xdpi="96"
@@ -2101,7 +2101,7 @@
        x="134.97452"
        y="-144.80203"
        id="text28465-9-2-0-5-7"
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png"><tspan
+><tspan
          id="tspan28463-0-5-8-02-8"
          sodipodi:role="line"
          x="134.97452"
@@ -2115,7 +2115,7 @@
        x="134.96335"
        y="-132.52327"
        id="text28465-9-2-0-5-3"
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png"><tspan
+><tspan
          id="tspan28463-0-5-8-02-2"
          sodipodi:role="line"
          x="134.96335"
@@ -2129,7 +2129,7 @@
        x="127.33167"
        style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.82222px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#808080;fill-opacity:1;stroke:none;stroke-width:0.465361;shape-rendering:crispEdges;enable-background:new"
        xml:space="preserve"
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png"><tspan
+><tspan
          style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.82222px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;fill:#808080;stroke-width:0.465361"
          y="-161.93181"
          x="127.33167"
@@ -2143,7 +2143,7 @@
        x="127.33121"
        style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.82222px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#808080;fill-opacity:1;stroke:none;stroke-width:0.465361;shape-rendering:crispEdges;enable-background:new"
        xml:space="preserve"
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png"><tspan
+><tspan
          style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.82222px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;fill:#808080;stroke-width:0.465361"
          y="-150.7195"
          x="127.33121"
@@ -2157,7 +2157,7 @@
        x="127.33121"
        style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.82222px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#808080;fill-opacity:1;stroke:none;stroke-width:0.465361;shape-rendering:crispEdges;enable-background:new"
        xml:space="preserve"
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png"><tspan
+><tspan
          style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.82222px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;fill:#808080;stroke-width:0.465361"
          y="-138.87181"
          x="127.33121"
@@ -2171,7 +2171,7 @@
        x="127.33121"
        style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.82222px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#808080;fill-opacity:1;stroke:none;stroke-width:0.465361;shape-rendering:crispEdges;enable-background:new"
        xml:space="preserve"
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png"><tspan
+><tspan
          style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.82222px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;fill:#808080;stroke-width:0.465361"
          y="-126.54981"
          x="127.33121"
@@ -2184,7 +2184,7 @@
        style="fill:none;stroke:#000000;stroke-width:0.421626px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:url(#marker28185-5-7-6-5)"
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96"
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png" />
+ />
     <path
        inkscape:connector-curvature="0"
        id="path28181-9-3"
@@ -2192,7 +2192,7 @@
        style="fill:none;stroke:#000000;stroke-width:0.422447px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:url(#marker28185-5-72)"
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96"
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png" />
+ />
     <text
        id="text35998-5-2"
        y="-166.37137"
@@ -2201,7 +2201,7 @@
        xml:space="preserve"
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96"
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png"><tspan
+><tspan
          style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.23333px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;stroke-width:0.465362"
          y="-166.37137"
          x="187.43306"
@@ -2212,7 +2212,7 @@
        transform="matrix(1.7588032,0,0,1.7588431,-66.196716,-106.06543)"
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96"
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png">
+>
       <path
          inkscape:connector-curvature="0"
          id="path35971-7"
@@ -2236,7 +2236,7 @@
        style="fill:none;stroke:#000000;stroke-width:0.515172px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:url(#marker36002-5)"
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96"
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png" />
+ />
     <text
        id="text35998-3"
        y="-147.08678"
@@ -2245,7 +2245,7 @@
        xml:space="preserve"
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96"
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png"><tspan
+><tspan
          style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.23333px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;stroke-width:0.465357"
          y="-147.08678"
          x="187.43295"
@@ -2258,7 +2258,7 @@
        inkscape:connector-curvature="0"
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96"
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png" />
+ />
     <text
        inkscape:export-ydpi="96"
        inkscape:export-xdpi="96"
@@ -2267,7 +2267,7 @@
        x="187.43295"
        y="-141.86646"
        id="text37206-6"
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png"><tspan
+><tspan
          id="tspan37204-7"
          sodipodi:role="line"
          x="187.43295"
@@ -2280,7 +2280,7 @@
        style="fill:none;stroke:#000000;stroke-width:0.421626px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:url(#marker28185-5-7-6-4)"
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96"
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png" />
+ />
     <text
        id="text35998-5-3-2-5"
        y="-130.85437"
@@ -2289,7 +2289,7 @@
        xml:space="preserve"
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96"
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png"><tspan
+><tspan
          style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.23333px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;stroke-width:0.465362"
          y="-130.85437"
          x="187.43306"

--- a/docs/projects/ad9209_fmca_ebz/ad9209_clocking_scheme.svg
+++ b/docs/projects/ad9209_fmca_ebz/ad9209_clocking_scheme.svg
@@ -9,7 +9,7 @@
    id="svg1993"
    inkscape:version="1.2.2 (732a01da63, 2022-12-09)"
    sodipodi:docname="ad9209_clocking_scheme.svg"
-   inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png"
+
    inkscape:export-xdpi="96"
    inkscape:export-ydpi="96"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
@@ -1717,7 +1717,7 @@
     <g
        inkscape:export-ydpi="180"
        inkscape:export-xdpi="180"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/generic_Tx_JESD_path.png"
+
        id="use13535"
        transform="matrix(0.26458333,0,0,0.26458333,-176.3204,566.91768)">
       <ellipse
@@ -1748,7 +1748,7 @@
     <g
        inkscape:export-ydpi="180"
        inkscape:export-xdpi="180"
-       inkscape:export-filename="/media/data/workspace/ws1/ghdl/docs/block_diagrams/jesd/generic_Tx_JESD_path.png"
+
        id="use13535-0"
        transform="matrix(0.26458333,0,0,0.26458333,-176.3204,566.91768)">
       <ellipse
@@ -1785,7 +1785,7 @@
        height="65.040627"
        x="-138.78259"
        y="-96.181931"
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png" />
+ />
     <text
        inkscape:export-ydpi="96"
        inkscape:export-xdpi="96"
@@ -1795,7 +1795,7 @@
        y="-124.926"
        id="text17738"
        transform="rotate(-90)"
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png"><tspan
+><tspan
          sodipodi:role="line"
          id="tspan17736"
          x="45.203575"
@@ -1806,7 +1806,7 @@
        transform="matrix(2.1625098,0,0,1.2566551,-181.33713,-58.04152)"
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96"
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png">
+>
       <rect
          inkscape:export-ydpi="96"
          inkscape:export-xdpi="96"
@@ -1836,7 +1836,7 @@
        transform="matrix(1.2496492,0,0,1.2567868,-161.02953,-58.037492)"
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96"
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png">
+>
       <rect
          inkscape:export-ydpi="96"
          inkscape:export-xdpi="96"
@@ -1869,7 +1869,7 @@
        x="2.4201453"
        style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.82222px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.465361;shape-rendering:crispEdges;enable-background:new"
        xml:space="preserve"
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png"><tspan
+><tspan
          style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.82222px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;stroke-width:0.465361"
          y="-45.021366"
          x="2.4201453"
@@ -1883,7 +1883,7 @@
        x="2.4201453"
        style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.82222px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.465361;shape-rendering:crispEdges;enable-background:new"
        xml:space="preserve"
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png"><tspan
+><tspan
          style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.82222px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;stroke-width:0.465361"
          y="-57.649849"
          x="2.4201453"
@@ -1897,7 +1897,7 @@
        x="2.4206314"
        style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.82222px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.465361;shape-rendering:crispEdges;enable-background:new"
        xml:space="preserve"
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png"><tspan
+><tspan
          style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.82222px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;stroke-width:0.465361"
          y="-80.613525"
          x="2.4206314"
@@ -1911,7 +1911,7 @@
        x="-28.868187"
        y="-48.323616"
        id="text27307"
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png"><tspan
+><tspan
          id="tspan27305"
          sodipodi:role="line"
          x="-28.868187"
@@ -1924,7 +1924,7 @@
        style="fill:none;stroke:#000000;stroke-width:0.410516px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:url(#marker28903)"
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96"
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png" />
+ />
     <text
        id="text28157"
        y="-83.35923"
@@ -1933,7 +1933,7 @@
        xml:space="preserve"
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96"
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png"><tspan
+><tspan
          style="stroke-width:0.465361"
          y="-83.35923"
          x="-115.96132"
@@ -1947,7 +1947,7 @@
        x="-115.96132"
        y="-47.385971"
        id="text28465"
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png"><tspan
+><tspan
          id="tspan28463"
          sodipodi:role="line"
          x="-115.96132"
@@ -1961,7 +1961,7 @@
        x="-115.96132"
        y="-71.437614"
        id="text28859"
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png"><tspan
+><tspan
          id="tspan28857"
          sodipodi:role="line"
          x="-115.96132"
@@ -1975,7 +1975,7 @@
        xml:space="preserve"
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96"
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png"><tspan
+><tspan
          style="stroke-width:0.465361"
          y="-104.83205"
          x="104.36283"
@@ -1989,14 +1989,14 @@
        x="-76.750298"
        y="-108.01334"
        id="text35792"
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png"><tspan
+><tspan
          id="tspan35790"
          sodipodi:role="line"
          x="-76.750298"
          y="-108.01334"
          style="stroke-width:0.465361">AD9209-FMCA-EBZ</tspan></text>
     <path
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png"
+
        inkscape:export-ydpi="96"
        inkscape:export-xdpi="96"
        style="fill:none;stroke:#000000;stroke-width:0.409876px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:url(#marker5160)"
@@ -2004,7 +2004,7 @@
        id="path5148"
        inkscape:connector-curvature="0" />
     <text
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png"
+
        id="text5152"
        y="-59.633789"
        x="-115.96251"
@@ -2018,7 +2018,7 @@
          sodipodi:role="line"
          id="tspan5150">CLKOUT10 </tspan></text>
     <text
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png"
+
        xml:space="preserve"
        style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.96383px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.465361;shape-rendering:crispEdges;enable-background:new"
        x="-28.866138"
@@ -2039,7 +2039,7 @@
        x="-85.868874"
        y="-48.323616"
        id="text28465-9"
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png"><tspan
+><tspan
          id="tspan28463-0"
          sodipodi:role="line"
          x="-85.868874"
@@ -2053,7 +2053,7 @@
        x="-85.868027"
        y="-60.579346"
        id="text28465-9-2"
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png"><tspan
+><tspan
          id="tspan28463-0-5"
          sodipodi:role="line"
          x="-85.868027"
@@ -2067,7 +2067,7 @@
        x="-86.074951"
        y="-83.26828"
        id="text28465-9-2-0-3"
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png"><tspan
+><tspan
          id="tspan28463-0-5-8-0"
          sodipodi:role="line"
          x="-86.074951"
@@ -2081,7 +2081,7 @@
        x="-41.68045"
        style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.13475px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.465361;shape-rendering:crispEdges;enable-background:new"
        xml:space="preserve"
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png"><tspan
+><tspan
          style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.13475px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;stroke-width:0.465361"
          y="-83.268715"
          x="-41.68045"
@@ -2095,7 +2095,7 @@
        x="1.6142108"
        y="-105.77497"
        id="text17738-3"
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png"><tspan
+><tspan
          sodipodi:role="line"
          id="tspan17736-1"
          x="1.6142108"
@@ -2108,7 +2108,7 @@
        style="fill:none;stroke:#000000;stroke-width:0.411158px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:url(#marker28185-1)"
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96"
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png" />
+ />
     <text
        inkscape:export-ydpi="96"
        inkscape:export-xdpi="96"
@@ -2117,7 +2117,7 @@
        x="20.39917"
        y="-83.037811"
        id="text28465-9-2-0-3-9"
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png"><tspan
+><tspan
          id="tspan28463-0-5-8-0-7"
          sodipodi:role="line"
          x="20.39917"
@@ -2130,7 +2130,7 @@
        style="fill:none;stroke:#000000;stroke-width:0.393319px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:url(#marker28185-1-3)"
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96"
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png" />
+ />
     <path
        inkscape:connector-curvature="0"
        id="path28181-9-1-2"
@@ -2138,7 +2138,7 @@
        style="fill:none;stroke:#000000;stroke-width:0.394845px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:url(#marker28185-5-7-1)"
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96"
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png" />
+ />
     <text
        inkscape:export-ydpi="96"
        inkscape:export-xdpi="96"
@@ -2147,7 +2147,7 @@
        x="20.985645"
        y="-60.477325"
        id="text28465-9-2-0-5-7"
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png"><tspan
+><tspan
          id="tspan28463-0-5-8-02-8"
          sodipodi:role="line"
          x="20.985645"
@@ -2160,7 +2160,7 @@
        style="fill:none;stroke:#000000;stroke-width:0.396198px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:url(#marker28185-5-2)"
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96"
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png" />
+ />
     <text
        inkscape:export-ydpi="96"
        inkscape:export-xdpi="96"
@@ -2169,7 +2169,7 @@
        x="20.97448"
        y="-48.198555"
        id="text28465-9-2-0-5-3"
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png"><tspan
+><tspan
          id="tspan28463-0-5-8-02-2"
          sodipodi:role="line"
          x="20.97448"
@@ -2183,7 +2183,7 @@
        x="-11.828721"
        style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.82222px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#808080;fill-opacity:1;stroke:none;stroke-width:0.465361;shape-rendering:crispEdges;enable-background:new"
        xml:space="preserve"
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png"><tspan
+><tspan
          style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.82222px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;fill:#808080;stroke-width:0.465361"
          y="-77.607384"
          x="-11.828721"
@@ -2197,7 +2197,7 @@
        x="13.342795"
        style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.82222px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#808080;fill-opacity:1;stroke:none;stroke-width:0.465361;shape-rendering:crispEdges;enable-background:new"
        xml:space="preserve"
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png"><tspan
+><tspan
          style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.82222px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;fill:#808080;stroke-width:0.465361"
          y="-77.607094"
          x="13.342795"
@@ -2211,7 +2211,7 @@
        x="-10.954977"
        style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.82222px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#808080;fill-opacity:1;stroke:none;stroke-width:0.465361;shape-rendering:crispEdges;enable-background:new"
        xml:space="preserve"
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png"><tspan
+><tspan
          style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.82222px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;fill:#808080;stroke-width:0.465361"
          y="-54.546936"
          x="-10.954977"
@@ -2225,7 +2225,7 @@
        x="-11.16582"
        style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.82222px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#808080;fill-opacity:1;stroke:none;stroke-width:0.465361;shape-rendering:crispEdges;enable-background:new"
        xml:space="preserve"
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png"><tspan
+><tspan
          style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.82222px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;fill:#808080;stroke-width:0.465361"
          y="-42.225094"
          x="-11.16582"
@@ -2239,7 +2239,7 @@
        x="13.342338"
        style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.82222px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#808080;fill-opacity:1;stroke:none;stroke-width:0.465361;shape-rendering:crispEdges;enable-background:new"
        xml:space="preserve"
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png"><tspan
+><tspan
          style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.82222px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;fill:#808080;stroke-width:0.465361"
          y="-54.547092"
          x="13.342338"
@@ -2253,7 +2253,7 @@
        x="13.342338"
        style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.82222px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#808080;fill-opacity:1;stroke:none;stroke-width:0.465361;shape-rendering:crispEdges;enable-background:new"
        xml:space="preserve"
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png"><tspan
+><tspan
          style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.82222px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;fill:#808080;stroke-width:0.465361"
          y="-42.225094"
          x="13.342338"
@@ -2267,7 +2267,7 @@
        x="75.814468"
        y="-82.813843"
        id="text28465-9-2-0-3-9-2"
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png"><tspan
+><tspan
          id="tspan28463-0-5-8-0-7-9"
          sodipodi:role="line"
          x="75.814468"
@@ -2281,7 +2281,7 @@
        x="59.472984"
        y="-59.807869"
        id="text28465-9-2-0-3-9-2-7"
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png"><tspan
+><tspan
          id="tspan28463-0-5-8-0-7-9-8"
          sodipodi:role="line"
          x="59.472984"
@@ -2295,7 +2295,7 @@
        x="70.098503"
        y="-47.378586"
        id="text28465-9-2-0-3-9-2-7-5"
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png"><tspan
+><tspan
          id="tspan28463-0-5-8-0-7-9-8-6"
          sodipodi:role="line"
          x="70.098503"

--- a/docs/projects/ad9695_fmc/ad9695_clock_scheme.svg
+++ b/docs/projects/ad9695_fmc/ad9695_clock_scheme.svg
@@ -9,7 +9,7 @@
    id="svg1993"
    inkscape:version="1.1.1 (3bf5ae0d25, 2021-09-20)"
    sodipodi:docname="ad9695_clock_scheme.svg"
-   inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png"
+
    inkscape:export-xdpi="96"
    inkscape:export-ydpi="96"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
@@ -1671,7 +1671,7 @@
        height="72.46138"
        x="-107.66005"
        y="-94.668304"
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png" />
+ />
     <text
        inkscape:export-ydpi="96"
        inkscape:export-xdpi="96"
@@ -1681,7 +1681,7 @@
        y="-95.216499"
        id="text17738"
        transform="rotate(-90)"
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png"><tspan
+><tspan
          sodipodi:role="line"
          id="tspan17736"
          x="35.282372"
@@ -1692,7 +1692,7 @@
        transform="matrix(1.8669511,0,0,0.6211237,-241.48338,-75.866365)"
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96"
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png">
+>
       <rect
          inkscape:export-ydpi="96"
          inkscape:export-xdpi="96"
@@ -1712,7 +1712,7 @@
        y="15.685423"
        id="text17738-3"
        transform="rotate(-90)"
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png"><tspan
+><tspan
          sodipodi:role="line"
          id="tspan17736-5"
          x="70.785057"
@@ -1723,7 +1723,7 @@
        transform="matrix(1.8669511,0,0,0.6211237,-241.48307,-35.4012)"
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96"
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png">
+>
       <rect
          inkscape:export-ydpi="96"
          inkscape:export-xdpi="96"
@@ -1743,7 +1743,7 @@
        y="12.738188"
        id="text17738-3-3"
        transform="rotate(-90)"
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png"><tspan
+><tspan
          sodipodi:role="line"
          id="tspan17736-5-7"
          x="29.31328"
@@ -1761,7 +1761,7 @@
        style="fill:none;stroke:#000000;stroke-width:0.411158px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:url(#marker28185)"
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96"
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png" />
+ />
     <text
        inkscape:export-ydpi="96"
        inkscape:export-xdpi="96"
@@ -1770,7 +1770,7 @@
        x="-31.447922"
        style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.465361;shape-rendering:crispEdges;enable-background:new"
        xml:space="preserve"
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png"><tspan
+><tspan
          style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;stroke-width:0.465361"
          y="-73.515472"
          x="-31.447922"
@@ -1787,7 +1787,7 @@
          x="-28.494009"
          y="-50.942856"
          id="text27307"
-         inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png"><tspan
+><tspan
            id="tspan27305"
            sodipodi:role="line"
            x="-28.494009"
@@ -1800,7 +1800,7 @@
          style="fill:none;stroke:#000000;stroke-width:0.410516px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:url(#marker28903)"
          inkscape:export-xdpi="96"
          inkscape:export-ydpi="96"
-         inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png" />
+ />
       <text
          inkscape:export-ydpi="96"
          inkscape:export-xdpi="96"
@@ -1809,7 +1809,7 @@
          x="-85.494698"
          y="-50.942856"
          id="text28465-9"
-         inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png"><tspan
+><tspan
            id="tspan28463-0"
            sodipodi:role="line"
            x="-85.494698"
@@ -1827,7 +1827,7 @@
          x="-28.28035"
          y="-41.327515"
          id="text27307-5"
-         inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png"><tspan
+><tspan
            id="tspan27305-5"
            sodipodi:role="line"
            x="-28.28035"
@@ -1840,7 +1840,7 @@
          style="fill:none;stroke:#000000;stroke-width:0.410516px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:url(#marker28903-0)"
          inkscape:export-xdpi="96"
          inkscape:export-ydpi="96"
-         inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png" />
+ />
       <text
          inkscape:export-ydpi="96"
          inkscape:export-xdpi="96"
@@ -1849,7 +1849,7 @@
          x="-85.281036"
          y="-41.327515"
          id="text28465-9-1"
-         inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png"><tspan
+><tspan
            sodipodi:role="line"
            x="-85.281036"
            y="-41.327515"
@@ -1860,7 +1860,7 @@
        id="g10703"
        transform="translate(0,11.641668)">
       <path
-         inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png"
+
          inkscape:export-ydpi="96"
          inkscape:export-xdpi="96"
          style="fill:none;stroke:#000000;stroke-width:0.409876px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:url(#marker5160)"
@@ -1868,7 +1868,7 @@
          id="path5148"
          inkscape:connector-curvature="0" />
       <text
-         inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png"
+
          xml:space="preserve"
          style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.465361;shape-rendering:crispEdges;enable-background:new"
          x="-28.491961"
@@ -1889,7 +1889,7 @@
          x="-85.493851"
          y="-63.198586"
          id="text28465-9-2"
-         inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png"><tspan
+><tspan
            id="tspan28463-0-5"
            sodipodi:role="line"
            x="-85.493851"
@@ -1904,7 +1904,7 @@
        x="-85.493858"
        y="-74.128525"
        id="text28465-9-2-0"
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png"><tspan
+><tspan
          id="tspan28463-0-5-8"
          sodipodi:role="line"
          x="-85.493858"
@@ -1918,7 +1918,7 @@
        x="-85.700775"
        y="-84.829185"
        id="text28465-9-2-0-3"
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png"><tspan
+><tspan
          id="tspan28463-0-5-8-0"
          sodipodi:role="line"
          x="-85.700775"
@@ -1932,7 +1932,7 @@
        x="-31.448055"
        style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.465361;shape-rendering:crispEdges;enable-background:new"
        xml:space="preserve"
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png"><tspan
+><tspan
          style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;stroke-width:0.465361"
          y="-84.82962"
          x="-31.448055"
@@ -1945,7 +1945,7 @@
        style="fill:none;stroke:#000000;stroke-width:0.411158px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:url(#marker28185-1)"
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96"
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png" />
+ />
     <path
        style="fill:none;stroke:#000000;stroke-width:0.349348;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:2.09609, 2.09609;stroke-dashoffset:0;stroke-opacity:1"
        d="m -44.974573,-101.99332 v 85.195825"

--- a/docs/projects/ad9695_fmc/ad9695_fmc_block_diagram.svg
+++ b/docs/projects/ad9695_fmc/ad9695_fmc_block_diagram.svg
@@ -9,7 +9,7 @@
    id="svg1993"
    inkscape:version="1.1.1 (3bf5ae0d25, 2021-09-20)"
    sodipodi:docname="ad9695_fmc_block_diagram.svg"
-   inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png"
+
    inkscape:export-xdpi="96"
    inkscape:export-ydpi="96"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"

--- a/docs/projects/ad_quadmxfe1_ebz/ad_quadmxfe1_ebz_clock_scheme.svg
+++ b/docs/projects/ad_quadmxfe1_ebz/ad_quadmxfe1_ebz_clock_scheme.svg
@@ -9,7 +9,7 @@
    id="svg1993"
    inkscape:version="1.4 (86a8ad7, 2024-10-11)"
    sodipodi:docname="ad_quadmxfe1_ebz_clock_scheme.svg"
-   inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png"
+
    inkscape:export-xdpi="96"
    inkscape:export-ydpi="96"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
@@ -2792,7 +2792,7 @@
        height="51.96344"
        x="10.231261"
        y="-108.96098"
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png" />
+ />
     <text
        inkscape:export-ydpi="96"
        inkscape:export-xdpi="96"
@@ -2802,7 +2802,7 @@
        y="18.322449"
        id="text17738"
        transform="rotate(-90)"
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png"><tspan
+><tspan
          sodipodi:role="line"
          id="tspan17736"
          x="72.359932"
@@ -2815,13 +2815,13 @@
        inkscape:connector-curvature="0"
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96"
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png" />
+ />
     <g
        id="g35957"
        transform="translate(-41.516354,-78.506363)"
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96"
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png">
+>
       <rect
          inkscape:export-ydpi="96"
          inkscape:export-xdpi="96"
@@ -2854,7 +2854,7 @@
        x="71.916153"
        y="-72.922844"
        id="text27307"
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png"><tspan
+><tspan
          id="tspan27305"
          sodipodi:role="line"
          x="71.916153"
@@ -2867,7 +2867,7 @@
        style="fill:none;stroke:#000000;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:url(#marker28903)"
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96"
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png" />
+ />
     <text
        inkscape:export-ydpi="96"
        inkscape:export-xdpi="96"
@@ -2876,7 +2876,7 @@
        x="23.243126"
        y="-72.867676"
        id="text28465"
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png"><tspan
+><tspan
          id="tspan28463"
          sodipodi:role="line"
          x="23.243126"
@@ -2889,7 +2889,7 @@
        inkscape:connector-curvature="0"
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96"
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png"
+
        sodipodi:nodetypes="cc" />
     <text
        id="text35788"
@@ -2899,7 +2899,7 @@
        xml:space="preserve"
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96"
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png"><tspan
+><tspan
          style="stroke-width:0.264583"
          y="-115.27708"
          x="64.662102"
@@ -2913,7 +2913,7 @@
        x="26.023445"
        y="-115.27708"
        id="text35792"
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png"><tspan
+><tspan
          id="tspan35790"
          sodipodi:role="line"
          x="26.023445"
@@ -2924,7 +2924,7 @@
        transform="translate(-73.894533,-71.619566)"
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96"
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png">
+>
       <path
          inkscape:connector-curvature="0"
          id="path35971"
@@ -2948,7 +2948,7 @@
        style="fill:none;stroke:#000000;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:url(#marker36002)"
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96"
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png" />
+ />
     <text
        id="text35998"
        y="-94.80899"
@@ -2957,7 +2957,7 @@
        xml:space="preserve"
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96"
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png"><tspan
+><tspan
          style="stroke-width:0.264583"
          y="-94.80899"
          x="70.045074"
@@ -2970,7 +2970,7 @@
        inkscape:connector-curvature="0"
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96"
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png" />
+ />
     <text
        inkscape:export-ydpi="96"
        inkscape:export-xdpi="96"
@@ -2979,7 +2979,7 @@
        x="70.045074"
        y="-91.57476"
        id="text37206"
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png"><tspan
+><tspan
          id="tspan37204"
          sodipodi:role="line"
          x="70.045074"
@@ -3332,7 +3332,7 @@
          y="-0.78845721"
          style="stroke-width:0.264583">RX/TX1</tspan></text>
     <path
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png"
+
        inkscape:export-ydpi="96"
        inkscape:export-xdpi="96"
        style="fill:none;stroke:#000000;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:url(#marker5160)"
@@ -3340,7 +3340,7 @@
        id="path5148"
        inkscape:connector-curvature="0" />
     <text
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png"
+
        id="text5152"
        y="-80.371605"
        x="23.243126"
@@ -3354,7 +3354,7 @@
          sodipodi:role="line"
          id="tspan5150">CLKOUT8 (500MHZ&lt;4&gt;)</tspan></text>
     <text
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png"
+
        xml:space="preserve"
        style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.82222px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583;shape-rendering:crispEdges;enable-background:new"
        x="64.247711"
@@ -3368,7 +3368,7 @@
          y="-80.426849"
          style="stroke-width:0.264583">DEVICE_CLK </tspan></text>
     <text
-       inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png"
+
        id="text5152-4"
        y="-93.492729"
        x="23.355551"

--- a/docs/projects/ad_quadmxfe1_ebz/ad_quadmxfe1_ebz_jesd204b_block_diagram.svg
+++ b/docs/projects/ad_quadmxfe1_ebz/ad_quadmxfe1_ebz_jesd204b_block_diagram.svg
@@ -9,7 +9,7 @@
    id="svg1993"
    inkscape:version="1.4 (86a8ad7, 2024-10-11)"
    sodipodi:docname="ad_quadmxfe1_ebz_jesd204b_block_diagram.svg"
-   inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png"
+
    inkscape:export-xdpi="96"
    inkscape:export-ydpi="96"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"

--- a/docs/projects/ad_quadmxfe1_ebz/ad_quadmxfe1_ebz_jesd204c_block_diagram.svg
+++ b/docs/projects/ad_quadmxfe1_ebz/ad_quadmxfe1_ebz_jesd204c_block_diagram.svg
@@ -9,7 +9,7 @@
    id="svg1993"
    inkscape:version="1.4 (86a8ad7, 2024-10-11)"
    sodipodi:docname="ad_quadmxfe1_ebz_jesd204c_block_diagram.svg"
-   inkscape:export-filename="C:\src\ghdl\docs\block_diagrams\ad9208_dual_ebz\ad9208_vcu118_clocking.png"
+
    inkscape:export-xdpi="96"
    inkscape:export-ydpi="96"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"

--- a/docs/projects/ada4355_fmc/ada4355_fmc_zed_block_diagram.svg
+++ b/docs/projects/ada4355_fmc/ada4355_fmc_zed_block_diagram.svg
@@ -654,7 +654,7 @@
        y="69.981445"
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36"
-       inkscape:export-filename="C:\workspace\ad\ghdl\docs\block_diagrams\cn0577\cn0577_block_diagram.png" />
+ />
     <rect
        style="display:inline;fill:none;fill-opacity:1;stroke:#3f4b55;stroke-width:0.436;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:0.436,1.308;stroke-dashoffset:0;stroke-opacity:1;shape-rendering:crispEdges;enable-background:new"
        id="rect6078"
@@ -664,7 +664,7 @@
        y="78.586243"
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36"
-       inkscape:export-filename="C:\workspace\ad\ghdl\docs\block_diagrams\cn0577\cn0577_block_diagram.png" />
+ />
     <rect
        style="fill:#ebebeb;fill-opacity:1;fill-rule:evenodd;stroke:#071414;stroke-width:0.360983;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:75.5906;stroke-opacity:1"
        id="rect46745"
@@ -680,7 +680,7 @@
        id="text4482-5"
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36"
-       inkscape:export-filename="C:\workspace\ad\ghdl\docs\block_diagrams\cn0577\cn0577_block_diagram.png"><tspan
+><tspan
          sodipodi:role="line"
          x="134.49785"
          y="111.41489"
@@ -693,7 +693,7 @@
        height="116.72887"
        x="45.85265"
        y="42.423283"
-       inkscape:export-filename="C:\workspace\ad\ghdl\docs\block_diagrams\cn0577\cn0577_block_diagram.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36" />
     <path
@@ -702,7 +702,7 @@
        id="path4518"
        d="M 133.57232,45.349186 V 40.279672"
        style="display:inline;fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:0.396875;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-start:url(#TriangleInM);marker-end:url(#TriangleOutM);shape-rendering:crispEdges;enable-background:new"
-       inkscape:export-filename="C:\workspace\ad\ghdl\docs\block_diagrams\cn0577\cn0577_block_diagram.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36" />
     <path
@@ -711,7 +711,7 @@
        id="path4518-5"
        d="M 140.48242,45.347446 V 40.304278"
        style="display:inline;fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:0.396875;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-start:url(#TriangleInM-7);marker-end:url(#TriangleOutM-2);shape-rendering:crispEdges;enable-background:new"
-       inkscape:export-filename="C:\workspace\ad\ghdl\docs\block_diagrams\cn0577\cn0577_block_diagram.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36" />
     <path
@@ -720,7 +720,7 @@
        id="path4518-5-9"
        d="M 147.39251,45.34172 V 40.272264"
        style="display:inline;fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:0.396875;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-start:url(#TriangleInM-7-1);marker-end:url(#TriangleOutM-2-8);shape-rendering:crispEdges;enable-background:new"
-       inkscape:export-filename="C:\workspace\ad\ghdl\docs\block_diagrams\cn0577\cn0577_block_diagram.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36" />
     <rect
@@ -731,7 +731,7 @@
        height="19.844805"
        x="-164.83311"
        y="46.539265"
-       inkscape:export-filename="C:\workspace\ad\ghdl\docs\block_diagrams\cn0577\cn0577_block_diagram.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36" />
     <path
@@ -739,7 +739,7 @@
        d="M 157.54764,46.715505 V 66.42975"
        id="path4179"
        inkscape:connector-curvature="0"
-       inkscape:export-filename="C:\workspace\ad\ghdl\docs\block_diagrams\cn0577\cn0577_block_diagram.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36" />
     <path
@@ -747,7 +747,7 @@
        d="M 150.76627,46.715505 V 66.42975"
        id="path4179-9"
        inkscape:connector-curvature="0"
-       inkscape:export-filename="C:\workspace\ad\ghdl\docs\block_diagrams\cn0577\cn0577_block_diagram.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36" />
     <path
@@ -755,7 +755,7 @@
        d="M 123.64077,46.715505 V 66.42975"
        id="path4179-0"
        inkscape:connector-curvature="0"
-       inkscape:export-filename="C:\workspace\ad\ghdl\docs\block_diagrams\cn0577\cn0577_block_diagram.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36" />
     <path
@@ -763,7 +763,7 @@
        d="M 130.42215,46.715505 V 66.42975"
        id="path4179-4"
        inkscape:connector-curvature="0"
-       inkscape:export-filename="C:\workspace\ad\ghdl\docs\block_diagrams\cn0577\cn0577_block_diagram.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36" />
     <path
@@ -771,7 +771,7 @@
        d="M 137.20352,46.715505 V 66.42975"
        id="path4179-7"
        inkscape:connector-curvature="0"
-       inkscape:export-filename="C:\workspace\ad\ghdl\docs\block_diagrams\cn0577\cn0577_block_diagram.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36" />
     <path
@@ -779,7 +779,7 @@
        d="M 143.98489,46.715505 V 66.42975"
        id="path4179-41"
        inkscape:connector-curvature="0"
-       inkscape:export-filename="C:\workspace\ad\ghdl\docs\block_diagrams\cn0577\cn0577_block_diagram.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36" />
     <path
@@ -787,7 +787,7 @@
        d="M 116.8594,46.715505 V 66.42975"
        id="path4179-0-3"
        inkscape:connector-curvature="0"
-       inkscape:export-filename="C:\workspace\ad\ghdl\docs\block_diagrams\cn0577\cn0577_block_diagram.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36" />
     <text
@@ -797,7 +797,7 @@
        x="-62.18874"
        style="font-style:normal;font-weight:normal;font-size:3.175px;line-height:0%;font-family:Arial;letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;shape-rendering:crispEdges"
        xml:space="preserve"
-       inkscape:export-filename="C:\workspace\ad\ghdl\docs\block_diagrams\cn0577\cn0577_block_diagram.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36"><tspan
          style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:2.97656px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial Bold';stroke-width:0.264583px"
@@ -812,7 +812,7 @@
        x="-60.271706"
        style="font-style:normal;font-weight:normal;font-size:3.175px;line-height:0%;font-family:Arial;letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;shape-rendering:crispEdges"
        xml:space="preserve"
-       inkscape:export-filename="C:\workspace\ad\ghdl\docs\block_diagrams\cn0577\cn0577_block_diagram.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36"><tspan
          style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:2.97656px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial Bold';stroke-width:0.264583px"
@@ -827,7 +827,7 @@
        x="-60.204849"
        style="font-style:normal;font-weight:normal;font-size:3.175px;line-height:0%;font-family:Arial;letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;shape-rendering:crispEdges"
        xml:space="preserve"
-       inkscape:export-filename="C:\workspace\ad\ghdl\docs\block_diagrams\cn0577\cn0577_block_diagram.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36"><tspan
          style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:2.97656px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial Bold';stroke-width:0.264583px"
@@ -842,7 +842,7 @@
        x="-58.415714"
        style="font-style:normal;font-weight:normal;font-size:3.175px;line-height:0%;font-family:Arial;letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;shape-rendering:crispEdges"
        xml:space="preserve"
-       inkscape:export-filename="C:\workspace\ad\ghdl\docs\block_diagrams\cn0577\cn0577_block_diagram.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36"><tspan
          style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:2.97656px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial Bold';stroke-width:0.264583px"
@@ -857,7 +857,7 @@
        x="-58.398273"
        style="font-style:normal;font-weight:normal;font-size:3.175px;line-height:0%;font-family:Arial;letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;shape-rendering:crispEdges"
        xml:space="preserve"
-       inkscape:export-filename="C:\workspace\ad\ghdl\docs\block_diagrams\cn0577\cn0577_block_diagram.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36"><tspan
          style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:2.97656px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial Bold';stroke-width:0.264583px"
@@ -874,7 +874,7 @@
        x="-63.036072"
        style="font-style:normal;font-weight:normal;font-size:3.175px;line-height:0%;font-family:Arial;letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;shape-rendering:crispEdges"
        xml:space="preserve"
-       inkscape:export-filename="C:\workspace\ad\ghdl\docs\block_diagrams\cn0577\cn0577_block_diagram.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36"><tspan
          style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:2.97656px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial Bold';stroke-width:0.264583px"
@@ -901,7 +901,7 @@
        x="-60.131454"
        style="font-style:normal;font-weight:normal;font-size:3.175px;line-height:0%;font-family:Arial;letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;shape-rendering:crispEdges"
        xml:space="preserve"
-       inkscape:export-filename="C:\workspace\ad\ghdl\docs\block_diagrams\cn0577\cn0577_block_diagram.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36"><tspan
          style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:2.97656px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial Bold';stroke-width:0.264583px"
@@ -918,7 +918,7 @@
        y="36.366516"
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36"
-       inkscape:export-filename="C:\workspace\ad\ghdl\docs\block_diagrams\cn0577\cn0577_block_diagram.png" />
+ />
     <text
        xml:space="preserve"
        style="font-style:normal;font-weight:normal;font-size:3.175px;line-height:0%;font-family:Arial;letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;shape-rendering:crispEdges;enable-background:new"
@@ -927,7 +927,7 @@
        id="text4595"
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36"
-       inkscape:export-filename="C:\workspace\ad\ghdl\docs\block_diagrams\cn0577\cn0577_block_diagram.png"><tspan
+><tspan
          style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:3.30729px;line-height:1.25;font-family:Arial;-inkscape-font-specification:Arial;stroke-width:0.264583px"
          sodipodi:role="line"
          id="tspan4597"
@@ -942,7 +942,7 @@
        y="85.137817"
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36"
-       inkscape:export-filename="C:\workspace\ad\ghdl\docs\block_diagrams\cn0577\cn0577_block_diagram.png" />
+ />
     <text
        xml:space="preserve"
        style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:3.88056px;line-height:0%;font-family:Arial;-inkscape-font-specification:'Arial, Bold';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;shape-rendering:crispEdges;enable-background:new"
@@ -952,7 +952,7 @@
        transform="rotate(-90)"
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36"
-       inkscape:export-filename="C:\workspace\ad\ghdl\docs\block_diagrams\cn0577\cn0577_block_diagram.png"><tspan
+><tspan
          sodipodi:role="line"
          id="tspan4491"
          x="-136.32645"
@@ -966,7 +966,7 @@
        id="text4482"
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36"
-       inkscape:export-filename="C:\workspace\ad\ghdl\docs\block_diagrams\cn0577\cn0577_block_diagram.png"><tspan
+><tspan
          sodipodi:role="line"
          x="179.62912"
          y="57.091106"
@@ -981,7 +981,7 @@
        y="65.548294"
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36"
-       inkscape:export-filename="C:\workspace\ad\ghdl\docs\block_diagrams\cn0577\cn0577_block_diagram.png" />
+ />
     <text
        xml:space="preserve"
        style="font-style:normal;font-weight:normal;font-size:3.175px;line-height:0%;font-family:Arial;letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;shape-rendering:crispEdges;enable-background:new"
@@ -991,7 +991,7 @@
        transform="rotate(-90)"
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36"
-       inkscape:export-filename="C:\workspace\ad\ghdl\docs\block_diagrams\cn0577\cn0577_block_diagram.png"><tspan
+><tspan
          sodipodi:role="line"
          id="tspan4493"
          x="-136.48291"
@@ -1006,7 +1006,7 @@
        y="69.953239"
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36"
-       inkscape:export-filename="C:\workspace\ad\ghdl\docs\block_diagrams\cn0577\cn0577_block_diagram.png" />
+ />
     <rect
        y="73.397713"
        x="72.880264"
@@ -1016,7 +1016,7 @@
        style="display:inline;vector-effect:none;fill:#ffcccc;fill-opacity:1;fill-rule:nonzero;stroke:#a01414;stroke-width:0.225601;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;shape-rendering:crispEdges;enable-background:new"
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36"
-       inkscape:export-filename="C:\workspace\ad\ghdl\docs\block_diagrams\cn0577\cn0577_block_diagram.png" />
+ />
     <text
        transform="rotate(-90)"
        id="text5788"
@@ -1026,7 +1026,7 @@
        xml:space="preserve"
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36"
-       inkscape:export-filename="C:\workspace\ad\ghdl\docs\block_diagrams\cn0577\cn0577_block_diagram.png"><tspan
+><tspan
          style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:4.63021px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial Bold';fill:#28170b;stroke:none;stroke-width:0.264583px;stroke-opacity:1"
          y="79.038582"
          x="-114.37154"
@@ -1039,7 +1039,7 @@
        x="69.524628"
        style="font-style:normal;font-weight:normal;font-size:3.175px;line-height:0%;font-family:Arial;letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;shape-rendering:crispEdges;enable-background:new"
        xml:space="preserve"
-       inkscape:export-filename="C:\workspace\ad\ghdl\docs\block_diagrams\cn0577\cn0577_block_diagram.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36"><tspan
          style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:3.96875px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial Bold';stroke-width:0.264583px"
@@ -1051,7 +1051,7 @@
        id="g5654"
        style="display:inline;fill:#a01414;fill-opacity:1;stroke:#a01414;stroke-width:0.91193;stroke-opacity:1;shape-rendering:crispEdges;enable-background:new"
        transform="matrix(0.32827811,0,0,0.26434798,19.943177,-34.962379)"
-       inkscape:export-filename="C:\workspace\ad\ghdl\docs\block_diagrams\cn0577\cn0577_block_diagram.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36">
       <path
@@ -1065,7 +1065,7 @@
        id="g5654-3"
        style="display:inline;fill:#a01414;fill-opacity:1;stroke:#a01414;stroke-width:0.57429;stroke-opacity:1;shape-rendering:crispEdges;enable-background:new"
        transform="matrix(0.80784318,0,0,0.27086297,-22.589664,-38.010224)"
-       inkscape:export-filename="C:\workspace\ad\ghdl\docs\block_diagrams\cn0577\cn0577_block_diagram.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36">
       <path
@@ -1166,7 +1166,7 @@
        style="display:inline;shape-rendering:crispEdges;enable-background:new"
        id="ddr"
        transform="matrix(0.37593397,0,0,0.37593391,-17.27073,-132.78758)"
-       inkscape:export-filename="C:\workspace\ad\ghdl\docs\block_diagrams\cn0577\cn0577_block_diagram.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36">
       <rect
@@ -1275,7 +1275,7 @@
        style="display:inline;shape-rendering:crispEdges;enable-background:new"
        id="g8892"
        transform="matrix(0.26458333,0,0,0.26458333,40.080594,-84.382617)"
-       inkscape:export-filename="C:\workspace\ad\ghdl\docs\block_diagrams\cn0577\cn0577_block_diagram.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36">
       <rect
@@ -1385,7 +1385,7 @@
        id="uart"
        transform="matrix(0,-0.10973853,0.10973855,0,102.98407,90.423989)"
        style="display:inline;stroke-width:2.41103;stroke-miterlimit:4;stroke-dasharray:none;shape-rendering:crispEdges;enable-background:new"
-       inkscape:export-filename="C:\workspace\ad\ghdl\docs\block_diagrams\cn0577\cn0577_block_diagram.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36">
       <rect
@@ -1485,7 +1485,7 @@
        y="112.67403"
        id="text2401-61-1-54-8"
        transform="scale(1.0162353,0.98402408)"
-       inkscape:export-filename="C:\workspace\ad\ghdl\docs\block_diagrams\cn0577\cn0577_block_diagram.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36"><tspan
          sodipodi:role="line"
@@ -1500,7 +1500,7 @@
        y="113.01427"
        id="text2401-61-1-54-8-3"
        transform="scale(1.0162353,0.98402408)"
-       inkscape:export-filename="C:\workspace\ad\ghdl\docs\block_diagrams\cn0577\cn0577_block_diagram.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36"><tspan
          sodipodi:role="line"

--- a/docs/projects/adaq8092_fmc/adaq8092_zed_hdl_block_diagram.svg
+++ b/docs/projects/adaq8092_fmc/adaq8092_zed_hdl_block_diagram.svg
@@ -142,7 +142,7 @@
        x="-162.83766"
        y="-35.351097"
        style="display:inline;fill:none;stroke:#000000;stroke-width:0.321257;stroke-opacity:1"
-       inkscape:export-filename="/media/data/ppop/github/project_docs/test_diagram.png"
+
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96" />
     <text
@@ -152,7 +152,7 @@
        y="40.802837"
        id="text4576"
        transform="matrix(0,-1.0919481,0.91579444,0,0,0)"
-       inkscape:export-filename="/media/data/ppop/github/project_docs/test_diagram.png"
+
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96"><tspan
          sodipodi:role="line"
@@ -167,7 +167,7 @@
        y="-7.9140444"
        id="text4598"
        transform="matrix(0,-1.1726554,0.85276544,0,0,0)"
-       inkscape:export-filename="/media/data/ppop/github/project_docs/test_diagram.png"
+
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96"><tspan
          sodipodi:role="line"
@@ -180,7 +180,7 @@
        xml:space="preserve"
        id="flowRoot5982"
        style="font-style:normal;font-weight:normal;line-height:0.01%;font-family:Arial;letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.328079px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;shape-rendering:crispEdges;enable-background:new"
-       inkscape:export-filename="/media/data/ppop/github/project_docs/test_diagram.png"
+
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96"><flowRegion
          id="flowRegion5984"
@@ -198,7 +198,7 @@
        id="flowRoot33657"
        style="font-style:normal;font-weight:normal;font-size:40px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.805304"
        transform="matrix(0.30527839,0,0,0.35359713,-299.69269,-120.38902)"
-       inkscape:export-filename="/media/data/ppop/github/project_docs/test_diagram.png"
+
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96"><flowRegion
          id="flowRegion33659"
@@ -218,7 +218,7 @@
        y="39.56118"
        id="text4576-5"
        transform="matrix(0,-1.0919481,0.91579444,0,0,0)"
-       inkscape:export-filename="/media/data/ppop/github/project_docs/test_diagram.png"
+
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96"><tspan
          sodipodi:role="line"
@@ -233,7 +233,7 @@
        y="-9.2474251"
        id="text4598-2"
        transform="matrix(0,-1.1726554,0.85276544,0,0,0)"
-       inkscape:export-filename="/media/data/ppop/github/project_docs/test_diagram.png"
+
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96"><tspan
          sodipodi:role="line"
@@ -246,7 +246,7 @@
        xml:space="preserve"
        id="flowRoot5982-0"
        style="font-style:normal;font-weight:normal;line-height:0.01%;font-family:Arial;letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.328079px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;shape-rendering:crispEdges;enable-background:new"
-       inkscape:export-filename="/media/data/ppop/github/project_docs/test_diagram.png"
+
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96"><flowRegion
          id="flowRegion5984-3"
@@ -266,7 +266,7 @@
        width="22.982616"
        id="rect5679"
        style="display:inline;fill:#ffcccc;fill-opacity:1;fill-rule:nonzero;stroke:#a01414;stroke-width:0.536625;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;shape-rendering:crispEdges;enable-background:new"
-       inkscape:export-filename="/media/data/ppop/github/project_docs/test_diagram.png"
+
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96" />
     <text
@@ -276,7 +276,7 @@
        y="-14.378081"
        id="text5771"
        transform="matrix(0,-0.97580567,1.0247942,0,0,0)"
-       inkscape:export-filename="/media/data/ppop/github/project_docs/test_diagram.png"
+
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96"><tspan
          sodipodi:role="line"
@@ -291,7 +291,7 @@
        height="220.92709"
        x="-150.92279"
        y="51.961403"
-       inkscape:export-filename="/media/data/ppop/github/project_docs/test_diagram.png"
+
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96" />
     <rect
@@ -301,7 +301,7 @@
        height="153.34886"
        x="-161.29205"
        y="87.52504"
-       inkscape:export-filename="/media/data/ppop/github/project_docs/test_diagram.png"
+
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96" />
     <text
@@ -311,7 +311,7 @@
        y="-143.34102"
        id="text4489"
        transform="matrix(0,-0.97515081,1.0254824,0,0,0)"
-       inkscape:export-filename="/media/data/ppop/github/project_docs/test_diagram.png"
+
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96"><tspan
          sodipodi:role="line"
@@ -323,7 +323,7 @@
        style="display:inline;stroke-width:0.328079;shape-rendering:crispEdges;enable-background:new"
        id="ddr"
        transform="matrix(1.1908229,0,0,1.1338977,-385.36109,-558.80348)"
-       inkscape:export-filename="/media/data/ppop/github/project_docs/test_diagram.png"
+
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96">
       <rect
@@ -432,7 +432,7 @@
        style="display:inline;stroke-width:0.328079;shape-rendering:crispEdges;enable-background:new"
        id="g8892"
        transform="matrix(0.83810432,0,0,0.79804018,-205.36905,-414.39977)"
-       inkscape:export-filename="/media/data/ppop/github/project_docs/test_diagram.png"
+
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96">
       <rect
@@ -542,7 +542,7 @@
        id="uart"
        transform="matrix(0,-0.33099504,0.34761207,0,-5.2754664,112.85447)"
        style="display:inline;stroke-width:0.79101;stroke-miterlimit:4;stroke-dasharray:none;shape-rendering:crispEdges;enable-background:new"
-       inkscape:export-filename="/media/data/ppop/github/project_docs/test_diagram.png"
+
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96">
       <rect
@@ -640,7 +640,7 @@
        style="display:inline;stroke-width:0.328079;shape-rendering:crispEdges;enable-background:new"
        id="g4600"
        transform="matrix(0.83810432,0,0,0.79804018,-153.60307,-397.50824)"
-       inkscape:export-filename="/media/data/ppop/github/project_docs/test_diagram.png"
+
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96">
       <rect
@@ -667,7 +667,7 @@
        xml:space="preserve"
        id="flowRoot3911"
        style="font-style:normal;font-weight:normal;line-height:0.01%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.328079px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;shape-rendering:crispEdges;enable-background:new"
-       inkscape:export-filename="/media/data/ppop/github/project_docs/test_diagram.png"
+
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96"><flowRegion
          id="flowRegion3913"
@@ -684,7 +684,7 @@
        id="g5654-0"
        style="display:inline;fill:#a01414;fill-opacity:1;stroke:#a01414;stroke-width:0.356891;stroke-opacity:1;shape-rendering:crispEdges;enable-background:new"
        transform="matrix(1.4812896,0,0,0.66228015,-332.59496,-196.22608)"
-       inkscape:export-filename="/media/data/ppop/github/project_docs/test_diagram.png"
+
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96">
       <path
@@ -698,7 +698,7 @@
        id="g5654-0-0"
        style="display:inline;fill:#a01414;fill-opacity:1;stroke:#a01414;stroke-width:0.460246;stroke-opacity:1;shape-rendering:crispEdges;enable-background:new"
        transform="matrix(1.4113727,0,0,0.75769535,-253.0497,-248.02128)"
-       inkscape:export-filename="/media/data/ppop/github/project_docs/test_diagram.png"
+
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96">
       <path
@@ -712,7 +712,7 @@
        style="display:inline;stroke-width:0.328079;shape-rendering:crispEdges;enable-background:new"
        id="g11134"
        transform="matrix(0.83810432,0,0,0.79804018,-227.3922,-177.26656)"
-       inkscape:export-filename="/media/data/ppop/github/project_docs/test_diagram.png"
+
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96">
       <path
@@ -870,14 +870,14 @@
        height="221.2597"
        x="-82.131126"
        y="51.961418"
-       inkscape:export-filename="/media/data/ppop/github/project_docs/test_diagram.png"
+
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96" />
     <g
        id="g5654-7-6-2"
        style="display:inline;fill:#a01414;fill-opacity:1;stroke:#a01414;stroke-width:0.284692;stroke-opacity:1;shape-rendering:crispEdges;enable-background:new"
        transform="matrix(1.1130219,0,0,0.79804018,-149.45286,-235.38855)"
-       inkscape:export-filename="/media/data/ppop/github/project_docs/test_diagram.png"
+
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96">
       <path
@@ -905,7 +905,7 @@
        y="48.999989"
        id="text3996"
        transform="scale(0.92916675,1.0762331)"
-       inkscape:export-filename="/media/data/ppop/github/project_docs/test_diagram.png"
+
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96"><tspan
          sodipodi:role="line"
@@ -917,7 +917,7 @@
        id="g5654-7-6"
        style="display:inline;fill:#a01414;fill-opacity:1;stroke:#a01414;stroke-width:0.284098;stroke-opacity:1;shape-rendering:crispEdges;enable-background:new"
        transform="matrix(1.1176788,0,0,0.79804018,-150.06047,-312.27974)"
-       inkscape:export-filename="/media/data/ppop/github/project_docs/test_diagram.png"
+
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96">
       <path
@@ -933,7 +933,7 @@
        x="5.2527289"
        y="129.86421"
        id="text3992"
-       inkscape:export-filename="/media/data/ppop/github/project_docs/test_diagram.png"
+
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96"
        transform="scale(1.0247942,0.97580567)"><tspan
@@ -948,7 +948,7 @@
        x="-55.451912"
        y="173.10661"
        id="text3992-3"
-       inkscape:export-filename="/media/data/ppop/github/project_docs/test_diagram.png"
+
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96"
        transform="scale(1.0247942,0.97580567)"><tspan
@@ -963,7 +963,7 @@
        x="-122.83739"
        y="172.83548"
        id="text3992-3-0"
-       inkscape:export-filename="/media/data/ppop/github/project_docs/test_diagram.png"
+
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96"
        transform="scale(1.0247942,0.97580567)"><tspan
@@ -978,7 +978,7 @@
        x="5.4789748"
        y="209.43987"
        id="text3992-3-3"
-       inkscape:export-filename="/media/data/ppop/github/project_docs/test_diagram.png"
+
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96"
        transform="scale(1.0247942,0.97580567)"><tspan
@@ -996,7 +996,7 @@
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96"
        transform="scale(0.92621941,1.0796578)"
-       inkscape:export-filename="/media/data/ppop/github/project_docs/test_diagram.png"><tspan
+><tspan
          sodipodi:role="line"
          id="tspan6098-9"
          x="-162.02396"
@@ -1010,7 +1010,7 @@
        id="text6100-6-9"
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96"
-       inkscape:export-filename="/media/data/ppop/github/project_docs/test_diagram.png"
+
        transform="scale(1.0247942,0.97580567)"><tspan
          sodipodi:role="line"
          id="tspan6098-9-4"
@@ -1024,13 +1024,13 @@
        y="-28.190569"
        id="text3104"
        transform="scale(0.92916675,1.0762331)"
-       inkscape:export-filename="/media/data/ppop/github/project_docs/test_diagram.png"
+
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96" />
     <g
        id="g1591"
        transform="matrix(3.1676382,0,0,1.9659589,-411.7593,-283.49237)"
-       inkscape:export-filename="/media/data/ppop/github/project_docs/test_diagram.png"
+
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96"
        style="display:inline;stroke-width:0.328079">
@@ -1059,7 +1059,7 @@
        d="M 18.410536,9.0989068 H -150.88137"
        id="path4305-3"
        inkscape:connector-curvature="0"
-       inkscape:export-filename="/media/data/ppop/github/project_docs/test_diagram.png"
+
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96" />
     <text
@@ -1069,7 +1069,7 @@
        y="4.3681002"
        id="text4307-4"
        transform="scale(1.0489055,0.95337473)"
-       inkscape:export-filename="/media/data/ppop/github/project_docs/test_diagram.png"
+
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96"><tspan
          sodipodi:role="line"
@@ -1084,7 +1084,7 @@
        y="22.520037"
        id="text4311-0"
        transform="scale(1.0489055,0.95337473)"
-       inkscape:export-filename="/media/data/ppop/github/project_docs/test_diagram.png"
+
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96"><tspan
          sodipodi:role="line"
@@ -1101,7 +1101,7 @@
        style="font-style:normal;font-weight:normal;font-size:11.0653px;line-height:0%;font-family:Arial;letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:0.858696;stroke:none;stroke-width:0.302525px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;shape-rendering:crispEdges;enable-background:new"
        xml:space="preserve"
        transform="scale(1.0564806,0.94653891)"
-       inkscape:export-filename="/media/data/ppop/github/project_docs/test_diagram.png"><tspan
+><tspan
          id="tspan3725"
          style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:18.4423px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:0.858696;stroke-width:0.302525px"
          y="16.898647"
@@ -1114,7 +1114,7 @@
        height="155.49106"
        x="-100.77206"
        y="85.455368"
-       inkscape:export-filename="/media/data/ppop/github/project_docs/test_diagram.png"
+
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96" />
     <text
@@ -1124,7 +1124,7 @@
        y="-79.512383"
        id="text5775-9"
        transform="matrix(0,-0.97580567,1.0247942,0,0,0)"
-       inkscape:export-filename="/media/data/ppop/github/project_docs/test_diagram.png"
+
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96"><tspan
          sodipodi:role="line"
@@ -1139,7 +1139,7 @@
        y="317.59787"
        id="text10629-4"
        transform="matrix(0,-1.2780579,0.78243716,0,0,0)"
-       inkscape:export-filename="/media/data/ppop/github/project_docs/test_diagram.png"
+
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96"><tspan
          sodipodi:role="line"
@@ -1155,7 +1155,7 @@
        pointer-events="stroke"
        id="path1743"
        style="display:inline;stroke-width:0.343958;stroke-miterlimit:10;stroke-dasharray:none;marker-start:url(#TriangleInM)"
-       inkscape:export-filename="/media/data/ppop/github/project_docs/test_diagram.png"
+
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96" />
     <path
@@ -1166,7 +1166,7 @@
        pointer-events="stroke"
        id="path1743-0"
        style="display:inline;stroke-width:0.343958;stroke-miterlimit:10;stroke-dasharray:none;marker-start:url(#TriangleInM)"
-       inkscape:export-filename="/media/data/ppop/github/project_docs/test_diagram.png"
+
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96" />
     <path
@@ -1177,7 +1177,7 @@
        stroke-miterlimit="10"
        pointer-events="stroke"
        id="path1755"
-       inkscape:export-filename="/media/data/ppop/github/project_docs/test_diagram.png"
+
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96"
        style="display:inline;marker-start:url(#TriangleInM)" />
@@ -1189,7 +1189,7 @@
        stroke-miterlimit="10"
        pointer-events="stroke"
        id="path1797"
-       inkscape:export-filename="/media/data/ppop/github/project_docs/test_diagram.png"
+
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96"
        style="display:inline;marker-start:url(#TriangleInM)" />
@@ -1200,7 +1200,7 @@
        y="316.14453"
        id="text10629-4-5-5"
        transform="matrix(0,-1.2780579,0.78243716,0,0,0)"
-       inkscape:export-filename="/media/data/ppop/github/project_docs/test_diagram.png"
+
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96"><tspan
          sodipodi:role="line"
@@ -1216,7 +1216,7 @@
        stroke-miterlimit="10"
        pointer-events="stroke"
        id="path1755-4"
-       inkscape:export-filename="/media/data/ppop/github/project_docs/test_diagram.png"
+
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96"
        style="display:inline;marker-start:url(#TriangleInM)" />
@@ -1228,7 +1228,7 @@
        stroke-miterlimit="10"
        pointer-events="stroke"
        id="path1797-4"
-       inkscape:export-filename="/media/data/ppop/github/project_docs/test_diagram.png"
+
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96"
        style="display:inline;marker-start:url(#TriangleInM)" />
@@ -1240,7 +1240,7 @@
        pointer-events="stroke"
        id="path1759"
        style="display:inline;stroke-width:0.343958;stroke-miterlimit:10;stroke-dasharray:none;marker-start:url(#TriangleInM)"
-       inkscape:export-filename="/media/data/ppop/github/project_docs/test_diagram.png"
+
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96" />
     <path
@@ -1251,7 +1251,7 @@
        pointer-events="stroke"
        id="path1763"
        style="display:inline;stroke-width:0.343958;stroke-miterlimit:10;stroke-dasharray:none;marker-start:url(#TriangleInM)"
-       inkscape:export-filename="/media/data/ppop/github/project_docs/test_diagram.png"
+
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96" />
     <rect
@@ -1263,7 +1263,7 @@
        stroke="none"
        pointer-events="all"
        id="rect1827"
-       inkscape:export-filename="/media/data/ppop/github/project_docs/test_diagram.png"
+
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96"
        style="display:inline;stroke-width:0.264583" />
@@ -1276,7 +1276,7 @@
        stroke="none"
        pointer-events="all"
        id="rect1835"
-       inkscape:export-filename="/media/data/ppop/github/project_docs/test_diagram.png"
+
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96"
        style="display:inline;stroke-width:0.264583" />
@@ -1290,7 +1290,7 @@
        id="text1829-3-4-7"
        style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:6.35px;font-family:Helvetica;-inkscape-font-specification:'Helvetica, Bold';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-anchor:middle;display:inline;fill:#000000;stroke-width:0.213071"
        transform="scale(1.0247942,0.97580569)"
-       inkscape:export-filename="/media/data/ppop/github/project_docs/test_diagram.png"
+
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96" />
     <text
@@ -1299,7 +1299,7 @@
        x="225.44699"
        y="77.758278"
        id="text10515"
-       inkscape:export-filename="/media/data/ppop/github/project_docs/test_diagram.png"
+
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96"><tspan
          sodipodi:role="line"
@@ -1313,7 +1313,7 @@
        x="216.95763"
        y="110.1365"
        id="text12805"
-       inkscape:export-filename="/media/data/ppop/github/project_docs/test_diagram.png"
+
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96"><tspan
          sodipodi:role="line"
@@ -1327,7 +1327,7 @@
        x="216.54033"
        y="121.75548"
        id="text16785"
-       inkscape:export-filename="/media/data/ppop/github/project_docs/test_diagram.png"
+
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96"><tspan
          sodipodi:role="line"
@@ -1341,7 +1341,7 @@
        x="216.63664"
        y="145.81725"
        id="text12805-94"
-       inkscape:export-filename="/media/data/ppop/github/project_docs/test_diagram.png"
+
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96"><tspan
          sodipodi:role="line"
@@ -1355,7 +1355,7 @@
        x="217.01311"
        y="156.64246"
        id="text16785-4"
-       inkscape:export-filename="/media/data/ppop/github/project_docs/test_diagram.png"
+
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96"><tspan
          sodipodi:role="line"
@@ -1367,7 +1367,7 @@
        id="switch1831-5-7-1-0"
        style="display:inline;stroke-width:0.328079"
        transform="matrix(0.82645762,0,0,0.78695028,-222.41382,-235.95628)"
-       inkscape:export-filename="/media/data/ppop/github/project_docs/test_diagram.png"
+
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96">
       <foreignObject
@@ -1424,7 +1424,7 @@
        id="switch1831-5-7-1-3"
        style="display:inline;stroke-width:0.328079"
        transform="matrix(0.82645762,0,0,0.78695028,-222.41382,-235.95628)"
-       inkscape:export-filename="/media/data/ppop/github/project_docs/test_diagram.png"
+
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96">
       <foreignObject
@@ -1487,7 +1487,7 @@
        pointer-events="all"
        id="rect4"
        style="display:inline;fill:none;stroke:#a01414;stroke-width:0.555625;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       inkscape:export-filename="/media/data/ppop/github/project_docs/test_diagram.png"
+
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96" />
     <path
@@ -1498,7 +1498,7 @@
        pointer-events="stroke"
        id="path6"
        style="display:inline;stroke-width:0.264583"
-       inkscape:export-filename="/media/data/ppop/github/project_docs/test_diagram.png"
+
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96" />
     <path
@@ -1509,7 +1509,7 @@
        pointer-events="all"
        id="path8"
        style="display:inline;stroke-width:0.264583"
-       inkscape:export-filename="/media/data/ppop/github/project_docs/test_diagram.png"
+
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96" />
     <path
@@ -1520,7 +1520,7 @@
        pointer-events="stroke"
        id="path10"
        style="display:inline;stroke-width:0.264583"
-       inkscape:export-filename="/media/data/ppop/github/project_docs/test_diagram.png"
+
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96" />
     <path
@@ -1531,7 +1531,7 @@
        pointer-events="all"
        id="path12"
        style="display:inline;stroke-width:0.264583"
-       inkscape:export-filename="/media/data/ppop/github/project_docs/test_diagram.png"
+
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96" />
     <rect
@@ -1544,14 +1544,14 @@
        pointer-events="all"
        id="rect14"
        style="display:inline;fill:#ffcccc;fill-opacity:1;stroke:#a01414;stroke-width:0.343958;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       inkscape:export-filename="/media/data/ppop/github/project_docs/test_diagram.png"
+
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96" />
     <g
        transform="matrix(0.32864041,0,0,0.64688425,-5.8035218,64.177293)"
        id="g20"
        style="display:inline;stroke-width:0.573837"
-       inkscape:export-filename="/media/data/ppop/github/project_docs/test_diagram.png"
+
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96">
       <switch
@@ -1594,14 +1594,14 @@
        pointer-events="all"
        id="rect22"
        style="display:inline;fill:#ffcccc;fill-opacity:1;stroke:#a01414;stroke-width:0.343958;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       inkscape:export-filename="/media/data/ppop/github/project_docs/test_diagram.png"
+
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96" />
     <g
        transform="matrix(0.32864041,0,0,0.64688425,-5.8035218,64.177293)"
        id="g28"
        style="display:inline;stroke-width:0.573837"
-       inkscape:export-filename="/media/data/ppop/github/project_docs/test_diagram.png"
+
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96">
       <switch
@@ -1644,14 +1644,14 @@
        pointer-events="all"
        id="rect30"
        style="display:inline;fill:#ffcccc;fill-opacity:1;stroke:#a01414;stroke-width:0.343958;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       inkscape:export-filename="/media/data/ppop/github/project_docs/test_diagram.png"
+
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96" />
     <g
        transform="matrix(0.32864041,0,0,0.64688425,-5.8035218,64.177293)"
        id="g36"
        style="display:inline;stroke-width:0.573837"
-       inkscape:export-filename="/media/data/ppop/github/project_docs/test_diagram.png"
+
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96">
       <switch
@@ -1692,7 +1692,7 @@
        pointer-events="stroke"
        id="path38"
        style="display:inline;stroke-width:0.264583"
-       inkscape:export-filename="/media/data/ppop/github/project_docs/test_diagram.png"
+
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96" />
     <path
@@ -1703,7 +1703,7 @@
        pointer-events="all"
        id="path40"
        style="display:inline;stroke-width:0.264583"
-       inkscape:export-filename="/media/data/ppop/github/project_docs/test_diagram.png"
+
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96" />
     <path
@@ -1714,7 +1714,7 @@
        pointer-events="all"
        id="path42"
        style="display:inline;stroke-width:0.264583"
-       inkscape:export-filename="/media/data/ppop/github/project_docs/test_diagram.png"
+
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96" />
     <rect
@@ -1727,14 +1727,14 @@
        pointer-events="all"
        id="rect44"
        style="display:inline;fill:#ffcccc;fill-opacity:1;stroke:#a01414;stroke-width:0.343958;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       inkscape:export-filename="/media/data/ppop/github/project_docs/test_diagram.png"
+
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96" />
     <g
        transform="matrix(0.32864041,0,0,0.64688425,-5.8035218,64.177293)"
        id="g50"
        style="display:inline;stroke-width:0.573837"
-       inkscape:export-filename="/media/data/ppop/github/project_docs/test_diagram.png"
+
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96">
       <switch
@@ -1775,7 +1775,7 @@
        pointer-events="stroke"
        id="path52"
        style="display:inline;stroke-width:0.264583"
-       inkscape:export-filename="/media/data/ppop/github/project_docs/test_diagram.png"
+
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96" />
     <path
@@ -1786,7 +1786,7 @@
        pointer-events="all"
        id="path54"
        style="display:inline;stroke-width:0.264583"
-       inkscape:export-filename="/media/data/ppop/github/project_docs/test_diagram.png"
+
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96" />
     <path
@@ -1797,7 +1797,7 @@
        pointer-events="all"
        id="path56"
        style="display:inline;stroke-width:0.264583"
-       inkscape:export-filename="/media/data/ppop/github/project_docs/test_diagram.png"
+
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96" />
     <path
@@ -1808,7 +1808,7 @@
        pointer-events="stroke"
        id="path58"
        style="display:inline;stroke-width:0.264583"
-       inkscape:export-filename="/media/data/ppop/github/project_docs/test_diagram.png"
+
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96" />
     <path
@@ -1819,7 +1819,7 @@
        pointer-events="all"
        id="path60"
        style="display:inline;stroke-width:0.264583"
-       inkscape:export-filename="/media/data/ppop/github/project_docs/test_diagram.png"
+
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96" />
     <path
@@ -1830,7 +1830,7 @@
        pointer-events="stroke"
        id="path62"
        style="display:inline;stroke-width:0.264583"
-       inkscape:export-filename="/media/data/ppop/github/project_docs/test_diagram.png"
+
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96" />
     <path
@@ -1841,7 +1841,7 @@
        pointer-events="all"
        id="path64"
        style="display:inline;stroke-width:0.264583"
-       inkscape:export-filename="/media/data/ppop/github/project_docs/test_diagram.png"
+
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96" />
     <rect
@@ -1854,14 +1854,14 @@
        pointer-events="all"
        id="rect66"
        style="display:inline;fill:#ffcccc;fill-opacity:1;stroke:#a01414;stroke-width:0.343958;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       inkscape:export-filename="/media/data/ppop/github/project_docs/test_diagram.png"
+
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96" />
     <g
        transform="matrix(0.32864041,0,0,0.64688425,-5.8035218,56.768959)"
        id="g72"
        style="display:inline;stroke-width:0.573837"
-       inkscape:export-filename="/media/data/ppop/github/project_docs/test_diagram.png"
+
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96">
       <switch
@@ -1904,7 +1904,7 @@
        pointer-events="all"
        id="rect234"
        style="display:inline;stroke-width:0.264583"
-       inkscape:export-filename="/media/data/ppop/github/project_docs/test_diagram.png"
+
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96" />
     <text
@@ -1913,7 +1913,7 @@
        x="68.944466"
        y="83.683884"
        id="text6777"
-       inkscape:export-filename="/media/data/ppop/github/project_docs/test_diagram.png"
+
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96"><tspan
          sodipodi:role="line"
@@ -1925,7 +1925,7 @@
        id="switch1831-5-7-1-6"
        style="display:inline;stroke-width:0.328079"
        transform="matrix(0.82645762,0,0,0.78695028,-222.41382,-235.95628)"
-       inkscape:export-filename="/media/data/ppop/github/project_docs/test_diagram.png"
+
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96">
       <foreignObject
@@ -1982,7 +1982,7 @@
        id="switch1831-5-7-1-2"
        style="display:inline;stroke-width:0.328079"
        transform="matrix(0.82645762,0,0,0.78695028,-222.41382,-235.95628)"
-       inkscape:export-filename="/media/data/ppop/github/project_docs/test_diagram.png"
+
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96">
       <foreignObject
@@ -2039,7 +2039,7 @@
        id="switch1831-5-7-1-02"
        style="display:inline;stroke-width:0.328079"
        transform="matrix(0.82645762,0,0,0.78695028,-222.41382,-235.95628)"
-       inkscape:export-filename="/media/data/ppop/github/project_docs/test_diagram.png"
+
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96">
       <foreignObject
@@ -2096,7 +2096,7 @@
        id="switch1831-5-7-1-9"
        style="display:inline;stroke-width:0.328079"
        transform="matrix(0.82645762,0,0,0.78695028,-222.41382,-235.95628)"
-       inkscape:export-filename="/media/data/ppop/github/project_docs/test_diagram.png"
+
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96">
       <foreignObject
@@ -2155,7 +2155,7 @@
        x="226.97646"
        y="175.99553"
        id="text23513"
-       inkscape:export-filename="/media/data/ppop/github/project_docs/test_diagram.png"
+
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96"><tspan
          sodipodi:role="line"
@@ -2169,7 +2169,7 @@
        x="227.59044"
        y="188.91794"
        id="text23513-0"
-       inkscape:export-filename="/media/data/ppop/github/project_docs/test_diagram.png"
+
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96"><tspan
          sodipodi:role="line"
@@ -2183,7 +2183,7 @@
        x="231.49365"
        y="210.85954"
        id="text23513-6"
-       inkscape:export-filename="/media/data/ppop/github/project_docs/test_diagram.png"
+
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96"><tspan
          sodipodi:role="line"
@@ -2197,7 +2197,7 @@
        x="231.27948"
        y="220.78853"
        id="text23513-6-0"
-       inkscape:export-filename="/media/data/ppop/github/project_docs/test_diagram.png"
+
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96"><tspan
          sodipodi:role="line"

--- a/docs/projects/admx100x_evb/admx100x-evb.svg
+++ b/docs/projects/admx100x_evb/admx100x-evb.svg
@@ -904,7 +904,7 @@
        id="flowRoot33657"
        style="font-style:normal;font-weight:normal;font-size:40px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.0168229;stroke-miterlimit:4;stroke-dasharray:0.0336457, 0.0336457;stroke-dashoffset:0"
        transform="matrix(0.30527839,0,0,0.35359713,-232.3735,-114.27306)"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD7768\AD7768_BLOCK_DIAGRAM.png"
+
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96"><flowRegion
          id="flowRegion33659"
@@ -923,7 +923,7 @@
        x="192.51585"
        y="192.08813"
        id="text3992-4"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD7768\AD7768_BLOCK_DIAGRAM.png"
+
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96"
        transform="scale(1.0247942,0.97580567)"><tspan
@@ -939,7 +939,7 @@
        y="54.682735"
        id="text3996"
        transform="scale(0.92916675,1.0762331)"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD7768\AD7768_BLOCK_DIAGRAM.png"
+
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96"><tspan
          sodipodi:role="line"
@@ -954,7 +954,7 @@
        y="-22.507824"
        id="text3104"
        transform="scale(0.92916675,1.0762331)"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD7768\AD7768_BLOCK_DIAGRAM.png"
+
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96" />
     <text
@@ -964,7 +964,7 @@
        y="71.028183"
        id="text4598"
        transform="matrix(0,-1.1726554,0.85276546,0,0,0)"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD7768\AD7768_BLOCK_DIAGRAM_new.png"
+
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96"><tspan
          sodipodi:role="line"
@@ -977,7 +977,7 @@
        xml:space="preserve"
        id="flowRoot5982"
        style="font-style:normal;font-weight:normal;line-height:0.01%;font-family:Arial;letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.328079px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;shape-rendering:crispEdges;enable-background:new"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD7768\AD7768_BLOCK_DIAGRAM_new.png"
+
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96"><flowRegion
          id="flowRegion5984"
@@ -997,7 +997,7 @@
        height="243.88745"
        x="-183.18832"
        y="-25.324032"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD7768\AD7768_BLOCK_DIAGRAM_new.png"
+
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96" />
     <text
@@ -1007,7 +1007,7 @@
        y="-14.942104"
        id="text4576-5"
        transform="matrix(0,-1.0919481,0.91579442,0,0,0)"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD7768\AD7768_BLOCK_DIAGRAM_new.png"
+
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96"><tspan
          sodipodi:role="line"
@@ -1022,7 +1022,7 @@
        y="69.694801"
        id="text4598-2"
        transform="matrix(0,-1.1726554,0.85276546,0,0,0)"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD7768\AD7768_BLOCK_DIAGRAM_new.png"
+
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96"><tspan
          sodipodi:role="line"
@@ -1035,7 +1035,7 @@
        xml:space="preserve"
        id="flowRoot5982-0"
        style="font-style:normal;font-weight:normal;line-height:0.01%;font-family:Arial;letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.328079px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;shape-rendering:crispEdges;enable-background:new"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD7768\AD7768_BLOCK_DIAGRAM_new.png"
+
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96"><flowRegion
          id="flowRegion5984-3"
@@ -1052,7 +1052,7 @@
        style="display:inline;stroke-width:0.328079;shape-rendering:crispEdges;enable-background:new"
        id="ddr"
        transform="matrix(1.1908229,0,0,1.1338977,-396.3709,-551.46501)"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD7768\AD7768_BLOCK_DIAGRAM_new.png"
+
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96">
       <rect
@@ -1161,7 +1161,7 @@
        style="display:inline;stroke-width:0.328079;shape-rendering:crispEdges;enable-background:new"
        id="g8892"
        transform="matrix(0.83810432,0,0,0.79804018,-216.37886,-407.0613)"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD7768\AD7768_BLOCK_DIAGRAM_new.png"
+
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96">
       <rect
@@ -1271,7 +1271,7 @@
        id="uart"
        transform="matrix(0,-0.33099504,0.34761207,0,-16.285282,120.19295)"
        style="display:inline;stroke-width:0.79101;stroke-miterlimit:4;stroke-dasharray:none;shape-rendering:crispEdges;enable-background:new"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD7768\AD7768_BLOCK_DIAGRAM_new.png"
+
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96">
       <rect
@@ -1370,7 +1370,7 @@
        xml:space="preserve"
        id="flowRoot3911"
        style="font-style:normal;font-weight:normal;line-height:0.01%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.328079px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;shape-rendering:crispEdges;enable-background:new"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD7768\AD7768_BLOCK_DIAGRAM_new.png"
+
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96"><flowRegion
          id="flowRegion3913"
@@ -1726,7 +1726,7 @@
        d="M 21.144596,12.83227 H -148.14732"
        id="path4305-3"
        inkscape:connector-curvature="0"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD7768\AD7768_BLOCK_DIAGRAM_new.png"
+
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96" />
     <text
@@ -1736,7 +1736,7 @@
        y="8.2840433"
        id="text4307-4"
        transform="scale(1.0489055,0.95337473)"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD7768\AD7768_BLOCK_DIAGRAM_new.png"
+
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96"><tspan
          sodipodi:role="line"
@@ -1751,7 +1751,7 @@
        y="28.656128"
        id="text4311-0"
        transform="scale(1.0489055,0.95337473)"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD7768\AD7768_BLOCK_DIAGRAM_new.png"
+
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96"><tspan
          sodipodi:role="line"
@@ -1768,7 +1768,7 @@
        style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:16.9333px;line-height:0%;font-family:Arial;-inkscape-font-specification:'Arial, Bold';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:0.858696;stroke:none;stroke-width:0.302525px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;shape-rendering:crispEdges;enable-background:new"
        xml:space="preserve"
        transform="scale(1.0564806,0.94653891)"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD7768\AD7768_BLOCK_DIAGRAM_new.png"><tspan
+><tspan
          sodipodi:role="line"
          id="tspan9"
          x="206.34032"
@@ -1782,7 +1782,7 @@
        stroke="none"
        pointer-events="all"
        id="rect1827"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD7768\AD7768_BLOCK_DIAGRAM_new.png"
+
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96"
        style="display:inline;stroke-width:0.264583" />
@@ -1795,7 +1795,7 @@
        stroke="none"
        pointer-events="all"
        id="rect1835"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD7768\AD7768_BLOCK_DIAGRAM_new.png"
+
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96"
        style="display:inline;stroke-width:0.264583" />
@@ -1814,7 +1814,7 @@
        style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:16.9333px;line-height:0%;font-family:Arial;-inkscape-font-specification:'Arial, Bold';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:0.858696;stroke:url(#linearGradient13);stroke-width:0.303;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;shape-rendering:crispEdges;enable-background:new"
        xml:space="preserve"
        transform="scale(1.0564806,0.94653891)"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD7768\AD7768_BLOCK_DIAGRAM_new.png"><tspan
+><tspan
          sodipodi:role="line"
          id="tspan3">ADMX100X-EVB</tspan></text>
     <path

--- a/docs/projects/admx6001_ebz/admx6001_ebz_block_diagram.svg
+++ b/docs/projects/admx6001_ebz/admx6001_ebz_block_diagram.svg
@@ -2825,7 +2825,7 @@
          id="g5654-3-7"
          style="display:inline;fill:#a01414;fill-opacity:1;stroke:#a01414;stroke-width:0.423032;stroke-opacity:1;shape-rendering:crispEdges;enable-background:new"
          transform="matrix(1.2201779,0,0,0.32008247,-180.94177,195.09078)"
-         inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\hammerhead\hammerhead_block_diagram.png"
+
          inkscape:export-xdpi="224.36"
          inkscape:export-ydpi="224.36">
         <path
@@ -2839,7 +2839,7 @@
          id="g5654-3-7-6"
          style="display:inline;fill:#a01414;fill-opacity:1;stroke:#a01414;stroke-width:0.375956;stroke-opacity:1;shape-rendering:crispEdges;enable-background:new"
          transform="matrix(1.5459899,0,0,0.31985378,-171.04641,195.2157)"
-         inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\hammerhead\hammerhead_block_diagram.png"
+
          inkscape:export-xdpi="224.36"
          inkscape:export-ydpi="224.36">
         <path
@@ -2855,7 +2855,7 @@
          marker-end="url(#marker1216-6-5-5-24)"
          id="path442-0"
          style="fill:none;stroke:#000000;stroke-width:0.520765;marker-end:url(#marker1216-6-5-5-24);shape-rendering:crispEdges"
-         inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\hammerhead\hammerhead_block_diagram.png"
+
          inkscape:export-xdpi="224.36"
          inkscape:export-ydpi="224.36" />
       <path
@@ -2864,7 +2864,7 @@
          marker-end="url(#marker1216-6-5-5-24-2)"
          id="path442-0-7"
          style="fill:none;stroke:#000000;stroke-width:0.520765;marker-end:url(#marker1216-6-5-5-24-2);shape-rendering:crispEdges"
-         inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\hammerhead\hammerhead_block_diagram.png"
+
          inkscape:export-xdpi="224.36"
          inkscape:export-ydpi="224.36" />
       <path
@@ -2873,7 +2873,7 @@
          marker-end="url(#marker1216-6-5-5-24-2-6)"
          id="path442-0-7-0"
          style="fill:none;stroke:#000000;stroke-width:0.520765;marker-end:url(#marker1216-6-5-5-24-2-6);shape-rendering:crispEdges"
-         inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\hammerhead\hammerhead_block_diagram.png"
+
          inkscape:export-xdpi="224.36"
          inkscape:export-ydpi="224.36" />
       <path
@@ -2882,7 +2882,7 @@
          marker-end="url(#marker1216-6-5-5-5-1)"
          id="path444-6"
          style="fill:none;stroke:#000000;stroke-width:0.520765;marker-end:url(#marker1216-6-5-5-5-1);shape-rendering:crispEdges"
-         inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\hammerhead\hammerhead_block_diagram.png"
+
          inkscape:export-xdpi="224.36"
          inkscape:export-ydpi="224.36" />
       <path
@@ -2891,7 +2891,7 @@
          marker-end="url(#marker1216-6-5-5-5-1-8)"
          id="path444-6-8"
          style="fill:none;stroke:#000000;stroke-width:0.520765;marker-end:url(#marker1216-6-5-5-5-1-8);shape-rendering:crispEdges"
-         inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\hammerhead\hammerhead_block_diagram.png"
+
          inkscape:export-xdpi="224.36"
          inkscape:export-ydpi="224.36" />
       <path
@@ -2900,7 +2900,7 @@
          marker-end="url(#marker1216-6-5-5-5-1-8-5)"
          id="path444-6-8-1"
          style="fill:none;stroke:#000000;stroke-width:0.520765;marker-end:url(#marker1216-6-5-5-5-1-8-5);shape-rendering:crispEdges"
-         inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\hammerhead\hammerhead_block_diagram.png"
+
          inkscape:export-xdpi="224.36"
          inkscape:export-ydpi="224.36" />
       <text
@@ -2916,7 +2916,7 @@
          style="font-size:3.12452px;line-height:0%;shape-rendering:crispEdges"
          xml:space="preserve"
          id="text152"
-         inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\hammerhead\hammerhead_block_diagram.png"
+
          inkscape:export-xdpi="224.36"
          inkscape:export-ydpi="224.36"><tspan
            x="-284.58072"
@@ -2940,7 +2940,7 @@
          style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:3.12457px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Bold';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#000000;stroke-width:0.260381;shape-rendering:crispEdges;enable-background:new"
          xml:space="preserve"
          id="text382-2"
-         inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\hammerhead\hammerhead_block_diagram.png"
+
          inkscape:export-xdpi="224.36"
          inkscape:export-ydpi="224.36"><tspan
            x="142.18272"
@@ -2961,7 +2961,7 @@
          style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:3.12457px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Bold';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#000000;stroke-width:0.260381;shape-rendering:crispEdges;enable-background:new"
          xml:space="preserve"
          id="text382-2-1"
-         inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\hammerhead\hammerhead_block_diagram.png"
+
          inkscape:export-xdpi="224.36"
          inkscape:export-ydpi="224.36"><tspan
            x="63.868397"
@@ -2984,7 +2984,7 @@
          stroke-width="0.520762"
          id="rect420-3"
          style="fill:#ffcccc;fill-opacity:1;stroke:#a01414;stroke-opacity:1;shape-rendering:crispEdges"
-         inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\hammerhead\hammerhead_block_diagram.png"
+
          inkscape:export-xdpi="224.36"
          inkscape:export-ydpi="224.36" />
       <rect
@@ -3000,7 +3000,7 @@
          stroke-width="0.520762"
          id="rect420-3-9"
          style="fill:#ffcccc;fill-opacity:1;stroke:#a01414;stroke-opacity:1;shape-rendering:crispEdges"
-         inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\hammerhead\hammerhead_block_diagram.png"
+
          inkscape:export-xdpi="224.36"
          inkscape:export-ydpi="224.36" />
       <text
@@ -3016,7 +3016,7 @@
          style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:5.23365px;line-height:0%;font-family:Arial;-inkscape-font-specification:'Arial, Bold';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.260381px;stroke-opacity:1;shape-rendering:crispEdges;enable-background:new"
          xml:space="preserve"
          id="text424-5"
-         inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\hammerhead\hammerhead_block_diagram.png"
+
          inkscape:export-xdpi="224.36"
          inkscape:export-ydpi="224.36"><tspan
            x="-413.07809"
@@ -3041,7 +3041,7 @@
          style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.68686px;line-height:0%;font-family:Arial;-inkscape-font-specification:'Arial, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;letter-spacing:0px;word-spacing:0px;fill:#feffff;fill-opacity:1;stroke:none;stroke-width:0.260381px;stroke-opacity:1;shape-rendering:crispEdges;enable-background:new"
          xml:space="preserve"
          id="text424-5-0"
-         inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\hammerhead\hammerhead_block_diagram.png"
+
          inkscape:export-xdpi="224.36"
          inkscape:export-ydpi="224.36"><tspan
            x="62.797581"
@@ -3066,7 +3066,7 @@
          style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.68686px;line-height:0%;font-family:Arial;-inkscape-font-specification:'Arial, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;letter-spacing:0px;word-spacing:0px;fill:#feffff;fill-opacity:1;stroke:none;stroke-width:0.260381px;stroke-opacity:1;shape-rendering:crispEdges;enable-background:new"
          xml:space="preserve"
          id="text424-5-0-5"
-         inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\hammerhead\hammerhead_block_diagram.png"
+
          inkscape:export-xdpi="224.36"
          inkscape:export-ydpi="224.36"><tspan
            x="5.3620806"
@@ -3084,7 +3084,7 @@
          x="167.98451"
          y="357.13309"
          id="text30814"
-         inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\hammerhead\hammerhead_block_diagram.png"
+
          inkscape:export-xdpi="224.36"
          inkscape:export-ydpi="224.36"
          transform="scale(1.0097229,0.99037073)"><tspan
@@ -3099,7 +3099,7 @@
          x="167.96269"
          y="362.17276"
          id="text30814-9"
-         inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\hammerhead\hammerhead_block_diagram.png"
+
          inkscape:export-xdpi="224.36"
          inkscape:export-ydpi="224.36"
          transform="scale(1.0097229,0.99037073)"><tspan
@@ -3116,7 +3116,7 @@
          x="167.98451"
          y="369.20224"
          id="text30814-7"
-         inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\hammerhead\hammerhead_block_diagram.png"
+
          inkscape:export-xdpi="224.36"
          inkscape:export-ydpi="224.36"
          transform="scale(1.0097229,0.99037073)"><tspan
@@ -3131,7 +3131,7 @@
          x="167.96269"
          y="374.24194"
          id="text30814-9-7"
-         inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\hammerhead\hammerhead_block_diagram.png"
+
          inkscape:export-xdpi="224.36"
          inkscape:export-ydpi="224.36"
          transform="scale(1.0097229,0.99037073)"><tspan
@@ -3146,7 +3146,7 @@
          x="166.88948"
          y="387.53378"
          id="text30814-7-8"
-         inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\hammerhead\hammerhead_block_diagram.png"
+
          inkscape:export-xdpi="224.36"
          inkscape:export-ydpi="224.36"
          transform="scale(1.0097229,0.99037073)"><tspan
@@ -3161,7 +3161,7 @@
          x="166.86765"
          y="392.57349"
          id="text30814-9-7-6"
-         inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\hammerhead\hammerhead_block_diagram.png"
+
          inkscape:export-xdpi="224.36"
          inkscape:export-ydpi="224.36"
          transform="scale(1.0097229,0.99037073)"><tspan
@@ -3176,7 +3176,7 @@
          x="79.740036"
          y="371.55786"
          id="text45529"
-         inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\hammerhead\hammerhead_block_diagram.png"
+
          inkscape:export-xdpi="224.36"
          inkscape:export-ydpi="224.36"><tspan
            sodipodi:role="line"
@@ -3213,7 +3213,7 @@
          marker-end="url(#Triangle-9)"
          id="path436-6"
          style="fill:none;stroke:#000000;stroke-width:0.885296;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;marker-start:url(#Triangle);marker-end:url(#Triangle-9)"
-         inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\hammerhead\hammerhead_block_diagram.png"
+
          inkscape:export-xdpi="224.36"
          inkscape:export-ydpi="224.36"
          sodipodi:nodetypes="cc" />
@@ -3221,21 +3221,21 @@
          style="fill:none;stroke:#000000;stroke-width:0.729066;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
          d="M 58.425922,414.3659 226.7973,414.19239"
          id="path5061"
-         inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\hammerhead\hammerhead_block_diagram.png"
+
          inkscape:export-xdpi="224.36"
          inkscape:export-ydpi="224.36" />
       <path
          style="fill:none;stroke:#000000;stroke-width:0.729066;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
          d="m 58.599039,421.00955 9.971893,-0.10235"
          id="path5061-8"
-         inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\hammerhead\hammerhead_block_diagram.png"
+
          inkscape:export-xdpi="224.36"
          inkscape:export-ydpi="224.36" />
       <path
          style="fill:none;stroke:#000000;stroke-width:0.729067;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
          d="m 19.76173,417.06088 25.587809,-0.10234"
          id="path5061-8-6"
-         inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\hammerhead\hammerhead_block_diagram.png"
+
          inkscape:export-xdpi="224.36"
          inkscape:export-ydpi="224.36" />
       <text
@@ -3244,7 +3244,7 @@
          x="69.202118"
          y="364.16171"
          id="text7884"
-         inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\hammerhead\hammerhead_block_diagram.png"
+
          inkscape:export-xdpi="224.36"
          inkscape:export-ydpi="224.36"
          transform="scale(0.88269386,1.1328956)"><tspan
@@ -3259,7 +3259,7 @@
          x="70.742096"
          y="370.87872"
          id="text7884-8"
-         inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\hammerhead\hammerhead_block_diagram.png"
+
          inkscape:export-xdpi="224.36"
          inkscape:export-ydpi="224.36"
          transform="scale(0.88269386,1.1328956)"><tspan
@@ -3275,7 +3275,7 @@
          height="12.680607"
          x="45.028389"
          y="410.71582"
-         inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\hammerhead\hammerhead_block_diagram.png"
+
          inkscape:export-xdpi="224.36"
          inkscape:export-ydpi="224.36" />
       <text
@@ -3284,7 +3284,7 @@
          x="55.458385"
          y="369.19135"
          id="text7884-8-5"
-         inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\hammerhead\hammerhead_block_diagram.png"
+
          inkscape:export-xdpi="224.36"
          inkscape:export-ydpi="224.36"
          transform="scale(0.88269386,1.1328956)"><tspan

--- a/docs/projects/admx6001_ebz/admx6001_ebz_clk_diagram.svg
+++ b/docs/projects/admx6001_ebz/admx6001_ebz_clk_diagram.svg
@@ -411,7 +411,7 @@
        height="483.65414"
        x="-414.64749"
        y="-63.876163"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\hammerhead\clk_diagram_export.png"
+
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96" />
     <rect
@@ -421,7 +421,7 @@
        height="108.2075"
        x="0.75193393"
        y="-104.32534"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\hammerhead\clk_diagram_export.png"
+
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96" />
     <rect
@@ -431,7 +431,7 @@
        height="220.32611"
        x="199.35062"
        y="181.18831"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\hammerhead\clk_diagram_export.png"
+
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96" />
     <rect
@@ -441,7 +441,7 @@
        height="623.83893"
        x="407.2366"
        y="-187.76823"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\hammerhead\clk_diagram_export.png"
+
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96" />
     <text
@@ -449,7 +449,7 @@
        transform="matrix(0.26458333,0,0,0.26458333,-135.24531,-114.59859)"
        id="text6207"
        style="font-size:48px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial, Normal';white-space:pre;shape-inside:url(#rect6209)"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\hammerhead\clk_diagram_export.png"
+
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96"><tspan
          x="-529.51562"
@@ -460,7 +460,7 @@
        transform="matrix(0.26458333,0,0,0.26458333,147.29716,-136.37279)"
        id="text6207-4"
        style="font-size:48px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial, Normal';white-space:pre;shape-inside:url(#rect6209-34)"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\hammerhead\clk_diagram_export.png"
+
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96"><tspan
          x="-529.51562"
@@ -471,7 +471,7 @@
        transform="matrix(0.26458333,0,0,0.26458333,349.34297,123.41477)"
        id="text6207-4-8"
        style="font-size:48px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial, Normal';white-space:pre;shape-inside:url(#rect6209-34-4)"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\hammerhead\clk_diagram_export.png"
+
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96"><tspan
          x="-529.51562"
@@ -482,7 +482,7 @@
        transform="matrix(0.26458333,0,0,0.26458333,346.47149,213.53101)"
        id="text6207-4-8-7"
        style="font-size:48px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial, Normal';white-space:pre;shape-inside:url(#rect6209-34-4-2)"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\hammerhead\clk_diagram_export.png"
+
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96"><tspan
          x="-529.51562"
@@ -493,7 +493,7 @@
        transform="matrix(0.26458333,0,0,0.26458333,146.99308,-113.65168)"
        id="text6207-4-2"
        style="font-size:48px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial, Normal';white-space:pre;shape-inside:url(#rect6209-34-7)"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\hammerhead\clk_diagram_export.png"
+
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96"><tspan
          x="-529.51562"
@@ -504,7 +504,7 @@
        transform="matrix(0.26458333,0,0,0.26458333,265.48896,-124.53929)"
        id="text6207-4-2-2"
        style="font-size:48px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial, Normal';white-space:pre;shape-inside:url(#rect6209-34-7-5)"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\hammerhead\clk_diagram_export.png"
+
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96"><tspan
          x="-529.51562"
@@ -515,7 +515,7 @@
        transform="matrix(0.26458333,0,0,0.26458333,549.86702,-58.122527)"
        id="text6207-4-2-3"
        style="font-size:48px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial, Normal';white-space:pre;shape-inside:url(#rect6209-34-7-8)"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\hammerhead\clk_diagram_export.png"
+
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96"><tspan
          x="-529.51562"
@@ -526,7 +526,7 @@
        transform="matrix(0.26458333,0,0,0.26458333,549.55994,-129.77432)"
        id="text6207-4-2-3-7"
        style="font-size:48px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial, Normal';white-space:pre;shape-inside:url(#rect6209-34-7-8-5)"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\hammerhead\clk_diagram_export.png"
+
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96"><tspan
          x="-529.51562"
@@ -537,7 +537,7 @@
        transform="matrix(0.26458333,0,0,0.26458333,549.27791,-30.154286)"
        id="text6207-4-2-3-4"
        style="font-size:48px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial, Normal';white-space:pre;shape-inside:url(#rect6209-34-7-8-0)"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\hammerhead\clk_diagram_export.png"
+
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96"><tspan
          x="-529.51562"
@@ -548,7 +548,7 @@
        transform="matrix(0.26458333,0,0,0.26458333,-142.24643,-86.608693)"
        id="text6207-8"
        style="font-size:48px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial, Normal';white-space:pre;shape-inside:url(#rect6209-3)"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\hammerhead\clk_diagram_export.png"
+
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96"><tspan
          x="-529.51562"
@@ -559,7 +559,7 @@
        transform="matrix(0.26458333,0,0,0.26458333,-135.1833,-58.618796)"
        id="text6207-3"
        style="font-size:48px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial, Normal';white-space:pre;shape-inside:url(#rect6209-9)"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\hammerhead\clk_diagram_export.png"
+
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96"><tspan
          x="-529.51562"
@@ -570,7 +570,7 @@
        transform="matrix(0.26458333,0,0,0.26458333,-143.74711,-30.628927)"
        id="text6207-8-4"
        style="font-size:48px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial, Normal';white-space:pre;shape-inside:url(#rect6209-3-2)"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\hammerhead\clk_diagram_export.png"
+
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96"><tspan
          x="-529.51562"
@@ -581,7 +581,7 @@
        transform="matrix(0.26458333,0,0,0.26458333,-141.99218,121.17811)"
        id="text6207-3-1"
        style="font-size:48px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial, Normal';white-space:pre;shape-inside:url(#rect6209-9-4)"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\hammerhead\clk_diagram_export.png"
+
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96"><tspan
          x="-529.51562"
@@ -592,7 +592,7 @@
        transform="matrix(0.26458333,0,0,0.26458333,-163.14438,213.53411)"
        id="text6207-3-1-0"
        style="font-size:48px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial, Normal';white-space:pre;shape-inside:url(#rect6209-9-4-4)"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\hammerhead\clk_diagram_export.png"
+
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96"><tspan
          x="-529.51562"
@@ -603,7 +603,7 @@
        transform="matrix(0.26458333,0,0,0.26458333,-135.23911,261.28427)"
        id="text6207-8-4-1"
        style="font-size:48px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial, Normal';white-space:pre;shape-inside:url(#rect6209-3-2-6)"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\hammerhead\clk_diagram_export.png"
+
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96"><tspan
          x="-529.51562"
@@ -614,7 +614,7 @@
        transform="matrix(0.26458333,0,0,0.26458333,-135.27011,277.13064)"
        id="text6207-3-1-4"
        style="font-size:48px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial, Normal';white-space:pre;shape-inside:url(#rect6209-9-4-8)"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\hammerhead\clk_diagram_export.png"
+
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96"><tspan
          x="-529.51562"
@@ -625,7 +625,7 @@
        transform="matrix(0.26458333,0,0,0.26458333,-143.81533,-2.6390203)"
        id="text6207-8-4-1-8"
        style="font-size:48px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial, Normal';white-space:pre;shape-inside:url(#rect6209-3-2-6-2)"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\hammerhead\clk_diagram_export.png"
+
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96"><tspan
          x="-529.51562"
@@ -636,7 +636,7 @@
        transform="matrix(0.26458333,0,0,0.26458333,-135.29492,292.97699)"
        id="text6207-3-1-4-6"
        style="font-size:48px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial, Normal';white-space:pre;shape-inside:url(#rect6209-9-4-8-8)"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\hammerhead\clk_diagram_export.png"
+
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96"><tspan
          x="-529.51562"
@@ -647,7 +647,7 @@
        transform="matrix(0.26458333,0,0,0.26458333,-143.76572,53.34075)"
        id="text6207-8-4-1-8-0"
        style="font-size:48px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial, Normal';white-space:pre;shape-inside:url(#rect6209-3-2-6-2-7)"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\hammerhead\clk_diagram_export.png"
+
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96"><tspan
          x="-529.51562"
@@ -658,7 +658,7 @@
        transform="matrix(0.26458333,0,0,0.26458333,-142.30844,308.8234)"
        id="text6207-3-1-4-6-0"
        style="font-size:48px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial, Normal';white-space:pre;shape-inside:url(#rect6209-9-4-8-8-5)"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\hammerhead\clk_diagram_export.png"
+
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96"><tspan
          x="-529.51562"
@@ -669,7 +669,7 @@
        transform="matrix(0.26458333,0,0,0.26458333,-148.11274,81.330668)"
        id="text6207-8-4-1-8-0-3"
        style="font-size:48px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial, Normal';white-space:pre;shape-inside:url(#rect6209-3-2-6-2-7-6)"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\hammerhead\clk_diagram_export.png"
+
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96"><tspan
          x="-529.51562"
@@ -680,7 +680,7 @@
        transform="matrix(0.26458333,0,0,0.26458333,-150.81025,324.66355)"
        id="text6207-8-4-1-8-0-3-4"
        style="font-size:48px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial, Normal';white-space:pre;shape-inside:url(#rect6209-3-2-6-2-7-6-1)"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\hammerhead\clk_diagram_export.png"
+
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96"><tspan
          x="-529.51562"
@@ -691,7 +691,7 @@
        transform="matrix(0.26458333,0,0,0.26458333,24.89541,77.951831)"
        id="text13581"
        style="font-size:64px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial, Normal';white-space:pre;shape-inside:url(#rect13583)"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\hammerhead\clk_diagram_export.png"
+
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96"><tspan
          x="-1528.2617"
@@ -704,7 +704,7 @@
        transform="matrix(0.26458333,0,0,0.26458333,900.59863,216.31573)"
        id="text13581-1"
        style="font-size:72px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial, Normal';white-space:pre;shape-inside:url(#rect13583-9)"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\hammerhead\clk_diagram_export.png"
+
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96"><tspan
          x="-1528.2617"
@@ -717,7 +717,7 @@
        d="m -238.45005,-34.801125 80.01778,-0.526644 0.92372,-23.819247 152.0393639,0.634572"
        id="path15299"
        sodipodi:nodetypes="cccc"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\hammerhead\clk_diagram_export.png"
+
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96" />
     <path
@@ -725,7 +725,7 @@
        d="m -239.03519,-6.7876444 100.63935,0.041272 0.69395,-28.2603406 133.0928132,0.374512"
        id="path15299-4-0"
        sodipodi:nodetypes="cccc"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\hammerhead\clk_diagram_export.png"
+
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96" />
     <text
@@ -733,7 +733,7 @@
        transform="matrix(0.26458333,0,0,0.26458333,-143.74711,25.350851)"
        id="text6207-8-4-1-8-0-1"
        style="font-size:48px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial, Normal';white-space:pre;shape-inside:url(#rect6209-3-2-6-2-7-4)"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\hammerhead\clk_diagram_export.png"
+
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96"><tspan
          x="-529.51562"
@@ -744,7 +744,7 @@
        d="m -239.8649,105.88607 639.91817,0.10613"
        id="path15299-4-7-0"
        sodipodi:nodetypes="cc"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\hammerhead\clk_diagram_export.png"
+
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96" />
     <path
@@ -752,7 +752,7 @@
        d="m -240.8013,134.4694 639.91818,0.10613"
        id="path15299-4-7-0-3"
        sodipodi:nodetypes="cc"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\hammerhead\clk_diagram_export.png"
+
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96" />
     <path
@@ -760,7 +760,7 @@
        d="m -240.8013,159.32954 639.91817,0.10613"
        id="path15299-4-7-0-3-8"
        sodipodi:nodetypes="cc"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\hammerhead\clk_diagram_export.png"
+
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96" />
     <path
@@ -768,7 +768,7 @@
        d="m -240.58909,340.29937 167.001342,0.01"
        id="path15299-4-19"
        sodipodi:nodetypes="cc"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\hammerhead\clk_diagram_export.png"
+
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96" />
     <path
@@ -776,7 +776,7 @@
        d="m -240.64162,20.250352 121.75925,0.09525 v 0 l 518.78963,-3.71659"
        id="path15299-4-2"
        sodipodi:nodetypes="cccc"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\hammerhead\clk_diagram_export.png"
+
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96" />
     <path
@@ -784,7 +784,7 @@
        d="m 163.76344,-50.15433 235.72333,-1.41421"
        id="path15299-4-2-8"
        sodipodi:nodetypes="cc"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\hammerhead\clk_diagram_export.png"
+
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96" />
     <path
@@ -792,7 +792,7 @@
        d="m -240.78849,48.506289 91.72203,-0.49441 v 0 c 59.442344,-0.51187 488.91264,-0.768023 548.35564,-0.432843"
        id="path15299-4-8"
        sodipodi:nodetypes="cccc"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\hammerhead\clk_diagram_export.png"
+
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96" />
     <path
@@ -800,7 +800,7 @@
        d="m -239.77375,78.532477 167.35945,-0.49441 v 0 c 52.895842,-0.51187 418.799,-0.696181 471.69542,-0.361001"
        id="path15299-4-8-2"
        sodipodi:nodetypes="cccc"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\hammerhead\clk_diagram_export.png"
+
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96" />
     <path
@@ -808,7 +808,7 @@
        d="m -240.58899,356.18556 32.52417,0.0154"
        id="path15299-4-05"
        sodipodi:nodetypes="cc"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\hammerhead\clk_diagram_export.png"
+
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96" />
     <path
@@ -816,7 +816,7 @@
        d="m -240.58899,372.08207 32.52417,0.0154"
        id="path15299-4-05-0"
        sodipodi:nodetypes="cc"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\hammerhead\clk_diagram_export.png"
+
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96" />
     <path
@@ -824,7 +824,7 @@
        d="m -240.58899,387.97867 32.52417,0.0154"
        id="path15299-4-05-0-6"
        sodipodi:nodetypes="cc"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\hammerhead\clk_diagram_export.png"
+
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96" />
     <path
@@ -832,7 +832,7 @@
        d="m -240.58899,403.87522 32.52417,0.0154"
        id="path15299-4-05-0-6-9"
        sodipodi:nodetypes="cc"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\hammerhead\clk_diagram_export.png"
+
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96" />
     <path
@@ -840,7 +840,7 @@
        d="m -238.96291,200.47255 431.88032,-0.6994"
        id="path15299-4-03"
        sodipodi:nodetypes="cc"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\hammerhead\clk_diagram_export.png"
+
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96" />
     <path
@@ -848,7 +848,7 @@
        d="m 129.91385,292.46204 63.92018,-0.6994"
        id="path15299-4-03-8"
        sodipodi:nodetypes="cc"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\hammerhead\clk_diagram_export.png"
+
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96" />
     <path
@@ -856,14 +856,14 @@
        d="m -238.30732,292.5745 185.265988,-0.6994"
        id="path15299-4-03-8-0"
        sodipodi:nodetypes="cc"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\hammerhead\clk_diagram_export.png"
+
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96" />
     <path
        style="fill:none;stroke:#000000;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
        d="m -384.74186,-1.7800692 v 0"
        id="path15301"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\hammerhead\clk_diagram_export.png"
+
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96" />
     <text
@@ -872,7 +872,7 @@
        x="46.123184"
        y="-40.189972"
        id="text20049"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\hammerhead\clk_diagram_export.png"
+
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96"><tspan
          sodipodi:role="line"
@@ -886,7 +886,7 @@
        x="266.08722"
        y="300.67102"
        id="text20049-2"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\hammerhead\clk_diagram_export.png"
+
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96"><tspan
          sodipodi:role="line"
@@ -901,7 +901,7 @@
        height="124.54273"
        x="-44.080326"
        y="226.7326"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\hammerhead\clk_diagram_export.png"
+
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96" />
     <text
@@ -910,7 +910,7 @@
        x="10.334445"
        y="297.88757"
        id="text20049-2-2"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\hammerhead\clk_diagram_export.png"
+
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96"><tspan
          sodipodi:role="line"
@@ -923,7 +923,7 @@
        transform="matrix(0.26458333,0,0,0.26458333,-437.9552,41.684175)"
        id="text93382"
        style="font-size:48px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial, Normal';white-space:pre;shape-inside:url(#rect93384)"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\hammerhead\clk_diagram_export.png"
+
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96"><tspan
          x="756.45117"
@@ -934,7 +934,7 @@
        transform="matrix(0.26458333,0,0,0.26458333,120.00282,-388.78413)"
        id="text101464"
        style="font-size:48px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial, Normal';white-space:pre;shape-inside:url(#rect101466)"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\hammerhead\clk_diagram_export.png"
+
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96"><tspan
          x="1092.707"
@@ -945,7 +945,7 @@
        transform="matrix(0.26458333,0,0,0.26458333,119.59355,-360.6671)"
        id="text101464-9"
        style="font-size:48px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial, Normal';white-space:pre;shape-inside:url(#rect101466-6)"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\hammerhead\clk_diagram_export.png"
+
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96"><tspan
          x="1092.707"
@@ -956,7 +956,7 @@
        transform="matrix(0.26458333,0,0,0.26458333,119.59355,-332.69888)"
        id="text101464-9-8"
        style="font-size:48px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial, Normal';white-space:pre;shape-inside:url(#rect101466-6-6)"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\hammerhead\clk_diagram_export.png"
+
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96"><tspan
          x="1092.707"
@@ -967,7 +967,7 @@
        transform="matrix(0.26458333,0,0,0.26458333,119.59355,-304.73061)"
        id="text101464-9-2"
        style="font-size:48px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial, Normal';white-space:pre;shape-inside:url(#rect101466-6-7)"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\hammerhead\clk_diagram_export.png"
+
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96"><tspan
          x="1092.707"
@@ -978,7 +978,7 @@
        transform="matrix(0.26458333,0,0,0.26458333,244.13187,213.4721)"
        id="text6207-4-8-7-7"
        style="font-size:48px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial, Normal';white-space:pre;shape-inside:url(#rect6209-34-4-2-3)"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\hammerhead\clk_diagram_export.png"
+
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96"><tspan
          x="-529.51562"
@@ -989,7 +989,7 @@
        transform="matrix(0.26458333,0,0,0.26458333,98.639601,213.53101)"
        id="text6207-4-8-7-7-4"
        style="font-size:48px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial, Normal';white-space:pre;shape-inside:url(#rect6209-34-4-2-3-8)"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\hammerhead\clk_diagram_export.png"
+
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96"><tspan
          x="-529.51562"

--- a/docs/projects/cn0577/cn0577_zed_block_diagram.svg
+++ b/docs/projects/cn0577/cn0577_zed_block_diagram.svg
@@ -892,7 +892,7 @@
        height="441.17999"
        x="27.624659"
        y="464.0343"
-       inkscape:export-filename="C:\workspace\ad\ghdl\docs\block_diagrams\cn0577\cn0577_block_diagram.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36" />
     <path
@@ -901,7 +901,7 @@
        id="path4518"
        d="M 342.19076,475.09283 V 455.93246"
        style="display:inline;fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-start:url(#TriangleInM);marker-end:url(#TriangleOutM);shape-rendering:crispEdges;enable-background:new"
-       inkscape:export-filename="C:\workspace\ad\ghdl\docs\block_diagrams\cn0577\cn0577_block_diagram.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36" />
     <path
@@ -910,7 +910,7 @@
        id="path4518-5"
        d="M 368.30766,475.08625 V 456.02546"
        style="display:inline;fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-start:url(#TriangleInM-7);marker-end:url(#TriangleOutM-2);shape-rendering:crispEdges;enable-background:new"
-       inkscape:export-filename="C:\workspace\ad\ghdl\docs\block_diagrams\cn0577\cn0577_block_diagram.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36" />
     <path
@@ -919,7 +919,7 @@
        id="path4518-5-9"
        d="M 394.42456,475.06461 V 455.90446"
        style="display:inline;fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-start:url(#TriangleInM-7-1);marker-end:url(#TriangleOutM-2-8);shape-rendering:crispEdges;enable-background:new"
-       inkscape:export-filename="C:\workspace\ad\ghdl\docs\block_diagrams\cn0577\cn0577_block_diagram.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36" />
     <rect
@@ -930,7 +930,7 @@
        height="75.00399"
        x="-460.34177"
        y="479.59076"
-       inkscape:export-filename="C:\workspace\ad\ghdl\docs\block_diagrams\cn0577\cn0577_block_diagram.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36" />
     <path
@@ -938,7 +938,7 @@
        d="M 432.80614,480.25687 V 554.7674"
        id="path4179"
        inkscape:connector-curvature="0"
-       inkscape:export-filename="C:\workspace\ad\ghdl\docs\block_diagrams\cn0577\cn0577_block_diagram.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36" />
     <path
@@ -946,7 +946,7 @@
        d="M 407.17575,480.25687 V 554.7674"
        id="path4179-9"
        inkscape:connector-curvature="0"
-       inkscape:export-filename="C:\workspace\ad\ghdl\docs\block_diagrams\cn0577\cn0577_block_diagram.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36" />
     <path
@@ -954,7 +954,7 @@
        d="M 304.6542,480.25687 V 554.7674"
        id="path4179-0"
        inkscape:connector-curvature="0"
-       inkscape:export-filename="C:\workspace\ad\ghdl\docs\block_diagrams\cn0577\cn0577_block_diagram.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36" />
     <path
@@ -962,7 +962,7 @@
        d="M 330.2846,480.25687 V 554.7674"
        id="path4179-4"
        inkscape:connector-curvature="0"
-       inkscape:export-filename="C:\workspace\ad\ghdl\docs\block_diagrams\cn0577\cn0577_block_diagram.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36" />
     <path
@@ -970,7 +970,7 @@
        d="M 355.91499,480.25687 V 554.7674"
        id="path4179-7"
        inkscape:connector-curvature="0"
-       inkscape:export-filename="C:\workspace\ad\ghdl\docs\block_diagrams\cn0577\cn0577_block_diagram.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36" />
     <path
@@ -978,7 +978,7 @@
        d="M 381.54535,480.25687 V 554.7674"
        id="path4179-41"
        inkscape:connector-curvature="0"
-       inkscape:export-filename="C:\workspace\ad\ghdl\docs\block_diagrams\cn0577\cn0577_block_diagram.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36" />
     <path
@@ -986,7 +986,7 @@
        d="M 279.02381,480.25687 V 554.7674"
        id="path4179-0-3"
        inkscape:connector-curvature="0"
-       inkscape:export-filename="C:\workspace\ad\ghdl\docs\block_diagrams\cn0577\cn0577_block_diagram.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36" />
     <text
@@ -996,7 +996,7 @@
        x="-536.56085"
        style="font-style:normal;font-weight:normal;line-height:0%;font-family:Arial;letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;shape-rendering:crispEdges"
        xml:space="preserve"
-       inkscape:export-filename="C:\workspace\ad\ghdl\docs\block_diagrams\cn0577\cn0577_block_diagram.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36"><tspan
          style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:11.25px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial Bold'"
@@ -1011,7 +1011,7 @@
        x="-529.31537"
        style="font-style:normal;font-weight:normal;line-height:0%;font-family:Arial;letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;shape-rendering:crispEdges"
        xml:space="preserve"
-       inkscape:export-filename="C:\workspace\ad\ghdl\docs\block_diagrams\cn0577\cn0577_block_diagram.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36"><tspan
          style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:11.25px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial Bold'"
@@ -1026,7 +1026,7 @@
        x="-529.06268"
        style="font-style:normal;font-weight:normal;line-height:0%;font-family:Arial;letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;shape-rendering:crispEdges"
        xml:space="preserve"
-       inkscape:export-filename="C:\workspace\ad\ghdl\docs\block_diagrams\cn0577\cn0577_block_diagram.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36"><tspan
          style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:11.25px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial Bold'"
@@ -1041,7 +1041,7 @@
        x="-522.3006"
        style="font-style:normal;font-weight:normal;line-height:0%;font-family:Arial;letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;shape-rendering:crispEdges"
        xml:space="preserve"
-       inkscape:export-filename="C:\workspace\ad\ghdl\docs\block_diagrams\cn0577\cn0577_block_diagram.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36"><tspan
          style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:11.25px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial Bold'"
@@ -1056,7 +1056,7 @@
        x="-522.23468"
        style="font-style:normal;font-weight:normal;line-height:0%;font-family:Arial;letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;shape-rendering:crispEdges"
        xml:space="preserve"
-       inkscape:export-filename="C:\workspace\ad\ghdl\docs\block_diagrams\cn0577\cn0577_block_diagram.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36"><tspan
          style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:11.25px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial Bold'"
@@ -1073,7 +1073,7 @@
        x="-539.76337"
        style="font-style:normal;font-weight:normal;line-height:0%;font-family:Arial;letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;shape-rendering:crispEdges"
        xml:space="preserve"
-       inkscape:export-filename="C:\workspace\ad\ghdl\docs\block_diagrams\cn0577\cn0577_block_diagram.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36"><tspan
          style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:11.25px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial Bold'"
@@ -1100,7 +1100,7 @@
        x="-528.78528"
        style="font-style:normal;font-weight:normal;line-height:0%;font-family:Arial;letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;shape-rendering:crispEdges"
        xml:space="preserve"
-       inkscape:export-filename="C:\workspace\ad\ghdl\docs\block_diagrams\cn0577\cn0577_block_diagram.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36"><tspan
          style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:11.25px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial Bold'"
@@ -1117,7 +1117,7 @@
        y="441.14258"
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36"
-       inkscape:export-filename="C:\workspace\ad\ghdl\docs\block_diagrams\cn0577\cn0577_block_diagram.png" />
+ />
     <text
        xml:space="preserve"
        style="font-style:normal;font-weight:normal;font-size:12px;line-height:0%;font-family:Arial;letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;shape-rendering:crispEdges;enable-background:new"
@@ -1126,7 +1126,7 @@
        id="text4595"
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36"
-       inkscape:export-filename="C:\workspace\ad\ghdl\docs\block_diagrams\cn0577\cn0577_block_diagram.png"><tspan
+><tspan
          style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.5px;line-height:1.25;font-family:Arial;-inkscape-font-specification:Arial;stroke-width:1px"
          sodipodi:role="line"
          id="tspan4597"
@@ -1141,7 +1141,7 @@
        y="591.02948"
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36"
-       inkscape:export-filename="C:\workspace\ad\ghdl\docs\block_diagrams\cn0577\cn0577_block_diagram.png" />
+ />
     <text
        xml:space="preserve"
        style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:14.6667px;line-height:0%;font-family:Arial;-inkscape-font-specification:'Arial, Bold';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;shape-rendering:crispEdges;enable-background:new"
@@ -1151,7 +1151,7 @@
        transform="rotate(-90)"
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36"
-       inkscape:export-filename="C:\workspace\ad\ghdl\docs\block_diagrams\cn0577\cn0577_block_diagram.png"><tspan
+><tspan
          sodipodi:role="line"
          id="tspan4491"
          x="-784.49829"
@@ -1165,7 +1165,7 @@
        id="text4482"
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36"
-       inkscape:export-filename="C:\workspace\ad\ghdl\docs\block_diagrams\cn0577\cn0577_block_diagram.png"><tspan
+><tspan
          sodipodi:role="line"
          x="516.26367"
          y="519.47174"
@@ -1180,7 +1180,7 @@
        y="568.04218"
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36"
-       inkscape:export-filename="C:\workspace\ad\ghdl\docs\block_diagrams\cn0577\cn0577_block_diagram.png" />
+ />
     <rect
        style="display:inline;vector-effect:none;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:1.73566;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:0;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;shape-rendering:crispEdges;enable-background:new"
        id="rect4488"
@@ -1190,7 +1190,7 @@
        y="578.815"
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36"
-       inkscape:export-filename="C:\workspace\ad\ghdl\docs\block_diagrams\cn0577\cn0577_block_diagram.png" />
+ />
     <text
        xml:space="preserve"
        style="font-style:normal;font-weight:normal;font-size:12px;line-height:0%;font-family:Arial;letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;shape-rendering:crispEdges;enable-background:new"
@@ -1200,7 +1200,7 @@
        transform="rotate(-90)"
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36"
-       inkscape:export-filename="C:\workspace\ad\ghdl\docs\block_diagrams\cn0577\cn0577_block_diagram.png"><tspan
+><tspan
          sodipodi:role="line"
          id="tspan4493"
          x="-819.53528"
@@ -1215,7 +1215,7 @@
        y="568.08453"
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36"
-       inkscape:export-filename="C:\workspace\ad\ghdl\docs\block_diagrams\cn0577\cn0577_block_diagram.png" />
+ />
     <rect
        y="619.60101"
        x="140.80345"
@@ -1225,7 +1225,7 @@
        style="display:inline;vector-effect:none;fill:#ffcccc;fill-opacity:1;fill-rule:nonzero;stroke:#a01414;stroke-width:0.852663;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;shape-rendering:crispEdges;enable-background:new"
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36"
-       inkscape:export-filename="C:\workspace\ad\ghdl\docs\block_diagrams\cn0577\cn0577_block_diagram.png" />
+ />
     <text
        transform="rotate(-90)"
        id="text5788"
@@ -1235,7 +1235,7 @@
        xml:space="preserve"
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36"
-       inkscape:export-filename="C:\workspace\ad\ghdl\docs\block_diagrams\cn0577\cn0577_block_diagram.png"><tspan
+><tspan
          style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:17.5px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial Bold';fill:#28170b;stroke:none;stroke-width:1px;stroke-opacity:1"
          y="166.07896"
          x="-713.67645"
@@ -1249,7 +1249,7 @@
        id="text6100-6"
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36"
-       inkscape:export-filename="C:\workspace\ad\ghdl\docs\block_diagrams\cn0577\cn0577_block_diagram.png"><tspan
+><tspan
          sodipodi:role="line"
          id="tspan6098-9"
          x="45.93198"
@@ -1264,7 +1264,7 @@
        id="g1985"
        transform="matrix(0.80242547,0,0,0.80242536,60.738336,118.74488)"
        style="opacity:1"
-       inkscape:export-filename="C:\workspace\ad\ghdl\docs\block_diagrams\cn0577\cn0577_block_diagram.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36">
       <rect
@@ -1300,7 +1300,7 @@
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36"
        transform="scale(1.0542308,0.94855889)"
-       inkscape:export-filename="C:\workspace\ad\ghdl\docs\block_diagrams\cn0577\cn0577_block_diagram.png"><tspan
+><tspan
          sodipodi:role="line"
          x="126.50691"
          y="874.3949"
@@ -1310,7 +1310,7 @@
        transform="matrix(0.82578137,0,0,1.1597906,582.54345,-200.03695)"
        style="display:inline;shape-rendering:crispEdges;enable-background:new"
        id="adc_core"
-       inkscape:export-filename="C:\workspace\ad\ghdl\docs\block_diagrams\cn0577\cn0577_block_diagram.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36">
       <rect
@@ -1343,7 +1343,7 @@
        x="98.946091"
        style="font-style:normal;font-weight:normal;line-height:0%;font-family:Arial;letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;shape-rendering:crispEdges;enable-background:new"
        xml:space="preserve"
-       inkscape:export-filename="C:\workspace\ad\ghdl\docs\block_diagrams\cn0577\cn0577_block_diagram.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36"><tspan
          style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:15px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial Bold'"
@@ -1355,7 +1355,7 @@
        id="g5654"
        style="display:inline;fill:#a01414;fill-opacity:1;stroke:#a01414;stroke-opacity:1;shape-rendering:crispEdges;enable-background:new"
        transform="matrix(1.9187911,0,0,0.97850243,-170.52233,156.54282)"
-       inkscape:export-filename="C:\workspace\ad\ghdl\docs\block_diagrams\cn0577\cn0577_block_diagram.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36">
       <path
@@ -1369,7 +1369,7 @@
        id="g5654-5"
        style="display:inline;fill:#a01414;fill-opacity:1;stroke:#a01414;stroke-opacity:1;shape-rendering:crispEdges;enable-background:new"
        transform="matrix(1.9187911,0,0,0.97850243,-73.61911,155.97969)"
-       inkscape:export-filename="C:\workspace\ad\ghdl\docs\block_diagrams\cn0577\cn0577_block_diagram.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36">
       <path
@@ -1398,7 +1398,7 @@
        id="g21139"
        transform="translate(-38.471435,572.29394)"
        style="shape-rendering:crispEdges"
-       inkscape:export-filename="C:\workspace\ad\ghdl\docs\block_diagrams\cn0577\cn0577_block_diagram.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36">
       <path
@@ -1429,7 +1429,7 @@
        id="g15320"
        transform="translate(-39.178492,530.29393)"
        style="shape-rendering:crispEdges"
-       inkscape:export-filename="C:\workspace\ad\ghdl\docs\block_diagrams\cn0577\cn0577_block_diagram.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36">
       <path
@@ -1460,7 +1460,7 @@
        id="g15302"
        transform="translate(-37.876492,552.29393)"
        style="shape-rendering:crispEdges"
-       inkscape:export-filename="C:\workspace\ad\ghdl\docs\block_diagrams\cn0577\cn0577_block_diagram.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36">
       <path
@@ -1491,7 +1491,7 @@
        id="g8767"
        transform="matrix(0.9352963,0,0,0.96441782,43.977577,506.7614)"
        style="shape-rendering:crispEdges"
-       inkscape:export-filename="C:\workspace\ad\ghdl\docs\block_diagrams\cn0577\cn0577_block_diagram.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36">
       <rect
@@ -1523,7 +1523,7 @@
        id="path8769"
        inkscape:connector-curvature="0"
        sodipodi:nodetypes="cc"
-       inkscape:export-filename="C:\workspace\ad\ghdl\docs\block_diagrams\cn0577\cn0577_block_diagram.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36" />
     <text
@@ -1534,7 +1534,7 @@
        id="text6100-2"
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36"
-       inkscape:export-filename="C:\workspace\ad\ghdl\docs\block_diagrams\cn0577\cn0577_block_diagram.png"><tspan
+><tspan
          sodipodi:role="line"
          x="459.34183"
          y="864.80933"
@@ -1548,7 +1548,7 @@
        id="text6100-2-2"
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36"
-       inkscape:export-filename="C:\workspace\ad\ghdl\docs\block_diagrams\cn0577\cn0577_block_diagram.png"><tspan
+><tspan
          sodipodi:role="line"
          x="467.1532"
          y="846.40479"
@@ -1560,7 +1560,7 @@
        id="path8769-9"
        inkscape:connector-curvature="0"
        sodipodi:nodetypes="cc"
-       inkscape:export-filename="C:\workspace\ad\ghdl\docs\block_diagrams\cn0577\cn0577_block_diagram.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36" />
     <text
@@ -1571,7 +1571,7 @@
        id="text6100-2-7"
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36"
-       inkscape:export-filename="C:\workspace\ad\ghdl\docs\block_diagrams\cn0577\cn0577_block_diagram.png"><tspan
+><tspan
          sodipodi:role="line"
          x="270.91885"
          y="829.04523"
@@ -1583,7 +1583,7 @@
        x="484.45453"
        y="885.14862"
        id="text2401-1-7-3-9-9-8"
-       inkscape:export-filename="C:\workspace\ad\ghdl\docs\block_diagrams\cn0577\cn0577_block_diagram.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36"><tspan
          sodipodi:role="line"
@@ -1597,7 +1597,7 @@
        x="356.99365"
        y="890.20453"
        id="text2401-1-7-3-9-9-8-2"
-       inkscape:export-filename="C:\workspace\ad\ghdl\docs\block_diagrams\cn0577\cn0577_block_diagram.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36"><tspan
          sodipodi:role="line"
@@ -1611,7 +1611,7 @@
        x="256.5871"
        y="869.4884"
        id="text2401-1-7-3-9-9-8-2-6"
-       inkscape:export-filename="C:\workspace\ad\ghdl\docs\block_diagrams\cn0577\cn0577_block_diagram.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36"><tspan
          sodipodi:role="line"
@@ -1625,7 +1625,7 @@
        id="path1206-7-8"
        inkscape:connector-curvature="0"
        sodipodi:nodetypes="cc"
-       inkscape:export-filename="C:\workspace\ad\ghdl\docs\block_diagrams\cn0577\cn0577_block_diagram.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36" />
     <path
@@ -1634,7 +1634,7 @@
        id="path1206-7-8-6"
        inkscape:connector-curvature="0"
        sodipodi:nodetypes="cc"
-       inkscape:export-filename="C:\workspace\ad\ghdl\docs\block_diagrams\cn0577\cn0577_block_diagram.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36" />
     <path
@@ -1643,7 +1643,7 @@
        id="path1206-7-8-6-5"
        inkscape:connector-curvature="0"
        sodipodi:nodetypes="cc"
-       inkscape:export-filename="C:\workspace\ad\ghdl\docs\block_diagrams\cn0577\cn0577_block_diagram.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36" />
     <path
@@ -1652,14 +1652,14 @@
        id="path1206-7-8-6-5-1"
        inkscape:connector-curvature="0"
        sodipodi:nodetypes="cc"
-       inkscape:export-filename="C:\workspace\ad\ghdl\docs\block_diagrams\cn0577\cn0577_block_diagram.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36" />
     <g
        style="display:inline;shape-rendering:crispEdges;enable-background:new"
        id="ddr"
        transform="matrix(1.4208528,0,0,1.4208526,-227.92472,-198.17999)"
-       inkscape:export-filename="C:\workspace\ad\ghdl\docs\block_diagrams\cn0577\cn0577_block_diagram.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36">
       <rect
@@ -1768,7 +1768,7 @@
        style="display:inline;shape-rendering:crispEdges;enable-background:new"
        id="g8892"
        transform="translate(-11.163807,-15.232099)"
-       inkscape:export-filename="C:\workspace\ad\ghdl\docs\block_diagrams\cn0577\cn0577_block_diagram.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36">
       <rect
@@ -1878,7 +1878,7 @@
        id="uart"
        transform="matrix(0,-0.41475982,0.41475987,0,226.58161,645.45429)"
        style="display:inline;stroke-width:2.41103;stroke-miterlimit:4;stroke-dasharray:none;shape-rendering:crispEdges;enable-background:new"
-       inkscape:export-filename="C:\workspace\ad\ghdl\docs\block_diagrams\cn0577\cn0577_block_diagram.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36">
       <rect
@@ -1975,7 +1975,7 @@
        id="g6577"
        style="display:inline;shape-rendering:crispEdges;enable-background:new"
        transform="matrix(1.3748693,0,0,1.4504246,-272.82364,-201.60361)"
-       inkscape:export-filename="C:\workspace\ad\ghdl\docs\block_diagrams\cn0577\cn0577_block_diagram.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36">
       <g
@@ -2017,7 +2017,7 @@
        y="707.78601"
        id="text2401-61-1-54-8"
        transform="scale(1.0162353,0.98402408)"
-       inkscape:export-filename="C:\workspace\ad\ghdl\docs\block_diagrams\cn0577\cn0577_block_diagram.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36"><tspan
          sodipodi:role="line"
@@ -2031,7 +2031,7 @@
        x="292.12854"
        y="695.64124"
        id="text2401-61-1-5-5"
-       inkscape:export-filename="C:\workspace\ad\ghdl\docs\block_diagrams\cn0577\cn0577_block_diagram.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36"><tspan
          sodipodi:role="line"
@@ -2043,7 +2043,7 @@
        id="path5471-9"
        cx="412.13211"
        cy="868.41241"
-       inkscape:export-filename="C:\workspace\ad\ghdl\docs\block_diagrams\cn0577\cn0577_block_diagram.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36"
        rx="3.5355339"
@@ -2053,7 +2053,7 @@
        id="path5471-9-9"
        cx="412.31796"
        cy="844.87549"
-       inkscape:export-filename="C:\workspace\ad\ghdl\docs\block_diagrams\cn0577\cn0577_block_diagram.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36"
        rx="3.5355339"
@@ -2063,7 +2063,7 @@
        id="path5471-9-9-1"
        cx="266.30038"
        cy="853.71436"
-       inkscape:export-filename="C:\workspace\ad\ghdl\docs\block_diagrams\cn0577\cn0577_block_diagram.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36"
        rx="3.5355339"
@@ -2073,7 +2073,7 @@
        d="m 442.26086,839.90074 v 19.8121 c 8.38158,-0.42783 17.58955,-2.88272 17.68176,-9.58651 0.0937,-6.80791 -7.94565,-10.21886 -17.68176,-10.22559 z"
        id="path5279"
        sodipodi:nodetypes="ccac"
-       inkscape:export-filename="C:\workspace\ad\ghdl\docs\block_diagrams\cn0577\cn0577_block_diagram.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36" />
     <path
@@ -2082,7 +2082,7 @@
        id="path1206-7-8-6-5-7"
        inkscape:connector-curvature="0"
        sodipodi:nodetypes="cc"
-       inkscape:export-filename="C:\workspace\ad\ghdl\docs\block_diagrams\cn0577\cn0577_block_diagram.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36" />
   </g>

--- a/docs/projects/cn0579/cn0579_block_diagram.svg
+++ b/docs/projects/cn0579/cn0579_block_diagram.svg
@@ -9,7 +9,7 @@
    id="svg31900"
    inkscape:version="1.1.2 (b8e25be833, 2022-02-05)"
    sodipodi:docname="cn0579_block_diagram.svg"
-   inkscape:export-filename="C:\Users\PPop\Documents\AD7771\wikipages\ad777x_ardz_xilinx.png"
+
    inkscape:export-xdpi="96"
    inkscape:export-ydpi="96"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
@@ -816,7 +816,7 @@
        id="flowRoot33657"
        style="font-style:normal;font-weight:normal;font-size:40px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;display:inline;opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.0168229;stroke-miterlimit:4;stroke-dasharray:0.0336457, 0.0336457;stroke-dashoffset:0"
        transform="matrix(1.1538081,0,0,1.3364301,-2.279908,-41.674062)"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD7768\AD7768_BLOCK_DIAGRAM.png"
+
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96"><flowRegion
          id="flowRegion33659"
@@ -835,7 +835,7 @@
        x="1582.4073"
        y="1125.9019"
        id="text3992-4"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD7768\AD7768_BLOCK_DIAGRAM.png"
+
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96"
        transform="scale(1.0247942,0.97580566)"><tspan
@@ -851,7 +851,7 @@
        y="569.25818"
        id="text3996"
        transform="scale(0.92916677,1.0762331)"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD7768\AD7768_BLOCK_DIAGRAM.png"
+
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96"><tspan
          sodipodi:role="line"
@@ -866,7 +866,7 @@
        y="277.51434"
        id="text3104"
        transform="scale(0.92916677,1.0762331)"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD7768\AD7768_BLOCK_DIAGRAM.png"
+
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96" />
     <text
@@ -982,7 +982,7 @@
        y="1295.6781"
        id="text4598"
        transform="matrix(0,-1.1726554,0.85276546,0,0,-4e-6)"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD7768\AD7768_BLOCK_DIAGRAM_new.png"
+
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96"><tspan
          sodipodi:role="line"
@@ -995,7 +995,7 @@
        xml:space="preserve"
        id="flowRoot5982"
        style="font-style:normal;font-weight:normal;line-height:0.01%;font-family:Arial;letter-spacing:0px;word-spacing:0px;display:inline;opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.328079px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;shape-rendering:crispEdges;enable-background:new"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD7768\AD7768_BLOCK_DIAGRAM_new.png"
+
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96"><flowRegion
          id="flowRegion5984"
@@ -1015,7 +1015,7 @@
        height="1185.1212"
        x="179.00754"
        y="294.60797"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD7768\AD7768_BLOCK_DIAGRAM_new.png"
+
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96" />
     <text
@@ -1025,7 +1025,7 @@
        y="900.05298"
        id="text4576-5"
        transform="matrix(0,-1.0919481,0.91579441,0,0,-4e-6)"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD7768\AD7768_BLOCK_DIAGRAM_new.png"
+
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96"><tspan
          sodipodi:role="line"
@@ -1040,7 +1040,7 @@
        y="1290.6385"
        id="text4598-2"
        transform="matrix(0,-1.1726554,0.85276546,0,0,-4e-6)"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD7768\AD7768_BLOCK_DIAGRAM_new.png"
+
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96"><tspan
          sodipodi:role="line"
@@ -1053,7 +1053,7 @@
        xml:space="preserve"
        id="flowRoot5982-0"
        style="font-style:normal;font-weight:normal;line-height:0.01%;font-family:Arial;letter-spacing:0px;word-spacing:0px;display:inline;opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.328079px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;shape-rendering:crispEdges;enable-background:new"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD7768\AD7768_BLOCK_DIAGRAM_new.png"
+
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96"><flowRegion
          id="flowRegion5984-3"
@@ -1070,7 +1070,7 @@
        transform="matrix(3.1676384,0,0,3.0162149,219.22989,-856.19057)"
        style="display:inline;opacity:1;stroke-width:0.328079;shape-rendering:crispEdges;enable-background:new"
        id="g6613"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD7768\AD7768_BLOCK_DIAGRAM_new.png"
+
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96">
       <rect
@@ -1100,7 +1100,7 @@
        height="448.6167"
        x="860"
        y="840.64032"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD7768\AD7768_BLOCK_DIAGRAM_new.png"
+
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96" />
     <rect
@@ -1110,7 +1110,7 @@
        height="448.60031"
        x="880"
        y="831.33173"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD7768\AD7768_BLOCK_DIAGRAM_new.png"
+
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96" />
     <text
@@ -1119,7 +1119,7 @@
        x="1166.2312"
        y="932.16541"
        id="text4964"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD7768\AD7768_BLOCK_DIAGRAM_new.png"
+
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96"
        transform="matrix(1.0247942,0,0,0.97580566,0,-4e-6)"><tspan
@@ -1139,7 +1139,7 @@
        x="1095.62"
        y="701.23883"
        id="text5138"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD7768\AD7768_BLOCK_DIAGRAM_new.png"
+
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96"
        transform="matrix(1.0247942,0,0,0.97580567,0,119.72915)"><tspan
@@ -1154,7 +1154,7 @@
        id="path5555"
        d="m 1625.9975,1095.231 v -18.6904 h 69.0485 c 0,0 -9e-4,-16.685 0,-24.8601 4e-4,-8.1752 0,-24.8603 0,-24.8603 h -69.0488 V 1008.13 l -46.3975,43.5505 z"
        style="display:inline;opacity:1;fill:#c8c8c8;fill-opacity:1;fill-rule:evenodd;stroke:#a01414;stroke-width:1.01409;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;shape-rendering:crispEdges;enable-background:new"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD7768\AD7768_BLOCK_DIAGRAM_new.png"
+
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96" />
     <path
@@ -1163,7 +1163,7 @@
        id="path5553"
        inkscape:connector-curvature="0"
        sodipodi:nodetypes="cccsccccc"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD7768\AD7768_BLOCK_DIAGRAM_new.png"
+
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96"
        transform="translate(0,119.72915)" />
@@ -1174,7 +1174,7 @@
        width="86.863434"
        id="rect5679"
        style="display:inline;opacity:1;fill:#ffcccc;fill-opacity:1;fill-rule:nonzero;stroke:#a01414;stroke-width:2.02819;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;shape-rendering:crispEdges;enable-background:new"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD7768\AD7768_BLOCK_DIAGRAM_new.png"
+
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96" />
     <text
@@ -1184,7 +1184,7 @@
        y="699.13574"
        id="text5771"
        transform="matrix(0,-0.97580567,1.0247942,0,0,0)"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD7768\AD7768_BLOCK_DIAGRAM_new.png"
+
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96"><tspan
          sodipodi:role="line"
@@ -1199,7 +1199,7 @@
        height="832.80414"
        x="260"
        y="617.18219"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD7768\AD7768_BLOCK_DIAGRAM_new.png"
+
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96" />
     <rect
@@ -1209,7 +1209,7 @@
        height="579.58624"
        x="200"
        y="740.14288"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD7768\AD7768_BLOCK_DIAGRAM_new.png"
+
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96" />
     <text
@@ -1219,7 +1219,7 @@
        y="253.57912"
        id="text4489"
        transform="matrix(0,-0.97515084,1.0254824,0,0,0)"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD7768\AD7768_BLOCK_DIAGRAM_new.png"
+
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96"><tspan
          sodipodi:role="line"
@@ -1231,7 +1231,7 @@
        style="display:inline;opacity:1;stroke-width:0.328079;shape-rendering:crispEdges;enable-background:new"
        id="ddr"
        transform="matrix(4.500748,0,0,4.2855976,-622.11262,-1694.0531)"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD7768\AD7768_BLOCK_DIAGRAM_new.png"
+
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96">
       <rect
@@ -1340,7 +1340,7 @@
        style="display:inline;opacity:1;stroke-width:0.328079;shape-rendering:crispEdges;enable-background:new"
        id="g8892"
        transform="matrix(3.1676384,0,0,3.0162149,58.172255,-1148.2753)"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD7768\AD7768_BLOCK_DIAGRAM_new.png"
+
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96">
       <rect
@@ -1450,7 +1450,7 @@
        id="uart"
        transform="matrix(0,-1.2510049,1.3138094,0,814.43146,844.4967)"
        style="display:inline;opacity:1;stroke-width:0.79101;stroke-miterlimit:4;stroke-dasharray:none;shape-rendering:crispEdges;enable-background:new"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD7768\AD7768_BLOCK_DIAGRAM_new.png"
+
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96">
       <rect
@@ -1548,7 +1548,7 @@
        style="display:inline;opacity:1;stroke-width:0.328079;shape-rendering:crispEdges;enable-background:new"
        id="g4600"
        transform="matrix(3.1676384,0,0,3.0162149,159.36508,-1108.0799)"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD7768\AD7768_BLOCK_DIAGRAM_new.png"
+
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96">
       <rect
@@ -1575,7 +1575,7 @@
        xml:space="preserve"
        id="flowRoot3911"
        style="font-style:normal;font-weight:normal;line-height:0.01%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;display:inline;opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.328079px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;shape-rendering:crispEdges;enable-background:new"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD7768\AD7768_BLOCK_DIAGRAM_new.png"
+
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96"><flowRegion
          id="flowRegion3913"
@@ -1592,7 +1592,7 @@
        id="g5654-0"
        style="display:inline;opacity:1;fill:#a01414;fill-opacity:1;stroke:#a01414;stroke-width:0.458074;stroke-opacity:1;shape-rendering:crispEdges;enable-background:new"
        transform="matrix(5.0559003,0,0,2.6616793,-359.6646,-425.10969)"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD7768\AD7768_BLOCK_DIAGRAM_new.png"
+
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96">
       <path
@@ -1608,7 +1608,7 @@
        x="336.65851"
        y="1068.465"
        id="text3992-5-0"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD7768\AD7768_BLOCK_DIAGRAM_new.png"
+
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96"
        transform="scale(1.0247942,0.97580567)"><tspan
@@ -1621,7 +1621,7 @@
        id="g5654-0-0"
        style="display:inline;opacity:1;fill:#a01414;fill-opacity:1;stroke:#a01414;stroke-width:0.460246;stroke-opacity:1;shape-rendering:crispEdges;enable-background:new"
        transform="matrix(4.4195902,0,0,3.0162149,-39.524689,-628.53912)"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD7768\AD7768_BLOCK_DIAGRAM_new.png"
+
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96">
       <path
@@ -1813,14 +1813,14 @@
        height="829.00214"
        x="500"
        y="620.98413"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD7768\AD7768_BLOCK_DIAGRAM_new.png"
+
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96" />
     <g
        id="g5654-7-6"
        style="display:inline;opacity:1;fill:#a01414;fill-opacity:1;stroke:#080a02;stroke-width:0.284098;stroke-opacity:1;shape-rendering:crispEdges;enable-background:new"
        transform="matrix(4.224298,0,0,3.0162149,186.45955,-713.14538)"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD7768\AD7768_BLOCK_DIAGRAM_new.png"
+
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96">
       <path
@@ -1839,7 +1839,7 @@
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96"
        transform="scale(0.92621941,1.0796578)"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD7768\AD7768_BLOCK_DIAGRAM_new.png"><tspan
+><tspan
          sodipodi:role="line"
          id="tspan6098-9"
          x="294.20703"
@@ -1853,7 +1853,7 @@
        id="text6100-6-9"
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD7768\AD7768_BLOCK_DIAGRAM_new.png"
+
        transform="matrix(1.0247942,0,0,0.97580566,0,-4e-6)"><tspan
          sodipodi:role="line"
          id="tspan6098-9-4"
@@ -1864,7 +1864,7 @@
        id="g6577"
        style="display:inline;opacity:1;stroke-width:0.343136;shape-rendering:crispEdges;enable-background:new"
        transform="matrix(2.8957493,0,0,3.0162149,329.92785,-826.34744)"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD7768\AD7768_BLOCK_DIAGRAM_new.png"
+
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96">
       <path
@@ -2023,7 +2023,7 @@
        x="1261.0869"
        y="1159.1587"
        id="text4574"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD7768\AD7768_BLOCK_DIAGRAM_new.png"
+
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96"
        transform="matrix(1.0247942,0,0,0.97580566,0,-4e-6)"><tspan
@@ -2040,7 +2040,7 @@
     <g
        id="g1591"
        transform="matrix(11.972176,0,0,8.3155223,-417.07461,-991.38815)"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD7768\AD7768_BLOCK_DIAGRAM_new.png"
+
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96"
        style="display:inline;opacity:1;stroke-width:0.310127">
@@ -2069,7 +2069,7 @@
        d="M 955.89872,438.72405 H 316.05524"
        id="path4305-3"
        inkscape:connector-curvature="0"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD7768\AD7768_BLOCK_DIAGRAM_new.png"
+
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96" />
     <text
@@ -2079,7 +2079,7 @@
        y="440.61801"
        id="text4307-4"
        transform="scale(1.0489055,0.95337473)"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD7768\AD7768_BLOCK_DIAGRAM_new.png"
+
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96"><tspan
          sodipodi:role="line"
@@ -2094,7 +2094,7 @@
        y="517.61487"
        id="text4311-0"
        transform="scale(1.0489055,0.95337473)"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD7768\AD7768_BLOCK_DIAGRAM_new.png"
+
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96"><tspan
          sodipodi:role="line"
@@ -2111,7 +2111,7 @@
        style="font-style:normal;font-weight:normal;font-size:41.8217px;line-height:0%;font-family:Arial;letter-spacing:0px;word-spacing:0px;display:inline;opacity:1;fill:#000000;fill-opacity:0.858696;stroke:none;stroke-width:1.1434px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;shape-rendering:crispEdges;enable-background:new"
        xml:space="preserve"
        transform="matrix(1.0564806,0,0,0.94653892,0,119.72915)"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD7768\AD7768_BLOCK_DIAGRAM_new.png"><tspan
+><tspan
          style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:69.703px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:0.858696;stroke-width:1.1434px"
          y="329.17755"
          x="1804.3037"
@@ -2129,7 +2129,7 @@
        height="587.68274"
        x="420.70715"
        y="752.04645"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD7768\AD7768_BLOCK_DIAGRAM_new.png"
+
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96" />
     <text
@@ -2139,7 +2139,7 @@
        y="482.23688"
        id="text5775-9"
        transform="matrix(0,-0.97580567,1.0247942,0,0,0)"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD7768\AD7768_BLOCK_DIAGRAM_new.png"
+
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96"><tspan
          sodipodi:role="line"
@@ -2154,7 +2154,7 @@
        y="2669.4829"
        id="text10629-4"
        transform="matrix(0,-1.2780579,0.78243716,0,0,119.72915)"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD7768\AD7768_BLOCK_DIAGRAM_new.png"
+
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96"><tspan
          sodipodi:role="line"
@@ -2169,7 +2169,7 @@
        y="2639.6152"
        id="text10629-4-5-5"
        transform="matrix(0,-1.2780579,0.78243716,0,0,119.72915)"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD7768\AD7768_BLOCK_DIAGRAM_new.png"
+
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96"><tspan
          sodipodi:role="line"
@@ -2186,7 +2186,7 @@
        stroke="none"
        pointer-events="all"
        id="rect1827"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD7768\AD7768_BLOCK_DIAGRAM_new.png"
+
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96"
        style="display:inline;opacity:1;stroke-width:0.999998"
@@ -2200,7 +2200,7 @@
        stroke="none"
        pointer-events="all"
        id="rect1835"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD7768\AD7768_BLOCK_DIAGRAM_new.png"
+
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96"
        style="display:inline;opacity:1;stroke-width:0.999998"
@@ -2212,7 +2212,7 @@
        height="600.66998"
        x="840"
        y="748.31036"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD7768\AD7768_BLOCK_DIAGRAM_new.png"
+
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96">
       <title
@@ -2222,7 +2222,7 @@
        id="g5654-7-6-2"
        style="display:inline;opacity:0.98718;fill:#a01414;fill-opacity:1;stroke:#000000;stroke-width:0.481182;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;shape-rendering:crispEdges;enable-background:new"
        transform="matrix(4.206697,0,0,3.0162149,188.9326,-523.65703)"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD7768\AD7768_BLOCK_DIAGRAM_new.png"
+
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96">
       <path
@@ -2249,7 +2249,7 @@
        x="757.57941"
        y="1165.4783"
        id="text3992"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD7768\AD7768_BLOCK_DIAGRAM_new.png"
+
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96"
        transform="scale(1.0247942,0.97580567)"><tspan
@@ -2264,7 +2264,7 @@
        x="550.94598"
        y="1057.4735"
        id="text3992-5"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD7768\AD7768_BLOCK_DIAGRAM_new.png"
+
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96"
        transform="scale(1.0247942,0.97580567)"><tspan
@@ -2279,7 +2279,7 @@
        x="744.46942"
        y="1067.6378"
        id="text3992-2"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD7768\AD7768_BLOCK_DIAGRAM_new.png"
+
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96"
        transform="scale(1.0247942,0.97580567)"><tspan
@@ -2294,7 +2294,7 @@
        x="759.15558"
        y="969.93774"
        id="text3992-6"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD7768\AD7768_BLOCK_DIAGRAM_new.png"
+
        inkscape:export-xdpi="96"
        inkscape:export-ydpi="96"
        transform="scale(1.0247942,0.97580567)"><tspan

--- a/docs/projects/cn0585/cn0585_zed_block_diagram.svg
+++ b/docs/projects/cn0585/cn0585_zed_block_diagram.svg
@@ -8,7 +8,7 @@
    viewBox="0 0 980.00007 1060"
    height="1060"
    width="980"
-   inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\LLDK\DIAGRAMS\final_diagram_hil.png"
+
    inkscape:export-xdpi="96"
    inkscape:export-ydpi="96"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
@@ -1652,7 +1652,7 @@
      id="path1206-9-7-0-71-02-2-4"
      d="m 114.24435,474.84488 h 32.47873"
      style="display:inline;fill:none;stroke:#000000;stroke-width:2.01137;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#marker1216-9-9-6-3-55-6-7);shape-rendering:crispEdges;enable-background:new"
-     inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\LLDK\DIAGRAMS\final_diagram_hil.png"
+
      inkscape:export-xdpi="224.36"
      inkscape:export-ydpi="224.36" />
   <path
@@ -1661,7 +1661,7 @@
      id="path1206-9-7-0-71-02-2"
      d="M 114.11627,420 H 146.595"
      style="display:inline;fill:none;stroke:#000000;stroke-width:2.01137;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#marker1216-9-9-6-3-55-6);shape-rendering:crispEdges;enable-background:new"
-     inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\LLDK\DIAGRAMS\final_diagram_hil.png"
+
      inkscape:export-xdpi="224.36"
      inkscape:export-ydpi="224.36" />
   <g
@@ -1685,7 +1685,7 @@
        id="path1206-7-8-6-5-7-4-2-0"
        inkscape:connector-curvature="0"
        sodipodi:nodetypes="cc"
-       inkscape:export-filename="C:\workspace\ad\ghdl\docs\block_diagrams\cn0577\cn0577_block_diagram.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36" />
     <path
@@ -1694,7 +1694,7 @@
        id="path1206-7-8-6-5-7-4-2-0-6"
        inkscape:connector-curvature="0"
        sodipodi:nodetypes="cc"
-       inkscape:export-filename="C:\workspace\ad\ghdl\docs\block_diagrams\cn0577\cn0577_block_diagram.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36" />
     <path
@@ -1703,7 +1703,7 @@
        id="path1206-7-8-6-5-7-4-2-0-7"
        inkscape:connector-curvature="0"
        sodipodi:nodetypes="ccc"
-       inkscape:export-filename="C:\workspace\ad\ghdl\docs\block_diagrams\cn0577\cn0577_block_diagram.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36" />
     <path
@@ -1712,7 +1712,7 @@
        id="path1206-7-8-6-5-7-4-2-0-6-8"
        inkscape:connector-curvature="0"
        sodipodi:nodetypes="cc"
-       inkscape:export-filename="C:\workspace\ad\ghdl\docs\block_diagrams\cn0577\cn0577_block_diagram.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36" />
     <rect
@@ -1728,7 +1728,7 @@
      style="fill:#a01414;fill-opacity:0.858824;stroke:#800000;stroke-width:0.999999px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;shape-rendering:crispEdges"
      d="m 744.99998,941.966 v 30 l 35.00001,-14.99999 z"
      id="path40445"
-     inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\LLDK\DIAGRAMS\final_diagram_hil.png"
+
      inkscape:export-xdpi="224.36"
      inkscape:export-ydpi="224.36" />
   <rect
@@ -1738,7 +1738,7 @@
      height="15.000009"
      x="54.999981"
      y="54.999992"
-     inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\LLDK\DIAGRAMS\final_diagram_hil.png"
+
      inkscape:export-xdpi="224.36"
      inkscape:export-ydpi="224.36" />
   <rect
@@ -1748,7 +1748,7 @@
      height="15.000009"
      x="54.999981"
      y="29.999998"
-     inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\LLDK\DIAGRAMS\final_diagram_hil.png"
+
      inkscape:export-xdpi="224.36"
      inkscape:export-ydpi="224.36" />
   <path
@@ -1757,7 +1757,7 @@
      id="path4518"
      inkscape:connector-curvature="0"
      sodipodi:nodetypes="cc"
-     inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\LLDK\DIAGRAMS\final_diagram_hil.png"
+
      inkscape:export-xdpi="224.36"
      inkscape:export-ydpi="224.36" />
   <path
@@ -1766,7 +1766,7 @@
      id="path4518-5"
      inkscape:connector-curvature="0"
      sodipodi:nodetypes="cc"
-     inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\LLDK\DIAGRAMS\final_diagram_hil.png"
+
      inkscape:export-xdpi="224.36"
      inkscape:export-ydpi="224.36" />
   <path
@@ -1775,7 +1775,7 @@
      id="path4518-5-9"
      inkscape:connector-curvature="0"
      sodipodi:nodetypes="cc"
-     inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\LLDK\DIAGRAMS\final_diagram_hil.png"
+
      inkscape:export-xdpi="224.36"
      inkscape:export-ydpi="224.36" />
   <rect
@@ -1786,14 +1786,14 @@
      id="rect4136"
      style="display:inline;fill:#ebebeb;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:2.28681;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:0;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;shape-rendering:crispEdges"
      transform="scale(-1,1)"
-     inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\LLDK\DIAGRAMS\final_diagram_hil.png"
+
      inkscape:export-xdpi="224.36"
      inkscape:export-ydpi="224.36" />
   <g
      transform="matrix(1.1787565,0,0,1.1091093,58.00812,183.87957)"
      id="g1870"
      style="shape-rendering:crispEdges"
-     inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\LLDK\DIAGRAMS\final_diagram_hil.png"
+
      inkscape:export-xdpi="224.36"
      inkscape:export-ydpi="224.36">
     <path
@@ -1839,7 +1839,7 @@
      y="529.47565"
      id="text4229"
      transform="matrix(0,-0.97701285,1.023528,0,0,0)"
-     inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\LLDK\DIAGRAMS\final_diagram_hil.png"
+
      inkscape:export-xdpi="224.36"
      inkscape:export-ydpi="224.36"><tspan
        sodipodi:role="line"
@@ -1854,7 +1854,7 @@
      y="557.8291"
      id="text4233"
      transform="matrix(0,-0.97701285,1.023528,0,0,0)"
-     inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\LLDK\DIAGRAMS\final_diagram_hil.png"
+
      inkscape:export-xdpi="224.36"
      inkscape:export-ydpi="224.36"><tspan
        sodipodi:role="line"
@@ -1869,7 +1869,7 @@
      y="500.90668"
      id="text4237"
      transform="matrix(0,-0.97701285,1.023528,0,0,0)"
-     inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\LLDK\DIAGRAMS\final_diagram_hil.png"
+
      inkscape:export-xdpi="224.36"
      inkscape:export-ydpi="224.36"><tspan
        sodipodi:role="line"
@@ -1884,7 +1884,7 @@
      y="616.86279"
      id="text4241"
      transform="matrix(0,-0.97701285,1.023528,0,0,0)"
-     inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\LLDK\DIAGRAMS\final_diagram_hil.png"
+
      inkscape:export-xdpi="224.36"
      inkscape:export-ydpi="224.36"><tspan
        sodipodi:role="line"
@@ -1899,7 +1899,7 @@
      y="588.88489"
      id="text4245"
      transform="matrix(0,-0.97701285,1.023528,0,0,0)"
-     inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\LLDK\DIAGRAMS\final_diagram_hil.png"
+
      inkscape:export-xdpi="224.36"
      inkscape:export-ydpi="224.36"><tspan
        sodipodi:role="line"
@@ -1916,7 +1916,7 @@
      y="470.5239"
      id="text4251"
      transform="matrix(0,-0.97701285,1.023528,0,0,0)"
-     inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\LLDK\DIAGRAMS\final_diagram_hil.png"
+
      inkscape:export-xdpi="224.36"
      inkscape:export-ydpi="224.36"><tspan
        sodipodi:role="line"
@@ -1931,7 +1931,7 @@
      y="191.46887"
      id="text4311"
      transform="scale(1.023528,0.97701285)"
-     inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\LLDK\DIAGRAMS\final_diagram_hil.png"
+
      inkscape:export-xdpi="224.36"
      inkscape:export-ydpi="224.36" />
   <text
@@ -1941,7 +1941,7 @@
      y="439.8667"
      id="text4301"
      transform="matrix(0,-0.97701285,1.023528,0,0,0)"
-     inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\LLDK\DIAGRAMS\final_diagram_hil.png"
+
      inkscape:export-xdpi="224.36"
      inkscape:export-ydpi="224.36"><tspan
        sodipodi:role="line"
@@ -1953,7 +1953,7 @@
      transform="matrix(1.1787565,0,0,1.1091093,58.00812,157.26095)"
      id="g1405"
      style="shape-rendering:crispEdges"
-     inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\LLDK\DIAGRAMS\final_diagram_hil.png"
+
      inkscape:export-xdpi="224.36"
      inkscape:export-ydpi="224.36" />
   <rect
@@ -1965,7 +1965,7 @@
      width="28.530003"
      id="rect4487"
      style="display:inline;vector-effect:none;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:3.60319;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:0;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;shape-rendering:crispEdges;enable-background:new"
-     inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\LLDK\DIAGRAMS\final_diagram_hil.png" />
+ />
   <text
      inkscape:export-ydpi="224.36"
      inkscape:export-xdpi="224.36"
@@ -1975,7 +1975,7 @@
      x="-744.27112"
      style="font-style:normal;font-weight:normal;font-size:13.7208px;line-height:0%;font-family:Arial;letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1.1434px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;shape-rendering:crispEdges;enable-background:new"
      xml:space="preserve"
-     inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\LLDK\DIAGRAMS\final_diagram_hil.png"><tspan
+><tspan
        style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:20.0095px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial Bold';stroke-width:1.1434px"
        y="103.43478"
        x="-744.27112"
@@ -1990,7 +1990,7 @@
      style="font-style:normal;font-weight:normal;font-size:13.7208px;line-height:0%;font-family:Arial;letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:0.858696;stroke:none;stroke-width:1.1434px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;shape-rendering:crispEdges;enable-background:new"
      xml:space="preserve"
      transform="scale(1.0309198,0.97000757)"
-     inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\LLDK\DIAGRAMS\final_diagram_hil.png"><tspan
+><tspan
        id="tspan3725"
        style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:22.8681px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:0.858696;stroke-width:1.1434px"
        y="153.87302"
@@ -2005,7 +2005,7 @@
      width="655.21973"
      id="rect6078"
      style="display:inline;vector-effect:none;fill:none;fill-opacity:1;stroke:#3f4b55;stroke-width:2.9902;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:2.9902, 8.97062;stroke-dashoffset:0;stroke-opacity:1;shape-rendering:crispEdges;enable-background:new"
-     inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\LLDK\DIAGRAMS\final_diagram_hil.png" />
+ />
   <rect
      inkscape:export-ydpi="224.36"
      inkscape:export-xdpi="224.36"
@@ -2015,7 +2015,7 @@
      width="33.440662"
      id="rect4488"
      style="display:inline;vector-effect:none;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:3.11114;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:0;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;shape-rendering:crispEdges;enable-background:new"
-     inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\LLDK\DIAGRAMS\final_diagram_hil.png" />
+ />
   <text
      inkscape:export-ydpi="224.36"
      inkscape:export-xdpi="224.36"
@@ -2025,7 +2025,7 @@
      x="-672.82245"
      style="font-style:normal;font-weight:normal;font-size:13.7208px;line-height:0%;font-family:Arial;letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1.1434px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;shape-rendering:crispEdges;enable-background:new"
      xml:space="preserve"
-     inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\LLDK\DIAGRAMS\final_diagram_hil.png"><tspan
+><tspan
        style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:20.0095px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial Bold';stroke-width:1.1434px"
        y="862.9726"
        x="-672.82245"
@@ -2040,7 +2040,7 @@
      width="102.36497"
      id="rect6057"
      style="display:inline;fill:none;fill-opacity:1;stroke:#3f4b55;stroke-width:3.27756;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:3.27756, 9.83267;stroke-dashoffset:0;stroke-opacity:1;shape-rendering:crispEdges;enable-background:new"
-     inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\LLDK\DIAGRAMS\final_diagram_hil.png" />
+ />
   <rect
      inkscape:export-ydpi="224.36"
      inkscape:export-xdpi="224.36"
@@ -2050,7 +2050,7 @@
      height="266.1095"
      x="160.93863"
      y="273.8222"
-     inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\LLDK\DIAGRAMS\final_diagram_hil.png" />
+ />
   <rect
      inkscape:export-ydpi="224.36"
      inkscape:export-xdpi="224.36"
@@ -2060,7 +2060,7 @@
      height="266.1095"
      x="229.73091"
      y="714.03925"
-     inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\LLDK\DIAGRAMS\final_diagram_hil.png" />
+ />
   <rect
      inkscape:export-ydpi="224.36"
      inkscape:export-xdpi="224.36"
@@ -2070,7 +2070,7 @@
      height="266.1095"
      x="154.51768"
      y="712.3161"
-     inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\LLDK\DIAGRAMS\final_diagram_hil.png" />
+ />
   <text
      inkscape:export-ydpi="224.36"
      inkscape:export-xdpi="224.36"
@@ -2080,7 +2080,7 @@
      y="185.19524"
      id="text5788"
      transform="matrix(0,-0.97000757,1.0309198,0,0,0)"
-     inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\LLDK\DIAGRAMS\final_diagram_hil.png"><tspan
+><tspan
        sodipodi:role="line"
        id="tspan5790"
        x="-456.48276"
@@ -2095,7 +2095,7 @@
      y="251.79082"
      id="text5788-2"
      transform="matrix(0,-0.97000757,1.0309198,0,0,0)"
-     inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\LLDK\DIAGRAMS\final_diagram_hil.png"><tspan
+><tspan
        sodipodi:role="line"
        id="tspan5790-0"
        x="-915.66266"
@@ -2110,7 +2110,7 @@
      y="176.48819"
      id="text5788-87"
      transform="matrix(0,-0.97000757,1.0309198,0,0,0)"
-     inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\LLDK\DIAGRAMS\final_diagram_hil.png"><tspan
+><tspan
        sodipodi:role="line"
        id="tspan5790-6"
        x="-917.48169"
@@ -2125,7 +2125,7 @@
      style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:13.5491px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#040404;fill-opacity:1;stroke:none;stroke-width:1.1434;stroke-opacity:1;shape-rendering:crispEdges;enable-background:new"
      xml:space="preserve"
      transform="scale(1.0309198,0.97000757)"
-     inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\LLDK\DIAGRAMS\final_diagram_hil.png"><tspan
+><tspan
        id="tspan5125"
        style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:13.5491px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;fill:#040404;fill-opacity:1;stroke:none;stroke-width:1.1434;stroke-opacity:1"
        y="432.98633"
@@ -2138,7 +2138,7 @@
      width="339.17905"
      id="rect35512"
      style="fill:#d2e6eb;fill-opacity:1;fill-rule:nonzero;stroke:#0f3296;stroke-width:1.99999;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:normal;shape-rendering:crispEdges"
-     inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\LLDK\DIAGRAMS\final_diagram_hil.png"
+
      inkscape:export-xdpi="224.36"
      inkscape:export-ydpi="224.36" />
   <rect
@@ -2148,14 +2148,14 @@
      width="317.71915"
      id="rect35512-8"
      style="display:inline;fill:#d2e6eb;fill-opacity:1;fill-rule:nonzero;stroke:#0f3296;stroke-width:1.99999;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:normal;shape-rendering:crispEdges;enable-background:new"
-     inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\LLDK\DIAGRAMS\final_diagram_hil.png"
+
      inkscape:export-xdpi="224.36"
      inkscape:export-ydpi="224.36" />
   <g
      id="adc_core"
      style="display:inline;shape-rendering:crispEdges;enable-background:new"
      transform="matrix(1.6808353,0,0,1.5352423,1079.89,-808.19341)"
-     inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\LLDK\DIAGRAMS\final_diagram_hil.png"
+
      inkscape:export-xdpi="224.36"
      inkscape:export-ydpi="224.36" />
   <path
@@ -2163,7 +2163,7 @@
      d="M 372.56771,141.83821 H 167.7273"
      id="path4305"
      inkscape:connector-curvature="0"
-     inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\LLDK\DIAGRAMS\final_diagram_hil.png"
+
      inkscape:export-xdpi="224.36"
      inkscape:export-ydpi="224.36" />
   <text
@@ -2173,7 +2173,7 @@
      y="138.24049"
      id="text4307-4"
      transform="scale(1.023528,0.97701285)"
-     inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\LLDK\DIAGRAMS\final_diagram_hil.png"
+
      inkscape:export-xdpi="224.36"
      inkscape:export-ydpi="224.36"><tspan
        sodipodi:role="line"
@@ -2188,7 +2188,7 @@
      y="161.2655"
      id="text4311-0"
      transform="scale(1.023528,0.97701285)"
-     inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\LLDK\DIAGRAMS\final_diagram_hil.png"
+
      inkscape:export-xdpi="224.36"
      inkscape:export-ydpi="224.36"><tspan
        sodipodi:role="line"
@@ -2200,7 +2200,7 @@
      transform="matrix(2.0602936,0,0,1.1091093,-35.802505,-356.75465)"
      style="display:inline;fill:#a01414;fill-opacity:1;stroke:#a01414;stroke-opacity:1;shape-rendering:crispEdges;enable-background:new"
      id="g5654-2"
-     inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\LLDK\DIAGRAMS\final_diagram_hil.png"
+
      inkscape:export-xdpi="224.36"
      inkscape:export-ydpi="224.36" />
   <text
@@ -2210,7 +2210,7 @@
      y="402.81137"
      id="text11366-4-8"
      transform="scale(1.0309198,0.97000757)"
-     inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\LLDK\DIAGRAMS\final_diagram_hil.png"
+
      inkscape:export-xdpi="224.36"
      inkscape:export-ydpi="224.36" />
   <path
@@ -2219,7 +2219,7 @@
      id="path1206-1-0"
      d="M 691.6116,363.51902 H 856.86084"
      style="display:inline;fill:#0f3296;fill-opacity:1;stroke:#0f3296;stroke-width:2.27896;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#marker1216-0-3);shape-rendering:crispEdges;enable-background:new"
-     inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\LLDK\DIAGRAMS\final_diagram_hil.png"
+
      inkscape:export-xdpi="224.36"
      inkscape:export-ydpi="224.36" />
   <path
@@ -2228,7 +2228,7 @@
      id="path1206-1-0-6"
      d="M 692.75074,402 H 857.99998"
      style="display:inline;fill:#0f3296;fill-opacity:1;stroke:#0f3296;stroke-width:2.27896;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#marker1216-0-3-80);shape-rendering:crispEdges;enable-background:new"
-     inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\LLDK\DIAGRAMS\final_diagram_hil.png"
+
      inkscape:export-xdpi="224.36"
      inkscape:export-ydpi="224.36" />
   <text
@@ -2238,7 +2238,7 @@
      y="309.27594"
      id="text4964-9-5"
      transform="scale(1.0309198,0.97000757)"
-     inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\LLDK\DIAGRAMS\final_diagram_hil.png"
+
      inkscape:export-xdpi="224.36"
      inkscape:export-ydpi="224.36"><tspan
        sodipodi:role="line"
@@ -2253,7 +2253,7 @@
      style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:13.5491px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1.1434;stroke-opacity:1;shape-rendering:crispEdges;enable-background:new"
      xml:space="preserve"
      transform="scale(1.0309198,0.97000757)"
-     inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\LLDK\DIAGRAMS\final_diagram_hil.png"
+
      inkscape:export-xdpi="224.36"
      inkscape:export-ydpi="224.36"><tspan
        y="371.13113"
@@ -2268,7 +2268,7 @@
      style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:13.5491px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1.1434;stroke-opacity:1;shape-rendering:crispEdges;enable-background:new"
      xml:space="preserve"
      transform="scale(1.0309198,0.97000757)"
-     inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\LLDK\DIAGRAMS\final_diagram_hil.png"
+
      inkscape:export-xdpi="224.36"
      inkscape:export-ydpi="224.36"><tspan
        y="391.74954"
@@ -2283,7 +2283,7 @@
      style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:13.5491px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;letter-spacing:0px;word-spacing:0px;display:inline;fill:#0f0202;fill-opacity:1;stroke:none;stroke-width:1.1434;stroke-opacity:1;shape-rendering:crispEdges;enable-background:new"
      xml:space="preserve"
      transform="scale(1.0309198,0.97000757)"
-     inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\LLDK\DIAGRAMS\final_diagram_hil.png"
+
      inkscape:export-xdpi="224.36"
      inkscape:export-ydpi="224.36"><tspan
        y="411.33701"
@@ -2297,7 +2297,7 @@
      id="path1206-9-4-1"
      d="M 791.43962,346.08089 H 767.86449"
      style="display:inline;fill:#0f3296;fill-opacity:1;stroke:#000000;stroke-width:1.7151;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;shape-rendering:crispEdges;enable-background:new"
-     inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\LLDK\DIAGRAMS\final_diagram_hil.png"
+
      inkscape:export-xdpi="224.36"
      inkscape:export-ydpi="224.36" />
   <text
@@ -2307,7 +2307,7 @@
      style="font-style:normal;font-weight:normal;font-size:18.2944px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1.1434;shape-rendering:crispEdges;enable-background:new"
      xml:space="preserve"
      transform="scale(1.0309198,0.97000757)"
-     inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\LLDK\DIAGRAMS\final_diagram_hil.png"
+
      inkscape:export-xdpi="224.36"
      inkscape:export-ydpi="224.36" />
   <rect
@@ -2317,7 +2317,7 @@
      width="120.23316"
      id="rect35512-6"
      style="display:inline;fill:#d2e6eb;fill-opacity:1;fill-rule:nonzero;stroke:#0f3296;stroke-width:1.99999;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:normal;shape-rendering:crispEdges;enable-background:new"
-     inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\LLDK\DIAGRAMS\final_diagram_hil.png"
+
      inkscape:export-xdpi="224.36"
      inkscape:export-ydpi="224.36" />
   <text
@@ -2327,7 +2327,7 @@
      y="377.93201"
      id="text4964-9-5-1"
      transform="scale(1.0309198,0.97000757)"
-     inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\LLDK\DIAGRAMS\final_diagram_hil.png"
+
      inkscape:export-xdpi="224.36"
      inkscape:export-ydpi="224.36" />
   <text
@@ -2337,7 +2337,7 @@
      style="font-style:normal;font-weight:normal;font-size:18.2944px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1.1434;shape-rendering:crispEdges;enable-background:new"
      xml:space="preserve"
      transform="scale(1.0309198,0.97000757)"
-     inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\LLDK\DIAGRAMS\final_diagram_hil.png"
+
      inkscape:export-xdpi="224.36"
      inkscape:export-ydpi="224.36"><tspan
        y="472.04846"
@@ -2354,7 +2354,7 @@
      style="fill:#d2e6eb;fill-opacity:1;stroke:#0f3296;stroke-width:2.06977;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;shape-rendering:crispEdges"
      transform="matrix(0.3735284,0,0,2.49971,483.31396,-27.750749)"
      id="g1816"
-     inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\LLDK\DIAGRAMS\final_diagram_hil.png"
+
      inkscape:export-xdpi="224.36"
      inkscape:export-ydpi="224.36">
     <rect
@@ -2374,7 +2374,7 @@
      xml:space="preserve"
      inkscape:export-xdpi="224.36"
      inkscape:export-ydpi="224.36"
-     inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\LLDK\DIAGRAMS\final_diagram_hil.png"><tspan
+><tspan
        style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:18px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial, Bold';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;stroke:none;stroke-width:0.802425px;stroke-opacity:1"
        y="665.9469"
        x="-445.50375"
@@ -2387,7 +2387,7 @@
      style="font-style:normal;font-weight:normal;font-size:18.2944px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1.1434;shape-rendering:crispEdges;enable-background:new"
      xml:space="preserve"
      transform="scale(1.0309198,0.97000757)"
-     inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\LLDK\DIAGRAMS\final_diagram_hil.png"
+
      inkscape:export-xdpi="224.36"
      inkscape:export-ydpi="224.36"><tspan
        id="tspan5269-7"
@@ -2406,7 +2406,7 @@
      id="path1206-9-7-0-71"
      d="M 202.03847,450.54543 H 364.99998"
      style="display:inline;fill:none;stroke:#000000;stroke-width:2.01137;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#marker1216-9-9-6-3);shape-rendering:crispEdges;enable-background:new"
-     inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\LLDK\DIAGRAMS\final_diagram_hil.png"
+
      inkscape:export-xdpi="224.36"
      inkscape:export-ydpi="224.36" />
   <path
@@ -2415,7 +2415,7 @@
      id="path1206-9-7-0-71-4"
      d="M 154.29492,838.003 H 124.99998"
      style="display:inline;fill:none;stroke:#000000;stroke-width:2.01136;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#marker1216-9-9-6-3-4);shape-rendering:crispEdges;enable-background:new"
-     inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\LLDK\DIAGRAMS\final_diagram_hil.png"
+
      inkscape:export-xdpi="224.36"
      inkscape:export-ydpi="224.36" />
   <path
@@ -2424,7 +2424,7 @@
      id="path1206-9-7-0-71-4-9"
      d="m 229.29344,837.811 -26.99008,3.9e-4"
      style="display:inline;fill:none;stroke:#000000;stroke-width:2.01137;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#marker1216-9-9-6-3-4-3);shape-rendering:crispEdges;enable-background:new"
-     inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\LLDK\DIAGRAMS\final_diagram_hil.png"
+
      inkscape:export-xdpi="224.36"
      inkscape:export-ydpi="224.36" />
   <path
@@ -2433,7 +2433,7 @@
      id="path1206-9-7-0-71-02"
      d="M 201.40519,431.08508 H 334.99997"
      style="display:inline;fill:none;stroke:#000000;stroke-width:2.01137;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#marker1216-9-9-6-3-55);shape-rendering:crispEdges;enable-background:new"
-     inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\LLDK\DIAGRAMS\final_diagram_hil.png"
+
      inkscape:export-xdpi="224.36"
      inkscape:export-ydpi="224.36" />
   <path
@@ -2442,7 +2442,7 @@
      id="path1206-1-0-95-1-9"
      d="M 692.11668,384.02738 H 856.67822"
      style="display:inline;fill:#0f3296;fill-opacity:1;stroke:#0f3296;stroke-width:2.27896;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#marker1216-0-3-1-2-0);image-rendering:auto;shape-rendering:crispEdges;enable-background:new"
-     inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\LLDK\DIAGRAMS\final_diagram_hil.png"
+
      inkscape:export-xdpi="224.36"
      inkscape:export-ydpi="224.36" />
   <rect
@@ -2452,7 +2452,7 @@
      width="119.99998"
      id="rect35512-6-1-2"
      style="display:inline;fill:#e5e5e5;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:1.99999;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:normal;shape-rendering:crispEdges;enable-background:new"
-     inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\LLDK\DIAGRAMS\final_diagram_hil.png"
+
      inkscape:export-xdpi="224.36"
      inkscape:export-ydpi="224.36" />
   <text
@@ -2462,7 +2462,7 @@
      style="font-style:normal;font-weight:normal;font-size:18.2944px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1.1434;shape-rendering:crispEdges;enable-background:new"
      xml:space="preserve"
      transform="scale(1.0309198,0.97000757)"
-     inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\LLDK\DIAGRAMS\final_diagram_hil.png"
+
      inkscape:export-xdpi="224.36"
      inkscape:export-ydpi="224.36"><tspan
        style="text-align:center;text-anchor:middle;stroke-width:1.1434"
@@ -2482,7 +2482,7 @@
      style="font-style:normal;font-weight:normal;font-size:18.2944px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1.1434;shape-rendering:crispEdges;enable-background:new"
      xml:space="preserve"
      transform="scale(1.0309198,0.97000757)"
-     inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\LLDK\DIAGRAMS\final_diagram_hil.png"
+
      inkscape:export-xdpi="224.36"
      inkscape:export-ydpi="224.36"><tspan
        id="tspan4332-2"
@@ -2499,7 +2499,7 @@
      style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.1963px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1.1434;shape-rendering:crispEdges;enable-background:new"
      xml:space="preserve"
      transform="scale(1.0309198,0.97000757)"
-     inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\LLDK\DIAGRAMS\final_diagram_hil.png"><tspan
+><tspan
        id="tspan331"
        style="stroke-width:1.1434"
        y="1034.1219"
@@ -2514,7 +2514,7 @@
      style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.1963px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1.1434;shape-rendering:crispEdges;enable-background:new"
      xml:space="preserve"
      transform="scale(1.0309198,0.97000757)"
-     inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\LLDK\DIAGRAMS\final_diagram_hil.png"><tspan
+><tspan
        id="tspan331-1"
        style="stroke-width:1.1434"
        y="1035.0079"
@@ -2525,7 +2525,7 @@
      id="flowRoot482"
      xml:space="preserve"
      transform="matrix(1.1787565,0,0,1.1091093,58.00812,265.95366)"
-     inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\LLDK\DIAGRAMS\final_diagram_hil.png"
+
      inkscape:export-xdpi="224.36"
      inkscape:export-ydpi="224.36"><flowRegion
        id="flowRegion484"><rect
@@ -2539,7 +2539,7 @@
      id="g1985"
      transform="matrix(0.80242547,0,0,0.80242536,372.20776,255.46083)"
      style="shape-rendering:crispEdges"
-     inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\LLDK\DIAGRAMS\final_diagram_hil.png"
+
      inkscape:export-xdpi="224.36"
      inkscape:export-ydpi="224.36">
     <rect
@@ -2573,7 +2573,7 @@
      width="247.00725"
      id="daccore0-6-4"
      style="display:inline;fill:#4cbeef;fill-opacity:0;fill-rule:nonzero;stroke:#a01414;stroke-width:1.71644;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;shape-rendering:crispEdges;enable-background:new"
-     inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\LLDK\DIAGRAMS\final_diagram_hil.png"
+
      inkscape:export-xdpi="224.36"
      inkscape:export-ydpi="224.36">
     <title
@@ -2586,7 +2586,7 @@
      width="247.00725"
      id="daccore0-6-4-9"
      style="display:inline;fill:#4cbeef;fill-opacity:0;fill-rule:nonzero;stroke:#a01414;stroke-width:1.71644;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;shape-rendering:crispEdges;enable-background:new"
-     inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\LLDK\DIAGRAMS\final_diagram_hil.png"
+
      inkscape:export-xdpi="224.36"
      inkscape:export-ydpi="224.36">
     <title
@@ -2599,7 +2599,7 @@
      width="247.00725"
      id="daccore0-6-4-9-6"
      style="display:inline;fill:#4cbeef;fill-opacity:0;fill-rule:nonzero;stroke:#a01414;stroke-width:1.71644;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;shape-rendering:crispEdges;enable-background:new"
-     inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\LLDK\DIAGRAMS\final_diagram_hil.png"
+
      inkscape:export-xdpi="224.36"
      inkscape:export-ydpi="224.36">
     <title
@@ -2612,7 +2612,7 @@
      width="247.00725"
      id="daccore0-6-4-9-9"
      style="display:inline;fill:#4cbeef;fill-opacity:0;fill-rule:nonzero;stroke:#a01414;stroke-width:1.71644;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;shape-rendering:crispEdges;enable-background:new"
-     inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\LLDK\DIAGRAMS\final_diagram_hil.png"
+
      inkscape:export-xdpi="224.36"
      inkscape:export-ydpi="224.36">
     <title
@@ -2625,7 +2625,7 @@
      style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:17.033px;line-height:0%;font-family:Arial;-inkscape-font-specification:'Arial, Bold';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:0.294118;stroke:none;stroke-width:0.830361;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;shape-rendering:crispEdges;enable-background:new"
      xml:space="preserve"
      transform="scale(0.88803716,1.126079)"
-     inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\LLDK\DIAGRAMS\final_diagram_hil.png"
+
      inkscape:export-xdpi="224.36"
      inkscape:export-ydpi="224.36"><tspan
        style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:17.033px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial, Bold';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;fill:#000000;fill-opacity:1;stroke-width:0.830361;stroke-miterlimit:4;stroke-dasharray:none"
@@ -2637,7 +2637,7 @@
      id="g21139"
      transform="matrix(0.9585553,0,0,1,295.48228,709.00988)"
      style="fill:none;fill-opacity:0.639216;stroke:#a01414;stroke-width:1.02139;stroke-opacity:0.858824;shape-rendering:crispEdges"
-     inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\LLDK\DIAGRAMS\final_diagram_hil.png"
+
      inkscape:export-xdpi="224.36"
      inkscape:export-ydpi="224.36">
     <path
@@ -2668,7 +2668,7 @@
      id="g15320"
      transform="matrix(0.95825745,0,0,1,294.95196,667.00988)"
      style="fill:none;fill-opacity:0.639216;stroke:#a01414;stroke-width:1.02155;stroke-opacity:0.858824;shape-rendering:crispEdges"
-     inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\LLDK\DIAGRAMS\final_diagram_hil.png"
+
      inkscape:export-xdpi="224.36"
      inkscape:export-ydpi="224.36">
     <path
@@ -2677,7 +2677,7 @@
        id="path1206-1-0-9"
        d="M 596,197.09448 H 498"
        style="display:inline;opacity:1;fill:none;fill-opacity:0.639216;stroke:#a01414;stroke-width:2.0431;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.858824;marker-end:url(#marker1216-0-3-74);shape-rendering:crispEdges;enable-background:new"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\LLDK\DIAGRAMS\lldk_fmc_card_UPDATED.svg.2022_12_21_15_46_15.0.jpg"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36" />
     <path
@@ -2686,7 +2686,7 @@
        id="path1206-1-0-8-8"
        d="M 596,209.09448 H 498"
        style="display:inline;opacity:1;fill:none;fill-opacity:0.639216;stroke:#a01414;stroke-width:2.0431;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.858824;marker-end:url(#marker1216-0-3-9-3);shape-rendering:crispEdges;enable-background:new"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\LLDK\DIAGRAMS\lldk_fmc_card_UPDATED.svg.2022_12_21_15_46_15.0.jpg"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36" />
     <text
@@ -2695,7 +2695,7 @@
        x="522.70721"
        style="font-style:normal;font-weight:normal;font-size:16px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;display:inline;opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1.02155;stroke-opacity:1;shape-rendering:crispEdges;enable-background:new"
        xml:space="preserve"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\LLDK\DIAGRAMS\lldk_fmc_card_UPDATED.svg.2022_12_21_15_46_15.0.jpg"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36"><tspan
          style="font-size:13.3333px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1.02155;stroke-opacity:1"
@@ -2708,7 +2708,7 @@
      id="g15302"
      transform="matrix(0.96188724,0,0,1,294.40771,689.00988)"
      style="fill:none;fill-opacity:0.639216;stroke:#a01414;stroke-width:1.01962;stroke-opacity:0.858824;shape-rendering:crispEdges"
-     inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\LLDK\DIAGRAMS\final_diagram_hil.png"
+
      inkscape:export-xdpi="224.36"
      inkscape:export-ydpi="224.36">
     <path
@@ -2743,7 +2743,7 @@
      id="text6100-2-7"
      inkscape:export-xdpi="224.36"
      inkscape:export-ydpi="224.36"
-     inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\LLDK\DIAGRAMS\final_diagram_hil.png"><tspan
+><tspan
        sodipodi:role="line"
        x="494.99997"
        y="955"
@@ -2755,7 +2755,7 @@
      x="783.25647"
      y="988.00409"
      id="text2401-1-7-3-9-9-8-9"
-     inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\LLDK\DIAGRAMS\final_diagram_hil.png"
+
      inkscape:export-xdpi="224.36"
      inkscape:export-ydpi="224.36"><tspan
        sodipodi:role="line"
@@ -2769,7 +2769,7 @@
      x="698.99994"
      y="953"
      id="text2401-1-7-3-9-9-8-9-9"
-     inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\LLDK\DIAGRAMS\final_diagram_hil.png"
+
      inkscape:export-xdpi="224.36"
      inkscape:export-ydpi="224.36"><tspan
        sodipodi:role="line"
@@ -2783,7 +2783,7 @@
      x="782.00006"
      y="946.99994"
      id="text2401-1-7-3-9-9-8-9-9-1"
-     inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\LLDK\DIAGRAMS\final_diagram_hil.png"
+
      inkscape:export-xdpi="224.36"
      inkscape:export-ydpi="224.36"><tspan
        sodipodi:role="line"
@@ -2797,7 +2797,7 @@
      x="781.29297"
      y="963"
      id="text2401-1-7-3-9-9-8-9-9-1-0"
-     inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\LLDK\DIAGRAMS\final_diagram_hil.png"
+
      inkscape:export-xdpi="224.36"
      inkscape:export-ydpi="224.36"><tspan
        sodipodi:role="line"
@@ -2811,7 +2811,7 @@
      x="421.46045"
      y="984.99908"
      id="text2401-1-7-3-9-9-8-2"
-     inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\LLDK\DIAGRAMS\final_diagram_hil.png"
+
      inkscape:export-xdpi="224.36"
      inkscape:export-ydpi="224.36"><tspan
        sodipodi:role="line"
@@ -2825,7 +2825,7 @@
      x="423.07935"
      y="957.71704"
      id="text2401-1-7-3-9-9-8-2-6"
-     inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\LLDK\DIAGRAMS\final_diagram_hil.png"
+
      inkscape:export-xdpi="224.36"
      inkscape:export-ydpi="224.36"><tspan
        sodipodi:role="line"
@@ -2839,14 +2839,14 @@
      id="path1206-7-8"
      inkscape:connector-curvature="0"
      sodipodi:nodetypes="cc"
-     inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\LLDK\DIAGRAMS\final_diagram_hil.png"
+
      inkscape:export-xdpi="224.36"
      inkscape:export-ydpi="224.36" />
   <g
      id="g6577"
      style="display:inline;fill:#ffcccc;fill-opacity:1;shape-rendering:crispEdges;enable-background:new"
      transform="matrix(1.3748693,0,0,1.4504246,40.645781,-64.887655)"
-     inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\LLDK\DIAGRAMS\final_diagram_hil.png"
+
      inkscape:export-xdpi="224.36"
      inkscape:export-ydpi="224.36">
     <g
@@ -2888,7 +2888,7 @@
      id="path5471-9-9-1"
      cx="580.27496"
      cy="961.64099"
-     inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\LLDK\DIAGRAMS\final_diagram_hil.png"
+
      inkscape:export-xdpi="224.36"
      inkscape:export-ydpi="224.36"
      rx="3.5355341"
@@ -2898,7 +2898,7 @@
      id="path5471-9-9-1-8"
      cx="765.77393"
      cy="967.42059"
-     inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\LLDK\DIAGRAMS\final_diagram_hil.png"
+
      inkscape:export-xdpi="224.36"
      inkscape:export-ydpi="224.36"
      rx="3.5355341"
@@ -2909,7 +2909,7 @@
      id="path1206-7-8-6-5-7"
      inkscape:connector-curvature="0"
      sodipodi:nodetypes="cc"
-     inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\LLDK\DIAGRAMS\final_diagram_hil.png"
+
      inkscape:export-xdpi="224.36"
      inkscape:export-ydpi="224.36" />
   <path
@@ -2918,7 +2918,7 @@
      id="path1206-7-8-6-5-7-9"
      inkscape:connector-curvature="0"
      sodipodi:nodetypes="cc"
-     inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\LLDK\DIAGRAMS\final_diagram_hil.png"
+
      inkscape:export-xdpi="224.36"
      inkscape:export-ydpi="224.36" />
   <path
@@ -2927,7 +2927,7 @@
      id="path1206-7-8-6-5-7-9-6"
      inkscape:connector-curvature="0"
      sodipodi:nodetypes="cc"
-     inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\LLDK\DIAGRAMS\final_diagram_hil.png"
+
      inkscape:export-xdpi="224.36"
      inkscape:export-ydpi="224.36" />
   <path
@@ -2936,7 +2936,7 @@
      id="path1206-7-8-6-5-7-9-7"
      inkscape:connector-curvature="0"
      sodipodi:nodetypes="cc"
-     inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\LLDK\DIAGRAMS\final_diagram_hil.png"
+
      inkscape:export-xdpi="224.36"
      inkscape:export-ydpi="224.36" />
   <path
@@ -2945,7 +2945,7 @@
      id="path1206-7-8-6-5-7-9-2"
      inkscape:connector-curvature="0"
      sodipodi:nodetypes="cc"
-     inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\LLDK\DIAGRAMS\final_diagram_hil.png"
+
      inkscape:export-xdpi="224.36"
      inkscape:export-ydpi="224.36" />
   <path
@@ -2954,7 +2954,7 @@
      id="path1206-7-8-6-5-7-2"
      inkscape:connector-curvature="0"
      sodipodi:nodetypes="cc"
-     inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\LLDK\DIAGRAMS\final_diagram_hil.png"
+
      inkscape:export-xdpi="224.36"
      inkscape:export-ydpi="224.36" />
   <text
@@ -2963,7 +2963,7 @@
      x="117.42435"
      y="655.22797"
      id="text1814"
-     inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\LLDK\DIAGRAMS\final_diagram_hil.png"
+
      inkscape:export-xdpi="224.36"
      inkscape:export-ydpi="224.36"><tspan
        sodipodi:role="line"
@@ -2977,7 +2977,7 @@
      x="220.99583"
      y="653.94226"
      id="text1818"
-     inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\LLDK\DIAGRAMS\final_diagram_hil.png"
+
      inkscape:export-xdpi="224.36"
      inkscape:export-ydpi="224.36"><tspan
        sodipodi:role="line"
@@ -2990,7 +2990,7 @@
      id="path5471-9-9-17"
      cx="405.3887"
      cy="828.04938"
-     inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\LLDK\DIAGRAMS\final_diagram_hil.png"
+
      inkscape:export-xdpi="224.36"
      inkscape:export-ydpi="224.36"
      rx="3.4019763"
@@ -3000,7 +3000,7 @@
      id="path5471-9-9-17-9"
      cx="390.03156"
      cy="812.51367"
-     inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\LLDK\DIAGRAMS\final_diagram_hil.png"
+
      inkscape:export-xdpi="224.36"
      inkscape:export-ydpi="224.36"
      rx="3.4019763"
@@ -3010,7 +3010,7 @@
      id="path5471-9-9-17-9-6"
      cx="364.67441"
      cy="798.40649"
-     inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\LLDK\DIAGRAMS\final_diagram_hil.png"
+
      inkscape:export-xdpi="224.36"
      inkscape:export-ydpi="224.36"
      rx="3.4019763"
@@ -3020,7 +3020,7 @@
      id="path5471-9-9-17-9-6-5"
      cx="351.10297"
      cy="782.15656"
-     inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\LLDK\DIAGRAMS\final_diagram_hil.png"
+
      inkscape:export-xdpi="224.36"
      inkscape:export-ydpi="224.36"
      rx="3.4019763"
@@ -3031,7 +3031,7 @@
      x="724.83789"
      y="405.65735"
      id="text5363"
-     inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\LLDK\DIAGRAMS\final_diagram_hil.png"
+
      inkscape:export-xdpi="224.36"
      inkscape:export-ydpi="224.36"><tspan
        sodipodi:role="line"
@@ -3043,7 +3043,7 @@
      style="display:inline;shape-rendering:crispEdges;enable-background:new"
      id="g6008"
      transform="translate(243.94543,-323.02098)"
-     inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\LLDK\DIAGRAMS\final_diagram_hil.png"
+
      inkscape:export-xdpi="224.36"
      inkscape:export-ydpi="224.36">
     <g
@@ -3140,7 +3140,7 @@
      x="94.999977"
      y="43.000008"
      id="text69411"
-     inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\LLDK\DIAGRAMS\final_diagram_hil.png"
+
      inkscape:export-xdpi="224.36"
      inkscape:export-ydpi="224.36"><tspan
        sodipodi:role="line"
@@ -3154,7 +3154,7 @@
      x="94.999977"
      y="67"
      id="text69411-5"
-     inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\LLDK\DIAGRAMS\final_diagram_hil.png"
+
      inkscape:export-xdpi="224.36"
      inkscape:export-ydpi="224.36"><tspan
        sodipodi:role="line"
@@ -3168,7 +3168,7 @@
      x="535"
      y="885"
      id="text9373"
-     inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\LLDK\DIAGRAMS\final_diagram_hil.png"
+
      inkscape:export-xdpi="224.36"
      inkscape:export-ydpi="224.36"><tspan
        sodipodi:role="line"
@@ -3183,7 +3183,7 @@
      height="59.999996"
      x="114.99998"
      y="600"
-     inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\LLDK\DIAGRAMS\final_diagram_hil.png"
+
      inkscape:export-xdpi="224.36"
      inkscape:export-ydpi="224.36" />
   <text
@@ -3192,7 +3192,7 @@
      x="154.99998"
      y="630"
      id="text8548"
-     inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\LLDK\DIAGRAMS\final_diagram_hil.png"
+
      inkscape:export-xdpi="224.36"
      inkscape:export-ydpi="224.36"><tspan
        sodipodi:role="line"
@@ -3206,7 +3206,7 @@
      x="119.99998"
      y="655"
      id="text11612"
-     inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\LLDK\DIAGRAMS\final_diagram_hil.png"
+
      inkscape:export-xdpi="224.36"
      inkscape:export-ydpi="224.36"><tspan
        sodipodi:role="line"
@@ -3220,7 +3220,7 @@
      x="219.99997"
      y="655"
      id="text14344"
-     inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\LLDK\DIAGRAMS\final_diagram_hil.png"
+
      inkscape:export-xdpi="224.36"
      inkscape:export-ydpi="224.36"><tspan
        sodipodi:role="line"
@@ -3236,7 +3236,7 @@
      id="text6100-2-2-8"
      inkscape:export-xdpi="224.36"
      inkscape:export-ydpi="224.36"
-     inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\LLDK\DIAGRAMS\final_diagram_hil.png"
+
      transform="scale(0.98002378,1.0203834)"><tspan
        sodipodi:role="line"
        x="612.23004"
@@ -3249,7 +3249,7 @@
      id="path1206-7-8-6-5"
      inkscape:connector-curvature="0"
      sodipodi:nodetypes="cc"
-     inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\LLDK\DIAGRAMS\final_diagram_hil.png"
+
      inkscape:export-xdpi="224.36"
      inkscape:export-ydpi="224.36" />
   <path
@@ -3258,7 +3258,7 @@
      id="path1206-7-8-6-5-8"
      inkscape:connector-curvature="0"
      sodipodi:nodetypes="cc"
-     inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\LLDK\DIAGRAMS\final_diagram_hil.png"
+
      inkscape:export-xdpi="224.36"
      inkscape:export-ydpi="224.36" />
   <path
@@ -3267,7 +3267,7 @@
      id="path1206-7-8-6-5-8-6"
      inkscape:connector-curvature="0"
      sodipodi:nodetypes="cc"
-     inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\LLDK\DIAGRAMS\final_diagram_hil.png"
+
      inkscape:export-xdpi="224.36"
      inkscape:export-ydpi="224.36" />
   <path
@@ -3276,7 +3276,7 @@
      id="path1206-7-8-6-5-1"
      inkscape:connector-curvature="0"
      sodipodi:nodetypes="cc"
-     inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\LLDK\DIAGRAMS\final_diagram_hil.png"
+
      inkscape:export-xdpi="224.36"
      inkscape:export-ydpi="224.36" />
   <path
@@ -3284,7 +3284,7 @@
      d="M 676.99997,947.15123 V 967 c 8.06497,-0.42862 16.92511,-2.88806 17.01382,-9.60426 0.0902,-6.82051 -7.64548,-10.23776 -17.01382,-10.24451 z"
      id="path5279"
      sodipodi:nodetypes="ccac"
-     inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\LLDK\DIAGRAMS\final_diagram_hil.png"
+
      inkscape:export-xdpi="224.36"
      inkscape:export-ydpi="224.36" />
   <path
@@ -3293,7 +3293,7 @@
      id="path1206-1-0-95-1"
      d="m 569.99997,357.53033 h 21.41424"
      style="display:inline;fill:#0f3296;fill-opacity:1;stroke:#0f3296;stroke-width:2.2712;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#marker1216-0-3-1-2);shape-rendering:crispEdges;enable-background:new"
-     inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\LLDK\DIAGRAMS\final_diagram_hil.png"
+
      inkscape:export-xdpi="224.36"
      inkscape:export-ydpi="224.36" />
   <path
@@ -3302,7 +3302,7 @@
      id="path1206-1-0-95-1-5"
      d="m 569.82318,410.70712 h 21.41424"
      style="display:inline;fill:#0f3296;fill-opacity:1;stroke:#0f3296;stroke-width:2.2712;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#marker1216-0-3-1-2-94);shape-rendering:crispEdges;enable-background:new"
-     inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\LLDK\DIAGRAMS\final_diagram_hil.png"
+
      inkscape:export-xdpi="224.36"
      inkscape:export-ydpi="224.36" />
   <path
@@ -3311,7 +3311,7 @@
      id="path1206-1-0-95-1-93"
      d="m 571.90927,392.8285 h 19.73192"
      style="display:inline;fill:#0f3296;fill-opacity:1;stroke:#0f3296;stroke-width:2.2712;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#marker1216-0-3-1-2-03);shape-rendering:crispEdges;enable-background:new"
-     inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\LLDK\DIAGRAMS\final_diagram_hil.png"
+
      inkscape:export-xdpi="224.36"
      inkscape:export-ydpi="224.36" />
   <path
@@ -3320,7 +3320,7 @@
      id="path1206-1-0-95-1-4"
      d="m 571.32872,375 h 19.73192"
      style="display:inline;fill:#0f3296;fill-opacity:1;stroke:#0f3296;stroke-width:2.2712;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#marker1216-0-3-1-2-4);shape-rendering:crispEdges;enable-background:new"
-     inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\LLDK\DIAGRAMS\final_diagram_hil.png"
+
      inkscape:export-xdpi="224.36"
      inkscape:export-ydpi="224.36" />
   <path
@@ -3328,7 +3328,7 @@
      id="path20012-1-0"
      d="m 139.99998,833 -5,10"
      style="fill:none;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;shape-rendering:crispEdges"
-     inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\LLDK\DIAGRAMS\final_diagram_hil.png"
+
      inkscape:export-xdpi="224.36"
      inkscape:export-ydpi="224.36" />
   <path
@@ -3336,7 +3336,7 @@
      id="path20012-1-06"
      d="m 216.4799,832.49523 -5,10"
      style="fill:none;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;shape-rendering:crispEdges"
-     inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\LLDK\DIAGRAMS\final_diagram_hil.png"
+
      inkscape:export-xdpi="224.36"
      inkscape:export-ydpi="224.36" />
   <path
@@ -3344,7 +3344,7 @@
      id="path20012-1-06-2"
      d="m 442.70132,774.89907 -5,10"
      style="fill:none;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;shape-rendering:crispEdges"
-     inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\LLDK\DIAGRAMS\final_diagram_hil.png"
+
      inkscape:export-xdpi="224.36"
      inkscape:export-ydpi="224.36" />
   <path
@@ -3352,7 +3352,7 @@
      id="path20012-1-06-2-3"
      d="m 442.70132,790.55644 -5,10"
      style="fill:none;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;shape-rendering:crispEdges"
-     inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\LLDK\DIAGRAMS\final_diagram_hil.png"
+
      inkscape:export-xdpi="224.36"
      inkscape:export-ydpi="224.36" />
   <path
@@ -3360,7 +3360,7 @@
      id="path20012-1-06-2-3-1"
      d="m 442.70132,805.20365 -5,10"
      style="fill:none;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;shape-rendering:crispEdges"
-     inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\LLDK\DIAGRAMS\final_diagram_hil.png"
+
      inkscape:export-xdpi="224.36"
      inkscape:export-ydpi="224.36" />
   <path
@@ -3368,7 +3368,7 @@
      id="path20012-1-06-2-3-1-3"
      d="m 442.70132,820.60848 -5,10"
      style="fill:none;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;shape-rendering:crispEdges"
-     inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\LLDK\DIAGRAMS\final_diagram_hil.png"
+
      inkscape:export-xdpi="224.36"
      inkscape:export-ydpi="224.36" />
   <g

--- a/docs/projects/pulsar_lvds_adc/pulsar_lvds_adc_block_diagram.svg
+++ b/docs/projects/pulsar_lvds_adc/pulsar_lvds_adc_block_diagram.svg
@@ -886,7 +886,7 @@
        y="290.30939"
        ry="4.2426405"
        rx="4.2426405"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD762x\ad7960_block_diagram.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36" />
     <path
@@ -895,7 +895,7 @@
        id="use1501-5"
        inkscape:connector-curvature="0"
        sodipodi:nodetypes="cc"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD762x\ad7960_block_diagram.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36" />
     <path
@@ -904,14 +904,14 @@
        id="use1501"
        inkscape:connector-curvature="0"
        sodipodi:nodetypes="cc"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD762x\ad7960_block_diagram.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36" />
     <g
        id="use1475"
        transform="matrix(1.2398233,0,0,1.0502642,-550.86908,-27.87137)"
        style="stroke-width:0.703194"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD762x\ad7960_block_diagram.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36">
       <rect
@@ -942,7 +942,7 @@
        transform="matrix(1.0673306,0,0,1.8499427,219.25772,-722.33135)"
        style="display:inline;stroke-width:0.710514;shape-rendering:crispEdges;enable-background:new"
        id="use1479"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD762x\ad7960_block_diagram.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36">
       <rect
@@ -974,7 +974,7 @@
        id="path4518"
        d="M -116.99853,382.44135 V 357.36307"
        style="display:inline;fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1.49999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-start:url(#TriangleInM);marker-end:url(#TriangleOutM);shape-rendering:crispEdges;enable-background:new"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD762x\ad7960_block_diagram.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36" />
     <path
@@ -983,7 +983,7 @@
        id="path4518-5"
        d="M -76.645434,382.43275 V 357.48479"
        style="display:inline;fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1.49999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-start:url(#TriangleInM-7);marker-end:url(#TriangleOutM-2);shape-rendering:crispEdges;enable-background:new"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD762x\ad7960_block_diagram.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36" />
     <path
@@ -992,7 +992,7 @@
        id="path4518-5-9"
        d="m -36.292394,382.40442 v -25.078"
        style="display:inline;fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1.49999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-start:url(#TriangleInM-7-1);marker-end:url(#TriangleOutM-2-8);shape-rendering:crispEdges;enable-background:new"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD762x\ad7960_block_diagram.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36" />
     <rect
@@ -1003,7 +1003,7 @@
        height="98.169884"
        x="-65.555916"
        y="388.32852"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD762x\ad7960_block_diagram.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36" />
     <path
@@ -1011,7 +1011,7 @@
        d="m 23.010776,389.20037 v 97.52402"
        id="path4179"
        inkscape:connector-curvature="0"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD762x\ad7960_block_diagram.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36" />
     <path
@@ -1019,7 +1019,7 @@
        d="m -16.590604,389.20037 v 97.52402"
        id="path4179-9"
        inkscape:connector-curvature="0"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD762x\ad7960_block_diagram.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36" />
     <path
@@ -1027,7 +1027,7 @@
        d="m -174.99613,389.20037 v 97.52402"
        id="path4179-0"
        inkscape:connector-curvature="0"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD762x\ad7960_block_diagram.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36" />
     <path
@@ -1035,7 +1035,7 @@
        d="m -135.39473,389.20037 v 97.52402"
        id="path4179-4"
        inkscape:connector-curvature="0"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD762x\ad7960_block_diagram.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36" />
     <path
@@ -1043,7 +1043,7 @@
        d="m -95.793334,389.20037 v 97.52402"
        id="path4179-7"
        inkscape:connector-curvature="0"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD762x\ad7960_block_diagram.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36" />
     <path
@@ -1051,7 +1051,7 @@
        d="m -56.191934,389.20037 v 97.52402"
        id="path4179-41"
        inkscape:connector-curvature="0"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD762x\ad7960_block_diagram.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36" />
     <path
@@ -1059,7 +1059,7 @@
        d="m -214.59743,389.20037 v 97.52402"
        id="path4179-0-3"
        inkscape:connector-curvature="0"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD762x\ad7960_block_diagram.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36" />
     <text
@@ -1069,7 +1069,7 @@
        x="-504.8009"
        style="font-style:normal;font-weight:normal;font-size:17.0649px;line-height:0%;font-family:Arial;letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;shape-rendering:crispEdges"
        xml:space="preserve"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD762x\ad7960_block_diagram.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36"><tspan
          style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:15.9984px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial Bold';stroke-width:1px"
@@ -1084,7 +1084,7 @@
        x="-494.49719"
        style="font-style:normal;font-weight:normal;font-size:17.0649px;line-height:0%;font-family:Arial;letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;shape-rendering:crispEdges"
        xml:space="preserve"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD762x\ad7960_block_diagram.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36"><tspan
          style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:15.9984px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial Bold';stroke-width:1px"
@@ -1099,7 +1099,7 @@
        x="-494.13788"
        style="font-style:normal;font-weight:normal;font-size:17.0649px;line-height:0%;font-family:Arial;letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;shape-rendering:crispEdges"
        xml:space="preserve"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD762x\ad7960_block_diagram.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36"><tspan
          style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:15.9984px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial Bold';stroke-width:1px"
@@ -1114,7 +1114,7 @@
        x="-484.52167"
        style="font-style:normal;font-weight:normal;font-size:17.0649px;line-height:0%;font-family:Arial;letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;shape-rendering:crispEdges"
        xml:space="preserve"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD762x\ad7960_block_diagram.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36"><tspan
          style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:15.9984px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial Bold';stroke-width:1px"
@@ -1129,7 +1129,7 @@
        x="-484.42786"
        style="font-style:normal;font-weight:normal;font-size:17.0649px;line-height:0%;font-family:Arial;letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;shape-rendering:crispEdges"
        xml:space="preserve"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD762x\ad7960_block_diagram.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36"><tspan
          style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:15.9984px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial Bold';stroke-width:1px"
@@ -1146,7 +1146,7 @@
        x="-509.3551"
        style="font-style:normal;font-weight:normal;font-size:17.0649px;line-height:0%;font-family:Arial;letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;shape-rendering:crispEdges"
        xml:space="preserve"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD762x\ad7960_block_diagram.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36"><tspan
          style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:15.9984px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial Bold';stroke-width:1px"
@@ -1161,7 +1161,7 @@
        x="131.22955"
        style="font-style:normal;font-weight:normal;line-height:0%;font-family:Arial;letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;shape-rendering:crispEdges"
        xml:space="preserve"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD762x\ad7960_block_diagram.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36"><tspan
          y="474.38336"
@@ -1176,7 +1176,7 @@
        x="-493.74341"
        style="font-style:normal;font-weight:normal;font-size:17.0649px;line-height:0%;font-family:Arial;letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;shape-rendering:crispEdges"
        xml:space="preserve"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD762x\ad7960_block_diagram.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36"><tspan
          style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:15.9984px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial Bold';stroke-width:1px"
@@ -1193,7 +1193,7 @@
        y="338.00516"
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD762x\ad7960_block_diagram.png" />
+ />
     <text
        xml:space="preserve"
        style="font-style:normal;font-weight:normal;font-size:17.0649px;line-height:0%;font-family:Arial;letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;shape-rendering:crispEdges;enable-background:new"
@@ -1202,7 +1202,7 @@
        id="text4595"
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD762x\ad7960_block_diagram.png"
+
        transform="scale(1.0865021,0.92038479)"><tspan
          style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:17.776px;line-height:1.25;font-family:Arial;-inkscape-font-specification:Arial;stroke-width:1px"
          sodipodi:role="line"
@@ -1217,7 +1217,7 @@
        id="text4482"
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD762x\ad7960_block_diagram.png"
+
        transform="scale(1.0865021,0.92038479)"><tspan
          sodipodi:role="line"
          x="139.86217"
@@ -1231,7 +1231,7 @@
        x="-457.88947"
        style="font-style:normal;font-weight:normal;font-size:17.0649px;line-height:0%;font-family:Arial;letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;shape-rendering:crispEdges;enable-background:new"
        xml:space="preserve"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD762x\ad7960_block_diagram.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36"><tspan
          style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:21.3312px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial Bold';stroke-width:1px"
@@ -1243,7 +1243,7 @@
        id="g5654"
        style="display:inline;fill:#a01414;fill-opacity:1;stroke:#a01414;stroke-width:0.449013;stroke-opacity:1;shape-rendering:crispEdges;enable-background:new"
        transform="matrix(3.3206195,0,0,1.5398491,-947.00529,-151.5917)"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD762x\ad7960_block_diagram.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36">
       <path
@@ -1257,7 +1257,7 @@
        id="g5654-2"
        style="display:inline;fill:#a01414;fill-opacity:1;stroke:#a01414;stroke-opacity:1;shape-rendering:crispEdges;enable-background:new"
        transform="matrix(1.7478534,0,0,1,-85.40762,-12.51405)"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD762x\ad7960_block_diagram.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36" />
     <text
@@ -1266,7 +1266,7 @@
        x="243.93425"
        style="font-style:normal;font-weight:normal;line-height:0%;font-family:Arial;letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;shape-rendering:crispEdges;enable-background:new"
        xml:space="preserve"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD762x\ad7960_block_diagram.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36"><tspan
          id="tspan11370-7-5"
@@ -1278,7 +1278,7 @@
        id="g21139"
        transform="matrix(1.5450945,0,0,1.3088622,-704.15763,583.40432)"
        style="stroke-width:0.703194;shape-rendering:crispEdges"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD762x\ad7960_block_diagram.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36">
       <path
@@ -1317,14 +1317,14 @@
        inkscape:transform-center-x="-9.2284841"
        inkscape:transform-center-y="0.25764112"
        d="m 1321.5825,846.40682 -31.3012,-18.69776 -31.3013,-18.69777 31.8434,-17.7588 31.8433,-17.7588 -0.5421,36.45657 z"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD762x\ad7960_block_diagram.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36" />
     <g
        style="display:inline;stroke-width:0.703194;shape-rendering:crispEdges;enable-background:new"
        id="g8892"
        transform="matrix(1.5450945,0,0,1.3088622,-662.96483,-259.32641)"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD762x\ad7960_block_diagram.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36">
       <rect
@@ -1434,7 +1434,7 @@
        id="uart"
        transform="matrix(0,-0.54286345,0.64084324,0,-295.62563,605.42102)"
        style="display:inline;stroke-width:1.69543;stroke-miterlimit:4;stroke-dasharray:none;shape-rendering:crispEdges;enable-background:new"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD762x\ad7960_block_diagram.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36">
       <rect
@@ -1535,7 +1535,7 @@
        height="783.39758"
        x="-608.15723"
        y="293.99307"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD762x\ad7960_block_diagram.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36" />
     <use
@@ -1547,7 +1547,7 @@
        width="100%"
        height="100%"
        transform="translate(6.033e-5)"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD762x\ad7960_block_diagram.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36" />
     <use
@@ -1559,7 +1559,7 @@
        width="100%"
        height="100%"
        transform="translate(6.033e-5)"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD762x\ad7960_block_diagram.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36" />
     <use
@@ -1571,7 +1571,7 @@
        width="100%"
        height="100%"
        transform="translate(6.033e-5)"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD762x\ad7960_block_diagram.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36" />
     <use
@@ -1583,7 +1583,7 @@
        width="100%"
        height="100%"
        transform="translate(6.033e-5)"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD762x\ad7960_block_diagram.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36" />
     <use
@@ -1595,7 +1595,7 @@
        width="100%"
        height="100%"
        transform="translate(6.033e-5)"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD762x\ad7960_block_diagram.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36" />
     <use
@@ -1607,7 +1607,7 @@
        width="100%"
        height="100%"
        transform="translate(6.033e-5)"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD762x\ad7960_block_diagram.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36" />
     <use
@@ -1619,7 +1619,7 @@
        width="100%"
        height="100%"
        transform="translate(6.033e-5)"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD762x\ad7960_block_diagram.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36" />
     <use
@@ -1631,7 +1631,7 @@
        width="100%"
        height="100%"
        transform="translate(6.033e-5)"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD762x\ad7960_block_diagram.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36" />
     <use
@@ -1643,7 +1643,7 @@
        width="100%"
        height="100%"
        transform="translate(6.033e-5)"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD762x\ad7960_block_diagram.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36" />
     <use
@@ -1655,7 +1655,7 @@
        width="100%"
        height="100%"
        transform="translate(6.033e-5)"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD762x\ad7960_block_diagram.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36" />
     <use
@@ -1667,7 +1667,7 @@
        width="100%"
        height="100%"
        transform="translate(6.033e-5)"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD762x\ad7960_block_diagram.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36" />
     <use
@@ -1679,7 +1679,7 @@
        width="100%"
        height="100%"
        transform="translate(6.033e-5)"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD762x\ad7960_block_diagram.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36" />
     <use
@@ -1691,7 +1691,7 @@
        width="100%"
        height="100%"
        transform="translate(6.033e-5)"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD762x\ad7960_block_diagram.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36" />
     <use
@@ -1703,7 +1703,7 @@
        width="100%"
        height="100%"
        transform="translate(6.033e-5)"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD762x\ad7960_block_diagram.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36" />
     <use
@@ -1715,7 +1715,7 @@
        width="100%"
        height="100%"
        transform="translate(6.033e-5)"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD762x\ad7960_block_diagram.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36" />
     <use
@@ -1727,7 +1727,7 @@
        width="100%"
        height="100%"
        transform="translate(6.033e-5)"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD762x\ad7960_block_diagram.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36" />
     <use
@@ -1739,7 +1739,7 @@
        width="100%"
        height="100%"
        transform="translate(6.033e-5)"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD762x\ad7960_block_diagram.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36" />
     <use
@@ -1751,7 +1751,7 @@
        width="100%"
        height="100%"
        transform="translate(6.033e-5)"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD762x\ad7960_block_diagram.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36" />
     <use
@@ -1763,7 +1763,7 @@
        width="100%"
        height="100%"
        transform="translate(6.033e-5)"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD762x\ad7960_block_diagram.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36" />
     <use
@@ -1775,7 +1775,7 @@
        width="100%"
        height="100%"
        transform="translate(6.133e-5)"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD762x\ad7960_block_diagram.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36" />
     <rect
@@ -1787,7 +1787,7 @@
        y="545.1864"
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD762x\ad7960_block_diagram.png" />
+ />
     <text
        xml:space="preserve"
        style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:20.8572px;line-height:0%;font-family:Arial;-inkscape-font-specification:'Arial, Bold';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;shape-rendering:crispEdges;enable-background:new"
@@ -1797,7 +1797,7 @@
        transform="matrix(0,-0.92038479,1.0865021,0,0,0)"
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD762x\ad7960_block_diagram.png"><tspan
+><tspan
          sodipodi:role="line"
          id="tspan32453"
          x="-867.47467"
@@ -1812,7 +1812,7 @@
        width="100%"
        height="100%"
        transform="translate(6.133e-5)"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD762x\ad7960_block_diagram.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36" />
     <rect
@@ -1824,7 +1824,7 @@
        y="517.15466"
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD762x\ad7960_block_diagram.png" />
+ />
     <rect
        style="display:inline;fill:none;fill-opacity:1;stroke:#3f4b55;stroke-width:2.03381;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:2.03381, 6.10143;stroke-dashoffset:0;stroke-opacity:1;shape-rendering:crispEdges;enable-background:new"
        id="use1467-5"
@@ -1834,7 +1834,7 @@
        y="517.15454"
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD762x\ad7960_block_diagram.png" />
+ />
     <text
        xml:space="preserve"
        style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:14px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Bold';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1;shape-rendering:crispEdges;enable-background:new"
@@ -1843,7 +1843,7 @@
        id="use1473"
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD762x\ad7960_block_diagram.png"
+
        transform="scale(1.1546692,0.8660489)"><tspan
          sodipodi:role="line"
          x="-506.41898"
@@ -1858,7 +1858,7 @@
        id="use1473-1"
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD762x\ad7960_block_diagram.png"
+
        transform="scale(1.1546692,0.8660489)"><tspan
          sodipodi:role="line"
          x="-188.69106"
@@ -1874,7 +1874,7 @@
        width="100%"
        height="100%"
        transform="translate(6.033e-5)"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD762x\ad7960_block_diagram.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36" />
     <use
@@ -1886,14 +1886,14 @@
        width="100%"
        height="100%"
        transform="matrix(0.66964978,0,0,1.0295248,5.7143093,-13.791464)"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD762x\ad7960_block_diagram.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36" />
     <g
        id="use1487"
        transform="matrix(1.5450945,0,0,1.3088622,-706.25013,504.72576)"
        style="stroke-width:0.703194;shape-rendering:crispEdges"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD762x\ad7960_block_diagram.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36">
       <path
@@ -1928,7 +1928,7 @@
        id="use1503"
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD762x\ad7960_block_diagram.png"
+
        transform="scale(0.95451552,1.0476519)"><tspan
          sodipodi:role="line"
          x="-103.83724"
@@ -1941,7 +1941,7 @@
        x="77.567307"
        y="972.91711"
        id="use1505"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD762x\ad7960_block_diagram.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36"
        transform="scale(1.0865021,0.92038479)"><tspan
@@ -1956,14 +1956,14 @@
        id="use1517"
        inkscape:connector-curvature="0"
        sodipodi:nodetypes="cc"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD762x\ad7960_block_diagram.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36" />
     <g
        style="display:inline;stroke-width:0.858876;shape-rendering:crispEdges;enable-background:new"
        id="use1519"
        transform="matrix(1.723039,0,0,1.5883337,-803.56673,-374.73699)"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD762x\ad7960_block_diagram.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36">
       <rect
@@ -2077,7 +2077,7 @@
        width="100%"
        height="100%"
        transform="translate(6.033e-5)"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD762x\ad7960_block_diagram.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36" />
     <use
@@ -2089,14 +2089,14 @@
        width="100%"
        height="100%"
        transform="translate(6.033e-5)"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD762x\ad7960_block_diagram.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36" />
     <g
        id="use1525"
        style="display:inline;stroke-width:0.841182;shape-rendering:crispEdges;enable-background:new"
        transform="matrix(2.490919,0,0,2.1197426,-1140.4833,-725.63285)"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD762x\ad7960_block_diagram.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36">
       <g
@@ -2173,7 +2173,7 @@
        y="760.92261"
        id="use1527"
        transform="scale(1.0902764,0.91719861)"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD762x\ad7960_block_diagram.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36"><tspan
          sodipodi:role="line"
@@ -2188,7 +2188,7 @@
        y="759.1181"
        id="use1527-3"
        transform="scale(1.0807618,0.92527326)"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD762x\ad7960_block_diagram.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36"><tspan
          sodipodi:role="line"
@@ -2201,7 +2201,7 @@
        d="m -32.487834,950.41121 v 40.76732 c 16.3104,-0.8803 34.2289303,-5.9317 34.4083803,-19.7261 0.18234,-14.00862 -15.4621103,-21.02742 -34.4083803,-21.04122 z"
        id="use1537"
        sodipodi:nodetypes="ccac"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD762x\ad7960_block_diagram.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36" />
     <path
@@ -2210,7 +2210,7 @@
        id="use1539-1"
        inkscape:connector-curvature="0"
        sodipodi:nodetypes="cc"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD762x\ad7960_block_diagram.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36" />
     <path
@@ -2219,7 +2219,7 @@
        id="use1539-1-72"
        inkscape:connector-curvature="0"
        sodipodi:nodetypes="cc"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD762x\ad7960_block_diagram.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36" />
     <path
@@ -2228,7 +2228,7 @@
        id="use1539-1-72-2"
        inkscape:connector-curvature="0"
        sodipodi:nodetypes="cc"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD762x\ad7960_block_diagram.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36" />
     <path
@@ -2237,7 +2237,7 @@
        id="use1539-1-72-2-5"
        inkscape:connector-curvature="0"
        sodipodi:nodetypes="cc"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD762x\ad7960_block_diagram.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36" />
     <path
@@ -2246,7 +2246,7 @@
        id="use1539-1-7"
        inkscape:connector-curvature="0"
        sodipodi:nodetypes="cc"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD762x\ad7960_block_diagram.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36" />
     <path
@@ -2255,7 +2255,7 @@
        id="use1539-1-5"
        inkscape:connector-curvature="0"
        sodipodi:nodetypes="cc"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD762x\ad7960_block_diagram.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36" />
     <path
@@ -2264,7 +2264,7 @@
        id="path1206-9-8"
        d="M 215.4315,676.93349 H 64.012235"
        style="display:inline;fill:none;stroke:#000000;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#marker1216-9-8);shape-rendering:crispEdges;enable-background:new"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD762x\ad7960_block_diagram.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36" />
     <rect
@@ -2276,7 +2276,7 @@
        style="display:inline;vector-effect:none;fill:#ffcccc;fill-opacity:1;fill-rule:nonzero;stroke:#a01414;stroke-width:0.852662;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;shape-rendering:crispEdges;enable-background:new"
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD762x\ad7960_block_diagram.png" />
+ />
     <text
        transform="matrix(0,-0.92038479,1.0865021,0,0,0)"
        id="use1471"
@@ -2286,7 +2286,7 @@
        xml:space="preserve"
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD762x\ad7960_block_diagram.png"><tspan
+><tspan
          style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:24.8865px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial Bold';fill:#28170b;stroke:none;stroke-width:1px;stroke-opacity:1"
          y="-331.76257"
          x="-777.62524"
@@ -2299,7 +2299,7 @@
        cy="914.27716"
        rx="3.3295474"
        ry="3.251775"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD762x\ad7960_block_diagram.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36" />
     <path
@@ -2308,7 +2308,7 @@
        id="use1501-5-0"
        inkscape:connector-curvature="0"
        sodipodi:nodetypes="cc"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD762x\ad7960_block_diagram.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36" />
     <path
@@ -2317,7 +2317,7 @@
        id="use1501-8"
        inkscape:connector-curvature="0"
        sodipodi:nodetypes="cc"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD762x\ad7960_block_diagram.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36" />
     <path
@@ -2338,7 +2338,7 @@
        inkscape:transform-center-x="-9.2284841"
        inkscape:transform-center-y="0.25764112"
        d="m 1321.5825,846.40682 -31.3012,-18.69776 -31.3013,-18.69777 31.8434,-17.7588 31.8433,-17.7588 -0.5421,36.45657 z"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD762x\ad7960_block_diagram.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36" />
     <text
@@ -2347,7 +2347,7 @@
        x="78.355026"
        y="1042.4747"
        id="use1505-8"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD762x\ad7960_block_diagram.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36"
        transform="scale(1.0865021,0.92038479)"><tspan
@@ -2363,7 +2363,7 @@
        cy="978.29694"
        rx="3.3295474"
        ry="3.251775"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD762x\ad7960_block_diagram.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36" />
     <rect
@@ -2376,14 +2376,14 @@
        height="193.85277"
        x="-969.28571"
        y="-298.34576"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD762x\ad7960_block_diagram.png" />
+ />
     <text
        xml:space="preserve"
        style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:11.3767px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1;shape-rendering:crispEdges;enable-background:new"
        x="-140.71672"
        y="988.16522"
        id="text2401-1-7-3-9-9-8-2"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD762x\ad7960_block_diagram.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36"
        transform="scale(1.0865021,0.92038479)"><tspan
@@ -2403,7 +2403,7 @@
        x="-139.63338"
        y="1041.292"
        id="text2401-1-7-3-9-9-8-2-60"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD762x\ad7960_block_diagram.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36"
        transform="scale(1.0865021,0.92038479)"><tspan
@@ -2419,7 +2419,7 @@
        y="901.9021"
        id="text4964-9-0-2-5"
        transform="scale(0.96611964,1.0350685)"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD762x\ad7960_block_diagram.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36"><tspan
          sodipodi:role="line"
@@ -2437,7 +2437,7 @@
        height="193.85277"
        x="-969.28571"
        y="-584.2135"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD762x\ad7960_block_diagram.png" />
+ />
     <text
        xml:space="preserve"
        style="font-style:normal;font-weight:normal;font-size:16.093px;line-height:0%;font-family:Arial;letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1.00699px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;shape-rendering:crispEdges;enable-background:new"
@@ -2445,7 +2445,7 @@
        y="898.59241"
        id="text4964-9-0-2-5-4"
        transform="scale(0.96611964,1.0350685)"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD762x\ad7960_block_diagram.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36"><tspan
          sodipodi:role="line"
@@ -2459,7 +2459,7 @@
        x="-394.65787"
        y="1006.6296"
        id="text2401-1-7-3-9-9-8-2-5"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD762x\ad7960_block_diagram.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36"
        transform="scale(1.0865021,0.92038479)"><tspan
@@ -2479,7 +2479,7 @@
        x="-360.28079"
        y="1000.3776"
        id="text2401-1-7-3-9-9-8-2-5-8"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD762x\ad7960_block_diagram.png"
+
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36"
        transform="scale(1.0865021,0.92038479)"><tspan
@@ -2497,7 +2497,7 @@
        y="543.96466"
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD762x\ad7960_block_diagram.png" />
+ />
     <text
        xml:space="preserve"
        style="font-style:normal;font-weight:normal;font-size:17.0649px;line-height:0%;font-family:Arial;letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;shape-rendering:crispEdges;enable-background:new"
@@ -2507,7 +2507,7 @@
        transform="matrix(0,-0.92038479,1.0865021,0,0,0)"
        inkscape:export-xdpi="224.36"
        inkscape:export-ydpi="224.36"
-       inkscape:export-filename="C:\Users\PPop\OneDrive - Analog Devices, Inc\Documents\AD762x\ad7960_block_diagram.png"><tspan
+><tspan
          sodipodi:role="line"
          id="tspan4493"
          x="-964.02057"


### PR DESCRIPTION
## PR Description

Inkscape saves the export path information, and this needs to be removed.

## PR Type
- [ ] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)
- [x] Documentation

## PR Checklist
- [ ] I have followed the code style guidelines
- [x] I have performed a self-review of changes
- [ ] I have compiled all hdl projects and libraries affected by this PR
- [ ] I have tested in hardware affected projects, at least on relevant boards
- [ ] I have commented my code, at least hard-to-understand parts
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe files, Copyright etc)
- [x] I have not introduced new Warnings/Critical Warnings on compilation
- [ ] I have added new hdl testbenches or updated existing ones
