### PR TITLE
library: Add axi_adf4030 IP for AION bsync and triggers synchronization

### DIFF
--- a/library/axi_adf4030/Makefile
+++ b/library/axi_adf4030/Makefile
@@ -1,0 +1,23 @@
+####################################################################################
+## Copyright (c) 2026 Analog Devices, Inc.
+### SPDX short identifier: BSD-1-Clause
+## Auto-generated, do not modify!
+####################################################################################
+
+LIBRARY_NAME := axi_adf4030
+
+GENERIC_DEPS += ../common/up_axi.v
+GENERIC_DEPS += ../common/ad_rst.v
+GENERIC_DEPS += ../util_cdc/sync_bits.v
+GENERIC_DEPS += ../util_cdc/sync_data.v
+GENERIC_DEPS += ../util_cdc/sync_event.v
+GENERIC_DEPS += axi_adf4030.sv
+GENERIC_DEPS += axi_adf4030_regmap.sv
+GENERIC_DEPS += bsync_generator.sv
+GENERIC_DEPS += trigger_channel.sv
+GENERIC_DEPS += trigger_bsync_stretcher.sv
+
+XILINX_DEPS += axi_adf4030_constr.ttcl
+XILINX_DEPS += axi_adf4030_ip.tcl
+
+include ../scripts/library.mk

--- a/library/axi_adf4030/axi_adf4030.sv
+++ b/library/axi_adf4030/axi_adf4030.sv
@@ -1,0 +1,262 @@
+// ***************************************************************************
+// ***************************************************************************
+// Copyright (C) 2026 Analog Devices, Inc. All rights reserved.
+//
+// In this HDL repository, there are many different and unique modules, consisting
+// of various HDL (Verilog or VHDL) components. The individual modules are
+// developed independently, and may be accompanied by separate and unique license
+// terms.
+//
+// The user should read each of these license terms, and understand the
+// freedoms and responsibilities that he or she has by using this source/core.
+//
+// This core is distributed in the hope that it will be useful, but WITHOUT ANY
+// WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+// A PARTICULAR PURPOSE.
+//
+// Redistribution and use of source or resulting binaries, with or without modification
+// of this file, are permitted under one of the following two license terms:
+//
+//   1. The GNU General Public License version 2 as published by the
+//      Free Software Foundation, which can be found in the top level directory
+//      of this repository (LICENSE_GPL2), and also online at:
+//      <https://www.gnu.org/licenses/old-licenses/gpl-2.0.html>
+//
+// OR
+//
+//   2. An ADI specific BSD license, which can be found in the top level directory
+//      of this repository (LICENSE_ADIBSD), and also on-line at:
+//      https://github.com/analogdevicesinc/hdl/blob/main/LICENSE_ADIBSD
+//      This will allow to generate bit files and not release the source code,
+//      as long as it attaches to an ADI device.
+//
+// ***************************************************************************
+// ***************************************************************************
+
+`timescale 1ns / 1ps
+
+module axi_adf4030 #(
+  // Peripheral ID
+  parameter ID = 0,
+  // FPGA FAMILY
+  parameter FPGA_FAMILY = 0,
+  // Number of active trigger channels
+  parameter CHANNEL_COUNT = 1,
+  parameter TRIGGER_STRETCH = 0
+) (
+
+  inout  logic bsync_p,
+  inout  logic bsync_n,
+  input  logic device_clk,
+  input  logic trigger,
+  output logic sysref,
+  output logic [CHANNEL_COUNT-1:0] trig_channel,
+  output logic trig_request_out,
+
+  // AXI BUS
+  input  logic                     s_axi_aresetn,
+  input  logic                     s_axi_aclk,
+  input  logic                     s_axi_awvalid,
+  input  logic [ 9:0]              s_axi_awaddr,
+  input  logic [ 2:0]              s_axi_awprot,
+  output logic                     s_axi_awready,
+  input  logic                     s_axi_wvalid,
+  input  logic [31:0]              s_axi_wdata,
+  input  logic [ 3:0]              s_axi_wstrb,
+  output logic                     s_axi_wready,
+  output logic                     s_axi_bvalid,
+  output logic [ 1:0]              s_axi_bresp,
+  input  logic                     s_axi_bready,
+  input  logic                     s_axi_arvalid,
+  input  logic [ 9:0]              s_axi_araddr,
+  input  logic [ 2:0]              s_axi_arprot,
+  output logic                     s_axi_arready,
+  output logic                     s_axi_rvalid,
+  output logic [ 1:0]              s_axi_rresp,
+  output logic [31:0]              s_axi_rdata,
+  input  logic                     s_axi_rready
+);
+
+  localparam SIM_DEVICE = (FPGA_FAMILY == 7) ? "VERSAL_PREMIUM" : ((FPGA_FAMILY == 6) ? "VERSAL_AI_CORE" : "ULTRASCALE");
+
+  logic        external_bsync;
+  logic        internal_bsync;
+  logic        trigger_sync;
+  logic        bsync_ready;
+  logic [15:0] bsync_ratio;
+  logic [ 4:0] bsync_delay;
+  logic        bsync_alignment_error;
+  logic        bsync_captured;
+  logic [ 2:0] bsync_state;
+  logic        bsync_event;
+  logic        manual_trig;
+  logic        select_trig;
+  logic        enable_debug_trig;
+  logic        debug_trig;
+  logic        enable_misalign_check;
+  logic        trig;
+  logic        trig_in;
+
+  // Internal up bus, translated by up_axi
+  logic        up_rstn;
+  logic        up_clk;
+  logic        up_wreq;
+  logic [ 7:0] up_waddr;
+  logic [31:0] up_wdata;
+  logic        up_wack;
+  logic        up_rreq;
+  logic [ 7:0] up_raddr;
+  logic [31:0] up_rdata;
+  logic        up_rack;
+
+  assign up_clk  = s_axi_aclk;
+  assign up_rstn = s_axi_aresetn;
+
+  logic [CHANNEL_COUNT-1:0] trig_channel_en;
+  logic [15:0]              trig_channel_phase [CHANNEL_COUNT - 1:0];
+  logic [ 2:0]              trig_state         [CHANNEL_COUNT - 1:0];
+  logic                     direction;
+  logic                     disable_internal_bsync;
+  logic [CHANNEL_COUNT-1:0] trig_channel_s;
+
+  IOBUFDS_DCIEN #(
+    .SIM_DEVICE      (SIM_DEVICE),
+    .USE_IBUFDISABLE ("TRUE")
+  ) IOBUFDS_inst (
+   .O              (external_bsync),
+   .DCITERMDISABLE (0),
+   .I              (internal_bsync),
+   .IBUFDISABLE    (!direction),
+   .IO             (bsync_p),
+   .IOB            (bsync_n),
+   .T              (direction));
+
+  assign sysref = external_bsync;
+
+  bsync_generator i_bsync_gen (
+    .clk                    (device_clk),
+    .rstn                   (rstn),
+    .direction              (direction),
+    .bsync_in               (external_bsync),
+    .disable_internal_bsync (disable_internal_bsync),
+    .enable_misalign_check  (enable_misalign_check),
+    .bsync_ready            (bsync_ready),
+    .bsync_delay            (bsync_delay),
+    .bsync_ratio            (bsync_ratio),
+    .bsync_alignment_error  (bsync_alignment_error),
+    .bsync_captured         (bsync_captured),
+    .bsync_state            (bsync_state),
+    .bsync_event            (bsync_event),
+    .bsync_out              (internal_bsync));
+
+  ad_rst i_trig_sync (
+    .rst_async (trigger),
+    .clk       (device_clk),
+    .rstn      (),
+    .rst       (trigger_sync));
+
+  assign trig = enable_debug_trig ? 1'b0 : (select_trig ? trigger_sync : manual_trig);
+
+  generate
+    if (TRIGGER_STRETCH) begin
+      trigger_bsync_stretcher i_trigger_stretcher (
+        .external_bsync(external_bsync),
+        .trigger(trig),
+        .sync_start(trig_in));
+    end else begin
+      assign trig_in = trig;
+    end
+  endgenerate
+
+  assign trig_request_out = trig_in;
+
+  genvar i;
+  generate
+    for (i = 0; i < CHANNEL_COUNT; i = i + 1) begin
+      trigger_channel i_channel (
+        .clk         (device_clk),
+        .rstn        (rstn),
+        .trigger     (trig_in),
+        .ch_en       (trig_channel_en[i]),
+        .ch_phase    (trig_channel_phase[i]),
+        .bsync_event (bsync_event),
+        .bsync_ready (bsync_ready),
+        .bsync_delay (bsync_delay),
+        .bsync_ratio (bsync_ratio),
+        .trig_state  (trig_state[i]),
+        .trig_out    (trig_channel_s[i]));
+
+      assign trig_channel[i] = enable_debug_trig ? debug_trig : trig_channel_s[i];
+    end
+  endgenerate
+
+  axi_adf4030_regmap #(
+    .ID            (ID),
+    .CHANNEL_COUNT (CHANNEL_COUNT)
+  ) i_regmap (
+    .clk                    (device_clk),
+    .rstn                   (rstn),
+
+    .trig_channel_en        (trig_channel_en),
+    .trig_channel_phase     (trig_channel_phase),
+    .direction              (direction),
+    .disable_internal_bsync (disable_internal_bsync),
+    .manual_trig            (manual_trig),
+    .select_trig            (select_trig),
+    .enable_debug_trig      (enable_debug_trig),
+    .debug_trig             (debug_trig),
+    .enable_misalign_check  (enable_misalign_check),
+
+    .bsync_ready            (bsync_ready),
+    .bsync_delay            (bsync_delay),
+    .bsync_ratio            (bsync_ratio),
+    .bsync_alignment_error  (bsync_alignment_error),
+    .bsync_captured         (bsync_captured),
+    .bsync_state            (bsync_state),
+    .trig_state             (trig_state),
+
+    .up_rstn                (up_rstn),
+    .up_clk                 (up_clk),
+    .up_wreq                (up_wreq),
+    .up_waddr               (up_waddr),
+    .up_wdata               (up_wdata),
+    .up_wack                (up_wack),
+    .up_rreq                (up_rreq),
+    .up_raddr               (up_raddr),
+    .up_rdata               (up_rdata),
+    .up_rack                (up_rack));
+
+  up_axi #(
+    .AXI_ADDRESS_WIDTH(10)
+  ) i_up_axi (
+    .up_rstn        (s_axi_aresetn),
+    .up_clk         (s_axi_aclk),
+
+    .up_axi_awvalid (s_axi_awvalid),
+    .up_axi_awaddr  (s_axi_awaddr),
+    .up_axi_awready (s_axi_awready),
+    .up_axi_wvalid  (s_axi_wvalid),
+    .up_axi_wdata   (s_axi_wdata),
+    .up_axi_wstrb   (s_axi_wstrb),
+    .up_axi_wready  (s_axi_wready),
+    .up_axi_bvalid  (s_axi_bvalid),
+    .up_axi_bresp   (s_axi_bresp),
+    .up_axi_bready  (s_axi_bready),
+    .up_axi_arvalid (s_axi_arvalid),
+    .up_axi_araddr  (s_axi_araddr),
+    .up_axi_arready (s_axi_arready),
+    .up_axi_rvalid  (s_axi_rvalid),
+    .up_axi_rresp   (s_axi_rresp),
+    .up_axi_rdata   (s_axi_rdata),
+    .up_axi_rready  (s_axi_rready),
+
+    .up_wreq        (up_wreq),
+    .up_waddr       (up_waddr),
+    .up_wdata       (up_wdata),
+    .up_wack        (up_wack),
+    .up_rreq        (up_rreq),
+    .up_raddr       (up_raddr),
+    .up_rdata       (up_rdata),
+    .up_rack        (up_rack));
+
+endmodule

--- a/library/axi_adf4030/axi_adf4030_constr.ttcl
+++ b/library/axi_adf4030/axi_adf4030_constr.ttcl
@@ -1,0 +1,174 @@
+###############################################################################
+## Copyright (C) 2026 Analog Devices, Inc. All rights reserved.
+### SPDX short identifier: ADIBSD
+###############################################################################
+
+<: set ComponentName [getComponentNameString] :>
+<: setOutputDirectory "./" :>
+<: setFileName [ttcl_add $ComponentName "_constr"] :>
+<: setFileExtension ".xdc" :>
+<: setFileProcessingOrder late :>
+
+set_property ASYNC_REG TRUE \
+  [get_cells -hier {*cdc_sync_stage1_reg*}] \
+  [get_cells -hier {*cdc_sync_stage2_reg*}]
+
+set_false_path \
+  -from [get_cells -hierarchical * -filter {NAME=~*i_regmap/up_direction_reg}] \
+  -to [get_cells -hierarchical * -filter {NAME=~*i_bsync_gen/bsync_counter_reg[*]}]
+
+set_false_path \
+  -from [get_cells -hierarchical * -filter {NAME=~*i_regmap/up_direction_reg_replica}] \
+  -to [get_cells -hierarchical * -filter {NAME=~*i_bsync_gen/bsync_counter_reg[*]}]
+
+set_false_path \
+  -from [get_cells -hierarchical * -filter {NAME=~*i_regmap/up_sw_reset_reg}] \
+  -to [get_cells -hierarchical * -filter {NAME=~*i_regmap/i_control_signals/cdc_sync_stage1_reg[1]}]
+
+set_false_path \
+  -from [get_cells -hierarchical * -filter {NAME=~*i_regmap/up_sw_reset_reg_replica}] \
+  -to [get_cells -hierarchical * -filter {NAME=~*i_regmap/i_control_signals/cdc_sync_stage1_reg[1]}]
+
+set_false_path \
+  -from [get_cells -hierarchical * -filter {NAME=~*i_regmap/up_sw_resetn_reg[*]}] \
+  -to [get_cells -hierarchical * -filter {NAME=~*i_regmap/i_control_signals/cdc_sync_stage1_reg[*]}]
+
+set_false_path \
+  -from [get_cells -hierarchical * -filter {NAME=~*i_regmap/up_disable_internal_bsync_reg[*]}] \
+  -to [get_cells -hierarchical * -filter {NAME=~*i_regmap/i_control_signals/cdc_sync_stage1_reg[*]}]
+
+set_false_path \
+  -from [get_cells -hierarchical * -filter {NAME=~*i_regmap/up_direction_reg[*]}] \
+  -to [get_cells -hierarchical * -filter {NAME=~*i_bsync_gen/i_control_signals/cdc_sync_stage1_reg[0]}]
+
+set_false_path \
+  -from [get_cells -hierarchical * -filter {NAME=~*i_regmap/up_direction_reg[*]}] \
+  -to [get_cells -hierarchical * -filter {NAME=~*i_regmap/i_control_signals/cdc_sync_stage1_reg[*]}]
+
+set_false_path \
+  -from [get_cells -hierarchical * -filter {NAME=~*i_regmap/*i_trig_channel_en/cdc_hold_reg*}] \
+  -to [get_cells -hierarchical * -filter {NAME=~*i_regmap/*i_trig_channel_en/out_data_reg*}]
+
+set_false_path \
+  -from [get_cells -hierarchical * -filter {NAME=~*i_regmap/*i_trig_channel_en/in_toggle_d1_reg}] \
+  -to [get_cells -hierarchical * -filter {NAME=~*i_regmap/*i_trig_channel_en/i_sync_out/cdc_sync_stage1_reg[*]}]
+
+set_false_path \
+  -from [get_cells -hierarchical * -filter {NAME=~*i_regmap/*i_trig_channel_en/out_toggle_d1_reg}] \
+  -to [get_cells -hierarchical * -filter {NAME=~*i_regmap/*i_trig_channel_en/i_sync_in/cdc_sync_stage1_reg[*]}]
+
+set_false_path \
+  -from [get_cells -hierarchical * -filter {NAME=~*i_regmap/*i_trig_channel_phase/cdc_hold_reg*}] \
+  -to [get_cells -hierarchical * -filter {NAME=~*i_regmap/*i_trig_channel_phase/out_data_reg*}]
+
+set_false_path \
+  -from [get_cells -hierarchical * -filter {NAME=~*i_regmap/*i_trig_channel_phase/in_toggle_d1_reg}] \
+  -to [get_cells -hierarchical * -filter {NAME=~*i_regmap/*i_trig_channel_phase/i_sync_out/cdc_sync_stage1_reg[*]}]
+
+set_false_path \
+  -from [get_cells -hierarchical * -filter {NAME=~*i_regmap/*i_trig_channel_phase/out_toggle_d1_reg}] \
+  -to [get_cells -hierarchical * -filter {NAME=~*i_regmap/*i_trig_channel_phase/i_sync_in/cdc_sync_stage1_reg[*]}]
+
+set_false_path \
+  -from [get_cells -hierarchical * -filter {NAME=~*i_regmap/i_bsync_state/cdc_hold_reg*}] \
+  -to [get_cells -hierarchical * -filter {NAME=~*i_regmap/i_bsync_state/out_data_reg*}]
+
+set_false_path \
+  -from [get_cells -hierarchical * -filter {NAME=~*i_regmap/i_bsync_state/in_toggle_d1_reg}] \
+  -to [get_cells -hierarchical * -filter {NAME=~*i_regmap/i_bsync_state/i_sync_out/cdc_sync_stage1_reg[*]}]
+
+set_false_path \
+  -from [get_cells -hierarchical * -filter {NAME=~*i_regmap/i_bsync_state/out_toggle_d1_reg}] \
+  -to [get_cells -hierarchical * -filter {NAME=~*i_regmap/i_bsync_state/i_sync_in/cdc_sync_stage1_reg[*]}]
+
+set_false_path \
+  -from [get_cells -hierarchical * -filter {NAME=~*i_regmap/i_bsync_ratio/cdc_hold_reg*}] \
+  -to [get_cells -hierarchical * -filter {NAME=~*i_regmap/i_bsync_ratio/out_data_reg*}]
+
+set_false_path \
+  -from [get_cells -hierarchical * -filter {NAME=~*i_regmap/i_bsync_ratio/in_toggle_d1_reg}] \
+  -to [get_cells -hierarchical * -filter {NAME=~*i_regmap/i_bsync_ratio/i_sync_out/cdc_sync_stage1_reg[*]}]
+
+set_false_path \
+  -from [get_cells -hierarchical * -filter {NAME=~*i_regmap/i_bsync_ratio/out_toggle_d1_reg}] \
+  -to [get_cells -hierarchical * -filter {NAME=~*i_regmap/i_bsync_ratio/i_sync_in/cdc_sync_stage1_reg[*]}]
+
+set_false_path \
+  -from [get_cells -hierarchical * -filter {NAME=~*i_regmap/i_bsync_delay/cdc_hold_reg*}] \
+  -to [get_cells -hierarchical * -filter {NAME=~*i_regmap/i_bsync_delay/out_data_reg*}]
+
+set_false_path \
+  -from [get_cells -hierarchical * -filter {NAME=~*i_regmap/i_bsync_delay/in_toggle_d1_reg}] \
+  -to [get_cells -hierarchical * -filter {NAME=~*i_regmap/i_bsync_delay/i_sync_out/cdc_sync_stage1_reg[*]}]
+
+set_false_path \
+  -from [get_cells -hierarchical * -filter {NAME=~*i_regmap/i_bsync_delay/out_toggle_d1_reg}] \
+  -to [get_cells -hierarchical * -filter {NAME=~*i_regmap/i_bsync_delay/i_sync_in/cdc_sync_stage1_reg[*]}]
+
+set_false_path \
+  -from [get_cells -hierarchical * -filter {NAME=~*i_regmap/*i_trig_channel_phase/in_toggle_d1_reg}] \
+  -to [get_cells -hierarchical * -filter {NAME=~*i_regmap/*i_trig_channel_phase/i_sync_in/cdc_sync_stage1_reg[*]}]
+
+set_false_path \
+  -from [get_cells -hierarchical * -filter {NAME=~*i_regmap/*i_trig_channel_phase/cdc_hold_reg[*]}] \
+  -to [get_cells -hierarchical * -filter {NAME=~*i_regmap/*i_trig_channel_phase/out_data_reg[*]}]
+
+set_false_path \
+  -from [get_cells -hierarchical * -filter {NAME=~*i_regmap/*i_trig_state/out_toggle_d1_reg_replica}] \
+  -to [get_cells -hierarchical * -filter {NAME=~*i_regmap/*i_trig_state/i_sync_in/cdc_sync_stage1_reg[*]}]
+
+set_false_path \
+  -from [get_cells -hierarchical * -filter {NAME=~*i_regmap/*i_trig_state/in_toggle_d1_reg}] \
+  -to [get_cells -hierarchical * -filter {NAME=~*i_regmap/*i_trig_state/i_sync_out/cdc_sync_stage1_reg[*]}]
+
+set_false_path \
+  -from [get_cells -hierarchical * -filter {NAME=~*i_regmap/*i_trig_state/cdc_hold_reg[*]}] \
+  -to [get_cells -hierarchical * -filter {NAME=~*i_regmap/*i_trig_state/out_data_reg[*]}]
+
+set_false_path \
+  -from [get_cells -hierarchical * -filter {NAME=~*i_regmap/up_enable_misalign_check_reg}] \
+  -to [get_cells -hierarchical * -filter {NAME=~*i_regmap/i_control_signals/cdc_sync_stage1_reg[*]}]
+
+set_false_path \
+  -from [get_cells -hierarchical * -filter {NAME=~*i_regmap/up_manual_trig_reg}] \
+  -to [get_cells -hierarchical * -filter {NAME=~*i_regmap/i_manual_trig/cdc_sync_stage1_reg[*]}]
+
+set_false_path \
+  -from [get_cells -hierarchical * -filter {NAME=~*i_bsync_gen/b_captured_reg}] \
+  -to [get_cells -hierarchical * -filter {NAME=~*i_regmap/i_debug_signals/cdc_sync_stage1_reg[*]}]
+
+set_false_path \
+  -from [get_cells -hierarchical * -filter {NAME=~*i_bsync_gen/calib_done_reg}] \
+  -to [get_cells -hierarchical * -filter {NAME=~*i_regmap/i_debug_signals/cdc_sync_stage1_reg[*]}]
+
+set_false_path \
+  -from [get_cells -hierarchical * -filter {NAME=~*i_bsync_gen/bsync_misaligned_reg}] \
+  -to [get_cells -hierarchical * -filter {NAME=~*i_regmap/i_debug_signals/cdc_sync_stage1_reg[*]}]
+
+set_false_path \
+  -from [get_cells -hierarchical * -filter {NAME=~*i_regmap/up_direction_reg_replica_1}] \
+  -to [get_cells -hierarchical * -filter {NAME=~*i_bsync_gen/i_control_signals/cdc_sync_stage1_reg[*]}]
+
+set_false_path \
+  -from [get_cells -hierarchical * -filter {NAME=~*i_regmap/up_disable_internal_bsync_reg}] \
+  -to [get_cells -hierarchical * -filter {NAME=~*i_regmap/i_control_signals/cdc_sync_stage1_reg[*]}]
+
+set_false_path \
+  -from [get_cells -hierarchical * -filter {NAME=~*i_regmap/up_select_trig_reg}] \
+  -to [get_cells -hierarchical * -filter {NAME=~*i_regmap/i_control_signals/cdc_sync_stage1_reg[*]}]
+
+set_false_path \
+  -from [get_cells -hierarchical * -filter {NAME=~*i_regmap/up_debug_trig_reg}] \
+  -to [get_cells -hierarchical * -filter {NAME=~*i_regmap/i_control_signals/cdc_sync_stage1_reg[*]}]
+
+set_false_path \
+  -from [get_cells -hierarchical * -filter {NAME=~*i_regmap/up_enable_debug_trig_reg}] \
+  -to [get_cells -hierarchical * -filter {NAME=~*i_regmap/i_control_signals/cdc_sync_stage1_reg[*]}]
+
+set_false_path \
+  -from [get_cells -hierarchical * -filter {NAME=~*i_regmap/*i_trig_state/out_toggle_d1_reg}] \
+  -to [get_cells -hierarchical * -filter {NAME=~*i_regmap/*i_trig_state/i_sync_in/cdc_sync_stage1_reg[*]}]
+
+set_false_path \
+  -to [get_cells -quiet -hier *cdc_sync_stage1_reg* \
+    -filter {NAME =~ *i_bsync_gen/i_control_signals* && IS_SEQUENTIAL}]

--- a/library/axi_adf4030/axi_adf4030_ip.tcl
+++ b/library/axi_adf4030/axi_adf4030_ip.tcl
@@ -1,0 +1,70 @@
+###############################################################################
+## Copyright (C) 2026 Analog Devices, Inc. All rights reserved.
+### SPDX short identifier: ADIBSD
+###############################################################################
+
+# ip
+
+if [info exists ::env(ADI_HDL_DIR)] {
+  set ADI_HDL_DIR $::env(ADI_HDL_DIR)
+  source $ADI_HDL_DIR/scripts/adi_env.tcl
+} else {
+  source ../../scripts/adi_env.tcl
+}
+
+source $ad_hdl_dir/library/scripts/adi_ip_xilinx.tcl
+
+adi_ip_create axi_adf4030
+adi_ip_files axi_adf4030 [list \
+  "$ad_hdl_dir/library/common/up_axi.v" \
+  "$ad_hdl_dir/library/common/ad_rst.v" \
+  "$ad_hdl_dir/library/util_cdc/sync_bits.v" \
+  "$ad_hdl_dir/library/util_cdc/sync_data.v" \
+  "$ad_hdl_dir/library/util_cdc/sync_event.v" \
+  "bsync_generator.sv" \
+  "trigger_channel.sv" \
+  "axi_adf4030_regmap.sv" \
+  "trigger_bsync_stretcher.sv" \
+  "axi_adf4030.sv" ]
+
+adi_ip_properties axi_adf4030
+adi_ip_ttcl axi_adf4030 "axi_adf4030_constr.ttcl"
+set_property display_name "ADI AXI ADF4030" [ipx::current_core]
+set_property description "ADI AXI ADF4030" [ipx::current_core]
+
+adi_init_bd_tcl
+
+proc add_reset {name polarity} {
+  set reset_intf [ipx::infer_bus_interface $name xilinx.com:signal:reset_rtl:1.0 [ipx::current_core]]
+  set reset_polarity [ipx::add_bus_parameter "POLARITY" $reset_intf]
+  set_property value $polarity $reset_polarity
+}
+
+ipx::infer_bus_interface device_clk xilinx.com:signal:clock_rtl:1.0 [ipx::current_core]
+ipx::infer_bus_interface s_axi_aclk xilinx.com:signal:clock_rtl:1.0 [ipx::current_core]
+
+add_reset rstn ACTIVE_LOW
+add_reset s_axi_aresetn ACTIVE_LOW
+
+ipx::add_bus_parameter ASSOCIATED_BUSIF [ipx::get_bus_interfaces s_axi_aclk -of_objects [ipx::current_core]]
+set_property value s_axi [ipx::get_bus_parameters ASSOCIATED_BUSIF -of_objects [ipx::get_bus_interfaces s_axi_aclk -of_objects [ipx::current_core]]]
+
+set_property -dict [list \
+        "value_validation_type" "range_long" \
+        "value_validation_range_minimum" "1" \
+        "value_validation_range_maximum" "8" \
+        ] \
+        [ipx::get_user_parameters CHANNEL_COUNT -of_objects [ipx::current_core]]
+
+set_property -dict [list \
+        "value_validation_type" "range_long" \
+        "value_validation_range_minimum" "0" \
+        "value_validation_range_maximum" "1" \
+        ] \
+        [ipx::get_user_parameters TRIGGER_STRETCH -of_objects [ipx::current_core]]
+
+adi_add_auto_fpga_spec_params
+ipx::create_xgui_files [ipx::current_core]
+
+ipx::save_core [ipx::current_core]
+

--- a/library/axi_adf4030/axi_adf4030_regmap.sv
+++ b/library/axi_adf4030/axi_adf4030_regmap.sv
@@ -1,0 +1,345 @@
+// ***************************************************************************
+// ***************************************************************************
+// Copyright (C) 2026 Analog Devices, Inc. All rights reserved.
+//
+// In this HDL repository, there are many different and unique modules, consisting
+// of various HDL (Verilog or VHDL) components. The individual modules are
+// developed independently, and may be accompanied by separate and unique license
+// terms.
+//
+// The user should read each of these license terms, and understand the
+// freedoms and responsibilities that he or she has by using this source/core.
+//
+// This core is distributed in the hope that it will be useful, but WITHOUT ANY
+// WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+// A PARTICULAR PURPOSE.
+//
+// Redistribution and use of source or resulting binaries, with or without modification
+// of this file, are permitted under one of the following two license terms:
+//
+//   1. The GNU General Public License version 2 as published by the
+//      Free Software Foundation, which can be found in the top level directory
+//      of this repository (LICENSE_GPL2), and also online at:
+//      <https://www.gnu.org/licenses/old-licenses/gpl-2.0.html>
+//
+// OR
+//
+//   2. An ADI specific BSD license, which can be found in the top level directory
+//      of this repository (LICENSE_ADIBSD), and also on-line at:
+//      https://github.com/analogdevicesinc/hdl/blob/main/LICENSE_ADIBSD
+//      This will allow to generate bit files and not release the source code,
+//      as long as it attaches to an ADI device.
+//
+// ***************************************************************************
+// ***************************************************************************
+
+`timescale 1ns / 1ps
+
+module axi_adf4030_regmap #(
+  parameter ID = 0,
+  parameter CHANNEL_COUNT = 1
+) (
+
+  input  logic                       clk,
+  output logic                       rstn,
+
+  // adf4030 control interface
+  output logic [CHANNEL_COUNT - 1:0] trig_channel_en,
+  output logic [15:0]                trig_channel_phase [CHANNEL_COUNT - 1:0],
+  output logic                       direction,
+  output logic                       disable_internal_bsync,
+  output logic                       manual_trig,
+  output logic                       select_trig,
+  output logic                       enable_debug_trig,
+  output logic                       debug_trig,
+  output logic                       enable_misalign_check,
+
+  // adf4030 debug interface
+  input  logic                       bsync_ready,
+  input  logic [ 4:0]                bsync_delay,
+  input  logic [15:0]                bsync_ratio,
+  input  logic                       bsync_alignment_error,
+  input  logic                       bsync_captured,
+  input  logic [ 2:0]                bsync_state,
+  input  logic [ 2:0]                trig_state [CHANNEL_COUNT - 1:0],
+
+  // bus interface
+  input  logic                       up_rstn,
+  input  logic                       up_clk,
+  input  logic                       up_wreq,
+  input  logic [ 7:0]                up_waddr,
+  input  logic [31:0]                up_wdata,
+  output logic                       up_wack,
+  input  logic                       up_rreq,
+  input  logic [ 7:0]                up_raddr,
+  output logic [31:0]                up_rdata,
+  output logic                       up_rack
+);
+
+  // local parameters
+  localparam [31:0] CORE_VERSION = 32'h00010061;  // 1.00.a
+  localparam [31:0] CORE_MAGIC   = 32'h41494F4E;  // AION
+
+  // internal registers
+  logic [31:0]                up_scratch;
+  logic                       up_manual_trig;
+  logic                       up_select_trig;
+  logic                       up_enable_debug_trig;
+  logic                       up_debug_trig;
+  logic                       up_sw_reset;
+  logic                       up_direction;
+  logic                       up_enable_misalign_check;
+  logic                       up_disable_internal_bsync;
+  logic [CHANNEL_COUNT - 1:0] up_trig_channel_en;
+  logic [15:0]                up_trig_channel_phase [CHANNEL_COUNT - 1:0];
+  logic [ 2:0]                up_trig_state         [CHANNEL_COUNT - 1:0];
+
+  //internal signals
+  logic                       up_bsync_ready_s;
+  logic [ 4:0]                up_bsync_delay_s;
+  logic [15:0]                up_bsync_ratio_s;
+  logic                       up_bsync_alignment_error_s;
+  logic                       up_bsync_captured_s;
+  logic [ 2:0]                up_bsync_state_s;
+  logic [31:0]                up_trig_channel_s [7:0];
+
+  //initial values
+  initial begin
+    up_rdata = 32'b0;
+    up_wack = 1'b0;
+    up_rack = 1'b0;
+    up_scratch = 32'b0;
+    up_manual_trig = 1'b0;
+    up_select_trig = 1'b0;
+    up_enable_debug_trig = 1'b0;
+    up_debug_trig = 1'b0;
+    up_enable_misalign_check = 1'b0;
+    up_sw_reset = 1'b0;
+    up_direction = 1'b1;
+    up_disable_internal_bsync = 1'b0;
+    up_trig_channel_en = '0;
+    up_trig_channel_phase = '{default:0};
+  end
+
+  // write interface
+  always @(posedge up_clk) begin
+    if (up_rstn == 1'b0 || up_sw_reset == 1'b1) begin
+      up_wack <= 1'b0;
+      up_scratch <= 32'b0;
+      up_select_trig <= 1'b0;
+      up_enable_debug_trig <= 1'b0;
+      up_debug_trig <= 1'b0;
+      up_enable_misalign_check <= 1'b0;
+      up_sw_reset <= 1'b0;
+      up_direction <= 1'b1;
+      up_disable_internal_bsync <= 1'b0;
+      up_trig_channel_en <= '0;
+    end else begin
+      up_wack <= up_wreq;
+      /* Scratch Register */
+      if ((up_wreq == 1'b1) && (up_waddr == 'h02)) begin
+        up_scratch <= up_wdata;
+      end
+      /* Control Register */
+      if ((up_wreq == 1'b1) && (up_waddr == 'h04)) begin
+        up_enable_misalign_check <= up_wdata[14];
+        up_debug_trig <= up_wdata[13];
+        up_enable_debug_trig <= up_wdata[12];
+        up_select_trig <= up_wdata[11];
+        up_sw_reset <= up_wdata[10];
+        up_trig_channel_en <= up_wdata[(CHANNEL_COUNT-1)+2:2];
+        up_disable_internal_bsync <= up_wdata[1];
+        up_direction <= up_wdata[0];
+      end
+    end
+  end
+
+  always @(posedge up_clk) begin
+    if (up_manual_trig == 1'b1) begin
+      up_manual_trig <= 1'b0;
+    end else begin
+      /* Manual Trigger Register */
+      if ((up_wreq == 1'b1) && (up_waddr == 'h06)) begin
+        up_manual_trig <= up_wdata[0];
+      end
+    end
+  end
+
+  // channel register generation
+  genvar i;
+  generate
+    for (i=0; i<CHANNEL_COUNT; i=i+1) begin
+      always @(posedge up_clk) begin
+        if (up_rstn == 0 || up_sw_reset == 1'b1) begin
+          up_trig_channel_phase[i] <= '0;
+        end else begin
+          if ((up_wreq == 1'b1) && (up_waddr == 'h07 + i) && up_trig_channel_en[i]) begin
+            up_trig_channel_phase[i] <= up_wdata[15:0];
+          end
+        end
+      end
+
+      assign up_trig_channel_s[i] = {13'b0,up_trig_state[i],up_trig_channel_phase[i]};
+
+      sync_data #(
+        .NUM_OF_BITS (3),
+        .ASYNC_CLK (1)
+      ) i_trig_state (
+        .in_clk (clk),
+        .in_data (trig_state[i]),
+        .out_clk (up_clk),
+        .out_data (up_trig_state[i]));
+
+      sync_data #(
+        .NUM_OF_BITS (16),
+        .ASYNC_CLK (1)
+      ) i_trig_channel_phase (
+        .in_clk (up_clk),
+        .in_data (up_trig_channel_phase[i]),
+        .out_clk (clk),
+        .out_data (trig_channel_phase[i]));
+    end
+
+    if (CHANNEL_COUNT<8) begin
+      assign up_trig_channel_s[7:CHANNEL_COUNT] = '{default:0};
+    end
+  endgenerate
+
+  //read interface for common registers
+  always @(posedge up_clk) begin
+    if (up_rstn == 1'b0 || up_sw_reset == 1'b1) begin
+      up_rack <= 1'b0;
+      up_rdata <= 32'b0;
+    end else begin
+      up_rack <= up_rreq;
+      if (up_rreq == 1'b1) begin
+        case(up_raddr)
+          /* Version Register */
+          'h00:  up_rdata <= {
+            CORE_VERSION[31:16], /* MAJOR */
+            CORE_VERSION[15: 8], /* MINOR */
+            CORE_VERSION[ 7: 0]  /* PATCH */
+          };
+          /* Peripheral ID Register */
+          'h01:  up_rdata <= ID;
+
+          /* Peripheral ID Register */
+          'h02:  up_rdata <= up_scratch;
+
+          /* Identification Register */
+          'h03:  up_rdata <= CORE_MAGIC;
+
+          /* Control Register */
+          'h04:  up_rdata <= {
+            17'b0,
+            up_enable_misalign_check,
+            up_debug_trig,
+            up_enable_debug_trig,
+            up_select_trig,
+            up_sw_reset,
+            {(8-CHANNEL_COUNT){1'b0}},
+            up_trig_channel_en,
+            up_disable_internal_bsync,
+            up_direction
+          };
+
+          /* Debug Register */
+          'h05: up_rdata <= {
+            5'b0,
+            up_bsync_state_s,
+            up_bsync_captured_s,
+            up_bsync_alignment_error_s,
+            up_bsync_ratio_s,
+            up_bsync_delay_s,
+            up_bsync_ready_s
+          };
+
+          /* Manual Trigger Register*/
+          'h06: up_rdata <= {
+            31'b0,
+            up_manual_trig
+          };
+
+          'h07: up_rdata <= up_trig_channel_s[0];
+          'h08: up_rdata <= up_trig_channel_s[1];
+          'h09: up_rdata <= up_trig_channel_s[2];
+          'h0A: up_rdata <= up_trig_channel_s[3];
+          'h0B: up_rdata <= up_trig_channel_s[4];
+          'h0C: up_rdata <= up_trig_channel_s[5];
+          'h0D: up_rdata <= up_trig_channel_s[6];
+          'h0E: up_rdata <= up_trig_channel_s[7];
+          default: up_rdata <= 32'b0;
+        endcase
+      end else begin
+        up_rdata <= 32'b0;
+      end
+    end
+  end /* read interface */
+
+  assign direction = up_direction;
+
+  // Clock Domain Crossing Logic for reset, control and status signals
+  sync_data #(
+    .NUM_OF_BITS (CHANNEL_COUNT),
+    .ASYNC_CLK (1)
+  ) i_trig_channel_en (
+    .in_clk (up_clk),
+    .in_data (up_trig_channel_en),
+    .out_clk (clk),
+    .out_data (trig_channel_en));
+
+  sync_bits #(
+    .NUM_OF_BITS (6),
+    .ASYNC_CLK (1)
+  ) i_control_signals (
+    .in_bits ({up_enable_misalign_check, up_debug_trig, up_enable_debug_trig, up_select_trig, ~up_sw_reset, up_disable_internal_bsync}),
+    .out_clk (clk),
+    .out_resetn (1'b1),
+    .out_bits ({enable_misalign_check, debug_trig, enable_debug_trig, select_trig, rstn, disable_internal_bsync}));
+
+  sync_event #(
+    .NUM_OF_EVENTS (1),
+    .ASYNC_CLK (1)
+  ) i_manual_trig (
+    .in_clk (up_clk),
+    .in_event (up_manual_trig),
+    .out_clk (clk),
+    .out_event (manual_trig));
+
+  sync_data #(
+    .NUM_OF_BITS (3),
+    .ASYNC_CLK (1)
+  ) i_bsync_state (
+    .in_clk (clk),
+    .in_data (bsync_state),
+    .out_clk (up_clk),
+    .out_data (up_bsync_state_s));
+
+  sync_data #(
+    .NUM_OF_BITS (16),
+    .ASYNC_CLK (1)
+  ) i_bsync_ratio (
+    .in_clk (clk),
+    .in_data (bsync_ratio),
+    .out_clk (up_clk),
+    .out_data (up_bsync_ratio_s));
+
+  sync_data #(
+    .NUM_OF_BITS (5),
+    .ASYNC_CLK (1)
+  ) i_bsync_delay (
+    .in_clk (clk),
+    .in_data (bsync_delay),
+    .out_clk (up_clk),
+    .out_data (up_bsync_delay_s));
+
+  sync_bits #(
+    .NUM_OF_BITS (3),
+    .ASYNC_CLK (1)
+  ) i_debug_signals (
+    .in_bits ({bsync_captured, bsync_alignment_error, bsync_ready}),
+    .out_clk (up_clk),
+    .out_resetn (1'b1),
+    .out_bits ({up_bsync_captured_s, up_bsync_alignment_error_s, up_bsync_ready_s}));
+
+endmodule

--- a/library/axi_adf4030/bsync_generator.sv
+++ b/library/axi_adf4030/bsync_generator.sv
@@ -1,0 +1,257 @@
+// ***************************************************************************
+// ***************************************************************************
+// Copyright (C) 2026 Analog Devices, Inc. All rights reserved.
+//
+// In this HDL repository, there are many different and unique modules, consisting
+// of various HDL (Verilog or VHDL) components. The individual modules are
+// developed independently, and may be accompanied by separate and unique license
+// terms.
+//
+// The user should read each of these license terms, and understand the
+// freedoms and responsibilities that he or she has by using this source/core.
+//
+// This core is distributed in the hope that it will be useful, but WITHOUT ANY
+// WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+// A PARTICULAR PURPOSE.
+//
+// Redistribution and use of source or resulting binaries, with or without modification
+// of this file, are permitted under one of the following two license terms:
+//
+//   1. The GNU General Public License version 2 as published by the
+//      Free Software Foundation, which can be found in the top level directory
+//      of this repository (LICENSE_GPL2), and also online at:
+//      <https://www.gnu.org/licenses/old-licenses/gpl-2.0.html>
+//
+// OR
+//
+//   2. An ADI specific BSD license, which can be found in the top level directory
+//      of this repository (LICENSE_ADIBSD), and also on-line at:
+//      https://github.com/analogdevicesinc/hdl/blob/main/LICENSE_ADIBSD
+//      This will allow to generate bit files and not release the source code,
+//      as long as it attaches to an ADI device.
+//
+// ***************************************************************************
+// ***************************************************************************
+
+`timescale 1ns / 1ps
+
+module bsync_generator (
+  input logic        clk,
+  input logic        rstn,
+  input logic        direction,
+  input logic        bsync_in,
+  input logic        disable_internal_bsync,
+  input logic        enable_misalign_check,
+  output             bsync_ready,
+  output     [ 4:0]  bsync_delay,
+  output     [15:0]  bsync_ratio,
+  output             bsync_alignment_error,
+  output             bsync_captured,
+  output     [ 2:0]  bsync_state,
+  output             bsync_event,
+  output             bsync_out
+);
+
+  localparam                   STATE_WIDTH            = 3;
+  localparam [STATE_WIDTH-1:0] IDLE                   = 0;
+  localparam [STATE_WIDTH-1:0] BSYNC_EDGE             = 1;
+  localparam [STATE_WIDTH-1:0] CALIB                  = 2;
+  localparam [STATE_WIDTH-1:0] BSYNC_GEN              = 3;
+  localparam [STATE_WIDTH-1:0] BSYNC_ALIGNMENT_ERROR  = 4;
+
+  logic  [STATE_WIDTH-1:0] curr_state = IDLE;
+  logic  [STATE_WIDTH-1:0] next_state;
+  logic  [15:0]            ratio_counter;
+  logic  [15:0]            bsync_counter;
+  logic                    calib_done;
+  logic                    b_edge;
+  logic                    b_captured;
+  logic                    bsync_buf;
+  logic                    bsync_r  = 1'b0;
+  logic                    bsync_d1 = 1'b0;
+  logic                    bsync_d2 = 1'b0;
+  logic                    bsync_d3 = 1'b0;
+  logic [4:0]              bsync_alignment;
+  logic                    bsync_misaligned;
+  logic [4:0]              bsync_next_alignment;
+  logic                    dir_changed = 1'b0;
+  logic                    direction_r = 1'b0;
+  logic                    direction_s;
+  logic                    bsync_edge;
+
+  sync_bits #(
+    .NUM_OF_BITS (1),
+    .ASYNC_CLK (1)
+  ) i_control_signals (
+    .in_bits (direction),
+    .out_clk (clk),
+    .out_resetn (1'b1),
+    .out_bits (direction_s));
+
+  always @* begin
+    next_state = curr_state;
+    case (curr_state)
+      IDLE : begin
+        if (b_captured) begin
+         next_state = BSYNC_EDGE;
+        end
+      end
+
+      BSYNC_EDGE : begin
+        if(bsync_edge) begin
+          next_state = CALIB;
+        end
+      end
+
+      CALIB : begin
+        if (calib_done) begin
+          next_state = BSYNC_GEN;
+        end
+      end
+
+      BSYNC_GEN : begin
+        if (enable_misalign_check && bsync_misaligned) begin
+          next_state = BSYNC_ALIGNMENT_ERROR;
+        end
+      end
+
+      BSYNC_ALIGNMENT_ERROR : begin
+        next_state = BSYNC_ALIGNMENT_ERROR;
+      end
+
+      default : next_state = IDLE;
+    endcase
+  end
+
+  always @(posedge clk) begin
+    if (rstn == 1'b0) begin
+      curr_state <= IDLE;
+    end else begin
+      curr_state <= next_state;
+    end
+  end
+
+  always @(posedge clk) begin
+    bsync_r <= bsync_in;
+    bsync_edge <= (bsync_in && !bsync_r);
+  end
+
+  /*
+   * Unfortunately setup and hold are often ignored on the bsync signal relative
+   * to the device clock. The device will often still work fine, just not
+   * deterministic. Reduce the probability that the meta-stability creeps into the
+   * reset of the system and causes non-reproducible issues.
+   */
+
+  always @(posedge clk) begin
+    bsync_d1 <= bsync_r;
+    bsync_d2 <= bsync_d1;
+    bsync_d3 <= bsync_d2;
+  end
+
+  always @(posedge clk) begin
+    if (bsync_d3 == 1'b0 && bsync_d2 == 1'b1) begin
+      b_edge <= 1'b1;
+    end else begin
+      b_edge <= 1'b0;
+    end
+  end
+
+  always @(posedge clk) begin
+    if (rstn == 1'b0 || direction_s == 1'b0) begin
+      b_captured <= 1'b0;
+    end else if (b_edge == 1'b1) begin
+      b_captured <= 1'b1;
+    end
+  end
+
+  always @(posedge clk) begin
+    if (rstn == 1'b0) begin
+      calib_done <= 1'b0;
+      ratio_counter <= 'h0001;
+      bsync_counter <= 1'b0;
+    end else begin
+      if (curr_state == CALIB) begin
+        if (bsync_in) begin
+          ratio_counter <= ratio_counter + 1'b1;
+        end else begin
+          if (bsync_counter < ratio_counter) begin
+            bsync_counter <= bsync_counter + 1'b1;
+          end else begin
+            bsync_counter <= 0;
+            calib_done <= 1'b1;
+          end
+        end
+      end else if (curr_state == BSYNC_GEN) begin
+        if (bsync_counter < (ratio_counter * 2) - 1) begin
+          bsync_counter <= bsync_counter + 1'b1;
+        end else begin
+          bsync_counter <= 'h0000;
+        end
+      end else if (curr_state == BSYNC_ALIGNMENT_ERROR) begin
+        calib_done <= 1'b0;
+      end
+    end
+  end
+
+  assign bsync_ready = calib_done;
+  assign bsync_ratio = ratio_counter;
+
+  always @(posedge clk) begin
+    if (rstn == 1'b0) begin
+      bsync_buf <= 1'b1;
+    end else begin
+      if (calib_done) begin
+        if (bsync_counter == (ratio_counter - 1) || bsync_counter == (ratio_counter * 2) - 1) begin
+          bsync_buf <= !bsync_buf;
+        end
+      end
+    end
+  end
+
+  assign bsync_out = (curr_state == BSYNC_GEN && !disable_internal_bsync) ? bsync_buf : 1'b0;
+
+  always @(posedge clk) begin
+    direction_r <= direction_s;
+    if (direction_s && !direction_r) begin
+      dir_changed <= 1'b1;
+    end else begin
+      if (b_captured && bsync_edge) begin
+        dir_changed <= 1'b0;
+      end
+    end
+  end
+
+  always @(posedge clk) begin
+    if (rstn == 1'b0) begin
+      bsync_alignment <= 'h000;
+      bsync_next_alignment <= 'h000;
+    end else begin
+      if (curr_state == BSYNC_GEN && enable_misalign_check && bsync_edge) begin
+        if (dir_changed) begin
+          bsync_alignment <= bsync_counter[4:0];
+          bsync_next_alignment <= bsync_counter[4:0];
+        end else begin
+          bsync_next_alignment <= bsync_counter[4:0];
+        end
+      end
+    end
+  end
+
+  always @(posedge clk) begin
+    if (rstn == 1'b0) begin
+      bsync_misaligned <= 1'b0;
+    end else begin
+      if (enable_misalign_check && bsync_alignment != bsync_next_alignment) begin
+        bsync_misaligned <= 1'b1;
+      end
+    end
+  end
+
+  assign bsync_delay = ((ratio_counter * 2) - bsync_next_alignment);
+  assign bsync_alignment_error = bsync_misaligned;
+  assign bsync_captured = b_captured;
+  assign bsync_state = curr_state;
+  assign bsync_event = bsync_edge;
+
+endmodule

--- a/library/axi_adf4030/trigger_bsync_stretcher.sv
+++ b/library/axi_adf4030/trigger_bsync_stretcher.sv
@@ -1,0 +1,67 @@
+// ***************************************************************************
+// ***************************************************************************
+// Copyright (C) 2026 Analog Devices, Inc. All rights reserved.
+//
+// In this HDL repository, there are many different and unique modules, consisting
+// of various HDL (Verilog or VHDL) components. The individual modules are
+// developed independently, and may be accompanied by separate and unique license
+// terms.
+//
+// The user should read each of these license terms, and understand the
+// freedoms and responsibilities that he or she has by using this source/core.
+//
+// This core is distributed in the hope that it will be useful, but WITHOUT ANY
+// WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+// A PARTICULAR PURPOSE.
+//
+// Redistribution and use of source or resulting binaries, with or without modification
+// of this file, are permitted under one of the following two license terms:
+//
+//   1. The GNU General Public License version 2 as published by the
+//      Free Software Foundation, which can be found in the top level directory
+//      of this repository (LICENSE_GPL2), and also online at:
+//      <https://www.gnu.org/licenses/old-licenses/gpl-2.0.html>
+//
+// OR
+//
+//   2. An ADI specific BSD license, which can be found in the top level directory
+//      of this repository (LICENSE_ADIBSD), and also on-line at:
+//      https://github.com/analogdevicesinc/hdl/blob/main/LICENSE_ADIBSD
+//      This will allow to generate bit files and not release the source code,
+//      as long as it attaches to an ADI device.
+//
+// ***************************************************************************
+// ***************************************************************************
+
+`timescale 1ns / 1ps;
+
+module trigger_bsync_stretcher (
+    input  logic external_bsync,
+    input  logic trigger,
+    output logic sync_start
+);
+
+  logic trigger_stretched = 1'b0;
+  logic trigger_captured;
+  logic sync_start_debug;
+
+  always @(posedge trigger or posedge trigger_captured) begin
+    if (trigger_captured)
+      trigger_stretched <= 1'b0;
+    else
+      trigger_stretched <= 1'b1;
+  end
+
+  logic trigger_sync1 = 1'b0;
+  logic trigger_sync2 = 1'b0;
+
+  always @(posedge external_bsync) begin
+    trigger_sync1 <= trigger_stretched;
+    trigger_sync2 <= trigger_sync1;
+  end
+
+  assign trigger_captured = trigger_sync2;
+
+  assign sync_start_debug = trigger_sync1 & ~trigger_sync2;
+  assign sync_start = sync_start_debug & external_bsync;
+endmodule

--- a/library/axi_adf4030/trigger_channel.sv
+++ b/library/axi_adf4030/trigger_channel.sv
@@ -1,0 +1,170 @@
+// ***************************************************************************
+// ***************************************************************************
+// Copyright (C) 2026 Analog Devices, Inc. All rights reserved.
+//
+// In this HDL repository, there are many different and unique modules, consisting
+// of various HDL (Verilog or VHDL) components. The individual modules are
+// developed independently, and may be accompanied by separate and unique license
+// terms.
+//
+// The user should read each of these license terms, and understand the
+// freedoms and responsibilities that he or she has by using this source/core.
+//
+// This core is distributed in the hope that it will be useful, but WITHOUT ANY
+// WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+// A PARTICULAR PURPOSE.
+//
+// Redistribution and use of source or resulting binaries, with or without modification
+// of this file, are permitted under one of the following two license terms:
+//
+//   1. The GNU General Public License version 2 as published by the
+//      Free Software Foundation, which can be found in the top level directory
+//      of this repository (LICENSE_GPL2), and also online at:
+//      <https://www.gnu.org/licenses/old-licenses/gpl-2.0.html>
+//
+// OR
+//
+//   2. An ADI specific BSD license, which can be found in the top level directory
+//      of this repository (LICENSE_ADIBSD), and also on-line at:
+//      https://github.com/analogdevicesinc/hdl/blob/main/LICENSE_ADIBSD
+//      This will allow to generate bit files and not release the source code,
+//      as long as it attaches to an ADI device.
+//
+// ***************************************************************************
+// ***************************************************************************
+
+`timescale 1ns / 1ps
+
+module trigger_channel (
+  input  logic        clk,
+  input  logic        rstn,
+  input  logic        trigger,
+  input  logic        ch_en,
+  input  logic [15:0] ch_phase,
+  input  logic        bsync_event,
+  input  logic        bsync_ready,
+  input  logic [ 4:0] bsync_delay,
+  input  logic [15:0] bsync_ratio,
+  output logic [ 2:0] trig_state,
+  output logic        trig_out
+);
+
+  localparam                   STATE_WIDTH = 3;
+  localparam [STATE_WIDTH-1:0] IDLE        = 0;
+  localparam [STATE_WIDTH-1:0] TRIG_EDGE   = 1;
+  localparam [STATE_WIDTH-1:0] PHASE_READ  = 2;
+  localparam [STATE_WIDTH-1:0] TRIG_ADJUST = 3;
+
+  logic  [STATE_WIDTH-1:0] curr_state = IDLE;
+  logic  [STATE_WIDTH-1:0] next_state;
+  logic  [15:0]            current_phase = 0;
+  logic  [15:0]            phase_counter;
+  logic  [15:0]            trigger_duration;
+  logic                    adjust_done;
+  logic                    trig_edge;
+  logic                    trig_r;
+  logic                    trig_event;
+  logic                    out;
+  logic  [15:0]            trig_phase;
+
+  assign trig_phase = ((2 * bsync_ratio) - 2) - ch_phase;
+
+  always @* begin
+    next_state = curr_state;
+    case(curr_state)
+      IDLE : begin
+        if (ch_en && bsync_ready) begin
+          next_state = TRIG_EDGE;
+        end
+      end
+
+      TRIG_EDGE : begin
+        if (ch_en && bsync_ready) begin
+          if (current_phase != trig_phase) begin
+            next_state = PHASE_READ;
+          end else if (trig_event && bsync_event) begin
+            next_state = TRIG_ADJUST;
+          end else begin
+            next_state = TRIG_EDGE;
+          end
+        end else begin
+          next_state = IDLE;
+        end
+      end
+
+      PHASE_READ : begin
+        if (current_phase == trig_phase) begin
+          next_state = TRIG_EDGE;
+        end
+      end
+
+      TRIG_ADJUST : begin
+        if (adjust_done) begin
+          next_state = TRIG_EDGE;
+        end
+      end
+
+      default: next_state = IDLE;
+    endcase
+  end
+
+  always @(posedge clk) begin
+    if (rstn == 1'b0) begin
+      curr_state <= IDLE;
+    end else begin
+      curr_state <= next_state;
+    end
+  end
+
+  always @(posedge clk) begin
+    trig_r <= trigger;
+    trig_edge <= (trigger && !trig_r);
+  end
+
+  always @(posedge clk) begin
+    if (rstn == 1'b0) begin
+      out <= 0;
+      phase_counter <= 0;
+      trigger_duration <= 0;
+      current_phase <= 0;
+      adjust_done <= 0;
+      trig_event <= 0;
+    end else begin
+      if (curr_state == TRIG_EDGE) begin
+        trigger_duration <= 0;
+        phase_counter <= 0;
+        out <= 0;
+        adjust_done <= 0;
+        if (trig_edge) begin
+          trig_event <= 1;
+        end
+      end else if (curr_state == PHASE_READ) begin
+        current_phase <= trig_phase;
+        adjust_done <= 1'b0;
+      end else if (curr_state == TRIG_ADJUST) begin
+        if (phase_counter < current_phase) begin
+          phase_counter <= phase_counter + 1'b1;
+        end else begin
+          if (trigger_duration < bsync_ratio) begin
+            trigger_duration <= trigger_duration + 1'b1;
+            out <= 1;
+          end else begin
+            out <= 0;
+            adjust_done <= 1;
+            trig_event <= 0;
+          end
+        end
+      end else begin
+        out <= 0;
+        phase_counter <= 0;
+        trigger_duration <= 0;
+        adjust_done <= 0;
+        trig_event <= 0;
+      end
+    end
+  end
+
+  assign trig_out = out;
+  assign trig_state = curr_state;
+
+endmodule


### PR DESCRIPTION
## PR Description

axi_adf4030 is an AXI4-Lite IP core for interfacing with the ADF4030 chip (used with latest Apollo based projects for Multi-Chip Sync). 

Key capabilities:

- Bidirectional BSYNC interface: Can receive external or generate internal BSYNC signal via differential I/O (IOBUFDS_DCIEN)
- Multi-channel trigger system: Up to 8 trigger channels with per-channel phase adjustment, synchronized to BSYNC events
- Multiple trigger modes: External, manual (software), and debug trigger sources
- BSYNC calibration: Auto-calibrates ratio/timing with alignment error detection
- Async Trigger pulse stretcher: used for generating a trigger pulse without sampling the BSYNC edge  
- Xilinx device support: UltraScale, Versal AI Core, Versal Premium

## PR Type
- [ ] Bug fix (change that fixes an issue)
- [x] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)
- [ ] Documentation

## PR Checklist
- [x] I have followed the code style guidelines
- [x] I have performed a self-review of changes
- [x] I have compiled all hdl projects and libraries affected by this PR
- [x] I have tested in hardware affected projects, at least on relevant boards
- [ ] I have commented my code, at least hard-to-understand parts
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe files, Copyright etc)
- [x] I have not introduced new Warnings/Critical Warnings on compilation
- [ ] I have added new hdl testbenches or updated existing ones
