### PR TITLE
library/axi_ad408x: Add configurable NUM_LANES parameter for single-lane support

### DIFF
--- a/library/axi_ad408x/ad408x_phy.v
+++ b/library/axi_ad408x/ad408x_phy.v
@@ -237,8 +237,15 @@ module ad408x_phy #(
   end
   endgenerate
 
-  assign serdes_in_p = {data_b_in_p, data_a_in_p};
-  assign serdes_in_n = {data_b_in_n, data_a_in_n};
+  generate
+  if (NUM_LANES == 2) begin
+    assign serdes_in_p = {data_b_in_p, data_a_in_p};
+    assign serdes_in_n = {data_b_in_n, data_a_in_n};
+  end else begin
+    assign serdes_in_p = data_a_in_p;
+    assign serdes_in_n = data_a_in_n;
+  end
+  endgenerate
 
   // Min 2 div_clk cycles once div_clk is running after deassertion of sync
   // Control externally the reset of serdes for precise timing
@@ -285,10 +292,20 @@ module ad408x_phy #(
     .delay_rst(delay_rst),
     .delay_locked(delay_locked));
 
-  assign {serdes_data_1[0],serdes_data_0[0]} = data_s0;  // f-e latest bit received
-  assign {serdes_data_1[1],serdes_data_0[1]} = data_s1;  // r-e
-  assign {serdes_data_1[2],serdes_data_0[2]} = data_s2;  // f-e
-  assign {serdes_data_1[3],serdes_data_0[3]} = data_s3;  // r-e oldest bit received
+  generate
+  if (NUM_LANES == 2) begin
+    assign {serdes_data_1[0],serdes_data_0[0]} = data_s0;  // f-e latest bit received
+    assign {serdes_data_1[1],serdes_data_0[1]} = data_s1;  // r-e
+    assign {serdes_data_1[2],serdes_data_0[2]} = data_s2;  // f-e
+    assign {serdes_data_1[3],serdes_data_0[3]} = data_s3;  // r-e oldest bit received
+  end else begin
+    assign serdes_data_0[0] = data_s0;
+    assign serdes_data_0[1] = data_s1;
+    assign serdes_data_0[2] = data_s2;
+    assign serdes_data_0[3] = data_s3;
+    assign serdes_data_1 = 4'b0;
+  end
+  endgenerate
 
   // Assert serdes valid after 2 clock cycles is pulled out of reset
 

--- a/library/axi_ad408x/ad408x_phy.v
+++ b/library/axi_ad408x/ad408x_phy.v
@@ -1,6 +1,6 @@
 // ***************************************************************************
 // ***************************************************************************
-// Copyright (C) 2022-2025 Analog Devices, Inc. All rights reserved.
+// Copyright (C) 2022-2026 Analog Devices, Inc. All rights reserved.
 //
 // In this HDL repository, there are many different and unique modules, consisting
 // of various HDL(Verilog or VHDL) components. The individual modules are

--- a/library/axi_ad408x/axi_ad408x.v
+++ b/library/axi_ad408x/axi_ad408x.v
@@ -38,6 +38,7 @@
 module axi_ad408x #(
   parameter   ID = 0,
   parameter   FPGA_TECHNOLOGY = 0,
+  parameter   NUM_LANES = 2,
   parameter   IO_DELAY_GROUP = "dev_if_delay_group",
   parameter   ADC_N_BITS = 20
 ) (
@@ -96,7 +97,7 @@ module axi_ad408x #(
   input         [ 2:0]    s_axi_arprot
 );
 
-  localparam DELAY_CTRL_NUM_LANES = 2;
+  localparam DELAY_CTRL_NUM_LANES = NUM_LANES;
   localparam DELAY_CTRL_DRP_WIDTH = 5;
   localparam ADC_DATA_WIDTH  = ((ADC_N_BITS > 16)? 32 : 16);
 
@@ -276,6 +277,7 @@ module axi_ad408x #(
 
   ad408x_phy #(
     .FPGA_TECHNOLOGY(FPGA_TECHNOLOGY),
+    .NUM_LANES(NUM_LANES),
     .IO_DELAY_GROUP(IO_DELAY_GROUP),
     .IODELAY_CTRL(1),
     .ADC_N_BITS(ADC_N_BITS),

--- a/library/axi_ad408x/axi_ad408x.v
+++ b/library/axi_ad408x/axi_ad408x.v
@@ -1,6 +1,6 @@
 // ***************************************************************************
 // ***************************************************************************
-// Copyright (C) 2022-2025 Analog Devices, Inc. All rights reserved.
+// Copyright (C) 2022-2026 Analog Devices, Inc. All rights reserved.
 //
 // In this HDL repository, there are many different and unique modules, consisting
 // of various HDL(Verilog or VHDL) components. The individual modules are


### PR DESCRIPTION
Expose NUM_LANES parameter (default 2) to allow single-lane operation for axi_ad408x. The PHY conditionally routes SERDES inputs and unpacks deserialized data based on the lane count.

## PR Type
- [ ] Bug fix (change that fixes an issue)
- [x] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)
- [ ] Documentation

## PR Checklist
- [x] I have followed the code style guidelines
- [x] I have performed a self-review of changes
- [x] I have compiled all hdl projects and libraries affected by this PR
- [x] I have tested in hardware affected projects, at least on relevant boards
- [x] I have commented my code, at least hard-to-understand parts
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe files, Copyright etc)
- [x] I have not introduced new Warnings/Critical Warnings on compilation
- [ ] I have added new hdl testbenches or updated existing ones
