### PR TITLE
adrv9001_dual/zcu102: Fix critical warnings; clean code

### DIFF
--- a/projects/adrv9001_dual/common/adrv9001_dual_bd.tcl
+++ b/projects/adrv9001_dual/common/adrv9001_dual_bd.tcl
@@ -95,7 +95,6 @@ create_bd_port -dir I adrv2_gpio_tx2_enable_in
 create_bd_port -dir I adrv1_ref_clk
 create_bd_port -dir I tx_output_enable
 create_bd_port -dir I mssi_sync
-create_bd_port -dir I adrv1_fpga_mcs_in
 
 set USE_RX_CLK_FOR_TX1 $ad_project_params(USE_RX_CLK_FOR_TX1)
 set USE_RX_CLK_FOR_TX2 $ad_project_params(USE_RX_CLK_FOR_TX2)
@@ -317,6 +316,7 @@ ad_connect  adrv1_tx1_enable                axi_adrv9001_1/tx1_enable
 ad_connect  adrv1_tx2_enable                axi_adrv9001_1/tx2_enable
 
 ad_connect  GND                             axi_adrv9001_1/tdd_sync
+ad_connect  GND                             axi_adrv9001_1/mcs_in
 
 ###############################################################################
 # adrv2
@@ -535,6 +535,7 @@ ad_connect  adrv2_tx1_enable                axi_adrv9001_2/tx1_enable
 ad_connect  adrv2_tx2_enable                axi_adrv9001_2/tx2_enable
 
 ad_connect  GND                             axi_adrv9001_2/tdd_sync
+ad_connect  GND                             axi_adrv9001_2/mcs_in
 
 ad_cpu_interconnect 0x44A00000  axi_adrv9001_1
 ad_cpu_interconnect 0x44A30000  axi_adrv9001_1_rx1_dma

--- a/projects/adrv9001_dual/zcu102/cmos_constr.xdc
+++ b/projects/adrv9001_dual/zcu102/cmos_constr.xdc
@@ -89,7 +89,7 @@ set_property  -dict {PACKAGE_PIN AH12   IOSTANDARD LVCMOS18}  [get_ports adrv2_t
 
 # clocks
 
-create_clock -name adrv1_ref_clk  -period  25.00 [get_ports fpga_ref_clk_p]
+create_clock -name adrv1_ref_clk  -period  25.00 [get_ports adrv1_fpga_ref_clk_p]
 
 create_clock -name adrv1_rx1_dclk_out   -period  12.5 [get_ports adrv1_rx1_dclk_out_p]
 create_clock -name adrv1_rx2_dclk_out   -period  12.5 [get_ports adrv1_rx2_dclk_out_p]

--- a/projects/adrv9001_dual/zcu102/lvds_constr.xdc
+++ b/projects/adrv9001_dual/zcu102/lvds_constr.xdc
@@ -89,7 +89,7 @@ set_property  -dict {PACKAGE_PIN AH12   IOSTANDARD LVDS}                        
 
 # clocks
 
-create_clock -name adrv1_ref_clk       -period  8.00 [get_ports fpga_ref_clk_p]
+create_clock -name adrv1_ref_clk       -period  8.00 [get_ports adrv1_fpga_ref_clk_p]
 
 create_clock -name adrv1_rx1_dclk_in   -period  2.034 [get_ports adrv1_rx1_dclk_out_p]
 create_clock -name adrv1_rx2_dclk_in   -period  2.034 [get_ports adrv1_rx2_dclk_out_p]
@@ -134,26 +134,6 @@ set_property CLOCK_DELAY_GROUP BALANCE_CLOCKS_3 \
 set_property CLOCK_DELAY_GROUP BALANCE_CLOCKS_4 \
   [list [get_nets -of [get_pins i_system_wrapper/system_i/axi_adrv9001_2/inst/i_if/i_rx_2_phy/i_div_clk_buf/O]] \
         [get_nets -of [get_pins i_system_wrapper/system_i/axi_adrv9001_2/inst/i_if/i_rx_2_phy/i_clk_buf_fast/O]] \
-  ]
-
-set_property CLOCK_DELAY_GROUP BALANCE_CLOCKS_5 \
-  [list [get_nets -of [get_pins i_system_wrapper/system_i/axi_adrv9001_1/inst/i_if/i_tx_1_phy/i_div_clk_buf/O]] \
-        [get_nets -of [get_pins i_system_wrapper/system_i/axi_adrv9001_1/inst/i_if/i_tx_1_phy/i_clk_buf_fast/O]] \
-  ]
-
-set_property CLOCK_DELAY_GROUP BALANCE_CLOCKS_6 \
-  [list [get_nets -of [get_pins i_system_wrapper/system_i/axi_adrv9001_1/inst/i_if/i_tx_2_phy/i_div_clk_buf/O]] \
-        [get_nets -of [get_pins i_system_wrapper/system_i/axi_adrv9001_1/inst/i_if/i_tx_2_phy/i_clk_buf_fast/O]] \
-  ]
-
-set_property CLOCK_DELAY_GROUP BALANCE_CLOCKS_7 \
-  [list [get_nets -of [get_pins i_system_wrapper/system_i/axi_adrv9001_2/inst/i_if/i_tx_1_phy/i_div_clk_buf/O]] \
-        [get_nets -of [get_pins i_system_wrapper/system_i/axi_adrv9001_2/inst/i_if/i_tx_1_phy/i_clk_buf_fast/O]] \
-  ]
-
-set_property CLOCK_DELAY_GROUP BALANCE_CLOCKS_8 \
-  [list [get_nets -of [get_pins i_system_wrapper/system_i/axi_adrv9001_2/inst/i_if/i_tx_2_phy/i_div_clk_buf/O]] \
-        [get_nets -of [get_pins i_system_wrapper/system_i/axi_adrv9001_2/inst/i_if/i_tx_2_phy/i_clk_buf_fast/O]] \
   ]
 
 set_property UNAVAILABLE_DURING_CALIBRATION TRUE [get_ports adrv1_tx1_strobe_in_p]

--- a/projects/adrv9001_dual/zcu102/system_constr.xdc
+++ b/projects/adrv9001_dual/zcu102/system_constr.xdc
@@ -22,8 +22,6 @@ set_property  -dict {PACKAGE_PIN T6    IOSTANDARD LVCMOS18}  [get_ports adrv1_dg
 set_property  -dict {PACKAGE_PIN AB6   IOSTANDARD LVCMOS18}  [get_ports adrv1_dgpio_10]                          ; #FMC_HPC0_LA11_P      IO_L10P_T1U_N6_QBC_AD4P_66
 set_property  -dict {PACKAGE_PIN L10   IOSTANDARD LVCMOS18}  [get_ports adrv1_dgpio_11]                          ; #FMC_HPC0_LA27_N      IO_L15N_T2L_N5_AD11N_67
 
-set_property  -dict {PACKAGE_PIN T11   IOSTANDARD LVDS DIFF_TERM_ADV TERM_100}  [get_ports adrv1_fpga_mcs_in_n]  ; #FMC_HPC0_LA32_N      IO_L6N_T0U_N11_AD6N_67
-set_property  -dict {PACKAGE_PIN U11   IOSTANDARD LVDS DIFF_TERM_ADV TERM_100}  [get_ports adrv1_fpga_mcs_in_p]  ; #FMC_HPC0_LA32_P      IO_L6P_T0U_N10_AD6P_67
 set_property  -dict {PACKAGE_PIN R8    IOSTANDARD LVDS DIFF_TERM_ADV TERM_100}  [get_ports adrv1_fpga_ref_clk_n] ; #FMC_HPC0_CLK1_M2C_N  IO_L12N_T1U_N11_GC_67
 set_property  -dict {PACKAGE_PIN T8    IOSTANDARD LVDS DIFF_TERM_ADV TERM_100}  [get_ports adrv1_fpga_ref_clk_p] ; #FMC_HPC0_CLK1_M2C_P  IO_L12P_T1U_N10_GC_67
 

--- a/projects/adrv9001_dual/zcu102/system_top.v
+++ b/projects/adrv9001_dual/zcu102/system_top.v
@@ -87,8 +87,6 @@ module system_top (
   output                  adrv1_platform_status,
 
 
-  input                   adrv1_fpga_mcs_in_n,
-  input                   adrv1_fpga_mcs_in_p,
   output                  adrv1_dev_mcs_fpga_out_n,
   output                  adrv1_dev_mcs_fpga_out_p,
   output                  adrv2_dev_mcs_fpga_out_n,
@@ -212,7 +210,6 @@ module system_top (
 
   wire                    adrv1_fpga_ref_clk;
   wire                    adrv2_fpga_ref_clk;
-  wire                    adrv1_fpga_mcs_in;
   wire                    tdd_sync_loc;
   wire                    tdd_sync_i;
   wire                    tdd_sync_cntr;
@@ -228,11 +225,6 @@ module system_top (
     .I (adrv2_fpga_ref_clk_p),
     .IB (adrv2_fpga_ref_clk_n),
     .O (adrv2_fpga_ref_clk));
-
-  IBUFDS i_ibufgs_fpga_mcs_in (
-    .I (adrv1_fpga_mcs_in_p),
-    .IB (adrv1_fpga_mcs_in_n),
-    .O (adrv1_fpga_mcs_in));
 
   OBUFDS i_obufds_adrv1_dev_mcs_fpga_in (
     .I (adrv1_dev_mcs_fpga_in),
@@ -330,7 +322,6 @@ module system_top (
 
   system_wrapper i_system_wrapper (
     .adrv1_ref_clk (adrv1_fpga_ref_clk),
-    .adrv1_fpga_mcs_in (adrv1_fpga_mcs_in),
     .mssi_sync (mssi_sync),
 
     .tx_output_enable (1'b1),


### PR DESCRIPTION
# ADRV9001 Dual ZCU102 Build Issues

Analysis of critical warnings from `adrv9001_zcu102_vivado.log` (build date: 2026-01-16).

## Build Status

- **Result**: SUCCESS (bitstream generated)
- **Timing**: MET (WNS = 0.322 ns)
- **Final stats**: 210 Infos, 2 Warnings, 0 Critical Warnings, 0 Errors

## Critical Warnings Found

### 1. Unconnected MCS Input Pins [FIXED]

**Warning**: `[BD 41-759]`
```
The input pins (listed below) are either not connected or do not have a source port:
/axi_adrv9001_1/mcs_in
/axi_adrv9001_2/mcs_in
```

**Location**: `common/adrv9001_dual_bd.tcl`

**Fix applied**: Connected both `mcs_in` pins to GND:
```tcl
ad_connect  GND  axi_adrv9001_1/mcs_in  # line 320
ad_connect  GND  axi_adrv9001_2/mcs_in  # line 539
```

### 2. Wrong Clock Port Name [FIXED]

**Warning**: `[Vivado 12-4739]`
```
create_clock: No valid object(s) found for '-objects [get_ports fpga_ref_clk_p]'
```

**Location**: `zcu102/lvds_constr.xdc:92` and `zcu102/cmos_constr.xdc:92`

**Cause**: The constraint uses `fpga_ref_clk_p` but the actual port name is `adrv1_fpga_ref_clk_p`.

**Fix applied**:
```tcl
# From:
create_clock -name adrv1_ref_clk -period 8.00 [get_ports fpga_ref_clk_p]
# To:
create_clock -name adrv1_ref_clk -period 8.00 [get_ports adrv1_fpga_ref_clk_p]
```

### 3. TX PHY Clock Buffer Constraints Invalid [FIXED]

**Warning**: `[Common 17-55]`
```
'set_property' expects at least one object.
```

**Locations**:
- `zcu102/lvds_constr.xdc:139` - BALANCE_CLOCKS_5 (adrv1 TX1)
- `zcu102/lvds_constr.xdc:144` - BALANCE_CLOCKS_6 (adrv1 TX2)
- `zcu102/lvds_constr.xdc:149` - BALANCE_CLOCKS_7 (adrv2 TX1)
- `zcu102/lvds_constr.xdc:154` - BALANCE_CLOCKS_8 (adrv2 TX2)

**Cause**: These constraints use incorrect buffer instance names. The buffers `i_div_clk_buf` and `i_clk_buf_fast` only exist in the **RX PHY** (`adrv9001_rx.v`), not in the TX PHY. The TX PHY uses different buffer names (`i_dac_clk_in_gbuf`).

| Buffer Name | RX PHY | TX PHY |
|-------------|--------|--------|
| `i_clk_buf_fast` | Exists | Does NOT exist |
| `i_div_clk_buf` | Exists | Does NOT exist |
| `i_dac_clk_in_gbuf` | - | Exists |

**Fix applied**: Removed BALANCE_CLOCKS_5 through BALANCE_CLOCKS_8 from `lvds_constr.xdc`. The single ADRV9001 project does not include these TX PHY constraints.

### 4. Registers Without Clocks [RESOLVED]

**Warning**: Post-implementation check
```
CRITICAL WARNING: There are 624 registers with no clocks !!! See no_clock.log for details.
```

**Location**: Generated during timing analysis

**Cause**: Missing `adrv1_ref_clk` clock definition due to wrong port name in constraint (issue #2).

**Status**: Resolved after clock constraint fix. New build (2026-01-16 11:37-12:11) shows **0 Critical Warnings** and no registers without clocks.

## Cleanup [DONE]

Removed unused `adrv1_fpga_mcs_in` port (was intended for MCS but now tied to GND internally):

- `common/adrv9001_dual_bd.tcl` - Removed `create_bd_port -dir I adrv1_fpga_mcs_in`
- `zcu102/system_top.v` - Removed input ports, wire, IBUFDS instance, and wrapper connection
- `zcu102/system_constr.xdc` - Removed pin constraints for `adrv1_fpga_mcs_in_n/p`

## PR Type
- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)
- [ ] Documentation

## PR Checklist
- [x] I have followed the code style guidelines
- [x] I have performed a self-review of changes
- [x] I have compiled all hdl projects and libraries affected by this PR
- [ ] I have tested in hardware affected projects, at least on relevant boards
- [ ] I have commented my code, at least hard-to-understand parts
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe files, Copyright etc)
- [x] I have not introduced new Warnings/Critical Warnings on compilation
- [ ] I have added new hdl testbenches or updated existing ones
