### PR TITLE
library: jesd204: versal_adapters: Fix CDC constraints for GTM mode

### DIFF
--- a/library/jesd204/jesd204_versal_gt_adapter_rx/jesd204_versal_gt_adapter_rx_constr.ttcl
+++ b/library/jesd204/jesd204_versal_gt_adapter_rx/jesd204_versal_gt_adapter_rx_constr.ttcl
@@ -9,17 +9,15 @@
 <: setFileExtension ".xdc" :>
 <: setFileProcessingOrder late :>
 
-set usr_clk [get_clocks -of_objects [get_ports -quiet {usr_clk}]]
-set phy_clk [get_clocks -of_objects [get_ports -quiet {phy_clk}]]
-
 # sync bits i_reset
+# The input is an asynchronous reset; constrain only the capture flop so the
+# path is cut regardless of the launching clock domain.
 set_false_path \
-  -from $phy_clk \
-  -to [get_cells -quiet -hier *cdc_sync_stage1_reg* \
+  -to [get_cells -quiet -hier *cdc_sync_stage1_reg[*] \
     -filter {NAME =~ *i_sync_i_reset* && IS_SEQUENTIAL}]
 
 set_property ASYNC_REG TRUE \
-      [get_cells -quiet -hier *cdc_sync_stage1_reg* \
+      [get_cells -quiet -hier *cdc_sync_stage1_reg[*] \
     -filter {NAME =~ *i_sync_i_reset* && IS_SEQUENTIAL}]
 
 set_property ASYNC_REG TRUE \
@@ -28,12 +26,11 @@ set_property ASYNC_REG TRUE \
 
 # sync bits o_reset
 set_false_path \
-  -from $usr_clk \
-  -to [get_cells -quiet -hier *cdc_sync_stage1_reg* \
+  -to [get_cells -quiet -hier *cdc_sync_stage1_reg[*] \
     -filter {NAME =~ *i_sync_o_reset* && IS_SEQUENTIAL}]
 
 set_property ASYNC_REG TRUE \
-      [get_cells -quiet -hier *cdc_sync_stage1_reg* \
+      [get_cells -quiet -hier *cdc_sync_stage1_reg[*] \
     -filter {NAME =~ *i_sync_o_reset* && IS_SEQUENTIAL}]
 
 set_property ASYNC_REG TRUE \

--- a/library/jesd204/jesd204_versal_gt_adapter_tx/jesd204_versal_gt_adapter_tx_constr.ttcl
+++ b/library/jesd204/jesd204_versal_gt_adapter_tx/jesd204_versal_gt_adapter_tx_constr.ttcl
@@ -9,17 +9,15 @@
 <: setFileExtension ".xdc" :>
 <: setFileProcessingOrder late :>
 
-set usr_clk [get_clocks -of_objects [get_ports -quiet {usr_clk}]]
-set phy_clk [get_clocks -of_objects [get_ports -quiet {phy_clk}]]
-
 # sync bits i_reset
+# The input is an asynchronous reset; constrain only the capture flop so the
+# path is cut regardless of the launching clock domain.
 set_false_path \
-  -from $phy_clk \
-  -to [get_cells -quiet -hier *cdc_sync_stage1_reg* \
+  -to [get_cells -quiet -hier *cdc_sync_stage1_reg[*] \
     -filter {NAME =~ *i_sync_i_reset* && IS_SEQUENTIAL}]
 
 set_property ASYNC_REG TRUE \
-      [get_cells -quiet -hier *cdc_sync_stage1_reg* \
+      [get_cells -quiet -hier *cdc_sync_stage1_reg[*] \
     -filter {NAME =~ *i_sync_i_reset* && IS_SEQUENTIAL}]
 
 set_property ASYNC_REG TRUE \
@@ -28,12 +26,11 @@ set_property ASYNC_REG TRUE \
 
 # sync bits o_reset
 set_false_path \
-  -from $usr_clk \
-  -to [get_cells -quiet -hier *cdc_sync_stage1_reg* \
+  -to [get_cells -quiet -hier *cdc_sync_stage1_reg[*] \
     -filter {NAME =~ *i_sync_o_reset* && IS_SEQUENTIAL}]
 
 set_property ASYNC_REG TRUE \
-      [get_cells -quiet -hier *cdc_sync_stage1_reg* \
+      [get_cells -quiet -hier *cdc_sync_stage1_reg[*] \
     -filter {NAME =~ *i_sync_o_reset* && IS_SEQUENTIAL}]
 
 set_property ASYNC_REG TRUE \


### PR DESCRIPTION
## PR Description

The async clock constraints weren't applied correctly when building with external link clock.


## PR Type
- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)
- [ ] Documentation

## PR Checklist
- [x] I have followed the code style guidelines
- [x] I have performed a self-review of changes
- [x] I have compiled all hdl projects and libraries affected by this PR
- [ ] I have tested in hardware affected projects, at least on relevant boards
- [ ] I have commented my code, at least hard-to-understand parts
- [ ] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe files, Copyright etc)
- [ ] I have not introduced new Warnings/Critical Warnings on compilation
- [ ] I have added new hdl testbenches or updated existing ones
