### PR TITLE
Revert "daq3_zcu102: Disable cache coherency"

### DIFF
--- a/projects/daq3/zcu102/system_bd.tcl
+++ b/projects/daq3/zcu102/system_bd.tcl
@@ -4,9 +4,6 @@
 ###############################################################################
 
 source $ad_hdl_dir/projects/common/zcu102/zcu102_system_bd.tcl
-
-set CACHE_COHERENCY false
-
 source ../common/daq3_bd.tcl
 source $ad_hdl_dir/projects/scripts/adi_pd.tcl
 
@@ -72,7 +69,7 @@ ad_connect axi_ad9680_cpack/packed_fifo_wr axi_ad9680_dma/fifo_wr
 
 ad_mem_hp0_interconnect sys_cpu_clk sys_ps8/S_AXI_HP0
 ad_mem_hp0_interconnect sys_cpu_clk axi_ad9680_xcvr/m_axi
-ad_mem_hp1_interconnect sys_dma_clk sys_ps8/S_AXI_HP1
-ad_mem_hp1_interconnect sys_dma_clk axi_ad9680_dma/m_dest_axi
-ad_mem_hp2_interconnect sys_dma_clk sys_ps8/S_AXI_HP2
-ad_mem_hp2_interconnect sys_dma_clk axi_ad9152_dma/m_src_axi
+ad_mem_hpc0_interconnect sys_dma_clk sys_ps8/S_AXI_HPC0
+ad_mem_hpc0_interconnect sys_dma_clk axi_ad9680_dma/m_dest_axi
+ad_mem_hpc1_interconnect sys_dma_clk sys_ps8/S_AXI_HPC1
+ad_mem_hpc1_interconnect sys_dma_clk axi_ad9152_dma/m_src_axi


### PR DESCRIPTION
This reverts commit c7e82e4ab58d96d00d4a1c540b0036916d000311.

## PR Description

revert the rm cc commit for daq3

## PR Type
- [ ] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)
- [ ] Documentation

## PR Checklist
- [ ] I have followed the code style guidelines
- [ ] I have performed a self-review of changes
- [ ] I have compiled all hdl projects and libraries affected by this PR
- [ ] I have tested in hardware affected projects, at least on relevant boards
- [ ] I have commented my code, at least hard-to-understand parts
- [ ] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe files, Copyright etc)
- [ ] I have not introduced new Warnings/Critical Warnings on compilation
- [ ] I have added new hdl testbenches or updated existing ones
