### PR TITLE
CPACK/UPACK: Add pipeline support

### DIFF
--- a/library/util_pack/tb/cpack_32ch_tb.v
+++ b/library/util_pack/tb/cpack_32ch_tb.v
@@ -1,6 +1,6 @@
 // ***************************************************************************
 // ***************************************************************************
-// Copyright (C) 2018-2023, 2026 Analog Devices, Inc. All rights reserved.
+// Copyright (C) 2026 Analog Devices, Inc. All rights reserved.
 //
 // In this HDL repository, there are many different and unique modules, consisting
 // of various HDL (Verilog or VHDL) components. The individual modules are
@@ -34,30 +34,67 @@
 // ***************************************************************************
 
 `timescale 1ns/100ps
-
-module cpack_tb;
-  parameter VCD_FILE = {"cpack_tb.vcd"};
-  parameter NUM_OF_CHANNELS = 4;
+module cpack_32ch_tb;
+  parameter VCD_FILE = {"cpack_32ch_tb.vcd"};
+  parameter NUM_OF_CHANNELS = 32;
   parameter SAMPLES_PER_CHANNEL = 1;
   parameter ENABLE_RANDOM = 0;
-  parameter PIPELINE_STAGES = 0;
+  parameter PIPELINE_STAGES = 2;
 
-  `define TIMEOUT 3000000
+  `define TIMEOUT 10000000
   `include "tb_base.v"
 
   localparam NUM_OF_PORTS = SAMPLES_PER_CHANNEL * NUM_OF_CHANNELS;
 
   reg fifo_wr_en = 1'b1;
-  reg [NUM_OF_PORTS*8-1:0] fifo_wr_data = 'h00;
+  reg [NUM_OF_PORTS*16-1:0] fifo_wr_data = 'h00;
 
   wire packed_fifo_wr_en;
-  wire [NUM_OF_PORTS*8-1:0] packed_fifo_wr_data;
-  reg [NUM_OF_PORTS*8-1:0] expected_packed_fifo_wr_data;
+  wire [NUM_OF_PORTS*16-1:0] packed_fifo_wr_data;
+  reg [NUM_OF_PORTS*16-1:0] expected_packed_fifo_wr_data;
 
   reg [NUM_OF_CHANNELS-1:0] enable = 'h1;
-  reg [NUM_OF_CHANNELS-1:0] next_enable = 'h1;
 
   integer counter;
+  integer test_index;
+
+  // Test representative enable masks instead of all 2^32 combinations
+  // Include all channels, single channels, non_power_of_two configs
+  reg [NUM_OF_CHANNELS-1:0] test_enables [0:31];
+  initial begin
+    test_enables[0]  = 32'hFFFFFFFF;  // All 32 channels
+    test_enables[1]  = 32'h7FFFFFFF;  // 31 channels (non-pow2)
+    test_enables[2]  = 32'hFFFFFFFE;  // 31 channels (different pattern)
+    test_enables[3]  = 32'h55555555;  // Alternating pattern (16 channels)
+    test_enables[4]  = 32'hAAAAAAAA;  // Alternating inverse (16 channels)
+    test_enables[5]  = 32'h0000FFFF;  // Lower 16 channels
+    test_enables[6]  = 32'hFFFF0000;  // Upper 16 channels
+    test_enables[7]  = 32'h00FF00FF;  // 16 channels grouped
+    test_enables[8]  = 32'hFF00FF00;  // 16 channels grouped inverse
+    test_enables[9]  = 32'h0F0F0F0F;  // 16 channels nibble pattern
+    test_enables[10] = 32'h00000007;  // 3 channels (non-pow2)
+    test_enables[11] = 32'h0000000F;  // 4 channels
+    test_enables[12] = 32'h0000001F;  // 5 channels (non-pow2)
+    test_enables[13] = 32'h0000003F;  // 6 channels (non-pow2)
+    test_enables[14] = 32'h0000007F;  // 7 channels (non-pow2)
+    test_enables[15] = 32'h000000FF;  // 8 channels
+    test_enables[16] = 32'h000001FF;  // 9 channels (non-pow2)
+    test_enables[17] = 32'h00000FFF;  // 12 channels (non-pow2)
+    test_enables[18] = 32'h00001FFF;  // 13 channels (non-pow2)
+    test_enables[19] = 32'h00007FFF;  // 15 channels (non-pow2)
+    test_enables[20] = 32'h0001FFFF;  // 17 channels (non-pow2)
+    test_enables[21] = 32'h001FFFFF;  // 21 channels (non-pow2)
+    test_enables[22] = 32'h00FFFFFF;  // 24 channels (non-pow2)
+    test_enables[23] = 32'h01FFFFFF;  // 25 channels (non-pow2)
+    test_enables[24] = 32'h07FFFFFF;  // 27 channels (non-pow2)
+    test_enables[25] = 32'h1FFFFFFF;  // 29 channels (non-pow2)
+    test_enables[26] = 32'h3FFFFFFF;  // 30 channels (non-pow2)
+    test_enables[27] = 32'hFFFFFFF7;  // 31 channels (1 disabled middle)
+    test_enables[28] = 32'hFFFF7FFF;  // 31 channels (1 disabled middle)
+    test_enables[29] = 32'hF7F7F7F7;  // 28 channels (scattered)
+    test_enables[30] = 32'h77777777;  // 24 channels (non-pow2 scattered)
+    test_enables[31] = 32'h00000001;  // 1 channel
+  end
 
   always @(*) begin
     if (counter == 15) do_trigger_reset();
@@ -65,8 +102,9 @@ module cpack_tb;
 
   always @(posedge clk) begin
     if (trigger_reset == 1'b1) begin
-      if (enable != {NUM_OF_CHANNELS{1'b1}}) begin
-        enable <= enable + 1'b1;
+      if (test_index < 31) begin
+        test_index <= test_index + 1;
+        enable <= test_enables[test_index + 1];
       end else begin
         if (failed == 1'b0)
           $display("SUCCESS");
@@ -84,6 +122,9 @@ module cpack_tb;
     if (reset == 1'b1) begin
       reset_data <= 1'b1;
       reset_counter <= 'h00;
+      if (test_index == 0) begin
+        enable <= test_enables[0];
+      end
     end else begin
       reset_counter <= reset_counter + 1'b1;
       if (reset_counter == 'h5) begin
@@ -95,6 +136,7 @@ module cpack_tb;
   always @(posedge clk) begin
     if (reset == 1'b1) begin
       counter <= 'h00;
+      test_index <= 0;
     end else if (packed_fifo_wr_en == 1'b1) begin
       counter <= counter + 1;
     end
@@ -119,10 +161,10 @@ module cpack_tb;
       for (h = 0; h < SAMPLES_PER_CHANNEL; h = h + 1) begin
         for (i = 0; i < NUM_OF_CHANNELS; i = i + 1) begin
           if (enable[i] == 1'b1) begin
-            fifo_wr_data[(i*SAMPLES_PER_CHANNEL+h)*8+:8] <= j;
+            fifo_wr_data[(i*SAMPLES_PER_CHANNEL+h)*16+:16] <= j;
             j = j + 1;
           end else begin
-            fifo_wr_data[(i*SAMPLES_PER_CHANNEL+h)*8+:8] <= 'hxx;
+            fifo_wr_data[(i*SAMPLES_PER_CHANNEL+h)*16+:16] <= 'hxxxx;
           end
         end
       end
@@ -130,7 +172,7 @@ module cpack_tb;
       for (h = 0; h < SAMPLES_PER_CHANNEL; h = h + 1) begin
         for (i = 0; i < NUM_OF_CHANNELS; i = i + 1) begin
           if (enable[i] == 1'b1) begin
-            fifo_wr_data[(i*SAMPLES_PER_CHANNEL+h)*8+:8] <= j;
+            fifo_wr_data[(i*SAMPLES_PER_CHANNEL+h)*16+:16] <= j;
             j = j + 1;
           end
         end
@@ -141,11 +183,11 @@ module cpack_tb;
   always @(posedge clk) begin
     if (reset == 1'b1) begin
       for (i = 0; i < NUM_OF_PORTS; i = i + 1) begin
-        expected_packed_fifo_wr_data[i*8+:8] <= i;
+        expected_packed_fifo_wr_data[i*16+:16] <= i;
       end
     end else if (packed_fifo_wr_en == 1'b1) begin
       for (i = 0; i < NUM_OF_PORTS; i = i + 1) begin
-        expected_packed_fifo_wr_data[i*8+:8] <= expected_packed_fifo_wr_data[i*8+:8] + NUM_OF_PORTS;
+        expected_packed_fifo_wr_data[i*16+:16] <= expected_packed_fifo_wr_data[i*16+:16] + NUM_OF_PORTS;
       end
     end
   end
@@ -161,19 +203,15 @@ module cpack_tb;
   util_cpack2_impl #(
     .NUM_OF_CHANNELS(NUM_OF_CHANNELS),
     .SAMPLES_PER_CHANNEL(SAMPLES_PER_CHANNEL),
-    .SAMPLE_DATA_WIDTH(8),
+    .SAMPLE_DATA_WIDTH(16),
     .PIPELINE_STAGES(PIPELINE_STAGES)
   ) i_cpack (
     .clk(clk),
     .reset(reset),
-
     .enable(enable),
-
     .fifo_wr_en({NUM_OF_CHANNELS{fifo_wr_en}}),
     .fifo_wr_data(fifo_wr_data),
-
     .packed_fifo_wr_en(packed_fifo_wr_en),
     .packed_fifo_wr_data(packed_fifo_wr_data),
     .packed_fifo_wr_overflow(1'b0));
-
 endmodule

--- a/library/util_pack/tb/cpack_64ch_tb.v
+++ b/library/util_pack/tb/cpack_64ch_tb.v
@@ -1,6 +1,6 @@
 // ***************************************************************************
 // ***************************************************************************
-// Copyright (C) 2018-2023, 2026 Analog Devices, Inc. All rights reserved.
+// Copyright (C) 2026 Analog Devices, Inc. All rights reserved.
 //
 // In this HDL repository, there are many different and unique modules, consisting
 // of various HDL (Verilog or VHDL) components. The individual modules are
@@ -34,30 +34,67 @@
 // ***************************************************************************
 
 `timescale 1ns/100ps
-
-module cpack_tb;
-  parameter VCD_FILE = {"cpack_tb.vcd"};
-  parameter NUM_OF_CHANNELS = 4;
+module cpack_64ch_tb;
+  parameter VCD_FILE = {"cpack_64ch_tb.vcd"};
+  parameter NUM_OF_CHANNELS = 64;
   parameter SAMPLES_PER_CHANNEL = 1;
   parameter ENABLE_RANDOM = 0;
-  parameter PIPELINE_STAGES = 0;
+  parameter PIPELINE_STAGES = 2;
 
-  `define TIMEOUT 3000000
+  `define TIMEOUT 20000000
   `include "tb_base.v"
 
   localparam NUM_OF_PORTS = SAMPLES_PER_CHANNEL * NUM_OF_CHANNELS;
 
   reg fifo_wr_en = 1'b1;
-  reg [NUM_OF_PORTS*8-1:0] fifo_wr_data = 'h00;
+  reg [NUM_OF_PORTS*16-1:0] fifo_wr_data = 'h00;
 
   wire packed_fifo_wr_en;
-  wire [NUM_OF_PORTS*8-1:0] packed_fifo_wr_data;
-  reg [NUM_OF_PORTS*8-1:0] expected_packed_fifo_wr_data;
+  wire [NUM_OF_PORTS*16-1:0] packed_fifo_wr_data;
+  reg [NUM_OF_PORTS*16-1:0] expected_packed_fifo_wr_data;
 
   reg [NUM_OF_CHANNELS-1:0] enable = 'h1;
-  reg [NUM_OF_CHANNELS-1:0] next_enable = 'h1;
 
   integer counter;
+  integer test_index;
+
+  // Test representative enable masks instead of all 2^64 combinations
+  // Include all channels, single channels, non_power_of_two configs
+  reg [NUM_OF_CHANNELS-1:0] test_enables [0:31];
+  initial begin
+    test_enables[0]  = 64'hFFFFFFFFFFFFFFFF;  // All 64 channels
+    test_enables[1]  = 64'h7FFFFFFFFFFFFFFF;  // 63 channels (non-pow2)
+    test_enables[2]  = 64'hFFFFFFFFFFFFFFFE;  // 63 channels (different pattern)
+    test_enables[3]  = 64'h5555555555555555;  // Alternating pattern (32 channels)
+    test_enables[4]  = 64'hAAAAAAAAAAAAAAAA;  // Alternating inverse (32 channels)
+    test_enables[5]  = 64'h00000000FFFFFFFF;  // Lower 32 channels
+    test_enables[6]  = 64'hFFFFFFFF00000000;  // Upper 32 channels
+    test_enables[7]  = 64'h0000FFFF0000FFFF;  // 32 channels grouped
+    test_enables[8]  = 64'hFFFF0000FFFF0000;  // 32 channels grouped inverse
+    test_enables[9]  = 64'h0F0F0F0F0F0F0F0F;  // 32 channels nibble pattern
+    test_enables[10] = 64'h0000000000000007;  // 3 channels (non-pow2)
+    test_enables[11] = 64'h000000000000000F;  // 4 channels
+    test_enables[12] = 64'h000000000000001F;  // 5 channels (non-pow2)
+    test_enables[13] = 64'h000000000000003F;  // 6 channels (non-pow2)
+    test_enables[14] = 64'h000000000000007F;  // 7 channels (non-pow2)
+    test_enables[15] = 64'h00000000000000FF;  // 8 channels
+    test_enables[16] = 64'h00000000000001FF;  // 9 channels (non-pow2)
+    test_enables[17] = 64'h0000000000000FFF;  // 12 channels (non-pow2)
+    test_enables[18] = 64'h000000000000FFFF;  // 16 channels
+    test_enables[19] = 64'h00000000001FFFFF;  // 21 channels (non-pow2)
+    test_enables[20] = 64'h0000000000FFFFFF;  // 24 channels (non-pow2)
+    test_enables[21] = 64'h00000000FFFFFFFF;  // 32 channels
+    test_enables[22] = 64'h000001FFFFFFFFFF;  // 41 channels (non-pow2)
+    test_enables[23] = 64'h0000FFFFFFFFFFFF;  // 48 channels (non-pow2)
+    test_enables[24] = 64'h001FFFFFFFFFFFFF;  // 53 channels (non-pow2)
+    test_enables[25] = 64'h00FFFFFFFFFFFFFF;  // 56 channels (non-pow2)
+    test_enables[26] = 64'h03FFFFFFFFFFFFFF;  // 58 channels (non-pow2)
+    test_enables[27] = 64'h0FFFFFFFFFFFFFFF;  // 60 channels (non-pow2)
+    test_enables[28] = 64'h1FFFFFFFFFFFFFFF;  // 61 channels (non-pow2)
+    test_enables[29] = 64'h3FFFFFFFFFFFFFFF;  // 62 channels (non-pow2)
+    test_enables[30] = 64'hF7F7F7F7F7F7F7F7;  // 56 channels (scattered)
+    test_enables[31] = 64'h0000000000000001;  // 1 channel
+  end
 
   always @(*) begin
     if (counter == 15) do_trigger_reset();
@@ -65,8 +102,9 @@ module cpack_tb;
 
   always @(posedge clk) begin
     if (trigger_reset == 1'b1) begin
-      if (enable != {NUM_OF_CHANNELS{1'b1}}) begin
-        enable <= enable + 1'b1;
+      if (test_index < 31) begin
+        test_index <= test_index + 1;
+        enable <= test_enables[test_index + 1];
       end else begin
         if (failed == 1'b0)
           $display("SUCCESS");
@@ -84,6 +122,9 @@ module cpack_tb;
     if (reset == 1'b1) begin
       reset_data <= 1'b1;
       reset_counter <= 'h00;
+      if (test_index == 0) begin
+        enable <= test_enables[0];
+      end
     end else begin
       reset_counter <= reset_counter + 1'b1;
       if (reset_counter == 'h5) begin
@@ -95,6 +136,7 @@ module cpack_tb;
   always @(posedge clk) begin
     if (reset == 1'b1) begin
       counter <= 'h00;
+      test_index <= 0;
     end else if (packed_fifo_wr_en == 1'b1) begin
       counter <= counter + 1;
     end
@@ -119,10 +161,10 @@ module cpack_tb;
       for (h = 0; h < SAMPLES_PER_CHANNEL; h = h + 1) begin
         for (i = 0; i < NUM_OF_CHANNELS; i = i + 1) begin
           if (enable[i] == 1'b1) begin
-            fifo_wr_data[(i*SAMPLES_PER_CHANNEL+h)*8+:8] <= j;
+            fifo_wr_data[(i*SAMPLES_PER_CHANNEL+h)*16+:16] <= j;
             j = j + 1;
           end else begin
-            fifo_wr_data[(i*SAMPLES_PER_CHANNEL+h)*8+:8] <= 'hxx;
+            fifo_wr_data[(i*SAMPLES_PER_CHANNEL+h)*16+:16] <= 'hxxxx;
           end
         end
       end
@@ -130,7 +172,7 @@ module cpack_tb;
       for (h = 0; h < SAMPLES_PER_CHANNEL; h = h + 1) begin
         for (i = 0; i < NUM_OF_CHANNELS; i = i + 1) begin
           if (enable[i] == 1'b1) begin
-            fifo_wr_data[(i*SAMPLES_PER_CHANNEL+h)*8+:8] <= j;
+            fifo_wr_data[(i*SAMPLES_PER_CHANNEL+h)*16+:16] <= j;
             j = j + 1;
           end
         end
@@ -141,11 +183,11 @@ module cpack_tb;
   always @(posedge clk) begin
     if (reset == 1'b1) begin
       for (i = 0; i < NUM_OF_PORTS; i = i + 1) begin
-        expected_packed_fifo_wr_data[i*8+:8] <= i;
+        expected_packed_fifo_wr_data[i*16+:16] <= i;
       end
     end else if (packed_fifo_wr_en == 1'b1) begin
       for (i = 0; i < NUM_OF_PORTS; i = i + 1) begin
-        expected_packed_fifo_wr_data[i*8+:8] <= expected_packed_fifo_wr_data[i*8+:8] + NUM_OF_PORTS;
+        expected_packed_fifo_wr_data[i*16+:16] <= expected_packed_fifo_wr_data[i*16+:16] + NUM_OF_PORTS;
       end
     end
   end
@@ -161,19 +203,15 @@ module cpack_tb;
   util_cpack2_impl #(
     .NUM_OF_CHANNELS(NUM_OF_CHANNELS),
     .SAMPLES_PER_CHANNEL(SAMPLES_PER_CHANNEL),
-    .SAMPLE_DATA_WIDTH(8),
+    .SAMPLE_DATA_WIDTH(16),
     .PIPELINE_STAGES(PIPELINE_STAGES)
   ) i_cpack (
     .clk(clk),
     .reset(reset),
-
     .enable(enable),
-
     .fifo_wr_en({NUM_OF_CHANNELS{fifo_wr_en}}),
     .fifo_wr_data(fifo_wr_data),
-
     .packed_fifo_wr_en(packed_fifo_wr_en),
     .packed_fifo_wr_data(packed_fifo_wr_data),
     .packed_fifo_wr_overflow(1'b0));
-
 endmodule

--- a/library/util_pack/tb/cpack_8ch_tb.v
+++ b/library/util_pack/tb/cpack_8ch_tb.v
@@ -1,6 +1,6 @@
 // ***************************************************************************
 // ***************************************************************************
-// Copyright (C) 2018-2023, 2026 Analog Devices, Inc. All rights reserved.
+// Copyright (C) 2026 Analog Devices, Inc. All rights reserved.
 //
 // In this HDL repository, there are many different and unique modules, consisting
 // of various HDL (Verilog or VHDL) components. The individual modules are
@@ -34,13 +34,12 @@
 // ***************************************************************************
 
 `timescale 1ns/100ps
-
-module cpack_tb;
-  parameter VCD_FILE = {"cpack_tb.vcd"};
-  parameter NUM_OF_CHANNELS = 4;
-  parameter SAMPLES_PER_CHANNEL = 1;
+module cpack_8ch_tb;
+  parameter VCD_FILE = {"cpack_8ch_tb.vcd"};
+  parameter NUM_OF_CHANNELS = 8;
+  parameter SAMPLES_PER_CHANNEL = 4;
   parameter ENABLE_RANDOM = 0;
-  parameter PIPELINE_STAGES = 0;
+  parameter PIPELINE_STAGES = 2;
 
   `define TIMEOUT 3000000
   `include "tb_base.v"
@@ -48,11 +47,11 @@ module cpack_tb;
   localparam NUM_OF_PORTS = SAMPLES_PER_CHANNEL * NUM_OF_CHANNELS;
 
   reg fifo_wr_en = 1'b1;
-  reg [NUM_OF_PORTS*8-1:0] fifo_wr_data = 'h00;
+  reg [NUM_OF_PORTS*16-1:0] fifo_wr_data = 'h00;
 
   wire packed_fifo_wr_en;
-  wire [NUM_OF_PORTS*8-1:0] packed_fifo_wr_data;
-  reg [NUM_OF_PORTS*8-1:0] expected_packed_fifo_wr_data;
+  wire [NUM_OF_PORTS*16-1:0] packed_fifo_wr_data;
+  reg [NUM_OF_PORTS*16-1:0] expected_packed_fifo_wr_data;
 
   reg [NUM_OF_CHANNELS-1:0] enable = 'h1;
   reg [NUM_OF_CHANNELS-1:0] next_enable = 'h1;
@@ -119,10 +118,10 @@ module cpack_tb;
       for (h = 0; h < SAMPLES_PER_CHANNEL; h = h + 1) begin
         for (i = 0; i < NUM_OF_CHANNELS; i = i + 1) begin
           if (enable[i] == 1'b1) begin
-            fifo_wr_data[(i*SAMPLES_PER_CHANNEL+h)*8+:8] <= j;
+            fifo_wr_data[(i*SAMPLES_PER_CHANNEL+h)*16+:16] <= j;
             j = j + 1;
           end else begin
-            fifo_wr_data[(i*SAMPLES_PER_CHANNEL+h)*8+:8] <= 'hxx;
+            fifo_wr_data[(i*SAMPLES_PER_CHANNEL+h)*16+:16] <= 'hxxxx;
           end
         end
       end
@@ -130,7 +129,7 @@ module cpack_tb;
       for (h = 0; h < SAMPLES_PER_CHANNEL; h = h + 1) begin
         for (i = 0; i < NUM_OF_CHANNELS; i = i + 1) begin
           if (enable[i] == 1'b1) begin
-            fifo_wr_data[(i*SAMPLES_PER_CHANNEL+h)*8+:8] <= j;
+            fifo_wr_data[(i*SAMPLES_PER_CHANNEL+h)*16+:16] <= j;
             j = j + 1;
           end
         end
@@ -141,11 +140,11 @@ module cpack_tb;
   always @(posedge clk) begin
     if (reset == 1'b1) begin
       for (i = 0; i < NUM_OF_PORTS; i = i + 1) begin
-        expected_packed_fifo_wr_data[i*8+:8] <= i;
+        expected_packed_fifo_wr_data[i*16+:16] <= i;
       end
     end else if (packed_fifo_wr_en == 1'b1) begin
       for (i = 0; i < NUM_OF_PORTS; i = i + 1) begin
-        expected_packed_fifo_wr_data[i*8+:8] <= expected_packed_fifo_wr_data[i*8+:8] + NUM_OF_PORTS;
+        expected_packed_fifo_wr_data[i*16+:16] <= expected_packed_fifo_wr_data[i*16+:16] + NUM_OF_PORTS;
       end
     end
   end
@@ -161,19 +160,15 @@ module cpack_tb;
   util_cpack2_impl #(
     .NUM_OF_CHANNELS(NUM_OF_CHANNELS),
     .SAMPLES_PER_CHANNEL(SAMPLES_PER_CHANNEL),
-    .SAMPLE_DATA_WIDTH(8),
+    .SAMPLE_DATA_WIDTH(16),
     .PIPELINE_STAGES(PIPELINE_STAGES)
   ) i_cpack (
     .clk(clk),
     .reset(reset),
-
     .enable(enable),
-
     .fifo_wr_en({NUM_OF_CHANNELS{fifo_wr_en}}),
     .fifo_wr_data(fifo_wr_data),
-
     .packed_fifo_wr_en(packed_fifo_wr_en),
     .packed_fifo_wr_data(packed_fifo_wr_data),
     .packed_fifo_wr_overflow(1'b0));
-
 endmodule

--- a/library/util_pack/tb/cpack_tb
+++ b/library/util_pack/tb/cpack_tb
@@ -7,6 +7,7 @@ SOURCE+=" ../util_pack_common/pack_interconnect.v"
 SOURCE+=" ../util_pack_common/pack_network.v"
 SOURCE+=" ../util_pack_common/pack_shell.v"
 SOURCE+=" ../../common/ad_perfect_shuffle.v"
+SOURCE+=" ../../common/util_pipeline_stage.v"
 
 cd `dirname $0`
 source ../../common/tb/run_tb.sh

--- a/library/util_pack/tb/cpack_tb.v
+++ b/library/util_pack/tb/cpack_tb.v
@@ -40,8 +40,9 @@ module cpack_tb;
   parameter NUM_OF_CHANNELS = 4;
   parameter SAMPLES_PER_CHANNEL = 1;
   parameter ENABLE_RANDOM = 0;
+  parameter PIPELINE_STAGES = 0;
 
-  `define TIMEOUT 1500000
+  `define TIMEOUT 3000000
   `include "tb_base.v"
 
   localparam NUM_OF_PORTS = SAMPLES_PER_CHANNEL * NUM_OF_CHANNELS;
@@ -160,7 +161,8 @@ module cpack_tb;
   util_cpack2_impl #(
     .NUM_OF_CHANNELS(NUM_OF_CHANNELS),
     .SAMPLES_PER_CHANNEL(SAMPLES_PER_CHANNEL),
-    .SAMPLE_DATA_WIDTH(8)
+    .SAMPLE_DATA_WIDTH(8),
+    .PIPELINE_STAGES(PIPELINE_STAGES)
   ) i_cpack (
     .clk(clk),
     .reset(reset),

--- a/library/util_pack/tb/tb_base.v
+++ b/library/util_pack/tb/tb_base.v
@@ -1,6 +1,6 @@
 // ***************************************************************************
 // ***************************************************************************
-// Copyright (C) 2018-2023 Analog Devices, Inc. All rights reserved.
+// Copyright (C) 2018-2023, 2026 Analog Devices, Inc. All rights reserved.
 //
 // In this HDL repository, there are many different and unique modules, consisting
 // of various HDL (Verilog or VHDL) components. The individual modules are
@@ -33,7 +33,7 @@
 // ***************************************************************************
 // ***************************************************************************
 
-  reg clk = 1'b1;
+  reg clk = 1'b0;
   reg [3:0] reset_shift = 4'b1111;
   reg trigger_reset = 1'b0;
   wire reset;
@@ -42,13 +42,22 @@
 
   initial
   begin
-    if (VCD_FILE != "") begin
-      $dumpfile (VCD_FILE);
-      $dumpvars;
-    end
+    $dumpfile (VCD_FILE);
+    $dumpvars;
+`ifdef TIMEOUT
+    #`TIMEOUT
+`else
+    #100000
+`endif
+    if (failed == 1'b0)
+      $display("SUCCESS");
+    else
+      $display("FAILED");
+    $finish;
   end
 
-  always @(*) #10 clk <= ~clk;
+  always #10 clk = ~clk;
+
   always @(posedge clk) begin
     if (trigger_reset == 1'b1) begin
       reset_shift <= 4'b1111;

--- a/library/util_pack/util_cpack2/Makefile
+++ b/library/util_pack/util_cpack2/Makefile
@@ -7,6 +7,7 @@
 LIBRARY_NAME := util_cpack2
 
 GENERIC_DEPS += ../../common/ad_perfect_shuffle.v
+GENERIC_DEPS += ../../common/util_pipeline_stage.v
 GENERIC_DEPS += ../util_pack_common/pack_ctrl.v
 GENERIC_DEPS += ../util_pack_common/pack_interconnect.v
 GENERIC_DEPS += ../util_pack_common/pack_network.v

--- a/library/util_pack/util_cpack2/Makefile
+++ b/library/util_pack/util_cpack2/Makefile
@@ -1,5 +1,5 @@
 ####################################################################################
-## Copyright (c) 2018 - 2023 Analog Devices, Inc.
+## Copyright (c) 2018 - 2023, 2026 Analog Devices, Inc.
 ### SPDX short identifier: BSD-1-Clause
 ## Auto-generated, do not modify!
 ####################################################################################

--- a/library/util_pack/util_cpack2/util_cpack2.v
+++ b/library/util_pack/util_cpack2/util_cpack2.v
@@ -39,7 +39,8 @@ module util_cpack2 #(
   parameter NUM_OF_CHANNELS = 4,
   parameter SAMPLES_PER_CHANNEL = 1,
   parameter SAMPLE_DATA_WIDTH = 16,
-  parameter PARALLEL_OR_SERIAL_N = 0
+  parameter PARALLEL_OR_SERIAL_N = 0,
+  parameter PIPELINE_STAGES = 0
 ) (
   input clk,
   input reset,
@@ -284,7 +285,8 @@ module util_cpack2 #(
     .NUM_OF_CHANNELS (REAL_NUM_OF_CHANNELS),
     .SAMPLE_DATA_WIDTH (SAMPLE_DATA_WIDTH),
     .SAMPLES_PER_CHANNEL (SAMPLES_PER_CHANNEL),
-    .PARALLEL_OR_SERIAL_N (PARALLEL_OR_SERIAL_N)
+    .PARALLEL_OR_SERIAL_N (PARALLEL_OR_SERIAL_N),
+    .PIPELINE_STAGES (PIPELINE_STAGES)
   ) i_cpack (
     .clk (clk),
     .reset (reset),

--- a/library/util_pack/util_cpack2/util_cpack2.v
+++ b/library/util_pack/util_cpack2/util_cpack2.v
@@ -1,6 +1,6 @@
 // ***************************************************************************
 // ***************************************************************************
-// Copyright (C) 2018-2025 Analog Devices, Inc. All rights reserved.
+// Copyright (C) 2018-2026 Analog Devices, Inc. All rights reserved.
 //
 // In this HDL repository, there are many different and unique modules, consisting
 // of various HDL (Verilog or VHDL) components. The individual modules are
@@ -189,12 +189,13 @@ module util_cpack2 #(
    * Round up to the next power of two and zero out the additional channels
    * internally.
    */
-  localparam REAL_NUM_OF_CHANNELS = NUM_OF_CHANNELS > 32 ? 64 :
-     NUM_OF_CHANNELS > 16 ? 32 :
-     NUM_OF_CHANNELS > 8 ? 16 :
-     NUM_OF_CHANNELS > 4 ? 8 :
-     NUM_OF_CHANNELS > 2 ? 4 :
-     NUM_OF_CHANNELS > 1 ? 2 : 1;
+  localparam
+    REAL_NUM_OF_CHANNELS = NUM_OF_CHANNELS > 32 ? 64 :
+    NUM_OF_CHANNELS > 16 ? 32 :
+    NUM_OF_CHANNELS > 8 ? 16 :
+    NUM_OF_CHANNELS > 4 ? 8 :
+    NUM_OF_CHANNELS > 2 ? 4 :
+    NUM_OF_CHANNELS > 1 ? 2 : 1;
 
   /* FIXME: Find out how to do this in the IP-XACT */
 

--- a/library/util_pack/util_cpack2/util_cpack2_hw.tcl
+++ b/library/util_pack/util_cpack2/util_cpack2_hw.tcl
@@ -10,6 +10,7 @@ source ../../scripts/adi_ip_intel.tcl
 ad_ip_create util_cpack2 {Channel Pack Utility v2} util_cpack_elab
 ad_ip_files util_cpack2_impl [list \
   $ad_hdl_dir/library/common/ad_perfect_shuffle.v \
+  $ad_hdl_dir/library/common/util_pipeline_stage.v \
   ../util_pack_common/pack_ctrl.v \
   ../util_pack_common/pack_interconnect.v \
   ../util_pack_common/pack_network.v \
@@ -34,6 +35,11 @@ ad_ip_parameter SAMPLE_DATA_WIDTH INTEGER 16 true [list \
 ad_ip_parameter PARALLEL_OR_SERIAL_N INTEGER 0 true [list \
   DISPLAY_NAME "Parallel prefix sum calculation" \
   ALLOWED_RANGES {"0:Serial" "1:Parallel"} \
+]
+
+ad_ip_parameter PIPELINE_STAGES INTEGER 0 true [list \
+  DISPLAY_NAME "Configure pipeline stages" \
+  ALLOWED_RANGES {"0:No Pipeline" "1:Pipeline every 2 stages" "2:Pipeline every stage"} \
 ]
 
 # defaults

--- a/library/util_pack/util_cpack2/util_cpack2_hw.tcl
+++ b/library/util_pack/util_cpack2/util_cpack2_hw.tcl
@@ -1,5 +1,5 @@
 ###############################################################################
-## Copyright (C) 2018-2025 Analog Devices, Inc. All rights reserved.
+## Copyright (C) 2018-2025, 2026 Analog Devices, Inc. All rights reserved.
 ### SPDX short identifier: ADIBSD
 ###############################################################################
 

--- a/library/util_pack/util_cpack2/util_cpack2_impl.v
+++ b/library/util_pack/util_cpack2/util_cpack2_impl.v
@@ -39,7 +39,8 @@ module util_cpack2_impl #(
   parameter NUM_OF_CHANNELS = 4,
   parameter SAMPLES_PER_CHANNEL = 1,
   parameter SAMPLE_DATA_WIDTH = 16,
-  parameter PARALLEL_OR_SERIAL_N = 0
+  parameter PARALLEL_OR_SERIAL_N = 0,
+  parameter PIPELINE_STAGES = 0
 ) (
   input clk,
   input reset,
@@ -57,6 +58,38 @@ module util_cpack2_impl #(
 );
 
   localparam TOTAL_DATA_WIDTH = SAMPLE_DATA_WIDTH * SAMPLES_PER_CHANNEL * NUM_OF_CHANNELS;
+  localparam NUM_OF_SAMPLES = NUM_OF_CHANNELS * SAMPLES_PER_CHANNEL;
+
+  localparam SAMPLE_ADDRESS_WIDTH =
+    NUM_OF_SAMPLES > 512 ? 10 :
+    NUM_OF_SAMPLES > 256 ? 9 :
+    NUM_OF_SAMPLES > 128 ? 8 :
+    NUM_OF_SAMPLES > 64 ? 7 :
+    NUM_OF_SAMPLES > 32 ? 6 :
+    NUM_OF_SAMPLES > 16 ? 5 :
+    NUM_OF_SAMPLES > 8 ? 4 :
+    NUM_OF_SAMPLES > 4 ? 3 :
+    NUM_OF_SAMPLES > 2 ? 2 : 1;
+
+  localparam NETWORK0_STAGES = SAMPLE_ADDRESS_WIDTH / 2;
+  localparam NETWORK1_STAGES = SAMPLE_ADDRESS_WIDTH % 2;
+
+  // Calculate pipeline latency per network based on PIPELINE_STAGES parameter
+  function integer calc_pipeline_latency;
+    input integer num_stages;
+    begin
+      if (PIPELINE_STAGES == 2)
+        calc_pipeline_latency = num_stages;
+      else if (PIPELINE_STAGES == 1)
+        calc_pipeline_latency = num_stages / 2;
+      else
+        calc_pipeline_latency = 0;
+    end
+  endfunction
+
+  localparam TOTAL_PIPELINE_LATENCY = (NUM_OF_CHANNELS == 1) ? 0 :
+                                       calc_pipeline_latency(NETWORK0_STAGES) +
+                                       calc_pipeline_latency(NETWORK1_STAGES);
 
   // Control signals from the pack shell.
   wire reset_data;
@@ -76,6 +109,16 @@ module util_cpack2_impl #(
    * somewhat backwards compatible to the previous upack.
    */
   wire data_wr_en = fifo_wr_en[0];
+  wire data_wr_en_delayed;
+
+  util_pipeline_stage #(
+    .REGISTERED(TOTAL_PIPELINE_LATENCY),
+    .WIDTH(1)
+  ) i_data_wr_en_pipe (
+    .clk(clk),
+    .in(data_wr_en),
+    .out(data_wr_en_delayed)
+  );
 
   /*
    * The cpack core itself has no backpressure. Overflows can only happen
@@ -102,7 +145,8 @@ module util_cpack2_impl #(
     .SAMPLES_PER_CHANNEL (SAMPLES_PER_CHANNEL),
     .SAMPLE_DATA_WIDTH (SAMPLE_DATA_WIDTH),
     .PACK (1),
-    .PARALLEL_OR_SERIAL_N (PARALLEL_OR_SERIAL_N)
+    .PARALLEL_OR_SERIAL_N (PARALLEL_OR_SERIAL_N),
+    .PIPELINE_STAGES (PIPELINE_STAGES)
   ) i_pack_shell (
     .clk (clk),
     .reset (reset),
@@ -121,7 +165,7 @@ module util_cpack2_impl #(
     if (reset_data == 1'b1) begin
       packed_fifo_wr_en <= 1'b0;
       packed_sync <= 1'b0;
-    end else if (ready == 1'b1 && data_wr_en == 1'b1) begin
+    end else if (ready == 1'b1 && data_wr_en_delayed == 1'b1) begin
       packed_fifo_wr_en <= 1'b1;
       packed_sync <= out_sync;
     end else begin
@@ -133,7 +177,7 @@ module util_cpack2_impl #(
   always @(posedge clk) begin: gen_packed_fifo_wr_data
     integer i;
 
-    if (data_wr_en == 1'b1) begin
+    if (data_wr_en_delayed == 1'b1) begin
       for (i = 0; i < NUM_OF_CHANNELS * SAMPLES_PER_CHANNEL; i = i + 1) begin
         if (out_valid[i] == 1'b1) begin
           packed_fifo_wr_data[i*SAMPLE_DATA_WIDTH+:SAMPLE_DATA_WIDTH] <= out_data[i*SAMPLE_DATA_WIDTH+:SAMPLE_DATA_WIDTH];

--- a/library/util_pack/util_cpack2/util_cpack2_impl.v
+++ b/library/util_pack/util_cpack2/util_cpack2_impl.v
@@ -1,6 +1,6 @@
 // ***************************************************************************
 // ***************************************************************************
-// Copyright (C) 2018-2025 Analog Devices, Inc. All rights reserved.
+// Copyright (C) 2018-2026 Analog Devices, Inc. All rights reserved.
 //
 // In this HDL repository, there are many different and unique modules, consisting
 // of various HDL (Verilog or VHDL) components. The individual modules are
@@ -60,8 +60,8 @@ module util_cpack2_impl #(
   localparam TOTAL_DATA_WIDTH = SAMPLE_DATA_WIDTH * SAMPLES_PER_CHANNEL * NUM_OF_CHANNELS;
   localparam NUM_OF_SAMPLES = NUM_OF_CHANNELS * SAMPLES_PER_CHANNEL;
 
-  localparam SAMPLE_ADDRESS_WIDTH =
-    NUM_OF_SAMPLES > 512 ? 10 :
+  localparam
+    SAMPLE_ADDRESS_WIDTH = NUM_OF_SAMPLES > 512 ? 10 :
     NUM_OF_SAMPLES > 256 ? 9 :
     NUM_OF_SAMPLES > 128 ? 8 :
     NUM_OF_SAMPLES > 64 ? 7 :
@@ -87,9 +87,10 @@ module util_cpack2_impl #(
     end
   endfunction
 
-  localparam TOTAL_PIPELINE_LATENCY = (NUM_OF_CHANNELS == 1) ? 0 :
-                                       calc_pipeline_latency(NETWORK0_STAGES) +
-                                       calc_pipeline_latency(NETWORK1_STAGES);
+  localparam
+    TOTAL_PIPELINE_LATENCY = (NUM_OF_CHANNELS == 1) ? 0 :
+    calc_pipeline_latency(NETWORK0_STAGES) +
+    calc_pipeline_latency(NETWORK1_STAGES);
 
   // Control signals from the pack shell.
   wire reset_data;
@@ -111,14 +112,27 @@ module util_cpack2_impl #(
   wire data_wr_en = fifo_wr_en[0];
   wire data_wr_en_delayed;
 
-  util_pipeline_stage #(
-    .REGISTERED(TOTAL_PIPELINE_LATENCY),
-    .WIDTH(1)
-  ) i_data_wr_en_pipe (
-    .clk(clk),
-    .in(data_wr_en),
-    .out(data_wr_en_delayed)
-  );
+  /*
+   * Ce-gated delay for data_wr_en to match the ce-gated data pipeline.
+   * When PIPELINE_STAGES > 0, the data pipeline is ce-gated, so this
+   * delay must also be ce-gated.
+   */
+  generate
+    if (TOTAL_PIPELINE_LATENCY == 0) begin: gen_wr_en_comb
+      assign data_wr_en_delayed = data_wr_en;
+    end else begin: gen_wr_en_pipe
+      (* shreg_extract = "no" *) reg [TOTAL_PIPELINE_LATENCY:0] wr_en_sr = 'h0;
+      integer wei;
+      always @(posedge clk) begin
+        if (data_wr_en == 1'b1) begin
+          wr_en_sr[0] <= data_wr_en;
+          for (wei = 1; wei <= TOTAL_PIPELINE_LATENCY; wei = wei + 1)
+            wr_en_sr[wei] <= wr_en_sr[wei-1];
+        end
+      end
+      assign data_wr_en_delayed = wr_en_sr[TOTAL_PIPELINE_LATENCY];
+    end
+  endgenerate
 
   /*
    * The cpack core itself has no backpressure. Overflows can only happen
@@ -165,7 +179,7 @@ module util_cpack2_impl #(
     if (reset_data == 1'b1) begin
       packed_fifo_wr_en <= 1'b0;
       packed_sync <= 1'b0;
-    end else if (ready == 1'b1 && data_wr_en_delayed == 1'b1) begin
+    end else if (ready == 1'b1 && data_wr_en == 1'b1) begin
       packed_fifo_wr_en <= 1'b1;
       packed_sync <= out_sync;
     end else begin
@@ -177,7 +191,7 @@ module util_cpack2_impl #(
   always @(posedge clk) begin: gen_packed_fifo_wr_data
     integer i;
 
-    if (data_wr_en_delayed == 1'b1) begin
+    if (data_wr_en == 1'b1) begin
       for (i = 0; i < NUM_OF_CHANNELS * SAMPLES_PER_CHANNEL; i = i + 1) begin
         if (out_valid[i] == 1'b1) begin
           packed_fifo_wr_data[i*SAMPLE_DATA_WIDTH+:SAMPLE_DATA_WIDTH] <= out_data[i*SAMPLE_DATA_WIDTH+:SAMPLE_DATA_WIDTH];

--- a/library/util_pack/util_cpack2/util_cpack2_ip.tcl
+++ b/library/util_pack/util_cpack2/util_cpack2_ip.tcl
@@ -1,5 +1,5 @@
 ###############################################################################
-## Copyright (C) 2018-2025 Analog Devices, Inc. All rights reserved.
+## Copyright (C) 2018-2025, 2026 Analog Devices, Inc. All rights reserved.
 ### SPDX short identifier: ADIBSD
 ###############################################################################
 

--- a/library/util_pack/util_cpack2/util_cpack2_ip.tcl
+++ b/library/util_pack/util_cpack2/util_cpack2_ip.tcl
@@ -9,6 +9,7 @@ source $ad_hdl_dir/library/scripts/adi_ip_xilinx.tcl
 adi_ip_create util_cpack2
 adi_ip_files util_cpack2 [list \
   "../../common/ad_perfect_shuffle.v" \
+  "../../common/util_pipeline_stage.v" \
   "../util_pack_common/pack_ctrl.v" \
   "../util_pack_common/pack_interconnect.v" \
   "../util_pack_common/pack_network.v" \
@@ -40,6 +41,7 @@ foreach {k v} { \
   "SAMPLES_PER_CHANNEL" "Samples per Channel" \
   "SAMPLE_DATA_WIDTH" "Sample Width" \
   "PARALLEL_OR_SERIAL_N" "Parallel prefix sum calculation" \
+  "PIPELINE_STAGES" "Configure pipeline stages" \
   } { \
   set p [ipgui::get_guiparamspec -name $k -component $cc]
 #  ipgui::move_param -component $cc -order $i $p -parent $

--- a/library/util_pack/util_pack_common/pack_ctrl.v
+++ b/library/util_pack/util_pack_common/pack_ctrl.v
@@ -1,6 +1,6 @@
 // ***************************************************************************
 // ***************************************************************************
-// Copyright (C) 2018-2023 Analog Devices, Inc. All rights reserved.
+// Copyright (C) 2018-2023, 2026 Analog Devices, Inc. All rights reserved.
 //
 // In this HDL repository, there are many different and unique modules, consisting
 // of various HDL (Verilog or VHDL) components. The individual modules are

--- a/library/util_pack/util_pack_common/pack_interconnect.v
+++ b/library/util_pack/util_pack_common/pack_interconnect.v
@@ -40,8 +40,10 @@ module pack_interconnect #(
   parameter PORT_ADDRESS_WIDTH = 3,
   parameter MUX_ORDER = 2,
   parameter NUM_STAGES = 2,
-  parameter PACK = 0 // 0 = Unpack, 1 = Pack
+  parameter PACK = 0, // 0 = Unpack, 1 = Pack
+  parameter PIPELINE_STAGES = 0 // 0 = no pipeline, 1 = pipeline every 2 stages, 2 = pipeline every stage
 ) (
+  input clk,
   input [2**PORT_ADDRESS_WIDTH*MUX_ORDER*NUM_STAGES-1:0] ctrl,
 
   input [PORT_DATA_WIDTH * 2**PORT_ADDRESS_WIDTH-1:0] data_in,
@@ -59,11 +61,55 @@ module pack_interconnect #(
 
   localparam NUM_PORTS = 2**PORT_ADDRESS_WIDTH;
   localparam TOTAL_DATA_WIDTH = PORT_DATA_WIDTH * NUM_PORTS;
+  localparam CTRL_WIDTH_PER_STAGE = NUM_PORTS * MUX_ORDER;
 
+  wire [TOTAL_DATA_WIDTH-1:0] interconnect_comb[0:NUM_STAGES];
   wire [TOTAL_DATA_WIDTH-1:0] interconnect[0:NUM_STAGES];
 
-  assign interconnect[0] = data_in;
+  assign interconnect_comb[0] = data_in;
   assign data_out = interconnect[NUM_STAGES];
+
+  /*
+   * Function to calculate cumulative pipeline delay for each stage.
+   * The control signals for each stage must be delayed to match when data arrives.
+   */
+  function integer calc_ctrl_delay;
+    input integer stage;
+    integer delay;
+    integer s;
+    begin
+      delay = 0;
+      for (s = 1; s <= stage; s = s + 1) begin
+        if (PIPELINE_STAGES == 2) begin
+          delay = delay + 1;
+        end else if (PIPELINE_STAGES == 1 && s % 2 == 0) begin
+          delay = delay + 1;
+        end
+      end
+      calc_ctrl_delay = delay;
+    end
+  endfunction
+
+  // Generate pipeline stages between MUX stages for DATA path
+  generate
+    genvar p;
+    for (p = 0; p <= NUM_STAGES; p = p + 1) begin: gen_pipeline
+      // PIPELINE_STAGES=0: no pipelining
+      // PIPELINE_STAGES=1: pipeline after every 2 MUX stages (at p=2,4,6,...)
+      // PIPELINE_STAGES=2: pipeline after every MUX stage (at p=1,2,3,...)
+      localparam SHOULD_REGISTER = (PIPELINE_STAGES == 2 && p > 0) ||
+                                   (PIPELINE_STAGES == 1 && p > 0 && p % 2 == 0);
+
+      util_pipeline_stage #(
+        .REGISTERED(SHOULD_REGISTER ? 1 : 0),
+        .WIDTH(TOTAL_DATA_WIDTH)
+      ) i_stage_pipe (
+        .clk(clk),
+        .in(interconnect_comb[p]),
+        .out(interconnect[p])
+      );
+    end
+  endgenerate
 
   generate
     genvar i, j;
@@ -76,10 +122,30 @@ module pack_interconnect #(
     for (i = 0; i < NUM_STAGES; i = i + 1) begin: gen_stages
       // Pack network are in the opposite direction
       localparam ctrl_stage = PACK ? NUM_STAGES - i - 1 : i;
+
+      // Calculate cumulative delay for this stage control signals
+      localparam CTRL_DELAY = calc_ctrl_delay(i);
+
       wire [TOTAL_DATA_WIDTH-1:0] shuffle_in;
       wire [TOTAL_DATA_WIDTH-1:0] shuffle_out;
       wire [TOTAL_DATA_WIDTH-1:0] mux_in;
       wire [TOTAL_DATA_WIDTH-1:0] mux_out;
+
+      wire [CTRL_WIDTH_PER_STAGE-1:0] ctrl_stage_in;
+      wire [CTRL_WIDTH_PER_STAGE-1:0] ctrl_stage_delayed;
+
+      // Extract control bits for this stage
+      assign ctrl_stage_in = ctrl[ctrl_stage*CTRL_WIDTH_PER_STAGE +: CTRL_WIDTH_PER_STAGE];
+
+      // Delay control signals to match data pipeline latency
+      util_pipeline_stage #(
+        .REGISTERED(CTRL_DELAY),
+        .WIDTH(CTRL_WIDTH_PER_STAGE)
+      ) i_ctrl_pipe (
+        .clk(clk),
+        .in(ctrl_stage_in),
+        .out(ctrl_stage_delayed)
+      );
 
       // Unpack uses forward shuffle and pack a reverse shuffle
       ad_perfect_shuffle #(
@@ -91,7 +157,7 @@ module pack_interconnect #(
         .data_out (shuffle_out));
 
       for (j = 0; j < NUM_PORTS; j = j + 1) begin: gen_ports
-        localparam ctrl_base = (ctrl_stage * NUM_PORTS + j) * MUX_ORDER;
+        localparam ctrl_offset = j * MUX_ORDER;
         localparam sel_base = j & ~(z-1); // base increments in 2**MUX_ORDER steps
 
         /*
@@ -107,22 +173,24 @@ module pack_interconnect #(
          * results in a different look-up table.
          */
 
-        wire [MUX_ORDER-1:0] sel = ctrl[ctrl_base+:MUX_ORDER];// + j % z;
+        // Use delayed control signals for proper timing alignment
+        wire [MUX_ORDER-1:0] sel = ctrl_stage_delayed[ctrl_offset+:MUX_ORDER];
         assign mux_out[j*w+:w] = mux_in[(sel_base+sel)*w+:w];
       end
 
       /*
        * Pack is MUX followed by shuffle.
        * Unpack is shuffle followed by MUX.
+       * Read from interconnect (pipelined) and write to interconnect_comb (combinational).
        */
       if (PACK) begin
         assign mux_in = interconnect[i];
         assign shuffle_in = mux_out;
-        assign interconnect[i+1] = shuffle_out;
+        assign interconnect_comb[i+1] = shuffle_out;
       end else begin
         assign shuffle_in = interconnect[i];
         assign mux_in = shuffle_out;
-        assign interconnect[i+1] = mux_out;
+        assign interconnect_comb[i+1] = mux_out;
       end
   end
   endgenerate

--- a/library/util_pack/util_pack_common/pack_interconnect.v
+++ b/library/util_pack/util_pack_common/pack_interconnect.v
@@ -1,6 +1,6 @@
 // ***************************************************************************
 // ***************************************************************************
-// Copyright (C) 2018-2023 Analog Devices, Inc. All rights reserved.
+// Copyright (C) 2018-2023, 2026 Analog Devices, Inc. All rights reserved.
 //
 // In this HDL repository, there are many different and unique modules, consisting
 // of various HDL (Verilog or VHDL) components. The individual modules are
@@ -41,9 +41,11 @@ module pack_interconnect #(
   parameter MUX_ORDER = 2,
   parameter NUM_STAGES = 2,
   parameter PACK = 0, // 0 = Unpack, 1 = Pack
-  parameter PIPELINE_STAGES = 0 // 0 = no pipeline, 1 = pipeline every 2 stages, 2 = pipeline every stage
+  parameter PIPELINE_STAGES = 0, // 0 = no pipeline, 1 = pipeline every 2 stages, 2 = pipeline every stage
+  parameter PIPELINE_OFFSET = 0  // Cumulative pipeline delay from previous networks
 ) (
   input clk,
+  (* max_fanout = 100 *) input ce,  // Clock enable for data pipeline registers
   input [2**PORT_ADDRESS_WIDTH*MUX_ORDER*NUM_STAGES-1:0] ctrl,
 
   input [PORT_DATA_WIDTH * 2**PORT_ADDRESS_WIDTH-1:0] data_in,
@@ -97,17 +99,24 @@ module pack_interconnect #(
       // PIPELINE_STAGES=0: no pipelining
       // PIPELINE_STAGES=1: pipeline after every 2 MUX stages (at p=2,4,6,...)
       // PIPELINE_STAGES=2: pipeline after every MUX stage (at p=1,2,3,...)
-      localparam SHOULD_REGISTER = (PIPELINE_STAGES == 2 && p > 0) ||
-                                   (PIPELINE_STAGES == 1 && p > 0 && p % 2 == 0);
+      localparam
+        SHOULD_REGISTER = (PIPELINE_STAGES == 2 && p > 0) ||
+        (PIPELINE_STAGES == 1 && p > 0 && p % 2 == 0);
 
-      util_pipeline_stage #(
-        .REGISTERED(SHOULD_REGISTER ? 1 : 0),
-        .WIDTH(TOTAL_DATA_WIDTH)
-      ) i_stage_pipe (
-        .clk(clk),
-        .in(interconnect_comb[p]),
-        .out(interconnect[p])
-      );
+      if (SHOULD_REGISTER == 0) begin
+        // No pipeline register, pass through
+        assign interconnect[p] = interconnect_comb[p];
+      end else begin
+        // Pipeline register advances only when ce is asserted
+        // This ensures data pipeline timing matches ce-gated control signals
+        (* shreg_extract = "no" *) reg [TOTAL_DATA_WIDTH-1:0] data_pipe = {TOTAL_DATA_WIDTH{1'b0}};
+        always @(posedge clk) begin
+          if (ce == 1'b1) begin
+            data_pipe <= interconnect_comb[p];
+          end
+        end
+        assign interconnect[p] = data_pipe;
+      end
     end
   endgenerate
 
@@ -124,7 +133,8 @@ module pack_interconnect #(
       localparam ctrl_stage = PACK ? NUM_STAGES - i - 1 : i;
 
       // Calculate cumulative delay for this stage control signals
-      localparam CTRL_DELAY = calc_ctrl_delay(i);
+      // Include PIPELINE_OFFSET from previous networks
+      localparam CTRL_DELAY = calc_ctrl_delay(i) + PIPELINE_OFFSET;
 
       wire [TOTAL_DATA_WIDTH-1:0] shuffle_in;
       wire [TOTAL_DATA_WIDTH-1:0] shuffle_out;
@@ -137,15 +147,26 @@ module pack_interconnect #(
       // Extract control bits for this stage
       assign ctrl_stage_in = ctrl[ctrl_stage*CTRL_WIDTH_PER_STAGE +: CTRL_WIDTH_PER_STAGE];
 
-      // Delay control signals to match data pipeline latency
-      util_pipeline_stage #(
-        .REGISTERED(CTRL_DELAY),
-        .WIDTH(CTRL_WIDTH_PER_STAGE)
-      ) i_ctrl_pipe (
-        .clk(clk),
-        .in(ctrl_stage_in),
-        .out(ctrl_stage_delayed)
-      );
+      // Delay control signals to match ce-gated data pipeline latency
+      // Control signals must also be ce-gated to maintain timing alignment
+      if (CTRL_DELAY == 0) begin: gen_ctrl_comb
+        assign ctrl_stage_delayed = ctrl_stage_in;
+      end else begin: gen_ctrl_pipe
+        (* shreg_extract = "no" *) reg [CTRL_WIDTH_PER_STAGE-1:0] ctrl_sr [0:CTRL_DELAY-1];
+        integer ci, cj;
+        initial begin
+          for (ci = 0; ci < CTRL_DELAY; ci = ci + 1)
+            ctrl_sr[ci] = {CTRL_WIDTH_PER_STAGE{1'b0}};
+        end
+        always @(posedge clk) begin
+          if (ce == 1'b1) begin
+            ctrl_sr[0] <= ctrl_stage_in;
+            for (cj = 1; cj < CTRL_DELAY; cj = cj + 1)
+              ctrl_sr[cj] <= ctrl_sr[cj-1];
+          end
+        end
+        assign ctrl_stage_delayed = ctrl_sr[CTRL_DELAY-1];
+      end
 
       // Unpack uses forward shuffle and pack a reverse shuffle
       ad_perfect_shuffle #(

--- a/library/util_pack/util_pack_common/pack_network.v
+++ b/library/util_pack/util_pack_common/pack_network.v
@@ -41,7 +41,8 @@ module pack_network #(
   parameter MIN_STAGE = 1,
   parameter NUM_STAGES = 1,
   parameter PACK = 0,
-  parameter PORT_DATA_WIDTH = 16
+  parameter PORT_DATA_WIDTH = 16,
+  parameter PIPELINE_STAGES = 0
 ) (
   input clk,
   input ce_ctrl,
@@ -97,8 +98,10 @@ module pack_network #(
     .PORT_ADDRESS_WIDTH (PORT_ADDRESS_WIDTH),
     .MUX_ORDER (MUX_ORDER),
     .NUM_STAGES (NUM_STAGES),
-    .PACK (PACK)
+    .PACK (PACK),
+    .PIPELINE_STAGES (PIPELINE_STAGES)
   ) i_interconnect (
+    .clk(clk),
     .ctrl(ctrl_),
 
     .data_in(data_in),

--- a/library/util_pack/util_pack_common/pack_network.v
+++ b/library/util_pack/util_pack_common/pack_network.v
@@ -1,6 +1,6 @@
 // ***************************************************************************
 // ***************************************************************************
-// Copyright (C) 2018-2023 Analog Devices, Inc. All rights reserved.
+// Copyright (C) 2018-2023, 2026 Analog Devices, Inc. All rights reserved.
 //
 // In this HDL repository, there are many different and unique modules, consisting
 // of various HDL (Verilog or VHDL) components. The individual modules are
@@ -42,10 +42,12 @@ module pack_network #(
   parameter NUM_STAGES = 1,
   parameter PACK = 0,
   parameter PORT_DATA_WIDTH = 16,
-  parameter PIPELINE_STAGES = 0
+  parameter PIPELINE_STAGES = 0,
+  parameter PIPELINE_OFFSET = 0
 ) (
   input clk,
   input ce_ctrl,
+  input ce,
 
   input [PORT_ADDRESS_WIDTH-1:0] rotate,
   input [2**PORT_ADDRESS_WIDTH*PORT_ADDRESS_WIDTH-1:0] prefix_count,
@@ -99,9 +101,11 @@ module pack_network #(
     .MUX_ORDER (MUX_ORDER),
     .NUM_STAGES (NUM_STAGES),
     .PACK (PACK),
-    .PIPELINE_STAGES (PIPELINE_STAGES)
+    .PIPELINE_STAGES (PIPELINE_STAGES),
+    .PIPELINE_OFFSET (PIPELINE_OFFSET)
   ) i_interconnect (
     .clk(clk),
+    .ce(ce),
     .ctrl(ctrl_),
 
     .data_in(data_in),

--- a/library/util_pack/util_pack_common/pack_shell.v
+++ b/library/util_pack/util_pack_common/pack_shell.v
@@ -40,7 +40,8 @@ module pack_shell #(
   parameter SAMPLES_PER_CHANNEL = 1,
   parameter SAMPLE_DATA_WIDTH = 16,
   parameter PACK = 0,
-  parameter PARALLEL_OR_SERIAL_N = 0
+  parameter PARALLEL_OR_SERIAL_N = 0,
+  parameter PIPELINE_STAGES = 0
 ) (
   input clk,
   input reset,
@@ -51,7 +52,7 @@ module pack_shell #(
 
   input ce,
 
-  output reg ready = 1'b0,
+  output ready,
   input [NUM_OF_CHANNELS*SAMPLE_DATA_WIDTH*SAMPLES_PER_CHANNEL-1:0] in_data,
 
   output [NUM_OF_CHANNELS*SAMPLE_DATA_WIDTH*SAMPLES_PER_CHANNEL-1:0] out_data,
@@ -67,6 +68,19 @@ module pack_shell #(
   localparam TOTAL_DATA_WIDTH = CHANNEL_DATA_WIDTH * NUM_OF_CHANNELS;
   localparam NUM_OF_SAMPLES = NUM_OF_CHANNELS * SAMPLES_PER_CHANNEL;
   localparam LOG2_NUM_OF_SAMPLES = $clog2(NUM_OF_SAMPLES);
+
+  // Function to calculate pipeline latency for a given number of MUX stages.
+  function integer calc_pipeline_latency;
+    input integer num_stages;
+    begin
+      if (PIPELINE_STAGES == 2)
+        calc_pipeline_latency = num_stages;
+      else if (PIPELINE_STAGES == 1)
+        calc_pipeline_latency = num_stages / 2;
+      else
+        calc_pipeline_latency = 0;
+    end
+  endfunction
 
   /*
    * Reset and control signals for the state machine. Data and control have
@@ -133,10 +147,7 @@ module pack_shell #(
       assign out_data = in_data;
       assign out_sync = 1'b1;
       assign out_valid = {NUM_OF_SAMPLES{1'b1}};
-
-      always @(*) begin
-        ready <= ce & ~reset_data;
-      end
+      assign ready = ce & ~reset_data;
     end else begin
       localparam SAMPLE_ADDRESS_WIDTH =
         NUM_OF_SAMPLES > 512 ? 10 :
@@ -148,6 +159,65 @@ module pack_shell #(
         NUM_OF_SAMPLES > 8 ? 4 :
         NUM_OF_SAMPLES > 4 ? 3 :
         NUM_OF_SAMPLES > 2 ? 2 : 1;
+
+      /*
+       * Calculate total pipeline latency from all pack_network stages.
+       * For PACK mode:
+       *   gen_network[0]: SAMPLE_ADDRESS_WIDTH / 2 stages (4:1 MUX)
+       *   gen_network[1]: SAMPLE_ADDRESS_WIDTH % 2 stages (2:1 MUX)
+       * For UNPACK mode:
+       *   i_ext_ctrl_interconnect: 1 stage (only if NON_POWER_OF_TWO)
+       *   gen_network[0]: (SAMPLE_ADDRESS_WIDTH - NON_POWER_OF_TWO) / 2 stages
+       *   gen_network[1]: (SAMPLE_ADDRESS_WIDTH - NON_POWER_OF_TWO) % 2 stages
+       */
+      localparam NETWORK0_STAGES = PACK ? (SAMPLE_ADDRESS_WIDTH / 2) :
+                                          ((SAMPLE_ADDRESS_WIDTH - NON_POWER_OF_TWO) / 2);
+      localparam NETWORK1_STAGES = PACK ? (SAMPLE_ADDRESS_WIDTH % 2) :
+                                          ((SAMPLE_ADDRESS_WIDTH - NON_POWER_OF_TWO) % 2);
+      localparam EXT_NETWORK_STAGES = (NON_POWER_OF_TWO == 1 && PACK == 0) ? 1 : 0;
+
+      localparam TOTAL_PIPELINE_LATENCY = calc_pipeline_latency(NETWORK0_STAGES) +
+                                          calc_pipeline_latency(NETWORK1_STAGES) +
+                                          calc_pipeline_latency(EXT_NETWORK_STAGES);
+
+      /*
+       * Internal versions of control signals before pipeline delay.
+       * These are delayed by TOTAL_PIPELINE_LATENCY cycles to match the
+       * data path latency through the pack/unpack network.
+       */
+      reg ready_int = 1'b0;
+      wire out_sync_int;
+      wire [NUM_OF_SAMPLES-1:0] out_valid_int;
+
+      // Pipeline delay for ready signal
+      util_pipeline_stage #(
+        .REGISTERED(TOTAL_PIPELINE_LATENCY),
+        .WIDTH(1)
+      ) i_ready_pipe (
+        .clk(clk),
+        .in(ready_int),
+        .out(ready)
+      );
+
+      // Pipeline delay for out_sync signal
+      util_pipeline_stage #(
+        .REGISTERED(TOTAL_PIPELINE_LATENCY),
+        .WIDTH(1)
+      ) i_out_sync_pipe (
+        .clk(clk),
+        .in(out_sync_int),
+        .out(out_sync)
+      );
+
+      // Pipeline delay for out_valid signal
+      util_pipeline_stage #(
+        .REGISTERED(TOTAL_PIPELINE_LATENCY),
+        .WIDTH(NUM_OF_SAMPLES)
+      ) i_out_valid_pipe (
+        .clk(clk),
+        .in(out_valid_int),
+        .out(out_valid)
+      );
 
       /*
        * `rotate` is used as an offset into the input data vector. When not all
@@ -330,7 +400,7 @@ module pack_shell #(
          * no configurations in which they'd be required.
          */
         always @(posedge clk) begin
-          if (ce == 1'b1 && ready == 1'b1) begin /* Just ready ??? */
+          if (ce == 1'b1 && ready_int == 1'b1) begin
             data_d1 <= in_data[TOTAL_DATA_WIDTH-1:2*CHANNEL_DATA_WIDTH];
           end
         end
@@ -340,13 +410,13 @@ module pack_shell #(
 
         always @(posedge clk) begin
           if (reset_ctrl == 1'b1) begin
-            ready <= 1'b0;
+            ready_int <= 1'b0;
             rotate_msb <= 1'b0;
 
             rotate <= 'h0;
             rotate_next <= 'h0;
           end else if (ce_ctrl == 1'b1) begin
-            ready <= 1'b0;
+            ready_int <= 1'b0;
             rotate_msb <= 1'b0;
 
             /*
@@ -356,7 +426,7 @@ module pack_shell #(
              */
             if (rotate_next_next[SAMPLE_ADDRESS_WIDTH] &
                 |rotate_next_next[SAMPLE_ADDRESS_WIDTH-1:0]) begin
-              ready <= 1'b1;
+              ready_int <= 1'b1;
               rotate_msb <= 1'b1;
             end
             /*
@@ -365,7 +435,7 @@ module pack_shell #(
              * previous cycle due to overconsumption.
              */
             if (rotate_next[SAMPLE_ADDRESS_WIDTH] == 1'b1 && rotate_msb == 1'b0) begin
-              ready <= 1'b1;
+              ready_int <= 1'b1;
             end
 
             rotate <= rotate_next;
@@ -383,7 +453,8 @@ module pack_shell #(
           .MUX_ORDER (2),
           .MIN_STAGE (0),
           .NUM_STAGES (1),
-          .PORT_DATA_WIDTH (SAMPLE_DATA_WIDTH)
+          .PORT_DATA_WIDTH (SAMPLE_DATA_WIDTH),
+          .PIPELINE_STAGES (PIPELINE_STAGES)
         ) i_ext_ctrl_interconnect (
           .clk (clk),
           .ce_ctrl (ce_ctrl),
@@ -416,7 +487,7 @@ module pack_shell #(
       end else begin
         always @(posedge clk) begin
           if (reset_ctrl == 1'b1) begin
-            ready <= 1'b0;
+            ready_int <= 1'b0;
             rotate <= 'h0;
           end else if (ce_ctrl == 1'b1) begin
             /*
@@ -426,7 +497,7 @@ module pack_shell #(
              * evenly divisible into the output data and there is no fractional
              * residual data. I.e. when ready is asserted rotate is 0.
              */
-            {ready,rotate} <= rotate + enable_count + 1'b1;
+            {ready_int,rotate} <= rotate + enable_count + 1'b1;
           end
         end
 
@@ -460,7 +531,8 @@ module pack_shell #(
             .MUX_ORDER (MUX_ORDER),
             .MIN_STAGE (MIN_STAGE),
             .NUM_STAGES (NUM_STAGES),
-            .PORT_DATA_WIDTH (SAMPLE_DATA_WIDTH)
+            .PORT_DATA_WIDTH (SAMPLE_DATA_WIDTH),
+            .PIPELINE_STAGES (PIPELINE_STAGES)
           ) i_ctrl_interconnect (
             .clk (clk),
             .ce_ctrl (ce_ctrl),
@@ -523,7 +595,7 @@ module pack_shell #(
           always @(posedge clk) begin
             if (reset_ctrl == 1'b1) begin
               sync <= 1'b1;
-            end else if (ready == 1'b1 && ce == 1'b1) begin
+            end else if (ready_int == 1'b1 && ce == 1'b1) begin
               if (rotate == 'h0) begin
                 sync <= 1'b1;
               end else begin
@@ -554,16 +626,16 @@ module pack_shell #(
             end
           end
 
-          assign out_sync = sync;
+          assign out_sync_int = sync;
         end else begin
           assign out_data = data[2];
-          assign out_sync = 1'b1;
+          assign out_sync_int = 1'b1;
         end
 
-        assign out_valid = valid;
+        assign out_valid_int = valid;
       end else begin
-        assign out_sync = 1'b1;
-        assign out_valid = {NUM_OF_SAMPLES{1'b1}};
+        assign out_sync_int = 1'b1;
+        assign out_valid_int = {NUM_OF_SAMPLES{1'b1}};
         assign out_data = data[2];
       end
     end

--- a/library/util_pack/util_pack_common/pack_shell.v
+++ b/library/util_pack/util_pack_common/pack_shell.v
@@ -1,6 +1,6 @@
 // ***************************************************************************
 // ***************************************************************************
-// Copyright (C) 2017-2023, 2025 Analog Devices, Inc. All rights reserved.
+// Copyright (C) 2017-2023, 2026 Analog Devices, Inc. All rights reserved.
 //
 // In this HDL repository, there are many different and unique modules, consisting
 // of various HDL (Verilog or VHDL) components. The individual modules are
@@ -149,8 +149,8 @@ module pack_shell #(
       assign out_valid = {NUM_OF_SAMPLES{1'b1}};
       assign ready = ce & ~reset_data;
     end else begin
-      localparam SAMPLE_ADDRESS_WIDTH =
-        NUM_OF_SAMPLES > 512 ? 10 :
+      localparam
+        SAMPLE_ADDRESS_WIDTH = NUM_OF_SAMPLES > 512 ? 10 :
         NUM_OF_SAMPLES > 256 ? 9 :
         NUM_OF_SAMPLES > 128 ? 8 :
         NUM_OF_SAMPLES > 64 ? 7 :
@@ -170,54 +170,90 @@ module pack_shell #(
        *   gen_network[0]: (SAMPLE_ADDRESS_WIDTH - NON_POWER_OF_TWO) / 2 stages
        *   gen_network[1]: (SAMPLE_ADDRESS_WIDTH - NON_POWER_OF_TWO) % 2 stages
        */
-      localparam NETWORK0_STAGES = PACK ? (SAMPLE_ADDRESS_WIDTH / 2) :
-                                          ((SAMPLE_ADDRESS_WIDTH - NON_POWER_OF_TWO) / 2);
-      localparam NETWORK1_STAGES = PACK ? (SAMPLE_ADDRESS_WIDTH % 2) :
-                                          ((SAMPLE_ADDRESS_WIDTH - NON_POWER_OF_TWO) % 2);
+      localparam
+        NETWORK0_STAGES = PACK ? (SAMPLE_ADDRESS_WIDTH / 2) :
+        ((SAMPLE_ADDRESS_WIDTH - NON_POWER_OF_TWO) / 2);
+      localparam
+        NETWORK1_STAGES = PACK ? (SAMPLE_ADDRESS_WIDTH % 2) :
+        ((SAMPLE_ADDRESS_WIDTH - NON_POWER_OF_TWO) % 2);
       localparam EXT_NETWORK_STAGES = (NON_POWER_OF_TWO == 1 && PACK == 0) ? 1 : 0;
 
-      localparam TOTAL_PIPELINE_LATENCY = calc_pipeline_latency(NETWORK0_STAGES) +
-                                          calc_pipeline_latency(NETWORK1_STAGES) +
-                                          calc_pipeline_latency(EXT_NETWORK_STAGES);
+      localparam
+        TOTAL_PIPELINE_LATENCY = calc_pipeline_latency(NETWORK0_STAGES) +
+        calc_pipeline_latency(NETWORK1_STAGES) +
+        calc_pipeline_latency(EXT_NETWORK_STAGES);
 
       /*
        * Internal versions of control signals before pipeline delay.
-       * These are delayed by TOTAL_PIPELINE_LATENCY cycles to match the
-       * data path latency through the pack/unpack network.
+       * These are delayed by TOTAL_PIPELINE_LATENCY clock enable cycles to match the
+       * ce-gated data path latency through the pack/unpack network.
+       *
+       * When PIPELINE_STAGES > 0, the data pipeline is ce-gated and control
+       * signal delays must also be ce-gated to maintain alignment.
        */
       reg ready_int = 1'b0;
       wire out_sync_int;
       wire [NUM_OF_SAMPLES-1:0] out_valid_int;
 
-      // Pipeline delay for ready signal
-      util_pipeline_stage #(
-        .REGISTERED(TOTAL_PIPELINE_LATENCY),
-        .WIDTH(1)
-      ) i_ready_pipe (
-        .clk(clk),
-        .in(ready_int),
-        .out(ready)
-      );
+      // Ce-gated pipeline delay for ready signal
+      // TOTAL_PIPELINE_LATENCY stages of ce-gated delay to match data pipeline
+      if (TOTAL_PIPELINE_LATENCY == 0) begin: gen_ready_comb
+        assign ready = ready_int;
+      end else begin: gen_ready_pipe
+        (* shreg_extract = "no" *) reg [TOTAL_PIPELINE_LATENCY-1:0] ready_sr = 'h0;
+        integer ri;
+        always @(posedge clk) begin
+          if (reset_ctrl == 1'b1) begin
+            ready_sr <= 'h0;
+          end else if (ce == 1'b1) begin
+            ready_sr[0] <= ready_int;
+            for (ri = 1; ri < TOTAL_PIPELINE_LATENCY; ri = ri + 1)
+              ready_sr[ri] <= ready_sr[ri-1];
+          end
+        end
+        assign ready = ready_sr[TOTAL_PIPELINE_LATENCY-1];
+      end
 
-      // Pipeline delay for out_sync signal
-      util_pipeline_stage #(
-        .REGISTERED(TOTAL_PIPELINE_LATENCY),
-        .WIDTH(1)
-      ) i_out_sync_pipe (
-        .clk(clk),
-        .in(out_sync_int),
-        .out(out_sync)
-      );
+      // Ce-gated pipeline delay for out_sync signal
+      if (TOTAL_PIPELINE_LATENCY == 0) begin: gen_sync_comb
+        assign out_sync = out_sync_int;
+      end else begin: gen_sync_pipe
+        (* shreg_extract = "no" *) reg [TOTAL_PIPELINE_LATENCY-1:0] sync_sr = 'h0;
+        integer si;
+        always @(posedge clk) begin
+          if (reset_ctrl == 1'b1) begin
+            sync_sr <= 'h0;
+          end else if (ce == 1'b1) begin
+            sync_sr[0] <= out_sync_int;
+            for (si = 1; si < TOTAL_PIPELINE_LATENCY; si = si + 1)
+              sync_sr[si] <= sync_sr[si-1];
+          end
+        end
+        assign out_sync = sync_sr[TOTAL_PIPELINE_LATENCY-1];
+      end
 
-      // Pipeline delay for out_valid signal
-      util_pipeline_stage #(
-        .REGISTERED(TOTAL_PIPELINE_LATENCY),
-        .WIDTH(NUM_OF_SAMPLES)
-      ) i_out_valid_pipe (
-        .clk(clk),
-        .in(out_valid_int),
-        .out(out_valid)
-      );
+      // Ce-gated pipeline delay for out_valid signal
+      if (TOTAL_PIPELINE_LATENCY == 0) begin: gen_valid_comb
+        assign out_valid = out_valid_int;
+      end else begin: gen_valid_pipe
+        (* shreg_extract = "no" *) reg [NUM_OF_SAMPLES-1:0] valid_sr [0:TOTAL_PIPELINE_LATENCY-1];
+        integer vi, vj;
+        initial begin
+          for (vi = 0; vi < TOTAL_PIPELINE_LATENCY; vi = vi + 1)
+            valid_sr[vi] = {NUM_OF_SAMPLES{1'b0}};
+        end
+        always @(posedge clk) begin
+          if (reset_ctrl == 1'b1) begin
+            for (vj = 0; vj < TOTAL_PIPELINE_LATENCY; vj = vj + 1)
+              valid_sr[vj] <= {NUM_OF_SAMPLES{1'b0}};
+          end else if (ce == 1'b1) begin
+            valid_sr[0] <= out_valid_int;
+            for (vj = 1; vj < TOTAL_PIPELINE_LATENCY; vj = vj + 1)
+              valid_sr[vj] <= valid_sr[vj-1];
+          end
+        end
+        assign out_valid = valid_sr[TOTAL_PIPELINE_LATENCY-1];
+      end
 
       /*
        * `rotate` is used as an offset into the input data vector. When not all
@@ -454,10 +490,12 @@ module pack_shell #(
           .MIN_STAGE (0),
           .NUM_STAGES (1),
           .PORT_DATA_WIDTH (SAMPLE_DATA_WIDTH),
-          .PIPELINE_STAGES (PIPELINE_STAGES)
+          .PIPELINE_STAGES (PIPELINE_STAGES),
+          .PIPELINE_OFFSET (0)
         ) i_ext_ctrl_interconnect (
           .clk (clk),
           .ce_ctrl (ce_ctrl),
+          .ce (ce),
 
           .rotate ({rotate_msb,rotate}),
           .prefix_count (ext_prefix_count),
@@ -518,11 +556,22 @@ module pack_shell #(
        */
       for (i = 0; i < 2; i = i + 1) begin: gen_network
         localparam MUX_ORDER = i == 0 ? 2 : 1;
-        localparam MIN_STAGE = PACK ? (i == 0 ? SAMPLE_ADDRESS_WIDTH % 2 : 0) :
-                                      (i == 0 ? NON_POWER_OF_TWO : SAMPLE_ADDRESS_WIDTH - 1);
-        localparam NUM_STAGES = PACK ? (i == 0 ? SAMPLE_ADDRESS_WIDTH / 2 : SAMPLE_ADDRESS_WIDTH % 2) :
-                                       (i == 0 ? (SAMPLE_ADDRESS_WIDTH - NON_POWER_OF_TWO) / 2 :
-                                                 (SAMPLE_ADDRESS_WIDTH - NON_POWER_OF_TWO) % 2);
+        localparam
+          MIN_STAGE = PACK ? (i == 0 ? SAMPLE_ADDRESS_WIDTH % 2 : 0) :
+          (i == 0 ? NON_POWER_OF_TWO : SAMPLE_ADDRESS_WIDTH - 1);
+        localparam
+          NUM_STAGES = PACK ?
+          (i == 0 ? SAMPLE_ADDRESS_WIDTH / 2 : SAMPLE_ADDRESS_WIDTH % 2) :
+          (i == 0 ? (SAMPLE_ADDRESS_WIDTH - NON_POWER_OF_TWO) / 2 :
+          (SAMPLE_ADDRESS_WIDTH - NON_POWER_OF_TWO) % 2);
+        // Cumulative pipeline delay from previous networks
+        // gen_network[0]: includes ext network latency (if present)
+        // gen_network[1]: includes ext network + gen_network[0] latency
+        localparam
+          PIPELINE_OFFSET = (i == 0) ?
+          calc_pipeline_latency(EXT_NETWORK_STAGES) :
+          calc_pipeline_latency(EXT_NETWORK_STAGES) +
+          calc_pipeline_latency(NETWORK0_STAGES);
 
         if (NUM_STAGES > 0) begin
           pack_network #(
@@ -532,10 +581,12 @@ module pack_shell #(
             .MIN_STAGE (MIN_STAGE),
             .NUM_STAGES (NUM_STAGES),
             .PORT_DATA_WIDTH (SAMPLE_DATA_WIDTH),
-            .PIPELINE_STAGES (PIPELINE_STAGES)
+            .PIPELINE_STAGES (PIPELINE_STAGES),
+            .PIPELINE_OFFSET (PIPELINE_OFFSET)
           ) i_ctrl_interconnect (
             .clk (clk),
             .ce_ctrl (ce_ctrl),
+            .ce (ce),
 
             .rotate (rotate),
             .prefix_count (prefix_count),
@@ -561,9 +612,17 @@ module pack_shell #(
          */
         reg [NUM_OF_SAMPLES-2*SAMPLES_PER_CHANNEL-1:0] prev_valid = 'h00;
 
+        /*
+         * Compute which positions are being filled. The mask is extended to
+         * the full width (NUM_OF_SAMPLES + prev_valid width) before shifting
+         * so that overflow bits properly go into prev_valid.
+         */
+        localparam PREV_VALID_WIDTH = NUM_OF_SAMPLES - 2 * SAMPLES_PER_CHANNEL;
+        localparam MASK_WIDTH = NUM_OF_SAMPLES + PREV_VALID_WIDTH;
+
         always @(posedge clk) begin
           if (ce_ctrl == 1'b1) begin
-            {prev_valid,valid} <= (({NUM_OF_SAMPLES{1'b1}} >> ~enable_count) << rotate) | prev_valid;
+            {prev_valid,valid} <= ({{PREV_VALID_WIDTH{1'b0}}, {NUM_OF_SAMPLES{1'b1}} >> ~enable_count} << rotate) | {{PREV_VALID_WIDTH{1'b0}}, prev_valid};
           end
         end
 
@@ -580,10 +639,38 @@ module pack_shell #(
           reg [DELAYED_DATA_WIDTH-1:0] data_d1 = 'h00;
 
           /*
-           * `prev_valid` delayed by one clock cyle. This is to compensate for
-           * the control pipeline delay.
+           * prev_valid_d1 needs ce-gated delay to match data_d1 timing.
+           * With ce-gated data pipeline of TOTAL_PIPELINE_LATENCY stages:
+           *   prev_valid: is set when overflow occurs
+           *   data_d1: captures overflow data (TOTAL_PIPELINE_LATENCY + 1) ce-cycles later
+           *   prev_valid_d1: must match this timing
+           *
+           * Use shift register for PV_DELAY ce-cycles delay.
            */
-          reg [NUM_OF_SAMPLES-2*SAMPLES_PER_CHANNEL-1:0] prev_valid_d1 = 'h00;
+          localparam PV_WIDTH = NUM_OF_SAMPLES - 2*SAMPLES_PER_CHANNEL;
+          localparam PV_DELAY = TOTAL_PIPELINE_LATENCY + 1;
+
+          (* shreg_extract = "no" *) reg [PV_WIDTH-1:0] pv_sr [0:PV_DELAY-1];
+          wire [PV_WIDTH-1:0] prev_valid_d1;
+
+          integer pv_i;
+          initial begin
+            for (pv_i = 0; pv_i < PV_DELAY; pv_i = pv_i + 1)
+              pv_sr[pv_i] = {PV_WIDTH{1'b0}};
+          end
+
+          always @(posedge clk) begin
+            if (reset_ctrl == 1'b1) begin
+              for (pv_i = 0; pv_i < PV_DELAY; pv_i = pv_i + 1)
+                pv_sr[pv_i] <= {PV_WIDTH{1'b0}};
+            end else if (ce_ctrl == 1'b1) begin
+              pv_sr[0] <= prev_valid;
+              for (pv_i = 1; pv_i < PV_DELAY; pv_i = pv_i + 1)
+                pv_sr[pv_i] <= pv_sr[pv_i-1];
+            end
+          end
+
+          assign prev_valid_d1 = pv_sr[PV_DELAY-1];
 
           /*
            * synchronization signal that indicates whether the first enabled
@@ -601,12 +688,6 @@ module pack_shell #(
               end else begin
                 sync <= 1'b0;
               end
-            end
-          end
-
-          always @(posedge clk) begin
-            if (ce_ctrl == 1'b1) begin
-              prev_valid_d1 <= prev_valid;
             end
           end
 

--- a/library/util_pack/util_upack2/Makefile
+++ b/library/util_pack/util_upack2/Makefile
@@ -7,6 +7,7 @@
 LIBRARY_NAME := util_upack2
 
 GENERIC_DEPS += ../../common/ad_perfect_shuffle.v
+GENERIC_DEPS += ../../common/util_pipeline_stage.v
 GENERIC_DEPS += ../util_pack_common/pack_ctrl.v
 GENERIC_DEPS += ../util_pack_common/pack_interconnect.v
 GENERIC_DEPS += ../util_pack_common/pack_network.v

--- a/library/util_pack/util_upack2/Makefile
+++ b/library/util_pack/util_upack2/Makefile
@@ -1,5 +1,5 @@
 ####################################################################################
-## Copyright (c) 2018 - 2023 Analog Devices, Inc.
+## Copyright (c) 2018 - 2023, 2026 Analog Devices, Inc.
 ### SPDX short identifier: BSD-1-Clause
 ## Auto-generated, do not modify!
 ####################################################################################

--- a/library/util_pack/util_upack2/util_upack2.v
+++ b/library/util_pack/util_upack2/util_upack2.v
@@ -1,6 +1,6 @@
 // ***************************************************************************
 // ***************************************************************************
-// Copyright (C) 2018-2023, 2025 Analog Devices, Inc. All rights reserved.
+// Copyright (C) 2018-2023, 2026 Analog Devices, Inc. All rights reserved.
 //
 // In this HDL repository, there are many different and unique modules, consisting
 // of various HDL (Verilog or VHDL) components. The individual modules are
@@ -189,12 +189,13 @@ module util_upack2 #(
    * Round up to the next power of two and zero out the additional channels
    * internally.
    */
-  localparam REAL_NUM_OF_CHANNELS = NUM_OF_CHANNELS > 32 ? 64 :
-     NUM_OF_CHANNELS > 16 ? 32 :
-     NUM_OF_CHANNELS > 8 ? 16 :
-     NUM_OF_CHANNELS > 4 ? 8 :
-     NUM_OF_CHANNELS > 2 ? 4 :
-     NUM_OF_CHANNELS > 1 ? 2 : 1;
+  localparam
+    REAL_NUM_OF_CHANNELS = NUM_OF_CHANNELS > 32 ? 64 :
+    NUM_OF_CHANNELS > 16 ? 32 :
+    NUM_OF_CHANNELS > 8 ? 16 :
+    NUM_OF_CHANNELS > 4 ? 8 :
+    NUM_OF_CHANNELS > 2 ? 4 :
+    NUM_OF_CHANNELS > 1 ? 2 : 1;
 
   /* FIXME: Find out how to do this in the IP-XACT */
 

--- a/library/util_pack/util_upack2/util_upack2.v
+++ b/library/util_pack/util_upack2/util_upack2.v
@@ -39,7 +39,8 @@ module util_upack2 #(
   parameter NUM_OF_CHANNELS = 4,
   parameter SAMPLES_PER_CHANNEL = 1,
   parameter SAMPLE_DATA_WIDTH = 16,
-  parameter PARALLEL_OR_SERIAL_N = 0
+  parameter PARALLEL_OR_SERIAL_N = 0,
+  parameter PIPELINE_STAGES = 0
 ) (
   input clk,
   input reset,
@@ -205,7 +206,8 @@ module util_upack2 #(
     .NUM_OF_CHANNELS(REAL_NUM_OF_CHANNELS),
     .SAMPLE_DATA_WIDTH(SAMPLE_DATA_WIDTH),
     .SAMPLES_PER_CHANNEL(SAMPLES_PER_CHANNEL),
-    .PARALLEL_OR_SERIAL_N (PARALLEL_OR_SERIAL_N)
+    .PARALLEL_OR_SERIAL_N (PARALLEL_OR_SERIAL_N),
+    .PIPELINE_STAGES (PIPELINE_STAGES)
   ) i_upack (
     .clk (clk),
     .reset (reset),

--- a/library/util_pack/util_upack2/util_upack2_hw.tcl
+++ b/library/util_pack/util_upack2/util_upack2_hw.tcl
@@ -1,5 +1,5 @@
 ###############################################################################
-## Copyright (C) 2018-2023, 2025 Analog Devices, Inc. All rights reserved.
+## Copyright (C) 2018-2023, 2026 Analog Devices, Inc. All rights reserved.
 ### SPDX short identifier: ADIBSD
 ###############################################################################
 

--- a/library/util_pack/util_upack2/util_upack2_hw.tcl
+++ b/library/util_pack/util_upack2/util_upack2_hw.tcl
@@ -10,6 +10,7 @@ source ../../scripts/adi_ip_intel.tcl
 ad_ip_create util_upack2 {Channel Unpack Utility v2} util_upack_elab
 ad_ip_files util_upack2_impl [list \
   $ad_hdl_dir/library/common/ad_perfect_shuffle.v \
+  $ad_hdl_dir/library/common/util_pipeline_stage.v \
   ../util_pack_common/pack_ctrl.v \
   ../util_pack_common/pack_interconnect.v \
   ../util_pack_common/pack_network.v \
@@ -38,6 +39,11 @@ ad_ip_parameter INTERFACE_TYPE INTEGER 0 false [list \
 ad_ip_parameter PARALLEL_OR_SERIAL_N INTEGER 0 true [list \
   DISPLAY_NAME "Parallel prefix sum calculation" \
   ALLOWED_RANGES {"0:Serial" "1:Parallel"} \
+]
+
+ad_ip_parameter PIPELINE_STAGES INTEGER 0 true [list \
+  DISPLAY_NAME "Configure pipeline stages" \
+  ALLOWED_RANGES {"0:No Pipeline" "1:Pipeline every 2 stages" "2:Pipeline every stage"} \
 ]
 
 # defaults

--- a/library/util_pack/util_upack2/util_upack2_impl.v
+++ b/library/util_pack/util_upack2/util_upack2_impl.v
@@ -1,6 +1,6 @@
 // ***************************************************************************
 // ***************************************************************************
-// Copyright (C) 2018-2023, 2025 Analog Devices, Inc. All rights reserved.
+// Copyright (C) 2018-2023, 2026 Analog Devices, Inc. All rights reserved.
 //
 // In this HDL repository, there are many different and unique modules, consisting
 // of various HDL (Verilog or VHDL) components. The individual modules are
@@ -59,8 +59,8 @@ module util_upack2_impl #(
 
   localparam NUM_OF_SAMPLES = NUM_OF_CHANNELS * SAMPLES_PER_CHANNEL;
 
-  localparam SAMPLE_ADDRESS_WIDTH =
-    NUM_OF_SAMPLES > 512 ? 10 :
+  localparam
+    SAMPLE_ADDRESS_WIDTH = NUM_OF_SAMPLES > 512 ? 10 :
     NUM_OF_SAMPLES > 256 ? 9 :
     NUM_OF_SAMPLES > 128 ? 8 :
     NUM_OF_SAMPLES > 64 ? 7 :
@@ -89,10 +89,11 @@ module util_upack2_impl #(
     end
   endfunction
 
-  localparam TOTAL_PIPELINE_LATENCY = (NUM_OF_CHANNELS == 1) ? 0 :
-                                       calc_pipeline_latency(NETWORK0_STAGES) +
-                                       calc_pipeline_latency(NETWORK1_STAGES) +
-                                       calc_pipeline_latency(EXT_NETWORK_STAGES);
+  localparam
+    TOTAL_PIPELINE_LATENCY = (NUM_OF_CHANNELS == 1) ? 0 :
+    calc_pipeline_latency(NETWORK0_STAGES) +
+    calc_pipeline_latency(NETWORK1_STAGES) +
+    calc_pipeline_latency(EXT_NETWORK_STAGES);
 
   /*
    * Final output data of the routing network that will be written to
@@ -142,8 +143,7 @@ module util_upack2_impl #(
   ) i_data_rd_en_pipe (
     .clk(clk),
     .in(data_rd_en),
-    .out(data_rd_en_delayed)
-  );
+    .out(data_rd_en_delayed));
 
   util_pipeline_stage #(
     .REGISTERED(TOTAL_PIPELINE_LATENCY),
@@ -151,8 +151,7 @@ module util_upack2_impl #(
   ) i_s_axis_valid_pipe (
     .clk(clk),
     .in(s_axis_valid),
-    .out(s_axis_valid_delayed)
-  );
+    .out(s_axis_valid_delayed));
 
   util_pipeline_stage #(
     .REGISTERED(TOTAL_PIPELINE_LATENCY),
@@ -160,8 +159,7 @@ module util_upack2_impl #(
   ) i_reset_data_pipe (
     .clk(clk),
     .in(reset_data),
-    .out(reset_data_delayed)
-  );
+    .out(reset_data_delayed));
 
   pack_shell #(
     .NUM_OF_CHANNELS (NUM_OF_CHANNELS),

--- a/library/util_pack/util_upack2/util_upack2_impl.v
+++ b/library/util_pack/util_upack2/util_upack2_impl.v
@@ -39,7 +39,8 @@ module util_upack2_impl #(
   parameter NUM_OF_CHANNELS = 4,
   parameter SAMPLES_PER_CHANNEL = 1,
   parameter SAMPLE_DATA_WIDTH = 16,
-  parameter PARALLEL_OR_SERIAL_N = 0
+  parameter PARALLEL_OR_SERIAL_N = 0,
+  parameter PIPELINE_STAGES = 0
 ) (
   input clk,
   input reset,
@@ -55,6 +56,43 @@ module util_upack2_impl #(
   output s_axis_ready,
   input [NUM_OF_CHANNELS*SAMPLE_DATA_WIDTH*SAMPLES_PER_CHANNEL-1:0] s_axis_data
 );
+
+  localparam NUM_OF_SAMPLES = NUM_OF_CHANNELS * SAMPLES_PER_CHANNEL;
+
+  localparam SAMPLE_ADDRESS_WIDTH =
+    NUM_OF_SAMPLES > 512 ? 10 :
+    NUM_OF_SAMPLES > 256 ? 9 :
+    NUM_OF_SAMPLES > 128 ? 8 :
+    NUM_OF_SAMPLES > 64 ? 7 :
+    NUM_OF_SAMPLES > 32 ? 6 :
+    NUM_OF_SAMPLES > 16 ? 5 :
+    NUM_OF_SAMPLES > 8 ? 4 :
+    NUM_OF_SAMPLES > 4 ? 3 :
+    NUM_OF_SAMPLES > 2 ? 2 : 1;
+
+  localparam NON_POWER_OF_TWO = NUM_OF_CHANNELS > 2;
+
+  localparam NETWORK0_STAGES = (SAMPLE_ADDRESS_WIDTH - NON_POWER_OF_TWO) / 2;
+  localparam NETWORK1_STAGES = (SAMPLE_ADDRESS_WIDTH - NON_POWER_OF_TWO) % 2;
+  localparam EXT_NETWORK_STAGES = NON_POWER_OF_TWO ? 1 : 0;
+
+  // Calculate pipeline latency per network based on PIPELINE_STAGES parameter
+  function integer calc_pipeline_latency;
+    input integer num_stages;
+    begin
+      if (PIPELINE_STAGES == 2)
+        calc_pipeline_latency = num_stages;
+      else if (PIPELINE_STAGES == 1)
+        calc_pipeline_latency = num_stages / 2;
+      else
+        calc_pipeline_latency = 0;
+    end
+  endfunction
+
+  localparam TOTAL_PIPELINE_LATENCY = (NUM_OF_CHANNELS == 1) ? 0 :
+                                       calc_pipeline_latency(NETWORK0_STAGES) +
+                                       calc_pipeline_latency(NETWORK1_STAGES) +
+                                       calc_pipeline_latency(EXT_NETWORK_STAGES);
 
   /*
    * Final output data of the routing network that will be written to
@@ -87,14 +125,51 @@ module util_upack2_impl #(
   assign data_rd_en = fifo_rd_en[0];
 
   assign ce = s_axis_valid & data_rd_en;
-  assign s_axis_ready = ready & ce;
+  /*
+   * Gate s_axis_ready with ~reset_data to immediately stop accepting data
+   * when the core is resetting. Without this the delayed 'ready' signal
+   * would allow data to enter during reset, causing incorrect output.
+   */
+  assign s_axis_ready = ready & ce & ~reset_data;
+
+  wire data_rd_en_delayed;
+  wire s_axis_valid_delayed;
+  wire reset_data_delayed;
+
+  util_pipeline_stage #(
+    .REGISTERED(TOTAL_PIPELINE_LATENCY),
+    .WIDTH(1)
+  ) i_data_rd_en_pipe (
+    .clk(clk),
+    .in(data_rd_en),
+    .out(data_rd_en_delayed)
+  );
+
+  util_pipeline_stage #(
+    .REGISTERED(TOTAL_PIPELINE_LATENCY),
+    .WIDTH(1)
+  ) i_s_axis_valid_pipe (
+    .clk(clk),
+    .in(s_axis_valid),
+    .out(s_axis_valid_delayed)
+  );
+
+  util_pipeline_stage #(
+    .REGISTERED(TOTAL_PIPELINE_LATENCY),
+    .WIDTH(1)
+  ) i_reset_data_pipe (
+    .clk(clk),
+    .in(reset_data),
+    .out(reset_data_delayed)
+  );
 
   pack_shell #(
     .NUM_OF_CHANNELS (NUM_OF_CHANNELS),
     .SAMPLES_PER_CHANNEL (SAMPLES_PER_CHANNEL),
     .SAMPLE_DATA_WIDTH (SAMPLE_DATA_WIDTH),
     .PACK (0),
-    .PARALLEL_OR_SERIAL_N (PARALLEL_OR_SERIAL_N)
+    .PARALLEL_OR_SERIAL_N (PARALLEL_OR_SERIAL_N),
+    .PIPELINE_STAGES (PIPELINE_STAGES)
   ) i_pack_shell (
     .clk (clk),
     .reset (reset),
@@ -124,19 +199,19 @@ module util_upack2_impl #(
     .data_out (deinterleaved_data));
 
   always @(posedge clk) begin
-    /* In case of an underflow the output vector should be zeroed */
-    if (reset_data == 1'b1 ||
-        (data_rd_en == 1'b1 && s_axis_valid == 1'b0)) begin
+    /* In case of an underflow or reset the output vector should be zeroed */
+    if (reset_data_delayed == 1'b1 ||
+        (data_rd_en_delayed == 1'b1 && s_axis_valid_delayed == 1'b0)) begin
       fifo_rd_data <= 'h00;
-    end else if (data_rd_en == 1'b1) begin
+    end else if (data_rd_en_delayed == 1'b1) begin
       fifo_rd_data <= deinterleaved_data;
     end
   end
 
   always @(posedge clk) begin
-    if (data_rd_en == 1'b1) begin
-      fifo_rd_valid <= s_axis_valid & ~reset_data;
-      fifo_rd_underflow <= ~(s_axis_valid & ~reset_data);
+    if (data_rd_en_delayed == 1'b1) begin
+      fifo_rd_valid <= s_axis_valid_delayed & ~reset_data_delayed;
+      fifo_rd_underflow <= ~(s_axis_valid_delayed & ~reset_data_delayed);
     end else begin
       fifo_rd_valid <= 1'b0;
       fifo_rd_underflow <= 1'b0;

--- a/library/util_pack/util_upack2/util_upack2_ip.tcl
+++ b/library/util_pack/util_upack2/util_upack2_ip.tcl
@@ -1,5 +1,5 @@
 ###############################################################################
-## Copyright (C) 2018-2023, 2025 Analog Devices, Inc. All rights reserved.
+## Copyright (C) 2018-2023, 2026 Analog Devices, Inc. All rights reserved.
 ### SPDX short identifier: ADIBSD
 ###############################################################################
 

--- a/library/util_pack/util_upack2/util_upack2_ip.tcl
+++ b/library/util_pack/util_upack2/util_upack2_ip.tcl
@@ -9,6 +9,7 @@ source $ad_hdl_dir/library/scripts/adi_ip_xilinx.tcl
 adi_ip_create util_upack2
 adi_ip_files util_upack2 [list \
   "../../common/ad_perfect_shuffle.v" \
+  "../../common/util_pipeline_stage.v" \
   "../util_pack_common/pack_ctrl.v" \
   "../util_pack_common/pack_interconnect.v" \
   "../util_pack_common/pack_network.v" \
@@ -41,6 +42,7 @@ foreach {k v} { \
   "SAMPLES_PER_CHANNEL" "Samples per Channel" \
   "SAMPLE_DATA_WIDTH" "Sample Width" \
   "PARALLEL_OR_SERIAL_N" "Parallel prefix sum calculation" \
+  "PIPELINE_STAGES" "Configure pipeline stages" \
   } { \
   set p [ipgui::get_guiparamspec -name $k -component $cc]
 #  ipgui::move_param -component $cc -order $i $p -parent $


### PR DESCRIPTION
## PR Description

High-speed JESD204B/C designs with many converters (high M) or many samples per converter (high S) face timing challenges in the cpack/upack routing networks. The long combinational paths through multiple MUX stages can become critical paths, limiting achievable clock frequencies.

This PR adds configurable pipelining support to util_cpack2 and util_upack2 cores to improve timing closure for high-speed JESD designs with large converter counts or high sample rates.

Key Features:

- New PIPELINE_STAGES parameter to control pipeline depth (possible values are: 0 = no pipeline, 1 = pipeline every 2 stages, 2 = pipeline every stage)
- Clock enabled pipeline stages to maintain proper data alignment
- Backwards compatible, default behavior unchanged (with PIPELINE_STAGES=0)

## PR Type
- [ ] Bug fix (change that fixes an issue)
- [x] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)
- [ ] Documentation

## PR Checklist
- [x] I have followed the code style guidelines
- [x] I have performed a self-review of changes
- [ ] I have compiled all hdl projects and libraries affected by this PR
- [x] I have tested in hardware affected projects, at least on relevant boards
- [x] I have commented my code, at least hard-to-understand parts
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe files, Copyright etc)
- [x] I have not introduced new Warnings/Critical Warnings on compilation
- [x] I have added new hdl testbenches or updated existing ones
