### PR TITLE
docs/projects: Add FMCOMMS6 HDL doc (obsolete)

### DIFF
--- a/docs/projects/fmcomms6/index.rst
+++ b/docs/projects/fmcomms6/index.rst
@@ -1,0 +1,38 @@
+.. imported from: https://wiki.analog.com/resources/eval/user-guides/ad-fmcomms6-ebz/reference_hdl
+
+.. _fmcomms6:
+
+AD-FMCOMMS6-EBZ HDL Project (OBSOLETE)
+======================================
+
+.. warning::
+
+   This design has been retired or deprecated, which means it is no longer
+   maintained or actively updated, even though the devices themselves may be
+   **Recommended for New Designs** or in **Production**. This page is here for
+   historical/reference purposes only.
+
+Supported Devices
+-----------------
+
+-  :adi:`EVAL-AD-FMCOMMS6-EBZ`
+
+Supported Carriers
+------------------
+
+-  :xilinx:`ZC706`
+
+Required Software
+-----------------
+
+-  We upgrade the Xilinx tools on every release. The supported version number can be found in our :git-hdl:`git repository </>`.
+
+FPGA Reference Designs
+----------------------
+
+- Last release with support for this project: :git-hdl:`hdl_2016_r1
+  <hdl_2016_r1:projects/fmcomms6>`
+
+.. hint::
+
+   -  Questions? :ez:`Ask Help & Support <community/fpga>`.

--- a/docs/projects/index.rst
+++ b/docs/projects/index.rst
@@ -117,6 +117,7 @@ Obsolete projects
    FMCADC2 (OBSOLETE) <fmcadc2/index>
    FMCADC5 (OBSOLETE) <fmcadc5/index>
    FMCOMMS1 (OBSOLETE) <fmcomms1/index>
+   FMCOMMS6 (OBSOLETE) <fmcomms6/index>
    FMCJESDADC1 (OBSOLETE) <fmcjesdadc1/index>
    IMAGEON (OBSOLETE) <imageon/index>
 
@@ -140,6 +141,8 @@ Linux images (the already built files):
      - :git-hdl:`hdl_2019_r1 <hdl_2019_r1:projects/ad_fmclidar1_ebz>`
    * - fmcomms1
      - :git-hdl:`hdl_2015_r2 <hdl_2015_r2:projects/fmcomms1>`
+   * - fmcomms6
+     - :git-hdl:`hdl_2016_r1 <hdl_2016_r1:projects/fmcomms6>`
    * - fmcadc2
      - :git-hdl:`hdl_2021_r2 <hdl_2021_r2:projects/fmcadc2>`
    * - fmcadc5


### PR DESCRIPTION
## PR Description

I ported this documentation for historical/reference purposes only.
https://wiki.analog.com/resources/eval/user-guides/ad-fmcomms6-ebz/reference_hdl


## PR Type
- [ ] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)
- [x] Documentation

## PR Checklist
- [x] I have followed the code style guidelines
- [x] I have performed a self-review of changes
- [ ] I have compiled all hdl projects and libraries affected by this PR
- [ ] I have tested in hardware affected projects, at least on relevant boards
- [ ] I have commented my code, at least hard-to-understand parts
- [x] I have signed off all commits from this PR
- [x] I have updated the documentation (wiki pages, ReadMe files, Copyright etc)
- [ ] I have not introduced new Warnings/Critical Warnings on compilation
- [ ] I have added new hdl testbenches or updated existing ones
