### PR TITLE
library/util_cpack2: Add AXI Streaming support

### DIFF
--- a/library/util_pack/util_cpack2/util_cpack2.v
+++ b/library/util_pack/util_cpack2/util_cpack2.v
@@ -1,6 +1,6 @@
 // ***************************************************************************
 // ***************************************************************************
-// Copyright (C) 2018-2025 Analog Devices, Inc. All rights reserved.
+// Copyright (C) 2018-2026 Analog Devices, Inc. All rights reserved.
 //
 // In this HDL repository, there are many different and unique modules, consisting
 // of various HDL (Verilog or VHDL) components. The individual modules are
@@ -39,6 +39,7 @@ module util_cpack2 #(
   parameter NUM_OF_CHANNELS = 4,
   parameter SAMPLES_PER_CHANNEL = 1,
   parameter SAMPLE_DATA_WIDTH = 16,
+  parameter INTERFACE_TYPE = 1,
   parameter PARALLEL_OR_SERIAL_N = 0
 ) (
   input clk,
@@ -177,6 +178,12 @@ module util_cpack2 #(
   input [SAMPLE_DATA_WIDTH*SAMPLES_PER_CHANNEL-1:0] fifo_wr_data_62,
   input [SAMPLE_DATA_WIDTH*SAMPLES_PER_CHANNEL-1:0] fifo_wr_data_63,
 
+  input m_axis_ready,
+  output m_axis_valid,
+  output [2**$clog2(NUM_OF_CHANNELS)*SAMPLE_DATA_WIDTH*SAMPLES_PER_CHANNEL-1:0] m_axis_data,
+  output [2**$clog2(NUM_OF_CHANNELS)*SAMPLE_DATA_WIDTH*SAMPLES_PER_CHANNEL/8-1:0] m_axis_keep,
+  output m_axis_last,
+
   output packed_fifo_wr_en,
   input packed_fifo_wr_overflow,
   output [2**$clog2(NUM_OF_CHANNELS)*SAMPLE_DATA_WIDTH*SAMPLES_PER_CHANNEL-1:0] packed_fifo_wr_data,
@@ -284,6 +291,7 @@ module util_cpack2 #(
     .NUM_OF_CHANNELS (REAL_NUM_OF_CHANNELS),
     .SAMPLE_DATA_WIDTH (SAMPLE_DATA_WIDTH),
     .SAMPLES_PER_CHANNEL (SAMPLES_PER_CHANNEL),
+    .INTERFACE_TYPE (INTERFACE_TYPE),
     .PARALLEL_OR_SERIAL_N (PARALLEL_OR_SERIAL_N)
   ) i_cpack (
     .clk (clk),
@@ -294,6 +302,12 @@ module util_cpack2 #(
     .fifo_wr_en ({REAL_NUM_OF_CHANNELS{fifo_wr_en}}),
     .fifo_wr_overflow (fifo_wr_overflow),
     .fifo_wr_data (fifo_wr_data),
+
+    .m_axis_ready (m_axis_ready),
+    .m_axis_valid (m_axis_valid),
+    .m_axis_data (m_axis_data),
+    .m_axis_keep (m_axis_keep),
+    .m_axis_last (m_axis_last),
 
     .packed_fifo_wr_en (packed_fifo_wr_en),
     .packed_fifo_wr_overflow (packed_fifo_wr_overflow),

--- a/library/util_pack/util_cpack2/util_cpack2_hw.tcl
+++ b/library/util_pack/util_cpack2/util_cpack2_hw.tcl
@@ -1,5 +1,5 @@
 ###############################################################################
-## Copyright (C) 2018-2025 Analog Devices, Inc. All rights reserved.
+## Copyright (C) 2018-2026 Analog Devices, Inc. All rights reserved.
 ### SPDX short identifier: ADIBSD
 ###############################################################################
 
@@ -20,7 +20,7 @@ ad_ip_files util_cpack2_impl [list \
 
 ad_ip_parameter NUM_OF_CHANNELS INTEGER 4 true [list \
   DISPLAY_NAME "Number of Channels" \
-  ALLOWED_RANGES {2, 4, 8, 16}
+  ALLOWED_RANGES {2 4 8 16 32 64}
 ]
 
 ad_ip_parameter SAMPLES_PER_CHANNEL INTEGER 1 true [list \
@@ -29,6 +29,11 @@ ad_ip_parameter SAMPLES_PER_CHANNEL INTEGER 1 true [list \
 
 ad_ip_parameter SAMPLE_DATA_WIDTH INTEGER 16 true [list \
   DISPLAY_NAME "Sample Data Width"
+]
+
+ad_ip_parameter INTERFACE_TYPE INTEGER 1 true [list \
+  DISPLAY_NAME "Interface Type" \
+  ALLOWED_RANGES {"0:AXIS" "1:FIFO"} \
 ]
 
 ad_ip_parameter PARALLEL_OR_SERIAL_N INTEGER 0 true [list \
@@ -42,9 +47,11 @@ proc util_cpack_elab {} {
   set num_channels [get_parameter_value NUM_OF_CHANNELS]
   set samples_per_channel [get_parameter_value SAMPLES_PER_CHANNEL]
   set sample_data_width [get_parameter_value SAMPLE_DATA_WIDTH]
+  set interface_type [get_parameter_value INTERFACE_TYPE]
 
   set channel_data_width [expr $sample_data_width * $samples_per_channel]
   set total_data_width [expr $num_channels * $channel_data_width]
+  set disabled_intfs {}
 
   add_interface clk clock end
   add_interface_port clk clk clk Input 1
@@ -52,12 +59,33 @@ proc util_cpack_elab {} {
   add_interface_port reset reset reset Input 1
   set_interface_property reset associatedClock clk
 
-  ad_interface signal packed_fifo_wr_en output 1 valid
-  ad_interface signal packed_fifo_wr_data output $total_data_width data
-  ad_interface signal packed_fifo_wr_overflow input 1 ovf
-  ad_interface signal packed_sync output 1 sync
+  add_interface m_axis axi4stream start
+  set_interface_property m_axis associatedClock clk
+  set_interface_property m_axis associatedReset reset
+  add_interface_port  m_axis  m_axis_valid tvalid  Output  1
+  add_interface_port  m_axis  m_axis_ready tready  Input   1
+  add_interface_port  m_axis  m_axis_last  tlast   Output  1
+  add_interface_port  m_axis  m_axis_data  tdata   Output  $total_data_width
+  add_interface_port  m_axis  m_axis_keep  tkeep   Output  $total_data_width/8
 
-  ad_interface signal fifo_wr_overflow output 1 ovf
+  ad_interface signal packed_fifo_wr_en       output 1                 valid
+  ad_interface signal packed_fifo_wr_data     output $total_data_width data
+  ad_interface signal packed_fifo_wr_overflow input  1                 ovf
+  ad_interface signal packed_sync             output 1                 sync
+
+  ad_interface signal fifo_wr_overflow        output 1                 ovf
+
+  if {$interface_type == 0} {
+    lappend disabled_intfs \
+      if_packed_fifo_wr_en if_packed_fifo_wr_data if_packed_fifo_wr_overflow \
+      if_packed_sync
+  } else {
+    lappend disabled_intfs m_axis
+  }
+
+  foreach intf $disabled_intfs {
+    set_interface_property $intf ENABLED false
+  }
 
   for {set n 0} {$n < $num_channels} {incr n} {
     add_interface adc_ch_$n conduit end

--- a/library/util_pack/util_cpack2/util_cpack2_impl.v
+++ b/library/util_pack/util_cpack2/util_cpack2_impl.v
@@ -1,6 +1,6 @@
 // ***************************************************************************
 // ***************************************************************************
-// Copyright (C) 2018-2025 Analog Devices, Inc. All rights reserved.
+// Copyright (C) 2018-2026 Analog Devices, Inc. All rights reserved.
 //
 // In this HDL repository, there are many different and unique modules, consisting
 // of various HDL (Verilog or VHDL) components. The individual modules are
@@ -39,6 +39,7 @@ module util_cpack2_impl #(
   parameter NUM_OF_CHANNELS = 4,
   parameter SAMPLES_PER_CHANNEL = 1,
   parameter SAMPLE_DATA_WIDTH = 16,
+  parameter INTERFACE_TYPE = 1,
   parameter PARALLEL_OR_SERIAL_N = 0
 ) (
   input clk,
@@ -50,17 +51,31 @@ module util_cpack2_impl #(
   output fifo_wr_overflow,
   input [NUM_OF_CHANNELS*SAMPLE_DATA_WIDTH*SAMPLES_PER_CHANNEL-1:0] fifo_wr_data,
 
-  output reg packed_fifo_wr_en = 1'b0,
+  input m_axis_ready,
+  output m_axis_valid,
+  output [NUM_OF_CHANNELS*SAMPLE_DATA_WIDTH*SAMPLES_PER_CHANNEL-1:0] m_axis_data,
+  output [NUM_OF_CHANNELS*SAMPLE_DATA_WIDTH*SAMPLES_PER_CHANNEL/8-1:0] m_axis_keep,
+  output m_axis_last,
+
+  output packed_fifo_wr_en,
   input packed_fifo_wr_overflow,
-  output reg [NUM_OF_CHANNELS*SAMPLE_DATA_WIDTH*SAMPLES_PER_CHANNEL-1:0] packed_fifo_wr_data = 'h00,
+  output [NUM_OF_CHANNELS*SAMPLE_DATA_WIDTH*SAMPLES_PER_CHANNEL-1:0] packed_fifo_wr_data,
   output reg packed_sync = 1'b1
 );
 
   localparam TOTAL_DATA_WIDTH = SAMPLE_DATA_WIDTH * SAMPLES_PER_CHANNEL * NUM_OF_CHANNELS;
 
+  //Internal write signal.
+  wire data_wr_en;
+
   // Control signals from the pack shell.
-  wire reset_data;
+  wire ce;
   wire ready;
+  wire reset_data;
+
+  wire out_ready_int;
+  reg out_valid_int = 1'b0;
+  reg [NUM_OF_CHANNELS*SAMPLE_DATA_WIDTH*SAMPLES_PER_CHANNEL-1:0] out_data_int = 'h00;
 
   // Interleaved version of `fifo_wr_data`.
   wire [TOTAL_DATA_WIDTH-1:0] interleaved_data;
@@ -70,12 +85,32 @@ module util_cpack2_impl #(
   wire out_sync;
   wire [NUM_OF_CHANNELS*SAMPLES_PER_CHANNEL-1:0] out_valid;
 
+  generate if (INTERFACE_TYPE == 1) begin
+    assign out_ready_int = 1'b1;
+    assign packed_fifo_wr_en = out_valid_int;
+    assign packed_fifo_wr_data = out_data_int;
+    assign m_axis_valid = 1'b0;
+    assign m_axis_data = 'h00;
+    assign m_axis_keep = 'h00;
+    assign m_axis_last = 1'b0;
+  end else begin
+    assign out_ready_int = m_axis_ready;
+    assign packed_fifo_wr_en = 1'b0;
+    assign packed_fifo_wr_data = 'h00;
+    assign m_axis_valid = out_valid_int;
+    assign m_axis_data = out_data_int;
+    assign m_axis_keep = {(NUM_OF_CHANNELS*SAMPLE_DATA_WIDTH*SAMPLES_PER_CHANNEL/8){1'b1}};
+    assign m_axis_last = 1'b0;
+  end endgenerate
+
   /*
    * Only the first signal of fifo_rd_en is used. All others are ignored. The
    * only reason why fifo_rd_en has multiple entries is to keep the interface
    * somewhat backwards compatible to the previous upack.
    */
-  wire data_wr_en = fifo_wr_en[0];
+  assign data_wr_en = fifo_wr_en[0];
+
+  assign ce = data_wr_en & out_ready_int;
 
   /*
    * The cpack core itself has no backpressure. Overflows can only happen
@@ -110,7 +145,7 @@ module util_cpack2_impl #(
     .reset_data (reset_data),
 
     .enable (enable),
-    .ce (data_wr_en),
+    .ce (ce),
     .ready (ready),
     .in_data (interleaved_data),
     .out_data (out_data),
@@ -119,13 +154,13 @@ module util_cpack2_impl #(
 
   always @(posedge clk) begin
     if (reset_data == 1'b1) begin
-      packed_fifo_wr_en <= 1'b0;
+      out_valid_int <= 1'b0;
       packed_sync <= 1'b0;
     end else if (ready == 1'b1 && data_wr_en == 1'b1) begin
-      packed_fifo_wr_en <= 1'b1;
+      out_valid_int <= 1'b1;
       packed_sync <= out_sync;
     end else begin
-      packed_fifo_wr_en <= 1'b0;
+      out_valid_int <= 1'b0;
       packed_sync <= 1'b0;
     end
   end
@@ -136,7 +171,7 @@ module util_cpack2_impl #(
     if (data_wr_en == 1'b1) begin
       for (i = 0; i < NUM_OF_CHANNELS * SAMPLES_PER_CHANNEL; i = i + 1) begin
         if (out_valid[i] == 1'b1) begin
-          packed_fifo_wr_data[i*SAMPLE_DATA_WIDTH+:SAMPLE_DATA_WIDTH] <= out_data[i*SAMPLE_DATA_WIDTH+:SAMPLE_DATA_WIDTH];
+          out_data_int[i*SAMPLE_DATA_WIDTH+:SAMPLE_DATA_WIDTH] <= out_data[i*SAMPLE_DATA_WIDTH+:SAMPLE_DATA_WIDTH];
         end
       end
     end

--- a/library/util_pack/util_cpack2/util_cpack2_ip.tcl
+++ b/library/util_pack/util_cpack2/util_cpack2_ip.tcl
@@ -1,5 +1,5 @@
 ###############################################################################
-## Copyright (C) 2018-2025 Analog Devices, Inc. All rights reserved.
+## Copyright (C) 2018-2026 Analog Devices, Inc. All rights reserved.
 ### SPDX short identifier: ADIBSD
 ###############################################################################
 
@@ -18,6 +18,18 @@ adi_ip_files util_cpack2 [list \
 
 adi_ip_properties_lite util_cpack2
 
+adi_add_bus "m_axis" "master" \
+  "xilinx.com:interface:axis_rtl:1.0" \
+  "xilinx.com:interface:axis:1.0" \
+  [list {"m_axis_ready" "TREADY"} \
+    {"m_axis_valid" "TVALID"} \
+    {"m_axis_data" "TDATA"} \
+    {"m_axis_keep" "TKEEP"} \
+    {"m_axis_last" "TLAST"}]
+
+adi_set_bus_dependency "m_axis" "m_axis" \
+  "(spirit:decode(id('MODELPARAM_VALUE.INTERFACE_TYPE')) = 0)"
+
 adi_add_bus "packed_fifo_wr" "master" \
   "analog.com:interface:fifo_wr_rtl:1.0" \
   "analog.com:interface:fifo_wr:1.0" \
@@ -26,7 +38,13 @@ adi_add_bus "packed_fifo_wr" "master" \
     {"packed_fifo_wr_data" "DATA"} \
     {"packed_fifo_wr_overflow" "OVERFLOW"} \
   }
-adi_add_bus_clock "clk" "packed_fifo_wr" "reset"
+
+adi_set_bus_dependency "packed_fifo_wr" "packed_fifo_wr" \
+  "(spirit:decode(id('MODELPARAM_VALUE.INTERFACE_TYPE')) = 1)"
+adi_set_ports_dependency "packed_sync" \
+  "(spirit:decode(id('MODELPARAM_VALUE.INTERFACE_TYPE')) = 1)"
+
+adi_add_bus_clock "clk" "m_axis:packed_fifo_wr" "reset"
 
 set cc [ipx::current_core]
 
@@ -35,18 +53,39 @@ for {set i 1} {$i < 64} {incr i} {
     [ipx::get_ports *_$i -of_objects $cc]
 }
 
+set_property -dict [list \
+  "value_validation_type" "pairs" \
+  "value_validation_pairs" { \
+    "AXI Streaming" "0" \
+    "FIFO Interface" "1" \
+  } \
+] [ipx::get_user_parameters INTERFACE_TYPE -of_objects $cc]
+
+set_property -dict [list \
+  "value_validation_type" "pairs" \
+  "value_validation_pairs" { \
+    "Serial" "0" \
+    "Parallel" "1" \
+  } \
+] [ipx::get_user_parameters PARALLEL_OR_SERIAL_N -of_objects $cc]
+
+set page0 [ipgui::get_pagespec -name "Page 0" -component $cc]
+
+set order 0
 foreach {k v} { \
   "NUM_OF_CHANNELS" "Number of Channels" \
   "SAMPLES_PER_CHANNEL" "Samples per Channel" \
   "SAMPLE_DATA_WIDTH" "Sample Width" \
+  "INTERFACE_TYPE" "Interface Type" \
   "PARALLEL_OR_SERIAL_N" "Parallel prefix sum calculation" \
   } { \
   set p [ipgui::get_guiparamspec -name $k -component $cc]
-#  ipgui::move_param -component $cc -order $i $p -parent $
+  ipgui::move_param -component $cc -order $order $p -parent $page0
   set_property -dict [list \
     DISPLAY_NAME $v \
   ] $p
-  incr i
+  incr order
 }
 
+ipx::create_xgui_files [ipx::current_core]
 ipx::save_core [ipx::current_core]

--- a/library/util_pack/util_pack_common/pack_shell.v
+++ b/library/util_pack/util_pack_common/pack_shell.v
@@ -1,6 +1,6 @@
 // ***************************************************************************
 // ***************************************************************************
-// Copyright (C) 2017-2023, 2025 Analog Devices, Inc. All rights reserved.
+// Copyright (C) 2017-2023, 2025-2026 Analog Devices, Inc. All rights reserved.
 //
 // In this HDL repository, there are many different and unique modules, consisting
 // of various HDL (Verilog or VHDL) components. The individual modules are
@@ -427,6 +427,9 @@ module pack_shell #(
              * residual data. I.e. when ready is asserted rotate is 0.
              */
             {ready,rotate} <= rotate + enable_count + 1'b1;
+          end else begin
+            ready <= 1'b0;
+            rotate <= 'h0;
           end
         end
 


### PR DESCRIPTION
## PR Description

Add AXI Stream support for CPACK in order to properly connect the CPACK to AXI Streaming subordinates, like the Data Offload.
By applying this change, the Data Offload _s_axis_ready_ will be removed from the CPACK external reset logic for the specific projects which implement this logic.

## PR Type
- [ ] Bug fix (change that fixes an issue)
- [x] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)
- [ ] Documentation

## PR Checklist
- [x] I have followed the code style guidelines
- [x] I have performed a self-review of changes
- [ ] I have compiled all hdl projects and libraries affected by this PR
- [x] I have tested in hardware affected projects, at least on relevant boards
- [ ] I have commented my code, at least hard-to-understand parts
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe files, Copyright etc)
- [ ] I have not introduced new Warnings/Critical Warnings on compilation
- [x] I have added new hdl testbenches or updated existing ones
