### PR TITLE
project: ad353xr: add support for ad3536r

### DIFF
--- a/docs/projects/ad353xr/index.rst
+++ b/docs/projects/ad353xr/index.rst
@@ -6,15 +6,16 @@ AD353XR HDL project
 Overview
 --------------------------------------------------------------------------------
 
-The :adi:`AD3530R`/ :adi:`AD3530`, :adi:`AD3531R`/ :adi:`AD3531`, and
-:adi:`AD3532R`/ :adi:`AD3532` are low power, 16-bit, buffered voltage output,
-digital-to-analog converters (DACs) that include a gain bit field, resulting in
-a full-scale output of 2.5V (gain = 1) or 5V (gain = 2) for a reference voltage
-of 2.5V. :adi:`AD3530`/ :adi:`AD3530R` has 8 channels, :adi:`AD3531`/
-:adi:`AD3531R` has 4 channels, and :adi:`AD3532`/ :adi:`AD3532R` has 16 channels.
-:adi:`AD3530R`, :adi:`AD3531R`, and :adi:`AD3532R` have an on-chip, buffered,
-2.5V reference available at the VREF pin, capable of sourcing external loads up
-to +5mA.
+The :adi:`AD3530R`/ :adi:`AD3530`, :adi:`AD3531R`/ :adi:`AD3531`,
+:adi:`AD3532R`/ :adi:`AD3532`, and :adi:`AD3536R`/ :adi:`AD3536` are low power,
+buffered voltage output, digital-to-analog converters (DACs) that include a gain
+bit field, resulting in a full-scale output of 2.5V (gain = 1) or 5V (gain = 2)
+for a reference voltage of 2.5V. :adi:`AD3530`/ :adi:`AD3530R` has 8 channels
+(16-bit), :adi:`AD3531`/ :adi:`AD3531R` has 4 channels (16-bit), :adi:`AD3532`/
+:adi:`AD3532R` has 16 channels (16-bit), and :adi:`AD3536`/ :adi:`AD3536R` has
+16 channels (12-bit). :adi:`AD3530R`, :adi:`AD3531R`, :adi:`AD3532R`, and
+:adi:`AD3536R` have an on-chip, buffered, 2.5V reference available at the VREF
+pin, capable of sourcing external loads up to +5mA.
 
 Each DAC channel has its own Input register and DAC register. The DAC Register 
 stores digital code equivalent to the DAC output voltage while the Input
@@ -28,15 +29,15 @@ without an LDAC.
 channels capable of sourcing 50mA and sinking up to 40mA of current.
 :adi:`AD3531R`/ :adi:`AD3531` contains four buffered voltage output DAC channels
 capable of sourcing 100mA and sinking 80 mA of current. :adi:`AD3532R`/
-:adi:`AD3532` contains sixteen buffered voltage output DAC channels capable of
-sourcing 25mA and sinking up to 20mA of current.
+:adi:`AD3532` and :adi:`AD3536R`/ :adi:`AD3536` contain sixteen buffered voltage
+output DAC channels capable of sourcing 25mA and sinking up to 20mA of current.
 
 The :adi:`AD3530R`/ :adi:`AD3530` contains a 27:1 multiplexer,
-:adi:`AD3531R`/ :adi:`AD3531` contains a 15:1 multiplexer, and :adi:`AD3532R`/
-:adi:`AD3532` contains a 51:1 multiplexer, in which all could output a voltage
-on the MUX_OUT pin that is a representative of either the output voltage or
-output current of a chosen channel, or the internal die temperature of the
-device.
+:adi:`AD3531R`/ :adi:`AD3531` contains a 15:1 multiplexer, :adi:`AD3532R`/
+:adi:`AD3532` contains a 51:1 multiplexer, and :adi:`AD3536R`/ :adi:`AD3536`
+contains a 51:1 multiplexer, in which all could output a voltage on the MUX_OUT
+pin that is a representative of either the output voltage or output current of a
+chosen channel, or the internal die temperature of the device.
 
 Applications:
 
@@ -51,6 +52,7 @@ Supported boards
 - :adi:`EVAL-AD3530R`
 - :adi:`EVAL-AD3531R`
 - :adi:`EVAL-AD3532R`
+- :adi:`EVAL-AD3536R`
 
 Supported devices
 -------------------------------------------------------------------------------
@@ -61,6 +63,8 @@ Supported devices
 - :adi:`AD3531R`
 - :adi:`AD3532`
 - :adi:`AD3532R`
+- :adi:`AD3536`
+- :adi:`AD3536R`
 
 Supported carriers
 -------------------------------------------------------------------------------
@@ -161,6 +165,8 @@ Hardware related
 - Product datasheet: :adi:`AD3531R`
 - Product datasheet: :adi:`AD3532`
 - Product datasheet: :adi:`AD3532R`
+- Product datasheet: :adi:`AD3536`
+- Product datasheet: :adi:`AD3536R`
 
 - `UG-1203: EVAL-AD3530RARDZ Board User Guide <https://www.analog.com/media/en/technical-documentation/user-guides/eval-ad3530r-ug-2276.pdf>`__
 

--- a/projects/ad353xr/README.md
+++ b/projects/ad353xr/README.md
@@ -4,6 +4,7 @@
   - [EVAL-AD3530R](https://www.analog.com/eval-ad3530r)
   - [EVAL-AD3531R](https://www.analog.com/eval-ad3531r)
   - [EVAL-AD3532R](https://www.analog.com/eval-ad3532r)
+  - [EVAL-AD3532R](https://www.analog.com/eval-ad3536r)
 - System documentation: https://wiki.analog.com/resources/eval/user-guides/ad353xr
 - HDL project documentation: http://analogdevicesinc.github.io/hdl/projects/ad353xr/index.html
 - Evaluation board VADJ range: 2.7V - 5.5V
@@ -18,6 +19,8 @@
 | [AD3531R](https://www.analog.com/ad3531r) | 4-Channel, 16-Bit Voltage Output DAC, On-Chip Reference, SPI |
 | [AD3532](https://www.analog.com/ad3532)   | 16-Channel, 16-Bit Voltage Output DAC, On-Chip Reference, SPI |
 | [AD3532R](https://www.analog.com/ad3532r) | 16-Channel, 16-Bit Voltage Output DAC, On-Chip Reference, SPI |
+| [AD3536](https://www.analog.com/ad3536)   | 16-Channel, 12-Bit Voltage Output DAC, On-Chip Reference, SPI |
+| [AD3536R](https://www.analog.com/ad3536r) | 16-Channel, 12-Bit Voltage Output DAC, On-Chip Reference, SPI |
 
 ## Building the project
 


### PR DESCRIPTION
## PR Description

AD3536R is a family with the current existing chips AD3530R, AD3531R and AD3532R.
AD3536R is a 16-Channel, 12-Bit Voltage Output DAC, On-Chip Reference, SPI.

## PR Type
- [ ] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)
- [X] Documentation

## PR Checklist
- [X] I have followed the code style guidelines
- [X] I have performed a self-review of changes
- [ ] I have compiled all hdl projects and libraries affected by this PR
- [ ] I have tested in hardware affected projects, at least on relevant boards
- [ ] I have commented my code, at least hard-to-understand parts
- [X] I have signed off all commits from this PR
- [X] I have updated the documentation (wiki pages, ReadMe files, Copyright etc)
- [X] I have not introduced new Warnings/Critical Warnings on compilation
- [ ] I have added new hdl testbenches or updated existing ones
