### PR TITLE
library/axi_dac_interpolate: Sync DAC channel start across different sample rates

### DIFF
--- a/library/axi_dac_interpolate/axi_dac_interpolate_filter.v
+++ b/library/axi_dac_interpolate/axi_dac_interpolate_filter.v
@@ -1,6 +1,6 @@
 // ***************************************************************************
 // ***************************************************************************
-// Copyright (C) 2017-2024 Analog Devices, Inc. All rights reserved.
+// Copyright (C) 2017-2026 Analog Devices, Inc. All rights reserved.
 //
 // In this HDL repository, there are many different and unique modules, consisting
 // of various HDL (Verilog or VHDL) components. The individual modules are
@@ -82,6 +82,8 @@ module axi_dac_interpolate_filter #(
   // internal registers
 
   reg               dac_int_ready;
+  reg               transfer_first_sample;
+  reg               transfer_start_m1;
   reg               dac_filt_int_valid;
   reg     [15:0]    interp_rate_cic;
   reg     [ 2:0]    filter_mask_d1;
@@ -175,9 +177,43 @@ module axi_dac_interpolate_filter #(
     end
   end
 
+  // Start-of-transfer channel sync. On the rising edge of transfer_start, arm
+  // transfer_first_sample so the first sample of the new transfer is handled
+  // specially on both channels. When it fires we do two things:
+  //   1. interpolation_counter <= 0 : realign the interpolation phase so both
+  //      channels count from the same origin even at different interpolation
+  //      ratios (different sample rates).
+  //   2. dac_int_ready <= 1'b1 : force the per-channel IDLE->WAIT gate below open
+  //      on this same dac_clk. dac_int_ready is otherwise per-channel (it pulses
+  //      only when that channel's interpolation_counter reaches its own ratio), so
+  //      without this force each channel would leave IDLE at a different, rate-
+  //      dependent time and the two channels' launch would be skewed. Forcing it
+  //      makes both channels leave IDLE together and catch the shared transfer_start
+  //      edge on the same clock -> zero startup skew across channels.
+  // This does NOT reintroduce the last-sample-hold glitch: transfer_first_sample
+  // can only assert AFTER transfer_start rose, and transfer_start requires
+  // transfer_ready (= dma_valid & dma_valid_adjacent in sync mode). So the forced
+  // ready only opens the gate once both channels' DMA already holds valid data --
+  // the FIR/CIC pipeline is fed real samples, not a reset value. (The historical
+  // glitch came from a different change: fully REMOVING the IDLE->WAIT dac_int_ready
+  // gate, which let a channel leave IDLE before dma_valid and emit a reset 0 as the
+  // first output sample. That gate is kept intact below.)
   always @(posedge dac_clk) begin
+    transfer_start_m1 <= transfer_start;
+
+    if (transfer_start && !transfer_start_m1) begin
+      transfer_first_sample <= 1'b1;
+    end else if (transfer_first_sample && dac_filt_int_valid & transfer_ready) begin
+      transfer_first_sample <= 1'b0;
+    end
+
     if (dac_filt_int_valid & transfer_ready) begin
-      if (interpolation_counter == interpolation_ratio) begin
+      if (transfer_first_sample) begin
+        // first sample of a new transfer: realign phase (counter) + force ready so
+        // both channels launch together (see block comment above)
+        interpolation_counter <= 0;
+        dac_int_ready <= 1'b1;
+      end else if (interpolation_counter == interpolation_ratio) begin
         interpolation_counter <= 0;
         dac_int_ready <= 1'b1;
       end else begin
@@ -219,6 +255,11 @@ module axi_dac_interpolate_filter #(
     case (transfer_sm)
       IDLE: begin
         transfer <= 1'b0;
+        // Gate on dac_int_ready: do NOT leave IDLE until the channel is ready
+        // (either the interpolation counter reached its ratio, or the forced
+        // first-sample ready above). Removing this dac_int_ready term lets the
+        // channel leave IDLE before dma_valid and emit a reset 0 as the first
+        // output sample -> one-sample glitch at every buffer transition. Keep it.
         if (dac_int_ready & !dma_transfer_suspend) begin
           transfer_sm_next <= WAIT;
         end

--- a/library/axi_dac_interpolate/axi_dac_interpolate_filter.v
+++ b/library/axi_dac_interpolate/axi_dac_interpolate_filter.v
@@ -1,6 +1,6 @@
 // ***************************************************************************
 // ***************************************************************************
-// Copyright (C) 2017-2026 Analog Devices, Inc. All rights reserved.
+// Copyright (C) 2017-2024, 2026 Analog Devices, Inc. All rights reserved.
 //
 // In this HDL repository, there are many different and unique modules, consisting
 // of various HDL (Verilog or VHDL) components. The individual modules are

--- a/library/axi_dac_interpolate/axi_dac_interpolate_reg.v
+++ b/library/axi_dac_interpolate/axi_dac_interpolate_reg.v
@@ -1,6 +1,6 @@
 // ***************************************************************************
 // ***************************************************************************
-// Copyright (C) 2017-2024 Analog Devices, Inc. All rights reserved.
+// Copyright (C) 2017-2026 Analog Devices, Inc. All rights reserved.
 //
 // In this HDL repository, there are many different and unique modules, consisting
 // of various HDL (Verilog or VHDL) components. The individual modules are
@@ -73,7 +73,7 @@ module axi_dac_interpolate_reg(
 
   reg     [31:0]  up_version = {16'h0002,     /* MAJOR */
                                  8'h05,       /* MINOR */
-                                 8'h00};      /* PATCH */
+                                 8'h01};      /* PATCH */
   reg     [31:0]  up_scratch = 32'h0;
 
   reg     [31:0]  up_interpolation_ratio_a = 32'h0;

--- a/library/axi_dac_interpolate/axi_dac_interpolate_reg.v
+++ b/library/axi_dac_interpolate/axi_dac_interpolate_reg.v
@@ -1,6 +1,6 @@
 // ***************************************************************************
 // ***************************************************************************
-// Copyright (C) 2017-2026 Analog Devices, Inc. All rights reserved.
+// Copyright (C) 2017-2024, 2026 Analog Devices, Inc. All rights reserved.
 //
 // In this HDL repository, there are many different and unique modules, consisting
 // of various HDL (Verilog or VHDL) components. The individual modules are


### PR DESCRIPTION
## PR Description
Add cross-channel start synchronization so both DAC channels begin a transfer aligned even when they run at different sample rates (different interpolation ratios).

On the rising edge of the shared transfer_start, both channels reset their interpolation_counter and assert dac_int_ready on the same dac_clk (transfer_first_sample). This opens the per-channel IDLE->WAIT gate of the transfer state machine simultaneously, so both channels leave IDLE together and launch on the shared transfer_start edge with zero startup skew, regardless of their individual interpolation ratios.

The IDLE->WAIT transition keeps its dac_int_ready gate: a channel must not leave IDLE before its DMA data is valid and the FIR/CIC pipeline has warmed up, otherwise the filter reset value (0) escapes as the first output sample of every new buffer - a single-sample spike at each last-sample-hold -> new-buffer handoff on both channels. Forcing dac_int_ready on the first sample is safe alongside this gate because transfer_first_sample only asserts after transfer_start, i.e. after transfer_ready (dma_valid & dma_valid_adjacent), so the pipeline is fed real samples rather than a reset value.

Bump the IP version 2.5.0 -> 2.5.1 (SemVer patch: no register-map change).

Validated on hardware (ADALM2000): libm2k test_last_sample_hold glitch check passes all 15 channel/rate cases, and different-rate channel sync is confirmed with a loopback capture.

## PR Type
- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)
- [ ] Documentation

## PR Checklist
- [x] I have followed the code style guidelines
- [x] I have performed a self-review of changes
- [x] I have compiled all hdl projects and libraries affected by this PR
- [x] I have tested in hardware affected projects, at least on relevant boards
- [x] I have commented my code, at least hard-to-understand parts
- [x] I have signed off all commits from this PR
- [x] I have updated the documentation (wiki pages, ReadMe files, Copyright etc)
- [x] I have not introduced new Warnings/Critical Warnings on compilation
- [ ] I have added new hdl testbenches or updated existing ones
