### PR TITLE
docs: Rename adi-kuiper-gen to kuiper

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -27,7 +27,7 @@ source_suffix = '.rst'
 # -- External docs configuration ----------------------------------------------
 
 interref_repos = [
-        'adi-kuiper-gen',
+        'kuiper',
         'doctools',
         'documentation',
         'no-OS',

--- a/docs/user_guide/build_boot_bin.rst
+++ b/docs/user_guide/build_boot_bin.rst
@@ -58,7 +58,7 @@ The script can take 3 parameters:
 
    Keep in mind that **the u-boot is FPGA-specific**!
 
-   See this :external+adi-kuiper-gen:ref:`tutorial <quick-start>` for
+   See this :external+kuiper:ref:`tutorial <quick-start>` for
    instructions on how to obtain the ADI Kuiper image and use it.
 
 If you didn't use ``make`` parameters when building the project, then
@@ -116,7 +116,7 @@ The script can take 4 parameters (the last one is optional):
 
    Keep in mind that **the u-boot is FPGA-specific**!
 
-   See this :external+adi-kuiper-gen:ref:`tutorial <quick-start>` for
+   See this :external+kuiper:ref:`tutorial <quick-start>` for
    instructions on how to obtain the ADI Kuiper image and use it.
 
 If you didn't use ``make`` parameters when building the project, then
@@ -173,7 +173,7 @@ The script can take 4 parameters:
 
    Keep in mind that **the u-boot is FPGA-specific**!
 
-   See this :external+adi-kuiper-gen:ref:`tutorial <quick-start>` for
+   See this :external+kuiper:ref:`tutorial <quick-start>` for
    instructions on how to obtain the ADI Kuiper image and use it.
 
 If you didn't use ``make`` parameters when building the project, then

--- a/docs/user_guide/build_hdl.rst
+++ b/docs/user_guide/build_hdl.rst
@@ -1141,9 +1141,9 @@ e.g. ``component.xml`` and ``.lock`` files.
 -------------------------------------------------------------------------------
 
 First, you have to write the SD card with the
-:external+adi-kuiper-gen:doc:`ADI Kuiper image <index>`.
+:external+kuiper:doc:`ADI Kuiper image <index>`.
 Check this
-:external+adi-kuiper-gen:ref:`tutorial <quick-start>`.
+:external+kuiper:ref:`tutorial <quick-start>`.
 
 Once you are done with that, you can go on with the following steps.
 


### PR DESCRIPTION

## PR Description

To encompass all features in the adi-kuiper-gen repository, it was renamed to just 'kuiper', and also simplify cross-references. Update cross-ref to match.

For curiosity, this kinda of bulk maintenance can be done with
```
# Clone all tracked gh-pages
   $ while read p; do \
       git clone https://github.com/analogdevicesinc/$p --branch gh-pages --depth=1 ; \
     done <<<"$(curl https://analogdevicesinc.github.io/doctools/metadata.json | jq -r '.repotoc | keys[]')"
   # Check for matches
   $ grep -r "github.io/adi-kuiper-gen" \
       | cut -d: -f1 \
       | cut -d/ -f1-2 \
       | sort -u
   # Then do some recursive sed to mass replace at the correct branch
```

## PR Type
- [ ] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)
- [x] Documentation

## PR Checklist
- [ ] I have followed the code style guidelines
- [ ] I have performed a self-review of changes
- [ ] I have compiled all hdl projects and libraries affected by this PR
- [ ] I have tested in hardware affected projects, at least on relevant boards
- [ ] I have commented my code, at least hard-to-understand parts
- [ ] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe files, Copyright etc)
- [ ] I have not introduced new Warnings/Critical Warnings on compilation
- [ ] I have added new hdl testbenches or updated existing ones
