### PR TITLE
scripts: project-intel: Remove Agilex build artifacts on clean

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -120,3 +120,10 @@ ipcfg
 _bld
 radiantc.*
 ltt
+dni/
+*.jic
+*.stp
+*.legacy
+*.info
+*.tcl.history*
+sm_hssi_port_rotation_param_map.json

--- a/projects/scripts/project-intel.mk
+++ b/projects/scripts/project-intel.mk
@@ -1,5 +1,5 @@
 ####################################################################################
-## Copyright (c) 2020 - 2021 Analog Devices, Inc.
+## Copyright (c) 2020 - 2021, 2026 Analog Devices, Inc.
 ## SPDX short identifier: BSD-1-Clause
 ####################################################################################
 
@@ -88,6 +88,12 @@ CLEAN_TARGET += ip
 CLEAN_TARGET += qdb
 CLEAN_TARGET += tmp-clearbox
 CLEAN_TARGET += *.log
+CLEAN_TARGET += dni
+CLEAN_TARGET += *.legacy
+CLEAN_TARGET += *.info
+CLEAN_TARGET += mem_init_*.txt
+CLEAN_TARGET += *.tcl.history*
+CLEAN_TARGET += sm_hssi_port_rotation_param_map.json
 ifneq ($(strip $(DIR_NAME)),)
     CLEAN_TARGET := $(addprefix $(DIR_NAME)/,$(CLEAN_TARGET))
 endif


### PR DESCRIPTION
## PR Description

When building Agilex projects, Quartus generates a lot of artifacts that were not being handled by the old Makefile.

## PR Type
- [ ] Bug fix (change that fixes an issue)
- [x] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)
- [ ] Documentation

## PR Checklist
- [x] I have followed the code style guidelines
- [x] I have performed a self-review of changes
- [x] I have compiled all hdl projects and libraries affected by this PR
- [ ] I have tested in hardware affected projects, at least on relevant boards
- [ ] I have commented my code, at least hard-to-understand parts
- [ ] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe files, Copyright etc)
- [ ] I have not introduced new Warnings/Critical Warnings on compilation
- [ ] I have added new hdl testbenches or updated existing ones
