### PR TITLE
project-xilinx: Redirect Vivado temporary files to project directory

### DIFF
--- a/projects/scripts/project-xilinx.mk
+++ b/projects/scripts/project-xilinx.mk
@@ -19,7 +19,7 @@ ifdef CFG
     DIR_NAME := $(basename $(notdir $(CFG)))
 endif
 
-VIVADO := vivado -mode batch -source
+VIVADO := vivado -tempDir .Xil -mode batch -source
 
 # Parse the variables passed to make and convert them to the filename format
 ifeq ($(shell expr $(MAKELEVEL) % 2),0)
@@ -39,7 +39,7 @@ ifneq ($(strip $(DIR_NAME)), )
     $(shell test -d $(DIR_NAME) || mkdir $(DIR_NAME))
     ADI_PROJECT_DIR := $(DIR_NAME)/
     export ADI_PROJECT_DIR
-	VIVADO := vivado -log $(DIR_NAME)/vivado.log -journal $(DIR_NAME)/vivado.jou -mode batch -source
+	VIVADO := vivado -tempDir $(DIR_NAME)/.Xil -log $(DIR_NAME)/vivado.log -journal $(DIR_NAME)/vivado.jou -mode batch -source
 endif
 
 CLEAN_TARGET := *.cache


### PR DESCRIPTION
## PR Description

Add -tempDir flag to Vivado commands to keep temporary Xilinx files organized within the build directory instead of the default location. This will allow for a refactoring of the pipelines set up for this project.

## PR Type
- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)
- [ ] Documentation

## PR Checklist
- [x] I have followed the code style guidelines
- [x] I have performed a self-review of changes
- [ ] I have compiled all hdl projects and libraries affected by this PR
- [ ] I have tested in hardware affected projects, at least on relevant boards
- [ ] I have commented my code, at least hard-to-understand parts
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe files, Copyright etc)
- [ ] I have not introduced new Warnings/Critical Warnings on compilation
- [ ] I have added new hdl testbenches or updated existing ones
