### PR TITLE
versal_xcvr_subsystem: Fix typo for external link clk on Tx

### DIFF
--- a/library/xilinx/scripts/versal_xcvr_subsystem.tcl
+++ b/library/xilinx/scripts/versal_xcvr_subsystem.tcl
@@ -566,7 +566,7 @@ proc create_versal_jesd_xcvr_subsystem {
     if {!$has_single_clock} {
       if {$external_link_clk} {
         set tx_phy_clk  ${ip_name}/bufg_gt_tx/usrclk
-        set rx_usrclk   ${ip_name}/tx_usrclk_in
+        set tx_usrclk   ${ip_name}/tx_usrclk_in
       } else {
         set tx_phy_clk  ${ip_name}/bufg_gt_tx/usrclk
         set tx_usrclk   ${ip_name}/tx_clkwiz/clk_out1


### PR DESCRIPTION
## PR Description

The external link clock case for Tx was setting the wrong clock (rx instead of tx).

## PR Type
- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)
- [ ] Documentation

## PR Checklist
- [x] I have followed the code style guidelines
- [x] I have performed a self-review of changes
- [x] I have compiled all hdl projects and libraries affected by this PR
- [ ] I have tested in hardware affected projects, at least on relevant boards
- [ ] I have commented my code, at least hard-to-understand parts
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe files, Copyright etc)
- [ ] I have not introduced new Warnings/Critical Warnings on compilation
- [ ] I have added new hdl testbenches or updated existing ones
