### PR TITLE
common: microzed: Make the project standalone buildable

### DIFF
--- a/projects/common/microzed/Makefile
+++ b/projects/common/microzed/Makefile
@@ -1,0 +1,16 @@
+####################################################################################
+## Copyright (c) 2018 - 2026 Analog Devices, Inc.
+### SPDX short identifier: BSD-1-Clause
+## Auto-generated, do not modify!
+####################################################################################
+
+PROJECT_NAME := template_microzed
+
+M_DEPS += ../../scripts/adi_pd.tcl
+M_DEPS += ../../common/microzed/microzed_system_constr.xdc
+M_DEPS += ../../common/microzed/microzed_system_bd.tcl
+
+LIB_DEPS += axi_sysid
+LIB_DEPS += sysid_rom
+
+include ../../scripts/project-xilinx.mk

--- a/projects/common/microzed/microzed_system_bd.tcl
+++ b/projects/common/microzed/microzed_system_bd.tcl
@@ -1,5 +1,5 @@
 ###############################################################################
-## Copyright (C) 2014-2025 Analog Devices, Inc. All rights reserved.
+## Copyright (C) 2014-2026 Analog Devices, Inc. All rights reserved.
 ### SPDX short identifier: ADIBSD
 ###############################################################################
 
@@ -11,9 +11,7 @@ set CACHE_COHERENCY false
 create_bd_intf_port -mode Master -vlnv xilinx.com:interface:ddrx_rtl:1.0 ddr
 create_bd_intf_port -mode Master -vlnv xilinx.com:display_processing_system7:fixedio_rtl:1.0 fixed_io
 
-create_bd_port -dir O spi0_csn_2_o
-create_bd_port -dir O spi0_csn_1_o
-create_bd_port -dir O spi0_csn_0_o
+create_bd_port -dir O -from 2 -to 0 spi0_csn
 create_bd_port -dir I spi0_csn_i
 create_bd_port -dir I spi0_clk_i
 create_bd_port -dir O spi0_clk_o
@@ -21,9 +19,7 @@ create_bd_port -dir I spi0_sdo_i
 create_bd_port -dir O spi0_sdo_o
 create_bd_port -dir I spi0_sdi_i
 
-create_bd_port -dir O spi1_csn_2_o
-create_bd_port -dir O spi1_csn_1_o
-create_bd_port -dir O spi1_csn_0_o
+create_bd_port -dir O -from 2 -to 0 spi1_csn
 create_bd_port -dir I spi1_csn_i
 create_bd_port -dir I spi1_clk_i
 create_bd_port -dir O spi1_clk_o
@@ -97,9 +93,13 @@ ad_connect  fixed_io      sys_ps7/FIXED_IO
 
 # spi connections
 
-ad_connect  spi0_csn_2_o sys_ps7/SPI0_SS2_O
-ad_connect  spi0_csn_1_o sys_ps7/SPI0_SS1_O
-ad_connect  spi0_csn_0_o sys_ps7/SPI0_SS_O
+ad_ip_instance ilconcat spi0_csn_sources
+ad_ip_parameter spi0_csn_sources config.num_ports {3}
+ad_connect  spi0_csn_sources/dout spi0_csn
+
+ad_connect  sys_ps7/SPI0_SS_O  spi0_csn_sources/in0
+ad_connect  sys_ps7/SPI0_SS1_O spi0_csn_sources/in1
+ad_connect  sys_ps7/SPI0_SS2_O spi0_csn_sources/in2
 ad_connect  spi0_csn_i sys_ps7/SPI0_SS_I
 ad_connect  spi0_clk_i sys_ps7/SPI0_SCLK_I
 ad_connect  spi0_clk_o sys_ps7/SPI0_SCLK_O
@@ -107,9 +107,13 @@ ad_connect  spi0_sdo_i sys_ps7/SPI0_MOSI_I
 ad_connect  spi0_sdo_o sys_ps7/SPI0_MOSI_O
 ad_connect  spi0_sdi_i sys_ps7/SPI0_MISO_I
 
-ad_connect  spi1_csn_2_o sys_ps7/SPI1_SS2_O
-ad_connect  spi1_csn_1_o sys_ps7/SPI1_SS1_O
-ad_connect  spi1_csn_0_o sys_ps7/SPI1_SS_O
+ad_ip_instance ilconcat spi1_csn_sources
+ad_ip_parameter spi1_csn_sources config.num_ports {3}
+ad_connect  spi1_csn_sources/dout spi1_csn
+
+ad_connect  sys_ps7/SPI1_SS_O  spi1_csn_sources/in0
+ad_connect  sys_ps7/SPI1_SS1_O spi1_csn_sources/in1
+ad_connect  sys_ps7/SPI1_SS2_O spi1_csn_sources/in2
 ad_connect  spi1_csn_i sys_ps7/SPI1_SS_I
 ad_connect  spi1_clk_i sys_ps7/SPI1_SCLK_I
 ad_connect  spi1_clk_o sys_ps7/SPI1_SCLK_O

--- a/projects/common/microzed/system_bd.tcl
+++ b/projects/common/microzed/system_bd.tcl
@@ -1,0 +1,14 @@
+###############################################################################
+## Copyright (C) 2026 Analog Devices, Inc. All rights reserved.
+### SPDX short identifier: ADIBSD
+###############################################################################
+
+source $ad_hdl_dir/projects/scripts/adi_pd.tcl
+source $ad_hdl_dir/projects/common/microzed/microzed_system_bd.tcl
+
+#system ID
+ad_ip_parameter axi_sysid_0 CONFIG.ROM_ADDR_BITS 9
+ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "$mem_init_sys_file_path/mem_init_sys.txt"
+ad_ip_parameter rom_sys_0 CONFIG.ROM_ADDR_BITS 9
+
+sysid_gen_sys_init_file

--- a/projects/common/microzed/system_project.tcl
+++ b/projects/common/microzed/system_project.tcl
@@ -1,0 +1,15 @@
+###############################################################################
+## Copyright (C) 2026 Analog Devices, Inc. All rights reserved.
+### SPDX short identifier: ADIBSD
+###############################################################################
+
+source ../../../scripts/adi_env.tcl
+source $ad_hdl_dir/projects/scripts/adi_project_xilinx.tcl
+source $ad_hdl_dir/projects/scripts/adi_board.tcl
+
+adi_project template_microzed
+adi_project_files template_microzed [list \
+  "$ad_hdl_dir/projects/common/microzed/microzed_system_constr.xdc" \
+  "system_top.v" ]
+
+adi_project_run template_microzed

--- a/projects/common/microzed/system_top.v
+++ b/projects/common/microzed/system_top.v
@@ -1,0 +1,121 @@
+// ***************************************************************************
+// ***************************************************************************
+// Copyright (C) 2026 Analog Devices, Inc. All rights reserved.
+//
+// In this HDL repository, there are many different and unique modules, consisting
+// of various HDL (Verilog or VHDL) components. The individual modules are
+// developed independently, and may be accompanied by separate and unique license
+// terms.
+//
+// The user should read each of these license terms, and understand the
+// freedoms and responsibilities that he or she has by using this source/core.
+//
+// This core is distributed in the hope that it will be useful, but WITHOUT ANY
+// WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+// A PARTICULAR PURPOSE.
+//
+// Redistribution and use of source or resulting binaries, with or without modification
+// of this file, are permitted under one of the following two license terms:
+//
+//   1. The GNU General Public License version 2 as published by the
+//      Free Software Foundation, which can be found in the top level directory
+//      of this repository (LICENSE_GPL2), and also online at:
+//      <https://www.gnu.org/licenses/old-licenses/gpl-2.0.html>
+//
+// OR
+//
+//   2. An ADI specific BSD license, which can be found in the top level directory
+//      of this repository (LICENSE_ADIBSD), and also on-line at:
+//      https://github.com/analogdevicesinc/hdl/blob/main/LICENSE_ADIBSD
+//      This will allow to generate bit files and not release the source code,
+//      as long as it attaches to an ADI device.
+//
+// ***************************************************************************
+// ***************************************************************************
+
+`timescale 1ns/100ps
+
+module system_top (
+
+  inout   [14:0]  ddr_addr,
+  inout   [ 2:0]  ddr_ba,
+  inout           ddr_cas_n,
+  inout           ddr_ck_n,
+  inout           ddr_ck_p,
+  inout           ddr_cke,
+  inout           ddr_cs_n,
+  inout   [ 3:0]  ddr_dm,
+  inout   [31:0]  ddr_dq,
+  inout   [ 3:0]  ddr_dqs_n,
+  inout   [ 3:0]  ddr_dqs_p,
+  inout           ddr_odt,
+  inout           ddr_ras_n,
+  inout           ddr_reset_n,
+  inout           ddr_we_n,
+
+  inout           fixed_io_ddr_vrn,
+  inout           fixed_io_ddr_vrp,
+  inout   [53:0]  fixed_io_mio,
+  inout           fixed_io_ps_clk,
+  inout           fixed_io_ps_porb,
+  inout           fixed_io_ps_srstb
+);
+
+  // internal signals
+
+  wire    [63:0]  gpio_i;
+  wire    [63:0]  gpio_o;
+  wire    [63:0]  gpio_t;
+  wire    [ 2:0]  spi0_csn;
+  wire    [ 2:0]  spi1_csn;
+
+  // assignments
+
+  assign gpio_i[63:0] = gpio_o[63:0];
+
+  // instantiations
+
+  system_wrapper i_system_wrapper (
+    .ddr_addr (ddr_addr),
+    .ddr_ba (ddr_ba),
+    .ddr_cas_n (ddr_cas_n),
+    .ddr_ck_n (ddr_ck_n),
+    .ddr_ck_p (ddr_ck_p),
+    .ddr_cke (ddr_cke),
+    .ddr_cs_n (ddr_cs_n),
+    .ddr_dm (ddr_dm),
+    .ddr_dq (ddr_dq),
+    .ddr_dqs_n (ddr_dqs_n),
+    .ddr_dqs_p (ddr_dqs_p),
+    .ddr_odt (ddr_odt),
+    .ddr_ras_n (ddr_ras_n),
+    .ddr_reset_n (ddr_reset_n),
+    .ddr_we_n (ddr_we_n),
+
+    .fixed_io_ddr_vrn (fixed_io_ddr_vrn),
+    .fixed_io_ddr_vrp (fixed_io_ddr_vrp),
+    .fixed_io_mio (fixed_io_mio),
+    .fixed_io_ps_clk (fixed_io_ps_clk),
+    .fixed_io_ps_porb (fixed_io_ps_porb),
+    .fixed_io_ps_srstb (fixed_io_ps_srstb),
+
+    .gpio_i (gpio_i),
+    .gpio_o (gpio_o),
+    .gpio_t (gpio_t),
+
+    .spi0_clk_i (1'b0),
+    .spi0_clk_o (),
+    .spi0_csn (spi0_csn),
+    .spi0_csn_i (1'b1),
+    .spi0_sdi_i (1'b0),
+    .spi0_sdo_i (1'b0),
+    .spi0_sdo_o (),
+    .spi1_clk_i (1'b0),
+    .spi1_clk_o (),
+    .spi1_csn (spi1_csn),
+    .spi1_csn_i (1'b1),
+    .spi1_sdi_i (1'b0),
+    .spi1_sdo_i (1'b0),
+    .spi1_sdo_o ());
+
+endmodule


### PR DESCRIPTION
## PR Description

The microzed carrier was already supported but was missing the system_top.v and Makefile. Updated it to match our standard format of the base designs.

## PR Type
- [ ] Bug fix (change that fixes an issue)
- [x] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)
- [ ] Documentation

## PR Checklist
- [x] I have followed the code style guidelines
- [x] I have performed a self-review of changes
- [x] I have compiled all hdl projects and libraries affected by this PR
- [ ] I have tested in hardware affected projects, at least on relevant boards
- [ ] I have commented my code, at least hard-to-understand parts
- [ ] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe files, Copyright etc)
- [ ] I have not introduced new Warnings/Critical Warnings on compilation
- [ ] I have added new hdl testbenches or updated existing ones
