### PR TITLE
library/xilinx/axi_selmap: Add missing makefile dependency

### DIFF
--- a/library/xilinx/axi_selmap/Makefile
+++ b/library/xilinx/axi_selmap/Makefile
@@ -1,5 +1,5 @@
 ####################################################################################
-## Copyright (c) 2024 - 2024 Analog Devices, Inc.
+## Copyright (c) 2024, 2026 Analog Devices, Inc.
 ### SPDX short identifier: BSD-1-Clause
 ## Auto-generated, do not modify!
 ####################################################################################
@@ -12,5 +12,7 @@ GENERIC_DEPS += axi_selmap_regmap.v
 GENERIC_DEPS += async_cdc_fifo.v
 
 XILINX_DEPS += axi_selmap_ip.tcl
+
+XILINX_LIB_DEPS += util_cdc
 
 include ../../scripts/library.mk


### PR DESCRIPTION
## PR Description

Axi_selmap IP requires the util_cdc to be built. Adds missing dependency to the makefile.


## PR Type
- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)
- [ ] Documentation

## PR Checklist
- [x] I have followed the code style guidelines
- [x] I have performed a self-review of changes
- [x] I have compiled all hdl projects and libraries affected by this PR
- [ ] I have tested in hardware affected projects, at least on relevant boards
- [ ] I have commented my code, at least hard-to-understand parts
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe files, Copyright etc)
- [x] I have not introduced new Warnings/Critical Warnings on compilation
- [ ] I have added new hdl testbenches or updated existing ones
