### PR TITLE
docs: clean-up math formulas

### DIFF
--- a/docs/projects/ad9083_evb/index.rst
+++ b/docs/projects/ad9083_evb/index.rst
@@ -98,11 +98,16 @@ The device clock and the link clock have different sources, and in this case,
 the link clock is double the device clock.
 
 .. math::
-   Lane Rate &= \frac{IQ Sample Rate * M * NP * \frac{10}{8}}{L} = 10Gbps
 
-   Link Clock &= \frac{LaneRate}{40} = 250Mbps
+   Lane Rate = \frac{IQ Sample Rate * M * NP * \frac{10}{8}}{L} = 10Gbps
 
-   Device Clock &= \frac{LinkClock}{2} = 125Mbps
+.. math::
+
+   Link Clock = \frac{LaneRate}{40} = 250Mbps
+
+.. math::
+
+   Device Clock = \frac{LinkClock}{2} = 125Mbps
 
 CPU/Memory interconnects addresses
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/user_guide/ip_cores/axi_adc/index.rst
+++ b/docs/user_guide/ip_cores/axi_adc/index.rst
@@ -239,7 +239,7 @@ is computed:
 
 .. math::
 
-   \text{HDL}_{reg} = 0x100 + (n \times 0x10) \\
+   \text{HDL}_{reg} = 0x100 + (n \times 0x10)
 
 .. math::   
 
@@ -272,7 +272,7 @@ In general, the address for the ``CHAN_CNTRL_3`` register of **channel *n*** can
 
 .. math::
   
-   \text{HDL}_{reg} = 0x100 + (n \times 0x10) + 0x06 \\
+   \text{HDL}_{reg} = 0x100 + (n \times 0x10) + 0x06
 
 .. math::
   

--- a/docs/user_guide/ip_cores/axi_dac/index.rst
+++ b/docs/user_guide/ip_cores/axi_dac/index.rst
@@ -232,7 +232,7 @@ is computed:
 
 .. math::
 
-   \text{HDL}_{reg} = 0x100 + (n \times 0x10) \\
+   \text{HDL}_{reg} = 0x100 + (n \times 0x10)
 
 .. math::   
 
@@ -265,7 +265,7 @@ In general, the address for the ``CHAN_CNTRL_3`` register of **channel *n*** can
 
 .. math::
   
-   \text{HDL}_{reg} = 0x100 + (n \times 0x10) + 0x06 \\
+   \text{HDL}_{reg} = 0x100 + (n \times 0x10) + 0x06
 
 .. math::
   


### PR DESCRIPTION
## PR Description

DokuWiki \\ artifacts causes the formula to add
  \[\begin{split}
Which is not support by matplotlib basic LaTeX formula parser. Also adding multiple formula in the same directive may also create these \begin nests.

## Why is matplotlib even used?

We use it as an shortcut to not require a full LaTeX install.

## PR Type
- [ ] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)
- [ ] Documentation

## PR Checklist
- [ ] I have followed the code style guidelines
- [ ] I have performed a self-review of changes
- [ ] I have compiled all hdl projects and libraries affected by this PR
- [ ] I have tested in hardware affected projects, at least on relevant boards
- [ ] I have commented my code, at least hard-to-understand parts
- [ ] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe files, Copyright etc)
- [ ] I have not introduced new Warnings/Critical Warnings on compilation
- [ ] I have added new hdl testbenches or updated existing ones
