### PR TITLE
library/axi_ad485x: Fix simulation issues

### DIFF
--- a/library/axi_ad485x/axi_ad485x.v
+++ b/library/axi_ad485x/axi_ad485x.v
@@ -1,6 +1,6 @@
 // ***************************************************************************
 // ***************************************************************************
-// Copyright (C) 2023-2025 Analog Devices, Inc. All rights reserved.
+// Copyright (C) 2023-2026 Analog Devices, Inc. All rights reserved.
 //
 // In this HDL repository, there are many different and unique modules, consisting
 // of various HDL (Verilog or VHDL) components. The individual modules are
@@ -158,15 +158,14 @@ module axi_ad485x #(
 
   localparam  [ 0:0]     READ_RAW = 1'b1;
   localparam             CONFIG = {18'd0, READ_RAW, 5'd0, ~LVDS_CMOS_N[0], 7'd0};
-  localparam  [ 7:0]     ACTIVE_LANES = {
-                         LANE_7_ENABLE == 1 ? 1'b1 : 1'b0,
-                         LANE_6_ENABLE == 1 ? 1'b1 : 1'b0,
-                         LANE_5_ENABLE == 1 ? 1'b1 : 1'b0,
-                         LANE_4_ENABLE == 1 ? 1'b1 : 1'b0,
-                         LANE_3_ENABLE == 1 ? 1'b1 : 1'b0,
-                         LANE_2_ENABLE == 1 ? 1'b1 : 1'b0,
-                         LANE_1_ENABLE == 1 ? 1'b1 : 1'b0,
-                         LANE_0_ENABLE == 1 ? 1'b1 : 1'b0};
+  localparam  [ 7:0]     ACTIVE_LANES = {LANE_7_ENABLE == 1 ? 1'b1 : 1'b0,
+                                         LANE_6_ENABLE == 1 ? 1'b1 : 1'b0,
+                                         LANE_5_ENABLE == 1 ? 1'b1 : 1'b0,
+                                         LANE_4_ENABLE == 1 ? 1'b1 : 1'b0,
+                                         LANE_3_ENABLE == 1 ? 1'b1 : 1'b0,
+                                         LANE_2_ENABLE == 1 ? 1'b1 : 1'b0,
+                                         LANE_1_ENABLE == 1 ? 1'b1 : 1'b0,
+                                         LANE_0_ENABLE == 1 ? 1'b1 : 1'b0};
 
   // internal registers
 
@@ -499,6 +498,13 @@ module axi_ad485x #(
       end else begin
         assign adc_data_s[i] = 'd0;
         assign adc_enable_s[i] = 'd0;
+        assign up_rack_s[i] = 'd0;
+        assign up_rdata_s[i] = 'd0;
+        assign up_wack_s[i] = 'd0;
+        assign up_adc_or_s[i] = 'd0;
+        assign up_adc_pn_oos[i] = 'd0;
+        assign up_adc_pn_err[i] = 'd0;
+
       end
     end
   endgenerate

--- a/library/axi_ad485x/axi_ad485x_16b_channel.v
+++ b/library/axi_ad485x/axi_ad485x_16b_channel.v
@@ -1,6 +1,6 @@
 // ***************************************************************************
 // ***************************************************************************
-// Copyright (C) 2024 Analog Devices, Inc. All rights reserved.
+// Copyright (C) 2024, 2026 Analog Devices, Inc. All rights reserved.
 //
 // In this HDL repository, there are many different and unique modules, consisting
 // of various HDL (Verilog or VHDL) components. The individual modules are
@@ -138,7 +138,7 @@ module axi_ad485x_16b_channel #(
         adc_status_header <= 7'd0;
         pattern <= {16'd0, adc_ch_data_in[15:0]};
       end
-      3'h1: begin // packet format 24 - oversampling off
+      default: begin // packet format 24 - oversampling off
         adc_raw_data <= {16'd0,adc_ch_data_in[23:8]};
         adc_or <= adc_ch_data_in[7];
         adc_status_header <= adc_ch_data_in[6:0];

--- a/library/axi_ad485x/axi_ad485x_ip.tcl
+++ b/library/axi_ad485x/axi_ad485x_ip.tcl
@@ -1,5 +1,5 @@
 ###############################################################################
-## Copyright (C) 2023-2025 Analog Devices, Inc. All rights reserved.
+## Copyright (C) 2023-2026 Analog Devices, Inc. All rights reserved.
 ### SPDX short identifier: ADIBSD
 ###############################################################################
 
@@ -96,6 +96,13 @@ for {set i 0} {$i < 8} {incr i} {
   set_property value true [ipx::get_hdl_parameters LANE_${i}_ENABLE -of_objects $cc]
 
   if { $i >= 4 } {
+    set_property value_tcl_expr {expr {[info exists LVDS_CMOS_N] && [info exists DEVICE] ? \
+                                                  $LVDS_CMOS_N == 1 ? 0 : \
+                                                  $DEVICE == {AD4854} ? 0 : \
+                                                  $DEVICE == {AD4853} ? 0 : \
+                                                  $DEVICE == {AD4852} ? 0 : \
+                                                  $DEVICE == {AD4851} ? 0 : 1 : 0}
+    } [ipx::get_user_parameters LANE_${i}_ENABLE -of_objects $cc]
     set_property enablement_tcl_expr {expr {$LVDS_CMOS_N == 1 ? 0 : \
                                                   $DEVICE == {AD4854} ? 0 : \
                                                   $DEVICE == {AD4853} ? 0 : \
@@ -103,6 +110,8 @@ for {set i 0} {$i < 8} {incr i} {
                                                   $DEVICE == {AD4851} ? 0 : 1}
     } [ipx::get_user_parameters LANE_${i}_ENABLE -of_objects $cc]
   } else {
+    set_property value_tcl_expr {expr {[info exists LVDS_CMOS_N] ? $LVDS_CMOS_N == 0 : 0}
+    } [ipx::get_user_parameters LANE_${i}_ENABLE -of_objects $cc]
     set_property enablement_tcl_expr {expr $LVDS_CMOS_N == 0
     } [ipx::get_user_parameters LANE_${i}_ENABLE -of_objects $cc]
   }

--- a/library/axi_ad485x/axi_ad485x_lvds.v
+++ b/library/axi_ad485x/axi_ad485x_lvds.v
@@ -1,6 +1,6 @@
 // ***************************************************************************
 // ***************************************************************************
-// Copyright (C) 2023-2024 Analog Devices, Inc. All rights reserved.
+// Copyright (C) 2023-2024, 2026 Analog Devices, Inc. All rights reserved.
 //
 // In this HDL repository, there are many different and unique modules, consisting
 // of various HDL (Verilog or VHDL) components. The individual modules are
@@ -96,69 +96,69 @@ module axi_ad485x_lvds #(
 
   // internal registers
 
-  reg        [  1:0]  packet_format;
-  reg        [  5:0]  packet_cnt_length;
-  reg        [ 15:0]  crc_data_length;
+  reg        [  1:0]  packet_format = 'h0;
+  reg        [  5:0]  packet_cnt_length = 'h0;
+  reg        [ 15:0]  crc_data_length = 'h0;
 
-  reg        [HBW:0]  rx_data_pos;
-  reg        [HBW:0]  rx_data_neg;
+  reg        [HBW:0]  rx_data_pos = 'h0;
+  reg        [HBW:0]  rx_data_neg = 'h0;
 
   reg        [  5:0]  data_counter = 'h0;
   reg        [  3:0]  ch_counter = 'h0;
 
-  reg                 busy_m1;
-  reg                 busy_m2;
-  reg                 cnvs_d;
-  reg        [ 31:0]  period_cnt;
+  reg                 busy_m1 = 'h0;
+  reg                 busy_m2 = 'h0;
+  reg                 cnvs_d = 'h0;
+  reg        [ 31:0]  period_cnt = 'h0;
 
-  reg                 conversion_quiet_time;
-  reg                 run_busy_period_cnt;
-  reg        [ 31:0]  busy_conversion_cnt;
-  reg        [ 31:0]  busy_measure_value;
-  reg        [ 31:0]  busy_measure_value_plus;
+  reg                 conversion_quiet_time = 'h0;
+  reg                 run_busy_period_cnt = 'h0;
+  reg        [ 31:0]  busy_conversion_cnt = 'h0;
+  reg        [ 31:0]  busy_measure_value = 'h0;
+  reg        [ 31:0]  busy_measure_value_plus = 'h0;
 
-  reg        [FBW:0]  adc_data_store;
-  reg        [FBW:0]  adc_data_init;
-  reg                 aquire_data;
-  reg                 capture_complete_init;
-  reg                 capture_complete_d;
-  reg                 start_transfer;
-  reg                 start_transfer_d;
+  reg        [FBW:0]  adc_data_store = 'h0;
+  reg        [FBW:0]  adc_data_init = 'h0;
+  reg                 aquire_data = 'h0;
+  reg                 capture_complete_init = 'h0;
+  reg                 capture_complete_d = 'h0;
+  reg                 start_transfer = 'h0;
+  reg                 start_transfer_d = 'h0;
 
-  reg        [ 15:0]  dynamic_delay;
-  reg                 adc_valid_init;
-  reg                 adc_valid_init_d;
-  reg                 adc_valid_init_d2;
+  reg        [ 15:0]  dynamic_delay = 'h0;
+  reg                 adc_valid_init = 'h0;
+  reg                 adc_valid_init_d = 'h0;
+  reg                 adc_valid_init_d2 = 'h0;
 
-  reg        [ BW:0]  adc_data_0;
-  reg        [ BW:0]  adc_data_1;
-  reg        [ BW:0]  adc_data_2;
-  reg                 crc_enable_window;
-  reg                 run_crc;
-  reg                 run_crc_d;
-  reg        [FBW:0]  crc_data_in;
-  reg        [FBW:0]  crc_data_in_sh;
-  reg        [ 15:0]  crc_cnt;
-  reg        [  7:0]  data_in_byte;
+  reg        [ BW:0]  adc_data_0 = 'h0;
+  reg        [ BW:0]  adc_data_1 = 'h0;
+  reg        [ BW:0]  adc_data_2 = 'h0;
+  reg                 crc_enable_window = 'h0;
+  reg                 run_crc = 'h0;
+  reg                 run_crc_d = 'h0;
+  reg        [FBW:0]  crc_data_in = 'h0;
+  reg        [FBW:0]  crc_data_in_sh = 'h0;
+  reg        [ 15:0]  crc_cnt= 'h0;
+  reg        [  7:0]  data_in_byte = 'h0;
 
-  reg        [  3:0]  ch_7_index;
-  reg        [  3:0]  ch_6_index;
-  reg        [  3:0]  ch_5_index;
-  reg        [  3:0]  ch_4_index;
-  reg        [  3:0]  ch_3_index;
-  reg        [  3:0]  ch_2_index;
-  reg        [  3:0]  ch_1_index;
-  reg        [  3:0]  ch_0_index;
-  reg        [  8:0]  ch_7_base;
-  reg        [  8:0]  ch_6_base;
-  reg        [  8:0]  ch_5_base;
-  reg        [  8:0]  ch_4_base;
-  reg        [  8:0]  ch_3_base;
-  reg        [  8:0]  ch_2_base;
-  reg        [  8:0]  ch_1_base;
-  reg        [  8:0]  ch_0_base;
-  reg        [  3:0]  max_channel_transfer;
-  reg        [ 31:0]  device_status_store;
+  reg        [  3:0]  ch_7_index = 'h0;
+  reg        [  3:0]  ch_6_index = 'h0;
+  reg        [  3:0]  ch_5_index = 'h0;
+  reg        [  3:0]  ch_4_index = 'h0;
+  reg        [  3:0]  ch_3_index = 'h0;
+  reg        [  3:0]  ch_2_index = 'h0;
+  reg        [  3:0]  ch_1_index = 'h0;
+  reg        [  3:0]  ch_0_index = 'h0;
+  reg        [  8:0]  ch_7_base = 'h0;
+  reg        [  8:0]  ch_6_base = 'h0;
+  reg        [  8:0]  ch_5_base = 'h0;
+  reg        [  8:0]  ch_4_base = 'h0;
+  reg        [  8:0]  ch_3_base = 'h0;
+  reg        [  8:0]  ch_2_base = 'h0;
+  reg        [  8:0]  ch_1_base = 'h0;
+  reg        [  8:0]  ch_0_base = 'h0;
+  reg        [  3:0]  max_channel_transfer = 'h0;
+  reg        [ 31:0]  device_status_store = 'h0;
 
   // internal wires
 
@@ -301,10 +301,9 @@ module axi_ad485x_lvds #(
    // It is added to constraint the tool to keep the logic in the same region
    // as the input pins, otherwise the tool will automatically add a bufg and
    // meeting the timing margins is harder.
-   BUFH BUFH_inst (
-      .O(scko),
-      .I(scko_s)
-   );
+  BUFH BUFH_inst (
+    .O(scko),
+    .I(scko_s));
 
   // receive
 


### PR DESCRIPTION
## PR Description

Added default assignments for disabled channel signals to prevent X propagation. Initialized registers in LVDS interface module.                                                     Added `value_tcl_expr` for lane enable parameters in IP configuration. Used default case for packet format handling.

## PR Type
- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)
- [ ] Documentation

## PR Checklist
- [x] I have followed the code style guidelines
- [x] I have performed a self-review of changes
- [x] I have compiled all hdl projects and libraries affected by this PR
- [ ] I have tested in hardware affected projects, at least on relevant boards
- [ ] I have commented my code, at least hard-to-understand parts
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe files, Copyright etc)
- [ ] I have not introduced new Warnings/Critical Warnings on compilation
- [x] I have added new hdl testbenches or updated existing ones
