### PR TITLE
library/jesd204/ad_ip_jesd204_tpl: Add option to bypass pn mon/gen

### DIFF
--- a/library/jesd204/ad_ip_jesd204_tpl_adc/ad_ip_jesd204_tpl_adc.v
+++ b/library/jesd204/ad_ip_jesd204_tpl_adc/ad_ip_jesd204_tpl_adc.v
@@ -1,6 +1,6 @@
 // ***************************************************************************
 // ***************************************************************************
-// Copyright (C) 2018-2023 Analog Devices, Inc. All rights reserved.
+// Copyright (C) 2018-2026 Analog Devices, Inc. All rights reserved.
 //
 // In this HDL repository, there are many different and unique modules, consisting
 // of various HDL (Verilog or VHDL) components. The individual modules are
@@ -51,6 +51,7 @@ module ad_ip_jesd204_tpl_adc #(
   parameter EN_FRAME_ALIGN = 1,
   parameter TWOS_COMPLEMENT = 1,
   parameter EXT_SYNC = 0,
+  parameter PNMON_ENABLE = 1,
   parameter PN7_ENABLE = 1,
   parameter PN15_ENABLE = 1
 ) (
@@ -208,6 +209,7 @@ module ad_ip_jesd204_tpl_adc #(
     .DATA_PATH_WIDTH (DATA_PATH_WIDTH),
     .DMA_BITS_PER_SAMPLE (DMA_BITS_PER_SAMPLE),
     .EXT_SYNC (EXT_SYNC),
+    .PNMON_ENABLE (PNMON_ENABLE),
     .PN7_ENABLE (PN7_ENABLE),
     .PN15_ENABLE(PN15_ENABLE)
   ) i_core (

--- a/library/jesd204/ad_ip_jesd204_tpl_adc/ad_ip_jesd204_tpl_adc_channel.v
+++ b/library/jesd204/ad_ip_jesd204_tpl_adc/ad_ip_jesd204_tpl_adc_channel.v
@@ -1,6 +1,6 @@
 // ***************************************************************************
 // ***************************************************************************
-// Copyright (C) 2018-2023 Analog Devices, Inc. All rights reserved.
+// Copyright (C) 2018-2026 Analog Devices, Inc. All rights reserved.
 //
 // In this HDL repository, there are many different and unique modules, consisting
 // of various HDL (Verilog or VHDL) components. The individual modules are
@@ -40,6 +40,7 @@ module ad_ip_jesd204_tpl_adc_channel #(
   parameter DATA_PATH_WIDTH = 2,
   parameter TWOS_COMPLEMENT = 1,
   parameter BITS_PER_SAMPLE = 16,
+  parameter PNMON_ENABLE = 1,
   parameter PN7_ENABLE = 1,
   parameter PN15_ENABLE = 1
 ) (
@@ -61,19 +62,26 @@ module ad_ip_jesd204_tpl_adc_channel #(
 
   // instantiations
 
-  ad_ip_jesd204_tpl_adc_pnmon #(
-    .CONVERTER_RESOLUTION (CONVERTER_RESOLUTION),
-    .DATA_PATH_WIDTH (DATA_PATH_WIDTH),
-    .TWOS_COMPLEMENT (TWOS_COMPLEMENT),
-    .PN7_ENABLE (PN7_ENABLE),
-    .PN15_ENABLE(PN15_ENABLE)
-  ) i_pnmon (
-    .clk (clk),
-    .data (raw_data),
+  generate
+  if (PNMON_ENABLE == 1) begin: g_pnmon
+    ad_ip_jesd204_tpl_adc_pnmon #(
+      .CONVERTER_RESOLUTION (CONVERTER_RESOLUTION),
+      .DATA_PATH_WIDTH (DATA_PATH_WIDTH),
+      .TWOS_COMPLEMENT (TWOS_COMPLEMENT),
+      .PN7_ENABLE (PN7_ENABLE),
+      .PN15_ENABLE(PN15_ENABLE)
+    ) i_pnmon (
+      .clk (clk),
+      .data (raw_data),
 
-    .pn_seq_sel (pn_seq_sel),
-    .pn_oos (pn_oos),
-    .pn_err (pn_err));
+      .pn_seq_sel (pn_seq_sel),
+      .pn_oos (pn_oos),
+      .pn_err (pn_err));
+  end else begin: g_no_pnmon
+    assign pn_oos = 1'b0;
+    assign pn_err = 1'b0;
+  end
+  endgenerate
 
   generate
   genvar n;

--- a/library/jesd204/ad_ip_jesd204_tpl_adc/ad_ip_jesd204_tpl_adc_core.v
+++ b/library/jesd204/ad_ip_jesd204_tpl_adc/ad_ip_jesd204_tpl_adc_core.v
@@ -1,6 +1,6 @@
 // ***************************************************************************
 // ***************************************************************************
-// Copyright (C) 2018-2023 Analog Devices, Inc. All rights reserved.
+// Copyright (C) 2018-2026 Analog Devices, Inc. All rights reserved.
 //
 // In this HDL repository, there are many different and unique modules, consisting
 // of various HDL (Verilog or VHDL) components. The individual modules are
@@ -49,6 +49,7 @@ module ad_ip_jesd204_tpl_adc_core #(
   parameter DMA_DATA_WIDTH = DATA_PATH_WIDTH * DMA_BITS_PER_SAMPLE * NUM_CHANNELS,
   parameter TWOS_COMPLEMENT = 1,
   parameter EXT_SYNC = 0,
+  parameter PNMON_ENABLE = 1,
   parameter PN7_ENABLE = 1,
   parameter PN15_ENABLE = 1
 ) (
@@ -134,6 +135,7 @@ module ad_ip_jesd204_tpl_adc_core #(
       .CONVERTER_RESOLUTION (CONVERTER_RESOLUTION),
       .TWOS_COMPLEMENT (TWOS_COMPLEMENT),
       .BITS_PER_SAMPLE (DMA_BITS_PER_SAMPLE),
+      .PNMON_ENABLE (PNMON_ENABLE),
       .PN7_ENABLE (PN7_ENABLE),
       .PN15_ENABLE(PN15_ENABLE)
     ) i_channel (

--- a/library/jesd204/ad_ip_jesd204_tpl_adc/ad_ip_jesd204_tpl_adc_ip.tcl
+++ b/library/jesd204/ad_ip_jesd204_tpl_adc/ad_ip_jesd204_tpl_adc_ip.tcl
@@ -1,5 +1,5 @@
 ###############################################################################
-## Copyright (C) 2018-2022 Analog Devices, Inc. All rights reserved.
+## Copyright (C) 2018-2026 Analog Devices, Inc. All rights reserved.
 ### SPDX short identifier: ADIJESD204
 ###############################################################################
 
@@ -119,6 +119,7 @@ foreach {k v w} {
   "EXT_SYNC" "Enable external sync" "checkBox" \
   "PN7_ENABLE" "Enable PN7" "checkBox" \
   "PN15_ENABLE" "Enable PN15" "checkBox" \
+  "PNMON_ENABLE" "Enable PN monitor" "checkBox" \
   } { \
   set p [ipgui::get_guiparamspec -name $k -component $cc]
   ipgui::move_param -component $cc -order $i $p -parent $datapath_group

--- a/library/jesd204/ad_ip_jesd204_tpl_dac/ad_ip_jesd204_tpl_dac.v
+++ b/library/jesd204/ad_ip_jesd204_tpl_dac/ad_ip_jesd204_tpl_dac.v
@@ -1,6 +1,6 @@
 // ***************************************************************************
 // ***************************************************************************
-// Copyright (C) 2018-2023 Analog Devices, Inc. All rights reserved.
+// Copyright (C) 2018-2026 Analog Devices, Inc. All rights reserved.
 //
 // In this HDL repository, there are many different and unique modules, consisting
 // of various HDL (Verilog or VHDL) components. The individual modules are
@@ -56,7 +56,8 @@ module ad_ip_jesd204_tpl_dac #(
   parameter DATAPATH_DISABLE = 0,
   parameter IQCORRECTION_DISABLE = 1,
   parameter EXT_SYNC = 0,
-  parameter XBAR_ENABLE = 0
+  parameter XBAR_ENABLE = 0,
+  parameter PNGEN_ENABLE = 1
 ) (
 
   // jesd interface
@@ -237,7 +238,8 @@ module ad_ip_jesd204_tpl_dac #(
     .DDS_CORDIC_DW (DDS_CORDIC_DW),
     .DDS_CORDIC_PHASE_DW (DDS_CORDIC_PHASE_DW),
     .DDS_PHASE_DW (DDS_PHASE_DW),
-    .EXT_SYNC (EXT_SYNC)
+    .EXT_SYNC (EXT_SYNC),
+    .PNGEN_ENABLE (PNGEN_ENABLE)
   ) i_core (
     .clk (link_clk),
 

--- a/library/jesd204/ad_ip_jesd204_tpl_dac/ad_ip_jesd204_tpl_dac_core.v
+++ b/library/jesd204/ad_ip_jesd204_tpl_dac/ad_ip_jesd204_tpl_dac_core.v
@@ -1,6 +1,6 @@
 // ***************************************************************************
 // ***************************************************************************
-// Copyright (C) 2018-2023 Analog Devices, Inc. All rights reserved.
+// Copyright (C) 2018-2026 Analog Devices, Inc. All rights reserved.
 //
 // In this HDL repository, there are many different and unique modules, consisting
 // of various HDL (Verilog or VHDL) components. The individual modules are
@@ -51,7 +51,8 @@ module ad_ip_jesd204_tpl_dac_core #(
   parameter DDS_CORDIC_DW = 16,
   parameter DDS_CORDIC_PHASE_DW = 16,
   parameter DDS_PHASE_DW = 16,
-  parameter EXT_SYNC = 0
+  parameter EXT_SYNC = 0,
+  parameter PNGEN_ENABLE = 1
 ) (
 
   // dac interface
@@ -143,15 +144,22 @@ module ad_ip_jesd204_tpl_dac_core #(
     .dac_data (dac_data_s));
 
   // PN generator
-  ad_ip_jesd204_tpl_dac_pn #(
-    .DATA_PATH_WIDTH (DATA_PATH_WIDTH),
-    .CONVERTER_RESOLUTION (CONVERTER_RESOLUTION)
-  ) i_pn_gen (
-    .clk (clk),
-    .reset (dac_sync_int),
+  generate
+  if (PNGEN_ENABLE == 1) begin: g_pngen
+    ad_ip_jesd204_tpl_dac_pn #(
+      .DATA_PATH_WIDTH (DATA_PATH_WIDTH),
+      .CONVERTER_RESOLUTION (CONVERTER_RESOLUTION)
+    ) i_pn_gen (
+      .clk (clk),
+      .reset (dac_sync_int),
 
-    .pn7_data (pn7_data),
-    .pn15_data (pn15_data));
+      .pn7_data (pn7_data),
+      .pn15_data (pn15_data));
+  end else begin: g_no_pngen
+    assign pn7_data = 0;
+    assign pn15_data = 0;
+  end
+  endgenerate
 
   // dac valid
 

--- a/library/jesd204/ad_ip_jesd204_tpl_dac/ad_ip_jesd204_tpl_dac_ip.tcl
+++ b/library/jesd204/ad_ip_jesd204_tpl_dac/ad_ip_jesd204_tpl_dac_ip.tcl
@@ -1,5 +1,5 @@
 ###############################################################################
-## Copyright (C) 2018-2022 Analog Devices, Inc. All rights reserved.
+## Copyright (C) 2018-2026 Analog Devices, Inc. All rights reserved.
 ### SPDX short identifier: ADIJESD204
 ###############################################################################
 
@@ -145,6 +145,7 @@ foreach {k v w} {
   "DDS_PHASE_DW" "DDS Phase Width" "text" \
   "DDS_CORDIC_DW" "CORDIC DDS Data Width" "text" \
   "DDS_CORDIC_PHASE_DW" "CORDIC DDS Phase Width" "text" \
+  "PNGEN_ENABLE" "Enable PN generator" "checkBox" \
   } { \
   set p [ipgui::get_guiparamspec -name $k -component $cc]
   ipgui::move_param -component $cc -order $i $p -parent $datapath_group


### PR DESCRIPTION
## PR Description

Add the option to bypass entirely the PN_MON and PN_GEN modules to improve resource utilization and close critical timings for projects with multiple JESD virtual channels!

- Use PNMON_ENABLE = 0 to disable the PN_MONITOR
- Use PNGEN_ENABLE = 0 to disable the PN_GENERATION

## PR Type
- [ ] Bug fix (change that fixes an issue)
- [x] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)
- [ ] Documentation

## PR Checklist
- [x] I have followed the code style guidelines
- [x] I have performed a self-review of changes
- [x] I have compiled all hdl projects and libraries affected by this PR
- [x] I have tested in hardware affected projects, at least on relevant boards
- [ ] I have commented my code, at least hard-to-understand parts
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe files, Copyright etc)
- [x] I have not introduced new Warnings/Critical Warnings on compilation
- [ ] I have added new hdl testbenches or updated existing ones
