### PR TITLE
projects: fix missing OFFLOAD_EN

### DIFF
--- a/projects/ad469x_evb/common/ad469x_qsys.tcl
+++ b/projects/ad469x_evb/common/ad469x_qsys.tcl
@@ -69,6 +69,7 @@ set axi_reset        sys_clk.clk_reset
 set spi_clk          spi_clk_pll.outclk0
 set data_width       32
 set async_spi_clk    1
+set offload_en       1
 set num_cs           1
 set num_sdi          1
 set num_sdo          1
@@ -76,7 +77,7 @@ set sdi_delay        0
 set echo_sclk        0
 set sdo_streaming    0
 
-spi_engine_create $spi_engine_hier $axi_clk $axi_reset $spi_clk $data_width $async_spi_clk $num_cs $num_sdi $num_sdo $sdi_delay $echo_sclk $sdo_streaming
+spi_engine_create $spi_engine_hier $axi_clk $axi_reset $spi_clk $data_width $async_spi_clk $offload_en $num_cs $num_sdi $num_sdo $sdi_delay $echo_sclk $sdo_streaming
 set_instance_parameter_value ${spi_engine_hier}_offload {ASYNC_TRIG} {1}
 
 # exported interface

--- a/projects/ad5766_sdz/common/ad5766_bd.tcl
+++ b/projects/ad5766_sdz/common/ad5766_bd.tcl
@@ -25,7 +25,7 @@ current_bd_instance /spi
         ad_ip_instance spi_engine_interconnect interconnect
 
         ad_ip_parameter execution CONFIG.NUM_OF_CS 1
-        ad_ip_parameter axi CONFIG.NUM_OFFLOAD 1
+        ad_ip_parameter axi CONFIG.OFFLOAD_EN 1
         ad_ip_parameter interconnect CONFIG.NUM_OF_SDI 2
 
         ad_connect  axi/spi_engine_offload_ctrl0 axi_ad5766/spi_engine_offload_ctrl

--- a/projects/ad738x_fmc/common/ad738x_pb.tcl
+++ b/projects/ad738x_fmc/common/ad738x_pb.tcl
@@ -62,7 +62,7 @@ adi_ip_instance -vlnv {analog.com:ip:axi_spi0:1.0} \
     ASYNC_SPI_CLK:1,
     DATA_WIDTH:$DATA_WIDTH,
     MM_IF_TYPE:0,
-    NUM_OFFLOAD:1,
+    OFFLOAD_EN:1,
     NUM_OF_SDI:$NUM_OF_SDI
   }] \
   -ip_iname "axi_spi0_inst"


### PR DESCRIPTION
Projects AD5766 and AD738x instantiate spi
engine IPs without the OFFLOAD_EN variable.They
were using the previous NUM_OFFLOAD.

AD469x had a missing offload_en variable set.

This commit fixes those issues.


## PR Type
- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)
- [ ] Documentation

## PR Checklist
- [x] I have followed the code style guidelines
- [x] I have performed a self-review of changes
- [x] I have compiled all hdl projects and libraries affected by this PR
- [ ] I have tested in hardware affected projects, at least on relevant boards
- [ ] I have commented my code, at least hard-to-understand parts
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe files, Copyright etc)
- [x] I have not introduced new Warnings/Critical Warnings on compilation
- [ ] I have added new hdl testbenches or updated existing ones
