### PR TITLE
lib:corundum:ethernet:k26: Correct width mismatches

### DIFF
--- a/library/corundum/ethernet/k26/ethernet_k26.v
+++ b/library/corundum/ethernet/k26/ethernet_k26.v
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BSD-2-Clause-Views
 /*
  * Copyright (c) 2023 The Regents of the University of California
- * Copyright (c) 2025 Analog Devices, Inc. All rights reserved
+ * Copyright (c) 2025-2026 Analog Devices, Inc. All rights reserved
  */
 /*
  * This file repackages Corundum MQNIC Core AXI with the sole purpose of
@@ -29,7 +29,8 @@ module ethernet_k26 #(
   parameter PTP_TS_ENABLE = 1,
   parameter PTP_TS_FMT_TOD = 1,
   parameter PTP_TS_WIDTH = PTP_TS_FMT_TOD ? 96 : 64,
-  parameter TX_TAG_WIDTH = 16,
+  // log2(TX_DESC_TABLE_SIZE - 32) + 1 = 6
+  parameter TX_TAG_WIDTH = 6,
   parameter PFC_ENABLE = 1,
   parameter LFC_ENABLE = PFC_ENABLE,
   parameter ENABLE_PADDING = 1,
@@ -171,7 +172,7 @@ module ethernet_k26 #(
   input  wire [PORT_COUNT-1:0]                     eth_tx_lfc_req,
   input  wire [PORT_COUNT*8-1:0]                   eth_tx_pfc_en,
   input  wire [PORT_COUNT*8-1:0]                   eth_tx_pfc_req,
-  output wire [PORT_COUNT*8-1:0]                   eth_tx_fc_quanta_clk_en,
+  output wire [PORT_COUNT-1:0]                     eth_tx_fc_quanta_clk_en,
 
   output wire [PORT_COUNT*AXIS_DATA_WIDTH-1:0]     axis_eth_rx_tdata,
   output wire [PORT_COUNT*AXIS_KEEP_WIDTH-1:0]     axis_eth_rx_tkeep,


### PR DESCRIPTION
## PR Description

lib:corundum:ethernet:k26: Correct width mismatches

## PR Type
- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)
- [ ] Documentation

## PR Checklist
- [x] I have followed the code style guidelines
- [x] I have performed a self-review of changes
- [ ] I have compiled all hdl projects and libraries affected by this PR
- [ ] I have tested in hardware affected projects, at least on relevant boards
- [ ] I have commented my code, at least hard-to-understand parts
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe files, Copyright etc)
- [x] I have not introduced new Warnings/Critical Warnings on compilation
- [ ] I have added new hdl testbenches or updated existing ones
