### PR TITLE
axi_ad9361: Enhance frame error check

### DIFF
--- a/library/axi_ad9361/xilinx/axi_ad9361_lvds_if.v
+++ b/library/axi_ad9361/xilinx/axi_ad9361_lvds_if.v
@@ -215,11 +215,13 @@ module axi_ad9361_lvds_if #(
   end
 
   // frame check
+  // Use case-equality (===) so unknown (X) bits in rx_frame_s never propagate
+  // as X into rx_error. Any unrecognised or X pattern is treated as an error.
 
-  assign rx_error = ~(({rx_frame_s, rx_frame} == 4'b1111) ||
-                      ({rx_frame_s, rx_frame} == 4'b1100) ||
-                      ({rx_frame_s, rx_frame} == 4'b0000) ||
-                      ({rx_frame_s, rx_frame} == 4'b0011));
+  assign rx_error = (({rx_frame_s, rx_frame} === 4'b1111) ||
+                     ({rx_frame_s, rx_frame} === 4'b1100) ||
+                     ({rx_frame_s, rx_frame} === 4'b0000) ||
+                     ({rx_frame_s, rx_frame} === 4'b0011)) ? 1'b0 : 1'b1;
 
   // delineation
 

--- a/library/axi_ad9361/xilinx/axi_ad9361_lvds_if.v
+++ b/library/axi_ad9361/xilinx/axi_ad9361_lvds_if.v
@@ -1,6 +1,6 @@
 // ***************************************************************************
 // ***************************************************************************
-// Copyright (C) 2014-2024 Analog Devices, Inc. All rights reserved.
+// Copyright (C) 2014-2024, 2026 Analog Devices, Inc. All rights reserved.
 //
 // In this HDL repository, there are many different and unique modules, consisting
 // of various HDL (Verilog or VHDL) components. The individual modules are
@@ -215,7 +215,11 @@ module axi_ad9361_lvds_if #(
   end
 
   // frame check
-  assign rx_error = ^rx_frame;
+
+  assign rx_error = ~(({rx_frame_s, rx_frame} == 4'b1111) ||
+                      ({rx_frame_s, rx_frame} == 4'b1100) ||
+                      ({rx_frame_s, rx_frame} == 4'b0000) ||
+                      ({rx_frame_s, rx_frame} == 4'b0011));
 
   // delineation
 


### PR DESCRIPTION
## PR Description

The AD9361 LVDS frame signal is sampled on DDR edges, producing two 2‑bit values: the current sample (rx_frame_s) and the previous one (rx_frame). Together they form a 4‑bit pattern representing two consecutive half‑cycles. Only four patterns are valid (1111, 1100, 0000, 0011), corresponding to a stable high/low or a single rising/falling edge at a frame boundary.

The original error check used XOR reduction on rx_frame. By adding just the missing rx_frame_s to the check like:

 assign rx_error = ^{rx_frame_s, rx_frame};

it would only tests parity (odd vs. even number of 1s). While all valid patterns have even parity, some invalid patterns also have even parity (e.g., 0101, 0110, 1001, 1010). These blind spots allow physically impossible “glitch” behaviors, toggling every half‑cycle, to pass undetected.

The fix is to explicitly whitelist the four valid patterns and flag everything else as an error. This checks bit positions, not just parity, and correctly detects fast toggling caused by noise or misalignment.

## PR Type
- [ ] Bug fix (change that fixes an issue)
- [x] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)
- [ ] Documentation

## PR Checklist
- [x] I have followed the code style guidelines
- [x] I have performed a self-review of changes
- [x] I have compiled all hdl projects and libraries affected by this PR
- [ ] I have tested in hardware affected projects, at least on relevant boards
- [ ] I have commented my code, at least hard-to-understand parts
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe files, Copyright etc)
- [x] I have not introduced new Warnings/Critical Warnings on compilation
- [ ] I have added new hdl testbenches or updated existing ones
