### PR TITLE
docs:util_mii_to_rmii: Correct software support section

### DIFF
--- a/docs/library/util_mii_to_rmii/index.rst
+++ b/docs/library/util_mii_to_rmii/index.rst
@@ -130,7 +130,6 @@ Software Support
 
 Analog Devices recommends to use the provided software drivers.
 
-* Linux driver at :git-linux:`drivers/net/mii.c`
 * :dokuwiki:`Analog Devices ADIN1300/ADIN1200 PHY Linux Driver <resources/tools-software/linux-drivers/net-phy/adin>`
 
 References


### PR DESCRIPTION
Eliminate the exposed Linux kernel driver as the util_mii_to_rmii is not a SW-controllable FPGA IP (included in last commit).


## PR Type
- [ ] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)
- [x] Documentation

## PR Checklist
- [x] I have followed the code style guidelines
- [x] I have performed a self-review of changes
- [ ] I have compiled all hdl projects and libraries affected by this PR
- [ ] I have tested in hardware affected projects, at least on relevant boards
- [ ] I have commented my code, at least hard-to-understand parts
- [x] I have signed off all commits from this PR
- [x] I have updated the documentation (wiki pages, ReadMe files, Copyright etc)
- [ ] I have not introduced new Warnings/Critical Warnings on compilation
- [ ] I have added new hdl testbenches or updated existing ones
