### PR TITLE
Daq3 timing fix

### DIFF
--- a/projects/daq3/kcu105/system_project.tcl
+++ b/projects/daq3/kcu105/system_project.tcl
@@ -73,7 +73,6 @@ adi_project_files daq3_kcu105 [list \
   "$ad_hdl_dir/library/common/ad_iobuf.v" \
   "$ad_hdl_dir/projects/common/kcu105/kcu105_system_constr.xdc" ]
 
-## To improve timing in DDR4 MIG
-set_property strategy Performance_ExploreWithRemap [get_runs impl_1]
+set_property strategy Congestion_SpreadLogic_high [get_runs impl_1]
 
 adi_project_run daq3_kcu105

--- a/projects/daq3/vcu118/system_project.tcl
+++ b/projects/daq3/vcu118/system_project.tcl
@@ -73,7 +73,6 @@ adi_project_files daq3_vcu118 [list \
   "$ad_hdl_dir/library/common/ad_iobuf.v" \
   "$ad_hdl_dir/projects/common/vcu118/vcu118_system_constr.xdc" ]
 
-## To improve timing in DDR4 MIG
-set_property strategy Performance_Retiming [get_runs impl_1]
+set_property strategy Congestion_SpreadLogic_high [get_runs impl_1]
 
 adi_project_run daq3_vcu118

--- a/projects/daq3/zc706/system_project.tcl
+++ b/projects/daq3/zc706/system_project.tcl
@@ -74,8 +74,7 @@ adi_project_files daq3_zc706 [list \
   "$ad_hdl_dir/projects/common/zc706/zc706_plddr3_constr.xdc" \
   "$ad_hdl_dir/projects/common/zc706/zc706_system_constr.xdc" ]
 
-set_property strategy Performance_ExtraTimingOpt [get_runs impl_1]
-
+set_property strategy Congestion_SpreadLogic_high [get_runs impl_1]
 
 set_property part "xc7z045ffg900-3" [get_runs synth_1]
 set_property part "xc7z045ffg900-3" [get_runs impl_1]

--- a/projects/daq3/zcu102/system_project.tcl
+++ b/projects/daq3/zcu102/system_project.tcl
@@ -73,4 +73,6 @@ adi_project_files daq3_zcu102 [list \
   "$ad_hdl_dir/library/common/ad_iobuf.v" \
   "$ad_hdl_dir/projects/common/zcu102/zcu102_system_constr.xdc" ]
 
+set_property strategy Congestion_SpreadLogic_high [get_runs impl_1]
+
 adi_project_run daq3_zcu102


### PR DESCRIPTION
## PR Description

ZC706 has a small -0.001 setup timing violation. This PR aims to fix this without HDL modification. It applies the ATF script and changes the implementation strategy.
All projects were built, and ZC706 was built 10 times. All builds finished successfully.


## PR Type
- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)
- [ ] Documentation

## PR Checklist
- [x] I have followed the code style guidelines
- [x] I have performed a self-review of changes
- [x] I have compiled all hdl projects and libraries affected by this PR
- [ ] I have tested in hardware affected projects, at least on relevant boards
- [ ] I have commented my code, at least hard-to-understand parts
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe files, Copyright etc)
- [x] I have not introduced new Warnings/Critical Warnings on compilation
- [ ] I have added new hdl testbenches or updated existing ones
