### PR TITLE
projects: ad9082_fmca_ebz: vpk180: Add corresponding REF_CLK_RATE

### DIFF
--- a/projects/ad9082_fmca_ebz/vpk180/README.md
+++ b/projects/ad9082_fmca_ebz/vpk180/README.md
@@ -64,6 +64,7 @@ Corresponding device tree: [versal-vpk180-reva-ad9082.dts](https://github.com/an
 make JESD_MODE=64B66B \
 RX_LANE_RATE=11.88 \
 TX_LANE_RATE=11.88 \
+REF_CLK_RATE=180 \
 RX_JESD_M=1 \
 RX_JESD_L=8 \
 RX_JESD_S=4 \


### PR DESCRIPTION
## PR Description

The REF_CLK_RATE parameter was missing. The HMC7044 is set to 2.88GHz in the devicetree so the default 375 MHz can't be generated.


## PR Type
- [ ] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)
- [x] Documentation

## PR Checklist
- [ ] I have followed the code style guidelines
- [ ] I have performed a self-review of changes
- [ ] I have compiled all hdl projects and libraries affected by this PR
- [ ] I have tested in hardware affected projects, at least on relevant boards
- [ ] I have commented my code, at least hard-to-understand parts
- [ ] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe files, Copyright etc)
- [ ] I have not introduced new Warnings/Critical Warnings on compilation
- [ ] I have added new hdl testbenches or updated existing ones
