### PR TITLE
docs: fix describing bus ports instead of bus

### DIFF
--- a/docs/library/axi_ad35xxr/index.rst
+++ b/docs/library/axi_ad35xxr/index.rst
@@ -89,12 +89,8 @@ Interface
 
    * - dac_clk
      - Reference clock
-   * - dma_data
+   * - s_axis
      - Data from the DMAC when input source is set to DMA_DATA.
-   * - valid_in_dma
-     - Valid from the DMAC.
-   * - dac_data_ready
-     - Data ready signal for the DMAC.
    * - data_in_a
      - Data for channel 1 when input source is set to ADC_DATA.
    * - data_in_b


### PR DESCRIPTION


## PR Description
Resolves docs warnings. When the interface is a bus, we describe the bus and not the individual ports of the bus, based on the stance that if it is a defined bus, the ports must match the bus definition. For example, an axis bus, must comply with {data, valid, ready} signals, another port in the bus would define another bus interface, that would need to be specified on its own section.
Fixes: 2cacad87bb51 ("docs: page for AD3552R IP (#1323)")

Clears:
```
WARNING: library/axi_ad35xxr/component.xml: Signal dma_data defined in the hdl-interfaces directive does not exist in the IP-XACT!
WARNING: library/axi_ad35xxr/component.xml: Signal valid_in_dma defined in the hdl-interfaces directive does not exist in the IP-XACT!
WARNING: library/axi_ad35xxr/component.xml: Signal dac_data_ready defined in the hdl-interfaces directive does not exist in the IP-XACT!
```


## PR Type
- [ ] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)
- [ ] Documentation

## PR Checklist
- [ ] I have followed the code style guidelines
- [ ] I have performed a self-review of changes
- [ ] I have compiled all hdl projects and libraries affected by this PR
- [ ] I have tested in hardware affected projects, at least on relevant boards
- [ ] I have commented my code, at least hard-to-understand parts
- [ ] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe files, Copyright etc)
- [ ] I have not introduced new Warnings/Critical Warnings on compilation
- [ ] I have added new hdl testbenches or updated existing ones
