### PR TITLE
axi_ad485x: Fix extra brace

### DIFF
--- a/library/axi_ad485x/axi_ad485x_constr.ttcl
+++ b/library/axi_ad485x/axi_ad485x_constr.ttcl
@@ -14,7 +14,7 @@ set up_clk [get_clocks -of_objects [get_ports s_axi_aclk]]
 
 set_false_path -quiet \
         -from $up_clk \
-        -to [get_cells -quiet -hier -filter {name =~ *i_adc_channel/pattern_reg*}}]
+        -to [get_cells -quiet -hier -filter {name =~ *i_adc_channel/pattern_reg*}]
 
 <: if { $lvds_cmos_n } { :>
 


### PR DESCRIPTION
Fixing a critical warning generated by an extra brace in the ip constraints file (ttcl)

## PR Type
- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)
- [ ] Documentation

## PR Checklist
- [x] I have followed the code style guidelines
- [x] I have performed a self-review of changes
- [x] I have compiled all hdl projects and libraries affected by this PR
- [ ] I have tested in hardware affected projects, at least on relevant boards
- [ ] I have commented my code, at least hard-to-understand parts
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe files, Copyright etc)
- [x] I have not introduced new Warnings/Critical Warnings on compilation
- [ ] I have added new hdl testbenches or updated existing ones
