### PR TITLE
Updated the axi_spdif_tx.vhd IP core to work with 24-bit audio

### DIFF
--- a/library/axi_spdif_tx/axi_spdif_tx.vhd
+++ b/library/axi_spdif_tx/axi_spdif_tx.vhd
@@ -112,7 +112,7 @@ architecture IMP of axi_spdif_tx is
 	signal chstat_freq : std_logic_vector(1 downto 0);
 	signal chstat_gstat, chstat_preem, chstat_copy, chstat_audio : std_logic;
 	signal sample_data_ack : std_logic;
-	signal sample_data: std_logic_vector(15 downto 0);
+	signal sample_data: std_logic_vector(31 downto 0);
 	signal conf_mode : std_logic_vector(3 downto 0);
 	signal conf_ratio : std_logic_vector(7 downto 0);
 	signal conf_tinten, conf_txdata, conf_txen : std_logic;
@@ -135,8 +135,7 @@ begin
 
 	fifo_reset <= not conf_txdata;
 	enable <= conf_txdata = '1';
-	fifo_data_ack <= channel and sample_data_ack;
-
+  fifo_data_ack <= sample_data_ack when conf_mode = "1000" else (channel and sample_data_ack);
 	streaming_dma_gen: if DMA_TYPE = 0 generate
 		fifo: entity axi_streaming_dma_tx_fifo
 			generic map (
@@ -203,14 +202,22 @@ begin
 		dma_req_drlast <= '0';
 	end generate;
 
-	sample_data_mux: process (fifo_data_out, channel) is
-	begin
-		if channel = '0' then
-			sample_data <= fifo_data_out(15 downto 0);
-		else
-			sample_data <= fifo_data_out(31 downto 16);
-		end if;
-	end process;
+  sample_data_mux: process (fifo_data_out, channel, conf_mode) is
+  begin
+      -- 24-bit audio
+      if conf_mode = "1000" then
+          sample_data <= fifo_data_out;
+      -- 16-bit audio
+      else
+          if channel = '0' then
+              sample_data(15 downto 0) <= fifo_data_out(15 downto 0);
+              sample_data(31 downto 16) <= (others => '0');
+          else
+              sample_data(15 downto 0) <= fifo_data_out(31 downto 16);
+              sample_data(31 downto 16) <= (others => '0');
+          end if;
+      end if;
+  end process;
 
 	-- Configuration signals update
 	conf_mode(3 downto 0)  <= config_reg(23 downto 20);
@@ -229,7 +236,7 @@ begin
 	-- Transmit encoder
 	TENC: tx_encoder
 		generic map (
-			DATA_WIDTH => 16
+			DATA_WIDTH => 32  -- always send 32 bits (padding)
 		)
 		port map (
 			up_clk		=> s_axi_aclk,

--- a/library/axi_spdif_tx/axi_spdif_tx.vhd
+++ b/library/axi_spdif_tx/axi_spdif_tx.vhd
@@ -135,7 +135,7 @@ begin
 
 	fifo_reset <= not conf_txdata;
 	enable <= conf_txdata = '1';
-  fifo_data_ack <= sample_data_ack when conf_mode = "1000" else (channel and sample_data_ack);
+  fifo_data_ack <= sample_data_ack when (conf_mode = "1000" or conf_mode = "1001") else (channel and sample_data_ack);
 	streaming_dma_gen: if DMA_TYPE = 0 generate
 		fifo: entity axi_streaming_dma_tx_fifo
 			generic map (
@@ -205,7 +205,7 @@ begin
   sample_data_mux: process (fifo_data_out, channel, conf_mode) is
   begin
       -- 24-bit audio
-      if conf_mode = "1000" then
+      if (conf_mode = "1000" or conf_mode = "1001") then
           sample_data <= fifo_data_out;
       -- 16-bit audio
       else

--- a/library/axi_spdif_tx/tx_encoder.vhd
+++ b/library/axi_spdif_tx/tx_encoder.vhd
@@ -50,11 +50,11 @@
 --
 
 library ieee;
-use ieee.std_logic_1164.all; 
+use ieee.std_logic_1164.all;
 use ieee.numeric_std.all;
 
-entity tx_encoder is	 
-  generic (DATA_WIDTH: integer range 16 to 32 := 32); 
+entity tx_encoder is
+  generic (DATA_WIDTH: integer range 16 to 32 := 32);
   port (
     up_clk: in std_logic;             -- clock
     data_clk : in std_logic;          -- data clock
@@ -91,7 +91,7 @@ architecture rtl of tx_encoder is
   signal audio : std_logic_vector(23 downto 0);
   signal par_vector : std_logic_vector(26 downto 0);
   signal send_audio : std_logic;
-  
+
   signal cdc_sync_stage0_tick_counter : std_logic := '0';
   signal cdc_sync_stage1_tick_counter : std_logic := '0';
   signal cdc_sync_stage2_tick_counter : std_logic := '0';
@@ -112,7 +112,7 @@ architecture rtl of tx_encoder is
     signal audio      : std_logic_vector(23 downto 0);
     signal toggle     : std_logic;
     signal prev_spdif : std_logic)      -- prev. value of spdif signal
-       
+
     return std_logic is
     variable spdif, next_bit : std_logic;
   begin
@@ -143,7 +143,7 @@ architecture rtl of tx_encoder is
     end if;
     return(spdif);
   end encode_bit;
-  
+
 begin
 
 -- SPDIF clock enable generation. The clock is a fraction of the data clock,
@@ -166,7 +166,7 @@ begin
   tick_counter <= cdc_sync_stage3_tick_counter xor cdc_sync_stage2_tick_counter;
 
   CGEN: process (up_clk)
-  begin 
+  begin
     if rising_edge(up_clk) then
       if resetn = '0' or conf_txen = '0' then
          clk_cnt <= 0;
@@ -187,7 +187,7 @@ begin
   end process CGEN;
 
   SRD: process (up_clk)
-  begin 
+  begin
     if rising_edge(up_clk) then
       if resetn = '0' or conf_txdata = '0' then
         bufctrl <= IDLE;
@@ -218,7 +218,7 @@ begin
             if chb_samp_ack = '1' then
               sample_data_ack <= '1';
               bufctrl <= READ_CHA;
-            end if;  
+            end if;
           when others =>
             bufctrl <= IDLE;
         end case;
@@ -232,11 +232,11 @@ begin
         spdif_tx_o <= spdif_out;
     end if;
   end process TXSYNC;
- 
+
 -- State machine that generates sub-frames and blocks
-  
+
   FRST: process (up_clk)
-  begin 
+  begin
     if rising_edge(up_clk) then
       if resetn = '0' or conf_txen = '0' then
         framest <= IDLE;
@@ -285,7 +285,7 @@ begin
                                         par_cnt, active_user_data,
                                         active_ch_status,
                                         audio, toggle, spdif_out);
-                if bit_cnt = 31 then 
+                if bit_cnt = 31 then
                   inv_preamble <= encode_bit(bit_cnt, valid, frame_cnt,
                                              par_cnt, active_user_data,
                                              active_ch_status,
@@ -294,7 +294,7 @@ begin
                 if toggle = '0' then
                   if bit_cnt > 3 and bit_cnt < 31 and
                     par_vector(bit_cnt - 4) = '1' then
-                    par_cnt <= par_cnt + 1;  
+                    par_cnt <= par_cnt + 1;
                   end if;
                 end if;
               end if;
@@ -330,7 +330,7 @@ begin
                                         par_cnt, active_user_data,
                                         active_ch_status,
                                         audio, toggle, spdif_out);
-                if bit_cnt = 31 then 
+                if bit_cnt = 31 then
                   inv_preamble <= encode_bit(bit_cnt, valid, frame_cnt,
                                              par_cnt, active_user_data,
                                              active_ch_status,
@@ -339,7 +339,7 @@ begin
                 if toggle = '0' then
                   if bit_cnt > 3 and bit_cnt < 31 and
                     par_vector(bit_cnt - 4) = '1' then
-                    par_cnt <= par_cnt + 1;  
+                    par_cnt <= par_cnt + 1;
                   end if;
                 end if;
               end if;
@@ -383,7 +383,7 @@ begin
                                         par_cnt, active_user_data,
                                         active_ch_status,
                                         audio, toggle, spdif_out);
-                if bit_cnt = 31 then 
+                if bit_cnt = 31 then
                   inv_preamble <= encode_bit(bit_cnt, valid, frame_cnt,
                                              par_cnt, active_user_data,
                                              active_ch_status,
@@ -392,7 +392,7 @@ begin
                 if toggle = '0' then
                   if bit_cnt > 3 and bit_cnt < 31 and
                     par_vector(bit_cnt - 4) = '1' then
-                    par_cnt <= par_cnt + 1;  
+                    par_cnt <= par_cnt + 1;
                   end if;
                 end if;
               end if;
@@ -407,7 +407,7 @@ begin
 -- Audio data latching
   DA32: if DATA_WIDTH = 32 generate
     ALAT: process (up_clk)
-    begin 
+    begin
       if rising_edge(up_clk) then
         if send_audio = '0' then
           audio(23 downto 0) <= (others => '0');
@@ -439,6 +439,8 @@ begin
               audio(0) <= '0';
             when 8 =>                   -- 24 bit audio
               audio(23 downto 0) <= sample_data(23 downto 0);
+            when 9 =>                   -- 32-bit audio (left aligned - only take 24 MS bits)
+              audio(23 downto 0) <= sample_data(31 downto 8);
             when others =>                -- unsupported modes
               audio(23 downto 0) <= (others => '0');
           end case;
@@ -449,7 +451,7 @@ begin
 
   DA16: if DATA_WIDTH = 16 generate
     ALAT: process (up_clk)
-    begin 
+    begin
       if rising_edge(up_clk) then
         if send_audio = '0' then
           audio(23 downto 0) <= (others => '0');
@@ -460,13 +462,13 @@ begin
       end if;
     end process ALAT;
   end generate DA16;
-                         
+
 -- Parity vector. These bits are counted to generate even parity
   par_vector(23 downto 0) <= audio(23 downto 0);
   par_vector(24) <= valid;
   par_vector(25) <= active_user_data(frame_cnt);
   par_vector(26) <= active_ch_status(frame_cnt);
-                             
+
 -- Channel status and user datat to be used if buffers are disabled.
 -- User data is then all zero, while channel status bits are taken from
 -- register TxChStat.
@@ -488,8 +490,8 @@ begin
 
 -- Generate channel status vector based on configuration register setting.
   active_ch_status <= def_ch_status;
-  
+
 -- Generate user data vector based on configuration register setting.
   active_user_data <= def_user_data;
-  
+
 end rtl;


### PR DESCRIPTION
## PR Description
[Issue](https://github.com/analogdevicesinc/hdl/issues/2074)
Made adi_spdif_tx.vhd IP core compatible with 24 bit audio data through the use of existing conf_mode register bits. Still works with existing linux driver, but separate patch will be pushed to expose S24_LE as a valid format.

Could not test compilation on all projects due to licensing restrictions in Vivado.
## PR Type
- [ ] Bug fix (change that fixes an issue)
- [x] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)
- [ ] Documentation

## PR Checklist
- [x] I have followed the code style guidelines
- [x] I have performed a self-review of changes
- [x] I have compiled all hdl projects and libraries affected by this PR
- [x] I have tested in hardware affected projects, at least on relevant boards
- [x] I have commented my code, at least hard-to-understand parts
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe files, Copyright etc)
- [x] I have not introduced new Warnings/Critical Warnings on compilation
- [ ] I have added new hdl testbenches or updated existing ones
