### PR TITLE
Add reference design for ADMX6020M and HMCAD1520 boards 

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -239,6 +239,9 @@
 # Code owners for fmcomms8 folder
 /projects/fmcomms8/         andrei.dragomir@analog.com  iulia.moldovan@analog.com
 
+# Code owners for hmcad1520_ebz folder
+/projects/hmcad1520_ebz/    paul.pop@analog.com  cristianmihai.popa@analog.com
+
 # Code owners for jupiter_sdr folder
 /projects/jupiter_sdr/      andrei.grozav@analog.com  stanca.pop@analog.com
 

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -322,6 +322,9 @@
 # Code owners for axi_dmac IP
 /library/axi_dmac/          ionut.podgoreanu@analog.com
 
+# Code owners for axi_hmcad15xx IP
+/library/axi_hmcad15xx/     paul.pop@analog.com  cristianmihai.popa@analog.com
+
 # Code owners for axi_ltc235x IP
 /library/axi_ltc235x/       sergiu.arpadi@analog.com
 

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -260,6 +260,9 @@
 # Code owners for pulsar_adc_pmdz folder
 /projects/pulsar_adc_pmdz/  sergiu.arpadi@analog.com  pop.ioan-daniel@analog.com
 
+# Code owners for admx6020m folder
+/projects/admx6020m/        paul.pop@analog.com  cristianmihai.popa@analog.com
+
 # Code owners for ltc2378_fmc folder
 /projects/ltc2378_fmc/      pop.ioan-daniel@analog.com sergiu.arpadi@analog.com
 

--- a/docs/library/axi_hmcad15xx/block_diagram.svg
+++ b/docs/library/axi_hmcad15xx/block_diagram.svg
@@ -1,0 +1,567 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="105.68468mm"
+   height="67.389977mm"
+   viewBox="0 0 105.6847 67.38998"
+   version="1.1"
+   id="svg1"
+   inkscape:version="1.4.3 (0d15f75, 2025-12-25)"
+   sodipodi:docname="block_diagram.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+     id="namedview1"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:document-units="mm"
+     inkscape:zoom="2.8284271"
+     inkscape:cx="249.43192"
+     inkscape:cy="137.00194"
+     inkscape:window-width="1920"
+     inkscape:window-height="1129"
+     inkscape:window-x="1912"
+     inkscape:window-y="-8"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="layer1" />
+  <defs
+     id="defs1">
+    <rect
+       x="176.25"
+       y="414.25"
+       width="67.25"
+       height="11"
+       id="rect6" />
+    <rect
+       x="180.75"
+       y="411.75"
+       width="79.75"
+       height="11.25"
+       id="rect5" />
+    <rect
+       x="505.75934"
+       y="440.80817"
+       width="91.509193"
+       height="18.625698"
+       id="rect4760" />
+    <rect
+       x="298.96634"
+       y="469.9407"
+       width="124.17132"
+       height="41.072052"
+       id="rect24670" />
+    <marker
+       style="overflow:visible"
+       id="TriangleInM-0"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="TriangleInM"
+       inkscape:isstock="true">
+      <path
+         transform="scale(-0.4)"
+         style="fill:context-stroke;fill-rule:evenodd;stroke:context-stroke;stroke-width:1pt"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         id="path42185-3" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="marker51146-9"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="TriangleInM"
+       inkscape:isstock="true">
+      <path
+         transform="scale(-0.4)"
+         style="fill:context-stroke;fill-rule:evenodd;stroke:context-stroke;stroke-width:1pt"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         id="path51144-3" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="marker1"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="TriangleInM"
+       inkscape:isstock="true">
+      <path
+         transform="scale(-0.4)"
+         style="fill:context-stroke;fill-rule:evenodd;stroke:context-stroke;stroke-width:1pt"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         id="path1" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="marker2"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="TriangleInM"
+       inkscape:isstock="true">
+      <path
+         transform="scale(-0.4)"
+         style="fill:context-stroke;fill-rule:evenodd;stroke:context-stroke;stroke-width:1pt"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         id="path2" />
+    </marker>
+    <rect
+       x="298.96634"
+       y="469.9407"
+       width="124.17132"
+       height="41.072052"
+       id="rect19" />
+    <rect
+       x="227.01418"
+       y="266.41333"
+       width="48.310867"
+       height="26.73514"
+       id="rect23" />
+  </defs>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(-51.408611,-81.623957)">
+    <rect
+       style="fill:#fefdfe;fill-opacity:1;fill-rule:evenodd;stroke:#071414;stroke-width:0.438228;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:75.5906;stroke-opacity:1"
+       id="rect46745"
+       width="58.360218"
+       height="66.951752"
+       x="75.096199"
+       y="81.843071" />
+    <rect
+       style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#a01414;stroke-width:0.354352;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:0.0354352, 0.0354352;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect19131"
+       width="27.503014"
+       height="23.095438"
+       x="100.2297"
+       y="90.118996" />
+    <rect
+       style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#a01414;stroke-width:0.482414;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:0.0482414, 0.0482414;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect19131-2"
+       width="51.605984"
+       height="6.0892682"
+       x="78.018616"
+       y="140.44829" />
+    <rect
+       style="fill:#ffcccc;fill-opacity:1;fill-rule:evenodd;stroke:#a01414;stroke-width:0.426;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:0.0426, 0.0426;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect958"
+       width="15.066154"
+       height="11.580877"
+       x="106.87206"
+       y="98.349861" />
+    <rect
+       style="fill:#ffcccc;fill-opacity:1;fill-rule:evenodd;stroke:#a01414;stroke-width:0.494615;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:0.0494615, 0.0494615;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect958-1"
+       width="24.853348"
+       height="13.759332"
+       x="77.327286"
+       y="116.93652" />
+    <text
+       xml:space="preserve"
+       transform="matrix(0.1434475,0,0,0.13069708,35.370517,45.035112)"
+       id="text4758"
+       style="font-size:14px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial, Normal';white-space:pre;shape-inside:url(#rect4760);display:inline;stroke-width:1.93234"><tspan
+         x="505.75977"
+         y="453.41916"
+         id="tspan1">ad_serdes_in</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.82222px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;stroke-width:0.264583"
+       x="102.08208"
+       y="94.184998"
+       id="text21502"
+       transform="scale(1.0050352,0.99499002)"><tspan
+         sodipodi:role="line"
+         id="tspan21500"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.82222px;font-family:Arial;-inkscape-font-specification:'Arial, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;stroke-width:0.264583"
+         x="102.08208"
+         y="94.184998">axi_hmcad15xx_if</tspan></text>
+    <text
+       xml:space="preserve"
+       transform="matrix(0.16760265,0,0,0.16592749,30.037726,44.598304)"
+       id="text24668"
+       style="font-size:16px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial, Normal';white-space:pre;shape-inside:url(#rect24670);display:inline;stroke-width:2.01426"><tspan
+         x="298.9668"
+         y="484.35348"
+         id="tspan2">ADC COMMON</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-size:4.20337px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial, Normal';stroke-width:0.264583"
+       x="95.761147"
+       y="145.28928"
+       id="text41823"
+       transform="scale(1.0050352,0.99499002)"><tspan
+         sodipodi:role="line"
+         id="tspan41821"
+         style="stroke-width:0.264583"
+         x="95.761147"
+         y="145.28928">UP_AXI</tspan></text>
+    <path
+       style="fill:#a01414;fill-opacity:1;stroke:#a01414;stroke-width:0.6;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:20;stroke-opacity:1;marker-start:url(#TriangleInM-0);marker-end:url(#marker51146-9)"
+       d="m 89.750633,132.81486 c 0,5.55327 0,5.33969 0,5.33969"
+       id="path42520-2-7" />
+    <text
+       xml:space="preserve"
+       style="font-size:3.15252px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial, Normal';stroke-width:0.264583"
+       x="89.262283"
+       y="87.617271"
+       id="text49535"
+       transform="scale(1.0050352,0.99499002)"><tspan
+         sodipodi:role="line"
+         id="tspan49533"
+         style="font-size:3.15252px;stroke-width:0.264583"
+         x="89.262283"
+         y="87.617271">AXI-HMCAD15XX IP </tspan></text>
+    <rect
+       style="fill:#ffcccc;fill-opacity:1;fill-rule:evenodd;stroke:#a01414;stroke-width:0.493867;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:0.0493867, 0.0493867;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4"
+       width="25.023428"
+       height="13.624562"
+       x="104.21902"
+       y="117.05737" />
+    <path
+       style="fill:#a01414;fill-opacity:1;stroke:#a01414;stroke-width:0.6;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:20;stroke-opacity:1;marker-start:url(#TriangleInM-0);marker-end:url(#marker51146-9)"
+       d="m 116.6492,132.81486 c 0,5.55327 0,5.33969 0,5.33969"
+       id="path6" />
+    <text
+       xml:space="preserve"
+       transform="matrix(0.1801039,0,0,0.17830378,51.79968,36.473985)"
+       id="text19"
+       style="font-size:16px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial, Normal';text-align:center;white-space:pre;shape-inside:url(#rect19);display:inline;stroke-width:2.01426"
+       x="62.085659"
+       y="0"><tspan
+         x="345.01046"
+         y="484.35348"
+         id="tspan6"><tspan
+           style="font-size:13.4284px"
+           id="tspan3">ADC 
+</tspan></tspan><tspan
+         x="324.48756"
+         y="504.35348"
+         id="tspan8"><tspan
+           style="font-size:13.4284px"
+           id="tspan7">CHANNELS</tspan></tspan></text>
+    <rect
+       style="fill:#ffcccc;fill-opacity:1;fill-rule:evenodd;stroke:#a01414;stroke-width:0.342;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:0.0342, 0.0342;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect20"
+       width="19.162409"
+       height="14.729539"
+       x="77.360336"
+       y="94.097115" />
+    <text
+       xml:space="preserve"
+       transform="matrix(0.3543127,0,0,0.3543127,-2.560862,5.2356974)"
+       id="text22"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:7.96534px;font-family:Arial;-inkscape-font-specification:'Arial, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:center;writing-mode:lr-tb;direction:ltr;white-space:pre;shape-inside:url(#rect23);display:inline;fill:#000000;stroke-width:1.2926;stroke-dasharray:0.12926, 0.12926;stroke-dashoffset:0"
+       x="24.155434"
+       y="0"><tspan
+         x="231.74029"
+         y="273.58888"
+         id="tspan10"><tspan
+           style="font-size:5.97401px"
+           id="tspan9">up_delay_cntrl</tspan></tspan></text>
+    <path
+       d="M 91.591863,81.473996"
+       style="fill:none;stroke:#000000;stroke-width:0.529167;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#marker1216);shape-rendering:crispEdges"
+       id="path1-1" />
+    <path
+       id="path3"
+       style="fill:#000000;fill-opacity:1;stroke:#000000;stroke-width:0.303073;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 72.826271,86.133018 v 1.1117 1.1117 l 0.962773,-0.55565 0.962772,-0.55605 c 0,0 -0.641877,-0.37039 -0.962772,-0.55565 -0.320953,-0.1853 -0.962773,-0.55605 -0.962773,-0.55605 z m -21.41766,1.13719 h 21.286943 z"
+       sodipodi:nodetypes="cccccscccc" />
+    <text
+       xml:space="preserve"
+       transform="scale(0.26458333)"
+       id="text5"
+       style="font-size:9.99999px;font-family:Arial;-inkscape-font-specification:'Arial, Normal';writing-mode:lr-tb;direction:ltr;white-space:pre;shape-inside:url(#rect5);fill:#000000;fill-opacity:1;stroke:#000000;stroke-width:1.46268;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+    <text
+       xml:space="preserve"
+       transform="scale(0.26458333)"
+       id="text6"
+       style="font-size:9.99999px;font-family:Arial;-inkscape-font-specification:'Arial, Normal';writing-mode:lr-tb;direction:ltr;white-space:pre;shape-inside:url(#rect6);fill:#000000;fill-opacity:1;stroke:#000000;stroke-width:1.46268;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+    <text
+       xml:space="preserve"
+       style="font-size:2.07204px;font-family:Arial;-inkscape-font-specification:'Arial, Normal';writing-mode:lr-tb;direction:ltr;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.303074;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       x="58.584198"
+       y="86.383125"
+       id="text11"><tspan
+         sodipodi:role="line"
+         id="tspan11"
+         style="stroke:none;stroke-width:0.303073"
+         x="58.584198"
+         y="86.383125">clk_in_p</tspan></text>
+    <path
+       id="path11"
+       style="fill:#000000;fill-opacity:1;stroke:#000000;stroke-width:0.303073;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 72.826271,89.914488 v 1.1117 1.1117 l 0.962773,-0.55564 0.962772,-0.55606 c 0,0 -0.641877,-0.37038 -0.962772,-0.55565 -0.320953,-0.18529 -0.962773,-0.55605 -0.962773,-0.55605 z m -21.41766,1.1372 h 21.286943 z"
+       sodipodi:nodetypes="cccccscccc" />
+    <text
+       xml:space="preserve"
+       style="font-size:2.07204px;font-family:Arial;-inkscape-font-specification:'Arial, Normal';writing-mode:lr-tb;direction:ltr;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.303074;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       x="58.584198"
+       y="90.164604"
+       id="text12"><tspan
+         sodipodi:role="line"
+         style="stroke:none;stroke-width:0.303073"
+         x="58.584198"
+         y="90.164604"
+         id="tspan13">clk_in_n</tspan></text>
+    <path
+       id="path14"
+       style="fill:#000000;fill-opacity:1;stroke:#000000;stroke-width:0.303073;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 72.826271,94.887398 v 1.1117 1.1117 l 0.962773,-0.55564 0.962772,-0.55606 c 0,0 -0.641877,-0.37038 -0.962772,-0.55565 -0.320953,-0.1853 -0.962773,-0.55605 -0.962773,-0.55605 z m -21.41766,1.1372 h 21.286943 z"
+       sodipodi:nodetypes="cccccscccc" />
+    <text
+       xml:space="preserve"
+       style="font-size:2.07204px;font-family:Arial;-inkscape-font-specification:'Arial, Normal';writing-mode:lr-tb;direction:ltr;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.303074;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       x="58.584198"
+       y="95.137505"
+       id="text14"><tspan
+         sodipodi:role="line"
+         style="stroke:none;stroke-width:0.303073"
+         x="58.584198"
+         y="95.137505"
+         id="tspan14">fclk_p</tspan></text>
+    <path
+       id="path15"
+       style="fill:#000000;fill-opacity:1;stroke:#000000;stroke-width:0.303073;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 72.826271,98.565278 v 1.1117 1.111702 l 0.962773,-0.55564 0.962772,-0.556062 c 0,0 -0.641877,-0.37038 -0.962772,-0.55565 -0.320953,-0.1853 -0.962773,-0.55605 -0.962773,-0.55605 z m -21.41766,1.1372 h 21.286943 z"
+       sodipodi:nodetypes="cccccscccc" />
+    <text
+       xml:space="preserve"
+       style="font-size:2.07204px;font-family:Arial;-inkscape-font-specification:'Arial, Normal';writing-mode:lr-tb;direction:ltr;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.303074;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       x="58.584198"
+       y="98.815399"
+       id="text15"><tspan
+         sodipodi:role="line"
+         style="stroke:none;stroke-width:0.303073"
+         x="58.584198"
+         y="98.815399"
+         id="tspan15">fclk_n</tspan></text>
+    <path
+       id="path16"
+       style="fill:#000000;fill-opacity:1;stroke:#000000;stroke-width:0.303073;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 72.826271,105.40303 v 1.1117 1.1117 l 0.962773,-0.55564 0.962772,-0.55606 c 0,0 -0.641877,-0.37039 -0.962772,-0.55565 -0.320953,-0.1853 -0.962773,-0.55605 -0.962773,-0.55605 z m -21.41766,1.1372 h 21.286943 z"
+       sodipodi:nodetypes="cccccscccc" />
+    <text
+       xml:space="preserve"
+       style="font-size:2.07204px;font-family:Arial;-inkscape-font-specification:'Arial, Normal';writing-mode:lr-tb;direction:ltr;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.303074;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       x="55.964958"
+       y="105.65316"
+       id="text16"><tspan
+         sodipodi:role="line"
+         style="stroke:none;stroke-width:0.303073"
+         x="55.964958"
+         y="105.65316"
+         id="tspan16">data_in_p [7:0]</tspan></text>
+    <path
+       id="path17"
+       style="fill:#000000;fill-opacity:1;stroke:#000000;stroke-width:0.303073;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 72.826271,108.6665 v 1.1117 1.1117 l 0.962773,-0.55564 0.962772,-0.55606 c 0,0 -0.641877,-0.37038 -0.962772,-0.55565 -0.320953,-0.1853 -0.962773,-0.55605 -0.962773,-0.55605 z m -21.41766,1.1372 h 21.286943 z"
+       sodipodi:nodetypes="cccccscccc" />
+    <text
+       xml:space="preserve"
+       style="font-size:2.07204px;font-family:Arial;-inkscape-font-specification:'Arial, Normal';writing-mode:lr-tb;direction:ltr;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.303074;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       x="56.058502"
+       y="108.91663"
+       id="text17"><tspan
+         sodipodi:role="line"
+         style="stroke:none;stroke-width:0.303073"
+         x="56.058502"
+         y="108.91663"
+         id="tspan17">data_in_n [7:0]</tspan></text>
+    <path
+       id="path18"
+       style="fill:#000000;fill-opacity:1;stroke:#000000;stroke-width:0.303073;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 72.826271,113.84661 v 1.1117 1.1117 l 0.962773,-0.55564 0.962772,-0.55606 c 0,0 -0.641877,-0.37038 -0.962772,-0.55565 -0.320953,-0.1853 -0.962773,-0.55605 -0.962773,-0.55605 z m -21.41766,1.1372 h 21.286943 z"
+       sodipodi:nodetypes="cccccscccc" />
+    <text
+       xml:space="preserve"
+       style="font-size:2.07204px;font-family:Arial;-inkscape-font-specification:'Arial, Normal';writing-mode:lr-tb;direction:ltr;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.303074;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       x="58.584198"
+       y="114.09675"
+       id="text18"><tspan
+         sodipodi:role="line"
+         style="stroke:none;stroke-width:0.303073"
+         x="58.584198"
+         y="114.09675"
+         id="tspan18">delay_clk</tspan></text>
+    <path
+       id="path19"
+       style="fill:#000000;fill-opacity:1;stroke:#000000;stroke-width:0.303073;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 154.86465,115.69082 v 1.1117 1.11169 l 0.96278,-0.55564 0.96277,-0.55605 c 0,0 -0.64188,-0.37039 -0.96277,-0.55566 -0.32096,-0.18529 -0.96278,-0.55604 -0.96278,-0.55604 z m -21.41766,1.13719 h 21.28695 z"
+       sodipodi:nodetypes="cccccscccc" />
+    <text
+       xml:space="preserve"
+       style="font-size:2.07204px;font-family:Arial;-inkscape-font-specification:'Arial, Normal';writing-mode:lr-tb;direction:ltr;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.303074;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       x="137.62917"
+       y="115.94094"
+       id="text20"><tspan
+         sodipodi:role="line"
+         style="stroke:none;stroke-width:0.303073"
+         x="137.62917"
+         y="115.94094"
+         id="tspan19">adc_data[127:0]</tspan></text>
+    <path
+       id="path20"
+       style="fill:#000000;fill-opacity:1;stroke:#000000;stroke-width:0.303073;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 154.86465,119.00609 v 1.11169 1.1117 l 0.96278,-0.55564 0.96277,-0.55606 c 0,0 -0.64188,-0.37038 -0.96277,-0.55565 -0.32096,-0.18529 -0.96278,-0.55604 -0.96278,-0.55604 z m -21.41766,1.13719 h 21.28695 z"
+       sodipodi:nodetypes="cccccscccc" />
+    <text
+       xml:space="preserve"
+       style="font-size:2.07204px;font-family:Arial;-inkscape-font-specification:'Arial, Normal';writing-mode:lr-tb;direction:ltr;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.303074;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       x="140.62259"
+       y="119.25622"
+       id="text21"><tspan
+         sodipodi:role="line"
+         style="stroke:none;stroke-width:0.303073"
+         x="140.62259"
+         y="119.25622"
+         id="tspan20">adc_clk</tspan></text>
+    <path
+       id="path21"
+       style="fill:#000000;fill-opacity:1;stroke:#000000;stroke-width:0.303073;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 154.86465,122.52856 v 1.1117 1.1117 l 0.96278,-0.55564 0.96277,-0.55606 c 0,0 -0.64188,-0.37038 -0.96277,-0.55565 -0.32096,-0.18529 -0.96278,-0.55605 -0.96278,-0.55605 z m -21.41766,1.1372 h 21.28695 z"
+       sodipodi:nodetypes="cccccscccc" />
+    <text
+       xml:space="preserve"
+       style="font-size:2.07204px;font-family:Arial;-inkscape-font-specification:'Arial, Normal';writing-mode:lr-tb;direction:ltr;white-space:pre;inline-size:10.974;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.303074;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       x="140.62259"
+       y="122.77869"
+       id="text23"><tspan
+         x="140.62259"
+         y="122.77869"
+         id="tspan22"><tspan
+           style="stroke-width:0.303073"
+           id="tspan12">adc_resetn
+</tspan></tspan></text>
+    <path
+       id="path23"
+       style="fill:#000000;fill-opacity:1;stroke:#000000;stroke-width:0.303073;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 154.86465,91.930558 v 1.1117 1.11169 l 0.96278,-0.55564 0.96277,-0.55605 c 0,0 -0.64188,-0.37039 -0.96277,-0.55566 -0.32096,-0.18529 -0.96278,-0.55604 -0.96278,-0.55604 z m -21.41766,1.13719 h 21.28695 z"
+       sodipodi:nodetypes="cccccscccc" />
+    <text
+       xml:space="preserve"
+       style="font-size:2.07204px;font-family:Arial;-inkscape-font-specification:'Arial, Normal';writing-mode:lr-tb;direction:ltr;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.303074;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       x="137.81625"
+       y="92.180679"
+       id="text24"><tspan
+         sodipodi:role="line"
+         style="stroke:none;stroke-width:0.303073"
+         x="137.81625"
+         y="92.180679"
+         id="tspan23">adc_enable_0</tspan></text>
+    <path
+       id="path24"
+       style="fill:#000000;fill-opacity:1;stroke:#000000;stroke-width:0.303073;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 154.86465,95.204608 v 1.1117 1.11169 l 0.96278,-0.55564 0.96277,-0.55605 c 0,0 -0.64188,-0.37039 -0.96277,-0.55566 -0.32096,-0.18529 -0.96278,-0.55604 -0.96278,-0.55604 z m -21.41766,1.13719 h 21.28695 z"
+       sodipodi:nodetypes="cccccscccc" />
+    <text
+       xml:space="preserve"
+       style="font-size:2.07204px;font-family:Arial;-inkscape-font-specification:'Arial, Normal';writing-mode:lr-tb;direction:ltr;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.303074;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       x="137.81625"
+       y="95.454735"
+       id="text25"><tspan
+         sodipodi:role="line"
+         style="stroke:none;stroke-width:0.303073"
+         x="137.81625"
+         y="95.454735"
+         id="tspan24">adc_enable_1</tspan></text>
+    <path
+       id="path25"
+       style="fill:#000000;fill-opacity:1;stroke:#000000;stroke-width:0.303073;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 154.86465,98.759288 v 1.1117 1.111692 l 0.96278,-0.55564 0.96277,-0.556052 c 0,0 -0.64188,-0.37039 -0.96277,-0.55566 -0.32096,-0.18529 -0.96278,-0.55604 -0.96278,-0.55604 z m -21.41766,1.13719 h 21.28695 z"
+       sodipodi:nodetypes="cccccscccc" />
+    <text
+       xml:space="preserve"
+       style="font-size:2.07204px;font-family:Arial;-inkscape-font-specification:'Arial, Normal';writing-mode:lr-tb;direction:ltr;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.303074;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       x="138.09689"
+       y="99.009415"
+       id="text26"><tspan
+         sodipodi:role="line"
+         style="stroke:none;stroke-width:0.303073"
+         x="138.09689"
+         y="99.009415"
+         id="tspan25">adc_enable_2</tspan></text>
+    <path
+       id="path26"
+       style="fill:#000000;fill-opacity:1;stroke:#000000;stroke-width:0.303073;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 154.86465,102.31397 v 1.1117 1.11169 l 0.96278,-0.55564 0.96277,-0.55605 c 0,0 -0.64188,-0.37039 -0.96277,-0.55566 -0.32096,-0.18529 -0.96278,-0.55604 -0.96278,-0.55604 z m -21.41766,1.13719 h 21.28695 z"
+       sodipodi:nodetypes="cccccscccc" />
+    <text
+       xml:space="preserve"
+       style="font-size:2.07204px;font-family:Arial;-inkscape-font-specification:'Arial, Normal';writing-mode:lr-tb;direction:ltr;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.303074;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       x="138.09689"
+       y="102.56409"
+       id="text27"><tspan
+         sodipodi:role="line"
+         style="stroke:none;stroke-width:0.303073"
+         x="138.09689"
+         y="102.56409"
+         id="tspan26">adc_enable_3</tspan></text>
+    <path
+       id="path28"
+       style="fill:#000000;fill-opacity:1;stroke:#000000;stroke-width:0.303073;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 154.86465,111.57487 v 1.1117 1.11169 l 0.96278,-0.55564 0.96277,-0.55605 c 0,0 -0.64188,-0.37039 -0.96277,-0.55566 -0.32096,-0.18529 -0.96278,-0.55604 -0.96278,-0.55604 z m -21.41766,1.13719 h 21.28695 z"
+       sodipodi:nodetypes="cccccscccc" />
+    <text
+       xml:space="preserve"
+       style="font-size:2.07204px;font-family:Arial;-inkscape-font-specification:'Arial, Normal';writing-mode:lr-tb;direction:ltr;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.303074;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       x="140.06133"
+       y="111.82499"
+       id="text28"><tspan
+         sodipodi:role="line"
+         style="stroke:none;stroke-width:0.303073"
+         x="140.06133"
+         y="111.82499"
+         id="tspan28">adc_valid</tspan></text>
+    <path
+       id="rect29"
+       style="fill:#38bcf2;fill-opacity:1;stroke:none;stroke-width:0.374975;stroke-opacity:1"
+       d="m 52.150971,139.52807 h 15.617118 l 6.803285,4.12446 -6.803285,3.82681 H 52.150971 Z"
+       sodipodi:nodetypes="cccccc" />
+    <text
+       xml:space="preserve"
+       style="font-size:2.64583px;font-family:Arial;-inkscape-font-specification:'Arial, Normal';writing-mode:lr-tb;direction:ltr;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.387001;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       x="54.757484"
+       y="144.40234"
+       id="text30"><tspan
+         sodipodi:role="line"
+         id="tspan30"
+         style="fill:#000000;fill-opacity:1;stroke-width:0.387"
+         x="54.757484"
+         y="144.40234">S_AXI_MM</tspan></text>
+    <path
+       id="path4"
+       style="fill:#000000;fill-opacity:1;stroke:#000000;stroke-width:0.303073;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 72.826271,118.33674 v 1.1117 1.1117 l 0.962773,-0.55564 0.962772,-0.55606 c 0,0 -0.641877,-0.37038 -0.962772,-0.55565 -0.320953,-0.1853 -0.962773,-0.55605 -0.962773,-0.55605 z m -21.41766,1.1372 h 21.286943 z"
+       sodipodi:nodetypes="cccccscccc" />
+    <text
+       xml:space="preserve"
+       style="font-size:2.07204px;font-family:Arial;-inkscape-font-specification:'Arial, Normal';writing-mode:lr-tb;direction:ltr;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.303074;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       x="58.584198"
+       y="118.58688"
+       id="text4"><tspan
+         sodipodi:role="line"
+         style="stroke:none;stroke-width:0.303073"
+         x="58.584198"
+         y="118.58688"
+         id="tspan4">adc_dovf</tspan><tspan
+         sodipodi:role="line"
+         style="stroke:none;stroke-width:0.303073"
+         x="58.584198"
+         y="121.17693"
+         id="tspan5" /></text>
+  </g>
+</svg>

--- a/docs/library/axi_hmcad15xx/index.rst
+++ b/docs/library/axi_hmcad15xx/index.rst
@@ -1,0 +1,251 @@
+.. _axi_hmcad15xx:
+
+AXI HMCAD15XX
+================================================================================
+
+.. hdl-component-diagram::
+
+The :git-hdl:`AXI HMCAD15XX <library/axi_hmcad15xx>` IP core can be used to
+interface the :adi:`HMCAD1511, HMCAD1520` devices.
+This documentation only covers the IP core and requires one to be
+familiar with the device, for a complete and better understanding.
+
+More about the generic framework interfacing ADCs can be read in :ref:`axi_adc`.
+
+Features
+--------------------------------------------------------------------------------
+
+* Support for 8/12/14 bits
+* Single/Dual/Quad channel
+* Support for Dual 8-bit Quad Channel.
+* Synchronization based on FCLK
+
+Files
+--------------------------------------------------------------------------------
+
+.. list-table::
+   :header-rows: 1
+
+   * - Name
+     - Description
+   * - :git-hdl:`library/axi_hmcad15xx/axi_hmcad15xx.v`
+     - Verilog source for the AXI HMCAD15xx.
+   * - :git-hdl:`library/axi_hmcad15xx/axi_hmcad15xx_if.v`
+     - Verilog source for the AXI HMCAD15xx physical interface.
+   * - :git-hdl:`library/axi_hmcad15xx/axi_hmcad15xx_ip.tcl`
+     - IP definition file (AMD tools)
+
+Block Diagram
+--------------------------------------------------------------------------------
+
+.. image:: block_diagram.svg
+   :alt: AXI HMCAD15XX block diagram
+
+Configuration Parameters
+--------------------------------------------------------------------------------
+
+.. hdl-parameters::
+
+   * - ID
+     - Core ID should be unique for each IP in the system
+   * - FPGA_TECHNOLOGY
+     - Used to select between FPGA devices, auto set in project.
+   * - NUM_CHANNELS
+     - Used when selecting channel mode Single/Dual/Quad.
+   * - FPGA_FAMILY
+     - Used to select the family variant of the FPGA device, auto set
+       in project.
+   * - SPEED_GRADE
+     - Used to set the FPGA’s speed-grade
+   * - DEV_PACKAGE
+     - Value describing the device package. The package might affect high-speed
+       interfaces
+   * - ADC_DATAPATH_DISABLE
+     - If set, the datapath processing is not generated and output data is
+       taken directly from the HMCAD15XX
+   * - IO_DELAY_GROUP
+     - The delay group name which is set for the delay controller
+   * - IODELAY_CTRL
+     - Enables the IO delay mechanism (controller + data delay) in the SERDES
+       module
+
+Interface
+--------------------------------------------------------------------------------
+
+.. hdl-interfaces::
+
+   * - fclk_p
+     - Positive side of the frame clock used to determine the start of sample.
+   * - fclk_n
+     - Negative side of the frame clock used to determine the start of sample.
+   * - clk_in_p
+     - LVDS input positive side of differential reference clock signal
+   * - clk_in_n
+     - LVDS input negative side of differential reference clock signal
+   * - data_in_p
+     - LVDS input positive side of differential data signal
+   * - data_in_n
+     - LVDS input negative side of differential data signal
+   * - delay_clk
+     - Delay clock input for IO_DELAY control, 200 MHz (7 series) or 300 MHz
+       (Ultrascale)
+   * - adc_dovf
+     - Data overflow. Must be connected to the DMA
+   * - s_axi
+     - Standard AXI Slave Memory Map interface
+   * - adc_clk
+     - The clock used to shift data out of the IP
+   * - adc_clk_g
+     - Global version of adc_clk, used for clocking global resources (FIFOs,
+       etc.)
+   * - adc_valid
+     - Indicates valid data
+   * - adc_data
+     - Received data output
+   * - adc_resetn
+     - Reset signal for the ADC
+
+The IP also provides per-channel enable signals (``adc_enable_0`` through
+``adc_enable_3``) directly from the ADC channel registers.
+
+Internal Interface Description
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The axi_hmcad15xx operates as follows:
+
+* The LVDS data is deserialized by the
+  :git-hdl:`ad_serdes_in<library/xilinx/common/ad_serdes_in.v>` module with
+  a 1:8 ratio.
+* The data lanes are processed by
+  :git-hdl:`sample_assembly<library/hmcad15xx/sample_assembly.v>` based
+  on resolution and frame_data. For 8-bit resolution data gets packed into
+  8-bit words, for 12/14 bit resolution data gets packed into 16-bit words.
+* 14-bit resoltion works only in Quad Channel Mode.
+* The bits in the sample are inverted by polarity_mask_s
+* All of the samples are sent at the same time on adc_data when adc_valid
+  asserts.
+
+Register Map
+--------------------------------------------------------------------------------
+
+The register map of the core contains instances of several generic register maps
+like ADC common, ADC channel,
+:git-hdl:`up_delay_cntrl <library/common/up_delay_cntrl.v>`.
+The following table presents the base addresses of each instance, after it you
+can find the detailed description of each generic register map.
+
+The absolute address of a register should be calculated by adding the instance
+base address to the registers relative address. For a more detailed explanation,
+see :ref:`ADC register access <generic-adc-register-access>`.
+
+.. list-table:: Register Map base addresses for axi_hmcad15xx
+   :header-rows: 1
+
+   * - HDL reg
+     - Software reg
+     - Name
+     - Description
+   * - 0x0000
+     - 0x0000
+     - BASE
+     - See the `Base <#hdl-regmap-COMMON>`__ table for more details.
+   * - 0x0000
+     - 0x0000
+     - RX COMMON
+     - See the `ADC Common <#hdl-regmap-ADC_COMMON>`__ table for more details.
+   * - 0x0000
+     - 0x0000
+     - RX CHANNELS
+     - See the `ADC Channel <#hdl-regmap-ADC_CHANNEL>`__ table for more details.
+   * - 0x0000
+     - 0x0800
+     - IO_DELAY_CNTRL
+     - See the `I/O Delay Control <#hdl-regmap-IO_DELAY_CNTRL>`__ table for
+       more details.
+
+.. hdl-regmap::
+   :name: COMMON
+   :no-type-info:
+
+.. hdl-regmap::
+   :name: ADC_COMMON
+   :no-type-info:
+
+.. hdl-regmap::
+   :name: ADC_CHANNEL
+   :no-type-info:
+
+.. hdl-regmap::
+   :name: IO_DELAY_CNTRL
+   :no-type-info:
+
+Design Guidelines
+--------------------------------------------------------------------------------
+
+The control of the HMCAD15xx chip is done through a SPI interface, which is
+needed at system level.
+
+The *ADC interface signals* must be connected directly to the top file of the
+design, as I/O primitives are part of the IP.
+
+The example design uses a DMA to move the data from the output of the IP to
+memory.
+
+If the data needs to be processed in HDL before moving it to the memory, it
+can be done at the output of the IP (at system level) or inside of the ADC
+channel module (at IP level).
+
+The example design uses a processor to program all the registers. If no
+processor is available in your system, you can create your own IP starting
+from the interface module.
+
+Software Guidelines
+--------------------------------------------------------------------------------
+
+.. list-table:: Main registers used to control the AXI HMCAD15xx IP
+   :header-rows: 1
+
+   * - Name
+     - Register
+     - BIT
+     - Description
+   * - RESOLUTION
+     - 0x4C (ADC Common)
+     - [1:0]
+     - This value is used to select the resolution for the ADC.
+       (2'b00 -> 8-bit resolution,
+       2'b01 -> Dual 8-bit resolution, 2'b10 -> 12-bit resolution,
+       2'b11 -> 14-bit resolution)
+   * - MODE
+     - 0x4C (ADC Common)
+     - [4:2]
+     - This field specifies the Channel Mode. (3'b001 -> Single Channel,
+       3'b010 -> Dual Channel, 3'b100 -> Quad Channel)
+   * - POLARITY_MASK_S
+     - 0x80 (ADC Common)
+     - [7:0]
+     - Used to invert data coming from each lane. (E.g.
+       polarity_mask_s == 8'b11010000 => bits coming on lanes 7, 6 and 4
+       will be inverted)
+
+.. note::
+
+  \* The register already exist in ADC Common. This is just a detailed
+     explanation.
+
+Software Suppport
+--------------------------------------------------------------------------------
+
+  - :git-linux:`HMCAD15XX Linux driver <drivers/iio/adc/hmcad15xx.c>`
+  - :git-linux:`HMCAD15XX-FMC-EVB Linux device tree <arch/arm/boot/dts/xilinx/zynq-zed-adv7511-hmcad15xx.dts>`
+  - :git-linux:`ADMX6020M device tree (8-bit) <arch/arm/boot/dts/xilinx/zynq-admx6020m.dts>`
+
+References
+-------------------------------------------------------------------------------
+
+* HDL IP core at :git-hdl:`library/axi_hmcad15xx`
+* HDL project at :git-hdl:`projects/hmcad1520_ebz`
+* HDL project documentation at :ref:`hmcad1520_ebz`
+* :adi:`HMCAD1520`
+* :xilinx:`Zynq-7000 SoC Overview <support/documentation/data_sheets/ds190-Zynq-7000-Overview.pdf>`
+* :xilinx:`Zynq-7000 SoC Packaging and Pinout <support/documentation/user_guides/ug865-Zynq-7000-Pkg-Pinout.pdf>`

--- a/docs/library/index.rst
+++ b/docs/library/index.rst
@@ -40,6 +40,7 @@ ADC/DAC
    axi_ada4355/index
    axi_adaq8092/index
    axi_adrv9001/index
+   axi_hmcad15xx/index
    axi_ltc235x/index
    axi_ltc2387/index
 

--- a/docs/projects/admx6020m/admx6020m_block_diagram.svg
+++ b/docs/projects/admx6020m/admx6020m_block_diagram.svg
@@ -1,0 +1,3812 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="1087.3005"
+   height="825.51117"
+   viewBox="0 0 1087.3005 825.51118"
+   version="1.1"
+   id="svg31900"
+   inkscape:version="1.4.3 (0d15f75, 2025-12-25)"
+   sodipodi:docname="admx6020m_block_diagram.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <defs
+     id="defs31894">
+    <marker
+       inkscape:stockid="TriangleOutM"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="TriangleOutM"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path4669"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="scale(0.4)"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:stockid="TriangleInM"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="TriangleInM-7-1"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         inkscape:connector-curvature="0"
+         id="path4660-1-6"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="scale(-0.4)" />
+    </marker>
+    <marker
+       inkscape:stockid="TriangleOutM"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker5537"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         inkscape:connector-curvature="0"
+         id="path5539"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="scale(0.4)" />
+    </marker>
+    <marker
+       inkscape:stockid="TriangleOutM"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="TriangleOutM-7"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path4669-8"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="scale(0.4)"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:stockid="TriangleInM"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="TriangleInM-7-1-8"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         inkscape:connector-curvature="0"
+         id="path4660-1-6-5"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="scale(-0.4)" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker10933-1"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="TriangleInM">
+      <path
+         transform="scale(-0.4)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         id="path10935-1"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:stockid="TriangleOutM"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker5537-0"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         inkscape:connector-curvature="0"
+         id="path5539-1"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="scale(0.4)" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker10933-1-7"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="TriangleInM">
+      <path
+         transform="scale(-0.4)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         id="path10935-1-7"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5412"
+       id="linearGradient1998"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(3.7795276,0,0,3.7795276,-104.69743,-302.92875)"
+       x1="172.53362"
+       y1="161.85487"
+       x2="184.83434"
+       y2="161.85487" />
+    <linearGradient
+       id="linearGradient5412"
+       inkscape:swatch="solid">
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0"
+         id="stop5410" />
+    </linearGradient>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker1216-6-7"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="TriangleOutM">
+      <path
+         transform="scale(0.4)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         id="path1214-0-2"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker1216-3"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="TriangleOutM">
+      <path
+         transform="scale(0.4)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         id="path1214-4"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker1216"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="TriangleOutM">
+      <path
+         transform="scale(0.4)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         id="path1214"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker1216-6"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="TriangleOutM">
+      <path
+         transform="scale(0.4)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         id="path1214-0"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker1216-6-7-9"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="TriangleOutM">
+      <path
+         transform="scale(0.4)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         id="path1214-0-2-7"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker1216-3-5"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="TriangleOutM">
+      <path
+         transform="scale(0.4)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         id="path1214-4-3"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker1216-6-0"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="TriangleOutM">
+      <path
+         transform="scale(0.4)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         id="path1214-0-5"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker1216-60"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="TriangleOutM">
+      <path
+         transform="scale(0.4)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         id="path1214-40"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker1216-6-7-0"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="TriangleOutM">
+      <path
+         transform="scale(0.4)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         id="path1214-0-2-74"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker1216-3-7"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="TriangleOutM">
+      <path
+         transform="scale(0.4)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         id="path1214-4-6"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker1216-6-05"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="TriangleOutM">
+      <path
+         transform="scale(0.4)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         id="path1214-0-6"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker1216-2"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="TriangleOutM">
+      <path
+         transform="scale(0.4)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         id="path1214-44"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker10933-1-8-6"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="TriangleInM">
+      <path
+         transform="scale(-0.4)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         id="path10935-1-14"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:stockid="TriangleOutM"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker5537-9"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         inkscape:connector-curvature="0"
+         id="path5539-1-7"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="scale(0.4)" />
+    </marker>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5412"
+       id="linearGradient6251"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-4.4178594,9.2486346)"
+       x1="172.53362"
+       y1="161.85487"
+       x2="184.83434"
+       y2="161.85487" />
+    <marker
+       inkscape:stockid="TriangleOutM"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker5537-81-6"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         inkscape:connector-curvature="0"
+         id="path5539-5-1"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="scale(0.4)" />
+    </marker>
+    <marker
+       inkscape:stockid="TriangleOutM"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker5537-3-3"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         inkscape:connector-curvature="0"
+         id="path5539-1-8"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="scale(0.4)" />
+    </marker>
+    <marker
+       inkscape:stockid="TriangleOutM"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker5537-5-9"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         inkscape:connector-curvature="0"
+         id="path5539-8-3"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="scale(0.4)" />
+    </marker>
+    <marker
+       inkscape:stockid="TriangleOutM"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker5537-44"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         inkscape:connector-curvature="0"
+         id="path5539-6"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="scale(0.4)" />
+    </marker>
+    <filter
+       inkscape:collect="always"
+       style="color-interpolation-filters:sRGB"
+       id="filter4222"
+       x="-0.0022982531"
+       width="1.0045965"
+       y="-0.0038715175"
+       height="1.0092941">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="0.00061692564"
+         id="feGaussianBlur4224" />
+    </filter>
+    <marker
+       inkscape:stockid="TriangleInM"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="TriangleInM-1"
+       style="overflow:visible"
+       inkscape:isstock="true"
+       inkscape:collect="always">
+      <path
+         id="path4660-0"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="scale(-0.4)"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:stockid="TriangleOutM"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="TriangleOutM-4-7"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path4669-8-9"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="scale(0.4)"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:stockid="TriangleInM"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="TriangleInM-7-1-0-7"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         inkscape:connector-curvature="0"
+         id="path4660-1-6-9-3"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="scale(-0.4)" />
+    </marker>
+    <marker
+       inkscape:stockid="TriangleOutM"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="TriangleOutM-2-8-1"
+       style="overflow:visible"
+       inkscape:isstock="true"
+       inkscape:collect="always">
+      <path
+         inkscape:connector-curvature="0"
+         id="path4669-5-5-7"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="scale(0.4)" />
+    </marker>
+    <filter
+       inkscape:collect="always"
+       style="color-interpolation-filters:sRGB"
+       id="filter4222-4"
+       x="-4.1809884e-05"
+       width="1.0000836"
+       y="-0.00010580112"
+       height="1.0002116">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="0.00061692564"
+         id="feGaussianBlur4224-3" />
+    </filter>
+    <marker
+       inkscape:stockid="TriangleOutM"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker5537-48"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         inkscape:connector-curvature="0"
+         id="path5539-82"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="scale(0.4)" />
+    </marker>
+    <marker
+       inkscape:stockid="TriangleOutM"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker1"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         inkscape:connector-curvature="0"
+         id="path1"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="scale(0.4)" />
+    </marker>
+    <marker
+       inkscape:stockid="TriangleOutM"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker5537-81"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         inkscape:connector-curvature="0"
+         id="path5539-5"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="scale(0.4)" />
+    </marker>
+    <marker
+       inkscape:stockid="TriangleOutM"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker5537-8"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         inkscape:connector-curvature="0"
+         id="path5539-17"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="scale(0.4)" />
+    </marker>
+    <marker
+       inkscape:stockid="TriangleOutM"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker5537-8-9"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         inkscape:connector-curvature="0"
+         id="path5539-17-0"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="scale(0.4)" />
+    </marker>
+    <marker
+       inkscape:stockid="TriangleOutM"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker5537-3"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         inkscape:connector-curvature="0"
+         id="path5539-1-4"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="scale(0.4)" />
+    </marker>
+    <marker
+       inkscape:stockid="TriangleOutM"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker5537-5"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         inkscape:connector-curvature="0"
+         id="path5539-8"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="scale(0.4)" />
+    </marker>
+    <marker
+       inkscape:stockid="TriangleOutM"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker2"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         inkscape:connector-curvature="0"
+         id="path2"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="scale(0.4)" />
+    </marker>
+    <marker
+       inkscape:stockid="TriangleOutM"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="TriangleOutM-5"
+       style="overflow:visible"
+       inkscape:isstock="true"
+       viewBox="0 0 4.2595265 4.9243081"
+       markerWidth="4.2595263"
+       markerHeight="4.9243078"
+       preserveAspectRatio="xMidYMid">
+      <path
+         id="path4669-51"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="scale(0.4)"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:stockid="TriangleOutM"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker5537-4"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         inkscape:connector-curvature="0"
+         id="path5539-23"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="scale(0.4)" />
+    </marker>
+    <marker
+       inkscape:stockid="TriangleOutM"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker3"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         inkscape:connector-curvature="0"
+         id="path3"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="scale(0.4)" />
+    </marker>
+    <marker
+       inkscape:stockid="TriangleOutM"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker4"
+       style="overflow:visible"
+       inkscape:isstock="true"
+       viewBox="0 0 4.2595265 4.9243081"
+       markerWidth="4.2595263"
+       markerHeight="4.9243078"
+       preserveAspectRatio="xMidYMid">
+      <path
+         id="path4"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="scale(0.4)"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:stockid="TriangleOutM"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker5"
+       style="overflow:visible"
+       inkscape:isstock="true"
+       viewBox="0 0 4.2595265 4.9243081"
+       markerWidth="4.2595263"
+       markerHeight="4.9243078"
+       preserveAspectRatio="xMidYMid">
+      <path
+         id="path5"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="scale(0.4)"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:stockid="TriangleOutM"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker6"
+       style="overflow:visible"
+       inkscape:isstock="true"
+       viewBox="0 0 4.2595265 4.9243081"
+       markerWidth="4.2595263"
+       markerHeight="4.9243078"
+       preserveAspectRatio="xMidYMid">
+      <path
+         id="path6"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="scale(0.4)"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:stockid="TriangleOutM"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker7"
+       style="overflow:visible"
+       inkscape:isstock="true"
+       viewBox="0 0 4.2595265 4.9243081"
+       markerWidth="4.2595263"
+       markerHeight="4.9243078"
+       preserveAspectRatio="xMidYMid">
+      <path
+         id="path7"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="scale(0.4)"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:stockid="TriangleOutM"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker8"
+       style="overflow:visible"
+       inkscape:isstock="true"
+       viewBox="0 0 4.2595265 4.9243081"
+       markerWidth="4.2595263"
+       markerHeight="4.9243078"
+       preserveAspectRatio="xMidYMid">
+      <path
+         id="path8"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="scale(0.4)"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:stockid="TriangleOutM"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker9"
+       style="overflow:visible"
+       inkscape:isstock="true"
+       viewBox="0 0 4.2595265 4.9243081"
+       markerWidth="4.2595263"
+       markerHeight="4.9243078"
+       preserveAspectRatio="xMidYMid">
+      <path
+         id="path9"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="scale(0.4)"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:stockid="TriangleOutM"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker5537-81-6-1"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         inkscape:connector-curvature="0"
+         id="path5539-5-1-6"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="scale(0.4)" />
+    </marker>
+    <marker
+       inkscape:stockid="TriangleOutM"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker5537-3-3-8"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         inkscape:connector-curvature="0"
+         id="path5539-1-8-5"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="scale(0.4)" />
+    </marker>
+    <marker
+       inkscape:stockid="TriangleOutM"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker5537-5-9-7"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         inkscape:connector-curvature="0"
+         id="path5539-8-3-6"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="scale(0.4)" />
+    </marker>
+    <marker
+       inkscape:stockid="TriangleOutM"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker5537-44-1"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         inkscape:connector-curvature="0"
+         id="path5539-6-8"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="scale(0.4)" />
+    </marker>
+    <marker
+       inkscape:stockid="TriangleOutM"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="TriangleOutM-4-7-5"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path4669-8-9-4"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="scale(0.4)"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:stockid="TriangleInM"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="TriangleInM-7-1-0-7-3"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         inkscape:connector-curvature="0"
+         id="path4660-1-6-9-3-4"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="scale(-0.4)" />
+    </marker>
+    <marker
+       inkscape:stockid="TriangleOutM"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker5537-48-7"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         inkscape:connector-curvature="0"
+         id="path5539-82-4"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="scale(0.4)" />
+    </marker>
+    <marker
+       inkscape:stockid="TriangleOutM"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker1-2"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         inkscape:connector-curvature="0"
+         id="path1-7"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="scale(0.4)" />
+    </marker>
+    <marker
+       inkscape:stockid="TriangleOutM"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker5537-81-7"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         inkscape:connector-curvature="0"
+         id="path5539-5-9"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="scale(0.4)" />
+    </marker>
+    <marker
+       inkscape:stockid="TriangleOutM"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker5537-8-3"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         inkscape:connector-curvature="0"
+         id="path5539-17-1"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="scale(0.4)" />
+    </marker>
+    <marker
+       inkscape:stockid="TriangleOutM"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker5537-3-9"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         inkscape:connector-curvature="0"
+         id="path5539-1-4-8"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="scale(0.4)" />
+    </marker>
+    <marker
+       inkscape:stockid="TriangleOutM"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker5537-5-6"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         inkscape:connector-curvature="0"
+         id="path5539-8-5"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="scale(0.4)" />
+    </marker>
+    <marker
+       inkscape:stockid="TriangleOutM"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker2-0"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         inkscape:connector-curvature="0"
+         id="path2-2"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="scale(0.4)" />
+    </marker>
+    <marker
+       inkscape:stockid="TriangleOutM"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker3-8"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         inkscape:connector-curvature="0"
+         id="path3-6"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="scale(0.4)" />
+    </marker>
+    <marker
+       inkscape:stockid="TriangleOutM"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="TriangleOutM-5-0"
+       style="overflow:visible"
+       inkscape:isstock="true"
+       viewBox="0 0 4.2595265 4.9243081"
+       markerWidth="4.2595263"
+       markerHeight="4.9243078"
+       preserveAspectRatio="xMidYMid">
+      <path
+         id="path4669-51-2"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="scale(0.4)"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:stockid="TriangleOutM"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker5537-4-4"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         inkscape:connector-curvature="0"
+         id="path5539-23-8"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="scale(0.4)" />
+    </marker>
+    <marker
+       inkscape:stockid="TriangleOutM"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker4-6"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         inkscape:connector-curvature="0"
+         id="path4-5"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="scale(0.4)" />
+    </marker>
+    <marker
+       inkscape:stockid="TriangleOutM"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker5-0"
+       style="overflow:visible"
+       inkscape:isstock="true"
+       viewBox="0 0 4.2595265 4.9243081"
+       markerWidth="4.2595263"
+       markerHeight="4.9243078"
+       preserveAspectRatio="xMidYMid">
+      <path
+         id="path5-9"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="scale(0.4)"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:stockid="TriangleOutM"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker6-0"
+       style="overflow:visible"
+       inkscape:isstock="true"
+       viewBox="0 0 4.2595265 4.9243081"
+       markerWidth="4.2595263"
+       markerHeight="4.9243078"
+       preserveAspectRatio="xMidYMid">
+      <path
+         id="path6-0"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="scale(0.4)"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:stockid="TriangleOutM"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker7-6"
+       style="overflow:visible"
+       inkscape:isstock="true"
+       viewBox="0 0 4.2595265 4.9243081"
+       markerWidth="4.2595263"
+       markerHeight="4.9243078"
+       preserveAspectRatio="xMidYMid">
+      <path
+         id="path7-1"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="scale(0.4)"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:stockid="TriangleOutM"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker8-3"
+       style="overflow:visible"
+       inkscape:isstock="true"
+       viewBox="0 0 4.2595265 4.9243081"
+       markerWidth="4.2595263"
+       markerHeight="4.9243078"
+       preserveAspectRatio="xMidYMid">
+      <path
+         id="path8-8"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="scale(0.4)"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:stockid="TriangleOutM"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker9-9"
+       style="overflow:visible"
+       inkscape:isstock="true"
+       viewBox="0 0 4.2595265 4.9243081"
+       markerWidth="4.2595263"
+       markerHeight="4.9243078"
+       preserveAspectRatio="xMidYMid">
+      <path
+         id="path9-3"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="scale(0.4)"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:stockid="TriangleOutM"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker10"
+       style="overflow:visible"
+       inkscape:isstock="true"
+       viewBox="0 0 4.2595265 4.9243081"
+       markerWidth="4.2595263"
+       markerHeight="4.9243078"
+       preserveAspectRatio="xMidYMid">
+      <path
+         id="path10-4"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="scale(0.4)"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:stockid="TriangleOutM"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker11"
+       style="overflow:visible"
+       inkscape:isstock="true"
+       viewBox="0 0 4.2595265 4.9243081"
+       markerWidth="4.2595263"
+       markerHeight="4.9243078"
+       preserveAspectRatio="xMidYMid">
+      <path
+         id="path11-4"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="scale(0.4)"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:stockid="TriangleOutM"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker12"
+       style="overflow:visible"
+       inkscape:isstock="true"
+       viewBox="0 0 4.2595265 4.9243081"
+       markerWidth="4.2595263"
+       markerHeight="4.9243078"
+       preserveAspectRatio="xMidYMid">
+      <path
+         id="path12-6"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="scale(0.4)"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:stockid="TriangleOutM"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker13"
+       style="overflow:visible"
+       inkscape:isstock="true"
+       viewBox="0 0 4.2595265 4.9243081"
+       markerWidth="4.2595263"
+       markerHeight="4.9243078"
+       preserveAspectRatio="xMidYMid">
+      <path
+         id="path13-0"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="scale(0.4)"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:stockid="TriangleOutM"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="TriangleOutM-5-4"
+       style="overflow:visible"
+       inkscape:isstock="true"
+       viewBox="0 0 4.2595265 4.9243081"
+       markerWidth="4.2595263"
+       markerHeight="4.9243078"
+       preserveAspectRatio="xMidYMid">
+      <path
+         id="path4669-51-8"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="scale(0.4)"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:stockid="TriangleOutM"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="TriangleOutM-5-45"
+       style="overflow:visible"
+       inkscape:isstock="true"
+       viewBox="0 0 4.2595265 4.9243081"
+       markerWidth="4.2595263"
+       markerHeight="4.9243078"
+       preserveAspectRatio="xMidYMid">
+      <path
+         id="path4669-51-5"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="scale(0.4)"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:stockid="TriangleInM"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="TriangleInM-7-1-8-2"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         inkscape:connector-curvature="0"
+         id="path4660-1-6-1"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="scale(-0.4)" />
+    </marker>
+    <marker
+       inkscape:stockid="TriangleInM"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="TriangleInM-7-1-7"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         inkscape:connector-curvature="0"
+         id="path4660-1-6-11"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="scale(-0.4)" />
+    </marker>
+    <marker
+       inkscape:stockid="TriangleOutM"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="TriangleOutM-4-3-4"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path4669-8-2-2"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="scale(0.4)"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:stockid="TriangleInM"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="TriangleInM-7-1-5"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         inkscape:connector-curvature="0"
+         id="path4660-1-6-7"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="scale(-0.4)" />
+    </marker>
+    <marker
+       inkscape:stockid="TriangleOutM"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="TriangleOutM-4-3-4-3"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path4669-8-2-2-86"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="scale(0.4)"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:stockid="TriangleInM"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="TriangleInM-7-1-8-59"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         inkscape:connector-curvature="0"
+         id="path4660-1-6-1-4"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="scale(-0.4)" />
+    </marker>
+    <marker
+       inkscape:stockid="TriangleOutM"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="TriangleOutM-4-3-4-2"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path4669-8-2-2-8"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="scale(0.4)"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:stockid="TriangleInM"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="TriangleInM-7-1-8-2-7"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         inkscape:connector-curvature="0"
+         id="path4660-1-6-1-8"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="scale(-0.4)" />
+    </marker>
+    <marker
+       inkscape:stockid="TriangleOutM"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="TriangleOutM-4-3-4-2-4"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path4669-8-2-2-8-7"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="scale(0.4)"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:stockid="TriangleInM"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="TriangleInM-7-1-8-4"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         inkscape:connector-curvature="0"
+         id="path4660-1-6-1-6"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="scale(-0.4)" />
+    </marker>
+    <marker
+       inkscape:stockid="TriangleOutM"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="TriangleOutM-4-3-4-2-2"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path4669-8-2-2-8-5"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="scale(0.4)"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:stockid="TriangleInM"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="TriangleInM-7-1-8-5"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         inkscape:connector-curvature="0"
+         id="path4660-1-6-1-1"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="scale(-0.4)" />
+    </marker>
+    <marker
+       inkscape:stockid="TriangleOutM"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="TriangleOutM-4-3-4-2-1"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path4669-8-2-2-8-0"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="scale(0.4)"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:stockid="TriangleInM"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="TriangleInM-1-0-1"
+       style="overflow:visible"
+       inkscape:isstock="true"
+       inkscape:collect="always">
+      <path
+         id="path4660-0-6-7"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="scale(-0.4)"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:stockid="TriangleOutM"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="TriangleOutM-5-8"
+       style="overflow:visible"
+       inkscape:isstock="true"
+       viewBox="0 0 4.2595265 4.9243081"
+       markerWidth="4.2595263"
+       markerHeight="4.9243078"
+       preserveAspectRatio="xMidYMid">
+      <path
+         id="path4669-51-4"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="scale(0.4)"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:stockid="TriangleOutM"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="TriangleOutM-5-8-4"
+       style="overflow:visible"
+       inkscape:isstock="true"
+       viewBox="0 0 4.2595265 4.9243081"
+       markerWidth="4.2595263"
+       markerHeight="4.9243078"
+       preserveAspectRatio="xMidYMid">
+      <path
+         id="path4669-51-4-4"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="scale(0.4)"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:stockid="TriangleOutM"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="TriangleOutM-5-1"
+       style="overflow:visible"
+       inkscape:isstock="true"
+       viewBox="0 0 4.2595265 4.9243081"
+       markerWidth="4.2595263"
+       markerHeight="4.9243078"
+       preserveAspectRatio="xMidYMid">
+      <path
+         id="path4669-51-3"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="scale(0.4)"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:stockid="TriangleOutM"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker2076"
+       style="overflow:visible"
+       inkscape:isstock="true"
+       viewBox="0 0 4.2595265 4.9243081"
+       markerWidth="4.2595263"
+       markerHeight="4.9243078"
+       preserveAspectRatio="xMidYMid">
+      <path
+         id="path2074"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="scale(0.4)"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:stockid="TriangleOutM"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker2080"
+       style="overflow:visible"
+       inkscape:isstock="true"
+       viewBox="0 0 4.2595265 4.9243081"
+       markerWidth="4.2595263"
+       markerHeight="4.9243078"
+       preserveAspectRatio="xMidYMid">
+      <path
+         id="path2078"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="scale(0.4)"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:stockid="TriangleOutM"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker2084"
+       style="overflow:visible"
+       inkscape:isstock="true"
+       viewBox="0 0 4.2595265 4.9243081"
+       markerWidth="4.2595263"
+       markerHeight="4.9243078"
+       preserveAspectRatio="xMidYMid">
+      <path
+         id="path2082"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="scale(0.4)"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:stockid="TriangleOutM"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker2088"
+       style="overflow:visible"
+       inkscape:isstock="true"
+       viewBox="0 0 4.2595265 4.9243081"
+       markerWidth="4.2595263"
+       markerHeight="4.9243078"
+       preserveAspectRatio="xMidYMid">
+      <path
+         id="path2086"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="scale(0.4)"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:stockid="TriangleOutM"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="TriangleOutM-5-4-0"
+       style="overflow:visible"
+       inkscape:isstock="true"
+       viewBox="0 0 4.2595265 4.9243081"
+       markerWidth="4.2595263"
+       markerHeight="4.9243078"
+       preserveAspectRatio="xMidYMid">
+      <path
+         id="path4669-51-8-2"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="scale(0.4)"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:stockid="TriangleOutM"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="TriangleOutM-5-18"
+       style="overflow:visible"
+       inkscape:isstock="true"
+       viewBox="0 0 4.2595265 4.9243081"
+       markerWidth="4.2595263"
+       markerHeight="4.9243078"
+       preserveAspectRatio="xMidYMid">
+      <path
+         id="path4669-51-0"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="scale(0.4)"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:stockid="TriangleOutM"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="TriangleOutM-5-45-0"
+       style="overflow:visible"
+       inkscape:isstock="true"
+       viewBox="0 0 4.2595265 4.9243081"
+       markerWidth="4.2595263"
+       markerHeight="4.9243078"
+       preserveAspectRatio="xMidYMid">
+      <path
+         id="path4669-51-5-3"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="scale(0.4)"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:stockid="TriangleOutM"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker2222"
+       style="overflow:visible"
+       inkscape:isstock="true"
+       viewBox="0 0 4.2595265 4.9243081"
+       markerWidth="4.2595263"
+       markerHeight="4.9243078"
+       preserveAspectRatio="xMidYMid">
+      <path
+         id="path2220"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="scale(0.4)"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:stockid="TriangleOutM"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker2226"
+       style="overflow:visible"
+       inkscape:isstock="true"
+       viewBox="0 0 4.2595265 4.9243081"
+       markerWidth="4.2595263"
+       markerHeight="4.9243078"
+       preserveAspectRatio="xMidYMid">
+      <path
+         id="path2224"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="scale(0.4)"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:stockid="TriangleOutM"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker2230"
+       style="overflow:visible"
+       inkscape:isstock="true"
+       viewBox="0 0 4.2595265 4.9243081"
+       markerWidth="4.2595263"
+       markerHeight="4.9243078"
+       preserveAspectRatio="xMidYMid">
+      <path
+         id="path2228"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="scale(0.4)"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:stockid="TriangleOutM"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker2234"
+       style="overflow:visible"
+       inkscape:isstock="true"
+       viewBox="0 0 4.2595265 4.9243081"
+       markerWidth="4.2595263"
+       markerHeight="4.9243078"
+       preserveAspectRatio="xMidYMid">
+      <path
+         id="path2232"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="scale(0.4)"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:stockid="TriangleOutM"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker2238"
+       style="overflow:visible"
+       inkscape:isstock="true"
+       viewBox="0 0 4.2595265 4.9243081"
+       markerWidth="4.2595263"
+       markerHeight="4.9243078"
+       preserveAspectRatio="xMidYMid">
+      <path
+         id="path2236"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="scale(0.4)"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:stockid="TriangleOutM"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="TriangleOutM-5-4-00"
+       style="overflow:visible"
+       inkscape:isstock="true"
+       viewBox="0 0 4.2595265 4.9243081"
+       markerWidth="4.2595263"
+       markerHeight="4.9243078"
+       preserveAspectRatio="xMidYMid">
+      <path
+         id="path4669-51-8-7"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="scale(0.4)"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:stockid="TriangleOutM"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="TriangleOutM-5-18-2"
+       style="overflow:visible"
+       inkscape:isstock="true"
+       viewBox="0 0 4.2595265 4.9243081"
+       markerWidth="4.2595263"
+       markerHeight="4.9243078"
+       preserveAspectRatio="xMidYMid">
+      <path
+         id="path4669-51-0-4"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="scale(0.4)"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:stockid="TriangleOutM"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker5730"
+       style="overflow:visible"
+       inkscape:isstock="true"
+       viewBox="0 0 4.2595265 4.9243081"
+       markerWidth="4.2595263"
+       markerHeight="4.9243078"
+       preserveAspectRatio="xMidYMid">
+      <path
+         id="path5728"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="scale(0.4)"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:stockid="TriangleOutM"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker5734"
+       style="overflow:visible"
+       inkscape:isstock="true"
+       viewBox="0 0 4.2595265 4.9243081"
+       markerWidth="4.2595263"
+       markerHeight="4.9243078"
+       preserveAspectRatio="xMidYMid">
+      <path
+         id="path5732"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="scale(0.4)"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:stockid="TriangleOutM"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="TriangleOutM-5-8-4-0"
+       style="overflow:visible"
+       inkscape:isstock="true"
+       viewBox="0 0 4.2595265 4.9243081"
+       markerWidth="4.2595263"
+       markerHeight="4.9243078"
+       preserveAspectRatio="xMidYMid">
+      <path
+         id="path4669-51-4-4-9"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="scale(0.4)"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <rect
+       x="505.75934"
+       y="440.80817"
+       width="91.509193"
+       height="18.625698"
+       id="rect4760" />
+    <rect
+       x="298.96634"
+       y="469.9407"
+       width="124.17132"
+       height="41.072052"
+       id="rect24670" />
+    <marker
+       style="overflow:visible"
+       id="TriangleInM-0"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="TriangleInM"
+       inkscape:isstock="true">
+      <path
+         transform="scale(-0.4)"
+         style="fill:context-stroke;fill-rule:evenodd;stroke:context-stroke;stroke-width:1pt"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         id="path42185-3" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="marker51146-9"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="TriangleInM"
+       inkscape:isstock="true">
+      <path
+         transform="scale(-0.4)"
+         style="fill:context-stroke;fill-rule:evenodd;stroke:context-stroke;stroke-width:1pt"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         id="path51144-3" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="marker1-0"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="TriangleInM"
+       inkscape:isstock="true">
+      <path
+         transform="scale(-0.4)"
+         style="fill:context-stroke;fill-rule:evenodd;stroke:context-stroke;stroke-width:1pt"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         id="path1-6" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="marker2-1"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="TriangleInM"
+       inkscape:isstock="true">
+      <path
+         transform="scale(-0.4)"
+         style="fill:context-stroke;fill-rule:evenodd;stroke:context-stroke;stroke-width:1pt"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         id="path2-3" />
+    </marker>
+    <rect
+       x="298.96634"
+       y="469.9407"
+       width="124.17132"
+       height="41.072052"
+       id="rect19" />
+    <rect
+       x="227.01418"
+       y="266.41333"
+       width="48.310867"
+       height="26.73514"
+       id="rect23" />
+    <marker
+       inkscape:stockid="TriangleInM"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="TriangleInM-1-0-1-9"
+       style="overflow:visible"
+       inkscape:isstock="true"
+       inkscape:collect="always">
+      <path
+         id="path4660-0-6-7-6"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="scale(-0.4)"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <rect
+       x="505.75934"
+       y="440.80817"
+       width="91.509193"
+       height="18.625698"
+       id="rect4760-1" />
+    <rect
+       x="298.96634"
+       y="469.9407"
+       width="124.17132"
+       height="41.072052"
+       id="rect24670-3" />
+    <marker
+       style="overflow:visible"
+       id="TriangleInM-0-5"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="TriangleInM"
+       inkscape:isstock="true">
+      <path
+         transform="scale(-0.4)"
+         style="fill:context-stroke;fill-rule:evenodd;stroke:context-stroke;stroke-width:1pt"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         id="path42185-3-9" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="marker51146-9-8"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="TriangleInM"
+       inkscape:isstock="true">
+      <path
+         transform="scale(-0.4)"
+         style="fill:context-stroke;fill-rule:evenodd;stroke:context-stroke;stroke-width:1pt"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         id="path51144-3-4" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="marker1-07"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="TriangleInM"
+       inkscape:isstock="true">
+      <path
+         transform="scale(-0.4)"
+         style="fill:context-stroke;fill-rule:evenodd;stroke:context-stroke;stroke-width:1pt"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         id="path1-63" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="marker2-6"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="TriangleInM"
+       inkscape:isstock="true">
+      <path
+         transform="scale(-0.4)"
+         style="fill:context-stroke;fill-rule:evenodd;stroke:context-stroke;stroke-width:1pt"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         id="path2-1" />
+    </marker>
+    <rect
+       x="298.96634"
+       y="469.9407"
+       width="124.17132"
+       height="41.072052"
+       id="rect19-5" />
+    <rect
+       x="227.01418"
+       y="266.41333"
+       width="48.310867"
+       height="26.73514"
+       id="rect23-4" />
+    <marker
+       style="overflow:visible"
+       id="TriangleInM-0-7"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="TriangleInM"
+       inkscape:isstock="true">
+      <path
+         transform="scale(-0.4)"
+         style="fill:context-stroke;fill-rule:evenodd;stroke:context-stroke;stroke-width:1pt"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         id="path42185-3-7" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="marker51146-9-3"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="TriangleInM"
+       inkscape:isstock="true">
+      <path
+         transform="scale(-0.4)"
+         style="fill:context-stroke;fill-rule:evenodd;stroke:context-stroke;stroke-width:1pt"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         id="path51144-3-3" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="marker51146-9-3-9"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="TriangleInM"
+       inkscape:isstock="true">
+      <path
+         transform="scale(-0.4)"
+         style="fill:context-stroke;fill-rule:evenodd;stroke:context-stroke;stroke-width:1pt"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         id="path51144-3-3-8" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker1216-8"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="TriangleOutM"
+       inkscape:collect="always">
+      <path
+         transform="scale(0.4)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         id="path1214-08"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker1216-9"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="TriangleOutM">
+      <path
+         transform="scale(0.4)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         id="path1214-1"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker2-3"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="TriangleOutM">
+      <path
+         transform="scale(0.4)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         id="path2-8"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker4-1"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="TriangleOutM">
+      <path
+         transform="scale(0.4)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         id="path4-0"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker6-4"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="TriangleOutM">
+      <path
+         transform="scale(0.4)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         id="path6-96"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker1216-8-1"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="TriangleOutM"
+       inkscape:collect="always">
+      <path
+         transform="scale(0.4)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         id="path1214-08-0"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker1216-9-9"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="TriangleOutM">
+      <path
+         transform="scale(0.4)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         id="path1214-1-9"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker2-34"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="TriangleOutM">
+      <path
+         transform="scale(0.4)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         id="path2-84"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker4-2"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="TriangleOutM">
+      <path
+         transform="scale(0.4)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         id="path4-55"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker6-3"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="TriangleOutM">
+      <path
+         transform="scale(0.4)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         id="path6-7"
+         inkscape:connector-curvature="0" />
+    </marker>
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="0.9899495"
+     inkscape:cx="495.47982"
+     inkscape:cy="470.22601"
+     inkscape:document-units="px"
+     inkscape:current-layer="g1661"
+     showgrid="false"
+     units="px"
+     inkscape:window-width="1920"
+     inkscape:window-height="1009"
+     inkscape:window-x="-8"
+     inkscape:window-y="-8"
+     inkscape:window-maximized="1"
+     inkscape:showpageshadow="2"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     showguides="true"
+     inkscape:lockguides="false">
+    <inkscape:grid
+       type="xygrid"
+       id="grid32445"
+       originx="147.60189"
+       originy="-656.13812"
+       spacingy="1"
+       spacingx="1"
+       units="px"
+       visible="false" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata31897">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(147.60189,-775.8673)">
+    <flowRoot
+       xml:space="preserve"
+       id="flowRoot33657"
+       style="font-style:normal;font-weight:normal;font-size:40px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none"><flowRegion
+         id="flowRegion33659"><rect
+           id="rect33661"
+           width="960"
+           height="750"
+           x="-50"
+           y="-5" /></flowRegion><flowPara
+         id="flowPara33663" /></flowRoot>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;font-size:10.5833px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+       x="227.54166"
+       y="254.66664"
+       id="text3104" />
+    <g
+       id="g1661"
+       transform="matrix(3.840523,0,0,3.840523,67.110146,-325.47247)">
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.34343px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.260381;stroke-miterlimit:4;stroke-dasharray:none;shape-rendering:crispEdges;enable-background:new"
+         x="9.4538183"
+         y="470.86331"
+         id="text17332-2-0-6"
+         transform="scale(0.97805471,1.0224377)"><tspan
+           sodipodi:role="line"
+           id="tspan28064"
+           x="9.4538183"
+           y="470.86331">s/m_axis_aclk</tspan></text>
+      <rect
+         style="display:inline;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#915f00;stroke-width:0.655158;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:2.62067, 2.62067;stroke-dashoffset:0;stroke-opacity:1;shape-rendering:crispEdges;enable-background:new"
+         id="rect6779-7-8"
+         width="54.895157"
+         height="159.198"
+         x="-40.2201"
+         y="339.21402" />
+      <rect
+         style="display:inline;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#915f00;stroke-width:0.50774335;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:2.03097552,2.03097552;stroke-dashoffset:0.30464579;stroke-opacity:1;shape-rendering:crispEdges;enable-background:new"
+         id="rect6779-7-8-2"
+         width="37.922642"
+         height="82.45919"
+         x="137.68208"
+         y="416.3916" />
+      <rect
+         style="display:inline;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#915f00;stroke-width:0.511706;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:2.04682, 2.04682;stroke-dashoffset:0.307024;stroke-opacity:1;shape-rendering:crispEdges;enable-background:new"
+         id="rect6779-7-8-2-0"
+         width="37.369682"
+         height="75.616203"
+         x="137.68407"
+         y="338.4285" />
+      <rect
+         style="display:inline;fill:#000000;fill-opacity:0;fill-rule:nonzero;stroke:#000000;stroke-width:0.499054;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:0;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;shape-rendering:crispEdges;enable-background:new"
+         id="rect4477-6"
+         width="223.78326"
+         height="198.73155"
+         x="-45.399487"
+         y="302.73468" />
+      <rect
+         style="display:inline;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#915f00;stroke-width:0.518824;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:2.0754, 2.0754;stroke-dashoffset:0;stroke-opacity:1;shape-rendering:crispEdges;enable-background:new"
+         id="rect6779-7-8-1"
+         width="118.55863"
+         height="82.178978"
+         x="17.586008"
+         y="416.52557" />
+      <rect
+         style="display:inline;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#915f00;stroke-width:0.506962;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:2.02794, 2.02794;stroke-dashoffset:0;stroke-opacity:1;shape-rendering:crispEdges;enable-background:new"
+         id="rect6779-7-8-1-6"
+         width="117.94888"
+         height="75.506424"
+         x="17.580078"
+         y="338.59525" />
+      <g
+         id="g16071"
+         transform="matrix(0.2603812,0,0,0.2603812,-44.913841,254.45543)"
+         style="display:inline;shape-rendering:crispEdges;enable-background:new">
+        <g
+           id="g15962">
+          <g
+             transform="translate(-6,-74.26771)"
+             style="display:inline;filter:url(#filter4222);shape-rendering:crispEdges;enable-background:new"
+             id="g8790">
+            <g
+               style="display:inline;shape-rendering:crispEdges;enable-background:new"
+               id="ddr-1"
+               transform="matrix(1.4720576,0,0,1.4720575,-251.70351,-425.48206)"
+               inkscape:export-xdpi="96"
+               inkscape:export-ydpi="96">
+              <rect
+                 style="opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.8;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+                 id="rect8406-1"
+                 width="29.358675"
+                 height="11.248666"
+                 x="-453.55264"
+                 y="391.80267"
+                 transform="rotate(-90)" />
+              <rect
+                 style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.67501;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.673913"
+                 id="rect8408-1"
+                 width="4.6139379"
+                 height="6.8413563"
+                 x="-451.4805"
+                 y="394.00632"
+                 transform="rotate(-90)" />
+              <rect
+                 y="394.00632"
+                 x="-444.69791"
+                 height="6.8413563"
+                 width="4.6139379"
+                 id="rect8410-3"
+                 style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.67501;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.673913"
+                 transform="rotate(-90)" />
+              <rect
+                 y="394.00632"
+                 x="-431.13275"
+                 height="6.8413563"
+                 width="4.6139379"
+                 id="rect8414-9"
+                 style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.67501;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.673913"
+                 transform="rotate(-90)" />
+              <rect
+                 style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.67501;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.673913"
+                 id="rect8416-0"
+                 width="4.6139379"
+                 height="6.8413563"
+                 x="-437.91531"
+                 y="394.00632"
+                 transform="rotate(-90)" />
+              <path
+                 style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:0.5506;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+                 d="m 402.9495,451.34818 h 3.46837 v -24.7395 h -3.63159"
+                 id="path8420-3"
+                 inkscape:connector-curvature="0"
+                 sodipodi:nodetypes="cccc" />
+              <path
+                 style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1.067;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+                 d="M 406.04958,449.00384 H 404.6091"
+                 id="path8422-5"
+                 inkscape:connector-curvature="0" />
+              <path
+                 inkscape:connector-curvature="0"
+                 id="path8424-5"
+                 d="M 406.04958,430.92913 H 404.6091"
+                 style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1.067;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+              <path
+                 style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1.067;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+                 d="M 406.04958,433.33004 H 404.6091"
+                 id="path8426-4"
+                 inkscape:connector-curvature="0" />
+              <path
+                 inkscape:connector-curvature="0"
+                 id="path8428-1"
+                 d="M 406.04958,435.45913 H 404.6091"
+                 style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1.067;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+              <path
+                 style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1.067;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+                 d="M 406.04958,437.86003 H 404.6091"
+                 id="path8430-2"
+                 inkscape:connector-curvature="0" />
+              <path
+                 inkscape:connector-curvature="0"
+                 id="path8432-1"
+                 d="M 406.04958,439.98913 H 404.6091"
+                 style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1.067;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+              <path
+                 style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1.067;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+                 d="M 406.04958,442.34471 H 404.6091"
+                 id="path8434-3"
+                 inkscape:connector-curvature="0" />
+              <path
+                 inkscape:connector-curvature="0"
+                 id="path8436-4"
+                 d="M 406.04958,444.51915 H 404.6091"
+                 style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1.067;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+              <path
+                 style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1.067;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+                 d="M 406.04958,446.82944 H 404.6091"
+                 id="path8438-3"
+                 inkscape:connector-curvature="0" />
+              <path
+                 style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1.067;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+                 d="M 406.04958,430.92913 H 404.6091"
+                 id="path8440-6"
+                 inkscape:connector-curvature="0" />
+              <path
+                 inkscape:connector-curvature="0"
+                 id="path8450-4"
+                 d="M 406.04958,428.80003 H 404.6091"
+                 style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1.067;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+            </g>
+            <g
+               id="uart-8"
+               transform="matrix(0,-0.42970699,0.42970702,0,191.71772,449.34041)"
+               style="display:inline;stroke-width:2.41103;stroke-miterlimit:4;stroke-dasharray:none;shape-rendering:crispEdges;enable-background:new"
+               inkscape:export-xdpi="96"
+               inkscape:export-ydpi="96">
+              <rect
+                 ry="4.5"
+                 y="388.11218"
+                 x="490.75"
+                 height="28.75"
+                 width="70"
+                 id="rect8910-4"
+                 style="opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:2.41103;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+              <path
+                 sodipodi:nodetypes="sssssssss"
+                 inkscape:connector-curvature="0"
+                 id="rect8912-2"
+                 d="m 507.25,394.11218 h 37 c 2.493,0 5.47668,2.20628 4.5,4.5 l -3.3,7.75 c -0.97668,2.29372 -3.507,4.5 -6,4.5 h -27.8 c -2.493,0 -4.37391,-2.22795 -5.4,-4.5 l -3.5,-7.75 c -1.02609,-2.27205 2.007,-4.5 4.5,-4.5 z"
+                 style="opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:2.41103;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+              <circle
+                 r="3.1875"
+                 cy="402.48718"
+                 cx="497.5126"
+                 id="path8915-8"
+                 style="opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:2.41103;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+              <circle
+                 style="opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:2.41103;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+                 id="circle8917-1"
+                 cx="554.13763"
+                 cy="402.48718"
+                 r="3.1875" />
+              <ellipse
+                 ry="1.0625"
+                 rx="1"
+                 cy="399.79968"
+                 cx="513.7403"
+                 id="path8919-9"
+                 style="opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:2.41103;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+              <ellipse
+                 ry="1.0625"
+                 rx="1"
+                 cy="399.79968"
+                 cx="537.7403"
+                 id="ellipse8923-8"
+                 style="opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:2.41103;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+              <ellipse
+                 style="opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:2.41103;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+                 id="ellipse8925-6"
+                 cx="531.7403"
+                 cy="399.79968"
+                 rx="1"
+                 ry="1.0625" />
+              <ellipse
+                 ry="1.0625"
+                 rx="1"
+                 cy="399.79968"
+                 cx="525.7403"
+                 id="ellipse8927-2"
+                 style="opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:2.41103;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+              <ellipse
+                 style="opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:2.41103;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+                 id="ellipse8929-8"
+                 cx="519.7403"
+                 cy="399.79968"
+                 rx="1"
+                 ry="1.0625" />
+              <ellipse
+                 style="opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:2.41103;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+                 id="ellipse8921-3"
+                 cx="516.7403"
+                 cy="405.79968"
+                 rx="1"
+                 ry="1.0625" />
+              <ellipse
+                 ry="1.0625"
+                 rx="1"
+                 cy="405.79968"
+                 cx="534.7403"
+                 id="ellipse8931-3"
+                 style="opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:2.41103;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+              <ellipse
+                 style="opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:2.41103;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+                 id="ellipse8933-6"
+                 cx="528.7403"
+                 cy="405.79968"
+                 rx="1"
+                 ry="1.0625" />
+              <ellipse
+                 ry="1.0625"
+                 rx="1"
+                 cy="405.79968"
+                 cx="522.7403"
+                 id="ellipse8935-8"
+                 style="opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:2.41103;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+            </g>
+            <path
+               sodipodi:nodetypes="cc"
+               inkscape:connector-curvature="0"
+               id="path4518-0"
+               d="M 336.70259,268.88332 V 249.03246"
+               style="display:inline;fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1.55406;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-start:url(#TriangleInM-1);marker-end:url(#TriangleOutM-4-7);shape-rendering:crispEdges;enable-background:new" />
+            <path
+               sodipodi:nodetypes="cc"
+               inkscape:connector-curvature="0"
+               id="path4518-5-9-0"
+               d="M 365.10452,268.85415 V 249.00352"
+               style="display:inline;fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1.55406;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-start:url(#TriangleInM-7-1-0-7);marker-end:url(#TriangleOutM-2-8-1);shape-rendering:crispEdges;enable-background:new" />
+            <rect
+               transform="scale(-1,1)"
+               style="display:inline;fill:#ebebeb;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:1.92694;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:0;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;shape-rendering:crispEdges"
+               id="rect4136-0"
+               width="419.86264"
+               height="77.788834"
+               x="-457.62451"
+               y="273.50232" />
+            <path
+               style="display:inline;fill:#a2dcea;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:2.07208;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;shape-rendering:crispEdges"
+               d="M 430.58359,274.23351 V 351.4293"
+               id="path4179-2"
+               inkscape:connector-curvature="0" />
+            <path
+               style="display:inline;fill:#a2dcea;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:2.07208;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;shape-rendering:crispEdges"
+               d="M 404.02952,274.23351 V 351.4293"
+               id="path4179-9-7"
+               inkscape:connector-curvature="0" />
+            <path
+               style="display:inline;fill:#a2dcea;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:2.07208;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;shape-rendering:crispEdges"
+               d="M 297.81329,274.23351 V 351.4293"
+               id="path4179-0-9"
+               inkscape:connector-curvature="0" />
+            <path
+               style="display:inline;fill:#a2dcea;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:2.07208;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;shape-rendering:crispEdges"
+               d="M 324.36737,274.23351 V 351.4293"
+               id="path4179-4-0"
+               inkscape:connector-curvature="0" />
+            <path
+               style="display:inline;fill:#a2dcea;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:2.07208;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;shape-rendering:crispEdges"
+               d="M 350.92142,274.23351 V 351.4293"
+               id="path4179-7-9"
+               inkscape:connector-curvature="0" />
+            <path
+               style="display:inline;fill:#a2dcea;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:2.07208;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;shape-rendering:crispEdges"
+               d="M 377.47546,274.23351 V 351.4293"
+               id="path4179-41-2"
+               inkscape:connector-curvature="0" />
+            <path
+               style="display:inline;fill:#a2dcea;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:2.07208;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;shape-rendering:crispEdges"
+               d="M 271.25923,274.23351 V 351.4293"
+               id="path4179-0-3-9"
+               inkscape:connector-curvature="0" />
+            <text
+               transform="matrix(0,-1.0072219,0.99282989,0,0,0)"
+               id="text4233-0"
+               y="370.38675"
+               x="-325.1571"
+               style="font-style:normal;font-weight:normal;font-size:12.4325px;line-height:0%;font-family:Arial;letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1.03604px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;shape-rendering:crispEdges"
+               xml:space="preserve"><tspan
+                 style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:11.6555px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial Bold';stroke-width:1.03604px"
+                 y="370.38675"
+                 x="-325.1571"
+                 id="tspan4235-1"
+                 sodipodi:role="line">UART</tspan></text>
+            <text
+               transform="matrix(0,-1.0072219,0.99282989,0,0,0)"
+               id="text4233-0-4"
+               y="397.95187"
+               x="-321.57706"
+               style="font-style:normal;font-weight:normal;font-size:12.4325px;line-height:0%;font-family:Arial;letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1.03604px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;shape-rendering:crispEdges"
+               xml:space="preserve"><tspan
+                 style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:11.6555px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial Bold';stroke-width:1.03604px"
+                 y="397.95187"
+                 x="-321.57706"
+                 id="tspan4235-1-9"
+                 sodipodi:role="line">GPIO</tspan></text>
+            <text
+               transform="matrix(0,-1.0072219,0.99282989,0,0,0)"
+               id="text4237-0"
+               y="345.16232"
+               x="-326.39975"
+               style="font-style:normal;font-weight:normal;font-size:12.4325px;line-height:0%;font-family:Arial;letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1.03604px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;shape-rendering:crispEdges"
+               xml:space="preserve"><tspan
+                 style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:11.6555px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial Bold';stroke-width:1.03604px"
+                 y="345.16232"
+                 x="-326.39975"
+                 id="tspan4239-3"
+                 sodipodi:role="line">DDRx</tspan></text>
+            <text
+               transform="matrix(0,-1.0072219,0.99282989,0,0,0)"
+               id="text4241-2"
+               y="449.91562"
+               x="-315.38226"
+               style="font-style:normal;font-weight:normal;font-size:12.4325px;line-height:0%;font-family:Arial;letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1.03604px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;shape-rendering:crispEdges"
+               xml:space="preserve"><tspan
+                 style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:11.6555px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial Bold';stroke-width:1.03604px"
+                 y="449.91562"
+                 x="-315.38226"
+                 id="tspan4243-2"
+                 sodipodi:role="line">SPI</tspan></text>
+            <text
+               transform="matrix(0,-1.0072219,0.99282989,0,0,0)"
+               id="text4245-3"
+               y="424.98514"
+               x="-315.31403"
+               style="font-style:normal;font-weight:normal;font-size:12.4325px;line-height:0%;font-family:Arial;letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1.03604px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;shape-rendering:crispEdges"
+               xml:space="preserve"><tspan
+                 style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:11.6555px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial Bold';stroke-width:1.03604px"
+                 y="424.98514"
+                 x="-315.31403"
+                 id="tspan4247-3"
+                 sodipodi:role="line">I<tspan
+   style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:11.6555px;font-family:Arial;-inkscape-font-specification:'Arial Bold';baseline-shift:super;stroke-width:1.03604px"
+   id="tspan4485-0">2</tspan>C</tspan></text>
+            <text
+               transform="matrix(0,-1.0072219,0.99282989,0,0,0)"
+               id="text4251-9"
+               y="317.63248"
+               x="-337.48605"
+               style="font-style:normal;font-weight:normal;font-size:12.4325px;line-height:0%;font-family:Arial;letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1.03604px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;shape-rendering:crispEdges"
+               xml:space="preserve"><tspan
+                 style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:11.6555px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial Bold';stroke-width:1.03604px"
+                 y="317.63248"
+                 x="-337.48605"
+                 id="tspan4253-1"
+                 sodipodi:role="line">Interrupts</tspan></text>
+            <text
+               transform="matrix(0,-1.0072219,0.99282989,0,0,0)"
+               id="text4301-8"
+               y="289.85397"
+               x="-326.11234"
+               style="font-style:normal;font-weight:normal;font-size:12.4325px;line-height:0%;font-family:Arial;letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1.03604px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;shape-rendering:crispEdges"
+               xml:space="preserve"><tspan
+                 style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:11.6555px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial Bold';stroke-width:1.03604px"
+                 y="289.85397"
+                 x="-326.11234"
+                 id="tspan4303-0"
+                 sodipodi:role="line">Timer</tspan></text>
+            <path
+               style="display:inline;fill:#a2dcea;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:2.07208;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;shape-rendering:crispEdges"
+               d="m 457.13757,274.23343 v 77.19581"
+               id="path4179-2-6"
+               inkscape:connector-curvature="0" />
+          </g>
+          <g
+             transform="translate(0.690104,-301.95584)"
+             style="display:inline;filter:url(#filter4222-4);shape-rendering:crispEdges;enable-background:new"
+             id="g8533-0">
+            <text
+               transform="scale(0.99282988,1.0072219)"
+               id="text4311-1"
+               y="541.61359"
+               x="131.56276"
+               style="font-style:normal;font-weight:normal;line-height:0%;font-family:Arial;letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;shape-rendering:crispEdges"
+               xml:space="preserve"><tspan
+                 style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:15px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial Bold'"
+                 y="541.61359"
+                 x="131.56276"
+                 id="tspan4313-9"
+                 sodipodi:role="line">Zynq </tspan></text>
+          </g>
+        </g>
+        <g
+           id="g4600-1"
+           transform="translate(13.027322,-274.83016)"
+           style="display:inline;shape-rendering:crispEdges;enable-background:new">
+          <rect
+             y="433.5928"
+             x="9.8994951"
+             height="15.55635"
+             width="15.55635"
+             id="rect4587-5"
+             style="display:inline;opacity:1;fill:#ffcccc;fill-opacity:1;fill-rule:nonzero;stroke:#af1414;stroke-width:0;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;shape-rendering:crispEdges;enable-background:new" />
+          <text
+             id="text4591-2"
+             y="444.86218"
+             x="34.016296"
+             style="font-style:normal;font-weight:normal;line-height:0%;font-family:Arial;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+             xml:space="preserve"><tspan
+               y="444.86218"
+               x="34.016296"
+               id="tspan4593-7"
+               sodipodi:role="line"
+               style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.5px;line-height:1.25;font-family:Arial;-inkscape-font-specification:Arial">Receive path</tspan></text>
+        </g>
+        <path
+           style="display:inline;fill:#ff6600;fill-opacity:0;fill-rule:evenodd;stroke:#915f00;stroke-width:1.79371;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:3.58742, 3.58742;stroke-dashoffset:0;stroke-opacity:1;shape-rendering:crispEdges;enable-background:new"
+           d="M 12.21364,137.33921 H 38.37659"
+           id="path6969"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="cc" />
+        <text
+           xml:space="preserve"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0%;font-family:Arial;-inkscape-font-specification:Arial;letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;shape-rendering:crispEdges;enable-background:new"
+           x="46.52092"
+           y="141.74141"
+           id="text8054"><tspan
+             sodipodi:role="line"
+             id="tspan8056"
+             x="46.52092"
+             y="141.74141"
+             style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.5px;line-height:1.25;font-family:Arial;-inkscape-font-specification:Arial">Clock domain</tspan></text>
+      </g>
+      <rect
+         style="display:inline;fill:#ffcccc;fill-opacity:1;fill-rule:nonzero;stroke:#a01414;stroke-width:0.520761;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;shape-rendering:crispEdges;enable-background:new"
+         id="rect5796-8-9-3-4"
+         width="18.86149"
+         height="50.824551"
+         x="8.1643162"
+         y="432.1369" />
+      <rect
+         style="display:inline;fill:#ffcccc;fill-opacity:1;fill-rule:nonzero;stroke:#a01414;stroke-width:0.520762;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;shape-rendering:crispEdges;enable-background:new"
+         id="rect5796-8-9-3-4-51"
+         width="15.442097"
+         height="50.824551"
+         x="-21.694109"
+         y="432.1369" />
+      <g
+         transform="matrix(0.26317814,0,0,0.2602511,-53.749155,210.14394)"
+         id="g5828-7"
+         style="display:inline;stroke:#a01414;stroke-opacity:1;shape-rendering:crispEdges;enable-background:new">
+        <text
+           transform="rotate(-90)"
+           id="text5771-1"
+           y="157.05742"
+           x="-987.86169"
+           style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:18.5719px;line-height:0%;font-family:Arial;-inkscape-font-specification:'Arial, Bold';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           xml:space="preserve"><tspan
+             style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:18.5719px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial, Bold';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;stroke:none;stroke-opacity:1"
+             y="157.05742"
+             x="-987.86169"
+             id="tspan5773-1"
+             sodipodi:role="line">AXI_DMAC</tspan></text>
+      </g>
+      <g
+         id="g4432-4-3"
+         transform="matrix(0.2603812,0,0,0.2603812,-69.122238,314.68935)"
+         style="display:inline;fill:#a01414;fill-opacity:1;stroke:#a01414;stroke-opacity:1;shape-rendering:crispEdges;enable-background:new">
+        <path
+           sodipodi:nodetypes="ccccccccc"
+           style="fill:#a01414;fill-opacity:1;fill-rule:evenodd;stroke:#a01414;stroke-width:1.35752px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1"
+           d="m 130.55745,546.5838 18.926,14.50562 V 554.441 l 23.51348,-3e-5 v -7.85571 -7.85571 l -23.51348,3e-5 v -6.64842 l -18.926,14.50562"
+           id="path5656-4-7-4-65-7-3"
+           inkscape:connector-curvature="0" />
+        <text
+           xml:space="preserve"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:13.3333px;line-height:1.25;font-family:Sans;-inkscape-font-specification:'Sans, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.3607"
+           x="138.42747"
+           y="551.55389"
+           id="text3347-26-3"><tspan
+             sodipodi:role="line"
+             id="tspan3345-9-10"
+             x="138.42747"
+             y="551.55389"
+             style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:13.3333px;font-family:Sans;-inkscape-font-specification:'Sans, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;fill:#ffffff;fill-opacity:1;stroke-width:0.3607"> 64b</tspan></text>
+      </g>
+      <rect
+         style="display:inline;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.523804;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;shape-rendering:crispEdges;enable-background:new"
+         id="rect4487-7"
+         width="6.4974332"
+         height="95.808876"
+         x="-43.700703"
+         y="368.97284" />
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-weight:normal;font-size:3.12457px;line-height:0%;font-family:Arial;letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.260381px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;shape-rendering:crispEdges;enable-background:new"
+         x="-445.53989"
+         y="-39.084114"
+         id="text4489-2"
+         transform="rotate(-90)"><tspan
+           sodipodi:role="line"
+           id="tspan4491-8"
+           x="-445.53989"
+           y="-39.084114"
+           style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:4.55667px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial Bold';stroke-width:0.260381px">MEMORY INTERCONNECT</tspan></text>
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:4.51327px;line-height:0%;font-family:Arial;-inkscape-font-specification:'Arial, Bold';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:0.858696;stroke:none;stroke-width:0.260381px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;shape-rendering:crispEdges;enable-background:new"
+         x="124.66552"
+         y="320.8403"
+         id="text4482-9"><tspan
+           sodipodi:role="line"
+           x="124.66552"
+           y="320.8403"
+           id="tspan4486-8"
+           style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:4.51327px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial, Bold';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:center;text-anchor:middle;fill:#000000;fill-opacity:0.858696;stroke-width:0.260381px">ADMX6020M</tspan></text>
+      <g
+         id="g4432-4-3-2"
+         transform="matrix(0.2603812,0,0,0.2603812,-39.360894,314.68943)"
+         style="display:inline;fill:#a01414;fill-opacity:1;stroke:#a01414;stroke-opacity:1;shape-rendering:crispEdges;enable-background:new">
+        <path
+           sodipodi:nodetypes="ccccccccc"
+           style="fill:#a01414;fill-opacity:1;fill-rule:evenodd;stroke:#a01414;stroke-width:1.35752px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1"
+           d="m 130.55745,546.5838 18.926,14.50562 V 554.441 l 23.51348,-3e-5 v -7.85571 -7.85571 l -23.51348,3e-5 v -6.64842 l -18.926,14.50562"
+           id="path5656-4-7-4-65-7-3-2"
+           inkscape:connector-curvature="0" />
+        <text
+           xml:space="preserve"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:13.3333px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.3607"
+           x="136.42747"
+           y="551.55389"
+           id="text3347-26-3-1"><tspan
+             sodipodi:role="line"
+             id="tspan3345-9-10-6"
+             x="136.42747"
+             y="551.55389"
+             style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:13.3333px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;fill:#ffffff;fill-opacity:1;stroke-width:0.3607"> 64b</tspan></text>
+      </g>
+      <g
+         id="g4432-4-3-2-8"
+         transform="matrix(0.2603812,0,0,0.2603812,-39.308798,234.88043)"
+         style="display:inline;fill:#a01414;fill-opacity:1;stroke:#a01414;stroke-opacity:1;shape-rendering:crispEdges;enable-background:new">
+        <path
+           sodipodi:nodetypes="ccccccccc"
+           style="fill:#a01414;fill-opacity:1;fill-rule:evenodd;stroke:#a01414;stroke-width:1.35752px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1"
+           d="m 130.55745,546.5838 18.926,14.50562 V 554.441 l 23.51348,-3e-5 v -7.85571 -7.85571 l -23.51348,3e-5 v -6.64842 l -18.926,14.50562"
+           id="path5656-4-7-4-65-7-3-2-9"
+           inkscape:connector-curvature="0" />
+        <text
+           xml:space="preserve"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:13.3333px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.3607"
+           x="136.42747"
+           y="551.55389"
+           id="text3347-26-3-1-8"><tspan
+             sodipodi:role="line"
+             id="tspan3345-9-10-6-4"
+             x="136.42747"
+             y="551.55389"
+             style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:13.3333px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;fill:#ffffff;fill-opacity:1;stroke-width:0.3607"> 64b</tspan></text>
+      </g>
+      <path
+         style="fill:none;stroke:#000000;stroke-width:0.393644;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-start:url(#TriangleInM-1-0-1)"
+         d="m 29.889202,435.71107 16.597992,1.2e-4"
+         id="path15409-6-0-2-8"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cc"
+         inkscape:export-xdpi="96"
+         inkscape:export-ydpi="96" />
+      <path
+         style="fill:none;stroke:#000000;stroke-width:0.466864;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-start:url(#TriangleInM-1-0-1-9)"
+         d="m 28.498755,402.8354 2.653805,-0.0329 c 0.111905,10.95796 -0.123149,23.14686 -0.123149,23.14686 0,0 -1.437773,0.19342 14.887292,0.0211"
+         id="path15409-6-0-2-8-7"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cccc"
+         inkscape:export-xdpi="96"
+         inkscape:export-ydpi="96" />
+      <g
+         transform="matrix(0.26317814,0,0,0.2602511,-22.36705,209.26516)"
+         id="g5828"
+         style="display:inline;stroke:#a01414;stroke-opacity:1;shape-rendering:crispEdges;enable-background:new">
+        <text
+           transform="rotate(-90)"
+           id="text5771-4"
+           y="157.05742"
+           x="-1017.8765"
+           style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:18.5719px;line-height:0%;font-family:Arial;-inkscape-font-specification:'Arial, Bold';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           xml:space="preserve"><tspan
+             style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:18.5719px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial, Bold';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;stroke:none;stroke-opacity:1"
+             y="157.05742"
+             x="-1017.8765"
+             id="tspan5773-2"
+             sodipodi:role="line">DATA_OFFLOAD</tspan></text>
+      </g>
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.34343px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.260381;stroke-miterlimit:4;stroke-dasharray:none;shape-rendering:crispEdges;enable-background:new"
+         x="9.1089592"
+         y="350.70663"
+         id="text17332-2-0-6-6"
+         transform="scale(0.97805471,1.0224377)"><tspan
+           sodipodi:role="line"
+           id="tspan28064-5"
+           x="9.1089592"
+           y="350.70663">s/m_axis_aclk</tspan></text>
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:2.08305px;line-height:0%;font-family:Arial;-inkscape-font-specification:'Arial, Bold';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.260381px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;shape-rendering:crispEdges;enable-background:new"
+         x="-7.5792103"
+         y="496.83597"
+         id="text39"><tspan
+           sodipodi:role="line"
+           x="-7.5792103"
+           y="496.83597"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.08305px;line-height:1.25;font-family:Arial;-inkscape-font-specification:Arial;font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;stroke-width:0.260381px"
+           id="tspan39">DMA_CLK = 150MHz</tspan></text>
+      <rect
+         style="fill:#ebebeb;fill-opacity:1;stroke:#000000;stroke-width:0.425556;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.533333"
+         id="rect20238"
+         width="32.105167"
+         height="19.33198"
+         x="45.534191"
+         y="419.54965" />
+      <rect
+         style="fill:#ebebeb;fill-opacity:1;stroke:#000000;stroke-width:0.854717;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.533333"
+         id="rect20238-1-4"
+         width="44.301197"
+         height="56.515358"
+         x="182.21405"
+         y="432.32196" />
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:5.5548px;font-family:Arial;-inkscape-font-specification:'Arial Bold';writing-mode:lr-tb;direction:ltr;fill:#000000;stroke-width:0.365315;stroke-dasharray:1.46126, 1.46126;stroke-dashoffset:0.219189"
+         x="189.23943"
+         y="462.8501"
+         id="text16-5"><tspan
+           sodipodi:role="line"
+           id="tspan16-8"
+           style="font-size:5.5548px;stroke-width:0.365315"
+           x="189.23943"
+           y="462.8501">HMCAD1520</tspan></text>
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-weight:normal;font-size:3.47174px;line-height:1.25;font-family:sans-serif;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.242862"
+         x="66.388069"
+         y="401.40271"
+         id="text25310"
+         transform="scale(0.93162149,1.0733973)"><tspan
+           sodipodi:role="line"
+           id="tspan25308"
+           x="66.388069"
+           y="401.40271"
+           style="font-size:3.47174px;stroke-width:0.242862">AXI_TDD</tspan></text>
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-weight:normal;font-size:2.77741px;line-height:1.25;font-family:sans-serif;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.260381"
+         x="46.930168"
+         y="436.18304"
+         id="text32585-8"><tspan
+           sodipodi:role="line"
+           id="tspan32583-3"
+           x="46.930168"
+           y="436.18304"
+           style="font-size:2.77741px;stroke-width:0.260381">channel_0</tspan></text>
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-weight:normal;font-size:2.77741px;line-height:1.25;font-family:sans-serif;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.260381"
+         x="47.039116"
+         y="426.68546"
+         id="text32585-8-1"><tspan
+           sodipodi:role="line"
+           id="tspan32583-3-8"
+           x="47.039116"
+           y="426.68546"
+           style="font-size:2.77741px;stroke-width:0.260381">channel_1</tspan></text>
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-weight:normal;font-size:2.77741px;line-height:1.25;font-family:sans-serif;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.260381"
+         x="31.624149"
+         y="434.17648"
+         id="text47709-0-4-0"><tspan
+           sodipodi:role="line"
+           id="tspan47707-3-1-9"
+           x="31.624149"
+           y="434.17648"
+           style="font-size:2.77741px;stroke-width:0.260381">rx_sync</tspan></text>
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-weight:normal;font-size:2.77741px;line-height:1.25;font-family:sans-serif;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.260381"
+         x="32.813301"
+         y="424.69067"
+         id="text47709-0-4-0-82"><tspan
+           sodipodi:role="line"
+           id="tspan47707-3-1-9-9"
+           x="32.813301"
+           y="424.69067"
+           style="font-size:2.77741px;stroke-width:0.260381">rx_sync</tspan></text>
+      <rect
+         style="display:inline;fill:#ffcccc;fill-opacity:1;fill-rule:nonzero;stroke:#a01414;stroke-width:0.520761;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;shape-rendering:crispEdges;enable-background:new"
+         id="rect5796-8-9-3-4-8"
+         width="18.86149"
+         height="50.824551"
+         x="7.4816198"
+         y="355.85403" />
+      <rect
+         style="display:inline;fill:#ffcccc;fill-opacity:1;fill-rule:nonzero;stroke:#a01414;stroke-width:0.520762;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;shape-rendering:crispEdges;enable-background:new"
+         id="rect5796-8-9-3-4-51-8"
+         width="15.442097"
+         height="50.824551"
+         x="-22.376808"
+         y="355.85403" />
+      <g
+         transform="matrix(0.26317814,0,0,0.2602511,-54.431852,133.86104)"
+         id="g5828-7-2"
+         style="display:inline;stroke:#a01414;stroke-opacity:1;shape-rendering:crispEdges;enable-background:new">
+        <text
+           transform="rotate(-90)"
+           id="text5771-1-4"
+           y="157.05742"
+           x="-987.86169"
+           style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:18.5719px;line-height:0%;font-family:Arial;-inkscape-font-specification:'Arial, Bold';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           xml:space="preserve"><tspan
+             style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:18.5719px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial, Bold';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;stroke:none;stroke-opacity:1"
+             y="157.05742"
+             x="-987.86169"
+             id="tspan5773-1-5"
+             sodipodi:role="line">AXI_DMAC</tspan></text>
+      </g>
+      <g
+         transform="matrix(0.26317814,0,0,0.2602511,-23.049747,132.98226)"
+         id="g5828-6"
+         style="display:inline;stroke:#a01414;stroke-opacity:1;shape-rendering:crispEdges;enable-background:new">
+        <text
+           transform="rotate(-90)"
+           id="text5771-4-8"
+           y="157.05742"
+           x="-1017.8765"
+           style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:18.5719px;line-height:0%;font-family:Arial;-inkscape-font-specification:'Arial, Bold';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           xml:space="preserve"><tspan
+             style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:18.5719px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial, Bold';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;stroke:none;stroke-opacity:1"
+             y="157.05742"
+             x="-1017.8765"
+             id="tspan5773-2-5"
+             sodipodi:role="line">DATA_OFFLOAD</tspan></text>
+      </g>
+      <text
+         xml:space="preserve"
+         style="font-size:8.3322px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial, Normal';stroke-width:0.260381"
+         x="7.1100211"
+         y="413.62912"
+         id="text13065"><tspan
+           sodipodi:role="line"
+           id="tspan13063"
+           style="stroke-width:0.260381"
+           x="7.1100211"
+           y="413.62912" /></text>
+      <rect
+         style="fill:#fefdfe;fill-opacity:1;fill-rule:evenodd;stroke:#071414;stroke-width:0.431268;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:75.5906;stroke-opacity:1"
+         id="rect46745"
+         width="57.433338"
+         height="65.88842"
+         x="80.867371"
+         y="343.11008" />
+      <rect
+         style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#a01414;stroke-width:0.348724;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:0.0348724, 0.0348724;stroke-dashoffset:0;stroke-opacity:1"
+         id="rect19131"
+         width="27.06621"
+         height="22.728636"
+         x="105.60171"
+         y="351.25458" />
+      <rect
+         style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#a01414;stroke-width:0.474752;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:0.0474752, 0.0474752;stroke-dashoffset:0;stroke-opacity:1"
+         id="rect19131-2"
+         width="50.786373"
+         height="5.992558"
+         x="83.743378"
+         y="400.78452" />
+      <rect
+         style="fill:#ffcccc;fill-opacity:1;fill-rule:evenodd;stroke:#a01414;stroke-width:0.419234;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:0.0419234, 0.0419234;stroke-dashoffset:0;stroke-opacity:1"
+         id="rect958"
+         width="14.826872"
+         height="11.396949"
+         x="112.13855"
+         y="359.35471" />
+      <rect
+         style="fill:#ffcccc;fill-opacity:1;fill-rule:evenodd;stroke:#a01414;stroke-width:0.486759;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:0.0486759, 0.0486759;stroke-dashoffset:0;stroke-opacity:1"
+         id="rect958-1"
+         width="24.458626"
+         height="13.540805"
+         x="83.063011"
+         y="377.64615" />
+      <text
+         xml:space="preserve"
+         transform="matrix(0.14116926,0,0,0.12862134,41.772613,306.88673)"
+         id="text4758"
+         style="font-size:14px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial, Normal';white-space:pre;shape-inside:url(#rect4760);display:inline;stroke-width:1.93234"><tspan
+           x="505.75977"
+           y="453.41916"
+           id="tspan6">ad_serdes_in</tspan></text>
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.7774px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;stroke-width:0.260381"
+         x="107.38977"
+         y="356.57812"
+         id="text21502"
+         transform="scale(1.0050352,0.99499002)"><tspan
+           sodipodi:role="line"
+           id="tspan21500"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.7774px;font-family:Arial;-inkscape-font-specification:'Arial, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;stroke-width:0.260381"
+           x="107.38977"
+           y="356.57812">axi_hmcad15xx_if</tspan></text>
+      <text
+         xml:space="preserve"
+         transform="matrix(0.16494077,0,0,0.16329222,36.524518,306.45686)"
+         id="text24668"
+         style="font-size:16px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial, Normal';white-space:pre;shape-inside:url(#rect24670);display:inline;stroke-width:2.01426"><tspan
+           x="298.9668"
+           y="484.35348"
+           id="tspan7">ADC COMMON</tspan></text>
+      <text
+         xml:space="preserve"
+         style="font-size:4.13661px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial, Normal';stroke-width:0.260381"
+         x="101.16924"
+         y="406.87076"
+         id="text41823"
+         transform="scale(1.0050352,0.99499002)"><tspan
+           sodipodi:role="line"
+           id="tspan41821"
+           style="stroke-width:0.260381"
+           x="101.16924"
+           y="406.87076">UP_AXI</tspan></text>
+      <path
+         style="fill:#a01414;fill-opacity:1;stroke:#a01414;stroke-width:0.590471;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:20;stroke-opacity:1;marker-start:url(#TriangleInM-0);marker-end:url(#marker51146-9)"
+         d="m 95.289064,393.27236 c 0,5.46507 0,5.25488 0,5.25488"
+         id="path42520-2-7" />
+      <path
+         style="fill:#a01414;fill-opacity:1;stroke:#a01414;stroke-width:1.39135;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:20;stroke-opacity:1;marker-end:url(#marker51146-9-3)"
+         d="m 79.061913,377.80008 c -48.827517,-0.0793 -46.949578,-0.0762 -46.949578,-0.0762"
+         id="path42520-2-7-9" />
+      <text
+         xml:space="preserve"
+         style="font-size:3.10245px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial, Normal';white-space:pre;inline-size:29.4803;display:inline;stroke-width:0.260381"
+         x="94.773582"
+         y="350.11472"
+         id="text49535"
+         transform="matrix(1.8238772,0,0,0.99499002,-88.233429,-1.301906)" />
+      <rect
+         style="fill:#ffcccc;fill-opacity:1;fill-rule:evenodd;stroke:#a01414;stroke-width:0.486023;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:0.0486023, 0.0486023;stroke-dashoffset:0;stroke-opacity:1"
+         id="rect4"
+         width="24.626005"
+         height="13.408176"
+         x="109.52766"
+         y="377.76508" />
+      <path
+         style="fill:#a01414;fill-opacity:1;stroke:#a01414;stroke-width:0.590471;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:20;stroke-opacity:1;marker-start:url(#TriangleInM-0);marker-end:url(#marker51146-9)"
+         d="m 121.76042,393.27236 c 0,5.46507 0,5.25488 0,5.25488"
+         id="path6-9" />
+      <text
+         xml:space="preserve"
+         transform="matrix(0.17724348,0,0,0.17547195,57.940847,298.46158)"
+         id="text19"
+         style="font-size:16px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial, Normal';text-align:center;white-space:pre;shape-inside:url(#rect19);display:inline;stroke-width:2.01426"
+         x="62.085659"
+         y="0"><tspan
+           x="345.01046"
+           y="484.35348"
+           id="tspan9"><tspan
+             style="font-size:13.4284px"
+             id="tspan8">ADC 
+</tspan></tspan><tspan
+           x="324.48756"
+           y="504.35348"
+           id="tspan11"><tspan
+             style="font-size:13.4284px"
+             id="tspan10">CHANNELS</tspan></tspan></text>
+      <rect
+         style="fill:#ffcccc;fill-opacity:1;fill-rule:evenodd;stroke:#a01414;stroke-width:0.336568;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:0.0336568, 0.0336568;stroke-dashoffset:0;stroke-opacity:1"
+         id="rect20"
+         width="18.85807"
+         height="14.495604"
+         x="83.095551"
+         y="355.16949" />
+      <text
+         xml:space="preserve"
+         transform="matrix(0.34868548,0,0,0.34868548,4.4436633,267.71942)"
+         id="text22"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:7.96534px;font-family:Arial;-inkscape-font-specification:'Arial, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:center;writing-mode:lr-tb;direction:ltr;white-space:pre;shape-inside:url(#rect23);display:inline;fill:#000000;stroke-width:1.2926;stroke-dasharray:0.12926, 0.12926;stroke-dashoffset:0"
+         x="24.155434"
+         y="0"><tspan
+           x="231.74029"
+           y="273.58888"
+           id="tspan17"><tspan
+             style="font-size:5.97401px"
+             id="tspan12">up_delay_cntrl</tspan></tspan></text>
+      <rect
+         style="fill:#fefdfe;fill-opacity:1;fill-rule:evenodd;stroke:#071414;stroke-width:0.431268;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:75.5906;stroke-opacity:1"
+         id="rect46745-0"
+         width="57.433338"
+         height="65.88842"
+         x="80.444397"
+         y="426.47971" />
+      <rect
+         style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#a01414;stroke-width:0.348724;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:0.0348724, 0.0348724;stroke-dashoffset:0;stroke-opacity:1"
+         id="rect19131-9"
+         width="27.06621"
+         height="22.728636"
+         x="105.17873"
+         y="434.62421" />
+      <rect
+         style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#a01414;stroke-width:0.474752;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:0.0474752, 0.0474752;stroke-dashoffset:0;stroke-opacity:1"
+         id="rect19131-2-7"
+         width="50.786373"
+         height="5.992558"
+         x="83.320396"
+         y="484.15414" />
+      <rect
+         style="fill:#ffcccc;fill-opacity:1;fill-rule:evenodd;stroke:#a01414;stroke-width:0.419234;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:0.0419234, 0.0419234;stroke-dashoffset:0;stroke-opacity:1"
+         id="rect958-3"
+         width="14.826872"
+         height="11.396949"
+         x="111.71559"
+         y="442.72433" />
+      <rect
+         style="fill:#ffcccc;fill-opacity:1;fill-rule:evenodd;stroke:#a01414;stroke-width:0.486759;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:0.0486759, 0.0486759;stroke-dashoffset:0;stroke-opacity:1"
+         id="rect958-1-7"
+         width="24.458626"
+         height="13.540805"
+         x="82.64006"
+         y="461.01578" />
+      <text
+         xml:space="preserve"
+         transform="matrix(0.14116926,0,0,0.12862134,41.34965,390.25634)"
+         id="text4758-2"
+         style="font-size:14px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial, Normal';white-space:pre;shape-inside:url(#rect4760-1);display:inline;stroke-width:1.93234"><tspan
+           x="505.75977"
+           y="453.41916"
+           id="tspan18">ad_serdes_in</tspan></text>
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.7774px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;stroke-width:0.260381"
+         x="106.96894"
+         y="440.36749"
+         id="text21502-6"
+         transform="scale(1.0050352,0.99499002)"><tspan
+           sodipodi:role="line"
+           id="tspan21500-0"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.7774px;font-family:Arial;-inkscape-font-specification:'Arial, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;stroke-width:0.260381"
+           x="106.96894"
+           y="440.36749">axi_hmcad15xx_if</tspan></text>
+      <text
+         xml:space="preserve"
+         transform="matrix(0.16494077,0,0,0.16329222,36.101555,389.82647)"
+         id="text24668-1"
+         style="font-size:16px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial, Normal';white-space:pre;shape-inside:url(#rect24670-3);display:inline;stroke-width:2.01426"><tspan
+           x="298.9668"
+           y="484.35348"
+           id="tspan19">ADC COMMON</tspan></text>
+      <text
+         xml:space="preserve"
+         style="font-size:4.13661px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial, Normal';stroke-width:0.260381"
+         x="100.7484"
+         y="490.66013"
+         id="text41823-6"
+         transform="scale(1.0050352,0.99499002)"><tspan
+           sodipodi:role="line"
+           id="tspan41821-5"
+           style="stroke-width:0.260381"
+           x="100.7484"
+           y="490.66013">UP_AXI</tspan></text>
+      <path
+         style="fill:#a01414;fill-opacity:1;stroke:#a01414;stroke-width:0.590471;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:20;stroke-opacity:1;marker-start:url(#TriangleInM-0-5);marker-end:url(#marker51146-9-8)"
+         d="m 94.866105,476.64197 c 0,5.46507 0,5.25488 0,5.25488"
+         id="path42520-2-7-7" />
+      <rect
+         style="fill:#ffcccc;fill-opacity:1;fill-rule:evenodd;stroke:#a01414;stroke-width:0.486023;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:0.0486023, 0.0486023;stroke-dashoffset:0;stroke-opacity:1"
+         id="rect4-1"
+         width="24.626005"
+         height="13.408176"
+         x="109.10469"
+         y="461.1347" />
+      <path
+         style="fill:#a01414;fill-opacity:1;stroke:#a01414;stroke-width:0.590471;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:20;stroke-opacity:1;marker-start:url(#TriangleInM-0-5);marker-end:url(#marker51146-9-8)"
+         d="m 121.33746,476.64197 c 0,5.46507 0,5.25488 0,5.25488"
+         id="path6-9-2" />
+      <text
+         xml:space="preserve"
+         transform="matrix(0.17724348,0,0,0.17547195,57.517884,381.83119)"
+         id="text19-0"
+         style="font-size:16px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial, Normal';text-align:center;white-space:pre;shape-inside:url(#rect19-5);display:inline;stroke-width:2.01426"
+         x="62.085659"
+         y="0"><tspan
+           x="345.01046"
+           y="484.35348"
+           id="tspan21"><tspan
+             style="font-size:13.4284px"
+             id="tspan20">ADC 
+</tspan></tspan><tspan
+           x="324.48756"
+           y="504.35348"
+           id="tspan23"><tspan
+             style="font-size:13.4284px"
+             id="tspan22">CHANNELS</tspan></tspan></text>
+      <rect
+         style="fill:#ffcccc;fill-opacity:1;fill-rule:evenodd;stroke:#a01414;stroke-width:0.336568;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:0.0336568, 0.0336568;stroke-dashoffset:0;stroke-opacity:1"
+         id="rect20-0"
+         width="18.85807"
+         height="14.495604"
+         x="82.672577"
+         y="438.53912" />
+      <text
+         xml:space="preserve"
+         transform="matrix(0.34868548,0,0,0.34868548,4.0206998,351.08903)"
+         id="text22-1"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:7.96534px;font-family:Arial;-inkscape-font-specification:'Arial, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:center;writing-mode:lr-tb;direction:ltr;white-space:pre;shape-inside:url(#rect23-4);display:inline;fill:#000000;stroke-width:1.2926;stroke-dasharray:0.12926, 0.12926;stroke-dashoffset:0"
+         x="24.155434"
+         y="0"><tspan
+           x="231.74029"
+           y="273.58888"
+           id="tspan27"><tspan
+             style="font-size:5.97401px"
+             id="tspan24">up_delay_cntrl</tspan></tspan></text>
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.1661px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.260381;shape-rendering:crispEdges;enable-background:new"
+         x="33.896858"
+         y="456.06625"
+         id="text6-9-8"
+         transform="rotate(-0.71530846)"><tspan
+           sodipodi:role="line"
+           x="33.896858"
+           y="456.06625"
+           style="font-size:4.1661px;stroke-width:0.260381"
+           id="tspan6-7-2">128b @ 125 MHz</tspan></text>
+      <path
+         style="fill:#a01414;fill-opacity:1;stroke:#a01414;stroke-width:1.39135;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:20;stroke-opacity:1;marker-end:url(#marker51146-9-3-9)"
+         d="m 78.851761,457.50356 c -48.827517,-0.0793 -46.949578,-0.0762 -46.949578,-0.0762"
+         id="path42520-2-7-9-6" />
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.08305px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;white-space:pre;inline-size:47.7941;stroke-width:0.260381"
+         x="97.591248"
+         y="496.90479"
+         id="text41772-4"
+         transform="translate(-5.5075643,0.37197315)"><tspan
+           x="97.591248"
+           y="496.90479"
+           id="tspan34"><tspan
+   style="font-size:3.12457px"
+   id="tspan28">adc_clk_g</tspan><tspan
+   style="font-weight:bold"
+   id="tspan33"> </tspan>: REF_CLK_A1(500MHz) / 4 </tspan></text>
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.08305px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;stroke-width:0.260381"
+         x="141.01414"
+         y="497.02832"
+         id="text41772-4-7"><tspan
+           sodipodi:role="line"
+           id="tspan41770-2-5"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.08305px;font-family:Arial;-inkscape-font-specification:'Arial, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;stroke-width:0.260381"
+           x="141.01414"
+           y="497.02832">REF_CLK_A1= CLK_IN(500MHz) </tspan></text>
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:3.12457px;font-family:Arial;-inkscape-font-specification:Arial;writing-mode:lr-tb;direction:ltr;fill:#000000;stroke-width:0.365315;stroke-dasharray:1.46126, 1.46126;stroke-dashoffset:0.219189"
+         x="95.611465"
+         y="348.06964"
+         id="text13"><tspan
+           sodipodi:role="line"
+           id="tspan13"
+           style="stroke-width:0.365315"
+           x="95.611465"
+           y="348.06964" /><tspan
+           sodipodi:role="line"
+           style="stroke-width:0.365315"
+           id="tspan14"
+           x="95.611465"
+           y="351.97534" /></text>
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:3.81892px;font-family:Arial;-inkscape-font-specification:'Arial Bold';writing-mode:lr-tb;direction:ltr;fill:#000000;stroke-width:0.365315;stroke-dasharray:1.46126, 1.46126;stroke-dashoffset:0.219189"
+         x="87.800026"
+         y="347.51169"
+         id="text15"><tspan
+           sodipodi:role="line"
+           id="tspan15"
+           style="font-size:3.81892px;stroke-width:0.365315"
+           x="87.800026"
+           y="347.51169">axi_hmcad15xx_a2_adc</tspan></text>
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:3.81892px;font-family:Arial;-inkscape-font-specification:'Arial Bold';writing-mode:lr-tb;direction:ltr;fill:#000000;stroke-width:0.365315;stroke-dasharray:1.46126, 1.46126;stroke-dashoffset:0.219189"
+         x="85.990028"
+         y="431.27228"
+         id="text15-4"><tspan
+           sodipodi:role="line"
+           id="tspan15-7"
+           style="font-size:3.81892px;stroke-width:0.365315"
+           x="85.990028"
+           y="431.27228">axi_hmcad15xx_a1_adc</tspan></text>
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.1661px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.260381;shape-rendering:crispEdges;enable-background:new"
+         x="33.961472"
+         y="376.21982"
+         id="text6-9-8-3"
+         transform="rotate(-0.71530846)"><tspan
+           sodipodi:role="line"
+           x="33.961472"
+           y="376.21982"
+           style="font-size:4.1661px;stroke-width:0.260381"
+           id="tspan6-7-2-5">128b @ 125 MHz</tspan></text>
+      <g
+         id="g4432-4-3-2-4"
+         transform="matrix(0.2603812,0,0,0.2603812,-68.955058,234.47126)"
+         style="display:inline;fill:#a01414;fill-opacity:1;stroke:#a01414;stroke-opacity:1;shape-rendering:crispEdges;enable-background:new">
+        <path
+           sodipodi:nodetypes="ccccccccc"
+           style="fill:#a01414;fill-opacity:1;fill-rule:evenodd;stroke:#a01414;stroke-width:1.35752px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1"
+           d="m 130.55745,546.5838 18.926,14.50562 V 554.441 l 23.51348,-3e-5 v -7.85571 -7.85571 l -23.51348,3e-5 v -6.64842 l -18.926,14.50562"
+           id="path5656-4-7-4-65-7-3-2-3"
+           inkscape:connector-curvature="0" />
+        <text
+           xml:space="preserve"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:13.3333px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.3607"
+           x="136.42747"
+           y="551.55389"
+           id="text3347-26-3-1-9"><tspan
+             sodipodi:role="line"
+             id="tspan3345-9-10-6-8"
+             x="136.42747"
+             y="551.55389"
+             style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:13.3333px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;fill:#ffffff;fill-opacity:1;stroke-width:0.3607"> 64b</tspan></text>
+      </g>
+      <text
+         id="text2401"
+         y="457.9664"
+         x="141.95209"
+         style="font-style:normal;font-weight:normal;font-size:4.35068px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.260381;shape-rendering:crispEdges"
+         xml:space="preserve"
+         transform="scale(1.0443046,0.95757502)"><tspan
+           style="font-size:3.62556px;stroke-width:0.260381"
+           y="457.9664"
+           x="141.95209"
+           id="tspan2399"
+           sodipodi:role="line">data_in_p</tspan></text>
+      <text
+         id="text2401-0"
+         y="463.68958"
+         x="141.99545"
+         style="font-style:normal;font-weight:normal;font-size:4.35068px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.260381;shape-rendering:crispEdges"
+         xml:space="preserve"
+         transform="scale(1.0443046,0.95757502)"><tspan
+           style="font-size:3.62556px;stroke-width:0.260381"
+           y="463.68958"
+           x="141.99545"
+           id="tspan2399-27"
+           sodipodi:role="line">data_in_n</tspan></text>
+      <path
+         sodipodi:nodetypes="cc"
+         inkscape:connector-curvature="0"
+         id="path24"
+         d="M 182.39511,439.77052 H 139.51496"
+         style="fill:none;stroke:#000000;stroke-width:0.561007;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#marker1216-8);shape-rendering:crispEdges" />
+      <path
+         sodipodi:nodetypes="cc"
+         inkscape:connector-curvature="0"
+         id="path25"
+         d="M 182.3951,445.32396 H 139.51496"
+         style="display:inline;fill:none;stroke:#000000;stroke-width:0.561007;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#marker1216-9);shape-rendering:crispEdges;enable-background:new" />
+      <text
+         id="text25"
+         y="457.9664"
+         x="141.95209"
+         style="font-style:normal;font-weight:normal;font-size:4.35068px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.260381;shape-rendering:crispEdges"
+         xml:space="preserve"
+         transform="scale(1.0443046,0.95757502)"><tspan
+           style="font-size:3.62556px;stroke-width:0.260381"
+           y="457.9664"
+           x="141.95209"
+           id="tspan25"
+           sodipodi:role="line">data_in_p</tspan></text>
+      <text
+         id="text26"
+         y="463.68958"
+         x="141.99545"
+         style="font-style:normal;font-weight:normal;font-size:4.35068px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.260381;shape-rendering:crispEdges"
+         xml:space="preserve"
+         transform="scale(1.0443046,0.95757502)"><tspan
+           style="font-size:3.62556px;stroke-width:0.260381"
+           y="463.68958"
+           x="141.99545"
+           id="tspan26"
+           sodipodi:role="line">data_in_n</tspan></text>
+      <path
+         sodipodi:nodetypes="cc"
+         inkscape:connector-curvature="0"
+         id="path28"
+         d="M 182.39511,457.65899 H 139.51496"
+         style="fill:none;stroke:#000000;stroke-width:0.561007;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#marker1216-8);shape-rendering:crispEdges" />
+      <path
+         sodipodi:nodetypes="cc"
+         inkscape:connector-curvature="0"
+         id="path29"
+         d="M 182.3951,463.21243 H 139.51496"
+         style="display:inline;fill:none;stroke:#000000;stroke-width:0.561007;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#marker1216-9);shape-rendering:crispEdges;enable-background:new" />
+      <text
+         id="text29"
+         y="476.71469"
+         x="141.95209"
+         style="font-style:normal;font-weight:normal;font-size:4.35068px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.260381;shape-rendering:crispEdges"
+         xml:space="preserve"
+         transform="scale(1.0443046,0.95757502)"><tspan
+           style="font-size:3.62556px;stroke-width:0.260381"
+           y="476.71469"
+           x="141.95209"
+           id="tspan29"
+           sodipodi:role="line">clk_in_p</tspan></text>
+      <text
+         id="text30"
+         y="482.4379"
+         x="141.99545"
+         style="font-style:normal;font-weight:normal;font-size:4.35068px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.260381;shape-rendering:crispEdges"
+         xml:space="preserve"
+         transform="scale(1.0443046,0.95757502)"><tspan
+           style="font-size:3.62556px;stroke-width:0.260381"
+           y="482.4379"
+           x="141.99545"
+           id="tspan30"
+           sodipodi:role="line">clk_in_n</tspan></text>
+      <path
+         sodipodi:nodetypes="cc"
+         inkscape:connector-curvature="0"
+         id="path30"
+         d="M 182.39511,475.91252 H 139.51496"
+         style="fill:none;stroke:#000000;stroke-width:0.561007;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#marker1216-8);shape-rendering:crispEdges" />
+      <path
+         sodipodi:nodetypes="cc"
+         inkscape:connector-curvature="0"
+         id="path31"
+         d="M 182.3951,481.46597 H 139.51496"
+         style="display:inline;fill:none;stroke:#000000;stroke-width:0.561007;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#marker1216-9);shape-rendering:crispEdges;enable-background:new" />
+      <text
+         id="text31"
+         y="495.84561"
+         x="146.16219"
+         style="font-style:normal;font-weight:normal;font-size:4.35068px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.260381;shape-rendering:crispEdges"
+         xml:space="preserve"
+         transform="scale(1.0443046,0.95757502)"><tspan
+           style="font-size:3.62556px;stroke-width:0.260381"
+           y="495.84561"
+           x="146.16219"
+           id="tspan31"
+           sodipodi:role="line">fclk_p</tspan></text>
+      <text
+         id="text32"
+         y="501.56882"
+         x="146.20557"
+         style="font-style:normal;font-weight:normal;font-size:4.35068px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.260381;shape-rendering:crispEdges"
+         xml:space="preserve"
+         transform="scale(1.0443046,0.95757502)"><tspan
+           style="font-size:3.62556px;stroke-width:0.260381"
+           y="501.56882"
+           x="146.20557"
+           id="tspan32"
+           sodipodi:role="line">fclk_n</tspan></text>
+      <text
+         id="text2401-08"
+         y="369.91077"
+         x="143.32533"
+         style="font-style:normal;font-weight:normal;font-size:4.35068px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.260381;shape-rendering:crispEdges"
+         xml:space="preserve"
+         transform="scale(1.0443046,0.95757502)"><tspan
+           style="font-size:3.62556px;stroke-width:0.260381"
+           y="369.91077"
+           x="143.32533"
+           id="tspan2399-8"
+           sodipodi:role="line">data_in_p</tspan></text>
+      <text
+         id="text2401-0-0"
+         y="375.63394"
+         x="143.3687"
+         style="font-style:normal;font-weight:normal;font-size:4.35068px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.260381;shape-rendering:crispEdges"
+         xml:space="preserve"
+         transform="scale(1.0443046,0.95757502)"><tspan
+           style="font-size:3.62556px;stroke-width:0.260381"
+           y="375.63394"
+           x="143.3687"
+           id="tspan2399-27-6"
+           sodipodi:role="line">data_in_n</tspan></text>
+      <path
+         sodipodi:nodetypes="cc"
+         inkscape:connector-curvature="0"
+         id="path24-8"
+         d="M 183.16998,355.97139 H 139.52904"
+         style="fill:none;stroke:#000000;stroke-width:0.565962;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#marker1216-8-1);shape-rendering:crispEdges" />
+      <path
+         sodipodi:nodetypes="cc"
+         inkscape:connector-curvature="0"
+         id="path25-1"
+         d="M 182.3951,361.00407 H 139.51496"
+         style="display:inline;fill:none;stroke:#000000;stroke-width:0.561007;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#marker1216-9-9);shape-rendering:crispEdges;enable-background:new" />
+      <text
+         id="text25-9"
+         y="369.91077"
+         x="143.32533"
+         style="font-style:normal;font-weight:normal;font-size:4.35068px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.260381;shape-rendering:crispEdges"
+         xml:space="preserve"
+         transform="scale(1.0443046,0.95757502)"><tspan
+           style="font-size:3.62556px;stroke-width:0.260381"
+           y="369.91077"
+           x="143.32533"
+           id="tspan25-8"
+           sodipodi:role="line">data_in_p</tspan></text>
+      <text
+         id="text26-9"
+         y="375.63394"
+         x="143.3687"
+         style="font-style:normal;font-weight:normal;font-size:4.35068px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.260381;shape-rendering:crispEdges"
+         xml:space="preserve"
+         transform="scale(1.0443046,0.95757502)"><tspan
+           style="font-size:3.62556px;stroke-width:0.260381"
+           y="375.63394"
+           x="143.3687"
+           id="tspan26-7"
+           sodipodi:role="line">data_in_n</tspan></text>
+      <path
+         sodipodi:nodetypes="cc"
+         inkscape:connector-curvature="0"
+         id="path28-2"
+         d="M 182.39511,373.3391 H 139.51496"
+         style="fill:none;stroke:#000000;stroke-width:0.561007;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#marker1216-8-1);shape-rendering:crispEdges" />
+      <rect
+         style="fill:#ebebeb;fill-opacity:1;stroke:#000000;stroke-width:0.854716;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.533333"
+         id="rect20238-1"
+         width="44.301193"
+         height="56.515358"
+         x="182.21405"
+         y="347.42709" />
+      <path
+         sodipodi:nodetypes="cc"
+         inkscape:connector-curvature="0"
+         id="path29-2"
+         d="M 182.3951,378.89254 H 139.51496"
+         style="display:inline;fill:none;stroke:#000000;stroke-width:0.561007;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#marker1216-9-9);shape-rendering:crispEdges;enable-background:new" />
+      <text
+         id="text29-8"
+         y="388.65906"
+         x="143.32533"
+         style="font-style:normal;font-weight:normal;font-size:4.35068px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.260381;shape-rendering:crispEdges"
+         xml:space="preserve"
+         transform="scale(1.0443046,0.95757502)"><tspan
+           style="font-size:3.62556px;stroke-width:0.260381"
+           y="388.65906"
+           x="143.32533"
+           id="tspan29-2"
+           sodipodi:role="line">clk_in_p</tspan></text>
+      <text
+         id="text30-8"
+         y="394.38226"
+         x="143.3687"
+         style="font-style:normal;font-weight:normal;font-size:4.35068px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.260381;shape-rendering:crispEdges"
+         xml:space="preserve"
+         transform="scale(1.0443046,0.95757502)"><tspan
+           style="font-size:3.62556px;stroke-width:0.260381"
+           y="394.38226"
+           x="143.3687"
+           id="tspan30-9"
+           sodipodi:role="line">clk_in_n</tspan></text>
+      <path
+         sodipodi:nodetypes="cc"
+         inkscape:connector-curvature="0"
+         id="path30-0"
+         d="M 182.39511,392.11339 H 139.51496"
+         style="fill:none;stroke:#000000;stroke-width:0.561007;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#marker1216-8-1);shape-rendering:crispEdges" />
+      <path
+         sodipodi:nodetypes="cc"
+         inkscape:connector-curvature="0"
+         id="path31-7"
+         d="M 182.3951,397.14608 H 139.51496"
+         style="display:inline;fill:none;stroke:#000000;stroke-width:0.561007;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#marker1216-9-9);shape-rendering:crispEdges;enable-background:new" />
+      <text
+         id="text31-8"
+         y="407.78998"
+         x="147.53543"
+         style="font-style:normal;font-weight:normal;font-size:4.35068px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.260381;shape-rendering:crispEdges"
+         xml:space="preserve"
+         transform="scale(1.0443046,0.95757502)"><tspan
+           style="font-size:3.62556px;stroke-width:0.260381"
+           y="407.78998"
+           x="147.53543"
+           id="tspan31-1"
+           sodipodi:role="line">fclk_p</tspan></text>
+      <text
+         id="text32-5"
+         y="413.51318"
+         x="147.57881"
+         style="font-style:normal;font-weight:normal;font-size:4.35068px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.260381;shape-rendering:crispEdges"
+         xml:space="preserve"
+         transform="scale(1.0443046,0.95757502)"><tspan
+           style="font-size:3.62556px;stroke-width:0.260381"
+           y="413.51318"
+           x="147.57881"
+           id="tspan32-8"
+           sodipodi:role="line">fclk_n</tspan></text>
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:5.5548px;font-family:Arial;-inkscape-font-specification:'Arial Bold';writing-mode:lr-tb;direction:ltr;fill:#000000;stroke-width:0.365315;stroke-dasharray:1.46126, 1.46126;stroke-dashoffset:0.219189"
+         x="188.23279"
+         y="374.66574"
+         id="text16"><tspan
+           sodipodi:role="line"
+           id="tspan16"
+           style="font-size:5.5548px;stroke-width:0.365315"
+           x="188.23279"
+           y="374.66574">HMCAD1520</tspan></text>
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.08305px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;stroke-width:0.260381"
+         x="92.090416"
+         y="412.48654"
+         id="text41772-4-2"><tspan
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.08305px;font-family:Arial;-inkscape-font-specification:'Arial, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;stroke-width:0.260381"
+           x="92.090416"
+           y="412.48654"
+           id="tspan1-8-9"
+           sodipodi:role="line"><tspan
+   style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:3.12457px;font-family:Arial;-inkscape-font-specification:'Arial Bold'"
+   id="tspan5">adc_clk_g:</tspan> REF_CLK_A2(500MHz) / 4 </tspan></text>
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.08305px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;stroke-width:0.260381"
+         x="141.56287"
+         y="412.47858"
+         id="text41772-4-7-3"><tspan
+           sodipodi:role="line"
+           id="tspan41770-2-5-0"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.08305px;font-family:Arial;-inkscape-font-specification:'Arial, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;stroke-width:0.260381"
+           x="141.56287"
+           y="412.47858">REF_CLK_A2= CLK_IN(500MHz) </tspan></text>
+      <text
+         xml:space="preserve"
+         style="font-size:3.12457px;writing-mode:lr-tb;direction:ltr;fill:#000000;stroke-width:0.260381"
+         x="97.717934"
+         y="496.56104"
+         id="text1"><tspan
+           sodipodi:role="line"
+           id="tspan1"
+           style="stroke-width:0.260381"
+           x="97.717934"
+           y="496.56104" /></text>
+      <text
+         xml:space="preserve"
+         style="font-size:3.12457px;writing-mode:lr-tb;direction:ltr;fill:#000000;stroke-width:0.260381"
+         x="133.33435"
+         y="497.11899"
+         id="text2"><tspan
+           sodipodi:role="line"
+           id="tspan2"
+           style="stroke-width:0.260381"></tspan></text>
+    </g>
+  </g>
+</svg>

--- a/docs/projects/admx6020m/admx6020m_clock_scheme.svg
+++ b/docs/projects/admx6020m/admx6020m_clock_scheme.svg
@@ -1,0 +1,716 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="278.91397mm"
+   height="178.31123mm"
+   viewBox="0 0 278.91397 178.31123"
+   version="1.1"
+   id="svg92524"
+   sodipodi:docname="admx6020m_clock_scheme.svg"
+   inkscape:version="1.4.3 (0d15f75, 2025-12-25)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+     id="namedview92526"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:document-units="mm"
+     showgrid="false"
+     inkscape:zoom="0.74029883"
+     inkscape:cx="692.288"
+     inkscape:cy="135.75599"
+     inkscape:window-width="2560"
+     inkscape:window-height="1369"
+     inkscape:window-x="1912"
+     inkscape:window-y="-8"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="layer1"
+     inkscape:showpageshadow="2"
+     inkscape:deskcolor="#d1d1d1" />
+  <defs
+     id="defs92521">
+    <rect
+       x="225.58458"
+       y="126.30035"
+       width="137.7822"
+       height="62.812473"
+       id="rect1" />
+    <marker
+       style="overflow:visible"
+       id="Arrow1Lend"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Lend"
+       inkscape:isstock="true">
+      <path
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         style="fill:context-stroke;fill-rule:evenodd;stroke:context-stroke;stroke-width:1pt"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path42052" />
+    </marker>
+    <rect
+       x="155.69173"
+       y="396.39307"
+       width="153.7814"
+       height="94.561234"
+       id="rect105127" />
+    <marker
+       style="overflow:visible"
+       id="Arrow1Lend-3"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Lend"
+       inkscape:isstock="true">
+      <path
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         style="fill:context-stroke;fill-rule:evenodd;stroke:context-stroke;stroke-width:1pt"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path42052-2" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="Arrow1Lend-3-4"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Lend"
+       inkscape:isstock="true">
+      <path
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         style="fill:context-stroke;fill-rule:evenodd;stroke:context-stroke;stroke-width:1pt"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path42052-2-7" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="Arrow1Lend-3-2"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Lend"
+       inkscape:isstock="true">
+      <path
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         style="fill:context-stroke;fill-rule:evenodd;stroke:context-stroke;stroke-width:1pt"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path42052-2-2" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="Arrow1Lend-3-4-2"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Lend"
+       inkscape:isstock="true">
+      <path
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         style="fill:context-stroke;fill-rule:evenodd;stroke:context-stroke;stroke-width:1pt"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path42052-2-7-9" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="Arrow1Lend-3-1"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Lend"
+       inkscape:isstock="true">
+      <path
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         style="fill:context-stroke;fill-rule:evenodd;stroke:context-stroke;stroke-width:1pt"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path42052-2-5" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="Arrow1Lend-3-4-6"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Lend"
+       inkscape:isstock="true">
+      <path
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         style="fill:context-stroke;fill-rule:evenodd;stroke:context-stroke;stroke-width:1pt"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path42052-2-7-2" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="Arrow1Lend-3-23"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Lend"
+       inkscape:isstock="true">
+      <path
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         style="fill:context-stroke;fill-rule:evenodd;stroke:context-stroke;stroke-width:1pt"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path42052-2-0" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="Arrow1Lend-3-4-9"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Lend"
+       inkscape:isstock="true">
+      <path
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         style="fill:context-stroke;fill-rule:evenodd;stroke:context-stroke;stroke-width:1pt"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path42052-2-7-5" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="Arrow1Lend-3-1-7"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Lend"
+       inkscape:isstock="true">
+      <path
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         style="fill:context-stroke;fill-rule:evenodd;stroke:context-stroke;stroke-width:1pt"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path42052-2-5-7" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="Arrow1Lend-3-4-6-8"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Lend"
+       inkscape:isstock="true">
+      <path
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         style="fill:context-stroke;fill-rule:evenodd;stroke:context-stroke;stroke-width:1pt"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path42052-2-7-2-7" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="Arrow1Lend-3-4-2-6"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Lend"
+       inkscape:isstock="true">
+      <path
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         style="fill:context-stroke;fill-rule:evenodd;stroke:context-stroke;stroke-width:1pt"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path42052-2-7-9-2" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="Arrow1Lend-3-2-9"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Lend"
+       inkscape:isstock="true">
+      <path
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         style="fill:context-stroke;fill-rule:evenodd;stroke:context-stroke;stroke-width:1pt"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path42052-2-2-1" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="Arrow1Lend-3-4-2-6-0"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Lend"
+       inkscape:isstock="true">
+      <path
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         style="fill:context-stroke;fill-rule:evenodd;stroke:context-stroke;stroke-width:1pt"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path42052-2-7-9-2-6" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="Arrow1Lend-3-6"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Lend"
+       inkscape:isstock="true">
+      <path
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         style="fill:context-stroke;fill-rule:evenodd;stroke:context-stroke;stroke-width:1pt"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path42052-2-9" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="Arrow1Lend-3-4-3"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Lend"
+       inkscape:isstock="true">
+      <path
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         style="fill:context-stroke;fill-rule:evenodd;stroke:context-stroke;stroke-width:1pt"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path42052-2-7-57" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="marker1"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Lend"
+       inkscape:isstock="true">
+      <path
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         style="fill:context-stroke;fill-rule:evenodd;stroke:context-stroke;stroke-width:1pt"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path1-6" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="marker2"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Lend"
+       inkscape:isstock="true">
+      <path
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         style="fill:context-stroke;fill-rule:evenodd;stroke:context-stroke;stroke-width:1pt"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path2-6" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="marker3"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Lend"
+       inkscape:isstock="true">
+      <path
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         style="fill:context-stroke;fill-rule:evenodd;stroke:context-stroke;stroke-width:1pt"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path3-5" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="marker4"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Lend"
+       inkscape:isstock="true">
+      <path
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         style="fill:context-stroke;fill-rule:evenodd;stroke:context-stroke;stroke-width:1pt"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path4-8" />
+    </marker>
+    <rect
+       x="225.58458"
+       y="126.30035"
+       width="137.7822"
+       height="62.812473"
+       id="rect1-2" />
+    <marker
+       style="overflow:visible"
+       id="Arrow1Lend-3-4-3-5"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Lend"
+       inkscape:isstock="true">
+      <path
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         style="fill:context-stroke;fill-rule:evenodd;stroke:context-stroke;stroke-width:1pt"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path42052-2-7-57-0" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="Arrow1Lend-3-4-3-5-4"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Lend"
+       inkscape:isstock="true">
+      <path
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         style="fill:context-stroke;fill-rule:evenodd;stroke:context-stroke;stroke-width:1pt"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path42052-2-7-57-0-9" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="Arrow1Lend-3-4-3-5-9"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Lend"
+       inkscape:isstock="true">
+      <path
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         style="fill:context-stroke;fill-rule:evenodd;stroke:context-stroke;stroke-width:1pt"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path42052-2-7-57-0-6" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="Arrow1Lend-3-4-3-5-2"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Lend"
+       inkscape:isstock="true">
+      <path
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         style="fill:context-stroke;fill-rule:evenodd;stroke:context-stroke;stroke-width:1pt"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path42052-2-7-57-0-8" />
+    </marker>
+  </defs>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(92.602665,-63.808551)">
+    <rect
+       style="fill:#aaccee;fill-opacity:1;fill-rule:evenodd;stroke:#003366;stroke-width:0.665001;stroke-linecap:round;stroke-linejoin:round;stroke-dashoffset:75.5906;stroke-opacity:1"
+       id="rect92805-43"
+       width="25.042"
+       height="16.984877"
+       x="-92.270164"
+       y="147.4848" />
+    <rect
+       style="fill:#ffcccc;fill-opacity:1;fill-rule:evenodd;stroke:#a01414;stroke-width:1.03538;stroke-linecap:round;stroke-linejoin:round;stroke-dashoffset:75.5906;stroke-opacity:1"
+       id="rect92805-1-8"
+       width="60.745148"
+       height="176.90039"
+       x="125.04848"
+       y="64.326241" />
+    <text
+       xml:space="preserve"
+       style="font-size:8.46667px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial, Normal';stroke-width:0.264583"
+       x="143.53365"
+       y="151.38008"
+       id="text103547"><tspan
+         sodipodi:role="line"
+         id="tspan103545"
+         style="stroke-width:0.264583"
+         x="143.53365"
+         y="151.38008">FPGA</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-size:4.23333px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial, Normal';text-align:center;text-anchor:middle;stroke-width:0.264583"
+       x="-79.34259"
+       y="154.98271"
+       id="text110315"><tspan
+         sodipodi:role="line"
+         style="font-size:4.23333px;stroke-width:0.264583"
+         x="-79.34259"
+         y="154.98271"
+         id="tspan8">FIXED CLK</tspan><tspan
+         sodipodi:role="line"
+         style="font-size:4.23333px;stroke-width:0.264583"
+         x="-79.34259"
+         y="160.27437"
+         id="tspan1">10MHz</tspan></text>
+    <rect
+       style="fill:#aaccee;fill-opacity:1;fill-rule:evenodd;stroke:#003366;stroke-width:0.585;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-dashoffset:75.5906;stroke-opacity:1"
+       id="rect92805-43-1-1"
+       width="41.571926"
+       height="120.84142"
+       x="-28.840469"
+       y="93.308983"
+       ry="0" />
+    <text
+       xml:space="preserve"
+       style="font-size:4.23333px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial, Normal';text-align:center;text-anchor:middle;stroke-width:0.264583"
+       x="-9.291501"
+       y="154.83409"
+       id="text110315-4-4"><tspan
+         sodipodi:role="line"
+         style="font-size:4.23333px;stroke-width:0.264583"
+         x="-9.291501"
+         y="154.83409"
+         id="tspan1-2-4">ADF4355-2BCPZ</tspan></text>
+    <g
+       id="g6763"
+       transform="translate(-64.421479,-7.5947653)">
+      <path
+         style="fill:none;stroke:#000000;stroke-width:0.465;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#Arrow1Lend-3)"
+         d="m 77.721384,110.72117 24.325296,0.0178"
+         id="path112105-4" />
+      <path
+         style="fill:none;stroke:#000000;stroke-width:0.465;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#Arrow1Lend-3-4)"
+         d="m 77.895159,119.18523 24.325291,0.0178"
+         id="path112105-4-3" />
+      <text
+         xml:space="preserve"
+         style="font-size:2.11667px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial, Normal';stroke-width:0.264583"
+         x="80.526627"
+         y="109.72063"
+         id="text115047"><tspan
+           sodipodi:role="line"
+           id="tspan115045"
+           style="font-size:2.11667px;stroke-width:0.264583"
+           x="80.526627"
+           y="109.72063">ADC_CLKP</tspan></text>
+      <text
+         xml:space="preserve"
+         style="font-size:2.11667px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial, Normal';stroke-width:0.264583"
+         x="81.122955"
+         y="118.24358"
+         id="text115047-6"><tspan
+           sodipodi:role="line"
+           id="tspan115045-8"
+           style="font-size:2.11667px;stroke-width:0.264583"
+           x="81.122955"
+           y="118.24358">ADC_CLKN</tspan></text>
+      <path
+         style="fill:none;stroke:#000000;stroke-width:0.465;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#Arrow1Lend-3-4)"
+         d="m 153.75575,134.34845 33.75174,0.0178"
+         id="path1"
+         sodipodi:nodetypes="cc" />
+      <path
+         style="fill:none;stroke:#000000;stroke-width:0.465;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#Arrow1Lend-3-4)"
+         d="m 153.75575,120.14177 33.75174,0.0178"
+         id="path2"
+         sodipodi:nodetypes="cc" />
+      <path
+         style="fill:none;stroke:#000000;stroke-width:0.465;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#Arrow1Lend-3-4)"
+         d="m 153.75575,105.48834 33.75174,0.0178"
+         id="path3"
+         sodipodi:nodetypes="cc" />
+      <path
+         style="fill:none;stroke:#000000;stroke-width:0.465;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#Arrow1Lend-3-4)"
+         d="m 153.75575,92.353864 33.75174,0.0178"
+         id="path4"
+         sodipodi:nodetypes="cc" />
+      <text
+         xml:space="preserve"
+         style="font-size:2.11667px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial, Normal';stroke-width:0.264583"
+         x="166.21346"
+         y="90.778389"
+         id="text4"><tspan
+           sodipodi:role="line"
+           id="tspan4"
+           style="font-size:2.11667px;stroke-width:0.264583"
+           x="166.21346"
+           y="90.778389">FCLKP</tspan></text>
+      <text
+         xml:space="preserve"
+         style="font-size:2.11667px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial, Normal';stroke-width:0.264583"
+         x="166.21346"
+         y="103.64481"
+         id="text5"><tspan
+           sodipodi:role="line"
+           id="tspan5"
+           style="font-size:2.11667px;stroke-width:0.264583"
+           x="166.21346"
+           y="103.64481">FCLKN</tspan></text>
+      <text
+         xml:space="preserve"
+         style="font-size:2.11667px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial, Normal';stroke-width:0.264583"
+         x="166.21346"
+         y="118.65565"
+         id="text6"><tspan
+           sodipodi:role="line"
+           id="tspan6"
+           style="font-size:2.11667px;stroke-width:0.264583"
+           x="166.21346"
+           y="118.65565">LCLKP</tspan></text>
+      <text
+         xml:space="preserve"
+         style="font-size:2.11667px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial, Normal';stroke-width:0.264583"
+         x="166.21346"
+         y="132.86232"
+         id="text7"><tspan
+           sodipodi:role="line"
+           id="tspan7"
+           style="font-size:2.11667px;stroke-width:0.264583"
+           x="166.21346"
+           y="132.86232">LCLKN</tspan></text>
+    </g>
+    <rect
+       style="fill:#aaccee;fill-opacity:1;fill-rule:evenodd;stroke:#003366;stroke-width:0.708381;stroke-linecap:round;stroke-linejoin:round;stroke-dashoffset:75.5906;stroke-opacity:1"
+       id="rect92805-4"
+       width="47.534294"
+       height="80.906189"
+       x="41.098122"
+       y="66.839668" />
+    <text
+       xml:space="preserve"
+       transform="matrix(0.26458333,0,0,0.26458333,-13.579041,67.918659)"
+       id="text1"
+       style="font-size:8px;font-family:Sans;-inkscape-font-specification:'Sans, Normal';text-align:center;writing-mode:lr-tb;direction:ltr;white-space:pre;shape-inside:url(#rect1);display:inline;fill:#000000;stroke-width:1.2926;stroke-dasharray:0.12926, 0.12926"
+       x="68.891098"
+       y="0"><tspan
+         x="231.63714"
+         y="145.51685"
+         id="tspan12"><tspan
+           style="font-size:21.3333px;font-family:Arial;-inkscape-font-specification:'Arial, Normal'"
+           id="tspan11">HMCAD1520</tspan></tspan></text>
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.474742;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#Arrow1Lend-3-6)"
+       d="m 13.346294,197.14635 25.78267,0.0175"
+       id="path112105-4-4" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.476577;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#Arrow1Lend-3-4-3)"
+       d="m 13.245985,205.61044 26.053934,0.0175"
+       id="path112105-4-3-1" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.540705;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#Arrow1Lend-3-4-3-5)"
+       d="m -66.808164,154.37253 37.363707,0.0156"
+       id="path112105-4-3-1-6" />
+    <text
+       xml:space="preserve"
+       style="font-size:2.11667px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial, Normal';stroke-width:0.264583"
+       x="17.622671"
+       y="196.1456"
+       id="text115047-61"><tspan
+         sodipodi:role="line"
+         id="tspan115045-6"
+         style="font-size:2.11667px;stroke-width:0.264583"
+         x="17.622671"
+         y="196.1456">ADC_CLKP</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-size:2.11667px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial, Normal';stroke-width:0.264583"
+       x="18.219"
+       y="204.66855"
+       id="text115047-6-3"><tspan
+         sodipodi:role="line"
+         id="tspan115045-8-3"
+         style="font-size:2.11667px;stroke-width:0.264583"
+         x="18.219"
+         y="204.66855">ADC_CLKN</tspan></text>
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.465;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#Arrow1Lend-3-4-3)"
+       d="m 90.851794,220.77342 33.751736,0.0178"
+       id="path5"
+       sodipodi:nodetypes="cc" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.465;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#Arrow1Lend-3-4-3)"
+       d="m 90.851794,206.56674 33.751736,0.0178"
+       id="path6"
+       sodipodi:nodetypes="cc" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.465;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#Arrow1Lend-3-4-3)"
+       d="m 90.851794,191.91331 33.751736,0.0178"
+       id="path7"
+       sodipodi:nodetypes="cc" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.465;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#Arrow1Lend-3-4-3)"
+       d="m 90.851794,178.77883 33.751736,0.0178"
+       id="path8"
+       sodipodi:nodetypes="cc" />
+    <text
+       xml:space="preserve"
+       style="font-size:2.11667px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial, Normal';stroke-width:0.264583"
+       x="103.3095"
+       y="177.20335"
+       id="text4-5"><tspan
+         sodipodi:role="line"
+         id="tspan4-5"
+         style="font-size:2.11667px;stroke-width:0.264583"
+         x="103.3095"
+         y="177.20335">FCLKP</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-size:2.11667px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial, Normal';stroke-width:0.264583"
+       x="103.3095"
+       y="190.06978"
+       id="text5-3"><tspan
+         sodipodi:role="line"
+         id="tspan5-2"
+         style="font-size:2.11667px;stroke-width:0.264583"
+         x="103.3095"
+         y="190.06978">FCLKN</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-size:2.11667px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial, Normal';stroke-width:0.264583"
+       x="103.3095"
+       y="205.08061"
+       id="text6-8"><tspan
+         sodipodi:role="line"
+         id="tspan6-2"
+         style="font-size:2.11667px;stroke-width:0.264583"
+         x="103.3095"
+         y="205.08061">LCLKP</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-size:2.11667px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial, Normal';stroke-width:0.264583"
+       x="103.3095"
+       y="219.28729"
+       id="text7-5"><tspan
+         sodipodi:role="line"
+         id="tspan7-3"
+         style="font-size:2.11667px;stroke-width:0.264583"
+         x="103.3095"
+         y="219.28729">LCLKN</tspan></text>
+    <rect
+       style="fill:#aaccee;fill-opacity:1;fill-rule:evenodd;stroke:#003366;stroke-width:0.708381;stroke-linecap:round;stroke-linejoin:round;stroke-dashoffset:75.5906;stroke-opacity:1"
+       id="rect92805-4-6"
+       width="47.534294"
+       height="80.906189"
+       x="41.098122"
+       y="160.85941" />
+    <text
+       xml:space="preserve"
+       transform="matrix(0.26458333,0,0,0.26458333,-12.061518,161.93839)"
+       id="text1-1"
+       style="font-size:8px;font-family:Sans;-inkscape-font-specification:'Sans, Normal';text-align:center;writing-mode:lr-tb;direction:ltr;white-space:pre;shape-inside:url(#rect1-2);display:inline;fill:#000000;stroke-width:1.2926;stroke-dasharray:0.12926, 0.12926"
+       x="68.891098"
+       y="0"><tspan
+         x="231.63714"
+         y="145.51685"
+         id="tspan14"><tspan
+           style="font-size:21.3333px;font-family:Arial;-inkscape-font-specification:'Arial, Normal'"
+           id="tspan13">HMCAD1520</tspan></tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-weight:bold;font-size:5.64444px;font-family:Arial;-inkscape-font-specification:'Arial Bold';writing-mode:lr-tb;direction:ltr;fill:#000000;stroke-width:0.37121;stroke-dasharray:1.48484, 1.48484;stroke-dashoffset:0.222726"
+       x="-6.6097274"
+       y="153.51613"
+       id="text9"><tspan
+         sodipodi:role="line"
+         id="tspan9"
+         style="stroke-width:0.37121"
+         x="-6.6097274"
+         y="153.51613"></tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-weight:bold;font-size:5.64444px;font-family:Arial;-inkscape-font-specification:'Arial Bold';writing-mode:lr-tb;direction:ltr;fill:#000000;stroke-width:0.37121;stroke-dasharray:1.48484, 1.48484;stroke-dashoffset:0.222726"
+       x="-78.26857"
+       y="164.77425"
+       id="text10"><tspan
+         sodipodi:role="line"
+         id="tspan10"
+         style="stroke-width:0.37121"
+         x="-78.26857"
+         y="164.77425"></tspan></text>
+  </g>
+</svg>

--- a/docs/projects/admx6020m/index.rst
+++ b/docs/projects/admx6020m/index.rst
@@ -1,0 +1,297 @@
+.. _admx6020m:
+
+ADMX6020M HDL Project
+===============================================================================
+
+Overview
+-------------------------------------------------------------------------------
+
+The ADMX6020M is a dual-channel HMCAD15xx ADC data acquisition system targeting
+Xilinx Zynq-7000. It supports synchronous capture from both ADCs in all
+supported resolutions (8/12/14-bit) for up to 64KB of data per channel.
+
+The design uses the TDD IP to generate a sync signal that triggers simultaneous
+capture start on both ADC channels, ensuring sample-aligned data acquisition.
+
+Key features:
+
+- 1 GSPS sampling rate (1 ns time resolution) / 8-bit vertical resolution
+- 2 differential input channels
+- 50-ohm input impedance
+- 0°C to 85°C(ambient)
+- Configurable input range (0.5V to 1.5V default, configurable to -4V min to
+  +4V max)
+- Built-in non-volatile storage
+- Programmable trigger functionality
+- SPI, I2C, USB interfaces for control and data offloading
+
+Supported boards
+-------------------------------------------------------------------------------
+
+- ADMX6020M
+
+Supported devices
+-------------------------------------------------------------------------------
+
+- :adi:`HMCAD1511` (12-bit, 1-channel)
+- :adi:`HMCAD1520` (14-bit, 4-channel)
+- :adi:`ADF4355` (PLL/clock generator)
+- :adi:`ADP5589` (GPIO expander)
+- :adi:`AD5696` (DAC)
+
+Block design
+-------------------------------------------------------------------------------
+
+The design implements a dual ADC capture system with BRAM-based data offload
+for synchronized acquisition. Each ADC channel has its own data path consisting
+of an LVDS interface, BRAM buffer, and DMA engine.
+
+Block diagram
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The data path and clock domains are depicted in the below diagram:
+
+.. image:: admx6020m_block_diagram.svg
+   :width: 1000
+   :align: center
+   :alt: ADMX6020M block diagram
+
+Clock scheme
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. image:: admx6020m_clock_scheme.svg
+   :width: 800
+   :align: center
+   :alt: ADMX6020M clock scheme
+
+The design uses the following clock domains(all the rates are described at the
+highest sampling rate of 1 GSPS):
+
+.. list-table::
+   :widths: 20 20 60
+   :header-rows: 1
+
+   * - Clock
+     - Frequency
+     - Description
+   * - FCLK_CLK0
+     - 100 MHz
+     - CPU clock, AXI register access
+   * - FCLK_CLK1
+     - 200 MHz
+     - IODELAY reference clock
+   * - FCLK_CLK2
+     - 150 MHz
+     - DMA clock DATA offload output
+   * - ref_clk_a1/a2
+     - 500 MHz
+     - ADC LVDS input clock (from ADF4355)
+   * - adc_clk/adc_clk_1
+     - 125 MHz
+     - Divided ADC clock (ref_clk/4)
+
+The ADF4355 PLL provides the 1GHz reference clock to both ADCs which then is
+sent to the FPGA as the 500MHz reference clock(ref_clk_a1/a2).
+The LVDS interface deserializes the DDR data and divides the clock by 4 to
+produce the 125 MHz sample clock.
+
+Configuration modes
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The design supports the following ADC operating modes controlled via SPI:
+
+- **8-bit mode**: 1 GSPS, single channel
+- **12-bit mode**: 500 MSPS, single channel (HMCAD1511)
+- **dual 8-bit mode (14-bit resolution)**: 125 MSPS, 4 channels interleaved
+  (HMCAD1520)
+
+The ``axi_hmcad15xx`` IP parameters:
+
+.. list-table::
+   :widths: 30 70
+   :header-rows: 1
+
+   * - Parameter
+     - Description
+   * - NUM_CHANNELS
+     - Number of ADC channels (1-4)
+   * - IODELAY_CTRL
+     - Set to 1 for one instance only (shared IDELAYCTRL)
+
+CPU/Memory interconnects addresses
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The addresses are dependent on the architecture of the FPGA, having an offset
+added to the base address from HDL (see more at :ref:`architecture cpu-intercon-addr`).
+
+==================== ===========
+Instance             Zynq
+==================== ===========
+axi_iic_main         0x4160_0000
+axi_hmcad15xx_a1_adc 0x44A0_0000
+hmcad15xx_a1_dma     0x44A3_0000
+axi_hmcad15xx_a2_adc 0x44A6_0000
+hmcad15xx_a2_dma     0x44A9_0000
+axi_tdd_sync         0x44AC_0000
+adc1_data_offload    0x44B0_0000
+adc2_data_offload    0x44B1_0000
+==================== ===========
+
+I2C connections
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. list-table::
+   :widths: 20 20 20 20 20
+   :header-rows: 1
+
+   * - I2C type
+     - I2C manager instance
+     - Alias
+     - Address
+     - I2C subordinate
+   * - PL
+     - axi_iic_main
+     - ---
+     - 0x34
+     - ADP5589 (GPIO expander)
+   * - PL
+     - axi_iic_main
+     - ---
+     - 0x0C
+     - AD5696 (DAC)
+   * - PL
+     - axi_iic_main
+     - ---
+     - 0x5F
+     - MAX31827 (temperature sensor)
+
+SPI connections
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. list-table::
+   :widths: 25 25 25 25
+   :header-rows: 1
+
+   * - SPI type
+     - SPI manager instance
+     - SPI subordinate
+     - CS
+   * - PS
+     - SPI 0
+     - HMCAD15xx (ADC1)
+     - 0
+   * - PS
+     - SPI 0
+     - HMCAD15xx (ADC2)
+     - 1
+   * - PS
+     - SPI 0
+     - ADF4355 (PLL)
+     - 2
+
+GPIOs
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. list-table::
+   :widths: 25 25 25 25
+   :header-rows: 2
+
+   * - GPIO signal
+     - Direction
+     - HDL GPIO EMIO
+     - Software GPIO
+   * -
+     - (from FPGA view)
+     -
+     - Zynq-7000
+   * - ad9696_ldac
+     - INOUT
+     - 0
+     - 54
+
+Interrupts
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Below are the Programmable Logic interrupts used in this project.
+
+=================== === ========== ===========
+Instance name       HDL Linux Zynq Actual Zynq
+=================== === ========== ===========
+axi_iic_main        15  59         91
+hmcad15xx_a2_dma    13  57         89
+hmcad15xx_a1_dma    12  56         88
+=================== === ========== ===========
+
+Building the HDL project
+-------------------------------------------------------------------------------
+
+The design is built upon ADI's generic HDL reference design framework.
+ADI distributes the bit/elf files of these projects as part of the
+:dokuwiki:`ADI Kuiper Linux <resources/tools-software/linux-software/kuiper-linux>`.
+If you want to build the sources, ADI makes them available on the
+:git-hdl:`HDL repository </>`. To get the source you must
+`clone <https://git-scm.com/book/en/v2/Git-Basics-Getting-a-Git-Repository>`__
+the HDL repository.
+
+Go to the hdl/projects/**admx6020m** location and run the make command.
+
+**Linux/Cygwin/WSL**
+
+.. shell::
+
+   $cd hdl/projects/admx6020m
+   $make
+
+A more comprehensive build guide can be found in the :ref:`build_hdl` user
+guide.
+
+Resources
+-------------------------------------------------------------------------------
+
+Hardware related
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+- Product datasheets:
+
+  - :adi:`HMCAD1520`
+  - :adi:`ADF4355`
+
+HDL related
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+- :git-hdl:`ADMX6020M HDL project source code <projects/admx6020m>`
+
+.. list-table::
+   :widths: 30 35 35
+   :header-rows: 1
+
+   * - IP name
+     - Source code link
+     - Documentation link
+   * - AXI_HMCAD15XX
+     - :git-hdl:`library/axi_hmcad15xx`
+     - :ref:`axi_hmcad15xx`
+   * - AXI_DMAC
+     - :git-hdl:`library/axi_dmac`
+     - :ref:`axi_dmac`
+   * - AXI_TDD
+     - :git-hdl:`library/axi_tdd`
+     - :ref:`axi_tdd`
+   * - DATA_OFFLOAD
+     - :git-hdl:`library/data_offload`
+     - :ref:`data_offload`
+   * - UTIL_DO_RAM
+     - :git-hdl:`library/util_do_ram`
+     - ---
+
+Software related
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+- :git-linux:`ADMX6020M device tree (14-bit) <gui+sharkbyte_pr:arch/arm/boot/dts/xilinx/zynq-admx6020m_14b.dts>`
+- :git-linux:`ADMX6020M device tree (12-bit) <gui+sharkbyte_pr:arch/arm/boot/dts/xilinx/zynq-admx6020m_12b.dts>`
+- :git-linux:`ADMX6020M device tree (8-bit) <gui+sharkbyte_pr:arch/arm/boot/dts/xilinx/zynq-admx6020m.dts>`
+- :git-linux:`HMCAD15XX Linux driver <gui+sharkbyte_pr:drivers/iio/adc/hmcad15xx.c>`
+
+.. include:: ../common/more_information.rst
+
+.. include:: ../common/support.rst

--- a/docs/projects/hmcad1520_ebz/hmcad1520_ebz_clock_scheme.svg
+++ b/docs/projects/hmcad1520_ebz/hmcad1520_ebz_clock_scheme.svg
@@ -1,0 +1,412 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="191.13405mm"
+   height="86.798576mm"
+   viewBox="0 0 191.13405 86.798574"
+   version="1.1"
+   id="svg92524"
+   sodipodi:docname="hmcad1520_ebz_clock_scheme.svg"
+   inkscape:version="1.4.3 (0d15f75, 2025-12-25)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+     id="namedview92526"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:document-units="mm"
+     showgrid="false"
+     inkscape:zoom="2.0938813"
+     inkscape:cx="356.51496"
+     inkscape:cy="176.94413"
+     inkscape:window-width="2400"
+     inkscape:window-height="1262"
+     inkscape:window-x="2392"
+     inkscape:window-y="-8"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="layer1"
+     inkscape:showpageshadow="2"
+     inkscape:deskcolor="#d1d1d1" />
+  <defs
+     id="defs92521">
+    <rect
+       x="225.58458"
+       y="126.30035"
+       width="137.7822"
+       height="62.812473"
+       id="rect1" />
+    <marker
+       style="overflow:visible"
+       id="Arrow1Lend"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Lend"
+       inkscape:isstock="true">
+      <path
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         style="fill:context-stroke;fill-rule:evenodd;stroke:context-stroke;stroke-width:1pt"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path42052" />
+    </marker>
+    <rect
+       x="155.69173"
+       y="396.39307"
+       width="153.7814"
+       height="94.561234"
+       id="rect105127" />
+    <marker
+       style="overflow:visible"
+       id="Arrow1Lend-3"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Lend"
+       inkscape:isstock="true">
+      <path
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         style="fill:context-stroke;fill-rule:evenodd;stroke:context-stroke;stroke-width:1pt"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path42052-2" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="Arrow1Lend-3-4"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Lend"
+       inkscape:isstock="true">
+      <path
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         style="fill:context-stroke;fill-rule:evenodd;stroke:context-stroke;stroke-width:1pt"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path42052-2-7" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="Arrow1Lend-3-2"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Lend"
+       inkscape:isstock="true">
+      <path
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         style="fill:context-stroke;fill-rule:evenodd;stroke:context-stroke;stroke-width:1pt"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path42052-2-2" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="Arrow1Lend-3-4-2"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Lend"
+       inkscape:isstock="true">
+      <path
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         style="fill:context-stroke;fill-rule:evenodd;stroke:context-stroke;stroke-width:1pt"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path42052-2-7-9" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="Arrow1Lend-3-1"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Lend"
+       inkscape:isstock="true">
+      <path
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         style="fill:context-stroke;fill-rule:evenodd;stroke:context-stroke;stroke-width:1pt"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path42052-2-5" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="Arrow1Lend-3-4-6"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Lend"
+       inkscape:isstock="true">
+      <path
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         style="fill:context-stroke;fill-rule:evenodd;stroke:context-stroke;stroke-width:1pt"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path42052-2-7-2" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="Arrow1Lend-3-23"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Lend"
+       inkscape:isstock="true">
+      <path
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         style="fill:context-stroke;fill-rule:evenodd;stroke:context-stroke;stroke-width:1pt"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path42052-2-0" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="Arrow1Lend-3-4-9"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Lend"
+       inkscape:isstock="true">
+      <path
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         style="fill:context-stroke;fill-rule:evenodd;stroke:context-stroke;stroke-width:1pt"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path42052-2-7-5" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="Arrow1Lend-3-1-7"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Lend"
+       inkscape:isstock="true">
+      <path
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         style="fill:context-stroke;fill-rule:evenodd;stroke:context-stroke;stroke-width:1pt"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path42052-2-5-7" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="Arrow1Lend-3-4-6-8"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Lend"
+       inkscape:isstock="true">
+      <path
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         style="fill:context-stroke;fill-rule:evenodd;stroke:context-stroke;stroke-width:1pt"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path42052-2-7-2-7" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="Arrow1Lend-3-4-2-6"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Lend"
+       inkscape:isstock="true">
+      <path
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         style="fill:context-stroke;fill-rule:evenodd;stroke:context-stroke;stroke-width:1pt"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path42052-2-7-9-2" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="Arrow1Lend-3-2-9"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Lend"
+       inkscape:isstock="true">
+      <path
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         style="fill:context-stroke;fill-rule:evenodd;stroke:context-stroke;stroke-width:1pt"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path42052-2-2-1" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="Arrow1Lend-3-4-2-6-0"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Lend"
+       inkscape:isstock="true">
+      <path
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         style="fill:context-stroke;fill-rule:evenodd;stroke:context-stroke;stroke-width:1pt"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path42052-2-7-9-2-6" />
+    </marker>
+  </defs>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(14.472543,-63.808551)">
+    <rect
+       style="fill:#aaccee;fill-opacity:1;fill-rule:evenodd;stroke:#003366;stroke-width:0.665001;stroke-linecap:round;stroke-linejoin:round;stroke-dashoffset:75.5906;stroke-opacity:1"
+       id="rect92805-43"
+       width="25.042"
+       height="16.984877"
+       x="-14.140042"
+       y="98.179298" />
+    <rect
+       style="fill:#ffcccc;fill-opacity:1;fill-rule:evenodd;stroke:#a01414;stroke-width:0.665002;stroke-linecap:round;stroke-linejoin:round;stroke-dashoffset:75.5906;stroke-opacity:1"
+       id="rect92805-1-8"
+       width="51.465702"
+       height="86.133575"
+       x="124.8633"
+       y="64.141052" />
+    <text
+       xml:space="preserve"
+       style="font-size:8.46667px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial, Normal';stroke-width:0.264583"
+       x="138.67809"
+       y="108.41707"
+       id="text103547"><tspan
+         sodipodi:role="line"
+         id="tspan103545"
+         style="stroke-width:0.264583"
+         x="138.67809"
+         y="108.41707">FPGA</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-size:4.23333px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial, Normal';stroke-width:0.264583"
+       x="-10.44045"
+       y="105.42447"
+       id="text110315"><tspan
+         sodipodi:role="line"
+         id="tspan110313"
+         style="font-size:4.23333px;stroke-width:0.264583"
+         x="-10.44045"
+         y="105.42447">EXT_CLK</tspan><tspan
+         sodipodi:role="line"
+         style="font-size:4.23333px;stroke-width:0.264583"
+         x="-10.44045"
+         y="110.71613"
+         id="tspan8"> 1GHz</tspan></text>
+    <g
+       id="g6763"
+       transform="translate(-64.421479,-7.5947653)">
+      <path
+         style="fill:none;stroke:#000000;stroke-width:0.465;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#Arrow1Lend-3)"
+         d="m 77.721384,110.72117 24.325296,0.0178"
+         id="path112105-4" />
+      <path
+         style="fill:none;stroke:#000000;stroke-width:0.465;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#Arrow1Lend-3-4)"
+         d="m 77.895159,119.18523 24.325291,0.0178"
+         id="path112105-4-3" />
+      <text
+         xml:space="preserve"
+         style="font-size:2.11667px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial, Normal';stroke-width:0.264583"
+         x="80.526627"
+         y="109.72063"
+         id="text115047"><tspan
+           sodipodi:role="line"
+           id="tspan115045"
+           style="font-size:2.11667px;stroke-width:0.264583"
+           x="80.526627"
+           y="109.72063">ADC_CLKP</tspan></text>
+      <text
+         xml:space="preserve"
+         style="font-size:2.11667px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial, Normal';stroke-width:0.264583"
+         x="81.122955"
+         y="118.24358"
+         id="text115047-6"><tspan
+           sodipodi:role="line"
+           id="tspan115045-8"
+           style="font-size:2.11667px;stroke-width:0.264583"
+           x="81.122955"
+           y="118.24358">ADC_CLKN</tspan></text>
+      <path
+         style="fill:none;stroke:#000000;stroke-width:0.465;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#Arrow1Lend-3-4)"
+         d="m 153.75575,134.34845 33.75174,0.0178"
+         id="path1"
+         sodipodi:nodetypes="cc" />
+      <path
+         style="fill:none;stroke:#000000;stroke-width:0.465;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#Arrow1Lend-3-4)"
+         d="m 153.75575,120.14177 33.75174,0.0178"
+         id="path2"
+         sodipodi:nodetypes="cc" />
+      <path
+         style="fill:none;stroke:#000000;stroke-width:0.465;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#Arrow1Lend-3-4)"
+         d="m 153.75575,105.48834 33.75174,0.0178"
+         id="path3"
+         sodipodi:nodetypes="cc" />
+      <path
+         style="fill:none;stroke:#000000;stroke-width:0.465;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#Arrow1Lend-3-4)"
+         d="m 153.75575,92.353864 33.75174,0.0178"
+         id="path4"
+         sodipodi:nodetypes="cc" />
+      <text
+         xml:space="preserve"
+         style="font-size:2.11667px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial, Normal';stroke-width:0.264583"
+         x="166.21346"
+         y="90.778389"
+         id="text4"><tspan
+           sodipodi:role="line"
+           id="tspan4"
+           style="font-size:2.11667px;stroke-width:0.264583"
+           x="166.21346"
+           y="90.778389">FCLKP</tspan></text>
+      <text
+         xml:space="preserve"
+         style="font-size:2.11667px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial, Normal';stroke-width:0.264583"
+         x="166.21346"
+         y="103.64481"
+         id="text5"><tspan
+           sodipodi:role="line"
+           id="tspan5"
+           style="font-size:2.11667px;stroke-width:0.264583"
+           x="166.21346"
+           y="103.64481">FCLKN</tspan></text>
+      <text
+         xml:space="preserve"
+         style="font-size:2.11667px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial, Normal';stroke-width:0.264583"
+         x="166.21346"
+         y="118.65565"
+         id="text6"><tspan
+           sodipodi:role="line"
+           id="tspan6"
+           style="font-size:2.11667px;stroke-width:0.264583"
+           x="166.21346"
+           y="118.65565">LCLKP</tspan></text>
+      <text
+         xml:space="preserve"
+         style="font-size:2.11667px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial, Normal';stroke-width:0.264583"
+         x="166.21346"
+         y="132.86232"
+         id="text7"><tspan
+           sodipodi:role="line"
+           id="tspan7"
+           style="font-size:2.11667px;stroke-width:0.264583"
+           x="166.21346"
+           y="132.86232">LCLKN</tspan></text>
+    </g>
+    <rect
+       style="fill:#aaccee;fill-opacity:1;fill-rule:evenodd;stroke:#003366;stroke-width:0.708381;stroke-linecap:round;stroke-linejoin:round;stroke-dashoffset:75.5906;stroke-opacity:1"
+       id="rect92805-4"
+       width="47.534294"
+       height="80.906189"
+       x="41.098122"
+       y="66.839668" />
+    <text
+       xml:space="preserve"
+       transform="matrix(0.26458333,0,0,0.26458333,-13.579041,67.918659)"
+       id="text1"
+       style="font-size:8px;font-family:Sans;-inkscape-font-specification:'Sans, Normal';text-align:center;writing-mode:lr-tb;direction:ltr;white-space:pre;shape-inside:url(#rect1);display:inline;fill:#000000;stroke-width:1.2926;stroke-dasharray:0.12926, 0.12926"
+       x="68.891098"
+       y="0"><tspan
+         x="231.63714"
+         y="145.51685"
+         id="tspan3"><tspan
+           style="font-size:21.3333px;font-family:Arial;-inkscape-font-specification:'Arial, Normal'"
+           id="tspan2">HMCAD1520</tspan></tspan></text>
+  </g>
+</svg>

--- a/docs/projects/hmcad1520_ebz/hmcad1520_ebz_zed_block_diagram.svg
+++ b/docs/projects/hmcad1520_ebz/hmcad1520_ebz_zed_block_diagram.svg
@@ -1,0 +1,1700 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="160.82281mm"
+   height="132.78648mm"
+   viewBox="0 0 160.82281 132.78648"
+   version="1.1"
+   id="svg29591"
+   inkscape:version="1.4.3 (0d15f75, 2025-12-25)"
+   sodipodi:docname="hmcad1520_ebz_zed_block_diagram.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+     id="namedview29593"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:document-units="mm"
+     showgrid="false"
+     inkscape:zoom="1.4142136"
+     inkscape:cx="187.02974"
+     inkscape:cy="417.54655"
+     inkscape:window-width="2400"
+     inkscape:window-height="1262"
+     inkscape:window-x="2392"
+     inkscape:window-y="-8"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="layer1"
+     inkscape:showpageshadow="2"
+     inkscape:deskcolor="#d1d1d1" />
+  <defs
+     id="defs29588">
+    <rect
+       x="227.01417"
+       y="266.41333"
+       width="48.310868"
+       height="26.73514"
+       id="rect23" />
+    <rect
+       x="225.52855"
+       y="269.97094"
+       width="44.44239"
+       height="22.884514"
+       id="rect22" />
+    <rect
+       x="222.87527"
+       y="267.98098"
+       width="52.733881"
+       height="21.226216"
+       id="rect21" />
+    <rect
+       x="152.64107"
+       y="344.79321"
+       width="66.527192"
+       height="21.275193"
+       id="rect1" />
+    <marker
+       inkscape:stockid="TriangleInM"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="TriangleInM-7-1"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         inkscape:connector-curvature="0"
+         id="path4660-1-6"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="scale(-0.4)" />
+    </marker>
+    <marker
+       inkscape:stockid="TriangleOutM"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker9011"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         inkscape:connector-curvature="0"
+         id="path9009"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="scale(0.4)" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker1216-7"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="TriangleOutM">
+      <path
+         transform="scale(0.4)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         id="path1214-5"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker1216-9-3"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="TriangleOutM">
+      <path
+         transform="scale(0.4)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         id="path1214-1-6"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker1216-0-3"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="TriangleOutM">
+      <path
+         transform="scale(0.4)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         id="path1214-3-7"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker1216-0-3-9"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="TriangleOutM">
+      <path
+         transform="scale(0.4)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         id="path1214-3-7-7"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker1216"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="TriangleOutM"
+       inkscape:collect="always">
+      <path
+         transform="scale(0.4)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         id="path1214"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker1216-9"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="TriangleOutM">
+      <path
+         transform="scale(0.4)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         id="path1214-1"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:stockid="TriangleInM"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker30716"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         inkscape:connector-curvature="0"
+         id="path30714"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="scale(-0.4)" />
+    </marker>
+    <marker
+       inkscape:stockid="TriangleOutM"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="TriangleOutM-2-8"
+       style="overflow:visible"
+       inkscape:isstock="true"
+       inkscape:collect="always">
+      <path
+         inkscape:connector-curvature="0"
+         id="path4669-5-5"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="scale(0.4)" />
+    </marker>
+    <marker
+       inkscape:stockid="TriangleInM"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="TriangleInM-7"
+       style="overflow:visible"
+       inkscape:isstock="true"
+       inkscape:collect="always">
+      <path
+         inkscape:connector-curvature="0"
+         id="path4660-1"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="scale(-0.4)" />
+    </marker>
+    <marker
+       inkscape:stockid="TriangleOutM"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="TriangleOutM-2"
+       style="overflow:visible"
+       inkscape:isstock="true"
+       inkscape:collect="always">
+      <path
+         inkscape:connector-curvature="0"
+         id="path4669-5"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="scale(0.4)" />
+    </marker>
+    <marker
+       inkscape:stockid="TriangleInM"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="TriangleInM"
+       style="overflow:visible"
+       inkscape:isstock="true"
+       inkscape:collect="always">
+      <path
+         id="path4660"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="scale(-0.4)"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:stockid="TriangleOutM"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="TriangleOutM"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path4669"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="scale(0.4)"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <rect
+       x="505.75934"
+       y="440.80817"
+       width="91.509193"
+       height="18.625698"
+       id="rect4760" />
+    <rect
+       x="505.75934"
+       y="440.80817"
+       width="91.509193"
+       height="18.625698"
+       id="rect4760-6" />
+    <rect
+       x="298.96634"
+       y="469.9407"
+       width="124.17132"
+       height="41.072052"
+       id="rect24670" />
+    <rect
+       x="298.96634"
+       y="469.9407"
+       width="124.17132"
+       height="41.072052"
+       id="rect24670-6" />
+    <marker
+       style="overflow:visible"
+       id="TriangleInM-3"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="TriangleInM"
+       inkscape:isstock="true">
+      <path
+         transform="scale(-0.4)"
+         style="fill:context-stroke;fill-rule:evenodd;stroke:context-stroke;stroke-width:1pt"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         id="path42185" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="marker51146"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="TriangleInM"
+       inkscape:isstock="true">
+      <path
+         transform="scale(-0.4)"
+         style="fill:context-stroke;fill-rule:evenodd;stroke:context-stroke;stroke-width:1pt"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         id="path51144" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="TriangleInM-0"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="TriangleInM"
+       inkscape:isstock="true">
+      <path
+         transform="scale(-0.4)"
+         style="fill:context-stroke;fill-rule:evenodd;stroke:context-stroke;stroke-width:1pt"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         id="path42185-3" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="marker51146-9"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="TriangleInM"
+       inkscape:isstock="true">
+      <path
+         transform="scale(-0.4)"
+         style="fill:context-stroke;fill-rule:evenodd;stroke:context-stroke;stroke-width:1pt"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         id="path51144-3" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="TriangleOutM-0"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="TriangleOutM"
+       inkscape:isstock="true">
+      <path
+         transform="scale(0.4)"
+         style="fill:context-stroke;fill-rule:evenodd;stroke:context-stroke;stroke-width:1pt"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         id="path42194" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="TriangleOutM-6"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="TriangleOutM"
+       inkscape:isstock="true">
+      <path
+         transform="scale(0.4)"
+         style="fill:context-stroke;fill-rule:evenodd;stroke:context-stroke;stroke-width:1pt"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         id="path42194-3" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="TriangleOutM-45"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="TriangleOutM"
+       inkscape:isstock="true">
+      <path
+         transform="scale(0.4)"
+         style="fill:context-stroke;fill-rule:evenodd;stroke:context-stroke;stroke-width:1pt"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         id="path42194-03" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="TriangleOutM-6-1"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="TriangleOutM"
+       inkscape:isstock="true">
+      <path
+         transform="scale(0.4)"
+         style="fill:context-stroke;fill-rule:evenodd;stroke:context-stroke;stroke-width:1pt"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         id="path42194-3-3" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="TriangleOutM-45-7"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="TriangleOutM"
+       inkscape:isstock="true">
+      <path
+         transform="scale(0.4)"
+         style="fill:context-stroke;fill-rule:evenodd;stroke:context-stroke;stroke-width:1pt"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         id="path42194-03-3" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="TriangleOutM-6-1-9"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="TriangleOutM"
+       inkscape:isstock="true">
+      <path
+         transform="scale(0.4)"
+         style="fill:context-stroke;fill-rule:evenodd;stroke:context-stroke;stroke-width:1pt"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         id="path42194-3-3-6" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="TriangleOutM-45-7-3"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="TriangleOutM"
+       inkscape:isstock="true">
+      <path
+         transform="scale(0.4)"
+         style="fill:context-stroke;fill-rule:evenodd;stroke:context-stroke;stroke-width:1pt"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         id="path42194-03-3-3" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="TriangleOutM-6-1-9-9"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="TriangleOutM"
+       inkscape:isstock="true">
+      <path
+         transform="scale(0.4)"
+         style="fill:context-stroke;fill-rule:evenodd;stroke:context-stroke;stroke-width:1pt"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         id="path42194-3-3-6-9" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="TriangleOutM-45-3"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="TriangleOutM"
+       inkscape:isstock="true">
+      <path
+         transform="scale(0.4)"
+         style="fill:context-stroke;fill-rule:evenodd;stroke:context-stroke;stroke-width:1pt"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         id="path42194-03-5" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="TriangleOutM-6-1-7"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="TriangleOutM"
+       inkscape:isstock="true">
+      <path
+         transform="scale(0.4)"
+         style="fill:context-stroke;fill-rule:evenodd;stroke:context-stroke;stroke-width:1pt"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         id="path42194-3-3-0" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="TriangleOutM-45-3-2"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="TriangleOutM"
+       inkscape:isstock="true">
+      <path
+         transform="scale(0.4)"
+         style="fill:context-stroke;fill-rule:evenodd;stroke:context-stroke;stroke-width:1pt"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         id="path42194-03-5-4" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="TriangleOutM-45-3-2-9"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="TriangleOutM"
+       inkscape:isstock="true">
+      <path
+         transform="scale(0.4)"
+         style="fill:context-stroke;fill-rule:evenodd;stroke:context-stroke;stroke-width:1pt"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         id="path42194-03-5-4-1" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="TriangleOutM-6-1-7-6-7"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="TriangleOutM"
+       inkscape:isstock="true">
+      <path
+         transform="scale(0.4)"
+         style="fill:context-stroke;fill-rule:evenodd;stroke:context-stroke;stroke-width:1pt"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         id="path42194-3-3-0-2-2" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="TriangleOutM-8"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="TriangleOutM"
+       inkscape:isstock="true">
+      <path
+         transform="scale(0.4)"
+         style="fill:context-stroke;fill-rule:evenodd;stroke:context-stroke;stroke-width:1pt"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         id="path42194-38" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="TriangleOutM-6-7"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="TriangleOutM"
+       inkscape:isstock="true">
+      <path
+         transform="scale(0.4)"
+         style="fill:context-stroke;fill-rule:evenodd;stroke:context-stroke;stroke-width:1pt"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         id="path42194-3-36" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker1216-9-6"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="TriangleOutM">
+      <path
+         transform="scale(0.4)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         id="path1214-1-4"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker1216-9-9"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="TriangleOutM">
+      <path
+         transform="scale(0.4)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         id="path1214-1-7"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <rect
+       x="298.96634"
+       y="469.9407"
+       width="124.17132"
+       height="41.072052"
+       id="rect13" />
+    <rect
+       x="298.96634"
+       y="469.9407"
+       width="124.17132"
+       height="41.072052"
+       id="rect16" />
+    <rect
+       x="298.96634"
+       y="469.9407"
+       width="124.17132"
+       height="41.072052"
+       id="rect19" />
+  </defs>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(-45.687375,-26.530943)">
+    <rect
+       style="display:inline;vector-effect:none;fill:none;fill-opacity:1;stroke:#3f4b55;stroke-width:0.333552;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:0.333552, 1.00066;stroke-dashoffset:0;stroke-opacity:1;shape-rendering:crispEdges;enable-background:new"
+       id="rect6078-6"
+       width="76.035355"
+       height="86.956375"
+       x="79.388474"
+       y="69.981445"
+       inkscape:export-xdpi="224.36"
+       inkscape:export-ydpi="224.36" />
+    <rect
+       style="display:inline;fill:none;fill-opacity:1;stroke:#3f4b55;stroke-width:0.436;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:0.436,1.308;stroke-dashoffset:0;stroke-opacity:1;shape-rendering:crispEdges;enable-background:new"
+       id="rect6078"
+       width="45.067265"
+       height="73.748421"
+       x="156.29265"
+       y="78.586243"
+       inkscape:export-xdpi="224.36"
+       inkscape:export-ydpi="224.36" />
+    <rect
+       style="fill:#fefdfe;fill-opacity:1;fill-rule:evenodd;stroke:#071414;stroke-width:0.438228;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:75.5906;stroke-opacity:1"
+       id="rect46745"
+       width="58.360218"
+       height="66.951752"
+       x="100.41457"
+       y="79.821976" />
+    <rect
+       style="display:inline;fill:#000000;fill-opacity:0;fill-rule:nonzero;stroke:#000000;stroke-width:0.330549;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:0;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;shape-rendering:crispEdges;enable-background:new"
+       id="rect4477"
+       width="156.8378"
+       height="116.72887"
+       x="45.85265"
+       y="42.423283"
+       inkscape:export-xdpi="224.36"
+       inkscape:export-ydpi="224.36" />
+    <path
+       sodipodi:nodetypes="cc"
+       inkscape:connector-curvature="0"
+       id="path4518"
+       d="M 133.57232,45.349186 V 40.279672"
+       style="display:inline;fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:0.396875;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-start:url(#TriangleInM);marker-end:url(#TriangleOutM);shape-rendering:crispEdges;enable-background:new"
+       inkscape:export-xdpi="224.36"
+       inkscape:export-ydpi="224.36" />
+    <path
+       sodipodi:nodetypes="cc"
+       inkscape:connector-curvature="0"
+       id="path4518-5"
+       d="M 140.48242,45.347446 V 40.304278"
+       style="display:inline;fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:0.396875;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-start:url(#TriangleInM-7);marker-end:url(#TriangleOutM-2);shape-rendering:crispEdges;enable-background:new"
+       inkscape:export-xdpi="224.36"
+       inkscape:export-ydpi="224.36" />
+    <path
+       sodipodi:nodetypes="cc"
+       inkscape:connector-curvature="0"
+       id="path4518-5-9"
+       d="M 147.39251,45.34172 V 40.272264"
+       style="display:inline;fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:0.396875;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-start:url(#TriangleInM-7-1);marker-end:url(#TriangleOutM-2-8);shape-rendering:crispEdges;enable-background:new"
+       inkscape:export-xdpi="224.36"
+       inkscape:export-ydpi="224.36" />
+    <rect
+       transform="scale(-1,1)"
+       style="display:inline;fill:#ebebeb;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.500933;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:0;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;shape-rendering:crispEdges"
+       id="rect4136"
+       width="111.22163"
+       height="19.844805"
+       x="-164.83311"
+       y="46.539265"
+       inkscape:export-xdpi="224.36"
+       inkscape:export-ydpi="224.36" />
+    <path
+       style="display:inline;fill:#a2dcea;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.529167;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;shape-rendering:crispEdges"
+       d="M 157.54764,46.715505 V 66.42975"
+       id="path4179"
+       inkscape:connector-curvature="0"
+       inkscape:export-xdpi="224.36"
+       inkscape:export-ydpi="224.36" />
+    <path
+       style="display:inline;fill:#a2dcea;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.529167;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;shape-rendering:crispEdges"
+       d="M 150.76627,46.715505 V 66.42975"
+       id="path4179-9"
+       inkscape:connector-curvature="0"
+       inkscape:export-xdpi="224.36"
+       inkscape:export-ydpi="224.36" />
+    <path
+       style="display:inline;fill:#a2dcea;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.529167;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;shape-rendering:crispEdges"
+       d="M 123.64077,46.715505 V 66.42975"
+       id="path4179-0"
+       inkscape:connector-curvature="0"
+       inkscape:export-xdpi="224.36"
+       inkscape:export-ydpi="224.36" />
+    <path
+       style="display:inline;fill:#a2dcea;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.529167;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;shape-rendering:crispEdges"
+       d="M 130.42215,46.715505 V 66.42975"
+       id="path4179-4"
+       inkscape:connector-curvature="0"
+       inkscape:export-xdpi="224.36"
+       inkscape:export-ydpi="224.36" />
+    <path
+       style="display:inline;fill:#a2dcea;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.529167;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;shape-rendering:crispEdges"
+       d="M 137.20352,46.715505 V 66.42975"
+       id="path4179-7"
+       inkscape:connector-curvature="0"
+       inkscape:export-xdpi="224.36"
+       inkscape:export-ydpi="224.36" />
+    <path
+       style="display:inline;fill:#a2dcea;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.529167;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;shape-rendering:crispEdges"
+       d="M 143.98489,46.715505 V 66.42975"
+       id="path4179-41"
+       inkscape:connector-curvature="0"
+       inkscape:export-xdpi="224.36"
+       inkscape:export-ydpi="224.36" />
+    <path
+       style="display:inline;fill:#a2dcea;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.529167;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;shape-rendering:crispEdges"
+       d="M 116.8594,46.715505 V 66.42975"
+       id="path4179-0-3"
+       inkscape:connector-curvature="0"
+       inkscape:export-xdpi="224.36"
+       inkscape:export-ydpi="224.36" />
+    <text
+       transform="matrix(0,-1.0072219,0.9928299,0,0,0)"
+       id="text4229"
+       y="142.68727"
+       x="-62.18874"
+       style="font-style:normal;font-weight:normal;font-size:3.175px;line-height:0%;font-family:Arial;letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;shape-rendering:crispEdges"
+       xml:space="preserve"
+       inkscape:export-xdpi="224.36"
+       inkscape:export-ydpi="224.36"><tspan
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:2.97656px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial Bold';stroke-width:0.264583px"
+         y="142.68727"
+         x="-62.18874"
+         id="tspan4231"
+         sodipodi:role="line">Ethernet</tspan></text>
+    <text
+       transform="matrix(0,-1.0072219,0.9928299,0,0,0)"
+       id="text4233"
+       y="149.24825"
+       x="-60.271706"
+       style="font-style:normal;font-weight:normal;font-size:3.175px;line-height:0%;font-family:Arial;letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;shape-rendering:crispEdges"
+       xml:space="preserve"
+       inkscape:export-xdpi="224.36"
+       inkscape:export-ydpi="224.36"><tspan
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:2.97656px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial Bold';stroke-width:0.264583px"
+         y="149.24825"
+         x="-60.271706"
+         id="tspan4235"
+         sodipodi:role="line">UART</tspan></text>
+    <text
+       transform="matrix(0,-1.0072219,0.9928299,0,0,0)"
+       id="text4237"
+       y="136.0764"
+       x="-60.204849"
+       style="font-style:normal;font-weight:normal;font-size:3.175px;line-height:0%;font-family:Arial;letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;shape-rendering:crispEdges"
+       xml:space="preserve"
+       inkscape:export-xdpi="224.36"
+       inkscape:export-ydpi="224.36"><tspan
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:2.97656px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial Bold';stroke-width:0.264583px"
+         y="136.0764"
+         x="-60.204849"
+         id="tspan4239"
+         sodipodi:role="line">DDRx</tspan></text>
+    <text
+       transform="matrix(0,-1.0072219,0.9928299,0,0,0)"
+       id="text4241"
+       y="162.90863"
+       x="-58.415714"
+       style="font-style:normal;font-weight:normal;font-size:3.175px;line-height:0%;font-family:Arial;letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;shape-rendering:crispEdges"
+       xml:space="preserve"
+       inkscape:export-xdpi="224.36"
+       inkscape:export-ydpi="224.36"><tspan
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:2.97656px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial Bold';stroke-width:0.264583px"
+         y="162.90863"
+         x="-58.415714"
+         id="tspan4243"
+         sodipodi:role="line">SPI</tspan></text>
+    <text
+       transform="matrix(0,-1.0072219,0.9928299,0,0,0)"
+       id="text4245"
+       y="156.43456"
+       x="-58.398273"
+       style="font-style:normal;font-weight:normal;font-size:3.175px;line-height:0%;font-family:Arial;letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;shape-rendering:crispEdges"
+       xml:space="preserve"
+       inkscape:export-xdpi="224.36"
+       inkscape:export-ydpi="224.36"><tspan
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:2.97656px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial Bold';stroke-width:0.264583px"
+         y="156.43456"
+         x="-58.398273"
+         id="tspan4247"
+         sodipodi:role="line">I<tspan
+   style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:2.97656px;font-family:Arial;-inkscape-font-specification:'Arial Bold';baseline-shift:super;stroke-width:0.264583px"
+   id="tspan4485">2</tspan>C</tspan></text>
+    <text
+       transform="matrix(0,-1.0072219,0.9928299,0,0,0)"
+       id="text4251"
+       y="129.04584"
+       x="-63.036072"
+       style="font-style:normal;font-weight:normal;font-size:3.175px;line-height:0%;font-family:Arial;letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;shape-rendering:crispEdges"
+       xml:space="preserve"
+       inkscape:export-xdpi="224.36"
+       inkscape:export-ydpi="224.36"><tspan
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:2.97656px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial Bold';stroke-width:0.264583px"
+         y="129.04584"
+         x="-63.036072"
+         id="tspan4253"
+         sodipodi:role="line">Interrupts</tspan></text>
+    <text
+       transform="scale(0.9928299,1.0072219)"
+       id="text4311"
+       y="27.874945"
+       x="82.596695"
+       style="font-style:normal;font-weight:normal;font-size:3.175px;line-height:0%;font-family:Arial;letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;shape-rendering:crispEdges"
+       xml:space="preserve"><tspan
+         y="27.874945"
+         x="82.596695"
+         id="tspan4313"
+         sodipodi:role="line"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:3.96875px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial Bold';stroke-width:0.264583px" /></text>
+    <text
+       transform="matrix(0,-1.0072219,0.9928299,0,0,0)"
+       id="text4301"
+       y="121.95177"
+       x="-60.131454"
+       style="font-style:normal;font-weight:normal;font-size:3.175px;line-height:0%;font-family:Arial;letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;shape-rendering:crispEdges"
+       xml:space="preserve"
+       inkscape:export-xdpi="224.36"
+       inkscape:export-ydpi="224.36"><tspan
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:2.97656px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial Bold';stroke-width:0.264583px"
+         y="121.95177"
+         x="-60.131454"
+         id="tspan4303"
+         sodipodi:role="line">Timer</tspan></text>
+    <rect
+       style="display:inline;vector-effect:none;fill:#ffcccc;fill-opacity:1;fill-rule:nonzero;stroke:#a01414;stroke-width:0.264583;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;shape-rendering:crispEdges;enable-background:new"
+       id="rect4589"
+       width="3.9288628"
+       height="4.2094946"
+       x="53.282852"
+       y="36.366516"
+       inkscape:export-xdpi="224.36"
+       inkscape:export-ydpi="224.36" />
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;font-size:3.175px;line-height:0%;font-family:Arial;letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;shape-rendering:crispEdges;enable-background:new"
+       x="58.305683"
+       y="39.394981"
+       id="text4595"
+       inkscape:export-xdpi="224.36"
+       inkscape:export-ydpi="224.36"><tspan
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:3.30729px;line-height:1.25;font-family:Arial;-inkscape-font-specification:Arial;stroke-width:0.264583px"
+         sodipodi:role="line"
+         id="tspan4597"
+         x="58.305683"
+         y="39.394981">Receive path</tspan></text>
+    <rect
+       style="display:inline;vector-effect:none;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.486876;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:0;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;shape-rendering:crispEdges;enable-background:new"
+       id="rect4487"
+       width="6.6456137"
+       height="53.193066"
+       x="55.800285"
+       y="85.137817"
+       inkscape:export-xdpi="224.36"
+       inkscape:export-ydpi="224.36" />
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:3.88056px;line-height:0%;font-family:Arial;-inkscape-font-specification:'Arial, Bold';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;shape-rendering:crispEdges;enable-background:new"
+       x="-136.32645"
+       y="60.250889"
+       id="text4489"
+       transform="rotate(-90)"
+       inkscape:export-xdpi="224.36"
+       inkscape:export-ydpi="224.36"><tspan
+         sodipodi:role="line"
+         id="tspan4491"
+         x="-136.32645"
+         y="60.250889"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:3.88056px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial, Bold';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;stroke-width:0.264583px">MEMORY INTERCONNECT</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;font-size:3.175px;line-height:0%;font-family:Arial;letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:0.858696;stroke:none;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;shape-rendering:crispEdges;enable-background:new"
+       x="179.62912"
+       y="57.091106"
+       id="text4482"
+       inkscape:export-xdpi="224.36"
+       inkscape:export-ydpi="224.36"><tspan
+         sodipodi:role="line"
+         x="179.62912"
+         y="57.091106"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:5.29167px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:0.858696;stroke-width:0.264583px"
+         id="tspan3725">ZedBoard</tspan></text>
+    <rect
+       style="display:inline;vector-effect:none;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.478442;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:0;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;shape-rendering:crispEdges;enable-background:new"
+       id="rect4488"
+       width="7.645824"
+       height="92.035782"
+       x="198.63475"
+       y="65.548294"
+       inkscape:export-xdpi="224.36"
+       inkscape:export-ydpi="224.36" />
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;font-size:3.175px;line-height:0%;font-family:Arial;letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;shape-rendering:crispEdges;enable-background:new"
+       x="-136.48291"
+       y="204.2204"
+       id="text4491"
+       transform="rotate(-90)"
+       inkscape:export-xdpi="224.36"
+       inkscape:export-ydpi="224.36"><tspan
+         sodipodi:role="line"
+         id="tspan4493"
+         x="-136.48291"
+         y="204.2204"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:4.63021px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial Bold';stroke-width:0.264583px">FMC CONNECTOR</tspan></text>
+    <rect
+       style="display:inline;fill:none;fill-opacity:1;stroke:#3f4b55;stroke-width:0.538112;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:0.538112, 1.61435;stroke-dashoffset:0;stroke-opacity:1;shape-rendering:crispEdges;enable-background:new"
+       id="rect6057"
+       width="27.030113"
+       height="86.814651"
+       x="48.339287"
+       y="69.953239"
+       inkscape:export-xdpi="224.36"
+       inkscape:export-ydpi="224.36" />
+    <rect
+       y="73.397713"
+       x="72.880264"
+       height="73.077057"
+       width="9.149436"
+       id="rect5786"
+       style="display:inline;vector-effect:none;fill:#ffcccc;fill-opacity:1;fill-rule:nonzero;stroke:#a01414;stroke-width:0.225601;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;shape-rendering:crispEdges;enable-background:new"
+       inkscape:export-xdpi="224.36"
+       inkscape:export-ydpi="224.36" />
+    <text
+       transform="rotate(-90)"
+       id="text5788"
+       y="79.038582"
+       x="-114.37154"
+       style="font-style:normal;font-weight:normal;font-size:3.175px;line-height:0%;font-family:Arial;letter-spacing:0px;word-spacing:0px;display:inline;fill:#28170b;fill-opacity:1;stroke:none;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;shape-rendering:crispEdges;enable-background:new"
+       xml:space="preserve"
+       inkscape:export-xdpi="224.36"
+       inkscape:export-ydpi="224.36"><tspan
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:4.63021px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial Bold';fill:#28170b;stroke:none;stroke-width:0.264583px;stroke-opacity:1"
+         y="79.038582"
+         x="-114.37154"
+         id="tspan5790"
+         sodipodi:role="line">DMA</tspan></text>
+    <text
+       transform="scale(0.9928299,1.0072219)"
+       id="text4311-0"
+       y="57.409237"
+       x="69.524628"
+       style="font-style:normal;font-weight:normal;font-size:3.175px;line-height:0%;font-family:Arial;letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;shape-rendering:crispEdges;enable-background:new"
+       xml:space="preserve"
+       inkscape:export-xdpi="224.36"
+       inkscape:export-ydpi="224.36"><tspan
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:3.96875px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial Bold';stroke-width:0.264583px"
+         y="57.409237"
+         x="69.524628"
+         id="tspan4313-9"
+         sodipodi:role="line">ARM (Zynq) </tspan></text>
+    <g
+       id="g5654"
+       style="display:inline;fill:#a01414;fill-opacity:1;stroke:#a01414;stroke-width:0.91193;stroke-opacity:1;shape-rendering:crispEdges;enable-background:new"
+       transform="matrix(0.32827811,0,0,0.26434798,19.943177,-34.962379)"
+       inkscape:export-xdpi="224.36"
+       inkscape:export-ydpi="224.36">
+      <path
+         inkscape:connector-curvature="0"
+         id="path5656"
+         d="m 130.73937,546.2302 10.03208,14.84925 v -6.80591 l 20.46375,-3e-5 c 0,-16.08362 0,0 0,-16.08362 l -20.46375,3e-5 v -6.80591 l -10.03208,14.84925"
+         style="fill:#a01414;fill-opacity:1;fill-rule:evenodd;stroke:#a01414;stroke-width:0.91193px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1"
+         sodipodi:nodetypes="cccccccc" />
+    </g>
+    <g
+       id="g5654-3"
+       style="display:inline;fill:#a01414;fill-opacity:1;stroke:#a01414;stroke-width:0.57429;stroke-opacity:1;shape-rendering:crispEdges;enable-background:new"
+       transform="matrix(0.69170149,0,0,0.27204749,-7.4214574,-38.846883)"
+       inkscape:export-xdpi="224.36"
+       inkscape:export-ydpi="224.36">
+      <path
+         inkscape:connector-curvature="0"
+         id="path5656-0"
+         d="m 130.73937,546.2302 10.03208,14.84925 v -6.80591 l 12.03139,-3e-5 v -16.08362 l -12.03139,3e-5 v -6.80591 l -10.03208,14.84925"
+         style="fill:#a01414;fill-opacity:1;fill-rule:evenodd;stroke:#a01414;stroke-width:0.57429px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1"
+         sodipodi:nodetypes="cccccccc" />
+    </g>
+    <g
+       id="g5654-2"
+       style="display:inline;fill:#a01414;fill-opacity:1;stroke:#a01414;stroke-opacity:1;shape-rendering:crispEdges;enable-background:new"
+       transform="matrix(0.46245287,0,0,0.26458333,24.934835,-101.65513)" />
+    <text
+       id="text11366-4-8"
+       y="76.660919"
+       x="112.0732"
+       style="font-style:normal;font-weight:normal;font-size:3.175px;line-height:0%;font-family:Arial;letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;shape-rendering:crispEdges;enable-background:new"
+       xml:space="preserve"><tspan
+         id="tspan11370-7-5"
+         y="76.660919"
+         x="112.0732"
+         sodipodi:role="line"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:3.30729px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:center;text-anchor:middle;stroke-width:0.264583px" /></text>
+    <path
+       sodipodi:nodetypes="cc"
+       inkscape:connector-curvature="0"
+       id="path1206"
+       d="M 198.39343,93.188272 H 160.98307"
+       style="fill:none;stroke:#000000;stroke-width:0.529167;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#marker1216);shape-rendering:crispEdges" />
+    <path
+       sodipodi:nodetypes="cc"
+       inkscape:connector-curvature="0"
+       id="path1206-9"
+       d="M 198.66335,98.320588 H 161.25301"
+       style="display:inline;fill:none;stroke:#000000;stroke-width:0.529167;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#marker1216-9);shape-rendering:crispEdges;enable-background:new" />
+    <text
+       id="text2401"
+       y="95.740036"
+       x="163.48874"
+       style="font-style:normal;font-weight:normal;font-size:4.42089px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583;shape-rendering:crispEdges"
+       xml:space="preserve"
+       transform="scale(1.0443046,0.95757502)"><tspan
+         style="font-size:3.68407px;stroke-width:0.264583"
+         y="95.740036"
+         x="163.48874"
+         id="tspan2399"
+         sodipodi:role="line">data_in_p</tspan></text>
+    <text
+       id="text2401-0"
+       y="101.55558"
+       x="163.53281"
+       style="font-style:normal;font-weight:normal;font-size:4.42089px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583;shape-rendering:crispEdges"
+       xml:space="preserve"
+       transform="scale(1.0443046,0.95757502)"><tspan
+         style="font-size:3.68407px;stroke-width:0.264583"
+         y="101.55558"
+         x="163.53281"
+         id="tspan2399-27"
+         sodipodi:role="line">data_in_n</tspan></text>
+    <g
+       style="display:inline;shape-rendering:crispEdges;enable-background:new"
+       id="ddr"
+       transform="matrix(0.37593397,0,0,0.37593391,-17.27073,-132.78758)"
+       inkscape:export-xdpi="224.36"
+       inkscape:export-ydpi="224.36">
+      <rect
+         style="opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.8;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+         id="rect8406"
+         width="29.358675"
+         height="11.248666"
+         x="-453.55264"
+         y="391.80267"
+         transform="rotate(-90)" />
+      <rect
+         style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.67501;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.673913"
+         id="rect8408"
+         width="4.6139379"
+         height="6.8413563"
+         x="-451.4805"
+         y="394.00632"
+         transform="rotate(-90)" />
+      <rect
+         y="394.00632"
+         x="-444.69791"
+         height="6.8413563"
+         width="4.6139379"
+         id="rect8410"
+         style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.67501;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.673913"
+         transform="rotate(-90)" />
+      <rect
+         y="394.00632"
+         x="-431.13275"
+         height="6.8413563"
+         width="4.6139379"
+         id="rect8414"
+         style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.67501;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.673913"
+         transform="rotate(-90)" />
+      <rect
+         style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.67501;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.673913"
+         id="rect8416"
+         width="4.6139379"
+         height="6.8413563"
+         x="-437.91531"
+         y="394.00632"
+         transform="rotate(-90)" />
+      <path
+         style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:0.5506;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         d="m 402.9495,451.34818 h 3.46837 v -24.7395 h -3.63159"
+         id="path8420"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cccc" />
+      <path
+         style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1.067;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         d="M 406.04958,449.00384 H 404.6091"
+         id="path8422"
+         inkscape:connector-curvature="0" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path8424"
+         d="M 406.04958,430.92913 H 404.6091"
+         style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1.067;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+      <path
+         style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1.067;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         d="M 406.04958,433.33004 H 404.6091"
+         id="path8426"
+         inkscape:connector-curvature="0" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path8428"
+         d="M 406.04958,435.45913 H 404.6091"
+         style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1.067;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+      <path
+         style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1.067;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         d="M 406.04958,437.86003 H 404.6091"
+         id="path8430"
+         inkscape:connector-curvature="0" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path8432"
+         d="M 406.04958,439.98913 H 404.6091"
+         style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1.067;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+      <path
+         style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1.067;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         d="M 406.04958,442.34471 H 404.6091"
+         id="path8434"
+         inkscape:connector-curvature="0" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path8436"
+         d="M 406.04958,444.51915 H 404.6091"
+         style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1.067;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+      <path
+         style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1.067;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         d="M 406.04958,446.82944 H 404.6091"
+         id="path8438"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1.067;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         d="M 406.04958,430.92913 H 404.6091"
+         id="path8440"
+         inkscape:connector-curvature="0" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path8450"
+         d="M 406.04958,428.80003 H 404.6091"
+         style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1.067;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    </g>
+    <g
+       style="display:inline;shape-rendering:crispEdges;enable-background:new"
+       id="g8892"
+       transform="matrix(0.26458333,0,0,0.26458333,40.080594,-84.382617)"
+       inkscape:export-xdpi="224.36"
+       inkscape:export-ydpi="224.36">
+      <rect
+         y="431.09491"
+         x="366.68005"
+         height="23.063002"
+         width="26.832939"
+         id="rect8762"
+         style="opacity:1;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:1.33851;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+      <path
+         inkscape:connector-curvature="0"
+         id="rect8764"
+         d="m 371.84168,433.47704 h 16.31637 c 1.2826,0 2.31516,1.03257 2.31516,2.31517 v 13.22948 c 0,1.28259 -1.03256,2.31515 -2.31516,2.31515 h -16.31637 c -1.2826,0 -2.31516,-1.03256 -2.31516,-2.31515 v -13.22948 c 0,-1.2826 1.03256,-2.31517 2.31516,-2.31517 z"
+         style="opacity:1;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:1.2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+      <g
+         style="fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-opacity:1"
+         transform="matrix(1.2472877,0,0,1.2472877,-94.749819,-45.663902)"
+         id="g8811">
+        <path
+           id="rect8801"
+           d="m 371.16019,393.86166 h 6.77743 v 5.24892 h -6.77743 z"
+           style="opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:#ffffff;stroke-width:0.479248;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+           inkscape:connector-curvature="0" />
+        <path
+           id="rect8809"
+           d="m 383.3136,393.86166 h 6.77743 v 5.24892 h -6.77743 z"
+           style="opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:#ffffff;stroke-width:0.479248;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+           inkscape:connector-curvature="0" />
+      </g>
+      <path
+         sodipodi:nodetypes="ccccc"
+         inkscape:connector-curvature="0"
+         id="path8818"
+         d="m 369.52814,445.26083 h 5.8318 v 2.82613 h 1.54776 v 3.24584"
+         style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1.2;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+      <path
+         style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1.2;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         d="m 390.47422,445.29053 h -5.89282 v 2.80734 h -1.56397 v 3.22427"
+         id="path8820"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccccc" />
+      <rect
+         y="447.10886"
+         x="369.1405"
+         height="3.8938534"
+         width="4.5168324"
+         id="rect8824"
+         style="opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.973;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+      <rect
+         style="opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.973;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+         id="rect8826"
+         width="4.5168324"
+         height="3.8938534"
+         x="386.27451"
+         y="447.10886" />
+      <rect
+         y="433.60046"
+         x="371.85117"
+         height="5.1640501"
+         width="1.2438545"
+         id="rect8828"
+         style="opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.308598;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+      <rect
+         style="opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.308598;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+         id="rect8830"
+         width="1.2438545"
+         height="5.1640501"
+         x="384.39578"
+         y="433.60046" />
+      <rect
+         y="433.60046"
+         x="381.88687"
+         height="5.1640501"
+         width="1.2438545"
+         id="rect8832"
+         style="opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.308598;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+      <rect
+         style="opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.308598;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+         id="rect8834"
+         width="1.2438545"
+         height="5.1640501"
+         x="379.37793"
+         y="433.60046" />
+      <rect
+         y="433.60046"
+         x="376.86902"
+         height="5.1640501"
+         width="1.2438545"
+         id="rect8836"
+         style="opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.308598;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+      <rect
+         style="opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.308598;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+         id="rect8838"
+         width="1.2438545"
+         height="5.1640501"
+         x="374.36008"
+         y="433.60046" />
+      <rect
+         style="opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.308598;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+         id="rect8840"
+         width="1.2438545"
+         height="5.1640501"
+         x="386.90469"
+         y="433.60046" />
+    </g>
+    <g
+       id="uart"
+       transform="matrix(0,-0.10973853,0.10973855,0,102.98407,90.423989)"
+       style="display:inline;stroke-width:2.41103;stroke-miterlimit:4;stroke-dasharray:none;shape-rendering:crispEdges;enable-background:new"
+       inkscape:export-xdpi="224.36"
+       inkscape:export-ydpi="224.36">
+      <rect
+         ry="4.5"
+         y="388.11218"
+         x="490.75"
+         height="28.75"
+         width="70"
+         id="rect8910"
+         style="opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:2.41103;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+      <path
+         sodipodi:nodetypes="sssssssss"
+         inkscape:connector-curvature="0"
+         id="rect8912"
+         d="m 507.25,394.11218 h 37 c 2.493,0 5.47668,2.20628 4.5,4.5 l -3.3,7.75 c -0.97668,2.29372 -3.507,4.5 -6,4.5 h -27.8 c -2.493,0 -4.37391,-2.22795 -5.4,-4.5 l -3.5,-7.75 c -1.02609,-2.27205 2.007,-4.5 4.5,-4.5 z"
+         style="opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:2.41103;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+      <circle
+         r="3.1875"
+         cy="402.48718"
+         cx="497.5126"
+         id="path8915"
+         style="opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:2.41103;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+      <circle
+         style="opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:2.41103;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+         id="circle8917"
+         cx="554.13763"
+         cy="402.48718"
+         r="3.1875" />
+      <ellipse
+         ry="1.0625"
+         rx="1"
+         cy="399.79968"
+         cx="513.7403"
+         id="path8919"
+         style="opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:2.41103;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+      <ellipse
+         ry="1.0625"
+         rx="1"
+         cy="399.79968"
+         cx="537.7403"
+         id="ellipse8923"
+         style="opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:2.41103;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+      <ellipse
+         style="opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:2.41103;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+         id="ellipse8925"
+         cx="531.7403"
+         cy="399.79968"
+         rx="1"
+         ry="1.0625" />
+      <ellipse
+         ry="1.0625"
+         rx="1"
+         cy="399.79968"
+         cx="525.7403"
+         id="ellipse8927"
+         style="opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:2.41103;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+      <ellipse
+         style="opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:2.41103;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+         id="ellipse8929"
+         cx="519.7403"
+         cy="399.79968"
+         rx="1"
+         ry="1.0625" />
+      <ellipse
+         style="opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:2.41103;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+         id="ellipse8921"
+         cx="516.7403"
+         cy="405.79968"
+         rx="1"
+         ry="1.0625" />
+      <ellipse
+         ry="1.0625"
+         rx="1"
+         cy="405.79968"
+         cx="534.7403"
+         id="ellipse8931"
+         style="opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:2.41103;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+      <ellipse
+         style="opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:2.41103;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+         id="ellipse8933"
+         cx="528.7403"
+         cy="405.79968"
+         rx="1"
+         ry="1.0625" />
+      <ellipse
+         ry="1.0625"
+         rx="1"
+         cy="405.79968"
+         cx="522.7403"
+         id="ellipse8935"
+         style="opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:2.41103;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+    </g>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:3.43958px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Bold';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;letter-spacing:0px;word-spacing:0px;display:inline;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.268639;shape-rendering:crispEdges;enable-background:new"
+       x="64.748016"
+       y="112.67403"
+       id="text2401-61-1-54-8"
+       transform="scale(1.0162353,0.98402408)"
+       inkscape:export-xdpi="224.36"
+       inkscape:export-ydpi="224.36"><tspan
+         sodipodi:role="line"
+         id="tspan2399-9-2-70-3"
+         x="64.748016"
+         y="112.67403"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:3.43958px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Bold';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;fill:#ffffff;fill-opacity:1;stroke-width:0.268639">64</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:3.43958px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Bold';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;letter-spacing:0px;word-spacing:0px;display:inline;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.269;stroke-miterlimit:4;stroke-dasharray:none;shape-rendering:crispEdges;enable-background:new"
+       x="86.179253"
+       y="112.63995"
+       id="text2401-61-1-54-8-3"
+       transform="scale(1.0162353,0.98402408)"
+       inkscape:export-xdpi="224.36"
+       inkscape:export-ydpi="224.36"><tspan
+         sodipodi:role="line"
+         id="tspan2399-9-2-70-3-9"
+         x="86.179253"
+         y="112.63995"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:3.43958px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Bold';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;fill:#ffffff;fill-opacity:1;stroke-width:0.269;stroke-miterlimit:4;stroke-dasharray:none">128</tspan></text>
+    <rect
+       style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#a01414;stroke-width:0.354352;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:0.0354352, 0.0354352;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect19131"
+       width="27.503014"
+       height="23.095438"
+       x="125.54807"
+       y="88.0979" />
+    <rect
+       style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#a01414;stroke-width:0.482414;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:0.0482414, 0.0482414;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect19131-2"
+       width="51.605984"
+       height="6.0892682"
+       x="103.33699"
+       y="138.42719" />
+    <rect
+       style="fill:#ffcccc;fill-opacity:1;fill-rule:evenodd;stroke:#a01414;stroke-width:0.426;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:0.0426, 0.0426;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect958"
+       width="15.066154"
+       height="11.580877"
+       x="132.19043"
+       y="96.328766" />
+    <rect
+       style="fill:#ffcccc;fill-opacity:1;fill-rule:evenodd;stroke:#a01414;stroke-width:0.494615;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:0.0494615, 0.0494615;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect958-1"
+       width="24.853348"
+       height="13.759332"
+       x="102.64566"
+       y="114.91541" />
+    <text
+       xml:space="preserve"
+       transform="matrix(0.1434475,0,0,0.13069708,60.688894,43.014016)"
+       id="text4758"
+       style="font-size:14px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial, Normal';white-space:pre;shape-inside:url(#rect4760);display:inline;stroke-width:1.93234"><tspan
+         x="505.75977"
+         y="453.41916"
+         id="tspan4">ad_serdes_in</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.82222px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;stroke-width:0.264583"
+       x="127.27362"
+       y="92.153725"
+       id="text21502"
+       transform="scale(1.0050352,0.99499002)"><tspan
+         sodipodi:role="line"
+         id="tspan21500"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.82222px;font-family:Arial;-inkscape-font-specification:'Arial, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;stroke-width:0.264583"
+         x="127.27362"
+         y="92.153725">axi_hmcad15xx_if</tspan></text>
+    <text
+       xml:space="preserve"
+       transform="matrix(0.16760265,0,0,0.16592749,55.356103,42.577208)"
+       id="text24668"
+       style="font-size:16px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial, Normal';white-space:pre;shape-inside:url(#rect24670);display:inline;stroke-width:2.01426"><tspan
+         x="298.9668"
+         y="484.35348"
+         id="tspan6">ADC COMMON</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-size:4.20337px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial, Normal';stroke-width:0.264583"
+       x="120.95268"
+       y="143.25801"
+       id="text41823"
+       transform="scale(1.0050352,0.99499002)"><tspan
+         sodipodi:role="line"
+         id="tspan41821"
+         style="stroke-width:0.264583"
+         x="120.95268"
+         y="143.25801">UP_AXI</tspan></text>
+    <path
+       style="fill:#a01414;fill-opacity:1;stroke:#a01414;stroke-width:0.6;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:20;stroke-opacity:1;marker-start:url(#TriangleInM-0);marker-end:url(#marker51146-9)"
+       d="m 115.06901,130.79376 c 0,5.55327 0,5.33969 0,5.33969"
+       id="path42520-2-7" />
+    <text
+       xml:space="preserve"
+       style="font-size:3.15252px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial, Normal';stroke-width:0.264583"
+       x="114.45382"
+       y="85.586006"
+       id="text49535"
+       transform="scale(1.0050352,0.99499002)"><tspan
+         sodipodi:role="line"
+         id="tspan49533"
+         style="font-size:3.15252px;stroke-width:0.264583"
+         x="114.45382"
+         y="85.586006">AXI-HMCAD15XX IP </tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.64583px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;stroke-width:0.264583"
+       x="49.604683"
+       y="154.91524"
+       id="text41772"><tspan
+         sodipodi:role="line"
+         id="tspan41770"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.64583px;font-family:Arial;-inkscape-font-specification:'Arial, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;stroke-width:0.264583"
+         x="49.604683"
+         y="154.91524">DMA_CLK=100MHz</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.64583px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;stroke-width:0.264583"
+       x="80.724274"
+       y="154.93251"
+       id="text41772-4"><tspan
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.64583px;font-family:Arial;-inkscape-font-specification:'Arial, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;stroke-width:0.264583"
+         x="80.724274"
+         y="154.93251"
+         id="tspan1"
+         sodipodi:role="line">REF_CLK: CLK_IN(500MHz) / 4 </tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.64583px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;stroke-width:0.264583"
+       x="157.8167"
+       y="149.63438"
+       id="text41772-4-7"><tspan
+         sodipodi:role="line"
+         id="tspan41770-2-5"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.64583px;font-family:Arial;-inkscape-font-specification:'Arial, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;stroke-width:0.264583"
+         x="157.8167"
+         y="149.63438">REF_CLK= CLK_IN(500MHz) </tspan></text>
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.498128;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-start:url(#TriangleInM-7-1);marker-end:url(#marker9011)"
+       d="m 160.90442,67.943553 -0.0847,5.47847 35.73134,-0.02886 v 0 0"
+       id="path54607"
+       sodipodi:nodetypes="ccccc" />
+    <text
+       xml:space="preserve"
+       style="font-size:2.11667px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial, Normal';stroke-width:0.264583"
+       x="166.85376"
+       y="71.951813"
+       id="text59898"><tspan
+         sodipodi:role="line"
+         id="tspan59896"
+         style="font-size:2.11667px;stroke-width:0.264583"
+         x="166.85376"
+         y="71.951813">HMCAD1520/MAX3013 SPI</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;font-size:10.5833px;line-height:1.25;font-family:sans-serif;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+       x="160.59171"
+       y="152.51469"
+       id="text3594"><tspan
+         sodipodi:role="line"
+         id="tspan3592"
+         style="stroke-width:0.264583" /></text>
+    <text
+       xml:space="preserve"
+       transform="matrix(0.26458333,0,0,0.26458333,45.687375,26.530943)"
+       id="text1"
+       style="text-align:start;writing-mode:lr-tb;direction:ltr;white-space:pre;shape-inside:url(#rect1);display:inline;fill:#ffffff;fill-opacity:1" />
+    <rect
+       style="fill:#ffcccc;fill-opacity:1;fill-rule:evenodd;stroke:#a01414;stroke-width:0.493867;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:0.0493867, 0.0493867;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4"
+       width="25.023428"
+       height="13.624562"
+       x="129.5374"
+       y="115.03626" />
+    <path
+       style="fill:#a01414;fill-opacity:1;stroke:#a01414;stroke-width:0.6;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:20;stroke-opacity:1;marker-start:url(#TriangleInM-0);marker-end:url(#marker51146-9)"
+       d="m 141.96758,130.79376 c 0,5.55327 0,5.33969 0,5.33969"
+       id="path6" />
+    <text
+       xml:space="preserve"
+       transform="matrix(0.1801039,0,0,0.17830378,77.118057,34.452889)"
+       id="text19"
+       style="font-size:16px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial, Normal';text-align:center;white-space:pre;shape-inside:url(#rect19);display:inline;stroke-width:2.01426"
+       x="62.085659"
+       y="0"><tspan
+         x="345.01046"
+         y="484.35348"
+         id="tspan8"><tspan
+           style="font-size:13.4284px"
+           id="tspan7">ADC 
+</tspan></tspan><tspan
+         x="324.48756"
+         y="504.35348"
+         id="tspan10"><tspan
+           style="font-size:13.4284px"
+           id="tspan9">CHANNELS</tspan></tspan></text>
+    <rect
+       style="fill:#ffcccc;fill-opacity:1;fill-rule:evenodd;stroke:#a01414;stroke-width:0.342;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:0.0342, 0.0342;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect20"
+       width="19.162409"
+       height="14.729539"
+       x="102.67871"
+       y="92.076019" />
+    <text
+       xml:space="preserve"
+       transform="matrix(0.3543127,0,0,0.3543127,22.757515,3.214601)"
+       id="text22"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:7.96534px;font-family:Arial;-inkscape-font-specification:'Arial, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:center;writing-mode:lr-tb;direction:ltr;white-space:pre;shape-inside:url(#rect23);fill:#000000;stroke-width:1.2926;stroke-dasharray:0.12926, 0.12926;stroke-dashoffset:0"
+       x="24.155434"
+       y="0"><tspan
+         x="231.74029"
+         y="273.58888"
+         id="tspan13"><tspan
+           style="font-size:5.97401px"
+           id="tspan11">up_delay_cntrl</tspan></tspan></text>
+    <path
+       sodipodi:nodetypes="cc"
+       inkscape:connector-curvature="0"
+       id="path24"
+       d="M 198.39343,93.188272 H 160.98307"
+       style="fill:none;stroke:#000000;stroke-width:0.529167;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#marker1216);shape-rendering:crispEdges" />
+    <path
+       sodipodi:nodetypes="cc"
+       inkscape:connector-curvature="0"
+       id="path25"
+       d="M 198.66335,98.320588 H 161.25301"
+       style="display:inline;fill:none;stroke:#000000;stroke-width:0.529167;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#marker1216-9);shape-rendering:crispEdges;enable-background:new" />
+    <text
+       id="text25"
+       y="95.740036"
+       x="163.48874"
+       style="font-style:normal;font-weight:normal;font-size:4.42089px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583;shape-rendering:crispEdges"
+       xml:space="preserve"
+       transform="scale(1.0443046,0.95757502)"><tspan
+         style="font-size:3.68407px;stroke-width:0.264583"
+         y="95.740036"
+         x="163.48874"
+         id="tspan25"
+         sodipodi:role="line">data_in_p</tspan></text>
+    <text
+       id="text26"
+       y="101.55558"
+       x="163.53281"
+       style="font-style:normal;font-weight:normal;font-size:4.42089px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583;shape-rendering:crispEdges"
+       xml:space="preserve"
+       transform="scale(1.0443046,0.95757502)"><tspan
+         style="font-size:3.68407px;stroke-width:0.264583"
+         y="101.55558"
+         x="163.53281"
+         id="tspan26"
+         sodipodi:role="line">data_in_n</tspan></text>
+    <path
+       sodipodi:nodetypes="cc"
+       inkscape:connector-curvature="0"
+       id="path28"
+       d="M 198.39343,111.4309 H 160.98307"
+       style="fill:none;stroke:#000000;stroke-width:0.529167;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#marker1216);shape-rendering:crispEdges" />
+    <path
+       sodipodi:nodetypes="cc"
+       inkscape:connector-curvature="0"
+       id="path29"
+       d="M 198.66335,116.56322 H 161.25301"
+       style="display:inline;fill:none;stroke:#000000;stroke-width:0.529167;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#marker1216-9);shape-rendering:crispEdges;enable-background:new" />
+    <text
+       id="text29"
+       y="114.7909"
+       x="163.48874"
+       style="font-style:normal;font-weight:normal;font-size:4.42089px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583;shape-rendering:crispEdges"
+       xml:space="preserve"
+       transform="scale(1.0443046,0.95757502)"><tspan
+         style="font-size:3.68407px;stroke-width:0.264583"
+         y="114.7909"
+         x="163.48874"
+         id="tspan29"
+         sodipodi:role="line">clk_in_p</tspan></text>
+    <text
+       id="text30"
+       y="120.60645"
+       x="163.53281"
+       style="font-style:normal;font-weight:normal;font-size:4.42089px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583;shape-rendering:crispEdges"
+       xml:space="preserve"
+       transform="scale(1.0443046,0.95757502)"><tspan
+         style="font-size:3.68407px;stroke-width:0.264583"
+         y="120.60645"
+         x="163.53281"
+         id="tspan30"
+         sodipodi:role="line">clk_in_n</tspan></text>
+    <path
+       sodipodi:nodetypes="cc"
+       inkscape:connector-curvature="0"
+       id="path30"
+       d="M 198.39343,130.04583 H 160.98307"
+       style="fill:none;stroke:#000000;stroke-width:0.529167;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#marker1216);shape-rendering:crispEdges" />
+    <path
+       sodipodi:nodetypes="cc"
+       inkscape:connector-curvature="0"
+       id="path31"
+       d="M 198.66335,135.17815 H 161.25301"
+       style="display:inline;fill:none;stroke:#000000;stroke-width:0.529167;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#marker1216-9);shape-rendering:crispEdges;enable-background:new" />
+    <text
+       id="text31"
+       y="134.23056"
+       x="167.76678"
+       style="font-style:normal;font-weight:normal;font-size:4.42089px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583;shape-rendering:crispEdges"
+       xml:space="preserve"
+       transform="scale(1.0443046,0.95757502)"><tspan
+         style="font-size:3.68407px;stroke-width:0.264583"
+         y="134.23056"
+         x="167.76678"
+         id="tspan31"
+         sodipodi:role="line">fclk_p</tspan></text>
+    <text
+       id="text32"
+       y="140.04611"
+       x="167.81085"
+       style="font-style:normal;font-weight:normal;font-size:4.42089px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583;shape-rendering:crispEdges"
+       xml:space="preserve"
+       transform="scale(1.0443046,0.95757502)"><tspan
+         style="font-size:3.68407px;stroke-width:0.264583"
+         y="140.04611"
+         x="167.81085"
+         id="tspan32"
+         sodipodi:role="line">fclk_n</tspan></text>
+  </g>
+</svg>

--- a/docs/projects/hmcad1520_ebz/index.rst
+++ b/docs/projects/hmcad1520_ebz/index.rst
@@ -1,0 +1,232 @@
+.. _hmcad1520_ebz:
+
+HMCAD1520-FMC-EVB HDL project
+================================================================================
+
+Overview
+-------------------------------------------------------------------------------
+The :adi:`HMCAD1520-EBZ` HDL design supports the following
+:adi:`HMCAD1520` features:
+
+* Single/Dual/Quad Channel modes
+* 8/12/14 bit resolution configurations
+* Sampling rates between 105 - 1000 MSPS
+
+The :adi:`HMCAD1520-EBZ` evaluation board was designed for
+use with the Digilent ZedBoard via the field programmable gate array(FPGA)
+mezzanine card (FMC) connector.
+
+Supported boards
+-------------------------------------------------------------------------------
+
+- :adi:`HMCAD1511-EBZ`
+- :adi:`HMCAD1520-EBZ`
+
+Supported devices
+-------------------------------------------------------------------------------
+
+- :adi:`HMCAD1511`
+- :adi:`HMCAD1520`
+- :adi:`ADN4661`
+- :adi:`ADM7154`
+- :adi:`MAX3013`
+- :adi:`LTC6419`
+- :adi:`LTM8078`
+
+Supported carriers
+-------------------------------------------------------------------------------
+
+.. list-table::
+   :widths: 35 35 30
+   :header-rows: 1
+
+   * - Evaluation board
+     - Carrier
+     - FMC slot
+   * - :adi:`HMCAD1511-EBZ`
+     - `ZedBoard <https://digilent.com/shop/zedboard-zynq-7000-arm-fpga-soc-development-board>`__
+     - FMC-LPC
+   * - :adi:`HMCAD1520-EBZ`
+     - `ZedBoard <https://digilent.com/shop/zedboard-zynq-7000-arm-fpga-soc-development-board>`__
+     - FMC-LPC
+
+Block design
+-------------------------------------------------------------------------------
+
+.. warning::
+    The VADJ for the Zedboard must be set to 2.5V.
+
+Block diagram
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The data path and clock domains are depicted in the below diagram:
+
+.. image:: ../hmcad1520_ebz/hmcad1520_ebz_zed_block_diagram.svg
+   :width: 800
+   :align: center
+   :alt: HMCAD1520_EBZ/ZedBoard block diagram
+
+Clock scheme
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. image:: ../hmcad1520_ebz/hmcad1520_ebz_clock_scheme.svg
+   :width: 800
+   :align: center
+   :alt: HMCAD1520_EBZ/ZedBoard clock scheme
+
+CPU/Memory interconnects addresses
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The addresses are dependent on the architecture of the FPGA, having an offset
+added to the base address from HDL (see more at :ref:`architecture cpu-intercon-addr`).
+
+==================== ===============
+Instance             Zynq/Microblaze
+==================== ===============
+axi_hmcad1520_adc    0x44A00000
+hmcad1520_dma        0x44A30000
+==================== ===============
+
+SPI connections
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. list-table::
+   :widths: 25 25 25 25
+   :header-rows: 1
+
+   * - SPI type
+     - SPI manager instance
+     - SPI subordinate
+     - CS
+   * - PS
+     - SPI 0
+     - HMCAD1520
+     - 0
+
+GPIOs
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. list-table::
+   :widths: 25 25 25 25
+   :header-rows: 2
+
+   * - GPIO signal
+     - Direction
+     - HDL GPIO EMIO
+     - Software GPIO
+   * -
+     - (from FPGA view)
+     -
+     - Zynq-7000
+   * - fmc_rstn
+     - INOUT
+     - 33
+     - 87
+   * - fmc_pd
+     - INOUT
+     - 32
+     - 86
+
+Interrupts
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Below are the Programmable Logic interrupts used in this project.
+
+================ === ========== ===========
+Instance name    HDL Linux Zynq Actual Zynq
+================ === ========== ===========
+hmcad1520_dma    13  57         89
+================ === ========== ===========
+
+Building the HDL project
+-------------------------------------------------------------------------------
+
+The design is built upon ADI's generic HDL reference design framework.
+ADI distributes the bit/elf files of these projects as part of the
+:dokuwiki:`ADI Kuiper Linux <resources/tools-software/linux-software/kuiper-linux>`.
+If you want to build the sources, ADI makes them available on the
+:git-hdl:`HDL repository </>`. To get the source you must
+`clone <https://git-scm.com/book/en/v2/Git-Basics-Getting-a-Git-Repository>`__
+the HDL repository, and then build the project as follows:
+
+**Linux/Cygwin/WSL**
+
+Example of building the project with ``make``
+
+.. shell::
+
+   $cd hdl/projects/hmcad1520/zed
+   $make
+
+A more comprehensive build guide can be found in the :ref:`build_hdl` user guide.
+
+Resources
+-------------------------------------------------------------------------------
+
+Systems related
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+- `EVAL01-HMCAD15xx User Guide <https://wiki.analog.com/_media/resources/eval/eval01-hmcad15xx_user_guide_analog_devices_wiki_.pdf>`__
+
+Hardware related
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+- Product datasheets:
+
+  - :adi:`HMCAD1511`
+  - :adi:`HMCAD1520`
+  - :adi:`ADN4661`
+  - :adi:`ADM7154`
+  - :adi:`MAX3013`
+  - :adi:`LTC6419`
+  - :adi:`LTM8078`
+
+HDL related
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+- :git-hdl:`HMCAD1520_EBZ HDL project source code <projects/hmcad1520_ebz>`
+
+.. list-table::
+   :widths: 30 35 35
+   :header-rows: 1
+
+   * - IP name
+     - Source code link
+     - Documentation link
+   * - AXI_HMCAD15XX
+     - :git-hdl:`library/axi_hmcad15xx`
+     - :ref:`axi_hmcad15xx`
+   * - AXI_CLKGEN
+     - :git-hdl:`library/axi_clkgen`
+     - :ref:`axi_clkgen`
+   * - AXI_DMAC
+     - :git-hdl:`library/axi_dmac`
+     - :ref:`axi_dmac`
+   * - AXI_HDMI_TX
+     - :git-hdl:`library/axi_hdmi_tx`
+     - :ref:`axi_hdmi_tx`
+   * - AXI_I2S_ADI
+     - :git-hdl:`library/axi_i2s_adi`
+     - ---
+   * - AXI_SPDIF_TX
+     - :git-hdl:`library/axi_spdif_tx`
+     - ---
+   * - AXI_SYSID
+     - :git-hdl:`library/axi_sysid`
+     - ---
+   * - SYSID_ROM
+     - :git-hdl:`library/sysid_rom`
+     - :ref:`axi_sysid`
+   * - UTIL_I2C_MIXER
+     - :git-hdl:`library/util_i2c_mixer`
+     - ---
+
+Software related
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+  - :git-linux:`HMCAD15XX-FMC-EVB Linux device tree <gui+sharkbyte_pr:arch/arm/boot/dts/xilinx/zynq-zed-adv7511-hmcad15xx.dts>`
+  - :git-linux:`HMCAD15XX Linux driver <gui+sharkbyte_pr:drivers/iio/adc/hmcad15xx.c>`
+
+.. include:: ../common/more_information.rst
+
+.. include:: ../common/support.rst

--- a/docs/projects/index.rst
+++ b/docs/projects/index.rst
@@ -98,6 +98,7 @@ Contents
    FMCOMMS5 <fmcomms5/index>
    FMCOMMS8 <fmcomms8/index>
    FMCOMMS11 <fmcomms11/index>
+   HMCAD1520 <hmcad1520_ebz/index>
    JUPITER-SDR <jupiter_sdr/index>
    LTC2378-FMC <ltc2378_fmc/index>
    M2K <m2k/index>
@@ -105,7 +106,7 @@ Contents
    PLUTO <pluto/index>
    PULSAR-ADC <pulsar_adc/index>
    PULSAR-LVDS-ADC <pulsar_lvds_adc/index>
-
+   
 Obsolete projects
 -------------------------------------------------------------------------------
 .. toctree::

--- a/docs/projects/index.rst
+++ b/docs/projects/index.rst
@@ -106,6 +106,7 @@ Contents
    PLUTO <pluto/index>
    PULSAR-ADC <pulsar_adc/index>
    PULSAR-LVDS-ADC <pulsar_lvds_adc/index>
+   ADMX6020M <admx6020m/index>
    
 Obsolete projects
 -------------------------------------------------------------------------------

--- a/library/axi_hmcad15xx/Makefile
+++ b/library/axi_hmcad15xx/Makefile
@@ -1,0 +1,32 @@
+####################################################################################
+## Copyright (c) 2018 - 2026 Analog Devices, Inc.
+### SPDX short identifier: BSD-1-Clause
+## Auto-generated, do not modify!
+####################################################################################
+
+LIBRARY_NAME := axi_hmcad15xx
+
+GENERIC_DEPS += ../common/ad_datafmt.v
+GENERIC_DEPS += ../common/ad_rst.v
+GENERIC_DEPS += ../common/up_adc_channel.v
+GENERIC_DEPS += ../common/up_adc_common.v
+GENERIC_DEPS += ../common/up_axi.v
+GENERIC_DEPS += ../common/up_clock_mon.v
+GENERIC_DEPS += ../common/up_delay_cntrl.v
+GENERIC_DEPS += ../common/up_xfer_cntrl.v
+GENERIC_DEPS += ../common/up_xfer_status.v
+GENERIC_DEPS += axi_hmcad15xx.v
+GENERIC_DEPS += axi_hmcad15xx_if.v
+GENERIC_DEPS += sample_assembly.v
+
+XILINX_DEPS += ../xilinx/common/ad_data_clk.v
+XILINX_DEPS += ../xilinx/common/ad_data_in.v
+XILINX_DEPS += ../xilinx/common/ad_dcfilter.v
+XILINX_DEPS += ../xilinx/common/ad_rst_constr.xdc
+XILINX_DEPS += ../xilinx/common/ad_serdes_in.v
+XILINX_DEPS += ../xilinx/common/up_clock_mon_constr.xdc
+XILINX_DEPS += ../xilinx/common/up_xfer_cntrl_constr.xdc
+XILINX_DEPS += ../xilinx/common/up_xfer_status_constr.xdc
+XILINX_DEPS += axi_hmcad15xx_ip.tcl
+
+include ../scripts/library.mk

--- a/library/axi_hmcad15xx/axi_hmcad15xx.v
+++ b/library/axi_hmcad15xx/axi_hmcad15xx.v
@@ -1,0 +1,370 @@
+// ***************************************************************************
+// ***************************************************************************
+// Copyright (C) 2025-2026 Analog Devices, Inc. All rights reserved.
+//
+// In this HDL repository, there are many different and unique modules, consisting
+// of various HDL (Verilog or VHDL) components. The individual modules are
+// developed independently, and may be accompanied by separate and unique license
+// terms.
+//
+// The user should read each of these license terms, and understand the
+// freedoms and responsibilities that he or she has by using this source/core.
+//
+// This core is distributed in the hope that it will be useful, but WITHOUT ANY
+// WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+// A PARTICULAR PURPOSE.
+//
+// Redistribution and use of source or resulting binaries, with or without modification
+// of this file, are permitted under one of the following two license terms:
+//
+//   1. The GNU General Public License version 2 as published by the
+//      Free Software Foundation, which can be found in the top level directory
+//      of this repository (LICENSE_GPL2), and also online at:
+//      <https://www.gnu.org/licenses/old-licenses/gpl-2.0.html>
+//
+// OR
+//
+//   2. An ADI specific BSD license, which can be found in the top level directory
+//      of this repository (LICENSE_ADIBSD), and also on-line at:
+//      https://github.com/analogdevicesinc/hdl/blob/main/LICENSE_ADIBSD
+//      This will allow to generate bit files and not release the source code,
+//      as long as it attaches to an ADI device.
+//
+// ***************************************************************************
+// ***************************************************************************
+
+`timescale 1ns / 1ps
+
+module axi_hmcad15xx #(
+  parameter   ID = 0,
+  parameter   NUM_CHANNELS = 4,
+  parameter   FPGA_TECHNOLOGY = 0,
+  parameter   IO_DELAY_GROUP = "adc_if_delay_group",
+  parameter   IODELAY_CTRL = 0
+) (
+
+  input           adc_dovf,
+  input           clk_in_p,
+  input           clk_in_n,
+  input           fclk_p,
+  input           fclk_n,
+  input   [ 7:0]  data_in_p,
+  input   [ 7:0]  data_in_n,
+
+  output          adc_enable_0,
+  output          adc_enable_1,
+  output          adc_enable_2,
+  output          adc_enable_3,
+
+  output          adc_valid,
+
+  output  [127:0] adc_data,
+
+  output          adc_clk,      // Regional clock (BUFR) - for IO-local logic
+  output          adc_clk_g,    // Global clock (BUFG) - for BRAM/fabric logic
+  output          adc_resetn,
+
+  // delay interface
+
+  input           delay_clk,
+
+  input           s_axi_aclk,
+  input           s_axi_aresetn,
+  input           s_axi_awvalid,
+  input   [15:0]  s_axi_awaddr,
+  input   [ 2:0]  s_axi_awprot,
+  output          s_axi_awready,
+  input           s_axi_wvalid,
+  input   [31:0]  s_axi_wdata,
+  input   [ 3:0]  s_axi_wstrb,
+  output          s_axi_wready,
+  output          s_axi_bvalid,
+  output  [ 1:0]  s_axi_bresp,
+  input           s_axi_bready,
+  input           s_axi_arvalid,
+  input   [15:0]  s_axi_araddr,
+  input   [ 2:0]  s_axi_arprot,
+  output          s_axi_arready,
+  output          s_axi_rvalid,
+  output  [ 1:0]  s_axi_rresp,
+  output  [31:0]  s_axi_rdata,
+  input           s_axi_rready
+);
+
+  localparam DELAY_CTRL_NUM_LANES = 9;
+  localparam DELAY_CTRL_DRP_WIDTH = 5;
+
+  // internal signals
+
+  wire  [DELAY_CTRL_DRP_WIDTH*DELAY_CTRL_NUM_LANES-1:0]  up_dwdata;
+  wire  [DELAY_CTRL_DRP_WIDTH*DELAY_CTRL_NUM_LANES-1:0]  up_drdata;
+  wire  [DELAY_CTRL_NUM_LANES-1:0]                       up_dld;
+
+  // internal registers
+
+  reg  [31:0] up_rdata = 'd0;
+  reg         up_rack = 'd0;
+  reg         up_wack = 'd0;
+
+  // internal signals
+
+  wire        adc_rst_s;
+  wire        up_rstn;
+  wire        up_clk;
+  wire [13:0] up_waddr_s;
+  wire [13:0] up_raddr_s;
+  wire        adc_clk_s;
+  wire        adc_clk_g_s;  // Global clock from BUFG
+  wire        up_wreq_s;
+  wire        up_rreq_s;
+  wire [31:0] up_wdata_s;
+
+  wire [31:0] up_rdata_s[0:5];
+
+  wire  [5:0] up_rack_s;
+  wire  [5:0] up_wack_s;
+
+  wire  [7:0] adc_enable;
+  wire  [4:0] adc_num_lanes;
+  wire        adc_crc_enable;
+
+  wire        delay_rst;
+
+  assign up_clk = s_axi_aclk;
+  assign up_rstn = s_axi_aresetn;
+  assign adc_clk = adc_clk_s;
+  assign adc_clk_g = adc_clk_g_s;  // Global clock for BRAM/fabric
+  assign adc_resetn = ~adc_rst_s;
+
+  assign adc_enable_0 = adc_enable[0];
+  assign adc_enable_1 = adc_enable[1];
+  assign adc_enable_2 = adc_enable[2];
+  assign adc_enable_3 = adc_enable[3];
+
+  always @(negedge up_rstn or posedge up_clk) begin
+    if (up_rstn == 0) begin
+      up_rdata <= 'd0;
+      up_rack <= 'd0;
+      up_wack <= 'd0;
+    end else begin
+      up_rdata <= up_rdata_s[0] | up_rdata_s[1] | up_rdata_s[2] | up_rdata_s[3] | up_rdata_s[4] | up_rdata_s[5];
+      up_rack  <= up_rack_s[0]  | up_rack_s[1]  | up_rack_s[2]  | up_rack_s[3]  | up_rack_s[4]  | up_rack_s[5];
+      up_wack  <= up_wack_s[0]  | up_wack_s[1]  | up_wack_s[2]  | up_wack_s[3]  | up_wack_s[4]  | up_wack_s[5];
+    end
+  end
+
+  // adc channels
+
+  generate
+    genvar i;
+    for (i = 0; i < NUM_CHANNELS; i=i+1) begin : hmcad15xx_channels
+      up_adc_channel #(
+        .CHANNEL_ID(i)
+      ) i_up_adc_channel (
+        .adc_clk (adc_clk_s),
+        .adc_rst (adc_rst_s),
+        .adc_enable (adc_enable[i]),
+        .adc_iqcor_enb (),
+        .adc_dcfilt_enb (),
+        .adc_dfmt_se (),
+        .adc_dfmt_type (),
+        .adc_dfmt_enable (),
+        .adc_dcfilt_offset (),
+        .adc_dcfilt_coeff (),
+        .adc_iqcor_coeff_1 (),
+        .adc_iqcor_coeff_2 (),
+        .adc_pnseq_sel (),
+        .adc_data_sel (),
+        .adc_pn_err (1'b0),
+        .adc_pn_oos (1'b0),
+        .adc_or (1'b0),
+        .adc_read_data ('d0),
+        .adc_status_header(),
+        .adc_crc_err(),
+        .up_adc_pn_err (),
+        .up_adc_pn_oos (),
+        .up_adc_or (),
+        .up_usr_datatype_be (),
+        .up_usr_datatype_signed (),
+        .up_usr_datatype_shift (),
+        .up_usr_datatype_total_bits (),
+        .up_usr_datatype_bits (),
+        .up_usr_decimation_m (),
+        .up_usr_decimation_n (),
+        .adc_usr_datatype_be (1'b0),
+        .adc_usr_datatype_signed (1'b1),
+        .adc_usr_datatype_shift (8'd0),
+        .adc_usr_datatype_total_bits (8'd32),
+        .adc_usr_datatype_bits (8'd32),
+        .adc_usr_decimation_m (16'd1),
+        .adc_usr_decimation_n (16'd1),
+        .up_rstn (up_rstn),
+        .up_clk (up_clk),
+        .up_wreq (up_wreq_s),
+        .up_waddr (up_waddr_s),
+        .up_wdata (up_wdata_s),
+        .up_wack (up_wack_s[i]),
+        .up_rreq (up_rreq_s),
+        .up_raddr (up_raddr_s),
+        .up_rdata (up_rdata_s[i]),
+        .up_rack (up_rack_s[i]));
+    end
+  endgenerate
+
+  // adc interface
+  wire             delay_locked;
+  wire [7:0]       adc_custom_control;
+  wire [1:0]       resolution;
+  wire [2:0]       mode;
+  wire [7:0]       polarity_mask_s;
+  wire [31:0]      adc_config_wr;
+
+  assign resolution      = adc_custom_control[1:0];
+  assign mode            = adc_custom_control[4:2];
+  assign polarity_mask_s = adc_config_wr[7:0];
+
+  axi_hmcad15xx_if  #(
+    .FPGA_TECHNOLOGY(FPGA_TECHNOLOGY),
+    .IO_DELAY_GROUP(IO_DELAY_GROUP),
+    .IODELAY_CTRL(IODELAY_CTRL)
+  ) i_axi_hmcad15xx_if (
+    .up_clk(up_clk),
+    .adc_rst(adc_rst_s),
+    .delay_clk(delay_clk),
+    .delay_rst(delay_rst),
+    .clk_in_p(clk_in_p),
+    .clk_in_n(clk_in_n),
+    .fclk_p(fclk_p),
+    .fclk_n(fclk_n),
+    .data_in_p (data_in_p),
+    .data_in_n (data_in_n),
+    .adc_clk (adc_clk_s),
+    .adc_clk_g (adc_clk_g_s),
+    .adc_valid (adc_valid),
+    .adc_data (adc_data),
+    .resolution(resolution),
+    .polarity_mask_s(polarity_mask_s),
+    .mode(mode),
+    .up_dld(up_dld),
+    .up_dwdata(up_dwdata),
+    .up_drdata(up_drdata),
+    .delay_locked(delay_locked));
+
+  // adc up common
+
+  up_adc_common #(
+    .ID(ID)
+  ) i_up_adc_common (
+    .mmcm_rst (),
+    .adc_clk (adc_clk_s),
+    .adc_rst (adc_rst_s),
+    .adc_r1_mode (),
+    .adc_ddr_edgesel (),
+    .adc_pin_mode (),
+    .adc_status ('h00),
+    .adc_sync_status (1'b1),
+    .adc_status_ovf (adc_dovf),
+    .adc_clk_ratio (32'd1),
+    .adc_start_code (),
+    .adc_sref_sync (),
+    .adc_sync (),
+    .adc_ext_sync_arm(),
+    .adc_ext_sync_disarm(),
+    .adc_ext_sync_manual_req(),
+    .adc_custom_control(adc_custom_control),
+    .adc_sdr_ddr_n(),
+    .adc_symb_op(),
+    .adc_symb_8_16b(),
+    .adc_num_lanes(),
+    .adc_crc_enable(),
+    .up_pps_rcounter (32'b0),
+    .up_pps_status (1'b0),
+    .up_pps_irq_mask (),
+    .up_adc_ce (),
+    .up_status_pn_err (1'b0),
+    .up_status_pn_oos (1'b0),
+    .up_status_or (1'b0),
+    .up_adc_r1_mode(),
+    .up_drp_sel (),
+    .up_drp_wr (),
+    .up_drp_addr (),
+    .up_drp_wdata (),
+    .up_drp_rdata (32'd0),
+    .up_drp_ready (1'd0),
+    .up_drp_locked (1'd1),
+    .adc_config_wr (adc_config_wr),
+    .adc_config_ctrl (),
+    .adc_config_rd ('d0),
+    .adc_ctrl_status ('d0),
+    .up_usr_chanmax_out (),
+    .up_usr_chanmax_in (NUM_CHANNELS),
+    .up_adc_gpio_in (32'b0),
+    .up_adc_gpio_out (),
+    .up_rstn (up_rstn),
+    .up_clk (up_clk),
+    .up_wreq (up_wreq_s),
+    .up_waddr (up_waddr_s),
+    .up_wdata (up_wdata_s),
+    .up_wack (up_wack_s[4]),
+    .up_rreq (up_rreq_s),
+    .up_raddr (up_raddr_s),
+    .up_rdata (up_rdata_s[4]),
+    .up_rack (up_rack_s[4]));
+
+ // adc delay control
+
+  up_delay_cntrl #(
+    .DATA_WIDTH(DELAY_CTRL_NUM_LANES),
+    .DRP_WIDTH(DELAY_CTRL_DRP_WIDTH),
+    .BASE_ADDRESS(6'h02)
+  ) i_delay_cntrl (
+    .core_rst(1'b0),
+    .delay_clk(delay_clk),
+    .delay_rst(delay_rst),
+    .delay_locked(delay_locked),
+    .up_dld(up_dld),
+    .up_dwdata(up_dwdata),
+    .up_drdata(up_drdata),
+    .up_rstn(up_rstn),
+    .up_clk(up_clk),
+    .up_wreq(up_wreq_s),
+    .up_waddr(up_waddr_s),
+    .up_wdata(up_wdata_s),
+    .up_wack(up_wack_s[5]),
+    .up_rreq(up_rreq_s),
+    .up_raddr(up_raddr_s),
+    .up_rdata(up_rdata_s[5]),
+    .up_rack(up_rack_s[5]));
+
+  // up bus interface
+
+  up_axi i_up_axi (
+    .up_rstn (up_rstn),
+    .up_clk (up_clk),
+    .up_axi_awvalid (s_axi_awvalid),
+    .up_axi_awaddr (s_axi_awaddr),
+    .up_axi_awready (s_axi_awready),
+    .up_axi_wvalid (s_axi_wvalid),
+    .up_axi_wdata (s_axi_wdata),
+    .up_axi_wstrb (s_axi_wstrb),
+    .up_axi_wready (s_axi_wready),
+    .up_axi_bvalid (s_axi_bvalid),
+    .up_axi_bresp (s_axi_bresp),
+    .up_axi_bready (s_axi_bready),
+    .up_axi_arvalid (s_axi_arvalid),
+    .up_axi_araddr (s_axi_araddr),
+    .up_axi_arready (s_axi_arready),
+    .up_axi_rvalid (s_axi_rvalid),
+    .up_axi_rresp (s_axi_rresp),
+    .up_axi_rdata (s_axi_rdata),
+    .up_axi_rready (s_axi_rready),
+    .up_wreq (up_wreq_s),
+    .up_waddr (up_waddr_s),
+    .up_wdata (up_wdata_s),
+    .up_wack (up_wack),
+    .up_rreq (up_rreq_s),
+    .up_raddr (up_raddr_s),
+    .up_rdata (up_rdata),
+    .up_rack (up_rack));
+
+endmodule

--- a/library/axi_hmcad15xx/axi_hmcad15xx_if.v
+++ b/library/axi_hmcad15xx/axi_hmcad15xx_if.v
@@ -1,0 +1,246 @@
+// ***************************************************************************
+// ***************************************************************************
+// Copyright (C) 2025-2026 Analog Devices, Inc. All rights reserved.
+//
+// In this HDL repository, there are many different and unique modules, consisting
+// of various HDL (Verilog or VHDL) components. The individual modules are
+// developed independently, and may be accompanied by separate and unique license
+// terms.
+//
+// The user should read each of these license terms, and understand the
+// freedoms and responsibilities that he or she has by using this source/core.
+//
+// This core is distributed in the hope that it will be useful, but WITHOUT ANY
+// WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+// A PARTICULAR PURPOSE.
+//
+// Redistribution and use of source or resulting binaries, with or without modification
+// of this file, are permitted under one of the following two license terms:
+//
+//   1. The GNU General Public License version 2 as published by the
+//      Free Software Foundation, which can be found in the top level directory
+//      of this repository (LICENSE_GPL2), and also online at:
+//      <https://www.gnu.org/licenses/old-licenses/gpl-2.0.html>
+//
+// OR
+//
+//   2. An ADI specific BSD license, which can be found in the top level directory
+//      of this repository (LICENSE_ADIBSD), and also on-line at:
+//      https://github.com/analogdevicesinc/hdl/blob/main/LICENSE_ADIBSD
+//      This will allow to generate bit files and not release the source code,
+//      as long as it attaches to an ADI device.
+//
+// ***************************************************************************
+// ***************************************************************************
+
+`timescale 1ns/100ps
+
+module axi_hmcad15xx_if #(
+  parameter          DRP_WIDTH = 5,
+  parameter          NUM_LANES = 9,  // Data lanes + frame lane
+  parameter          FPGA_TECHNOLOGY = 0,
+  parameter          IODELAY_CTRL = 0,
+  parameter          IO_DELAY_GROUP = "adc_if_delay_group",
+  parameter          REFCLK_FREQUENCY = 200
+) (
+
+  // device-interface
+
+  input                  clk_in_p,
+  input                  clk_in_n,
+  input                  fclk_p,
+  input                  fclk_n,
+  input   [ 7:0]         data_in_p,
+  input   [ 7:0]         data_in_n,
+
+  input                  adc_rst,
+
+  input   [ 1:0]         resolution,
+  input   [ 2:0]         mode,
+  input   [ 7:0]         polarity_mask_s,
+
+  // data path interface
+
+  output                 adc_clk,      // Regional clock (BUFR) - for local IO logic only
+  output                 adc_clk_g,    // Global clock (BUFG) - for BRAM/fabric logic
+  output                 adc_valid,
+  output    [127:0]      adc_data,
+
+  // delay control signals
+  input                                     up_clk,
+  input       [NUM_LANES-1:0]               up_dld,
+  input       [(DRP_WIDTH*NUM_LANES)-1:0]   up_dwdata,
+  output      [(DRP_WIDTH*NUM_LANES)-1:0]   up_drdata,
+  input                                     delay_clk,
+  input                                     delay_rst,
+  output                                    delay_locked
+);
+
+  wire [15:0]  sample_assembly_out [0:7];
+  wire [ 7:0]  serdes_data [0:7];
+  wire         adc_clk_in_fast;
+  wire [15:0]  data_out [0:7];
+  wire         adc_clk_div;      // Regional clock from BUFR
+  wire         adc_clk_global;   // Global clock from BUFG
+  wire [ 7:0]  frame_data;
+  wire         clk_in_s;
+  wire [ 7:0]  data_en;
+  wire [ 8:0]  data_s0;
+  wire [ 8:0]  data_s1;
+  wire [ 8:0]  data_s2;
+  wire [ 8:0]  data_s3;
+  wire [ 8:0]  data_s4;
+  wire [ 8:0]  data_s5;
+  wire [ 8:0]  data_s6;
+  wire [ 8:0]  data_s7;
+
+  reg  [127:0] wr_data14_reg;
+  reg          wr_en14_reg;
+  reg          wr_en8_reg;
+  reg  [127:0] wr_data_int;
+  reg  [127:0] wr_data_reg;
+  reg          wr_en_reg;
+
+  assign adc_valid   = (resolution == 2'b00 || resolution == 2'b01) ? wr_en8_reg  : (resolution != 2'b11) ? wr_en_reg : (wr_en14_reg && data_en[0]);
+  assign adc_data    = (resolution != 2'b11) ? wr_data_reg :  wr_data14_reg;
+  assign adc_clk     = adc_clk_div;     // Regional clock for IO-local logic
+  assign adc_clk_g   = adc_clk_global;  // Global clock for BRAM/fabric
+
+  IBUFDS i_clk_in_ibuf(
+    .I (clk_in_p),
+    .IB(clk_in_n),
+    .O(clk_in_s));
+
+  BUFIO i_clk_buf(
+    .I(clk_in_s),
+    .O(adc_clk_in_fast));
+
+  // Regional clock buffer - drives ISERDES and local IO logic
+  // Limited to resources within the same clock region
+  BUFR #(
+    .BUFR_DIVIDE("4")
+  ) i_div_clk_buf (
+    .CLR(1'b0),
+    .CE(1'b1),
+    .I(clk_in_s),
+    .O(adc_clk_div));
+
+  // Global clock buffer - drives BRAM and fabric logic anywhere on chip
+  // Converts regional BUFR clock to global routing network
+  BUFG i_global_clk_buf (
+    .I(adc_clk_div),
+    .O(adc_clk_global));
+
+  ad_serdes_in #(
+    .FPGA_TECHNOLOGY (FPGA_TECHNOLOGY),
+    .IODELAY_GROUP (IO_DELAY_GROUP),
+    .IODELAY_CTRL (IODELAY_CTRL),
+    .DATA_WIDTH (NUM_LANES),
+    .DRP_WIDTH (DRP_WIDTH),
+    .SERDES_FACTOR (8),
+    .DDR_OR_SDR_N (1),
+    .CMOS_LVDS_N (0)
+  ) ad_serdes_data_inst (
+    .rst (adc_rst),
+    .clk (adc_clk_in_fast),
+    .div_clk (adc_clk_div),
+    .data_s0 (data_s0),
+    .data_s1 (data_s1),
+    .data_s2 (data_s2),
+    .data_s3 (data_s3),
+    .data_s4 (data_s4),
+    .data_s5 (data_s5),
+    .data_s6 (data_s6),
+    .data_s7 (data_s7),
+    .data_in_p ({fclk_p, data_in_p}),
+    .data_in_n ({fclk_n, data_in_n}),
+    .up_clk (up_clk),
+    .up_dld (up_dld),
+    .up_dwdata (up_dwdata),
+    .up_drdata (up_drdata),
+    .delay_clk (delay_clk),
+    .delay_rst (delay_rst),
+    .delay_locked (delay_locked));
+
+  assign {frame_data[7],serdes_data[7][7],serdes_data[6][7],serdes_data[5][7],serdes_data[4][7],serdes_data[3][7],serdes_data[2][7],serdes_data[1][7],serdes_data[0][7]} = data_s0;  //latest bit received
+  assign {frame_data[6],serdes_data[7][6],serdes_data[6][6],serdes_data[5][6],serdes_data[4][6],serdes_data[3][6],serdes_data[2][6],serdes_data[1][6],serdes_data[0][6]} = data_s1;  //
+  assign {frame_data[5],serdes_data[7][5],serdes_data[6][5],serdes_data[5][5],serdes_data[4][5],serdes_data[3][5],serdes_data[2][5],serdes_data[1][5],serdes_data[0][5]} = data_s2;  //
+  assign {frame_data[4],serdes_data[7][4],serdes_data[6][4],serdes_data[5][4],serdes_data[4][4],serdes_data[3][4],serdes_data[2][4],serdes_data[1][4],serdes_data[0][4]} = data_s3;  //
+  assign {frame_data[3],serdes_data[7][3],serdes_data[6][3],serdes_data[5][3],serdes_data[4][3],serdes_data[3][3],serdes_data[2][3],serdes_data[1][3],serdes_data[0][3]} = data_s4;  //
+  assign {frame_data[2],serdes_data[7][2],serdes_data[6][2],serdes_data[5][2],serdes_data[4][2],serdes_data[3][2],serdes_data[2][2],serdes_data[1][2],serdes_data[0][2]} = data_s5;  //
+  assign {frame_data[1],serdes_data[7][1],serdes_data[6][1],serdes_data[5][1],serdes_data[4][1],serdes_data[3][1],serdes_data[2][1],serdes_data[1][1],serdes_data[0][1]} = data_s6;  //
+  assign {frame_data[0],serdes_data[7][0],serdes_data[6][0],serdes_data[5][0],serdes_data[4][0],serdes_data[3][0],serdes_data[2][0],serdes_data[1][0],serdes_data[0][0]} = data_s7;  // oldest bit received
+
+  generate
+    genvar i;
+      for (i = 0; i < NUM_LANES-1; i=i+1) begin: sample_assembly_lanes
+        sample_assembly sample_assembly_inst (
+          .clk (adc_clk_div),
+          .frame (frame_data),
+          .data_in (serdes_data[i]),
+          .resolution (resolution),
+          .data_en (data_en[i]),
+          .data_out (sample_assembly_out[i]));
+      end
+  endgenerate
+
+  //==========================================================================
+  // Arrange samples in capture format
+  //==========================================================================
+
+  assign data_out[0] = {16{polarity_mask_s[0]}}^sample_assembly_out[0];
+  assign data_out[1] = {16{polarity_mask_s[1]}}^sample_assembly_out[1];
+  assign data_out[2] = {16{polarity_mask_s[2]}}^sample_assembly_out[2];
+  assign data_out[3] = {16{polarity_mask_s[3]}}^sample_assembly_out[3];
+  assign data_out[4] = {16{polarity_mask_s[4]}}^sample_assembly_out[4];
+  assign data_out[5] = {16{polarity_mask_s[5]}}^sample_assembly_out[5];
+  assign data_out[6] = {16{polarity_mask_s[6]}}^sample_assembly_out[6];
+  assign data_out[7] = {16{polarity_mask_s[7]}}^sample_assembly_out[7];
+
+  always @(posedge adc_clk_div) begin
+    if((resolution == 2'b11) && (mode == 3'b100)) begin           // 14-bit  single lane quad channel
+      wr_data_int <= {data_out[6], data_out[4], data_out[2], data_out[0], 64'b0};
+    end else if((resolution == 2'b10) && (mode == 3'b100)) begin  // 12-bit quad channel
+      wr_data_int <= {data_out[7], data_out[5], data_out[3], data_out[1],
+                      data_out[6], data_out[4], data_out[2], data_out[0]};
+    end else if((resolution == 2'b10) && (mode == 3'b010)) begin  // 12-bit dual channel
+      wr_data_int <= {data_out[7], data_out[3], data_out[6], data_out[2],
+                      data_out[5], data_out[1], data_out[4], data_out[0]};
+    end else if((resolution == 2'b10) && (mode == 3'b001)) begin  // 12-bit single channel
+      wr_data_int <= {data_out[7], data_out[6], data_out[5], data_out[4],
+                      data_out[3], data_out[2], data_out[1], data_out[0]};
+    end else if((resolution == 2'b01) && (mode == 3'b100)) begin  //  dual 8-bit quad channel
+      wr_data_int <= {data_out[6][ 7:0], data_out[7][ 7:0], data_out[4][ 7:0], data_out[5][ 7:0], data_out[2][ 7:0], data_out[3][ 7:0], data_out[0][ 7:0], data_out[1][ 7:0],
+                      data_out[6][15:8], data_out[7][15:8], data_out[4][15:8], data_out[5][15:8], data_out[2][15:8], data_out[3][15:8], data_out[0][15:8], data_out[1][15:8]};
+    end else if((resolution == 2'b00) && (mode == 3'b100)) begin  //  8-bit quad channel
+      wr_data_int <= {data_out[6][ 7:0], data_out[4][ 7:0], data_out[2][ 7:0], data_out[0][ 7:0], data_out[7][ 7:0], data_out[5][ 7:0], data_out[3][ 7:0], data_out[1][ 7:0],
+                      data_out[6][15:8], data_out[4][15:8], data_out[2][15:8], data_out[0][15:8], data_out[7][15:8], data_out[5][15:8], data_out[3][15:8], data_out[1][15:8]};
+    end else if((resolution == 2'b00) && (mode == 3'b010)) begin  //  8-bit dual channel
+      wr_data_int <= {data_out[7][ 7:0], data_out[3][ 7:0], data_out[6][ 7:0], data_out[2][ 7:0], data_out[5][ 7:0], data_out[1][ 7:0], data_out[4][ 7:0], data_out[0][ 7:0],
+                      data_out[7][15:8], data_out[3][15:8], data_out[6][15:8], data_out[2][15:8], data_out[5][15:8], data_out[1][15:8], data_out[4][15:8], data_out[0][15:8]};
+    end else if((resolution == 2'b00) && (mode == 3'b001)) begin  //  8-bit single channel
+      wr_data_int <= {data_out[7][ 7:0], data_out[6][ 7:0], data_out[5][ 7:0], data_out[4][ 7:0],
+                      data_out[3][ 7:0], data_out[2][ 7:0], data_out[1][ 7:0], data_out[0][ 7:0],
+                      data_out[7][15:8], data_out[6][15:8], data_out[5][15:8], data_out[4][15:8],
+                      data_out[3][15:8], data_out[2][15:8], data_out[1][15:8], data_out[0][15:8]};
+    end
+  end
+
+  always @(posedge adc_clk_div) begin
+    if(adc_rst) begin
+      wr_en8_reg    <= 1'b0;
+      wr_en14_reg   <= 1'b0;
+      wr_data14_reg <= 128'b0;
+    end else if(data_en[0]) begin
+      wr_en8_reg    <= ~wr_en8_reg;
+      wr_en14_reg   <= ~wr_en14_reg;
+      wr_data14_reg <= {wr_data14_reg[63:0], wr_data_int[127:64]};
+    end
+  end
+
+  always @(posedge adc_clk_div) begin
+    wr_en_reg   <= data_en[0];
+    wr_data_reg <= wr_data_int;
+  end
+
+endmodule

--- a/library/axi_hmcad15xx/axi_hmcad15xx_ip.tcl
+++ b/library/axi_hmcad15xx/axi_hmcad15xx_ip.tcl
@@ -1,0 +1,58 @@
+###############################################################################
+## Copyright (C) 2025-2026 Analog Devices, Inc. All rights reserved.
+### SPDX short identifier: ADIBSD
+###############################################################################
+
+# ip
+source ../../scripts/adi_env.tcl
+source $ad_hdl_dir/library/scripts/adi_ip_xilinx.tcl
+
+adi_ip_create axi_hmcad15xx
+
+adi_ip_files axi_hmcad15xx [list \
+  "$ad_hdl_dir/library/xilinx/common/ad_data_clk.v" \
+  "$ad_hdl_dir/library/xilinx/common/ad_data_in.v" \
+  "$ad_hdl_dir/library/xilinx/common/ad_serdes_in.v" \
+  "$ad_hdl_dir/library/xilinx/common/ad_dcfilter.v" \
+  "$ad_hdl_dir/library/common/ad_rst.v" \
+  "$ad_hdl_dir/library/common/ad_datafmt.v" \
+  "$ad_hdl_dir/library/common/up_xfer_status.v" \
+  "$ad_hdl_dir/library/common/up_xfer_cntrl.v" \
+  "$ad_hdl_dir/library/common/up_clock_mon.v" \
+  "$ad_hdl_dir/library/common/up_delay_cntrl.v" \
+  "$ad_hdl_dir/library/common/up_adc_common.v" \
+  "$ad_hdl_dir/library/common/up_adc_channel.v" \
+  "$ad_hdl_dir/library/common/up_axi.v" \
+  "$ad_hdl_dir/library/xilinx/common/up_xfer_cntrl_constr.xdc" \
+  "$ad_hdl_dir/library/xilinx/common/ad_rst_constr.xdc" \
+  "$ad_hdl_dir/library/xilinx/common/up_xfer_status_constr.xdc" \
+  "$ad_hdl_dir/library/xilinx/common/up_clock_mon_constr.xdc" \
+  "sample_assembly.v"  \
+  "axi_hmcad15xx_if.v" \
+  "axi_hmcad15xx.v" ]
+
+adi_ip_properties axi_hmcad15xx
+
+adi_init_bd_tcl
+adi_ip_bd axi_hmcad15xx "bd/bd.tcl"
+
+set cc [ipx::current_core]
+
+set_property company_url {https://analogdevicesinc.github.io/hdl/library/axi_hmcad15xx/index.html} $cc
+
+
+set_property driver_value 0 [ipx::get_ports *dovf* -of_objects $cc]
+set_property driver_value 0 [ipx::get_ports *adc* -of_objects  $cc]
+
+
+ipx::infer_bus_interface adc_clk xilinx.com:signal:clock_rtl:1.0 $cc
+ipx::infer_bus_interface adc_clk_g xilinx.com:signal:clock_rtl:1.0 $cc
+ipx::infer_bus_interface clk_in xilinx.com:signal:clock_rtl:1.0 $cc
+set reset_intf [ipx::infer_bus_interface adc_reset xilinx.com:signal:reset_rtl:1.0 $cc ]
+set reset_polarity [ipx::add_bus_parameter "POLARITY" $reset_intf]
+set_property value "ACTIVE_HIGH" $reset_polarity
+
+adi_add_auto_fpga_spec_params
+ipx::create_xgui_files $cc
+
+ipx::save_core $cc

--- a/library/axi_hmcad15xx/sample_assembly.v
+++ b/library/axi_hmcad15xx/sample_assembly.v
@@ -1,0 +1,656 @@
+// ***************************************************************************
+// ***************************************************************************
+// Copyright (C) 2025-2026 Analog Devices, Inc. All rights reserved.
+//
+// In this HDL repository, there are many different and unique modules, consisting
+// of various HDL (Verilog or VHDL) components. The individual modules are
+// developed independently, and may be accompanied by separate and unique license
+// terms.
+//
+// The user should read each of these license terms, and understand the
+// freedoms and responsibilities that he or she has by using this source/core.
+//
+// This core is distributed in the hope that it will be useful, but WITHOUT ANY
+// WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+// A PARTICULAR PURPOSE.
+//
+// Redistribution and use of source or resulting binaries, with or without modification
+// of this file, are permitted under one of the following two license terms:
+//
+//   1. The GNU General Public License version 2 as published by the
+//      Free Software Foundation, which can be found in the top level directory
+//      of this repository (LICENSE_GPL2), and also online at:
+//      <https://www.gnu.org/licenses/old-licenses/gpl-2.0.html>
+//
+// OR
+//
+//   2. An ADI specific BSD license, which can be found in the top level directory
+//      of this repository (LICENSE_ADIBSD), and also on-line at:
+//      https://github.com/analogdevicesinc/hdl/blob/main/LICENSE_ADIBSD
+//      This will allow to generate bit files and not release the source code,
+//      as long as it attaches to an ADI device.
+//
+// ***************************************************************************
+// ***************************************************************************
+
+`timescale 1ns/100ps
+
+module sample_assembly (
+   input         clk,
+   input  [7:0]  frame,
+   input  [7:0]  data_in,
+   input  [1:0]  resolution,
+   output        data_en,
+   output [15:0] data_out
+);
+
+   //==========================================================================
+   // Signal declarations
+   //==========================================================================
+   reg  [7:0]  data_in_reg;
+   reg  [7:0]  frame_in_reg;
+   reg  [6:0]  carry_reg;
+   reg  [15:0] data_int_reg;
+   reg         data_int_rdy;
+   reg  [15:0] data_out_reg;
+   reg  [15:0] sample14_reg;
+   reg  [15:0] sample12_reg;
+   reg  [15:0] sample8_reg;
+
+   //==========================================================================
+   // Register input data
+   //==========================================================================
+   always @(posedge clk)
+      begin
+         frame_in_reg <= frame;
+         data_in_reg  <= data_in;
+      end
+
+   //==========================================================================
+   // Process data for each configuration
+   //==========================================================================
+   always @(posedge clk) begin
+      if(resolution == 2'b11) begin  // 14-bits
+         case(frame_in_reg)
+            8'b01111111: // 0
+               begin
+                  data_int_reg[15] <= data_in_reg[0]; //D0
+                  data_int_reg[14] <= data_in_reg[1];
+                  data_int_reg[13] <= data_in_reg[2];
+                  data_int_reg[12] <= data_in_reg[3];
+                  data_int_reg[11] <= data_in_reg[4];
+                  data_int_reg[10] <= data_in_reg[5];
+                  data_int_reg[9]  <= data_in_reg[6];
+                  data_int_reg[8]  <= data_in_reg[7]; //D7
+                  data_int_rdy     <= 0;
+               end
+            8'b00111111: // 1
+               begin
+                  data_int_reg[15] <= carry_reg[0];   //D0 from carry
+                  data_int_reg[14] <= data_in_reg[0]; //D1
+                  data_int_reg[13] <= data_in_reg[1];
+                  data_int_reg[12] <= data_in_reg[2];
+                  data_int_reg[11] <= data_in_reg[3];
+                  data_int_reg[10] <= data_in_reg[4];
+                  data_int_reg[9]  <= data_in_reg[5];
+                  data_int_reg[8]  <= data_in_reg[6];
+                  data_int_reg[7]  <= data_in_reg[7]; //D8
+                  data_int_rdy     <= 0;
+               end
+            8'b00011111: // 2
+               begin
+                  data_int_reg[15] <= carry_reg[1];   //D0 from carry
+                  data_int_reg[14] <= carry_reg[0];   //D1 from carry
+                  data_int_reg[13] <= data_in_reg[0]; //D2
+                  data_int_reg[12] <= data_in_reg[1];
+                  data_int_reg[11] <= data_in_reg[2];
+                  data_int_reg[10] <= data_in_reg[3];
+                  data_int_reg[9]  <= data_in_reg[4];
+                  data_int_reg[8]  <= data_in_reg[5];
+                  data_int_reg[7]  <= data_in_reg[6];
+                  data_int_reg[6]  <= data_in_reg[7]; //D9
+                  data_int_rdy     <= 0;
+               end
+            8'b00001111: // 3
+               begin
+                  data_int_reg[15] <= carry_reg[2];   //D0 from carry
+                  data_int_reg[14] <= carry_reg[1];
+                  data_int_reg[13] <= carry_reg[0];   //D2 from carry
+                  data_int_reg[12] <= data_in_reg[0]; //D3
+                  data_int_reg[11] <= data_in_reg[1];
+                  data_int_reg[10] <= data_in_reg[2];
+                  data_int_reg[9]  <= data_in_reg[3];
+                  data_int_reg[8]  <= data_in_reg[4];
+                  data_int_reg[7]  <= data_in_reg[5];
+                  data_int_reg[6]  <= data_in_reg[6];
+                  data_int_reg[5]  <= data_in_reg[7]; //D10
+                  data_int_rdy     <= 0;
+               end
+            8'b00000111: // 4
+               begin
+                  data_int_reg[15] <= carry_reg[3];   //D0 from carry
+                  data_int_reg[14] <= carry_reg[2];
+                  data_int_reg[13] <= carry_reg[1];
+                  data_int_reg[12] <= carry_reg[0];   //D3 from carry
+                  data_int_reg[11] <= data_in_reg[0]; //D4
+                  data_int_reg[10] <= data_in_reg[1];
+                  data_int_reg[9]  <= data_in_reg[2];
+                  data_int_reg[8]  <= data_in_reg[3];
+                  data_int_reg[7]  <= data_in_reg[4];
+                  data_int_reg[6]  <= data_in_reg[5];
+                  data_int_reg[5]  <= data_in_reg[6];
+                  data_int_reg[4]  <= data_in_reg[7]; //D11
+                  data_int_rdy     <= 0;
+               end
+            8'b00000011: // 5
+               begin
+                  data_int_reg[15] <= carry_reg[4];   //D0 from carry
+                  data_int_reg[14] <= carry_reg[3];
+                  data_int_reg[13] <= carry_reg[2];
+                  data_int_reg[12] <= carry_reg[1];
+                  data_int_reg[11] <= carry_reg[0];   //D4 from carry
+                  data_int_reg[10] <= data_in_reg[0]; //D5
+                  data_int_reg[9]  <= data_in_reg[1];
+                  data_int_reg[8]  <= data_in_reg[2];
+                  data_int_reg[7]  <= data_in_reg[3];
+                  data_int_reg[6]  <= data_in_reg[4];
+                  data_int_reg[5]  <= data_in_reg[5];
+                  data_int_reg[4]  <= data_in_reg[6];
+                  data_int_reg[3]  <= data_in_reg[7]; //D12
+                  data_int_rdy     <= 0;
+               end
+            8'b00000001: // 6
+               begin
+                  data_int_reg[15] <= carry_reg[5];   //D0 from carry
+                  data_int_reg[14] <= carry_reg[4];
+                  data_int_reg[13] <= carry_reg[3];
+                  data_int_reg[12] <= carry_reg[2];
+                  data_int_reg[11] <= carry_reg[1];
+                  data_int_reg[10] <= carry_reg[0];   //D5 from carry
+                  data_int_reg[9]  <= data_in_reg[0]; //D6
+                  data_int_reg[8]  <= data_in_reg[1];
+                  data_int_reg[7]  <= data_in_reg[2];
+                  data_int_reg[6]  <= data_in_reg[3];
+                  data_int_reg[5]  <= data_in_reg[4];
+                  data_int_reg[4]  <= data_in_reg[5];
+                  data_int_reg[3]  <= data_in_reg[6];
+                  data_int_reg[2]  <= data_in_reg[7]; //D13
+                  data_int_rdy     <= 1;
+               end
+            8'b10000000: // 7
+               begin
+                  data_int_reg[15] <= carry_reg[6];   //D0 from carry
+                  data_int_reg[14] <= carry_reg[5];
+                  data_int_reg[13] <= carry_reg[4];
+                  data_int_reg[12] <= carry_reg[3];
+                  data_int_reg[11] <= carry_reg[2];
+                  data_int_reg[10] <= carry_reg[1];
+                  data_int_reg[9]  <= carry_reg[0];   //D6 from carry
+                  data_int_reg[8]  <= data_in_reg[0]; //D7
+                  data_int_reg[7]  <= data_in_reg[1];
+                  data_int_reg[6]  <= data_in_reg[2];
+                  data_int_reg[5]  <= data_in_reg[3];
+                  data_int_reg[4]  <= data_in_reg[4];
+                  data_int_reg[3]  <= data_in_reg[5];
+                  data_int_reg[2]  <= data_in_reg[6]; //D13
+                  carry_reg[0]     <= data_in_reg[7]; //D0 to carry
+                  data_int_rdy     <= 1;
+               end
+            8'b11000000: // 8
+               begin
+                  data_int_reg[7]  <= data_in_reg[0]; //D8
+                  data_int_reg[6]  <= data_in_reg[1];
+                  data_int_reg[5]  <= data_in_reg[2];
+                  data_int_reg[4]  <= data_in_reg[3];
+                  data_int_reg[3]  <= data_in_reg[4];
+                  data_int_reg[2]  <= data_in_reg[5]; //D13
+                  carry_reg[1]     <= data_in_reg[6]; //D0 to carry
+                  carry_reg[0]     <= data_in_reg[7]; //D1 to carry
+                  data_int_rdy     <= 1;
+               end
+            8'b11100000: // 9
+               begin
+                  data_int_reg[6]  <= data_in_reg[0]; //D9
+                  data_int_reg[5]  <= data_in_reg[1];
+                  data_int_reg[4]  <= data_in_reg[2];
+                  data_int_reg[3]  <= data_in_reg[3];
+                  data_int_reg[2]  <= data_in_reg[4]; //D13
+                  carry_reg[2]     <= data_in_reg[5]; //D0 to carry
+                  carry_reg[1]     <= data_in_reg[6];
+                  carry_reg[0]     <= data_in_reg[7]; //D2 to carry
+                  data_int_rdy     <= 1;
+               end
+            8'b11110000: // 10
+               begin
+                  data_int_reg[5]  <= data_in_reg[0]; //D10
+                  data_int_reg[4]  <= data_in_reg[1];
+                  data_int_reg[3]  <= data_in_reg[2];
+                  data_int_reg[2]  <= data_in_reg[3]; //D13
+                  carry_reg[3]     <= data_in_reg[4]; //D0 to carry
+                  carry_reg[2]     <= data_in_reg[5];
+                  carry_reg[1]     <= data_in_reg[6];
+                  carry_reg[0]     <= data_in_reg[7]; //D3 to carry
+                  data_int_rdy     <= 1;
+               end
+            8'b11111000: // 11
+               begin
+                  data_int_reg[4]  <= data_in_reg[0]; //D11
+                  data_int_reg[3]  <= data_in_reg[1];
+                  data_int_reg[2]  <= data_in_reg[2]; //D13
+                  carry_reg[4]     <= data_in_reg[3]; //D0 to carry
+                  carry_reg[3]     <= data_in_reg[4];
+                  carry_reg[2]     <= data_in_reg[5];
+                  carry_reg[1]     <= data_in_reg[6];
+                  carry_reg[0]     <= data_in_reg[7]; //D4 to carry
+                  data_int_rdy     <= 1;
+               end
+            8'b11111100: // 12
+               begin
+                  data_int_reg[3]  <= data_in_reg[0]; //D12
+                  data_int_reg[2]  <= data_in_reg[1]; //D13
+                  carry_reg[5]     <= data_in_reg[2]; //D0 to carry
+                  carry_reg[4]     <= data_in_reg[3];
+                  carry_reg[3]     <= data_in_reg[4];
+                  carry_reg[2]     <= data_in_reg[5];
+                  carry_reg[1]     <= data_in_reg[6];
+                  carry_reg[0]     <= data_in_reg[7]; //D5 to carry
+                  data_int_rdy     <= 1;
+               end
+            8'b11111110: // 13
+               begin
+                  data_int_reg[2]  <= data_in_reg[0]; //D13
+                  carry_reg[6]     <= data_in_reg[1]; //D0 to carry
+                  carry_reg[5]     <= data_in_reg[2];
+                  carry_reg[4]     <= data_in_reg[3];
+                  carry_reg[3]     <= data_in_reg[4];
+                  carry_reg[2]     <= data_in_reg[5];
+                  carry_reg[1]     <= data_in_reg[6];
+                  carry_reg[0]     <= data_in_reg[7]; //D6 to carry
+                  data_int_rdy     <= 1;
+               end
+            default:
+                  data_int_rdy     <= 0;
+         endcase
+         data_int_reg[1] <= 0;
+         data_int_reg[0] <= 0;
+      end else if(resolution == 2'b10) begin  // 12-bits
+         case(frame_in_reg)
+            8'b00111111: // 0
+               begin
+                  data_int_reg[15] <=  data_in_reg[0]; //D0
+                  data_int_reg[14] <=  data_in_reg[1];
+                  data_int_reg[13] <=  data_in_reg[2];
+                  data_int_reg[12] <=  data_in_reg[3];
+                  data_int_reg[11] <=  data_in_reg[4];
+                  data_int_reg[10] <=  data_in_reg[5];
+                  data_int_reg[9]  <=  data_in_reg[6];
+                  data_int_reg[8]  <=  data_in_reg[7]; //D7
+                  data_int_rdy     <=  0;
+               end
+            8'b00011111: // 1
+               begin
+                  data_int_reg[15] <=  carry_reg[0];   //D0 from carry
+                  data_int_reg[14] <=  data_in_reg[0]; //D1
+                  data_int_reg[13] <=  data_in_reg[1];
+                  data_int_reg[12] <=  data_in_reg[2];
+                  data_int_reg[11] <=  data_in_reg[3];
+                  data_int_reg[10] <=  data_in_reg[4];
+                  data_int_reg[9]  <=  data_in_reg[5];
+                  data_int_reg[8]  <=  data_in_reg[6];
+                  data_int_reg[7]  <=  data_in_reg[7]; //D8
+                  data_int_rdy     <=  0;
+               end
+            8'b00001111: // 2
+               begin
+                  data_int_reg[15] <=  carry_reg[1];   //D0 from carry
+                  data_int_reg[14] <=  carry_reg[0];   //D1 from carry
+                  data_int_reg[13] <=  data_in_reg[0]; //D2
+                  data_int_reg[12] <=  data_in_reg[1];
+                  data_int_reg[11] <=  data_in_reg[2];
+                  data_int_reg[10] <=  data_in_reg[3];
+                  data_int_reg[9]  <=  data_in_reg[4];
+                  data_int_reg[8]  <=  data_in_reg[5];
+                  data_int_reg[7]  <=  data_in_reg[6];
+                  data_int_reg[6]  <=  data_in_reg[7]; //D9
+                  data_int_rdy     <=  0;
+               end
+            8'b00000111: // 3
+               begin
+                  data_int_reg[15] <=  carry_reg[2];    //D0 from carry
+                  data_int_reg[14] <=  carry_reg[1];
+                  data_int_reg[13] <=  carry_reg[0];   //D2 from carry
+                  data_int_reg[12] <=  data_in_reg[0]; //D3
+                  data_int_reg[11] <=  data_in_reg[1];
+                  data_int_reg[10] <=  data_in_reg[2];
+                  data_int_reg[9]  <=  data_in_reg[3];
+                  data_int_reg[8]  <=  data_in_reg[4];
+                  data_int_reg[7]  <=  data_in_reg[5];
+                  data_int_reg[6]  <=  data_in_reg[6];
+                  data_int_reg[5]  <=  data_in_reg[7]; //D10
+                  data_int_rdy     <=  0;
+               end
+            8'b00000011: // 4
+               begin
+                  data_int_reg[15] <=  carry_reg[3];   //D0 from carry
+                  data_int_reg[14] <=  carry_reg[2];
+                  data_int_reg[13] <=  carry_reg[1];
+                  data_int_reg[12] <=  carry_reg[0];   //D3 from carry
+                  data_int_reg[11] <=  data_in_reg[0]; //D4
+                  data_int_reg[10] <=  data_in_reg[1];
+                  data_int_reg[9]  <=  data_in_reg[2];
+                  data_int_reg[8]  <=  data_in_reg[3];
+                  data_int_reg[7]  <=  data_in_reg[4];
+                  data_int_reg[6]  <=  data_in_reg[5];
+                  data_int_reg[5]  <=  data_in_reg[6];
+                  data_int_reg[4]  <=  data_in_reg[7]; //D11
+                  data_int_rdy     <=  1;
+               end
+            8'b10000001: // 5
+               begin
+                  data_int_reg[15] <=  carry_reg[4];   //D0 from carry
+                  data_int_reg[14] <=  carry_reg[3];
+                  data_int_reg[13] <=  carry_reg[2];
+                  data_int_reg[12] <=  carry_reg[1];
+                  data_int_reg[11] <=  carry_reg[0];   //D4 from carry
+                  data_int_reg[10] <=  data_in_reg[0]; //D5
+                  data_int_reg[9]  <=  data_in_reg[1];
+                  data_int_reg[8]  <=  data_in_reg[2];
+                  data_int_reg[7]  <=  data_in_reg[3];
+                  data_int_reg[6]  <=  data_in_reg[4];
+                  data_int_reg[5]  <=  data_in_reg[5];
+                  data_int_reg[4]  <=  data_in_reg[6]; //D11
+                  carry_reg[0]     <=  data_in_reg[7]; //D0 to carry
+                  data_int_rdy     <=  1;
+               end
+            8'b11000000: // 6
+               begin
+                  data_int_reg[15] <=  carry_reg[5];   //D0 from carry
+                  data_int_reg[14] <=  carry_reg[4];
+                  data_int_reg[13] <=  carry_reg[3];
+                  data_int_reg[12] <=  carry_reg[2];
+                  data_int_reg[11] <=  carry_reg[1];
+                  data_int_reg[10] <=  carry_reg[0];   //D5 from carry
+                  data_int_reg[9]  <=  data_in_reg[0]; //D6
+                  data_int_reg[8]  <=  data_in_reg[1];
+                  data_int_reg[7]  <=  data_in_reg[2];
+                  data_int_reg[6]  <=  data_in_reg[3];
+                  data_int_reg[5]  <=  data_in_reg[4];
+                  data_int_reg[4]  <=  data_in_reg[5]; //D11
+                  carry_reg[1]     <=  data_in_reg[6]; //D0 to carry
+                  carry_reg[0]     <=  data_in_reg[7]; //D1 to carry
+                  data_int_rdy     <=  1;
+               end
+            8'b11100000: // 7
+               begin
+                  data_int_reg[15] <=  carry_reg[6];   //D0 from carry
+                  data_int_reg[14] <=  carry_reg[5];
+                  data_int_reg[13] <=  carry_reg[4];
+                  data_int_reg[12] <=  carry_reg[3];
+                  data_int_reg[11] <=  carry_reg[2];
+                  data_int_reg[10] <=  carry_reg[1];
+                  data_int_reg[9]  <=  carry_reg[0];   //D6 from carry
+                  data_int_reg[8]  <=  data_in_reg[0]; //D7
+                  data_int_reg[7]  <=  data_in_reg[1];
+                  data_int_reg[6]  <=  data_in_reg[2];
+                  data_int_reg[5]  <=  data_in_reg[3];
+                  data_int_reg[4]  <=  data_in_reg[4]; //D11
+                  carry_reg[2]     <=  data_in_reg[5]; //D0 to carry
+                  carry_reg[1]     <=  data_in_reg[6];
+                  carry_reg[0]     <=  data_in_reg[7]; //D2 to carry
+                  data_int_rdy     <=  1;
+               end
+            8'b11110000: // 8
+               begin
+                  data_int_reg[7]  <=  data_in_reg[0]; //D8
+                  data_int_reg[6]  <=  data_in_reg[1];
+                  data_int_reg[5]  <=  data_in_reg[2];
+                  data_int_reg[4]  <=  data_in_reg[3]; //D11
+                  carry_reg[3]     <=  data_in_reg[4]; //D0 to carry
+                  carry_reg[2]     <=  data_in_reg[5];
+                  carry_reg[1]     <=  data_in_reg[6];
+                  carry_reg[0]     <=  data_in_reg[7]; //D3 to carry
+                  data_int_rdy     <=  1;
+               end
+            8'b11111000: // 9
+               begin
+                  data_int_reg[6]  <=  data_in_reg[0]; //D9
+                  data_int_reg[5]  <=  data_in_reg[1];
+                  data_int_reg[4]  <=  data_in_reg[2]; //D11
+                  carry_reg[4]     <=  data_in_reg[3]; //D0 to carry
+                  carry_reg[3]     <=  data_in_reg[4];
+                  carry_reg[2]     <=  data_in_reg[5];
+                  carry_reg[1]     <=  data_in_reg[6];
+                  carry_reg[0]     <=  data_in_reg[7]; //D4 to carry
+                  data_int_rdy     <=  1;
+               end
+            8'b11111100: // 10
+               begin
+                  data_int_reg[5]  <=  data_in_reg[0]; //D10
+                  data_int_reg[4]  <=  data_in_reg[1]; //D11
+                  carry_reg[5]     <=  data_in_reg[2]; //D0 to carry
+                  carry_reg[4]     <=  data_in_reg[3];
+                  carry_reg[3]     <=  data_in_reg[4];
+                  carry_reg[2]     <=  data_in_reg[5];
+                  carry_reg[1]     <=  data_in_reg[6];
+                  carry_reg[0]     <=  data_in_reg[7]; //D5 to carry
+                  data_int_rdy     <=  1;
+               end
+            8'b01111110: // 11
+               begin
+                  data_int_reg[4]  <=  data_in_reg[0];//D11
+                  carry_reg[6]     <=  data_in_reg[1];//D0 to carry
+                  carry_reg[5]     <=  data_in_reg[2];
+                  carry_reg[4]     <=  data_in_reg[3];
+                  carry_reg[3]     <=  data_in_reg[4];
+                  carry_reg[2]     <=  data_in_reg[5];
+                  carry_reg[1]     <=  data_in_reg[6];
+                  carry_reg[0]     <=  data_in_reg[7];//D6 to carry
+                  data_int_rdy     <=  1;
+               end
+            default:
+                  data_int_rdy     <= 0;
+         endcase
+         data_int_reg[3] <= 0;
+         data_int_reg[2] <= 0;
+         data_int_reg[1] <= 0;
+         data_int_reg[0] <= 0;
+      end else if(resolution == 2'b00  || resolution == 2'b01 ) begin  // 8-bits or dual 8-bit
+         case(frame_in_reg)
+            8'b00001111: // 0
+               begin
+                  data_int_reg[15] <= data_in_reg[0]; //D0
+                  data_int_reg[14] <= data_in_reg[1];
+                  data_int_reg[13] <= data_in_reg[2];
+                  data_int_reg[12] <= data_in_reg[3];
+                  data_int_reg[11] <= data_in_reg[4];
+                  data_int_reg[10] <= data_in_reg[5];
+                  data_int_reg[9]  <= data_in_reg[6];
+                  data_int_reg[8]  <= data_in_reg[7]; //D7
+                  data_int_rdy     <= 1;
+               end
+            8'b10000111: // 1
+               begin
+                  data_int_reg[15] <= carry_reg[0];   //D0 from carry
+                  data_int_reg[14] <= data_in_reg[0]; //D1
+                  data_int_reg[13] <= data_in_reg[1];
+                  data_int_reg[12] <= data_in_reg[2];
+                  data_int_reg[11] <= data_in_reg[3];
+                  data_int_reg[10] <= data_in_reg[4];
+                  data_int_reg[9]  <= data_in_reg[5];
+                  data_int_reg[8]  <= data_in_reg[6]; //D7
+                  carry_reg[0]     <= data_in_reg[7]; //D0 to carry
+                  data_int_rdy     <= 1;
+               end
+            8'b11000011: // 2
+               begin
+                  data_int_reg[15] <= carry_reg[1];   //D0 from carry
+                  data_int_reg[14] <= carry_reg[0];   //D1 from carry
+                  data_int_reg[13] <= data_in_reg[0]; //D2
+                  data_int_reg[12] <= data_in_reg[1];
+                  data_int_reg[11] <= data_in_reg[2];
+                  data_int_reg[10] <= data_in_reg[3];
+                  data_int_reg[9]  <= data_in_reg[4];
+                  data_int_reg[8]  <= data_in_reg[5]; //D7
+                  carry_reg[1]     <= data_in_reg[6]; //D0 to carry
+                  carry_reg[0]     <= data_in_reg[7]; //D1 to carry
+                  data_int_rdy     <= 1;
+               end
+            8'b11100001: // 3
+               begin
+                  data_int_reg[15] <= carry_reg[2];   //D0 from carry
+                  data_int_reg[14] <= carry_reg[1];
+                  data_int_reg[13] <= carry_reg[0];   //D2 from carry
+                  data_int_reg[12] <= data_in_reg[0]; //D3
+                  data_int_reg[11] <= data_in_reg[1];
+                  data_int_reg[10] <= data_in_reg[2];
+                  data_int_reg[9]  <= data_in_reg[3];
+                  data_int_reg[8]  <= data_in_reg[4]; //D7
+                  carry_reg[2]     <= data_in_reg[5]; //D0 to carry
+                  carry_reg[1]     <= data_in_reg[6];
+                  carry_reg[0]     <= data_in_reg[7]; //D2 to carry
+                  data_int_rdy     <= 1;
+               end
+            8'b11110000: // 4
+               begin
+                  data_int_reg[15] <= carry_reg[3];   //D0 from carry
+                  data_int_reg[14] <= carry_reg[2];
+                  data_int_reg[13] <= carry_reg[1];
+                  data_int_reg[12] <= carry_reg[0];   //D3 from carry
+                  data_int_reg[11] <= data_in_reg[0]; //D4
+                  data_int_reg[10] <= data_in_reg[1];
+                  data_int_reg[9]  <= data_in_reg[2];
+                  data_int_reg[8]  <= data_in_reg[3]; //D7
+                  carry_reg[3]     <= data_in_reg[4]; //D0 to carry
+                  carry_reg[2]     <= data_in_reg[5];
+                  carry_reg[1]     <= data_in_reg[6];
+                  carry_reg[0]     <= data_in_reg[7]; //D3 to carry
+                  data_int_rdy     <= 1;
+               end
+            8'b01111000: // 5
+               begin
+                  data_int_reg[15] <= carry_reg[4];   //D0 from carry
+                  data_int_reg[14] <= carry_reg[3];
+                  data_int_reg[13] <= carry_reg[2];
+                  data_int_reg[12] <= carry_reg[1];
+                  data_int_reg[11] <= carry_reg[0];   //D4 from carry
+                  data_int_reg[10] <= data_in_reg[0]; //D5
+                  data_int_reg[9]  <= data_in_reg[1];
+                  data_int_reg[8]  <= data_in_reg[2]; //D7
+                  carry_reg[4]     <= data_in_reg[3]; //D0 to carry
+                  carry_reg[3]     <= data_in_reg[4];
+                  carry_reg[2]     <= data_in_reg[5];
+                  carry_reg[1]     <= data_in_reg[6];
+                  carry_reg[0]     <= data_in_reg[7]; //D4 to carry
+                  data_int_rdy     <= 1;
+               end
+            8'b00111100: // 6
+               begin
+                  data_int_reg[15] <= carry_reg[5];   //D0 from carry
+                  data_int_reg[14] <= carry_reg[4];
+                  data_int_reg[13] <= carry_reg[3];
+                  data_int_reg[12] <= carry_reg[2];
+                  data_int_reg[11] <= carry_reg[1];
+                  data_int_reg[10] <= carry_reg[0];   //D5 from carry
+                  data_int_reg[9]  <= data_in_reg[0]; //D6
+                  data_int_reg[8]  <= data_in_reg[1]; //D7
+                  carry_reg[5]     <= data_in_reg[2]; //D0 to carry
+                  carry_reg[4]     <= data_in_reg[3];
+                  carry_reg[3]     <= data_in_reg[4];
+                  carry_reg[2]     <= data_in_reg[5];
+                  carry_reg[1]     <= data_in_reg[6];
+                  carry_reg[0]     <= data_in_reg[7]; //D5 to carry
+                  data_int_rdy     <= 1;
+               end
+            8'b00011110: // 7
+               begin
+                  data_int_reg[15] <= carry_reg[6];   //D0 from carry
+                  data_int_reg[14] <= carry_reg[5];
+                  data_int_reg[13] <= carry_reg[4];
+                  data_int_reg[12] <= carry_reg[3];
+                  data_int_reg[11] <= carry_reg[2];
+                  data_int_reg[10] <= carry_reg[1];
+                  data_int_reg[9]  <= carry_reg[0];   //D6 from carry
+                  data_int_reg[8]  <= data_in_reg[0]; //D7
+                  carry_reg[6]     <= data_in_reg[1]; //D0 to carry
+                  carry_reg[5]     <= data_in_reg[2];
+                  carry_reg[4]     <= data_in_reg[3];
+                  carry_reg[3]     <= data_in_reg[4];
+                  carry_reg[2]     <= data_in_reg[5];
+                  carry_reg[1]     <= data_in_reg[6];
+                  carry_reg[0]     <= data_in_reg[7]; //D6 to carry
+                  data_int_rdy     <= 1;
+               end
+            default:
+                  data_int_rdy     <= 0;
+         endcase
+         data_int_reg[7] <= 0;
+         data_int_reg[6] <= 0;
+         data_int_reg[5] <= 0;
+         data_int_reg[4] <= 0;
+         data_int_reg[3] <= 0;
+         data_int_reg[2] <= 0;
+         data_int_reg[1] <= 0;
+         data_int_reg[0] <= 0;
+      end else begin  // Resolution control invalid
+         data_int_reg <= 16'b0;
+         data_int_rdy <= 1'b0;
+      end
+   end
+
+   //==========================================================================
+   // Register output data for each configuration, MSB justified
+   //==========================================================================
+   always @(posedge clk) begin
+      if(data_int_rdy) begin
+         sample14_reg <= {data_int_reg[2],
+                          data_int_reg[3],
+                          data_int_reg[4],
+                          data_int_reg[5],
+                          data_int_reg[6],
+                          data_int_reg[7],
+                          data_int_reg[8],
+                          data_int_reg[9],
+                          data_int_reg[10],
+                          data_int_reg[11],
+                          data_int_reg[12],
+                          data_int_reg[13],
+                          data_int_reg[14],
+                          data_int_reg[15], 2'b0};
+         sample12_reg <= {data_int_reg[4],
+                          data_int_reg[5],
+                          data_int_reg[6],
+                          data_int_reg[7],
+                          data_int_reg[8],
+                          data_int_reg[9],
+                          data_int_reg[10],
+                          data_int_reg[11],
+                          data_int_reg[12],
+                          data_int_reg[13],
+                          data_int_reg[14],
+                          data_int_reg[15], 4'b0};
+         sample8_reg  <= {sample8_reg[7:0],
+                          data_int_reg[8],
+                          data_int_reg[9],
+                          data_int_reg[10],
+                          data_int_reg[11],
+                          data_int_reg[12],
+                          data_int_reg[13],
+                          data_int_reg[14],
+                          data_int_reg[15]};
+      end
+   end
+
+   always @(posedge clk) begin
+      if(resolution == 2'b11) begin          // 14-bits
+         data_out_reg <= sample14_reg;
+      end else if(resolution == 2'b10) begin // 12-bits
+         data_out_reg <= sample12_reg;
+      end else begin                         //  8-bits
+         data_out_reg <= sample8_reg;
+      end
+   end
+
+   assign data_en  = data_int_rdy;
+   assign data_out = data_out_reg;
+
+endmodule

--- a/projects/admx6020m/Makefile
+++ b/projects/admx6020m/Makefile
@@ -1,0 +1,21 @@
+####################################################################################
+## Copyright (c) 2018 - 2026 Analog Devices, Inc.
+### SPDX short identifier: BSD-1-Clause
+## Auto-generated, do not modify!
+####################################################################################
+
+PROJECT_NAME := admx6020m
+
+M_DEPS += ../common/xilinx/data_offload_bd.tcl
+M_DEPS += ../../library/util_hbm/scripts/adi_util_hbm.tcl
+M_DEPS += ../../library/common/ad_iobuf.v
+M_DEPS += ../../library/axi_tdd/scripts/axi_tdd.tcl
+
+LIB_DEPS += axi_dmac
+LIB_DEPS += axi_hmcad15xx
+LIB_DEPS += axi_tdd
+LIB_DEPS += data_offload
+LIB_DEPS += util_do_ram
+LIB_DEPS += util_hbm
+
+include ../scripts/project-xilinx.mk

--- a/projects/admx6020m/README.md
+++ b/projects/admx6020m/README.md
@@ -1,0 +1,25 @@
+# ADMX6020M HDL Project
+
+- Evaluation board product page: TO BE ADDED
+- System documentation: TO BE ADDED
+- HDL project documentation: https://analogdevicesinc.github.io/hdl/projects/admx6020m/index.html
+- Evaluation board VADJ: 2.5V
+
+## Supported parts
+
+| Part name                                      | Description                                                       |
+|------------------------------------------------|-------------------------------------------------------------------|
+| [HMCAD1520](https://www.analog.com/hmcad1520)  | High Speed Multi-Mode 8/12/14-Bit 1000/640/105 MSPS A/D Converter |
+
+## Building the project
+
+```
+cd projects/admx6020m
+make
+```
+
+Corresponding device trees:
+
+- [ADMX6020M device tree (14-bit)](https://github.com/analogdevicesinc/linux/blob/sharkbyte_pr/arch/arm/boot/dts/xilinx/zynq-admx6020m_14b.dts)
+- [ADMX6020M device tree (12-bit)](https://github.com/analogdevicesinc/linux/blob/sharkbyte_pr/arch/arm/boot/dts/xilinx/zynq-admx6020m_12b.dts)
+- [ADMX6020M device tree (8-bit)](https://github.com/analogdevicesinc/linux/blob/sharkbyte_pr/arch/arm/boot/dts/xilinx/zynq-admx6020m.dts)

--- a/projects/admx6020m/system_bd.tcl
+++ b/projects/admx6020m/system_bd.tcl
@@ -1,0 +1,334 @@
+###############################################################################
+## Copyright (C) 2025-2026 Analog Devices, Inc. All rights reserved.
+### SPDX short identifier: ADIBSD
+###############################################################################
+
+# Source data_offload helper for synchronized dual-ADC capture with BRAM storage
+source $ad_hdl_dir/projects/common/xilinx/data_offload_bd.tcl
+
+# create board design
+create_bd_intf_port -mode Master -vlnv xilinx.com:interface:ddrx_rtl:1.0 ddr
+create_bd_intf_port -mode Master -vlnv xilinx.com:display_processing_system7:fixedio_rtl:1.0 fixed_io
+create_bd_intf_port -mode Master -vlnv xilinx.com:interface:iic_rtl:1.0 iic_main
+
+create_bd_port -dir O spi0_csn_2_o
+create_bd_port -dir O spi0_csn_1_o
+create_bd_port -dir O spi0_csn_0_o
+create_bd_port -dir I spi0_csn_i
+create_bd_port -dir I spi0_clk_i
+create_bd_port -dir O spi0_clk_o
+create_bd_port -dir I spi0_sdo_i
+create_bd_port -dir O spi0_sdo_o
+create_bd_port -dir I spi0_sdi_i
+
+create_bd_port -dir I -from 17 -to 0 gpio_i
+create_bd_port -dir O -from 17 -to 0 gpio_o
+create_bd_port -dir O -from 17 -to 0 gpio_t
+
+# hmcad15xx interface
+
+create_bd_port -dir I -from 7 -to 0 data_in_a1_p
+create_bd_port -dir I -from 7 -to 0 data_in_a1_n
+create_bd_port -dir I -from 7 -to 0 data_in_a2_p
+create_bd_port -dir I -from 7 -to 0 data_in_a2_n
+
+create_bd_port -dir I clk_in_a1_p
+create_bd_port -dir I clk_in_a1_n
+create_bd_port -dir I clk_in_a2_p
+create_bd_port -dir I clk_in_a2_n
+create_bd_port -dir I fclk_a1_p
+create_bd_port -dir I fclk_a1_n
+create_bd_port -dir I fclk_a2_p
+create_bd_port -dir I fclk_a2_n
+
+# instance: sys_ps7
+
+ad_ip_instance processing_system7 sys_ps7
+
+# ps7 settings
+
+ad_ip_parameter sys_ps7 CONFIG.PCW_PRESET_BANK0_VOLTAGE {LVCMOS 1.8V}
+ad_ip_parameter sys_ps7 CONFIG.PCW_PRESET_BANK1_VOLTAGE {LVCMOS 1.8V}
+ad_ip_parameter sys_ps7 CONFIG.PCW_PACKAGE_NAME clg225
+# Using HP0 and HP2 for better DDR interleaving (different internal paths)
+ad_ip_parameter sys_ps7 CONFIG.PCW_USE_S_AXI_HP0 1
+ad_ip_parameter sys_ps7 CONFIG.PCW_USE_S_AXI_HP2 1
+ad_ip_parameter sys_ps7 CONFIG.PCW_EN_CLK1_PORT 1
+ad_ip_parameter sys_ps7 CONFIG.PCW_EN_RST1_PORT 1
+ad_ip_parameter sys_ps7 CONFIG.PCW_FPGA0_PERIPHERAL_FREQMHZ 100.0
+ad_ip_parameter sys_ps7 CONFIG.PCW_FPGA1_PERIPHERAL_FREQMHZ 200.0
+ad_ip_parameter sys_ps7 CONFIG.PCW_GPIO_EMIO_GPIO_ENABLE 1
+ad_ip_parameter sys_ps7 CONFIG.PCW_GPIO_EMIO_GPIO_IO 18
+ad_ip_parameter sys_ps7 CONFIG.PCW_SPI1_PERIPHERAL_ENABLE 0
+ad_ip_parameter sys_ps7 CONFIG.PCW_I2C0_PERIPHERAL_ENABLE 0
+ad_ip_parameter sys_ps7 CONFIG.PCW_SD1_PERIPHERAL_ENABLE {1}
+ad_ip_parameter sys_ps7 CONFIG.PCW_SD1_GRP_CD_ENABLE {1}
+ad_ip_parameter sys_ps7 CONFIG.PCW_SD1_GRP_POW_ENABLE {0}
+ad_ip_parameter sys_ps7 CONFIG.PCW_SD1_GRP_WP_ENABLE {0}
+ad_ip_parameter sys_ps7 CONFIG.PCW_SD1_SD1_IO {MIO 10 .. 15}
+ad_ip_parameter sys_ps7 CONFIG.PCW_UART1_PERIPHERAL_ENABLE 1
+ad_ip_parameter sys_ps7 CONFIG.PCW_UART1_UART1_IO {MIO 48 .. 49}
+ad_ip_parameter sys_ps7 CONFIG.PCW_I2C1_PERIPHERAL_ENABLE 0
+ad_ip_parameter sys_ps7 CONFIG.PCW_QSPI_PERIPHERAL_ENABLE 1
+ad_ip_parameter sys_ps7 CONFIG.PCW_QSPI_GRP_SINGLE_SS_ENABLE 1
+ad_ip_parameter sys_ps7 CONFIG.PCW_SD0_PERIPHERAL_ENABLE 0
+ad_ip_parameter sys_ps7 CONFIG.PCW_SPI0_PERIPHERAL_ENABLE 1
+ad_ip_parameter sys_ps7 CONFIG.PCW_SPI0_SPI0_IO EMIO
+ad_ip_parameter sys_ps7 CONFIG.PCW_TTC0_PERIPHERAL_ENABLE 0
+ad_ip_parameter sys_ps7 CONFIG.PCW_USE_FABRIC_INTERRUPT 1
+ad_ip_parameter sys_ps7 CONFIG.PCW_USB0_PERIPHERAL_ENABLE 1
+ad_ip_parameter sys_ps7 CONFIG.PCW_GPIO_MIO_GPIO_ENABLE 1
+ad_ip_parameter sys_ps7 CONFIG.PCW_GPIO_MIO_GPIO_IO MIO
+ad_ip_parameter sys_ps7 CONFIG.PCW_USB0_RESET_IO {MIO 52}
+ad_ip_parameter sys_ps7 CONFIG.PCW_USB0_RESET_ENABLE 1
+ad_ip_parameter sys_ps7 CONFIG.PCW_IRQ_F2P_INTR 1
+ad_ip_parameter sys_ps7 CONFIG.PCW_IRQ_F2P_MODE REVERSE
+ad_ip_parameter sys_ps7 CONFIG.PCW_MIO_0_PULLUP {enabled}
+ad_ip_parameter sys_ps7 CONFIG.PCW_MIO_9_PULLUP {enabled}
+ad_ip_parameter sys_ps7 CONFIG.PCW_MIO_10_PULLUP {enabled}
+ad_ip_parameter sys_ps7 CONFIG.PCW_MIO_11_PULLUP {enabled}
+ad_ip_parameter sys_ps7 CONFIG.PCW_MIO_48_PULLUP {enabled}
+ad_ip_parameter sys_ps7 CONFIG.PCW_MIO_49_PULLUP {disabled}
+ad_ip_parameter sys_ps7 CONFIG.PCW_MIO_53_PULLUP {enabled}
+
+# DDR MT41K256M16 HA-125 (32M, 16bit, 8banks)
+
+ad_ip_parameter sys_ps7 CONFIG.PCW_UIPARAM_DDR_PARTNO {MT41K256M16 RE-125}
+ad_ip_parameter sys_ps7 CONFIG.PCW_UIPARAM_DDR_BUS_WIDTH {16 Bit}
+ad_ip_parameter sys_ps7 CONFIG.PCW_UIPARAM_DDR_USE_INTERNAL_VREF 0
+ad_ip_parameter sys_ps7 CONFIG.PCW_UIPARAM_DDR_TRAIN_WRITE_LEVEL 1
+ad_ip_parameter sys_ps7 CONFIG.PCW_UIPARAM_DDR_TRAIN_READ_GATE 1
+ad_ip_parameter sys_ps7 CONFIG.PCW_UIPARAM_DDR_TRAIN_DATA_EYE 1
+ad_ip_parameter sys_ps7 CONFIG.PCW_UIPARAM_DDR_BOARD_DELAY0 0.0822516875
+ad_ip_parameter sys_ps7 CONFIG.PCW_UIPARAM_DDR_BOARD_DELAY1 0.0545553125
+ad_ip_parameter sys_ps7 CONFIG.PCW_UIPARAM_DDR_DQS_TO_CLK_DELAY_0 0.072623
+ad_ip_parameter sys_ps7 CONFIG.PCW_UIPARAM_DDR_DQS_TO_CLK_DELAY_1 0.0553525
+ad_ip_parameter sys_ps7 CONFIG.PCW_EN_CLK2_PORT 1
+ad_ip_parameter sys_ps7 CONFIG.PCW_FPGA2_PERIPHERAL_FREQMHZ 150.0
+ad_ip_parameter sys_ps7 CONFIG.PCW_EN_RST2_PORT 1
+
+ad_ip_instance xlconcat sys_concat_intc
+ad_ip_parameter sys_concat_intc CONFIG.NUM_PORTS 16
+
+ad_ip_instance proc_sys_reset sys_rstgen
+ad_ip_parameter sys_rstgen CONFIG.C_EXT_RST_WIDTH 1
+
+ad_ip_instance proc_sys_reset sys_150m_rstgen
+ad_ip_parameter sys_150m_rstgen CONFIG.C_EXT_RST_WIDTH 1
+ad_connect  sys_ps7/FCLK_CLK2 sys_150m_rstgen/slowest_sync_clk
+ad_connect  sys_150m_rstgen/ext_reset_in sys_ps7/FCLK_RESET2_N
+
+ad_connect  sys_cpu_clk sys_ps7/FCLK_CLK0
+ad_connect  sys_cpu_reset sys_rstgen/peripheral_reset
+ad_connect  sys_cpu_resetn sys_rstgen/peripheral_aresetn
+ad_connect  sys_cpu_clk sys_rstgen/slowest_sync_clk
+ad_connect  sys_rstgen/ext_reset_in sys_ps7/FCLK_RESET0_N
+
+ad_ip_instance axi_dmac hmcad15xx_a1_dma
+ad_ip_parameter hmcad15xx_a1_dma CONFIG.DMA_TYPE_SRC 1
+ad_ip_parameter hmcad15xx_a1_dma CONFIG.DMA_TYPE_DEST 0
+ad_ip_parameter hmcad15xx_a1_dma CONFIG.CYCLIC 0
+ad_ip_parameter hmcad15xx_a1_dma CONFIG.SYNC_TRANSFER_START 0
+ad_ip_parameter hmcad15xx_a1_dma CONFIG.AXI_SLICE_SRC 1
+ad_ip_parameter hmcad15xx_a1_dma CONFIG.AXI_SLICE_DEST 1
+ad_ip_parameter hmcad15xx_a1_dma CONFIG.DMA_2D_TRANSFER 0
+ad_ip_parameter hmcad15xx_a1_dma CONFIG.DMA_DATA_WIDTH_SRC 64
+ad_ip_parameter hmcad15xx_a1_dma CONFIG.DMA_DATA_WIDTH_DEST 64
+ad_ip_parameter hmcad15xx_a1_dma CONFIG.FIFO_SIZE 8
+ad_ip_parameter hmcad15xx_a1_dma CONFIG.MAX_BYTES_PER_BURST 4096
+
+ad_connect  hmcad15xx_a1_dma/m_dest_axi_aresetn sys_150m_rstgen/peripheral_aresetn
+
+# ADC2 DMA - receives AXI Stream from data_offload, writes to DDR via HP2
+ad_ip_instance axi_dmac hmcad15xx_a2_dma
+ad_ip_parameter hmcad15xx_a2_dma CONFIG.DMA_TYPE_SRC 1
+ad_ip_parameter hmcad15xx_a2_dma CONFIG.DMA_TYPE_DEST 0
+ad_ip_parameter hmcad15xx_a2_dma CONFIG.CYCLIC 0
+ad_ip_parameter hmcad15xx_a2_dma CONFIG.SYNC_TRANSFER_START 0
+ad_ip_parameter hmcad15xx_a2_dma CONFIG.AXI_SLICE_SRC 1
+ad_ip_parameter hmcad15xx_a2_dma CONFIG.AXI_SLICE_DEST 1
+ad_ip_parameter hmcad15xx_a2_dma CONFIG.DMA_2D_TRANSFER 0
+ad_ip_parameter hmcad15xx_a2_dma CONFIG.DMA_DATA_WIDTH_SRC 64
+ad_ip_parameter hmcad15xx_a2_dma CONFIG.DMA_DATA_WIDTH_DEST 64
+ad_ip_parameter hmcad15xx_a2_dma CONFIG.FIFO_SIZE 8
+ad_ip_parameter hmcad15xx_a2_dma CONFIG.MAX_BYTES_PER_BURST 4096
+
+ad_connect  hmcad15xx_a2_dma/m_dest_axi_aresetn sys_150m_rstgen/peripheral_aresetn
+
+# =============================================================================
+# ADC1: HMCAD15xx LVDS Interface
+# =============================================================================
+
+ad_ip_instance axi_hmcad15xx axi_hmcad15xx_a1_adc
+ad_ip_parameter axi_hmcad15xx_a1_adc CONFIG.IODELAY_CTRL 0
+ad_ip_parameter axi_hmcad15xx_a1_adc CONFIG.NUM_CHANNELS 4
+
+ad_connect axi_hmcad15xx_a1_adc/s_axi_aclk    sys_cpu_clk
+ad_connect axi_hmcad15xx_a1_adc/clk_in_p      clk_in_a1_p
+ad_connect axi_hmcad15xx_a1_adc/clk_in_n      clk_in_a1_n
+ad_connect axi_hmcad15xx_a1_adc/fclk_p        fclk_a1_p
+ad_connect axi_hmcad15xx_a1_adc/fclk_n        fclk_a1_n
+ad_connect axi_hmcad15xx_a1_adc/data_in_p     data_in_a1_p
+ad_connect axi_hmcad15xx_a1_adc/data_in_n     data_in_a1_n
+ad_connect axi_hmcad15xx_a1_adc/delay_clk     sys_ps7/FCLK_CLK1
+
+# 512 KB BRAM buffer for ADC1
+ad_data_offload_create adc1_data_offload 0 0 [expr 64*1024] 128 64
+
+ad_ip_parameter adc1_data_offload/i_data_offload CONFIG.SYNC_EXT_ADD_INTERNAL_CDC 0
+
+ad_connect sys_cpu_clk                           adc1_data_offload/s_axi_aclk
+ad_connect sys_cpu_resetn                        adc1_data_offload/s_axi_aresetn
+ad_connect axi_hmcad15xx_a1_adc/adc_clk_g        adc1_data_offload/s_axis_aclk
+ad_connect axi_hmcad15xx_a1_adc/adc_resetn       adc1_data_offload/s_axis_aresetn
+ad_connect sys_ps7/FCLK_CLK2                     adc1_data_offload/m_axis_aclk
+ad_connect sys_150m_rstgen/peripheral_aresetn    adc1_data_offload/m_axis_aresetn
+
+ad_connect axi_hmcad15xx_a1_adc/adc_valid   adc1_data_offload/i_data_offload/s_axis_valid
+ad_connect axi_hmcad15xx_a1_adc/adc_data    adc1_data_offload/i_data_offload/s_axis_data
+
+# Connect data_offload AXI Stream output to DMA input
+ad_connect adc1_data_offload/m_axis        hmcad15xx_a1_dma/s_axis
+ad_connect sys_ps7/FCLK_CLK2               hmcad15xx_a1_dma/s_axis_aclk
+
+# Handshake: data_offload requests transfer, DMA acknowledges ready
+ad_connect adc1_data_offload/init_req      hmcad15xx_a1_dma/s_axis_xfer_req
+
+# =============================================================================
+# ADC2: HMCAD15xx LVDS Interface
+# =============================================================================
+
+ad_ip_instance axi_hmcad15xx axi_hmcad15xx_a2_adc
+ad_ip_parameter axi_hmcad15xx_a2_adc CONFIG.IODELAY_CTRL 1
+ad_ip_parameter axi_hmcad15xx_a2_adc CONFIG.NUM_CHANNELS 4
+
+ad_connect axi_hmcad15xx_a2_adc/s_axi_aclk    sys_cpu_clk
+ad_connect axi_hmcad15xx_a2_adc/clk_in_p      clk_in_a2_p
+ad_connect axi_hmcad15xx_a2_adc/clk_in_n      clk_in_a2_n
+ad_connect axi_hmcad15xx_a2_adc/fclk_p        fclk_a2_p
+ad_connect axi_hmcad15xx_a2_adc/fclk_n        fclk_a2_n
+ad_connect axi_hmcad15xx_a2_adc/data_in_p     data_in_a2_p
+ad_connect axi_hmcad15xx_a2_adc/data_in_n     data_in_a2_n
+ad_connect axi_hmcad15xx_a2_adc/delay_clk     sys_ps7/FCLK_CLK1
+
+# =============================================================================
+# ADC2 Data Path: ADC -> data_offload (BRAM) -> DMA -> DDR
+# =============================================================================
+
+# 512 KB BRAM buffer for ADC2
+ad_data_offload_create adc2_data_offload 0 0 [expr 64*1024] 128 64
+
+ad_ip_parameter adc2_data_offload/i_data_offload CONFIG.SYNC_EXT_ADD_INTERNAL_CDC 0
+
+ad_connect sys_cpu_clk                           adc2_data_offload/s_axi_aclk
+ad_connect sys_cpu_resetn                        adc2_data_offload/s_axi_aresetn
+ad_connect axi_hmcad15xx_a2_adc/adc_clk_g        adc2_data_offload/s_axis_aclk
+ad_connect  axi_hmcad15xx_a1_adc/adc_resetn      adc2_data_offload/s_axis_aresetn
+ad_connect sys_ps7/FCLK_CLK2                     adc2_data_offload/m_axis_aclk
+ad_connect sys_150m_rstgen/peripheral_aresetn    adc2_data_offload/m_axis_aresetn
+
+ad_connect axi_hmcad15xx_a2_adc/adc_valid   adc2_data_offload/i_data_offload/s_axis_valid
+ad_connect axi_hmcad15xx_a2_adc/adc_data    adc2_data_offload/i_data_offload/s_axis_data
+
+# data_offload AXI Stream output -> DMA
+ad_connect adc2_data_offload/m_axis        hmcad15xx_a2_dma/s_axis
+ad_connect sys_ps7/FCLK_CLK2               hmcad15xx_a2_dma/s_axis_aclk
+
+# Handshake for transfer synchronization
+ad_connect adc2_data_offload/init_req      hmcad15xx_a2_dma/s_axis_xfer_req
+
+# TDD configuration - 2 channels, sync internal, polarity 0, rest defaults
+ad_tdd_gen_create axi_tdd_sync 2
+
+ad_connect axi_tdd_sync/clk           axi_hmcad15xx_a1_adc/adc_clk_g
+ad_connect axi_tdd_sync/resetn        axi_hmcad15xx_a1_adc/adc_resetn
+ad_connect axi_tdd_sync/s_axi_aclk    sys_cpu_clk
+ad_connect axi_tdd_sync/s_axi_aresetn sys_cpu_resetn
+ad_connect axi_tdd_sync/sync_in GND
+
+# Route TDD sync to data_offload for synchronized capture start
+
+ad_connect axi_tdd_sync/tdd_channel_0 adc1_data_offload/sync_ext
+ad_connect axi_tdd_sync/tdd_channel_1 adc2_data_offload/sync_ext
+
+# interface connections
+
+ad_connect  ddr sys_ps7/DDR
+ad_connect  gpio_i sys_ps7/GPIO_I
+ad_connect  gpio_o sys_ps7/GPIO_O
+ad_connect  gpio_t sys_ps7/GPIO_T
+ad_connect  fixed_io sys_ps7/FIXED_IO
+
+# ps7 spi connections
+
+ad_connect  spi0_csn_2_o sys_ps7/SPI0_SS2_O
+ad_connect  spi0_csn_1_o sys_ps7/SPI0_SS1_O
+ad_connect  spi0_csn_0_o sys_ps7/SPI0_SS_O
+ad_connect  spi0_csn_i sys_ps7/SPI0_SS_I
+ad_connect  spi0_clk_i sys_ps7/SPI0_SCLK_I
+ad_connect  spi0_clk_o sys_ps7/SPI0_SCLK_O
+ad_connect  spi0_sdo_i sys_ps7/SPI0_MOSI_I
+ad_connect  spi0_sdo_o sys_ps7/SPI0_MOSI_O
+ad_connect  spi0_sdi_i sys_ps7/SPI0_MISO_I
+
+# interrupts
+
+ad_connect  sys_concat_intc/dout sys_ps7/IRQ_F2P
+ad_connect  sys_concat_intc/In15 GND
+ad_connect  sys_concat_intc/In14 GND
+ad_connect  sys_concat_intc/In13 GND
+ad_connect  sys_concat_intc/In12 GND
+ad_connect  sys_concat_intc/In11 GND
+ad_connect  sys_concat_intc/In10 GND
+ad_connect  sys_concat_intc/In9 GND
+ad_connect  sys_concat_intc/In8 GND
+ad_connect  sys_concat_intc/In7 GND
+ad_connect  sys_concat_intc/In6 GND
+ad_connect  sys_concat_intc/In5 GND
+ad_connect  sys_concat_intc/In4 GND
+ad_connect  sys_concat_intc/In3 GND
+ad_connect  sys_concat_intc/In2 GND
+ad_connect  sys_concat_intc/In1 GND
+ad_connect  sys_concat_intc/In0 GND
+
+# iic
+
+ad_ip_instance axi_iic axi_iic_main
+ad_connect  iic_main axi_iic_main/iic
+
+# cpu / memory interconnects
+
+ad_cpu_interconnect 0x41600000 axi_iic_main
+ad_cpu_interconnect 0x44A00000 axi_hmcad15xx_a1_adc
+ad_cpu_interconnect 0x44A30000 hmcad15xx_a1_dma
+ad_cpu_interconnect 0x44A60000 axi_hmcad15xx_a2_adc
+ad_cpu_interconnect 0x44A90000 hmcad15xx_a2_dma
+ad_cpu_interconnect 0x44AC0000 axi_tdd_sync
+ad_cpu_interconnect 0x44B00000 adc1_data_offload
+ad_cpu_interconnect 0x44B10000 adc2_data_offload
+
+ad_ip_parameter sys_ps7 CONFIG.PCW_USE_S_AXI_HP0 {1}
+ad_ip_parameter sys_ps7 CONFIG.PCW_USE_S_AXI_HP2 {1}
+ad_connect sys_ps7/FCLK_CLK2 sys_ps7/S_AXI_HP0_ACLK
+ad_connect sys_ps7/FCLK_CLK2 sys_ps7/S_AXI_HP2_ACLK
+
+ad_connect hmcad15xx_a1_dma/m_dest_axi sys_ps7/S_AXI_HP0
+create_bd_addr_seg -range 0x20000000 -offset 0x00000000 \
+                    [get_bd_addr_spaces hmcad15xx_a1_dma/m_dest_axi] \
+                    [get_bd_addr_segs sys_ps7/S_AXI_HP0/HP0_DDR_LOWOCM] \
+                    SEG_sys_ps7_HP0_DDR_LOWOCM
+
+ad_connect hmcad15xx_a2_dma/m_dest_axi sys_ps7/S_AXI_HP2
+create_bd_addr_seg -range 0x20000000 -offset 0x00000000 \
+                    [get_bd_addr_spaces hmcad15xx_a2_dma/m_dest_axi] \
+                    [get_bd_addr_segs sys_ps7/S_AXI_HP2/HP2_DDR_LOWOCM] \
+                    SEG_sys_ps7_HP2_DDR_LOWOCM
+
+ad_connect sys_ps7/FCLK_CLK2 hmcad15xx_a1_dma/m_dest_axi_aclk
+ad_connect sys_ps7/FCLK_CLK2 hmcad15xx_a2_dma/m_dest_axi_aclk
+
+# interrupts
+
+ad_cpu_interrupt ps-12 mb-12 hmcad15xx_a1_dma/irq
+ad_cpu_interrupt ps-13 mb-13 hmcad15xx_a2_dma/irq
+ad_cpu_interrupt ps-15 mb-15 axi_iic_main/iic2intc_irpt

--- a/projects/admx6020m/system_constr.xdc
+++ b/projects/admx6020m/system_constr.xdc
@@ -1,0 +1,291 @@
+###############################################################################
+## Copyright (C) 2025-2026 Analog Devices, Inc. All rights reserved.
+### SPDX short identifier: ADIBSD
+###############################################################################
+
+# hmcad15xx, 1st ADC
+
+# switch P & N
+set_property -dict {PACKAGE_PIN N14 IOSTANDARD LVDS_25 DIFF_TERM 1} [get_ports {data_in_a1_n[0]}];  # A1DP1A IO_L7N_T1_34
+set_property -dict {PACKAGE_PIN N13 IOSTANDARD LVDS_25 DIFF_TERM 1} [get_ports {data_in_a1_p[0]}];  # A1DN1A IO_L7P_T1_34
+
+set_property -dict {PACKAGE_PIN M15 IOSTANDARD LVDS_25 DIFF_TERM 1} [get_ports {data_in_a1_n[1]}];  # A1DP1B IO_L8N_T1_34
+set_property -dict {PACKAGE_PIN L15 IOSTANDARD LVDS_25 DIFF_TERM 1} [get_ports {data_in_a1_p[1]}];  # A1DN1B IO_L8P_T1_34
+
+set_property -dict {PACKAGE_PIN K15 IOSTANDARD LVDS_25 DIFF_TERM 1} [get_ports {data_in_a1_n[2]}];  # A1DP2A IO_L4N_T0_34
+set_property -dict {PACKAGE_PIN J15 IOSTANDARD LVDS_25 DIFF_TERM 1} [get_ports {data_in_a1_p[2]}];  # A1DN2A IO_L4P_T0_34
+
+set_property -dict {PACKAGE_PIN J14 IOSTANDARD LVDS_25 DIFF_TERM 1} [get_ports {data_in_a1_n[3]}];  # A1DP2B IO_L5N_T0_34
+set_property -dict {PACKAGE_PIN J13 IOSTANDARD LVDS_25 DIFF_TERM 1} [get_ports {data_in_a1_p[3]}];  # A1DN2B IO_L5P_T0_34
+
+set_property -dict {PACKAGE_PIN J11 IOSTANDARD LVDS_25 DIFF_TERM 1} [get_ports {data_in_a1_n[4]}];  # A1DP3A IO_L6N_T0_VREF_34
+set_property -dict {PACKAGE_PIN H11 IOSTANDARD LVDS_25 DIFF_TERM 1} [get_ports {data_in_a1_p[4]}];  # A1DN3A IO_L6P_T0_34
+
+set_property -dict {PACKAGE_PIN H14 IOSTANDARD LVDS_25 DIFF_TERM 1} [get_ports {data_in_a1_n[5]}];  # A1DP3B IO_L3N_T0_DQS_34
+set_property -dict {PACKAGE_PIN G14 IOSTANDARD LVDS_25 DIFF_TERM 1} [get_ports {data_in_a1_p[5]}];  # A1DN3B IO_L3P_T0_DQS_PUDC_B_34
+
+set_property -dict {PACKAGE_PIN H13 IOSTANDARD LVDS_25 DIFF_TERM 1} [get_ports {data_in_a1_n[6]}];  # A1DP4A IO_L2N_T0_34
+set_property -dict {PACKAGE_PIN G12 IOSTANDARD LVDS_25 DIFF_TERM 1} [get_ports {data_in_a1_p[6]}];  # A1DN4A IO_L2P_T0_34
+
+set_property -dict {PACKAGE_PIN H12 IOSTANDARD LVDS_25 DIFF_TERM 1} [get_ports {data_in_a1_n[7]}];  # A1DP4B IO_L1N_T0_34
+set_property -dict {PACKAGE_PIN G11 IOSTANDARD LVDS_25 DIFF_TERM 1} [get_ports {data_in_a1_p[7]}];  # A1DN4B IO_L1P_T0_34
+
+set_property -dict {PACKAGE_PIN K12 IOSTANDARD LVDS_25 DIFF_TERM 1} [get_ports clk_in_a1_n];        # A1LCLKN IO_L11N_T1_SRCC_34
+set_property -dict {PACKAGE_PIN K11 IOSTANDARD LVDS_25 DIFF_TERM 1} [get_ports clk_in_a1_p];        # A1LCLKP IO_L11P_T1_SRCC_34
+
+set_property -dict {PACKAGE_PIN M12 IOSTANDARD LVDS_25 DIFF_TERM 1} [get_ports fclk_a1_n];          # A1FCLKN IO_L12N_T1_MRCC_34
+set_property -dict {PACKAGE_PIN L12 IOSTANDARD LVDS_25 DIFF_TERM 1} [get_ports fclk_a1_p];          # A1FCLKP IO_L12P_T1_MRCC_34
+
+# hmcad15xx, 2nd ADC
+
+set_property -dict {PACKAGE_PIN N7 IOSTANDARD LVDS_25 DIFF_TERM 1} [get_ports {data_in_a2_p[0]}];   # A2DP1A IO_L22P_T3_34
+set_property -dict {PACKAGE_PIN N8 IOSTANDARD LVDS_25 DIFF_TERM 1} [get_ports {data_in_a2_n[0]}];   # A2DN1A IO_L22N_T3_34
+
+set_property -dict {PACKAGE_PIN M9 IOSTANDARD LVDS_25 DIFF_TERM 1} [get_ports {data_in_a2_p[1]}];   # A2DP1B IO_L19P_T3_34
+set_property -dict {PACKAGE_PIN N9 IOSTANDARD LVDS_25 DIFF_TERM 1} [get_ports {data_in_a2_n[1]}];   # A2DN1B IO_L19N_T3_VREF_34
+
+set_property -dict {PACKAGE_PIN M10 IOSTANDARD LVDS_25 DIFF_TERM 1} [get_ports {data_in_a2_p[2]}];   # A2DP2A IO_L21P_T3_DQS_34
+set_property -dict {PACKAGE_PIN M11 IOSTANDARD LVDS_25 DIFF_TERM 1} [get_ports {data_in_a2_n[2]}];   # A2DN2A IO_L21N_T3_DQS_34
+
+set_property -dict {PACKAGE_PIN R7 IOSTANDARD LVDS_25 DIFF_TERM 1} [get_ports {data_in_a2_p[3]}];   # A2DP2B IO_L20P_T3_34
+set_property -dict {PACKAGE_PIN R8 IOSTANDARD LVDS_25 DIFF_TERM 1} [get_ports {data_in_a2_n[3]}];   # A2DN2B IO_L20N_T3_34
+
+set_property -dict {PACKAGE_PIN P8 IOSTANDARD LVDS_25 DIFF_TERM 1} [get_ports {data_in_a2_p[4]}];   # A2DP3A IO_L23P_T3_34
+set_property -dict {PACKAGE_PIN P9 IOSTANDARD LVDS_25 DIFF_TERM 1} [get_ports {data_in_a2_n[4]}];   # A2DN3A IO_L23N_T3_34
+
+set_property -dict {PACKAGE_PIN R10 IOSTANDARD LVDS_25 DIFF_TERM 1} [get_ports {data_in_a2_n[5]}];  # A2DP3B IO_L24N_T3_34
+set_property -dict {PACKAGE_PIN P10 IOSTANDARD LVDS_25 DIFF_TERM 1} [get_ports {data_in_a2_p[5]}];  # A2DN3B IO_L24P_T3_34
+
+set_property -dict {PACKAGE_PIN R12 IOSTANDARD LVDS_25 DIFF_TERM 1} [get_ports {data_in_a2_p[6]}];  # A2DP4A IO_L17P_T2_34
+set_property -dict {PACKAGE_PIN R13 IOSTANDARD LVDS_25 DIFF_TERM 1} [get_ports {data_in_a2_n[6]}];  # A2DN4A IO_L17N_T2_34
+
+set_property -dict {PACKAGE_PIN P13 IOSTANDARD LVDS_25 DIFF_TERM 1} [get_ports {data_in_a2_p[7]}];  # A2DP4B IO_L18P_T2_34
+set_property -dict {PACKAGE_PIN P14 IOSTANDARD LVDS_25 DIFF_TERM 1} [get_ports {data_in_a2_n[7]}];  # A2DN4B IO_L18N_T2_34
+
+# switch LCLK with FCLK according to the datasheet
+
+set_property -dict {PACKAGE_PIN P15 IOSTANDARD LVDS_25 DIFF_TERM 1} [get_ports fclk_a2_p];          # A2FCLKP IO_L15P_T2_DQS_34
+set_property -dict {PACKAGE_PIN R15 IOSTANDARD LVDS_25 DIFF_TERM 1} [get_ports fclk_a2_n];          # A2FCLKN IO_L15N_T2_DQS_34
+
+set_property -dict {PACKAGE_PIN N11 IOSTANDARD LVDS_25 DIFF_TERM 1} [get_ports clk_in_a2_p];        # A2LCLKP IO_L13P_T2_MRCC_34
+set_property -dict {PACKAGE_PIN N12 IOSTANDARD LVDS_25 DIFF_TERM 1} [get_ports clk_in_a2_n];        # A2LCLKN IO_L13N_T2_MRCC_34
+
+create_clock -period 4.000 -name ref_clk_a1 [get_ports clk_in_a1_p]
+create_clock -period 4.000 -name ref_clk_a2 [get_ports clk_in_a2_p]
+
+# Both ADC clocks come from same ADF4355 but are treated as asynchronous domains
+# No timing paths need to be analyzed between them (data synchronization handled in software)
+set_clock_groups -asynchronous -group [get_clocks -include_generated_clocks ref_clk_a1] -group [get_clocks -include_generated_clocks ref_clk_a2]
+
+# input                  ____________________
+# clock    _____________|                    |_____________
+#                       |                    |
+#                dv_bre | dv_are      dv_bfe | dv_afe
+#               <------>|<------>    <------>|<------>
+#          _    ________|________    ________|________    _
+# data     _XXXX____Rise_Data____XXXX____Fall_Data____XXXX_
+
+# # Input Delay Constraint
+
+set_input_delay -clock ref_clk_a1 -max 1.050 [get_ports {data_in_a1_p[*]}]
+set_input_delay -clock ref_clk_a1 -min 1.000 [get_ports {data_in_a1_p[*]}]
+set_input_delay -clock ref_clk_a1 -clock_fall -max -add_delay 1.050 [get_ports {data_in_a1_p[*]}]
+set_input_delay -clock ref_clk_a1 -clock_fall -min -add_delay 1.000 [get_ports {data_in_a1_p[*]}]
+
+set_input_delay -clock ref_clk_a1 -max 1.050 [get_ports fclk_a1_p]
+set_input_delay -clock ref_clk_a1 -min 1.000 [get_ports fclk_a1_p]
+set_input_delay -clock ref_clk_a1 -clock_fall -max -add_delay 1.050 [get_ports fclk_a1_p]
+set_input_delay -clock ref_clk_a1 -clock_fall -min -add_delay 1.000 [get_ports fclk_a1_p]
+
+set_input_delay -clock ref_clk_a2 -max 1.050 [get_ports {data_in_a2_p[*]}]
+set_input_delay -clock ref_clk_a2 -min 1.000 [get_ports {data_in_a2_p[*]}]
+set_input_delay -clock ref_clk_a2 -clock_fall -max -add_delay 1.050 [get_ports {data_in_a2_p[*]}]
+set_input_delay -clock ref_clk_a2 -clock_fall -min -add_delay 1.000 [get_ports {data_in_a2_p[*]}]
+
+set_input_delay -clock ref_clk_a2 -max 1.050 [get_ports fclk_a2_p]
+set_input_delay -clock ref_clk_a2 -min 1.000 [get_ports fclk_a2_p]
+set_input_delay -clock ref_clk_a2 -clock_fall -max -add_delay 1.050 [get_ports fclk_a2_p]
+set_input_delay -clock ref_clk_a2 -clock_fall -min -add_delay 1.000 [get_ports fclk_a2_p]
+
+set_property IDELAY_VALUE 13 [get_cells {i_system_wrapper/system_i/axi_hmcad15xx_a1_adc/inst/i_axi_hmcad15xx_if/ad_serdes_data_inst/g_data[*].i_idelay}]
+set_property IDELAY_VALUE 13 [get_cells {i_system_wrapper/system_i/axi_hmcad15xx_a2_adc/inst/i_axi_hmcad15xx_if/ad_serdes_data_inst/g_data[*].i_idelay}]
+
+# I2C
+
+set_property -dict {PACKAGE_PIN M14 IOSTANDARD LVCMOS25} [get_ports iic_scl]
+set_property -dict {PACKAGE_PIN L14 IOSTANDARD LVCMOS25} [get_ports iic_sca]
+
+# GPIOs
+
+set_property -dict {PACKAGE_PIN L13 IOSTANDARD LVCMOS25} [get_ports ad9696_ldac]
+
+# SPI
+
+set_property -dict {PACKAGE_PIN F14 IOSTANDARD LVCMOS25} [get_ports pll_csn]
+set_property -dict {PACKAGE_PIN F12 IOSTANDARD LVCMOS25} [get_ports spi_a1_csn]
+set_property -dict {PACKAGE_PIN E13 IOSTANDARD LVCMOS25} [get_ports spi_a2_csn]
+set_property -dict {PACKAGE_PIN E11 IOSTANDARD LVCMOS25} [get_ports spi_clk]
+set_property -dict {PACKAGE_PIN E12 IOSTANDARD LVCMOS25} [get_ports spi_sdata]
+
+create_clock -period 10.000 -name clk_fpga_0 [get_pins {i_system_wrapper/system_i/sys_ps7/inst/PS7_i/FCLKCLK[0]}]
+create_clock -period  5.000 -name clk_fpga_1 [get_pins {i_system_wrapper/system_i/sys_ps7/inst/PS7_i/FCLKCLK[1]}]
+create_clock -period  6.666 -name clk_fpga_2 [get_pins {i_system_wrapper/system_i/sys_ps7/inst/PS7_i/FCLKCLK[2]}]
+create_clock -period 40.000 -name spi0_clk   [get_pins -hier */EMIOSPI0SCLKO]
+
+set_input_jitter clk_fpga_0 0.300
+set_input_jitter clk_fpga_1 0.150
+set_input_jitter clk_fpga_2 0.200
+
+set_property IOSTANDARD LVCMOS18 [get_ports *fixed_io_mio*]
+set_property SLEW SLOW [get_ports *fixed_io_mio*]
+set_property DRIVE 8 [get_ports *fixed_io_mio*]
+set_property PULLTYPE PULLUP [get_ports {fixed_io_mio[0]}]
+set_property PULLTYPE PULLUP [get_ports {fixed_io_mio[1]}]
+set_property -dict {PACKAGE_PIN A8} [get_ports {fixed_io_mio[2]}]
+set_property -dict {PACKAGE_PIN A7} [get_ports {fixed_io_mio[3]}]
+set_property -dict {PACKAGE_PIN C8} [get_ports {fixed_io_mio[4]}]
+set_property -dict {PACKAGE_PIN A9} [get_ports {fixed_io_mio[5]}]
+set_property -dict {PACKAGE_PIN A10} [get_ports {fixed_io_mio[6]}]
+set_property -dict {PACKAGE_PIN D9} [get_ports {fixed_io_mio[7]}]
+set_property -dict {PACKAGE_PIN B6} [get_ports {fixed_io_mio[8]}]
+set_property PULLTYPE PULLUP [get_ports {fixed_io_mio[9]}]
+set_property PULLTYPE PULLUP [get_ports {fixed_io_mio[10]}]
+set_property PULLTYPE PULLUP [get_ports {fixed_io_mio[11]}]
+set_property PULLTYPE PULLUP [get_ports {fixed_io_mio[12]}]
+set_property PULLTYPE PULLUP [get_ports {fixed_io_mio[13]}]
+set_property PULLTYPE PULLUP [get_ports {fixed_io_mio[14]}]
+set_property PULLTYPE PULLUP [get_ports {fixed_io_mio[15]}]
+set_property PULLTYPE PULLUP [get_ports {fixed_io_mio[16]}]
+set_property PULLTYPE PULLUP [get_ports {fixed_io_mio[17]}]
+set_property PULLTYPE PULLUP [get_ports {fixed_io_mio[18]}]
+set_property PULLTYPE PULLUP [get_ports {fixed_io_mio[19]}]
+set_property PULLTYPE PULLUP [get_ports {fixed_io_mio[20]}]
+set_property PULLTYPE PULLUP [get_ports {fixed_io_mio[21]}]
+set_property PULLTYPE PULLUP [get_ports {fixed_io_mio[22]}]
+set_property PULLTYPE PULLUP [get_ports {fixed_io_mio[23]}]
+set_property PULLTYPE PULLUP [get_ports {fixed_io_mio[24]}]
+set_property PULLTYPE PULLUP [get_ports {fixed_io_mio[25]}]
+set_property PULLTYPE PULLUP [get_ports {fixed_io_mio[26]}]
+set_property PULLTYPE PULLUP [get_ports {fixed_io_mio[27]}]
+set_property PULLTYPE PULLUP [get_ports {fixed_io_mio[28]}]
+set_property PULLTYPE PULLUP [get_ports {fixed_io_mio[29]}]
+set_property PULLTYPE PULLUP [get_ports {fixed_io_mio[30]}]
+set_property PULLTYPE PULLUP [get_ports {fixed_io_mio[31]}]
+
+set_property IOSTANDARD LVCMOS18 [get_ports *fixed_io_ps*]
+set_property SLEW SLOW [get_ports *fixed_io_ps*]
+set_property DRIVE 8 [get_ports *fixed_io_ps*]
+
+set_property IOSTANDARD SSTL15_T_DCI [get_ports *fixed_io_ddr_vr*]
+set_property SLEW FAST [get_ports *fixed_io_ddr_vr*]
+
+set_property IOSTANDARD DIFF_SSTL15 [get_ports ddr_ck_n]
+set_property IOSTANDARD DIFF_SSTL15 [get_ports ddr_ck_p]
+set_property SLEW FAST [get_ports ddr_ck_n]
+set_property SLEW FAST [get_ports ddr_ck_p]
+
+set_property IOSTANDARD SSTL15 [get_ports *ddr_addr*]
+set_property SLEW SLOW [get_ports *ddr_addr*]
+
+set_property IOSTANDARD SSTL15 [get_ports *ddr_ba*]
+set_property SLEW SLOW [get_ports *ddr_ba*]
+
+set_property IOSTANDARD SSTL15 [get_ports ddr_reset_n]
+set_property SLEW FAST [get_ports ddr_reset_n]
+set_property IOSTANDARD SSTL15 [get_ports ddr_cs_n]
+set_property SLEW SLOW [get_ports ddr_cs_n]
+set_property IOSTANDARD SSTL15 [get_ports ddr_ras_n]
+set_property SLEW SLOW [get_ports ddr_ras_n]
+set_property IOSTANDARD SSTL15 [get_ports ddr_cas_n]
+set_property SLEW SLOW [get_ports ddr_cas_n]
+set_property IOSTANDARD SSTL15 [get_ports ddr_we_n]
+set_property SLEW SLOW [get_ports ddr_we_n]
+set_property IOSTANDARD SSTL15 [get_ports ddr_cke]
+set_property SLEW SLOW [get_ports ddr_cke]
+set_property IOSTANDARD SSTL15 [get_ports ddr_odt]
+set_property SLEW SLOW [get_ports ddr_odt]
+
+set_property IOSTANDARD SSTL15_T_DCI [get_ports {*ddr_dq[*]}]
+set_property SLEW FAST [get_ports {*ddr_dq[*]}]
+set_property IOSTANDARD SSTL15_T_DCI [get_ports {*ddr_dm[*]}]
+set_property SLEW FAST [get_ports {*ddr_dm[*]}]
+set_property IOSTANDARD DIFF_SSTL15_T_DCI [get_ports *ddr_dqs*]
+set_property SLEW FAST [get_ports *ddr_dqs*]
+set_property PACKAGE_PIN R6 [get_ports ddr_ras_n]
+set_property PACKAGE_PIN C9 [get_ports fixed_io_ps_porb]
+set_property PACKAGE_PIN K3 [get_ports ddr_odt]
+set_property PACKAGE_PIN C13 [get_ports {fixed_io_mio[31]}]
+set_property PACKAGE_PIN A12 [get_ports {fixed_io_mio[30]}]
+set_property PACKAGE_PIN D13 [get_ports {fixed_io_mio[29]}]
+set_property PACKAGE_PIN B12 [get_ports {fixed_io_mio[28]}]
+set_property PACKAGE_PIN D14 [get_ports {fixed_io_mio[27]}]
+set_property PACKAGE_PIN A13 [get_ports {fixed_io_mio[26]}]
+set_property PACKAGE_PIN C14 [get_ports {fixed_io_mio[25]}]
+set_property PACKAGE_PIN B14 [get_ports {fixed_io_mio[24]}]
+set_property PACKAGE_PIN A14 [get_ports {fixed_io_mio[23]}]
+set_property PACKAGE_PIN D15 [get_ports {fixed_io_mio[22]}]
+set_property PACKAGE_PIN C11 [get_ports {fixed_io_mio[21]}]
+set_property PACKAGE_PIN E15 [get_ports {fixed_io_mio[20]}]
+set_property PACKAGE_PIN C12 [get_ports {fixed_io_mio[19]}]
+set_property PACKAGE_PIN B15 [get_ports {fixed_io_mio[18]}]
+set_property PACKAGE_PIN D11 [get_ports {fixed_io_mio[17]}]
+set_property PACKAGE_PIN A15 [get_ports {fixed_io_mio[16]}]
+set_property PACKAGE_PIN D10 [get_ports {fixed_io_mio[15]}]
+set_property PACKAGE_PIN B9 [get_ports {fixed_io_mio[14]}]
+set_property PACKAGE_PIN C6 [get_ports {fixed_io_mio[13]}]
+set_property PACKAGE_PIN B7 [get_ports {fixed_io_mio[12]}]
+set_property PACKAGE_PIN B10 [get_ports {fixed_io_mio[11]}]
+set_property PACKAGE_PIN D6 [get_ports {fixed_io_mio[10]}]
+set_property PACKAGE_PIN B5 [get_ports {fixed_io_mio[9]}]
+set_property PACKAGE_PIN A5 [get_ports {fixed_io_mio[1]}]
+set_property PACKAGE_PIN D8 [get_ports {fixed_io_mio[0]}]
+set_property PACKAGE_PIN L4 [get_ports ddr_reset_n]
+set_property PACKAGE_PIN R3 [get_ports ddr_we_n]
+set_property PACKAGE_PIN J3 [get_ports fixed_io_ddr_vrn]
+set_property PACKAGE_PIN H3 [get_ports fixed_io_ddr_vrp]
+set_property PACKAGE_PIN P1 [get_ports {ddr_addr[0]}]
+set_property PACKAGE_PIN N1 [get_ports {ddr_addr[1]}]
+set_property PACKAGE_PIN M1 [get_ports {ddr_addr[2]}]
+set_property PACKAGE_PIN M4 [get_ports {ddr_addr[3]}]
+set_property PACKAGE_PIN P3 [get_ports {ddr_addr[4]}]
+set_property PACKAGE_PIN P4 [get_ports {ddr_addr[5]}]
+set_property PACKAGE_PIN P5 [get_ports {ddr_addr[6]}]
+set_property PACKAGE_PIN M5 [get_ports {ddr_addr[7]}]
+set_property PACKAGE_PIN P6 [get_ports {ddr_addr[8]}]
+set_property PACKAGE_PIN N4 [get_ports {ddr_addr[9]}]
+set_property PACKAGE_PIN J1 [get_ports {ddr_addr[10]}]
+set_property PACKAGE_PIN L2 [get_ports {ddr_addr[11]}]
+set_property PACKAGE_PIN M2 [get_ports {ddr_addr[12]}]
+set_property PACKAGE_PIN K1 [get_ports {ddr_addr[14]}]
+set_property PACKAGE_PIN K2 [get_ports {ddr_addr[13]}]
+set_property PACKAGE_PIN M6 [get_ports {ddr_ba[0]}]
+set_property PACKAGE_PIN R1 [get_ports {ddr_ba[1]}]
+set_property PACKAGE_PIN N6 [get_ports {ddr_ba[2]}]
+set_property PACKAGE_PIN R5 [get_ports ddr_cas_n]
+set_property PACKAGE_PIN L3 [get_ports ddr_cke]
+set_property PACKAGE_PIN N2 [get_ports ddr_ck_n]
+set_property PACKAGE_PIN N3 [get_ports ddr_ck_p]
+set_property PACKAGE_PIN C7 [get_ports fixed_io_ps_clk]
+set_property PACKAGE_PIN R2 [get_ports ddr_cs_n]
+set_property PACKAGE_PIN B1 [get_ports {ddr_dm[0]}]
+set_property PACKAGE_PIN D3 [get_ports {ddr_dm[1]}]
+set_property PACKAGE_PIN D4 [get_ports {ddr_dq[0]}]
+set_property PACKAGE_PIN A2 [get_ports {ddr_dq[1]}]
+set_property PACKAGE_PIN C4 [get_ports {ddr_dq[2]}]
+set_property PACKAGE_PIN C1 [get_ports {ddr_dq[3]}]
+set_property PACKAGE_PIN B4 [get_ports {ddr_dq[4]}]
+set_property PACKAGE_PIN A4 [get_ports {ddr_dq[5]}]
+set_property PACKAGE_PIN C3 [get_ports {ddr_dq[6]}]
+set_property PACKAGE_PIN A3 [get_ports {ddr_dq[7]}]
+set_property PACKAGE_PIN E1 [get_ports {ddr_dq[8]}]
+set_property PACKAGE_PIN D1 [get_ports {ddr_dq[9]}]
+set_property PACKAGE_PIN E2 [get_ports {ddr_dq[10]}]
+set_property PACKAGE_PIN E3 [get_ports {ddr_dq[11]}]
+set_property PACKAGE_PIN F3 [get_ports {ddr_dq[12]}]
+set_property PACKAGE_PIN G1 [get_ports {ddr_dq[13]}]
+set_property PACKAGE_PIN H1 [get_ports {ddr_dq[14]}]
+set_property PACKAGE_PIN H2 [get_ports {ddr_dq[15]}]
+set_property PACKAGE_PIN B2 [get_ports {ddr_dqs_n[0]}]
+set_property PACKAGE_PIN F2 [get_ports {ddr_dqs_n[1]}]
+set_property PACKAGE_PIN C2 [get_ports {ddr_dqs_p[0]}]
+set_property PACKAGE_PIN G2 [get_ports {ddr_dqs_p[1]}]

--- a/projects/admx6020m/system_project.tcl
+++ b/projects/admx6020m/system_project.tcl
@@ -1,0 +1,21 @@
+###############################################################################
+## Copyright (C) 2025-2026 Analog Devices, Inc. All rights reserved.
+### SPDX short identifier: ADIBSD
+###############################################################################
+
+source ../../scripts/adi_env.tcl
+source $ad_hdl_dir/projects/scripts/adi_project_xilinx.tcl
+source $ad_hdl_dir/projects/scripts/adi_board.tcl
+source $ad_hdl_dir/library/axi_tdd/scripts/axi_tdd.tcl
+
+adi_project_create admx6020m 0 {} "xc7z010clg225-2"
+
+adi_project_files admx6020m [list \
+  "system_top.v" \
+  "system_constr.xdc" \
+  "$ad_hdl_dir/library/common/ad_iobuf.v"]
+
+set_property strategy Performance_ExtraTimingOpt [get_runs impl_1]
+
+set_property is_enabled false [get_files  *system_sys_ps7_0.xdc]
+adi_project_run admx6020m

--- a/projects/admx6020m/system_top.v
+++ b/projects/admx6020m/system_top.v
@@ -1,0 +1,175 @@
+// ***************************************************************************
+// ***************************************************************************
+// Copyright (C) 2025-2026 Analog Devices, Inc. All rights reserved.
+//
+// In this HDL repository, there are many different and unique modules, consisting
+// of various HDL (Verilog or VHDL) components. The individual modules are
+// developed independently, and may be accompanied by separate and unique license
+// terms.
+//
+// The user should read each of these license terms, and understand the
+// freedoms and responsibilities that he or she has by using this source/core.
+//
+// This core is distributed in the hope that it will be useful, but WITHOUT ANY
+// WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+// A PARTICULAR PURPOSE.
+//
+// Redistribution and use of source or resulting binaries, with or without modification
+// of this file, are permitted under one of the following two license terms:
+//
+//   1. The GNU General Public License version 2 as published by the
+//      Free Software Foundation, which can be found in the top level directory
+//      of this repository (LICENSE_GPL2), and also online at:
+//      <https://www.gnu.org/licenses/old-licenses/gpl-2.0.html>
+//
+// OR
+//
+//   2. An ADI specific BSD license, which can be found in the top level directory
+//      of this repository (LICENSE_ADIBSD), and also on-line at:
+//      https://github.com/analogdevicesinc/hdl/blob/main/LICENSE_ADIBSD
+//      This will allow to generate bit files and not release the source code,
+//      as long as it attaches to an ADI device.
+//
+// ***************************************************************************
+// ***************************************************************************
+
+`timescale 1ns/100ps
+
+module system_top (
+
+  inout   [14:0]  ddr_addr,
+  inout   [ 2:0]  ddr_ba,
+  inout           ddr_cas_n,
+  inout           ddr_ck_n,
+  inout           ddr_ck_p,
+  inout           ddr_cke,
+  inout           ddr_cs_n,
+  inout   [ 1:0]  ddr_dm,
+  inout   [15:0]  ddr_dq,
+  inout   [ 1:0]  ddr_dqs_n,
+  inout   [ 1:0]  ddr_dqs_p,
+  inout           ddr_odt,
+  inout           ddr_ras_n,
+  inout           ddr_reset_n,
+  inout           ddr_we_n,
+
+  inout           fixed_io_ddr_vrn,
+  inout           fixed_io_ddr_vrp,
+  inout   [31:0]  fixed_io_mio,
+  inout           fixed_io_ps_clk,
+  inout           fixed_io_ps_porb,
+  inout           fixed_io_ps_srstb,
+
+  inout           iic_scl,
+  inout           iic_sca,
+
+  inout           ad9696_ldac,
+
+  input           clk_in_a1_p,
+  input           clk_in_a1_n,
+
+  input           clk_in_a2_p,
+  input           clk_in_a2_n,
+
+  input           fclk_a1_p,
+  input           fclk_a1_n,
+
+  input           fclk_a2_p,
+  input           fclk_a2_n,
+
+  input   [7:0]   data_in_a1_p,
+  input   [7:0]   data_in_a1_n,
+  input   [7:0]   data_in_a2_p,
+  input   [7:0]   data_in_a2_n,
+
+  output          spi_a1_csn,
+  output          spi_a2_csn,
+  output          pll_csn,
+  output          spi_clk,
+  output          spi_sdata
+);
+
+  // internal signals
+
+  wire    [17:0]  gpio_i;
+  wire    [17:0]  gpio_o;
+  wire    [17:0]  gpio_t;
+  wire    [6:0]   ps_gpio;
+
+  // ADF4355 SCLK/SDIO pins swapped on PCB
+  // When PLL is selected (pll_csn low), swap clk and data signals
+
+  wire w_spi_clk, w_spi_sdata, w_pll_csn;
+
+  assign spi_clk = ~w_pll_csn ? w_spi_sdata : w_spi_clk;
+  assign spi_sdata = ~w_pll_csn ? w_spi_clk : w_spi_sdata;
+  assign pll_csn = w_pll_csn;
+
+  // instantiations
+
+  ad_iobuf #(
+    .DATA_WIDTH(1)
+  ) i_iobuf (
+    .dio_t (gpio_t[0]),
+    .dio_i (gpio_o[0]),
+    .dio_o (gpio_i[0]),
+    .dio_p (ad9696_ldac));
+
+  assign gpio_i[17:1] = gpio_o[17:1];
+  assign ps_gpio[6:0] = ps_gpio[6:0];
+
+  system_wrapper i_system_wrapper (
+    .ddr_addr (ddr_addr),
+    .ddr_ba (ddr_ba),
+    .ddr_cas_n (ddr_cas_n),
+    .ddr_ck_n (ddr_ck_n),
+    .ddr_ck_p (ddr_ck_p),
+    .ddr_cke (ddr_cke),
+    .ddr_cs_n (ddr_cs_n),
+    .ddr_dm (ddr_dm),
+    .ddr_dq (ddr_dq),
+    .ddr_dqs_n (ddr_dqs_n),
+    .ddr_dqs_p (ddr_dqs_p),
+    .ddr_odt (ddr_odt),
+    .ddr_ras_n (ddr_ras_n),
+    .ddr_reset_n (ddr_reset_n),
+    .ddr_we_n (ddr_we_n),
+    .fixed_io_ddr_vrn (fixed_io_ddr_vrn),
+    .fixed_io_ddr_vrp (fixed_io_ddr_vrp),
+    .fixed_io_mio (fixed_io_mio),
+    .fixed_io_ps_clk (fixed_io_ps_clk),
+    .fixed_io_ps_porb (fixed_io_ps_porb),
+    .fixed_io_ps_srstb (fixed_io_ps_srstb),
+    .gpio_i (gpio_i),
+    .gpio_o (gpio_o),
+    .gpio_t (gpio_t),
+
+    .spi0_clk_i (1'b0),
+    .spi0_clk_o (w_spi_clk),
+    .spi0_csn_0_o (spi_a1_csn), // 1st ADC
+    .spi0_csn_1_o (spi_a2_csn), // 2nd ADC
+    .spi0_csn_2_o (w_pll_csn), // ADF4355
+    .spi0_csn_i (1'b1),
+    .spi0_sdi_i (1'b0),
+    .spi0_sdo_i (1'b0),
+    .spi0_sdo_o (w_spi_sdata),
+
+    .clk_in_a1_p (clk_in_a1_p),
+    .clk_in_a1_n (clk_in_a1_n),
+    .clk_in_a2_p (clk_in_a2_p),
+    .clk_in_a2_n (clk_in_a2_n),
+
+    .fclk_a1_p (fclk_a1_p),
+    .fclk_a1_n (fclk_a1_n),
+    .fclk_a2_p (fclk_a2_p),
+    .fclk_a2_n (fclk_a2_n),
+
+    .data_in_a1_p (data_in_a1_p),
+    .data_in_a1_n (data_in_a1_n),
+    .data_in_a2_p (data_in_a2_p),
+    .data_in_a2_n (data_in_a2_n),
+
+    .iic_main_scl_io (iic_scl),
+    .iic_main_sda_io (iic_sca));
+
+endmodule

--- a/projects/hmcad1520_ebz/Makefile
+++ b/projects/hmcad1520_ebz/Makefile
@@ -1,0 +1,7 @@
+####################################################################################
+## Copyright (c) 2018 - 2026 Analog Devices, Inc.
+### SPDX short identifier: BSD-1-Clause
+## Auto-generated, do not modify!
+####################################################################################
+
+include ../scripts/project-toplevel.mk

--- a/projects/hmcad1520_ebz/README.md
+++ b/projects/hmcad1520_ebz/README.md
@@ -1,0 +1,17 @@
+# HMCAD1520-EBZ HDL Project
+
+- Evaluation board product page: TO BE ADDED
+- System documentation: TO BE ADDED
+- HDL project documentation: https://analogdevicesinc.github.io/hdl/projects/hmcad1520_ebz/index.html
+- Evaluation board VADJ: 2.5V
+
+## Supported parts
+
+| Part name                                       | Description                                    |
+|-------------------------------------------------|------------------------------------------------|
+| [HMCAD1520](https://www.analog.com/hmcad1520)   | 14-Bit, 1 Gsps/500 Msps High Speed ADC         |
+| [HMCAD1511](https://www.analog.com/hmcad1511)   | 12-Bit, 1 Gsps/500 Msps High Speed ADC         |
+
+## Building the project
+
+Please enter the folder for the FPGA carrier you want to use and read the README.md.

--- a/projects/hmcad1520_ebz/common/hmcad1520_ebz_bd.tcl
+++ b/projects/hmcad1520_ebz/common/hmcad1520_ebz_bd.tcl
@@ -1,0 +1,78 @@
+###############################################################################
+## Copyright (C) 2025-2026 Analog Devices, Inc. All rights reserved.
+### SPDX short identifier: ADIBSD
+###############################################################################
+
+# hmcad15xx interface
+
+create_bd_port -dir I clk_in_p
+create_bd_port -dir I clk_in_n
+create_bd_port -dir I fclk_p
+create_bd_port -dir I fclk_n
+create_bd_port -dir I -from 7 -to 0 data_in_p
+create_bd_port -dir I -from 7 -to 0 data_in_n
+
+# instances
+
+ad_ip_instance axi_dmac hmcad1520_dma
+ad_ip_parameter hmcad1520_dma CONFIG.DMA_TYPE_SRC 2
+ad_ip_parameter hmcad1520_dma CONFIG.DMA_TYPE_DEST 0
+ad_ip_parameter hmcad1520_dma CONFIG.CYCLIC 0
+ad_ip_parameter hmcad1520_dma CONFIG.SYNC_TRANSFER_START 1
+ad_ip_parameter hmcad1520_dma CONFIG.AXI_SLICE_SRC 0
+ad_ip_parameter hmcad1520_dma CONFIG.AXI_SLICE_DEST 0
+ad_ip_parameter hmcad1520_dma CONFIG.DMA_2D_TRANSFER 0
+ad_ip_parameter hmcad1520_dma CONFIG.DMA_DATA_WIDTH_SRC 128
+ad_ip_parameter hmcad1520_dma CONFIG.DMA_DATA_WIDTH_DEST 64
+ad_ip_parameter hmcad1520_dma CONFIG.FIFO_SIZE 32
+ad_ip_parameter hmcad1520_dma CONFIG.MAX_BYTES_PER_BURST 4096
+
+# axi_hmcad15xx
+
+ad_ip_instance axi_hmcad15xx axi_hmcad1520_adc
+ad_ip_parameter axi_hmcad1520_adc CONFIG.NUM_CHANNELS 4
+ad_ip_parameter axi_hmcad1520_adc CONFIG.IODELAY_CTRL 1
+
+ad_connect axi_hmcad1520_adc/s_axi_aclk    sys_cpu_clk
+ad_connect axi_hmcad1520_adc/clk_in_p      clk_in_p
+ad_connect axi_hmcad1520_adc/clk_in_n      clk_in_n
+ad_connect axi_hmcad1520_adc/fclk_p        fclk_p
+ad_connect axi_hmcad1520_adc/fclk_n        fclk_n
+ad_connect axi_hmcad1520_adc/data_in_p     data_in_p
+ad_connect axi_hmcad1520_adc/data_in_n     data_in_n
+ad_connect axi_hmcad1520_adc/delay_clk     $sys_iodelay_clk
+
+ad_connect axi_hmcad1520_adc/adc_clk   hmcad1520_dma/fifo_wr_clk
+ad_connect axi_hmcad1520_adc/adc_data  hmcad1520_dma/fifo_wr_din
+ad_connect axi_hmcad1520_adc/adc_valid hmcad1520_dma/fifo_wr_en
+ad_connect axi_hmcad1520_adc/adc_dovf  hmcad1520_dma/fifo_wr_overflow
+
+ad_ip_parameter sys_ps7 CONFIG.PCW_EN_CLK2_PORT 1
+ad_ip_parameter sys_ps7 CONFIG.PCW_FPGA2_PERIPHERAL_FREQMHZ 150.0
+ad_ip_parameter sys_ps7 CONFIG.PCW_EN_RST2_PORT 1
+
+ad_ip_instance proc_sys_reset sys_150m_rstgen
+ad_ip_parameter sys_150m_rstgen CONFIG.C_EXT_RST_WIDTH 1
+ad_connect  sys_ps7/FCLK_CLK2 sys_150m_rstgen/slowest_sync_clk
+ad_connect  sys_150m_rstgen/ext_reset_in sys_ps7/FCLK_RESET2_N
+
+# Create named clock/reset nets for ad_mem_hp*_interconnect
+
+set_property NAME sys_150m_clk [get_bd_nets sys_ps7_FCLK_CLK2]
+create_bd_net sys_150m_resetn
+ad_connect sys_150m_rstgen/peripheral_aresetn sys_150m_resetn
+
+#DMA
+
+ad_connect  hmcad1520_dma/m_dest_axi_aresetn    sys_150m_resetn
+
+# interrupts
+
+ad_cpu_interrupt ps-13 mb-12  hmcad1520_dma/irq
+
+# cpu / memory interconnects
+ad_cpu_interconnect 0x44A00000 axi_hmcad1520_adc
+ad_cpu_interconnect 0x44A30000 hmcad1520_dma
+
+ad_mem_hp1_interconnect sys_150m_clk sys_ps7/S_AXI_HP1
+ad_mem_hp1_interconnect sys_150m_clk hmcad1520_dma/m_dest_axi

--- a/projects/hmcad1520_ebz/zed/Makefile
+++ b/projects/hmcad1520_ebz/zed/Makefile
@@ -1,0 +1,25 @@
+####################################################################################
+## Copyright (c) 2018 - 2026 Analog Devices, Inc.
+### SPDX short identifier: BSD-1-Clause
+## Auto-generated, do not modify!
+####################################################################################
+
+PROJECT_NAME := hmcad1520_ebz_zed
+
+M_DEPS += ../common/hmcad1520_ebz_bd.tcl
+M_DEPS += ../../scripts/adi_pd.tcl
+M_DEPS += ../../common/zed/zed_system_constr.xdc
+M_DEPS += ../../common/zed/zed_system_bd.tcl
+M_DEPS += ../../../library/common/ad_iobuf.v
+
+LIB_DEPS += axi_clkgen
+LIB_DEPS += axi_dmac
+LIB_DEPS += axi_hdmi_tx
+LIB_DEPS += axi_hmcad15xx
+LIB_DEPS += axi_i2s_adi
+LIB_DEPS += axi_spdif_tx
+LIB_DEPS += axi_sysid
+LIB_DEPS += sysid_rom
+LIB_DEPS += util_i2c_mixer
+
+include ../../scripts/project-xilinx.mk

--- a/projects/hmcad1520_ebz/zed/README.md
+++ b/projects/hmcad1520_ebz/zed/README.md
@@ -1,0 +1,14 @@
+<!-- no_build_example, no_no_os -->
+
+# HMCAD1520-EBZ/ZED HDL Project
+
+- VADJ with which it was tested in hardware: 2.5V
+
+## Building the project
+
+```
+cd projects/hmcad1520_ebz/zed
+make
+```
+
+Corresponding device tree: [zynq-zed-adv7511-hmcad15xx.dts](https://github.com/analogdevicesinc/linux/blob/sharkbyte_pr/arch/arm/boot/dts/xilinx/zynq-zed-adv7511-hmcad15xx.dts)

--- a/projects/hmcad1520_ebz/zed/system_bd.tcl
+++ b/projects/hmcad1520_ebz/zed/system_bd.tcl
@@ -1,0 +1,16 @@
+###############################################################################
+## Copyright (C) 2025-2026 Analog Devices, Inc. All rights reserved.
+### SPDX short identifier: ADIBSD
+###############################################################################
+
+source $ad_hdl_dir/projects/common/zed/zed_system_bd.tcl
+source $ad_hdl_dir/projects/scripts/adi_pd.tcl
+
+#system ID
+ad_ip_parameter axi_sysid_0 CONFIG.ROM_ADDR_BITS 9
+ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "$mem_init_sys_file_path/mem_init_sys.txt"
+ad_ip_parameter rom_sys_0 CONFIG.ROM_ADDR_BITS 9
+
+sysid_gen_sys_init_file
+
+source ../common/hmcad1520_ebz_bd.tcl

--- a/projects/hmcad1520_ebz/zed/system_constr.xdc
+++ b/projects/hmcad1520_ebz/zed/system_constr.xdc
@@ -1,0 +1,40 @@
+###############################################################################
+## Copyright (C) 2025-2026 Analog Devices, Inc. All rights reserved.
+### SPDX short identifier: ADIBSD
+###############################################################################
+
+set_property  -dict {PACKAGE_PIN  N19  IOSTANDARD LVDS_25 DIFF_TERM 1}  [get_ports clk_in_p]    ; ##D8    FMC_LA01_CC_P   IO_L14P_T2_SRCC_34
+set_property  -dict {PACKAGE_PIN  N20  IOSTANDARD LVDS_25 DIFF_TERM 1}  [get_ports clk_in_n]    ; ##D9    FMC_LA01_CC_N   IO_L14N_T2_SRCC_34
+
+set_property  -dict {PACKAGE_PIN M19  IOSTANDARD LVDS_25 DIFF_TERM 1}  [get_ports fclk_p]       ; ##G6    FMC_LA00_CC_P   IO_L13P_T2_MRCC_34
+set_property  -dict {PACKAGE_PIN M20  IOSTANDARD LVDS_25 DIFF_TERM 1}  [get_ports fclk_n]       ; ##G7    FMC_LA00_CC_N   IO_L13N_T2_MRCC_34
+
+set_property  -dict {PACKAGE_PIN L17  IOSTANDARD LVDS_25 DIFF_TERM 1}  [get_ports trig_p]       ; ##D17   FMC_LA13_P    IO_L4P_T0_34
+set_property  -dict {PACKAGE_PIN M17  IOSTANDARD LVDS_25 DIFF_TERM 1}  [get_ports trig_n]       ; ##D18   FMC_LA13_N    IO_L4N_T0_34
+
+set_property  -dict {PACKAGE_PIN R19  IOSTANDARD LVDS_25 DIFF_TERM 1}  [get_ports data_in_p[0]] ; ##C14   FMC_LA10_P    IO_L22P_T3_34
+set_property  -dict {PACKAGE_PIN N17  IOSTANDARD LVDS_25 DIFF_TERM 1}  [get_ports data_in_p[1]] ; ##H16   FMC_LA11_P    IO_L5P_T0_34
+set_property  -dict {PACKAGE_PIN R20  IOSTANDARD LVDS_25 DIFF_TERM 1}  [get_ports data_in_p[2]] ; ##D14   FMC_LA09_P    IO_L17P_T2_34
+set_property  -dict {PACKAGE_PIN T16  IOSTANDARD LVDS_25 DIFF_TERM 1}  [get_ports data_in_p[3]] ; ##H13   FMC_LA07_P    IO_L21P_T3_DQS_34
+set_property  -dict {PACKAGE_PIN J21  IOSTANDARD LVDS_25 DIFF_TERM 1}  [get_ports data_in_p[4]] ; ##G12   FMC_LA08_P    IO_L8P_T1_34
+set_property  -dict {PACKAGE_PIN J18  IOSTANDARD LVDS_25 DIFF_TERM 1}  [get_ports data_in_p[5]] ; ##D11   FMC_LA05_P    IO_L7P_T1_34
+set_property  -dict {PACKAGE_PIN M21  IOSTANDARD LVDS_25 DIFF_TERM 1}  [get_ports data_in_p[6]] ; ##H10   FMC_LA04_P    IO_L15P_T2_DQS_34
+set_property  -dict {PACKAGE_PIN L21  IOSTANDARD LVDS_25 DIFF_TERM 1}  [get_ports data_in_p[7]] ; ##C10   FMC_LA06_P    IO_L10P_T1_34
+
+set_property  -dict {PACKAGE_PIN T19  IOSTANDARD LVDS_25 DIFF_TERM 1}  [get_ports data_in_n[0]] ; ##C15   FMC_LA10_N    IO_L22N_T3_34
+set_property  -dict {PACKAGE_PIN N18  IOSTANDARD LVDS_25 DIFF_TERM 1}  [get_ports data_in_n[1]] ; ##H17   FMC_LA11_N    IO_L5N_T0_34
+set_property  -dict {PACKAGE_PIN R21  IOSTANDARD LVDS_25 DIFF_TERM 1}  [get_ports data_in_n[2]] ; ##D15   FMC_LA09_N    IO_L17N_T2_34
+set_property  -dict {PACKAGE_PIN T17  IOSTANDARD LVDS_25 DIFF_TERM 1}  [get_ports data_in_n[3]] ; ##H14   FMC_LA07_N    IO_L21N_T3_DQS_34
+set_property  -dict {PACKAGE_PIN J22  IOSTANDARD LVDS_25 DIFF_TERM 1}  [get_ports data_in_n[4]] ; ##G13   FMC_LA08_N    IO_L8N_T1_34
+set_property  -dict {PACKAGE_PIN K18  IOSTANDARD LVDS_25 DIFF_TERM 1}  [get_ports data_in_n[5]] ; ##D12   FMC_LA05_N    IO_L7N_T1_34
+set_property  -dict {PACKAGE_PIN M22  IOSTANDARD LVDS_25 DIFF_TERM 1}  [get_ports data_in_n[6]] ; ##H11   FMC_LA04_N    IO_L15N_T2_DQS_34
+set_property  -dict {PACKAGE_PIN L22  IOSTANDARD LVDS_25 DIFF_TERM 1}  [get_ports data_in_n[7]] ; ##C11   FMC_LA06_N    IO_L10N_T1_34
+
+set_property  -dict {PACKAGE_PIN P22  IOSTANDARD LVCMOS25}  [get_ports spi_csn]      ; ## G10  FMC_LA03_N       IO_L16N_T2_34
+set_property  -dict {PACKAGE_PIN P17  IOSTANDARD LVCMOS25}  [get_ports spi_clk]      ; ## H7   FMC_LA02_P       IO_L20P_T3_34
+set_property  -dict {PACKAGE_PIN P18  IOSTANDARD LVCMOS25}  [get_ports spi_sdata]    ; ## H8   FMC_LA02_N       IO_L20N_T3_34
+
+set_property  -dict {PACKAGE_PIN P20  IOSTANDARD LVCMOS25}  [get_ports fmc_pd]       ; ##G15   FMC_LA12_P       IO_L18P_T2_34
+set_property  -dict {PACKAGE_PIN P21  IOSTANDARD LVCMOS25}  [get_ports fmc_rstn]     ; ##G16   FMC_LA12_N       IO_L18N_T2_34
+
+create_clock -name adc_clk   -period 2 [get_ports clk_in_p]

--- a/projects/hmcad1520_ebz/zed/system_project.tcl
+++ b/projects/hmcad1520_ebz/zed/system_project.tcl
@@ -1,0 +1,17 @@
+###############################################################################
+## Copyright (C) 2025-2026 Analog Devices, Inc. All rights reserved.
+### SPDX short identifier: ADIBSD
+###############################################################################
+
+source ../../../scripts/adi_env.tcl
+source $ad_hdl_dir/projects/scripts/adi_project_xilinx.tcl
+source $ad_hdl_dir/projects/scripts/adi_board.tcl
+
+adi_project hmcad1520_ebz_zed
+adi_project_files hmcad1520_ebz_zed [list \
+  "$ad_hdl_dir/projects/common/zed/zed_system_constr.xdc" \
+  "$ad_hdl_dir/library/common/ad_iobuf.v" \
+  "system_constr.xdc" \
+  "system_top.v" ]
+
+adi_project_run hmcad1520_ebz_zed

--- a/projects/hmcad1520_ebz/zed/system_top.v
+++ b/projects/hmcad1520_ebz/zed/system_top.v
@@ -1,0 +1,221 @@
+// ***************************************************************************
+// ***************************************************************************
+// Copyright (C) 2025-2026 Analog Devices, Inc. All rights reserved.
+//
+// In this HDL repository, there are many different and unique modules, consisting
+// of various HDL (Verilog or VHDL) components. The individual modules are
+// developed independently, and may be accompanied by separate and unique license
+// terms.
+//
+// The user should read each of these license terms, and understand the
+// freedoms and responsibilities that he or she has by using this source/core.
+//
+// This core is distributed in the hope that it will be useful, but WITHOUT ANY
+// WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+// A PARTICULAR PURPOSE.
+//
+// Redistribution and use of source or resulting binaries, with or without modification
+// of this file, are permitted under one of the following two license terms:
+//
+//   1. The GNU General Public License version 2 as published by the
+//      Free Software Foundation, which can be found in the top level directory
+//      of this repository (LICENSE_GPL2), and also online at:
+//      <https://www.gnu.org/licenses/old-licenses/gpl-2.0.html>
+//
+// OR
+//
+//   2. An ADI specific BSD license, which can be found in the top level directory
+//      of this repository (LICENSE_ADIBSD), and also on-line at:
+//      https://github.com/analogdevicesinc/hdl/blob/main/LICENSE_ADIBSD
+//      This will allow to generate bit files and not release the source code,
+//      as long as it attaches to an ADI device.
+//
+// ***************************************************************************
+// ***************************************************************************
+
+`timescale 1ns/100ps
+
+module system_top (
+
+  inout       [14:0]      ddr_addr,
+  inout       [ 2:0]      ddr_ba,
+  inout                   ddr_cas_n,
+  inout                   ddr_ck_n,
+  inout                   ddr_ck_p,
+  inout                   ddr_cke,
+  inout                   ddr_cs_n,
+  inout       [ 3:0]      ddr_dm,
+  inout       [31:0]      ddr_dq,
+  inout       [ 3:0]      ddr_dqs_n,
+  inout       [ 3:0]      ddr_dqs_p,
+  inout                   ddr_odt,
+  inout                   ddr_ras_n,
+  inout                   ddr_reset_n,
+  inout                   ddr_we_n,
+
+  inout                   fixed_io_ddr_vrn,
+  inout                   fixed_io_ddr_vrp,
+  inout       [53:0]      fixed_io_mio,
+  inout                   fixed_io_ps_clk,
+  inout                   fixed_io_ps_porb,
+  inout                   fixed_io_ps_srstb,
+
+  inout       [31:0]      gpio_bd,
+
+  output                  hdmi_out_clk,
+  output                  hdmi_vsync,
+  output                  hdmi_hsync,
+  output                  hdmi_data_e,
+  output      [15:0]      hdmi_data,
+
+  output                  i2s_mclk,
+  output                  i2s_bclk,
+  output                  i2s_lrclk,
+  output                  i2s_sdata_out,
+  input                   i2s_sdata_in,
+
+  output                  spdif,
+
+  inout                   iic_scl,
+  inout                   iic_sda,
+  inout       [ 1:0]      iic_mux_scl,
+  inout       [ 1:0]      iic_mux_sda,
+
+  input                   otg_vbusoc,
+
+  input                   clk_in_p,
+  input                   clk_in_n,
+
+  input                   fclk_p,
+  input                   fclk_n,
+
+  input                   trig_p,
+  input                   trig_n,
+
+  input       [ 7:0]      data_in_p,
+  input       [ 7:0]      data_in_n,
+
+  output                  spi_csn,
+  output                  spi_clk,
+  output                  spi_sdata,
+
+  output                  fmc_pd,
+  output                  fmc_rstn
+);
+
+  // internal signals
+
+  wire    [63:0]  adc_gpio_i;
+  wire    [63:0]  adc_gpio_o;
+  wire    [63:0]  adc_gpio_t;
+  wire    [63:0]  gpio_i;
+  wire    [63:0]  gpio_o;
+  wire    [63:0]  gpio_t;
+  wire    [ 1:0]  iic_mux_scl_i_s;
+  wire    [ 1:0]  iic_mux_scl_o_s;
+  wire            iic_mux_scl_t_s;
+  wire    [ 1:0]  iic_mux_sda_i_s;
+  wire    [ 1:0]  iic_mux_sda_o_s;
+  wire            iic_mux_sda_t_s;
+  wire            spi_mosi;
+  wire            spi_miso;
+
+  ad_iobuf #(
+    .DATA_WIDTH(32)
+  ) i_iobuf_bd (
+    .dio_t (gpio_t[31:0]),
+    .dio_i (gpio_o[31:0]),
+    .dio_o (gpio_i[31:0]),
+    .dio_p (gpio_bd));
+
+  assign fmc_pd   = gpio_o[32];
+  assign fmc_rstn = gpio_o[33];
+  assign gpio_i[63:34] = gpio_o[63:34];
+
+  ad_iobuf #(
+    .DATA_WIDTH(2)
+  ) i_iic_mux_scl (
+    .dio_t ({iic_mux_scl_t_s, iic_mux_scl_t_s}),
+    .dio_i (iic_mux_scl_o_s),
+    .dio_o (iic_mux_scl_i_s),
+    .dio_p (iic_mux_scl));
+
+  ad_iobuf #(
+    .DATA_WIDTH(2)
+  ) i_iic_mux_sda (
+    .dio_t ({iic_mux_sda_t_s, iic_mux_sda_t_s}),
+    .dio_i (iic_mux_sda_o_s),
+    .dio_o (iic_mux_sda_i_s),
+    .dio_p (iic_mux_sda));
+
+  system_wrapper i_system_wrapper (
+    .clk_in_p (clk_in_p),
+    .clk_in_n (clk_in_n),
+    .fclk_p (fclk_p),
+    .fclk_n (fclk_n),
+    .data_in_p (data_in_p),
+    .data_in_n (data_in_n),
+    .ddr_addr (ddr_addr),
+    .ddr_ba (ddr_ba),
+    .ddr_cas_n (ddr_cas_n),
+    .ddr_ck_n (ddr_ck_n),
+    .ddr_ck_p (ddr_ck_p),
+    .ddr_cke (ddr_cke),
+    .ddr_cs_n (ddr_cs_n),
+    .ddr_dm (ddr_dm),
+    .ddr_dq (ddr_dq),
+    .ddr_dqs_n (ddr_dqs_n),
+    .ddr_dqs_p (ddr_dqs_p),
+    .ddr_odt (ddr_odt),
+    .ddr_ras_n (ddr_ras_n),
+    .ddr_reset_n (ddr_reset_n),
+    .ddr_we_n (ddr_we_n),
+    .fixed_io_ddr_vrn (fixed_io_ddr_vrn),
+    .fixed_io_ddr_vrp (fixed_io_ddr_vrp),
+    .fixed_io_mio (fixed_io_mio),
+    .fixed_io_ps_clk (fixed_io_ps_clk),
+    .fixed_io_ps_porb (fixed_io_ps_porb),
+    .fixed_io_ps_srstb (fixed_io_ps_srstb),
+    .gpio_i (gpio_i),
+    .gpio_o (gpio_o),
+    .gpio_t (gpio_t),
+    .hdmi_data (hdmi_data),
+    .hdmi_data_e (hdmi_data_e),
+    .hdmi_hsync (hdmi_hsync),
+    .hdmi_out_clk (hdmi_out_clk),
+    .hdmi_vsync (hdmi_vsync),
+    .i2s_bclk (i2s_bclk),
+    .i2s_lrclk (i2s_lrclk),
+    .i2s_mclk (i2s_mclk),
+    .i2s_sdata_in (i2s_sdata_in),
+    .i2s_sdata_out (i2s_sdata_out),
+    .iic_fmc_scl_io (iic_scl),
+    .iic_fmc_sda_io (iic_sda),
+    .iic_mux_scl_i (iic_mux_scl_i_s),
+    .iic_mux_scl_o (iic_mux_scl_o_s),
+    .iic_mux_scl_t (iic_mux_scl_t_s),
+    .iic_mux_sda_i (iic_mux_sda_i_s),
+    .iic_mux_sda_o (iic_mux_sda_o_s),
+    .iic_mux_sda_t (iic_mux_sda_t_s),
+    .otg_vbusoc (otg_vbusoc),
+    .spdif (spdif),
+    .spi0_clk_i (1'b0),
+    .spi0_clk_o (spi_clk),
+    .spi0_csn_0_o (spi_csn),
+    .spi0_csn_1_o (),
+    .spi0_csn_2_o (),
+    .spi0_csn_i (1'b1),
+    .spi0_sdi_i (1'b0),
+    .spi0_sdo_i (1'b0),
+    .spi0_sdo_o (spi_sdata),
+    .spi1_clk_i (1'b0),
+    .spi1_clk_o (),
+    .spi1_csn_0_o (),
+    .spi1_csn_1_o (),
+    .spi1_csn_2_o (),
+    .spi1_csn_i (1'b1),
+    .spi1_sdi_i (1'b0),
+    .spi1_sdo_i (1'b0),
+    .spi1_sdo_o ());
+
+endmodule


### PR DESCRIPTION
## PR Description

This PR adds support for the HMCAD1511/HMCAD1520 high-speed ADC family, including the interface IP, two reference designs, and documentation.

New IP Core:

- axi_hmcad15xx: Interface IP for HMCAD1511 and HMCAD1520 ADCs
   - Support for 8/12/14-bit resolution modes
   - Single/Dual/Quad channel configurations
   - Support for Dual 8-bit Quad Channel mode
   - FCLK-based synchronization
 
New Reference Designs:

- hmcad1520_ebz/zed: Reference design for HMCAD1520-EBZ evaluation board on ZedBoard
- ADMX6020M: Dual-channel synchronized ADC capture system

Documentation:

- IP documentation: docs/library/axi_hmcad15xx/
- Project documentation: docs/projects/hmcad1520_ebz/ and docs/projects/admx6020m/

## PR Type
- [ ] Bug fix (change that fixes an issue)
- [x] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)
- [x] Documentation

## PR Checklist
- [x] I have followed the code style guidelines
- [x] I have performed a self-review of changes
- [x] I have compiled all hdl projects and libraries affected by this PR
- [x] I have tested in hardware affected projects, at least on relevant boards
- [x] I have commented my code, at least hard-to-understand parts
- [x] I have signed off all commits from this PR
- [x] I have updated the documentation (wiki pages, ReadMe files, Copyright etc)
- [x] I have not introduced new Warnings/Critical Warnings on compilation
- [ ] I have added new hdl testbenches or updated existing ones
