### PR TITLE
ad4052/common: fixup sdi_delay

### DIFF
--- a/projects/ad4052_ardz/common/ad4052_qsys.tcl
+++ b/projects/ad4052_ardz/common/ad4052_qsys.tcl
@@ -67,7 +67,7 @@ set async_spi_clk 1
 set num_cs 1
 set num_sdi 1
 set num_sdo 1
-set sdi_delay 0
+set sdi_delay 1
 set echo_sclk 0
 set sdo_streaming 0
 


### PR DESCRIPTION
Mismatch with the AMD Xilinx project, should be set to '1'.

## PR Description

Please replace this comment with summary, motivation and context of the changes.
List any dependencies required for this change.

You can check the checkboxes below by inserting a 'x' between square brackets
(without any other characters or spaces) or just check them after publishing the PR.

If there is a breaking change, specify dependent PRs in description and
try to push all related PRs at the same time.


## PR Type
- [ ] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)
- [ ] Documentation

## PR Checklist
- [ ] I have followed the code style guidelines
- [ ] I have performed a self-review of changes
- [ ] I have compiled all hdl projects and libraries affected by this PR
- [ ] I have tested in hardware affected projects, at least on relevant boards
- [ ] I have commented my code, at least hard-to-understand parts
- [ ] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe files, Copyright etc)
- [ ] I have not introduced new Warnings/Critical Warnings on compilation
- [ ] I have added new hdl testbenches or updated existing ones
