### PR TITLE
pulse_sync: mask output after reset to prevent spurious pulse

### DIFF
--- a/library/axi_hsci/pulse_sync.v
+++ b/library/axi_hsci/pulse_sync.v
@@ -49,6 +49,9 @@ module pulse_sync (
   reg [2:0] t_d;
   reg       dout_r;
 
+  // mask output for 3 cycles after reset to let t_d track t
+  reg [2:0] rst_mask;
+
   always @(posedge inclk) begin
     if(rst_inclk) begin
       din_d1 <= 1'b0;
@@ -63,11 +66,13 @@ module pulse_sync (
 
   always @(posedge outclk) begin
     if(rst_outclk) begin
-      t_d <= 'b0;
-      dout_r <= 1'b0;
+      t_d      <= 3'b0;
+      dout_r   <= 1'b0;
+      rst_mask <= 3'b111;
     end else begin
-      t_d <= {t_d[1:0], t};
-      dout_r <= t_d[2] ^ t_d[1];
+      t_d      <= {t_d[1:0], t};
+      rst_mask <= {1'b0, rst_mask[2:1]};
+      dout_r   <= rst_mask[0] ? 1'b0 : (t_d[2] ^ t_d[1]);
     end
   end
 


### PR DESCRIPTION
## PR Description

When `rst_outclk` is asserted and then released, `t_d` is cleared to zero
while `t` (in the inclk domain) retains its last value from a previous
transfer. After reset release, `t_d` shifts in the current value of `t`
over 3 outclk cycles. If `t` is non-zero, `t_d[2] ^ t_d[1]` momentarily
becomes 1, generating a spurious `dout` pulse even though no new `din`
edge has occurred.

This issue is reproducible in designs where `rst_inclk` is not asserted
during the reset sequence (e.g. only the outclk domain is reset between
repeated link setup/teardown cycles).

Fix: add a 3-bit shift register `rst_mask` that is set to `3'b111` on
reset and shifts right each outclk cycle after release. The `dout` output
is suppressed during these 3 cycles, giving `t_d` time to track the
current value of `t` before edge detection resumes.

The 3-cycle mask is sufficient regardless of the clock frequency ratio
between `inclk` and `outclk`, since `t_d` is a synchronizer chain in the
outclk domain and only needs 3 outclk cycles to settle.

No functional change when both `rst_inclk` and `rst_outclk` are asserted
together.

## PR Type
- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)
- [ ] Documentation

## PR Checklist
- [x] I have followed the code style guidelines
- [x] I have performed a self-review of changes
- [ ] I have compiled all hdl projects and libraries affected by this PR
- [x] I have tested in hardware affected projects, at least on relevant boards
- [x] I have commented my code, at least hard-to-understand parts
- [ ] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe files, Copyright etc)
- [x] I have not introduced new Warnings/Critical Warnings on compilation
- [ ] I have added new hdl testbenches or updated existing ones