### PR TITLE
spi_engine Lattice update + make sim update

### DIFF
--- a/docs/projects/ad738x_fmc/index.rst
+++ b/docs/projects/ad738x_fmc/index.rst
@@ -347,7 +347,7 @@ Then, to build the project:
 .. shell::
 
    $cd hdl/projects/ad738x_fmc/lfcpnx
-   $make ALERT_SPI_N=0 NUM_OF_SDI=4 SYSMEM_INIT_FILE=<path_to>/<sysmem_init>.mem
+   $make ALERT_SPI_N=0 NUM_OF_SDIO=4 SYSMEM_INIT_FILE=<path_to>/<sysmem_init>.mem
 
 The SYSMEM_INIT_FILE parameter for LFCPNX-EVN is optional, use it to build the 
 project with an already initialized system memory for the RISC-V RX CPU, 

--- a/library/spi_engine/axi_spi_engine/axi_spi_engine_ltt.tcl
+++ b/library/spi_engine/axi_spi_engine/axi_spi_engine_ltt.tcl
@@ -86,9 +86,12 @@ set ip [ipl::add_ip_files -ip $ip -dpath rtl -flist [list \
     "$ad_hdl_dir/library/common/up_axi.v" \
     "$ad_hdl_dir/library/common/ad_rst.v" \
     "$ad_hdl_dir/library/util_cdc/sync_bits.v" \
+    "$ad_hdl_dir/library/util_cdc/sync_data.v" \
+    "$ad_hdl_dir/library/util_cdc/sync_event.v" \
     "$ad_hdl_dir/library/util_cdc/sync_gray.v" \
     "$ad_hdl_dir/library/common/ad_mem.v" \
     "$ad_hdl_dir/library/util_axis_fifo/util_axis_fifo.v" \
+    "$ad_hdl_dir/library/util_axis_fifo_asym/util_axis_fifo_asym.v" \
     "$ad_hdl_dir/library/util_axis_fifo/util_axis_fifo_address_generator.v" \
     "axi_spi_engine.v" ]]
 

--- a/library/spi_engine/spi_engine_execution/spi_engine_execution_ltt.tcl
+++ b/library/spi_engine/spi_engine_execution/spi_engine_execution_ltt.tcl
@@ -44,6 +44,15 @@ set ip [ipl::add_interface -ip $ip \
     } \
     -vlnv {analog.com:ADI:spi_engine_ctrl:1.0}]
 set ip [ipl::add_interface -ip $ip \
+    -inst_name s_offload_active_ctrl \
+    -display_name s_offload_active_ctrl \
+    -description spi_engine_interconnect_ctrl \
+    -master_slave slave \
+    -portmap { \
+        {"s_offload_active" "INTERCONNECT_DIR"} \
+    } \
+    -vlnv {analog.com:ADI:spi_engine_interconnect_ctrl:1.0}]
+set ip [ipl::add_interface -ip $ip \
     -inst_name spi_master \
     -display_name spi_master \
     -description spi_master \
@@ -60,7 +69,8 @@ set ip [ipl::add_interface -ip $ip \
 
 set ip [ipl::add_ip_files -ip $ip -dpath rtl -flist [list \
     "spi_engine_execution.v" \
-    "spi_engine_execution_shiftreg.v" ]]
+    "spi_engine_execution_shiftreg.v" \
+    "spi_engine_execution_shiftreg_data_assemble.v" ]]
 
 set ip [ipl::set_parameter -ip $ip \
     -id DATA_WIDTH \

--- a/library/spi_engine/spi_engine_interconnect/spi_engine_interconnect_ltt.tcl
+++ b/library/spi_engine/spi_engine_interconnect/spi_engine_interconnect_ltt.tcl
@@ -73,7 +73,17 @@ set ip [ipl::add_interface -ip $ip \
     -description spi_engine_interconnect_ctrl \
     -master_slave slave \
     -portmap { \
-        {"interconnect_dir" "INTERCONNECT_DIR"} \
+        {"s_interconnect_dir" "INTERCONNECT_DIR"} \
+    } \
+    -vlnv {analog.com:ADI:spi_engine_interconnect_ctrl:1.0}]
+
+set ip [ipl::add_interface -ip $ip \
+    -inst_name m_offload_active_ctrl \
+    -display_name m_offload_active_ctrl \
+    -description spi_engine_interconnect_ctrl \
+    -master_slave master \
+    -portmap { \
+        {"m_offload_active" "INTERCONNECT_DIR"} \
     } \
     -vlnv {analog.com:ADI:spi_engine_interconnect_ctrl:1.0}]
 

--- a/projects/ad738x_fmc/common/ad738x_pb.tcl
+++ b/projects/ad738x_fmc/common/ad738x_pb.tcl
@@ -122,11 +122,12 @@ adi_ip_instance -vlnv {analog.com:ip:spi_exec0:1.0} \
 sbp_add_port -direction out spi_master0_cs
 sbp_add_port -direction out spi_master0_sclk
 if { $NUM_OF_SDIO > 1 } {
-sbp_add_port -from [expr $NUM_OF_SDIO - 1] -to 0 -direction in spi_master0_sdi
+  sbp_add_port -from [expr $NUM_OF_SDIO - 1] -to 0 -direction in spi_master0_sdi
+  sbp_add_port -from [expr $NUM_OF_SDIO - 1] -to 0 -direction out spi_master0_sdo
 } else {
   sbp_add_port -direction in spi_master0_sdi
+  sbp_add_port -direction out spi_master0_sdo
 }
-sbp_add_port -direction out spi_master0_sdo
 sbp_add_port -direction out spi_master0_sdo_t
 sbp_add_port -direction out spi_master0_three_wire
 
@@ -199,6 +200,8 @@ sbp_connect_interface_net $project_name/spi_interc0_inst/s1_ctrl \
   $project_name/axi_spi0_inst/spi_engine_ctrl
 sbp_connect_interface_net $project_name/spi_exec0_inst/spi_engine_ctrl \
   $project_name/spi_interc0_inst/m_ctrl
+sbp_connect_interface_net $project_name/spi_interc0_inst/m_offload_active_ctrl \
+  $project_name/spi_exec0_inst/s_offload_active_ctrl
 sbp_connect_interface_net $project_name/axi_interc0_inst/AXIL_M05 \
   $project_name/pwm0_inst/s_axi
 sbp_connect_interface_net $project_name/axi_interc0_inst/AXIL_M04 \

--- a/projects/scripts/project-lattice.mk
+++ b/projects/scripts/project-lattice.mk
@@ -18,7 +18,8 @@
 # * pb-force and rd-force: you can build the respective projects without
 #   checking for dependencies.
 # * sim: runs Questasim simulation using qsim.do in GUI mode.
-# * sim-cli: runs Questasim simulation using qsim.do in command-line mode.
+# * sim-cli: runs Questasim simulation in command-line mode using a wrapper
+# *   around qsim.do that propagates failures back to make.
 # * open-pb: opens the generated Propel Builder project (.sbx).
 # * open-v: opens the generated verification Propel Builder project (.sbx).
 # * open-rd: opens the generated Radiant project file (.rdf).
@@ -196,7 +197,7 @@ $(SIM_STAMP_FILE): $(SIM_DEPS)
 	fi
 	@touch $(SIM_STAMP_FILE)
 
-DEFAULT_SIM_CMD := cd $(dir $(ADI_SIM_DO)) && $(SIMULATOR) -do $(notdir $(ADI_SIM_DO))
+DEFAULT_SIM_CMD := cd $(dir $(GEN_SIM_DO)) && $(SIMULATOR) -do $(notdir $(GEN_SIM_DO))
 SIM_CMD ?= $(DEFAULT_SIM_CMD)
 
 sim: $(SIM_DEPS)


### PR DESCRIPTION
## PR Description

- Updating interface port map and file dependencies in the Lattice spi_engine scripts.
- projects/scripts/project-lattice.mk: Using the default generated .do file for 'make sim'; If using the patched .do file the Questasim GUI closes when using the simulation stop button.

## PR Type
- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)
- [ ] Documentation

## PR Checklist
- [x] I have followed the code style guidelines
- [x] I have performed a self-review of changes
- [ ] I have compiled all hdl projects and libraries affected by this PR
- [ ] I have tested in hardware affected projects, at least on relevant boards
- [ ] I have commented my code, at least hard-to-understand parts
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe files, Copyright etc)
- [ ] I have not introduced new Warnings/Critical Warnings on compilation
- [ ] I have added new hdl testbenches or updated existing ones
