### PR TITLE
library/axi_ad485x: Fix simulation issue

### DIFF
--- a/library/axi_ad485x/axi_ad485x_cmos.v
+++ b/library/axi_ad485x/axi_ad485x_cmos.v
@@ -1,6 +1,6 @@
 // ***************************************************************************
 // ***************************************************************************
-// Copyright (C) 2023-2025 Analog Devices, Inc. All rights reserved.
+// Copyright (C) 2023-2026 Analog Devices, Inc. All rights reserved.
 //
 // In this HDL repository, there are many different and unique modules, consisting
 // of various HDL (Verilog or VHDL) components. The individual modules are
@@ -719,7 +719,6 @@ module axi_ad485x_cmos #(
     end
   endgenerate
 
-
   // relax timing
   reg  adc_valid_crc_d;
   always @(posedge clk) begin
@@ -795,7 +794,7 @@ module axi_ad485x_cmos #(
       if (crc_res == 16'd0) begin
         crc_error <= 1'd0;
       end else begin
-        crc_error <= 1'd1;
+        crc_error <= crc_enable_window;
       end
     end
   end

--- a/library/axi_ad485x/axi_ad485x_lvds.v
+++ b/library/axi_ad485x/axi_ad485x_lvds.v
@@ -214,7 +214,7 @@ module axi_ad485x_lvds #(
 
   // busy period counter
   always @(posedge clk) begin
-    if (cnvs == 1'b1 && busy_m2 == 1'b1) begin
+    if (cnvs == 1'b1 && busy_m2 == 1'b1 && oversampling_en == 1) begin
       run_busy_period_cnt <= 1'b1;
     end else if (start_transfer == 1'b1) begin
       run_busy_period_cnt <= 1'b0;
@@ -274,7 +274,7 @@ module axi_ad485x_lvds #(
       end
     end
 
-    if (data_counter == packet_cnt_length && ch_counter == max_channel_transfer) begin
+    if (data_counter == packet_cnt_length && ch_counter == max_channel_transfer && packet_cnt_length != 0) begin
       aquire_data <= 1'b0;
       capture_complete_init <= 1'b1;
     end else if (aquire_data | start_transfer) begin
@@ -572,7 +572,7 @@ module axi_ad485x_lvds #(
       if (crc_res == 16'd0) begin
         crc_error <= 1'd0;
       end else begin
-        crc_error <= 1'd1;
+        crc_error <= crc_enable_window;
       end
     end
   end


### PR DESCRIPTION
## PR Description

Fixed false CRC errors in CMOS and LVDS by gating crc_error with crc_enable_window                                                                                                                             
Fixed LVDS busy period counter running outside oversampling mode                                                                                                                                               
Fixed LVDS premature data acquisition stop when packet_cnt_length is zero


## PR Type
- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)
- [ ] Documentation

## PR Checklist
- [x] I have followed the code style guidelines
- [x] I have performed a self-review of changes
- [x] I have compiled all hdl projects and libraries affected by this PR
- [ ] I have tested in hardware affected projects, at least on relevant boards
- [ ] I have commented my code, at least hard-to-understand parts
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe files, Copyright etc)
- [ ] I have not introduced new Warnings/Critical Warnings on compilation
- [x] I have added new hdl testbenches or updated existing ones
