### PR TITLE
projects: enable register slice

### DIFF
--- a/library/spi_engine/axi_spi_engine/axi_spi_engine.v
+++ b/library/spi_engine/axi_spi_engine/axi_spi_engine.v
@@ -52,7 +52,8 @@ module axi_spi_engine #(
   parameter CFG_INFO_0 = 0,
   parameter CFG_INFO_1 = 0,
   parameter CFG_INFO_2 = 0,
-  parameter CFG_INFO_3 = 0
+  parameter CFG_INFO_3 = 0,
+  parameter SRC_REG_SLICE_EN = 0
 ) (
 
   // Slave AXI interface
@@ -513,7 +514,8 @@ module axi_spi_engine #(
     .ALMOST_FULL_THRESHOLD(31),
     .TLAST_EN(0),
     .TKEEP_EN(1),
-    .REDUCED_FIFO(0)
+    .REDUCED_FIFO(0),
+    .SRC_REG_SLICE_EN(SRC_REG_SLICE_EN)
   ) i_sdi_fifo(
     .s_axis_aclk(spi_clk),
     .s_axis_aresetn(spi_resetn),

--- a/library/spi_engine/axi_spi_engine/axi_spi_engine_hw.tcl
+++ b/library/spi_engine/axi_spi_engine/axi_spi_engine_hw.tcl
@@ -17,6 +17,7 @@ ad_ip_files axi_spi_engine [list\
   $ad_hdl_dir/library/util_cdc/sync_gray.v \
   $ad_hdl_dir/library/common/ad_mem.v \
   $ad_hdl_dir/library/util_axis_fifo_asym/util_axis_fifo_asym.v \
+  $ad_hdl_dir/library/axi_dmac/axi_register_slice.v \
   $ad_hdl_dir/library/common/up_axi.v \
   $ad_hdl_dir/library/common/ad_rst.v \
   $ad_hdl_dir/library/intel/common/up_rst_constr.sdc \
@@ -37,6 +38,7 @@ ad_ip_parameter OFFLOAD0_SDO_MEM_ADDRESS_WIDTH INTEGER 4
 ad_ip_parameter ID INTEGER 0
 ad_ip_parameter DATA_WIDTH INTEGER 8
 ad_ip_parameter NUM_OF_SDIO INTEGER 1
+ad_ip_parameter SRC_REG_SLICE_EN INTEGER 0
 
 proc p_elaboration {} {
 

--- a/library/spi_engine/axi_spi_engine/axi_spi_engine_ip.tcl
+++ b/library/spi_engine/axi_spi_engine/axi_spi_engine_ip.tcl
@@ -203,6 +203,14 @@ set_property -dict [list \
  ] \
  [ipx::get_user_parameters NUM_OF_SDIO -of_objects $cc]
 
+## SRC_REG_SLICE_EN
+set_property -dict [list \
+  "value_validation_type" "range_long" \
+  "value_validation_range_minimum" "0" \
+  "value_validation_range_maximum" "1" \
+ ] \
+ [ipx::get_user_parameters SRC_REG_SLICE_EN -of_objects $cc]
+
 ## Customize IP Layout
 
 ## Remove the automatically generated GUI page
@@ -233,6 +241,12 @@ set_property -dict [list \
   "display_name" "Number of MISO/MOSI lines" \
   "tooltip" "\[NUM_OF_SDIO\] Define the number of MISO/MOSI lines" \
 ] [ipgui::get_guiparamspec -name "NUM_OF_SDIO" -component $cc]
+
+ipgui::add_param -name "SRC_REG_SLICE_EN" -component $cc -parent $general_group
+set_property -dict [list \
+  "display_name" "Source register slice enable" \
+  "tooltip" "\[SRC_REG_SLICE_EN\] Enable the source register slice" \
+] [ipgui::get_guiparamspec -name "SRC_REG_SLICE_EN" -component $cc]
 
 ipgui::add_param -name "MM_IF_TYPE" -component $cc -parent $general_group
 set_property -dict [list \

--- a/library/spi_engine/axi_spi_engine/axi_spi_engine_ltt.tcl
+++ b/library/spi_engine/axi_spi_engine/axi_spi_engine_ltt.tcl
@@ -90,6 +90,8 @@ set ip [ipl::add_ip_files -ip $ip -dpath rtl -flist [list \
     "$ad_hdl_dir/library/common/ad_mem.v" \
     "$ad_hdl_dir/library/util_axis_fifo/util_axis_fifo.v" \
     "$ad_hdl_dir/library/util_axis_fifo/util_axis_fifo_address_generator.v" \
+    "$ad_hdl_dir/library/util_axis_fifo_asym/util_axis_fifo_asym.v" \
+    "$ad_hdl_dir/library/axi_dmac/axi_register_slice.v" \
     "axi_spi_engine.v" ]]
 
 set ip [ipl::set_parameter -ip $ip \
@@ -123,6 +125,17 @@ set ip [ipl::set_parameter -ip $ip \
     -default 1 \
     -output_formatter nostr \
     -value_range {(1, 8)} \
+    -group1 {General Configuration} \
+    -group2 Config]
+set ip [ipl::set_parameter -ip $ip \
+    -id SRC_REG_SLICE_EN \
+    -type param \
+    -value_type int \
+    -conn_mod axi_spi_engine \
+    -title {Source register slice enable} \
+    -default 0 \
+    -output_formatter nostr \
+    -options {[('True', 1), ('False', 0)]} \
     -group1 {General Configuration} \
     -group2 Config]
 set ip [ipl::set_parameter -ip $ip \

--- a/library/spi_engine/scripts/spi_engine.tcl
+++ b/library/spi_engine/scripts/spi_engine.tcl
@@ -49,6 +49,7 @@ proc spi_engine_create {args} {
     set sdo_fifo_addr_width   [optional_param $args 13 5]
     set sync_fifo_addr_width  [optional_param $args 14 4]
     set cmd_fifo_addr_width   [optional_param $args 15 4]
+    set src_reg_slice_en      [optional_param $args 16 0]
 
   } elseif {$vendor == "intel"} {
     # Intel: name + clocks & resets + optional parameters
@@ -74,6 +75,7 @@ proc spi_engine_create {args} {
     set sdo_fifo_addr_width   [optional_param $args 16 5]
     set sync_fifo_addr_width  [optional_param $args 17 4]
     set cmd_fifo_addr_width   [optional_param $args 18 4]
+    set src_reg_slice_en      [optional_param $args 19 0]
   }
 
   # Component instance names
@@ -129,6 +131,7 @@ proc spi_engine_create {args} {
   ad_ip_parameter $axi_regmap CONFIG.SDO_FIFO_ADDRESS_WIDTH $sdo_fifo_addr_width
   ad_ip_parameter $axi_regmap CONFIG.SYNC_FIFO_ADDRESS_WIDTH $sync_fifo_addr_width
   ad_ip_parameter $axi_regmap CONFIG.CMD_FIFO_ADDRESS_WIDTH $cmd_fifo_addr_width
+  ad_ip_parameter $axi_regmap CONFIG.SRC_REG_SLICE_EN $src_reg_slice_en
 
   # Instantiate Offload and interconnect modules only if offload is enabled
   if {$offload_en == 1} {

--- a/projects/ad4052_ardz/common/ad4052_bd.tcl
+++ b/projects/ad4052_ardz/common/ad4052_bd.tcl
@@ -22,6 +22,7 @@ set echo_sclk        0
 spi_engine_create $hier_spi_engine $data_width $async_spi_clk $offload_en $num_cs $num_sdi $num_sdo $sdi_delay $echo_sclk
 
 ad_ip_parameter $hier_spi_engine/${hier_spi_engine}_offload CONFIG.ASYNC_TRIG 1
+ad_ip_parameter $hier_spi_engine/${hier_spi_engine}_axi_regmap CONFIG.SRC_REG_SLICE_EN 1
 
 ad_ip_instance axi_clkgen spi_clkgen
 ad_ip_parameter spi_clkgen CONFIG.CLK0_DIV 5

--- a/projects/ad4052_ardz/common/ad4052_qsys.tcl
+++ b/projects/ad4052_ardz/common/ad4052_qsys.tcl
@@ -76,6 +76,7 @@ set sdo_streaming    0
 
 spi_engine_create $spi_engine_hier $axi_clk $axi_reset $spi_clk $data_width $async_spi_clk $offload_en $num_cs $num_sdi $num_sdo $sdi_delay $echo_sclk $sdo_streaming
 set_instance_parameter_value ${spi_engine_hier}_offload {ASYNC_TRIG} {1}
+set_instance_parameter_value ${spi_engine_hier}_axi_regmap {SRC_REG_SLICE_EN} {1}
 # exported interface
 
 add_interface adc_spi_sclk    clock source

--- a/projects/ad4630_fmc/common/ad463x_bd.tcl
+++ b/projects/ad4630_fmc/common/ad463x_bd.tcl
@@ -90,6 +90,8 @@ ad_ip_parameter $hier_spi_engine/${hier_spi_engine}_axi_regmap CONFIG.CFG_INFO_0
 ad_ip_parameter $hier_spi_engine/${hier_spi_engine}_axi_regmap CONFIG.CFG_INFO_1 $CAPTURE_ZONE
 ad_ip_parameter $hier_spi_engine/${hier_spi_engine}_axi_regmap CONFIG.CFG_INFO_2 $CLK_MODE
 ad_ip_parameter $hier_spi_engine/${hier_spi_engine}_axi_regmap CONFIG.CFG_INFO_3 $DDR_EN
+# Enable a register slice for timing closure on spi_clk domain for the SDI path
+ad_ip_parameter $hier_spi_engine/${hier_spi_engine}_axi_regmap CONFIG.SRC_REG_SLICE_EN 1
 
 ## to setup the sample rate of the system change the PULSE_PERIOD value of the
 ## CNV generator; the actual sample rate will be PULSE_PERIOD * (1/cnv_ref_clk)


### PR DESCRIPTION
* Enable register slice for the AD4630 and AD4052 projects. Those projects were facing timing issues;
* Adapted the SPI engine script to include this new parameter.


## PR Type
- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)
- [ ] Documentation

## PR Checklist
- [x] I have followed the code style guidelines
- [x] I have performed a self-review of changes
- [x] I have compiled all hdl projects and libraries affected by this PR
- [ ] I have tested in hardware affected projects, at least on relevant boards
- [x] I have commented my code, at least hard-to-understand parts
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe files, Copyright etc)
- [x] I have not introduced new Warnings/Critical Warnings on compilation
- [ ] I have added new hdl testbenches or updated existing ones
