### PR TITLE
library/scripts/adi_xilinx_device_info_enc.tcl: Add xcau (Artix UltraScale+) family

### DIFF
--- a/library/scripts/adi_xilinx_device_info_enc.tcl
+++ b/library/scripts/adi_xilinx_device_info_enc.tcl
@@ -116,10 +116,10 @@ proc adi_device_spec {cellpath param} {
       FPGA_TECHNOLOGY {
           switch  -regexp -- $part {
              ^xc7          {set series_name 7series}
-             ^xczu         {set series_name ultrascale+}
-             ^xcvu.?.p     {set series_name ultrascale+}
-             ^x.zu..?p     {set series_name ultrascale+}
-             ^xck26        {set series_name ultrascale+}
+             ^xc(zu|au)       {set series_name ultrascale+}
+             ^xc\d*[vk]u\S*p  {set series_name ultrascale+}
+             ^x.zu..?p        {set series_name ultrascale+}
+             ^xck26           {set series_name ultrascale+}
              ^xc.u         {set series_name ultrascale }
              ^xcv[ecmph]   {set series_name versal}
              default {


### PR DESCRIPTION
## PR Description

Adds the `^xcau` regex prefix to the `FPGA_TECHNOLOGY` part-family switch in
`adi_device_spec`, mapping Artix UltraScale+ parts (e.g. `xcau15p`) to
`series_name 'ultrascale+'`, alongside the existing `xczu`/`xcvu`/`xck26`
ultrascale+ entries.

### Motivation

Without this entry, `xcau` parts are matched by the more general `^xc.u`
branch that follows in the same switch and are silently misclassified as
plain `ultrascale`. The returned `FPGA_TECHNOLOGY` then drives downstream
IP configuration — for example, IDELAY primitive selection in `axi_ad9361` —
and the resulting attribute combination is rejected by Vivado's bitgen DRC
stage, which refuses to generate a bitfile for the design.

This change is consistent in shape and intent with prior single-line
additions to the same switch (e.g. K26 in 7112fbce7, Versal in 4d12c4d99,
VCU128 regex change in 9d94f21d8).

### Test

Tested on `xcau15p-ffvb676-2-e` on the **AUBoard-15P Development Kit**,
building an `axi_ad9361`-based reference design: with this change,
`adi_device_spec` returns `ultrascale+`, downstream IP picks the correct
primitive variants, and bitgen completes successfully and the bitstream
runs on hardware.

## PR Type
- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)
- [ ] Documentation

## PR Checklist
- [x] I have followed the code style guidelines
- [x] I have performed a self-review of changes
- [x] I have compiled all hdl projects and libraries affected by this PR
- [x] I have tested in hardware affected projects, at least on relevant boards
- [x] I have commented my code, at least hard-to-understand parts
- [x] I have signed off all commits from this PR
- [x] I have updated the documentation (wiki pages, ReadMe files, Copyright etc)
- [x] I have not introduced new Warnings/Critical Warnings on compilation
- [x] I have added new hdl testbenches or updated existing ones