### PR TITLE
library/spi_engine: fix spi engine for SDI backpressure

### DIFF
--- a/library/spi_engine/spi_engine_execution/spi_engine_execution_shiftreg.v
+++ b/library/spi_engine/spi_engine_execution/spi_engine_execution_shiftreg.v
@@ -1,6 +1,6 @@
 // ***************************************************************************
 // ***************************************************************************
-// Copyright (C) 2025 Analog Devices, Inc. All rights reserved.
+// Copyright (C) 2025-2026 Analog Devices, Inc. All rights reserved.
 //
 // In this HDL repository, there are many different and unique modules, consisting
 // of various HDL (Verilog or VHDL) components. The individual modules are
@@ -150,6 +150,7 @@ module spi_engine_execution_shiftreg #(
   // interface.
 
   genvar i;
+
   // NOTE: SPI configuration (CPOL/PHA) is only hardware configurable at this point, unless ECHO_SCLK=0
   generate
   if (ECHO_SCLK == 1) begin : g_echo_sclk_miso_latch
@@ -244,9 +245,7 @@ module spi_engine_execution_shiftreg #(
     end
 
     always @(posedge clk) begin
-      if (cs_activate) begin
-        sdi_data_valid <= 1'b0;
-      end else if (sdi_enabled == 1'b1 && echo_last_bit) begin
+      if (sdi_enabled == 1'b1 && echo_last_bit) begin
         sdi_data_valid <= 1'b1;
       end else if (sdi_data_ready == 1'b1) begin
         sdi_data_valid <= 1'b0;


### PR DESCRIPTION
During the tests with the ADAQ4216, @machschmitt found some issues when enabling and disabling offload. After a couple of those enable/disable, the SDI data started to be scrambled and noisy.

The problem was related to the FSMs of the SPI Engine that were not considering the SDI data backpressure, which caused some data leakage from the offload to the FIFO mode. This PR fixes those issues.


## PR Type
- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)
- [ ] Documentation

## PR Checklist
- [x] I have followed the code style guidelines
- [x] I have performed a self-review of changes
- [x] I have compiled all hdl projects and libraries affected by this PR
- [x] I have tested in hardware affected projects, at least on relevant boards
- [x] I have commented my code, at least hard-to-understand parts
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe files, Copyright etc)
- [x] I have not introduced new Warnings/Critical Warnings on compilation
- [x] I have added new hdl testbenches or updated existing ones
