### PR TITLE
library/util_axis_fifo_asym: Insert reg slice

### DIFF
--- a/docs/library/util_axis_fifo_asym/index.rst
+++ b/docs/library/util_axis_fifo_asym/index.rst
@@ -61,6 +61,9 @@ Configuration Parameters
      - Enable ``TKEEP`` logical port on the AXI streaming interface.
    * - REDUCED_FIFO
      - Reduce the FIFO size when master and slave data widths are not equal
+   * - SRC_REG_SLICE_EN
+     - Add an additional register slice to the slave AXI stream interface. It
+       is deasserted by default.
 
 Interface
 --------------------------------------------------------------------------------

--- a/library/util_axis_fifo_asym/Makefile
+++ b/library/util_axis_fifo_asym/Makefile
@@ -6,6 +6,7 @@
 
 LIBRARY_NAME := util_axis_fifo_asym
 
+GENERIC_DEPS += ../axi_dmac/axi_register_slice.v
 GENERIC_DEPS += util_axis_fifo_asym.v
 
 XILINX_DEPS += util_axis_fifo_asym_ip.tcl

--- a/library/util_axis_fifo_asym/util_axis_fifo_asym.v
+++ b/library/util_axis_fifo_asym/util_axis_fifo_asym.v
@@ -1,6 +1,6 @@
 // ***************************************************************************
 // ***************************************************************************
-// Copyright (C) 2021-2025 Analog Devices, Inc. All rights reserved.
+// Copyright (C) 2021-2026 Analog Devices, Inc. All rights reserved.
 //
 // In this HDL repository, there are many different and unique modules, consisting
 // of various HDL (Verilog or VHDL) components. The individual modules are
@@ -44,7 +44,8 @@ module util_axis_fifo_asym #(
   parameter ALMOST_FULL_THRESHOLD = 4,
   parameter TLAST_EN = 0,
   parameter TKEEP_EN = 0,
-  parameter REDUCED_FIFO = 1
+  parameter REDUCED_FIFO = 1,
+  parameter SRC_REG_SLICE_EN = 0
 ) (
   input m_axis_aclk,
   input m_axis_aresetn,
@@ -81,6 +82,14 @@ module util_axis_fifo_asym #(
   localparam A_ALMOST_FULL_THRESHOLD = (REDUCED_FIFO) ? ((ALMOST_FULL_THRESHOLD+RATIO-1)/RATIO) : ALMOST_FULL_THRESHOLD;
   localparam A_ALMOST_EMPTY_THRESHOLD = (REDUCED_FIFO) ? ((ALMOST_EMPTY_THRESHOLD+RATIO-1)/RATIO) : ALMOST_EMPTY_THRESHOLD;
 
+  localparam MEM_WORD = (TKEEP_EN & TLAST_EN) ? (A_WIDTH+A_WIDTH/8+1) :
+                        (TKEEP_EN)            ? (A_WIDTH+A_WIDTH/8)   :
+                        (TLAST_EN)            ? (A_WIDTH+1)           :
+                                                (A_WIDTH);
+
+  wire [MEM_WORD-1:0] slice_s_data [RATIO-1:0];
+  wire [MEM_WORD-1:0] slice_m_data [RATIO-1:0];
+
   // slave and master sequencers
   reg [$clog2(RATIO)-1:0] s_axis_counter;
   reg [$clog2(RATIO)-1:0] m_axis_counter;
@@ -96,6 +105,7 @@ module util_axis_fifo_asym #(
 
   wire [RATIO-1:0] s_axis_ready_int_s;
   wire [RATIO-1:0] s_axis_valid_int_s;
+  wire [RATIO-1:0] slice_m_valid;
   wire [RATIO*A_WIDTH-1:0] s_axis_data_int_s;
   wire [RATIO*A_WIDTH/8-1:0] s_axis_tkeep_int_s;
   wire [RATIO-1:0] s_axis_tlast_int_s;
@@ -104,6 +114,12 @@ module util_axis_fifo_asym #(
   wire [RATIO*A_ADDRESS-1:0] s_axis_room_int_s;
 
   wire m_axis_valid_int;
+
+  wire [RATIO-1:0] fifo_s_ready;
+  wire [RATIO-1:0] fifo_s_valid;
+  wire [RATIO*A_WIDTH-1:0] fifo_s_data;
+  wire [RATIO*A_WIDTH/8-1:0] fifo_s_tkeep;
+  wire [RATIO-1:0] fifo_s_tlast;
 
   // instantiate the FIFOs
   genvar i;
@@ -132,14 +148,66 @@ module util_axis_fifo_asym #(
         .m_axis_almost_empty (m_axis_almost_empty_int_s[i]),
         .s_axis_aclk    (s_axis_aclk),
         .s_axis_aresetn (s_axis_aresetn),
-        .s_axis_ready   (s_axis_ready_int_s[i]),
-        .s_axis_valid   (s_axis_valid_int_s[i]),
-        .s_axis_data    (s_axis_data_int_s[A_WIDTH*i+:A_WIDTH]),
-        .s_axis_tkeep   (s_axis_tkeep_int_s[A_WIDTH/8*i+:A_WIDTH/8]),
-        .s_axis_tlast   (s_axis_tlast_int_s[i]),
+        .s_axis_ready   (fifo_s_ready[i]),
+        .s_axis_valid   (fifo_s_valid[i]),
+        .s_axis_data    (fifo_s_data[A_WIDTH*i+:A_WIDTH]),
+        .s_axis_tkeep   (fifo_s_tkeep[A_WIDTH/8*i+:A_WIDTH/8]),
+        .s_axis_tlast   (fifo_s_tlast[i]),
         .s_axis_room    (s_axis_room_int_s[A_ADDRESS*i+:A_ADDRESS]),
         .s_axis_full    (s_axis_full_int_s[i]),
         .s_axis_almost_full (s_axis_almost_full_int_s[i]));
+
+      // SRC_REG_SLICE_EN: Adds an AXI register slice on the slave (source) side
+      // of the FIFO to break timing critical paths. This is required for high-
+      // frequency clock domains such as the SPI Engine's spi_clk (150-160 MHz),
+      // where the combinatorial path from s_axis_* signals through the FIFO
+      // creates timing violations. Disabled by default (0) since modules like
+      // data_offload do not require this additional latency.
+      if (SRC_REG_SLICE_EN) begin : gen_with_slice
+        axi_register_slice #(
+          .DATA_WIDTH(MEM_WORD),
+          .FORWARD_REGISTERED(1),
+          .BACKWARD_REGISTERED(1)
+        ) i_src_dst_slice (
+          .clk(s_axis_aclk),
+          .resetn(s_axis_aresetn),
+          .s_axi_data(slice_s_data[i]),
+          .s_axi_valid(s_axis_valid_int_s[i]),
+          .s_axi_ready(s_axis_ready_int_s[i]),
+          .m_axi_data(slice_m_data[i]),
+          .m_axi_valid(slice_m_valid[i]),
+          .m_axi_ready(fifo_s_ready[i]));
+
+        // Connect slice master to FIFO slave
+        assign fifo_s_valid[i] = slice_m_valid[i];
+
+        // TLAST and TKEEP packing/unpacking
+        if (TLAST_EN & TKEEP_EN) begin
+          assign slice_s_data[i]                      = {s_axis_data_int_s[A_WIDTH*i+:A_WIDTH], s_axis_tkeep_int_s[A_WIDTH/8*i+:A_WIDTH/8], s_axis_tlast_int_s[i]};
+          assign fifo_s_data[A_WIDTH*i+:A_WIDTH]      = slice_m_data[i][(MEM_WORD-1)-:A_WIDTH];
+          assign fifo_s_tkeep[A_WIDTH/8*i+:A_WIDTH/8] = slice_m_data[i][(MEM_WORD-A_WIDTH-1)-:A_WIDTH/8];
+          assign fifo_s_tlast[i]                      = slice_m_data[i][(MEM_WORD-A_WIDTH-(A_WIDTH/8)-1)];
+        end else if (TKEEP_EN) begin
+          assign slice_s_data[i]                      = {s_axis_data_int_s[A_WIDTH*i+:A_WIDTH], s_axis_tkeep_int_s[A_WIDTH/8*i+:A_WIDTH/8]};
+          assign fifo_s_data[A_WIDTH*i+:A_WIDTH]      = slice_m_data[i][(MEM_WORD-1)-:A_WIDTH];
+          assign fifo_s_tkeep[A_WIDTH/8*i+:A_WIDTH/8] = slice_m_data[i][(MEM_WORD-A_WIDTH-1)-:A_WIDTH/8];
+        end else if (TLAST_EN) begin
+          assign slice_s_data[i]                      = {s_axis_data_int_s[A_WIDTH*i+:A_WIDTH], s_axis_tlast_int_s[i]};
+          assign fifo_s_data[A_WIDTH*i+:A_WIDTH]      = slice_m_data[i][(MEM_WORD-1)-:A_WIDTH];
+          assign fifo_s_tlast[i]                      = slice_m_data[i][(MEM_WORD-A_WIDTH-1)];
+        end else begin
+          assign slice_s_data[i]                      = {s_axis_data_int_s[A_WIDTH*i+:A_WIDTH]};
+          assign fifo_s_data[A_WIDTH*i+:A_WIDTH]      = slice_m_data[i][(MEM_WORD-1)-:A_WIDTH];
+        end
+
+      end else begin : gen_without_slice
+        // Direct connection - bypass register slice
+        assign s_axis_ready_int_s[i]                = fifo_s_ready[i];
+        assign fifo_s_valid[i]                      = s_axis_valid_int_s[i];
+        assign fifo_s_data[A_WIDTH*i+:A_WIDTH]      = s_axis_data_int_s[A_WIDTH*i+:A_WIDTH];
+        assign fifo_s_tkeep[A_WIDTH/8*i+:A_WIDTH/8] = s_axis_tkeep_int_s[A_WIDTH/8*i+:A_WIDTH/8];
+        assign fifo_s_tlast[i]                      = s_axis_tlast_int_s[i];
+      end
     end
   endgenerate
 

--- a/library/util_axis_fifo_asym/util_axis_fifo_asym_ip.tcl
+++ b/library/util_axis_fifo_asym/util_axis_fifo_asym_ip.tcl
@@ -10,6 +10,7 @@ global VIVADO_IP_LIBRARY
 
 adi_ip_create util_axis_fifo_asym
 adi_ip_files util_axis_fifo_asym [list \
+  "$ad_hdl_dir/library/axi_dmac/axi_register_slice.v" \
   "util_axis_fifo_asym.v" \
 ]
 


### PR DESCRIPTION
This library had timing issues when RATIO is high. To improve that, it was inserted a register slice into the library that is enabled only when required.

To avoid any latency on the current projects, SRC_REG_SLICE_EN is disabled by default.

Note: register slice definition is inside the DMA. I chose not to move the IP to a common folder to avoid another PR. Future solution need to consider moving this register slice library to common folder in the libraries.


## PR Type
- [ ] Bug fix (change that fixes an issue)
- [x] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)
- [x] Documentation

## PR Checklist
- [x] I have followed the code style guidelines
- [x] I have performed a self-review of changes
- [ ] I have compiled all hdl projects and libraries affected by this PR
- [ ] I have tested in hardware affected projects, at least on relevant boards
- [ ] I have commented my code, at least hard-to-understand parts
- [x] I have signed off all commits from this PR
- [x] I have updated the documentation (wiki pages, ReadMe files, Copyright etc)
- [x] I have not introduced new Warnings/Critical Warnings on compilation
- [ ] I have added new hdl testbenches or updated existing ones
