### PR TITLE
docs(ad7606x_fmc/zed): fix FMC pin comment for adc_os[1] (H07 -> LA02_P, not LA04_P)

### DIFF
--- a/projects/ad7606x_fmc/zed/system_constr_pif.xdc
+++ b/projects/ad7606x_fmc/zed/system_constr_pif.xdc
@@ -30,7 +30,7 @@ set_property -dict {PACKAGE_PIN T16 IOSTANDARD LVCMOS25} [get_ports adc_busy];  
 set_property -dict {PACKAGE_PIN J21 IOSTANDARD LVCMOS25} [get_ports adc_first_data]; ## G12 FMC_LPC_LA08_P
 set_property -dict {PACKAGE_PIN L21 IOSTANDARD LVCMOS25} [get_ports adc_reset];      ## C10 FMC_LPC_LA06_P
 set_property -dict {PACKAGE_PIN P20 IOSTANDARD LVCMOS25} [get_ports adc_os[0]];      ## G15 FMC_LPC_LA12_P
-set_property -dict {PACKAGE_PIN P17 IOSTANDARD LVCMOS25} [get_ports adc_os[1]];      ## H07 FMC_LPC_LA04_P
+set_property -dict {PACKAGE_PIN P17 IOSTANDARD LVCMOS25} [get_ports adc_os[1]];      ## H07 FMC_LPC_LA02_P
 set_property -dict {PACKAGE_PIN N17 IOSTANDARD LVCMOS25} [get_ports adc_os[2]];      ## H16 FMC_LPC_LA11_P
 set_property -dict {PACKAGE_PIN T19 IOSTANDARD LVCMOS25} [get_ports adc_stby];       ## C15 FMC_LPC_LA10_N
 set_property -dict {PACKAGE_PIN R21 IOSTANDARD LVCMOS25} [get_ports adc_range];      ## D15 FMC_LPC_LA09_N


### PR DESCRIPTION
## Summary

\`projects/ad7606x_fmc/zed/system_constr_pif.xdc:33\` annotates \`adc_os[1]\` with:

\`\`\`
## H07 FMC_LPC_LA04_P
\`\`\`

Per the FMC LPC pinout, connector pin **H07** maps to **LA02_P** — LA04_P lives at H10 (and is correctly noted on the adjacent \`adc_cs_n\` line on line 25). Comment-only fix; PACKAGE_PIN P17 and all timing are untouched.

Closes #2039

## Testing

Comment-only edit in a Vivado .xdc constraint file. No functional change.