### PR TITLE
Extend XCVR automation support for JESD204C

### DIFF
--- a/docs/library/jesd204/xgt_wizard/index.rst
+++ b/docs/library/jesd204/xgt_wizard/index.rst
@@ -1,7 +1,7 @@
 .. _xgt_wizard:
 
 Xilinx FPGAs Transceivers Wizard
-================================================================================
+===============================================================================
 
 The 7 Series and Ultrascale FPGAs Transceivers Wizard can be used to configure
 the transceivers inside the :ref:`util_adxcvr <util_adxcvr>` core. In general
@@ -26,33 +26,45 @@ configuration for a JESD204B interface.
    :xilinx:`UG578 <support/documentation/user_guides/ug578-ultrascale-gty-transceivers.pdf>`
    and :xilinx:`PG168 <support/documentation/user_guides/pg168-gtwizard.pdf>`.
 
-Required features by the JESD204B
---------------------------------------------------------------------------------
+Required features by the JESD204B/C interface
+-------------------------------------------------------------------------------
 
 The following features are required for a JESD204B interface:
 
 - QPLL and CPLL for clock generation
 - 8B/10B encoding and decoding
-- TX and RX buffer to solve rate and phase differences between XCLK (PMA parallel clock) and USRCLK (device clock)
+- TX and RX buffer to solve rate and phase differences between XCLK (PMA
+  parallel clock) and USRCLK (device clock)
 - RX Equalization and CDR
 - RX Byte and Word alignment
 - Tx configurable driver
 - Polarity control
 
+For JESD204C, the following features are used instead of or in addition to the
+above:
+
+- 64B/66B encoding and decoding
+- Wider internal data widths (64-bit user data, 66-bit internal)
+
+The JESD mode (8B10B or 64B66B) is selected via the ``JESD_MODE`` parameter
+during the build. JESD204C (64B66B) is currently supported on ZCU102 (GTHE4) and
+VCU118 (GTYE4). All other carriers support only JESD204B (8B10B).
+
 There are 3 flows for generating transceivers using the wizard
 -------------------------------------------------------------------------------
 
 The first one is an automated flow integrated in the HDL build system. It uses
-project-defined parameters to generate and extract only the necessary transceiver
-settings, with no user interaction required. The second one is using the GT
-wizard manually as explained below:
+project-defined parameters to generate and extract only the necessary
+transceiver settings, with no user interaction required. The second one is using
+the GT wizard manually as explained below:
 :ref:`Using_the_GUI_of_the_Wizard <xgt_wizard_gui_of_the_wizard>` ,
 and a third one that uses a script to generate one or more configurations:
 :ref:`Using_the_generator_script <xgt_wizard_generator_script>` .
-Please keep in mind that the script is capable of generating only **configurations
-where the TX ad RX lane rates are even and supports only JESD204B**. For more
-customization, you can use the script to generate the configurations, then edit
-them manually as you please.
+The automated flow and the generator script support both **JESD204B (8B10B)**
+and **JESD204C (64B66B)** modes, as well as configurations where **TX and RX use
+different PLL types, lane rates or reference clocks**. For more customization,
+you can use the script to generate the configurations, then edit them manually
+as you please.
 
 If you used the script method, there is another script that parses the generated
 configurations and generates a list containing only the parameters that are
@@ -72,39 +84,67 @@ and supporting Tcl scripts.
 The automated transceiver configuration flow is currently integrated into the
 following projects:
 
+- :git-hdl:`AD9081_FMCA_EBZ <projects/ad9081_fmca_ebz>`
+- :git-hdl:`AD9083_EVB <projects/ad9083_evb>`
+- :git-hdl:`ADRV9009 <projects/adrv9009>`
+- :git-hdl:`ADRV9026 <projects/adrv9026>`
+- :git-hdl:`ADRV9371x <projects/adrv9371x>`
 - :git-hdl:`DAQ2 <projects/daq2>`
 - :git-hdl:`DAQ3 <projects/daq3>`
-- :git-hdl:`ADRV9009 <projects/adrv9009>`
-- :git-hdl:`ADRV9371x <projects/adrv9371x>`
 
 xcvr_wizard
 *******************************************************************************
 
-The :git-hdl:`xcvr_wizard HDL project <projects/xcvr_wizard>` is used
-internally to generate transceiver configuration files based on a set of
-parameters:
+The :git-hdl:`xcvr_wizard HDL project <projects/xcvr_wizard>` is used internally
+to generate transceiver configuration files based on a set of parameters. It
+supports the following carrier boards:
 
-- LANE_RATE: lane speed in Gbps
-- REF_CLK: reference clock frequency in MHz
-- PLL_TYPE: the type of PLL used (CPLL or QPLL)
+========  =======  ================  ==================
+Carrier   GT Type  JESD204B (8B10B)  JESD204C (64B66B)
+========  =======  ================  ==================
+ZC706     GTXE2    Yes               No
+KC705     GTXE2    Yes               No
+KCU105    GTHE3    Yes               No
+ZCU102    GTHE4    Yes               Yes
+VCU118    GTYE4    Yes               Yes
+========  =======  ================  ==================
 
-It builds a Vivado project for a specific carrier and configuration, producing
-files such as GT_Type_cfng.txt and, for GTXE2 devices,
-gtxe2_<plltype>_<rate>_<refclk>_common.v. These files are later parsed by
+The required parameters are:
+
+- **LANE_RATE**: Lane speed in Gbps (applies to both TX and RX)
+- **REF_CLK**: Reference clock frequency in MHz
+- **PLL_TYPE**: The type of PLL used (CPLL, QPLL, QPLL0 or QPLL1)
+
+The following optional parameters are also supported:
+
+- **JESD_MODE**: Link layer encoding mode (``8B10B`` or ``64B66B``, default:
+  ``8B10B``). The xcvr_wizard and generator scripts support both modes on GTHE4
+  and GTYE4 transceivers. Each calling project defines whether it uses this
+  parameter.
+- **XCVR_RX_PLL_TYPE**: PLL type for the RX path (e.g., CPLL when TX uses QPLL0)
+- **XCVR_RX_LANE_RATE**: Lane speed in Gbps for the RX path
+- **XCVR_RX_REF_CLK**: Reference clock frequency in MHz for the RX path
+
+When the RX parameters are not provided (or set to empty ``{}``), the RX path
+uses the same values as TX, preserving backward compatibility.
+
+The project builds a Vivado design for a specific carrier and configuration,
+producing files such as ``GT_Type_cfng.txt`` and, for GTXE2 devices,
+``gtxe2_<plltype>_<rate>_<refclk>_common.v``. These files are later parsed by
 automation scripts to extract only the required configuration parameters.
 
 adi_xcvr_project
 *******************************************************************************
 
-This function builds the `xcvr_wizard` using user-defined parameters. These
+This function builds the ``xcvr_wizard`` using user-defined parameters. These
 values define the configuration for which the transceiver settings will be
-generated. The function returns a dictionary (`xcvr_config_paths`) with the
+generated. The function returns a dictionary (``xcvr_config_paths``) with the
 paths to the generated files.
 
-In the HDL build flow, it is called from `system_project.tcl`, located in the
-carrier-specific folder (e.g., `projects/<carrier>/system_project.tcl`).
+In the HDL build flow, it is called from ``system_project.tcl``, located in the
+carrier-specific folder (e.g., ``projects/<project>/carrier/system_project.tcl``).
 
-**Example:**
+**Basic example** (same PLL for TX and RX):
 
 .. code-block:: tcl
 
@@ -115,6 +155,28 @@ carrier-specific folder (e.g., `projects/<carrier>/system_project.tcl`).
      REF_CLK 500
      PLL_TYPE QPLL
    ]]
+
+**Example with different TX/RX lane rates and PLL types**:
+
+.. code-block:: tcl
+
+   global xcvr_config_paths
+
+   set xcvr_config_paths [adi_xcvr_project [list
+     LANE_RATE          [get_env_param LANE_RATE             4]
+     REF_CLK            [get_env_param REF_CLK             100]
+     PLL_TYPE           [get_env_param PLL_TYPE          QPLL0]
+     JESD_MODE          [get_env_param JESD_MODE         8B10B]
+     XCVR_RX_PLL_TYPE   [get_env_param XCVR_RX_PLL_TYPE   CPLL]
+     XCVR_RX_LANE_RATE  [get_env_param XCVR_RX_LANE_RATE     2]
+   ]]
+
+These parameters can also be overridden from the command line:
+
+.. code-block:: bash
+
+   make LANE_RATE=10 REF_CLK=250 PLL_TYPE=QPLL0
+   make JESD_MODE=8B10B RX_LANE_RATE=2 TX_LANE_RATE=4 RX_JESD_M=8 RX_JESD_L=2 RX_JESD_S=1 TX_JESD_M=8 TX_JESD_L=4 TX_JESD_S=1 PLL_TYPE=QPLL0 REF_CLK=100 LANE_RATE=4 XCVR_RX_PLL_TYPE=CPLL XCVR_RX_LANE_RATE=2
 
 adi_xcvr_parameters
 *******************************************************************************
@@ -158,20 +220,20 @@ the Shared Logic section in order to have both COMMON and CHANNEL instances in
 the generated code.
 
 Line Rate and RefClk Selection
-********************************************************************************
+*******************************************************************************
 
 First, you need to select **JESD204** as targeted **protocol** and specify your
 **line rate** and **reference clock**. A valid reference clock depends on your
-line rate. Make sure that you're using a valid reference clock form the drop-down
-list. Also you should set the used **PLLs** for **TX** and **RX**. If your line
-rate is equal for both directions, you can use the same PLL. Be aware that each
-PLL's VCO has a different frequency range where the circuit can function
-correctly. If your targeted line rate is too high or too low, you may be
-restricted to use just one of the two PLLs. All other settings can be left on
+line rate. Make sure that you're using a valid reference clock form the
+drop-down list. Also you should set the used **PLLs** for **TX** and **RX**. If
+your line rate is equal for both directions, you can use the same PLL. Be aware
+that each PLL's VCO has a different frequency range where the circuit can
+function correctly. If your targeted line rate is too high or too low, you may
+be restricted to use just one of the two PLLs. All other settings can be left on
 their default value in this tab.
 
 Encoding and Clocking
-********************************************************************************
+*******************************************************************************
 
 If you selected **JESD204** to be the used protocol, you don't have to change
 anything here. The JESD204B interface is using 8B/10B encoding/decoding, and
@@ -182,13 +244,13 @@ the TXOUTCLK and RXOUTCLK source selection, you can leave the options unchecked,
 as both clocks are already using PLLREFCLK as their source.
 
 Other tabs
-********************************************************************************
+*******************************************************************************
 
 The setting from the tabs **PCIe, SATA, PRBS** and **CB and CC Sequence** can
 be left to their default values.
 
 Generated files
-''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
+'''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
 
 Location of the **COMMON** instance:
  - <project_name>/<project_name>.gen/sources_1/ip/<component_name>/<component_name>_common.v
@@ -206,27 +268,28 @@ These instances should be compared with the COMMON and CHANNEL instances used in
 :git-hdl:`util_adxcvr_xch.v <library/xilinx/util_adxcvr/util_adxcvr_xch.v>`.
 
 Ultrascale FPGAs Transceiver Wizard
-********************************************************************************
+*******************************************************************************
 
 The overall workflow with the Ultrascale FPGAs Transceiver Wizard is similar to
 the 7 Series one, it just has a different GUI. To open up the wizard in the
-**Project Manager** select **IP Catalog** and search after the keyword **wizard**,
-then select the **Ultrascale FPGAs Transceivers Wizard**. You can define a
-custom name for your component and leave it on default. The tools should
-recognize your transceiver type automatically, if not, you may have to double
-check if you have the right FPGA device selected for your project. To apply the
-general JESD204B setting, select the **GTH-JESD204 preset**. In the first tab,
-called **Basic** you can find all the necessary settings. Select the targeted
-**line rate, PLL** and **reference clock**. The tool will tell you what PLL and
-reference clock can be used with a specific line rate. Note that the current
-version of the util_adxcvr core does not support **QPLL Fractional-N option**.
+**Project Manager** select **IP Catalog** and search after the keyword
+**wizard**, then select the **Ultrascale FPGAs Transceivers Wizard**. You can
+define a custom name for your component and leave it on default. The tools
+should recognize your transceiver type automatically, if not, you may have to
+double check if you have the right FPGA device selected for your project. To
+apply the general JESD204B setting, select the **GTH-JESD204 preset**. In the
+first tab, called **Basic** you can find all the necessary settings. Select the
+targeted **line rate, PLL** and **reference clock**. The tool will tell you what
+PLL and reference clock can be used with a specific line rate. Note that the
+current version of the util_adxcvr core does not support **QPLL Fractional-N
+option**.
 
 To have both COMMON and CHANNEL instances inside the generated core, in the
-**Structural Options** tab the **Include transceiver COMMON in the Core**
-option must be selected.
+**Structural Options** tab the **Include transceiver COMMON in the Core** option
+must be selected.
 
 Generated files
-''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
+'''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
 
 To find the actual instance attributes, two different files should be examined.
 A generic one, which contains the actual software macro instance, and a wrapper,
@@ -262,12 +325,12 @@ and :git-hdl:`util_adxcvr_xch.v <library/xilinx/util_adxcvr/util_adxcvr_xch.v>` 
 .. _xgt_wizard_generator_script:
 
 Using the generator script
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. warning::
 
-   If you are using Windows, please use the ad_gth_generator command followed
-   by the parsing script call, since the get_diff_params only works for linux
+   If you are using Windows, please use the ad_gth_generator command followed by
+   the parsing script call, since the get_diff_params only works for linux
    systems
 
 Open the TCL console inside your Vivado project. Source gtwizard_generator.tcl
@@ -277,12 +340,12 @@ Open the TCL console inside your Vivado project. Source gtwizard_generator.tcl
    source ../../scripts/gtwizard_generator.tcl
 
 Generating configuration
-********************************************************************************
+*******************************************************************************
 
 Here you have 2 options.
 
 ad_gth_generator
-''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
+'''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
 
 **Recommended method for generating multiple configurations**
 
@@ -297,8 +360,8 @@ ad_gth_generator with the desired parameters.
 The first parameter represents the lane rate that will be set to both RX and TX.
 The second one can be CPLL, QPLL, QPLL0, QPLL1, depending on the transceiver of
 the board. The third one is the reference clock. If left empty, then it will be
-filled with all the viable values for the lane rate given. This feature does
-not work at the moment for GTXE2 transceivers.
+filled with all the viable values for the lane rate given. This feature does not
+work at the moment for GTXE2 transceivers.
 
 .. code-block:: tcl
 
@@ -310,25 +373,32 @@ IPs with all the combinations between the lane rate and reference clock.
 
 .. code-block:: tcl
 
-   ad_gth_generator {9.8304 4.9152} QPLL0 {245.76 122.88} false
+   ad_gth_generator {9.8304 4.9152} QPLL0 {245.76 122.88}
 
 This call makes 4 instances of transceivers. Now you can double click on the
 <ip_name>.xci from the sources window to further customize the IP, including
-configurations where RX and TX have different rates. After you are all set,
-run the Parsing_script to get the list of parameters that need to be changed
-into the project.
+configurations where RX and TX have different rates. After you are all set, run
+the Parsing_script to get the list of parameters that need to be changed into
+the project.
+
+The optional fourth parameter selects the JESD mode (``8B10B`` or ``64B66B``,
+default: ``8B10B``). Three additional optional parameters allow configuring the
+RX path independently from TX:
+
+.. code-block:: tcl
+
+   ad_gth_generator {9.8304} QPLL0 {245.76} 8B10B CPLL {} {}
+
+The fifth parameter is the RX PLL type, the sixth is the RX lane rate and the
+seventh is the RX reference clock. When left empty, they default to the TX
+values.
 
 get_diff_params
-''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
+'''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
 
 **Recommended method for generating a single configuration**
 
 This function generates the IP and calls the parsing script.
-
-.. note::
-
-   This method works only with configurations where TX and RX have the same
-   lane rate
 
 Call the get_diff_params method with the desired parameters.
 
@@ -336,36 +406,43 @@ Call the get_diff_params method with the desired parameters.
 
    get_diff_params 15.4 QPLL0 385
 
-The first parameter represents the lane rate that will be set to both RX and
-TX. The second one can be CPLL, QPLL0, QPLL1. The third one is the reference
-clock. If left empty, then it will be filled with all the viable values for
-the lane rate given.
+The first parameter represents the lane rate that will be set to both RX and TX.
+The second one can be CPLL, QPLL0, QPLL1. The third one is the reference clock.
+If left empty, then it will be filled with all the viable values for the lane
+rate given.
+
+The optional fourth parameter selects the JESD mode (``8B10B`` or ``64B66B``,
+default: ``8B10B``). Three additional optional parameters (5th, 6th, 7th) allow
+configuring the RX path independently. When left empty, they default to the TX
+values:
 
 .. code-block:: tcl
 
-   get_diff_params {9.8304} QPLL0 {} false
+   get_diff_params {9.8304} QPLL0 {245.76} 8B10B CPLL {} {}
 
-The fourth parameter is optional. If you set it to false, the script will
-remove from the project and delete from disk the generated IPs after the
+The 8th parameter controls IP cleanup. If you set it to ``false``, the script
+will remove from the project and delete from disk the generated IPs after the
 list of parameters is done, so you don't have to do that manually.
 
-Both the first and the third parameters are actually lists, so you can use
-that to generate multiple configurations. Keep in mind that the script will
-generate IPs with all the combinations between the lane rate and reference
-clock.
+.. code-block:: tcl
+
+   get_diff_params {9.8304} QPLL0 {} 8B10B {} {} {} false
+
+Both the first and the third parameters are actually lists, so you can use that
+to generate multiple configurations. Keep in mind that the script will generate
+IPs with all the combinations between the lane rate and reference clock.
 
 .. code-block:: tcl
 
-   get_diff_params {9.8304 4.9152} QPLL0 {245.76 122.88} false
+   get_diff_params {9.8304 4.9152} QPLL0 {245.76 122.88}
 
-This call makes 4 instances of transceivers, and also deletes them after
-generating the list because of the 4th parameter is set to false.
+This call makes 4 instances of transceivers.
 
 Parsing script
-********************************************************************************
+*******************************************************************************
 
-If you used the get_diff_params method from the script to generate the IP,
-there is no need to call it again.
+If you used the get_diff_params method from the script to generate the IP, there
+is no need to call it again.
 
 If you used the ad_gth_generator method from the script, you will have to call
 the parsing script from the shell, as explained below.
@@ -381,10 +458,10 @@ the gtwiz_parser.pl script, specifying the GT type as in the example.
    ../../../../../scripts/gtwiz_parser.pl GTHE4
 
 If you run the script wile having multiple configurations, it will include the
-unique parameters for each IP, plus the gt_global list that contains the
-common parameters within generated configurations that are different from the
-default values. Now, you should find the files at <project_name>.gen/sources_1/ip
-Make sure to overwrite the list from system_bd with the one in <GT_Type>_cfng.txt.
+unique parameters for each IP, plus the gt_global list that contains the common
+parameters within generated configurations that are different from the default
+values. Now, you should find the files at <project_name>.gen/sources_1/ip Make
+sure to overwrite the list from system_bd with the one in <GT_Type>_cfng.txt.
 
 .. warning::
 
@@ -392,30 +469,31 @@ Make sure to overwrite the list from system_bd with the one in <GT_Type>_cfng.tx
    paring script will not work
 
 Output products
-********************************************************************************
+*******************************************************************************
 
 Output products can be found at this location: <project_name>.gen/sources_1/ip
 
 Most of the output files make sense in the context of parsing multiple
 configurations at once. If this is not the case, and you just used it to
-generate a single configuration, then the only file you need is <GT_Type>_cfng.txt.
+generate a single configuration, then the only file you need is
+<GT_Type>_cfng.txt.
 
 If you had multiple configurations, all the output files should give you some
 valuable information.
 
 GT_Type_cfng.txt
-''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
+'''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
 
 This file contains 2 lists. The first one is a list of parameters that are
 unique for the desired configuration/configurations, different from the default
 values, and these parameters should be written into the system_bd file for your
 project. The next list called “gt_global” is a list of parameters that are
 common between the multiple generated configurations. These are also only the
-ones different from the default ones. This list should be empty if you have
-only one configuration generated.
+ones different from the default ones. This list should be empty if you have only
+one configuration generated.
 
 GT_Type_var_dist.txt
-''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
+'''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
 
 Here you will find a list with the distribution of each DRP attribute in
 relation to the lane rates of your instances.
@@ -451,7 +529,7 @@ relation to the lane rates of your instances.
          };
 
 GT_Type_vco_dist.txt
-''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
+'''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
 
 Here you will find a list with the distribution of each DRP attribute in
 relation to the VCO frequency of your instances. If this list is empty, that
@@ -459,17 +537,17 @@ means that the attributes are the same for the used VCOs (Probably all the
 instances have the same VCO) This should look similar to “GT_Type_var_dist.txt”
 
 table_common.csv
-''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
+'''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
 
-This is a table containing 3 columns: The first one is the name of the parameter.
-The second one is the default value for that parameter, and it is that value
-found in the util_adxcvr file. The third column is called gt_global, and it
-contains the value that all the configurations have in common, but is different
-from the default. If there is an empty cell in this column, it means that there
-is used the default value.
+This is a table containing 3 columns: The first one is the name of the
+parameter. The second one is the default value for that parameter, and it is
+that value found in the util_adxcvr file. The third column is called gt_global,
+and it contains the value that all the configurations have in common, but is
+different from the default. If there is an empty cell in this column, it means
+that there is used the default value.
 
 table_unique.csv
-''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
+'''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
 
 This table contains the unique parameters for each individual configurations.
 The values found here are the ones that differ among your generated
@@ -479,7 +557,7 @@ configurations.
 
    If you encounter errors using the script, please make sure that you have the
    <project_name>.gen/sources_1/ip and <project_name>.srcs/sources_1/ip folders
-   clear from other previous gtwizard IP instances. Also, the script uses git
-   to update the default util_adxcvr files, and it will probably not work if
-   you are in detached HEAD state, or any state that could generate git
-   conflicts with it.
+   clear from other previous gtwizard IP instances. Also, the script uses git to
+   update the default util_adxcvr files, and it will probably not work if you
+   are in detached HEAD state, or any state that could generate git conflicts
+   with it.

--- a/library/xilinx/scripts/xcvr_automation.tcl
+++ b/library/xilinx/scripts/xcvr_automation.tcl
@@ -30,6 +30,7 @@ proc adi_xcvr_parameters {file_paths parameters} {
         "QPLL_CP_G3" "10'b0000011111"
         "QPLL_LPF" "10'b0100110111"
         "QPLL_CP" "10'b0001111111"
+        "QPLLCLKOUT_RATE" "HALF"
         "CPLL_FBDIV" "2"
         "CPLL_FBDIV_4_5" "5"
         "CPLL_CFG0" "16'b0000000111111010"
@@ -125,7 +126,7 @@ proc adi_xcvr_parameters {file_paths parameters} {
         set param [lindex $matches $i+1]
         set value [lindex $matches $i+2]
 
-        set cleaned_value [string map {"\\" ""} $value]
+        set cleaned_value [string map {"\\" "" "\"" ""} $value]
         set corrected_param $param
 
         if {[dict exists $correction_map $param]} {

--- a/library/xilinx/util_adxcvr/util_adxcvr.v
+++ b/library/xilinx/util_adxcvr/util_adxcvr.v
@@ -1,6 +1,6 @@
 // ***************************************************************************
 // ***************************************************************************
-// Copyright (C) 2014-2023 Analog Devices, Inc. All rights reserved.
+// Copyright (C) 2014-2023, 2026 Analog Devices, Inc. All rights reserved.
 //
 // In this HDL repository, there are many different and unique modules, consisting
 // of various HDL (Verilog or VHDL) components. The individual modules are
@@ -68,6 +68,7 @@ module util_adxcvr #(
   parameter   [15:0]  QPLL_CP_G3 = 10'b0000011111,
   parameter   [15:0]  QPLL_LPF = 10'b0100110111,
   parameter   [15:0]  QPLL_CP = 10'b0001111111,
+  parameter           QPLLCLKOUT_RATE = "HALF",
 
   // cpll-configuration
 
@@ -2711,7 +2712,8 @@ module util_adxcvr #(
     .QPLL_CP_G3 (QPLL_CP_G3),
     .QPLL_LPF (QPLL_LPF),
     .QPLL_CP (QPLL_CP),
-    .QPLL_CFG4 (QPLL_CFG4)
+    .QPLL_CFG4 (QPLL_CFG4),
+    .QPLLCLKOUT_RATE (QPLLCLKOUT_RATE)
   ) i_xcm_0 (
     .qpll_ref_clk (qpll_ref_clk_0),
     .qpll_sel (qpll_sel_0),
@@ -3366,7 +3368,8 @@ module util_adxcvr #(
     .QPLL_CP_G3 (QPLL_CP_G3),
     .QPLL_LPF (QPLL_LPF),
     .QPLL_CP (QPLL_CP),
-    .QPLL_CFG4 (QPLL_CFG4)
+    .QPLL_CFG4 (QPLL_CFG4),
+    .QPLLCLKOUT_RATE (QPLLCLKOUT_RATE)
   ) i_xcm_4 (
     .qpll_ref_clk (qpll_ref_clk_4),
     .qpll_sel (qpll_sel_4),
@@ -4021,7 +4024,8 @@ module util_adxcvr #(
     .QPLL_CP_G3 (QPLL_CP_G3),
     .QPLL_LPF (QPLL_LPF),
     .QPLL_CP (QPLL_CP),
-    .QPLL_CFG4 (QPLL_CFG4)
+    .QPLL_CFG4 (QPLL_CFG4),
+    .QPLLCLKOUT_RATE (QPLLCLKOUT_RATE)
   ) i_xcm_8 (
     .qpll_ref_clk (qpll_ref_clk_8),
     .qpll_sel (qpll_sel_8),
@@ -4676,7 +4680,8 @@ module util_adxcvr #(
     .QPLL_CP_G3 (QPLL_CP_G3),
     .QPLL_LPF (QPLL_LPF),
     .QPLL_CP (QPLL_CP),
-    .QPLL_CFG4 (QPLL_CFG4)
+    .QPLL_CFG4 (QPLL_CFG4),
+    .QPLLCLKOUT_RATE (QPLLCLKOUT_RATE)
   ) i_xcm_12 (
     .qpll_ref_clk (qpll_ref_clk_12),
     .qpll_sel (qpll_sel_12),
@@ -5331,7 +5336,8 @@ module util_adxcvr #(
     .QPLL_CP_G3 (QPLL_CP_G3),
     .QPLL_LPF (QPLL_LPF),
     .QPLL_CP (QPLL_CP),
-    .QPLL_CFG4 (QPLL_CFG4)
+    .QPLL_CFG4 (QPLL_CFG4),
+    .QPLLCLKOUT_RATE (QPLLCLKOUT_RATE)
   ) i_xcm_16 (
     .qpll_ref_clk (qpll_ref_clk_16),
     .qpll_sel (qpll_sel_16),
@@ -5986,7 +5992,8 @@ module util_adxcvr #(
     .QPLL_CP_G3 (QPLL_CP_G3),
     .QPLL_LPF (QPLL_LPF),
     .QPLL_CP (QPLL_CP),
-    .QPLL_CFG4 (QPLL_CFG4)
+    .QPLL_CFG4 (QPLL_CFG4),
+    .QPLLCLKOUT_RATE (QPLLCLKOUT_RATE)
   ) i_xcm_20 (
     .qpll_ref_clk (qpll_ref_clk_20),
     .qpll_sel (qpll_sel_20),
@@ -6641,7 +6648,8 @@ module util_adxcvr #(
     .QPLL_CP_G3 (QPLL_CP_G3),
     .QPLL_LPF (QPLL_LPF),
     .QPLL_CP (QPLL_CP),
-    .QPLL_CFG4 (QPLL_CFG4)
+    .QPLL_CFG4 (QPLL_CFG4),
+    .QPLLCLKOUT_RATE (QPLLCLKOUT_RATE)
   ) i_xcm_24 (
     .qpll_ref_clk (qpll_ref_clk_24),
     .qpll_sel (qpll_sel_24),
@@ -7296,7 +7304,8 @@ module util_adxcvr #(
     .QPLL_CP_G3 (QPLL_CP_G3),
     .QPLL_LPF (QPLL_LPF),
     .QPLL_CP (QPLL_CP),
-    .QPLL_CFG4 (QPLL_CFG4)
+    .QPLL_CFG4 (QPLL_CFG4),
+    .QPLLCLKOUT_RATE (QPLLCLKOUT_RATE)
   ) i_xcm_28 (
     .qpll_ref_clk (qpll_ref_clk_28),
     .qpll_sel (qpll_sel_28),

--- a/library/xilinx/util_adxcvr/util_adxcvr_xcm.v
+++ b/library/xilinx/util_adxcvr/util_adxcvr_xcm.v
@@ -1,6 +1,6 @@
 // ***************************************************************************
 // ***************************************************************************
-// Copyright (C) 2014-2023 Analog Devices, Inc. All rights reserved.
+// Copyright (C) 2014-2023, 2026 Analog Devices, Inc. All rights reserved.
 //
 // In this HDL repository, there are many different and unique modules, consisting
 // of various HDL (Verilog or VHDL) components. The individual modules are
@@ -56,7 +56,8 @@ module util_adxcvr_xcm #(
   parameter   [15:0]  QPLL_CFG4 = 16'b0000000000000011,
   parameter   [15:0]  QPLL_CP_G3 = 10'b0000011111,
   parameter   [15:0]  QPLL_LPF = 10'b0100110111,
-  parameter   [15:0]  QPLL_CP = 10'b0001111111
+  parameter   [15:0]  QPLL_CP = 10'b0001111111,
+  parameter           QPLLCLKOUT_RATE = "HALF"
 ) (
 
   // reset and clocks
@@ -384,7 +385,7 @@ module util_adxcvr_xcm #(
     .POR_CFG (POR_CFG),
     .PPF0_CFG (PPF0_CFG),
     .PPF1_CFG (PPF1_CFG),
-    .QPLL0CLKOUT_RATE ("HALF"),
+    .QPLL0CLKOUT_RATE (QPLLCLKOUT_RATE),
     .QPLL0_CFG0 (QPLL_CFG0),
     .QPLL0_CFG1 (QPLL_CFG1),
     .QPLL0_CFG1_G3 (QPLL_CFG1_G3),
@@ -408,7 +409,7 @@ module util_adxcvr_xcm #(
     .QPLL0_SDM_CFG0 (16'b0000000010000000),
     .QPLL0_SDM_CFG1 (16'b0000000000000000),
     .QPLL0_SDM_CFG2 (16'b0000000000000000),
-    .QPLL1CLKOUT_RATE ("HALF"),
+    .QPLL1CLKOUT_RATE (QPLLCLKOUT_RATE),
     .QPLL1_CFG0 (QPLL_CFG0),
     .QPLL1_CFG1 (QPLL_CFG1),
     .QPLL1_CFG1_G3 (QPLL_CFG1_G3),
@@ -559,7 +560,7 @@ module util_adxcvr_xcm #(
       .POR_CFG (16'b0000000000000000),
       .PPF0_CFG (PPF0_CFG),
       .PPF1_CFG (PPF1_CFG),
-      .QPLL0CLKOUT_RATE ("HALF"),
+      .QPLL0CLKOUT_RATE (QPLLCLKOUT_RATE),
       .QPLL0_CFG0 (QPLL_CFG0),
       .QPLL0_CFG1 (QPLL_CFG1),
       .QPLL0_CFG1_G3 (QPLL_CFG1_G3),
@@ -583,7 +584,7 @@ module util_adxcvr_xcm #(
       .QPLL0_SDM_CFG0 (16'b0000000010000000),
       .QPLL0_SDM_CFG1 (16'b0000000000000000),
       .QPLL0_SDM_CFG2 (16'b0000000000000000),
-      .QPLL1CLKOUT_RATE ("HALF"),
+      .QPLL1CLKOUT_RATE (QPLLCLKOUT_RATE),
       .QPLL1_CFG0 (QPLL_CFG0),
       .QPLL1_CFG1 (QPLL_CFG1),
       .QPLL1_CFG1_G3 (QPLL_CFG1_G3),

--- a/projects/ad9081_fmca_ebz/README.md
+++ b/projects/ad9081_fmca_ebz/README.md
@@ -1,12 +1,13 @@
 # AD9081-FMCA-EBZ HDL Project
 
-- Evaluation board product pages: 
+- Evaluation board product pages:
   - [EVAL-AD9081](https://www.analog.com/eval-ad9081)
   - [EVAL-AD9082](https://www.analog.com/eval-ad9082)
   - [EVAL-AD9986](https://www.analog.com/eval-ad9986)
   - [EVAL-AD9988](https://www.analog.com/eval-ad9988)
 - System documentation: https://wiki.analog.com/resources/eval/user-guides/ad9081_fmca_ebz/quickstart
 - HDL project documentation: https://analogdevicesinc.github.io/hdl/projects/ad9081_fmca_ebz/index.html
+- Transceiver configuration support for Xilinx carriers (xcvr_wizard): https://analogdevicesinc.github.io/hdl/library/jesd204/xgt_wizard/index.html
 - Evaluation board VADJ range: 1.2V - 3.3V
 
 ## Supported parts

--- a/projects/ad9081_fmca_ebz/common/ad9081_fmca_ebz_bd.tcl
+++ b/projects/ad9081_fmca_ebz/common/ad9081_fmca_ebz_bd.tcl
@@ -27,6 +27,7 @@ if {![info exists ADI_PHY_SEL]} {
 source $ad_hdl_dir/projects/common/xilinx/data_offload_bd.tcl
 source $ad_hdl_dir/library/jesd204/scripts/jesd204.tcl
 source $ad_hdl_dir/library/axi_tdd/scripts/axi_tdd.tcl
+source $ad_hdl_dir/library/xilinx/scripts/xcvr_automation.tcl
 
 if {![info exists INTF_CFG]} {
   set INTF_CFG RXTX
@@ -166,38 +167,33 @@ if {!$ADI_PHY_SEL} {
 }
 
 # common xcvr
+
+global xcvr_config_paths
+
 if {$ADI_PHY_SEL == 1} {
-  ad_ip_instance util_adxcvr util_mxfe_xcvr
-  ad_ip_parameter util_mxfe_xcvr CONFIG.CPLL_FBDIV_4_5 5
   switch $INTF_CFG {
     "RXTX" {
-      # Rx & Tx
-      ad_ip_parameter util_mxfe_xcvr CONFIG.TX_NUM_OF_LANES $TX_NUM_OF_LANES
-      ad_ip_parameter util_mxfe_xcvr CONFIG.RX_NUM_OF_LANES $RX_NUM_OF_LANES
-      ad_ip_parameter util_mxfe_xcvr CONFIG.RX_OUT_DIV 1
-      ad_ip_parameter util_mxfe_xcvr CONFIG.LINK_MODE $ENCODER_SEL
-      ad_ip_parameter util_mxfe_xcvr CONFIG.RX_LANE_RATE $RX_LANE_RATE
-      ad_ip_parameter util_mxfe_xcvr CONFIG.TX_LANE_RATE $TX_LANE_RATE
     }
     "RX" {
       # Rx only
-      ad_ip_parameter util_mxfe_xcvr CONFIG.TX_NUM_OF_LANES 0
-      ad_ip_parameter util_mxfe_xcvr CONFIG.RX_NUM_OF_LANES $RX_NUM_OF_LANES
-      ad_ip_parameter util_mxfe_xcvr CONFIG.RX_OUT_DIV 1
-      ad_ip_parameter util_mxfe_xcvr CONFIG.LINK_MODE $ENCODER_SEL
-      ad_ip_parameter util_mxfe_xcvr CONFIG.RX_LANE_RATE $RX_LANE_RATE
-      ad_ip_parameter util_mxfe_xcvr CONFIG.TX_LANE_RATE 0
+      set TX_NUM_OF_LANES 0
+      set TX_LANE_RATE 0
     }
     "TX" {
       # Tx only
-      ad_ip_parameter util_mxfe_xcvr CONFIG.TX_NUM_OF_LANES $TX_NUM_OF_LANES
-      ad_ip_parameter util_mxfe_xcvr CONFIG.RX_NUM_OF_LANES 0
-      ad_ip_parameter util_mxfe_xcvr CONFIG.RX_OUT_DIV 1
-      ad_ip_parameter util_mxfe_xcvr CONFIG.LINK_MODE $ENCODER_SEL
-      ad_ip_parameter util_mxfe_xcvr CONFIG.RX_LANE_RATE 0
-      ad_ip_parameter util_mxfe_xcvr CONFIG.TX_LANE_RATE $TX_LANE_RATE
+      set RX_NUM_OF_LANES 0
+      set RX_LANE_RATE 0
     }
   }
+
+  set util_adxcvr_parameters [adi_xcvr_parameters $xcvr_config_paths [list \
+    RX_NUM_OF_LANES $RX_NUM_OF_LANES\
+    TX_NUM_OF_LANES $TX_NUM_OF_LANES\
+    RX_LANE_RATE $RX_LANE_RATE\
+    TX_LANE_RATE $TX_LANE_RATE\
+    LINK_MODE $ENCODER_SEL\
+  ]]
+  ad_ip_instance util_adxcvr util_mxfe_xcvr $util_adxcvr_parameters
 } else {
   source $ad_hdl_dir/library/xilinx/scripts/versal_xcvr_subsystem.tcl
 

--- a/projects/ad9081_fmca_ebz/vcu118/system_bd.tcl
+++ b/projects/ad9081_fmca_ebz/vcu118/system_bd.tcl
@@ -1,5 +1,5 @@
 ###############################################################################
-## Copyright (C) 2019-2025 Analog Devices, Inc. All rights reserved.
+## Copyright (C) 2019-2026 Analog Devices, Inc. All rights reserved.
 ### SPDX short identifier: ADIBSD
 ###############################################################################
 
@@ -44,104 +44,11 @@ KS/CH=$ad_project_params(TX_KS_PER_CHANNEL)"
 
 sysid_gen_sys_init_file $sys_cstring 10
 
-# Parameters for 15.5Gpbs lane rate
-
-ad_ip_parameter util_mxfe_xcvr CONFIG.RX_CLK25_DIV 31
-ad_ip_parameter util_mxfe_xcvr CONFIG.TX_CLK25_DIV 31
-ad_ip_parameter util_mxfe_xcvr CONFIG.CPLL_CFG0 0x1fa
-ad_ip_parameter util_mxfe_xcvr CONFIG.CPLL_CFG1 0x2b
-ad_ip_parameter util_mxfe_xcvr CONFIG.CPLL_CFG2 0x2
-ad_ip_parameter util_mxfe_xcvr CONFIG.CPLL_FBDIV 2
-ad_ip_parameter util_mxfe_xcvr CONFIG.CH_HSPMUX 0x4040
-ad_ip_parameter util_mxfe_xcvr CONFIG.PREIQ_FREQ_BST 1
-ad_ip_parameter util_mxfe_xcvr CONFIG.RTX_BUF_CML_CTRL 0x5
-ad_ip_parameter util_mxfe_xcvr CONFIG.RXPI_CFG0 0x3002
-ad_ip_parameter util_mxfe_xcvr CONFIG.RXCDR_CFG2 0x1E9
-ad_ip_parameter util_mxfe_xcvr CONFIG.RXCDR_CFG3 0x23
-ad_ip_parameter util_mxfe_xcvr CONFIG.RXCDR_CFG3_GEN2 0x23
-ad_ip_parameter util_mxfe_xcvr CONFIG.RXCDR_CFG3_GEN3 0x23
-ad_ip_parameter util_mxfe_xcvr CONFIG.RXCDR_CFG3_GEN4 0x23
-ad_ip_parameter util_mxfe_xcvr CONFIG.RX_WIDEMODE_CDR 0x1
-ad_ip_parameter util_mxfe_xcvr CONFIG.RX_XMODE_SEL 0x0
-ad_ip_parameter util_mxfe_xcvr CONFIG.TXDRV_FREQBAND 1
-ad_ip_parameter util_mxfe_xcvr CONFIG.TXFE_CFG1 0xAA00
-ad_ip_parameter util_mxfe_xcvr CONFIG.TXFE_CFG2 0xAA00
-ad_ip_parameter util_mxfe_xcvr CONFIG.TXFE_CFG3 0xAA00
-ad_ip_parameter util_mxfe_xcvr CONFIG.TXPI_CFG0 0x3100
-ad_ip_parameter util_mxfe_xcvr CONFIG.TXPI_CFG1 0x0
-ad_ip_parameter util_mxfe_xcvr CONFIG.TX_PI_BIASSET 1
-ad_ip_parameter util_mxfe_xcvr CONFIG.RXPI_CFG1 0x54
-
-ad_ip_parameter util_mxfe_xcvr CONFIG.QPLL_REFCLK_DIV 1
-ad_ip_parameter util_mxfe_xcvr CONFIG.QPLL_CFG0 0x333c
-ad_ip_parameter util_mxfe_xcvr CONFIG.QPLL_CFG4 0x2
-ad_ip_parameter util_mxfe_xcvr CONFIG.QPLL_FBDIV 20
-ad_ip_parameter util_mxfe_xcvr CONFIG.PPF0_CFG 0xB00
-ad_ip_parameter util_mxfe_xcvr CONFIG.QPLL_LPF 0x2ff
-
 # 204C params 16.5Gbps..24.75Gpbs
 if {$ad_project_params(JESD_MODE) == "64B66B"} {
 
   # Set higher swing for the diff driver, other case 16.5Gbps won't work
   ad_ip_parameter axi_mxfe_tx_xcvr CONFIG.TX_DIFFCTRL 0xC
-
-  # Lane rate indepentent parameters
-  ad_ip_parameter util_mxfe_xcvr CONFIG.RXCDR_CFG3_GEN2 0x12
-  ad_ip_parameter util_mxfe_xcvr CONFIG.RXCDR_CFG3_GEN3 0x12
-  ad_ip_parameter util_mxfe_xcvr CONFIG.RXCDR_CFG3_GEN4 0x12
-  ad_ip_parameter util_mxfe_xcvr CONFIG.RXPI_CFG1 0x0
-  ad_ip_parameter util_mxfe_xcvr CONFIG.RX_WIDEMODE_CDR 0x2
-  ad_ip_parameter util_mxfe_xcvr CONFIG.CH_HSPMUX 0x6060
-  ad_ip_parameter util_mxfe_xcvr CONFIG.PREIQ_FREQ_BST 2
-  ad_ip_parameter util_mxfe_xcvr CONFIG.TX_PI_BIASSET 2
-  ad_ip_parameter util_mxfe_xcvr CONFIG.RXDFE_KH_CFG2 0x281C
-  ad_ip_parameter util_mxfe_xcvr CONFIG.RXDFE_KH_CFG3 0x4120
-
-  # Lane rate indepentent QPLL parameters
-  ad_ip_parameter util_mxfe_xcvr CONFIG.PPF0_CFG 0x600
-  ad_ip_parameter util_mxfe_xcvr CONFIG.QPLL_CFG0 0x331c
-
-  # Lane rate dependent QPLL params (these match for 16.5 Gbps and 24.75 Gpbs)
-  ad_ip_parameter util_mxfe_xcvr CONFIG.PPF1_CFG 0x400
-  ad_ip_parameter util_mxfe_xcvr CONFIG.QPLL_LPF 0x33f
-  ad_ip_parameter util_mxfe_xcvr CONFIG.QPLL_CFG2 0x0FC1
-  ad_ip_parameter util_mxfe_xcvr CONFIG.QPLL_CFG2_G3 0x0FC1
-  ad_ip_parameter util_mxfe_xcvr CONFIG.QPLL_CFG4 0x03
-
-  # set dividers for 24.75Gbps, are overwritten by software
-  ad_ip_parameter util_mxfe_xcvr CONFIG.RX_CLK25_DIV 10
-  ad_ip_parameter util_mxfe_xcvr CONFIG.TX_CLK25_DIV 10
-  ad_ip_parameter util_mxfe_xcvr CONFIG.QPLL_FBDIV 66
-  ad_ip_parameter util_mxfe_xcvr CONFIG.QPLL_REFCLK_DIV 2
-
-  if {$ad_project_params(RX_LANE_RATE) < 20} {
-    ad_ip_parameter util_mxfe_xcvr CONFIG.RTX_BUF_CML_CTRL 0x5
-    ad_ip_parameter util_mxfe_xcvr CONFIG.RXPI_CFG0 0x0104
-  } else {
-    ad_ip_parameter util_mxfe_xcvr CONFIG.RTX_BUF_CML_CTRL 0x6
-    ad_ip_parameter util_mxfe_xcvr CONFIG.RXPI_CFG0 0x3004
-  }
-
-  if {$ad_project_params(TX_LANE_RATE) < 20} {
-    ad_ip_parameter util_mxfe_xcvr CONFIG.TXDRV_FREQBAND   1
-    ad_ip_parameter util_mxfe_xcvr CONFIG.TXFE_CFG0 0x3C2
-    ad_ip_parameter util_mxfe_xcvr CONFIG.TXFE_CFG1 0xAA00
-    ad_ip_parameter util_mxfe_xcvr CONFIG.TXFE_CFG2 0xAA00
-    ad_ip_parameter util_mxfe_xcvr CONFIG.TXFE_CFG3 0xAA00
-    ad_ip_parameter util_mxfe_xcvr CONFIG.TXPI_CFG0 0x0100
-    ad_ip_parameter util_mxfe_xcvr CONFIG.TXPI_CFG1 0x1000
-    ad_ip_parameter util_mxfe_xcvr CONFIG.TXSWBST_EN 0
-  } else {
-    ad_ip_parameter util_mxfe_xcvr CONFIG.TXDRV_FREQBAND   3
-    ad_ip_parameter util_mxfe_xcvr CONFIG.TXFE_CFG0 0x3C6
-    ad_ip_parameter util_mxfe_xcvr CONFIG.TXFE_CFG1 0xF800
-    ad_ip_parameter util_mxfe_xcvr CONFIG.TXFE_CFG2 0xF800
-    ad_ip_parameter util_mxfe_xcvr CONFIG.TXFE_CFG3 0xF800
-    ad_ip_parameter util_mxfe_xcvr CONFIG.TXPI_CFG0 0x3000
-    ad_ip_parameter util_mxfe_xcvr CONFIG.TXPI_CFG1 0x0
-    ad_ip_parameter util_mxfe_xcvr CONFIG.TXSWBST_EN 1
-  }
-
 }
 
 if {$ad_project_params(CORUNDUM) == "1"} {
@@ -276,5 +183,4 @@ if {$ad_project_params(CORUNDUM) == "1"} {
 
     ad_connect output_enable_concat_corundum/dout corundum_hierarchy/output_enable
   }
-
 }

--- a/projects/ad9081_fmca_ebz/vcu118/system_project.tcl
+++ b/projects/ad9081_fmca_ebz/vcu118/system_project.tcl
@@ -1,5 +1,5 @@
 ###############################################################################
-## Copyright (C) 2019-2025 Analog Devices, Inc. All rights reserved.
+## Copyright (C) 2019-2026 Analog Devices, Inc. All rights reserved.
 ### SPDX short identifier: ADIBSD
 ###############################################################################
 
@@ -13,15 +13,40 @@ set ADI_POST_ROUTE_SCRIPT [file normalize $ad_hdl_dir/projects/scripts/auto_timi
 #
 #   Use over-writable parameters from the environment.
 #
-#    e.g.
+#    e.g. JESD only
 #      make JESD_MODE=64B66B RX_LANE_RATE=24.75 TX_LANE_RATE=12.375 RX_JESD_L=4 TX_JESD_L=4
 #      make JESD_MODE=64B66B RX_LANE_RATE=16.22016 TX_LANE_RATE=16.22016 RX_JESD_M=8 RX_JESD_L=2 TX_JESD_M=16 TX_JESD_L=4
 #      make JESD_MODE=64B66B RX_LANE_RATE=16.50 TX_LANE_RATE=16.50 RX_JESD_M=4 RX_JESD_L=4 RX_JESD_S=1 RX_JESD_NP=16 TX_JESD_M=4 TX_JESD_L=4 TX_JESD_S=1 TX_JESD_NP=16
 #      make JESD_MODE=64B66B RX_LANE_RATE=24.75 TX_LANE_RATE=24.75 RX_JESD_M=4 RX_JESD_L=4 RX_JESD_S=2 RX_JESD_NP=12 TX_JESD_M=4 TX_JESD_L=4 TX_JESD_S=2 TX_JESD_NP=12
 #      make JESD_MODE=64B66B RX_LANE_RATE=16.50 TX_LANE_RATE=16.50 RX_JESD_M=4 RX_JESD_L=4 RX_JESD_S=2 RX_JESD_NP=12 TX_JESD_M=4 TX_JESD_L=4 TX_JESD_S=2 TX_JESD_NP=12
-#      make JESD_MODE=8B10B  RX_JESD_L=4 RX_JESD_M=8 TX_JESD_L=4 TX_JESD_M=8
-
+#      make JESD_MODE=8B10B RX_JESD_L=4 RX_JESD_M=8 TX_JESD_L=4 TX_JESD_M=8
 #
+#    e.g. XCVR only
+#      make PLL_TYPE=QPLL0 REF_CLK=500 LANE_RATE=10
+#
+#    e.g. JESD and XCVR
+#      make JESD_MODE=8B10B RX_LANE_RATE=15 TX_LANE_RATE=15 RX_JESD_M=4 RX_JESD_L=8 RX_JESD_S=1 RX_JESD_NP=16 RX_NUM_LINKS=1 \
+#           TX_JESD_M=4 TX_JESD_L=8 TX_JESD_S=1 TX_JESD_NP=16 TX_NUM_LINKS=1 PLL_TYPE=QPLL0 REF_CLK=750 LANE_RATE=15
+#      make JESD_MODE=64B66B RX_LANE_RATE=16.5 TX_LANE_RATE=16.5 RX_JESD_M=4 RX_JESD_L=4 RX_JESD_S=1 RX_JESD_NP=16 RX_NUM_LINKS=1 \
+#           TX_JESD_M=4 TX_JESD_L=4 TX_JESD_S=1 TX_JESD_NP=16 TX_NUM_LINKS=1 PLL_TYPE=QPLL1 REF_CLK=250 LANE_RATE=16.5
+
+global xcvr_config_paths
+
+# Parameter description:
+#   LANE_RATE: Value of lane rate [gbps]
+#   REF_CLK: Value of the reference clock [MHz] (usually LANE_RATE/20 or LANE_RATE/40)
+#   PLL_TYPE: The PLL used for driving the link [CPLL/QPLL1/QPLL0]
+#   XCVR_RX_LANE_RATE: Value of lane rate for the RX link [gbps] (Optional)
+#   XCVR_RX_REF_CLK: Value of the reference clock for the RX link [MHz] (usually XCVR_RX_LANE_RATE/20 or XCVR_RX_LANE_RATE/40) (Optional)
+#   XCVR_RX_PLL_TYPE: The PLL used for driving the RX link [CPLL/QPLL1/QPLL0] (Optional)
+#   JESD_MODE: Used link layer encoder mode [64B66B - JESD 204C, 8B10B - JESD 204B] (Optional)
+
+set xcvr_config_paths [adi_xcvr_project [list \
+  LANE_RATE [get_env_param LANE_RATE   10] \
+  REF_CLK   [get_env_param REF_CLK    500] \
+  PLL_TYPE  [get_env_param PLL_TYPE QPLL0] \
+]]
+
 # Parameter description:
 #   JESD_MODE : Used link layer encoder mode
 #      64B66B - 64b66b link layer defined in JESD 204C
@@ -35,7 +60,6 @@ set ADI_POST_ROUTE_SCRIPT [file normalize $ad_hdl_dir/projects/scripts/auto_timi
 #   [RX/TX]_JESD_NP : Number of bits per sample
 #   [RX/TX]_NUM_LINKS : Number of links
 #   [RX/TX]_KS_PER_CHANNEL : Number of samples stored in internal buffers in kilosamples per converter (M)
-#
 
 adi_project ad9081_fmca_ebz_vcu118 0 [list \
   JESD_MODE         [get_env_param JESD_MODE      8B10B ] \

--- a/projects/ad9081_fmca_ebz/zc706/system_project.tcl
+++ b/projects/ad9081_fmca_ebz/zc706/system_project.tcl
@@ -1,5 +1,5 @@
 ###############################################################################
-## Copyright (C) 2019-2023 Analog Devices, Inc. All rights reserved.
+## Copyright (C) 2019-2023, 2026 Analog Devices, Inc. All rights reserved.
 ### SPDX short identifier: ADIBSD
 ###############################################################################
 
@@ -12,12 +12,35 @@ source $ad_hdl_dir/projects/scripts/adi_board.tcl
 #
 #   Use over-writable parameters from the environment.
 #
-#    e.g.
+#    e.g. JESD only
 #      make RX_JESD_L=4 RX_JESD_M=8 RX_JESD_S=1 TX_JESD_L=4 TX_JESD_M=8 TX_JESD_S=1
 #      make RX_JESD_L=8 RX_JESD_M=4 RX_JESD_S=1 TX_JESD_L=8 TX_JESD_M=4 TX_JESD_S=1
 #      make RX_JESD_L=2 RX_JESD_M=8 RX_JESD_S=1 RX_JESD_NP=12 TX_JESD_L=2 TX_JESD_M=8 TX_JESD_S=1 TX_JESD_NP=12
-
 #
+#    e.g. XCVR only
+#      make PLL_TYPE=QPLL REF_CLK=250 LANE_RATE=10
+#
+#    e.g. JESD and XCVR
+#      make RX_JESD_L=4 RX_JESD_M=8 RX_JESD_S=1 TX_JESD_L=4 TX_JESD_M=8 TX_JESD_S=1 PLL_TYPE=QPLL REF_CLK=250 LANE_RATE=10
+#      make RX_JESD_L=2 RX_JESD_M=8 RX_JESD_S=1 RX_JESD_NP=12 TX_JESD_L=2 TX_JESD_M=8 TX_JESD_S=1 TX_JESD_NP=12 PLL_TYPE=QPLL REF_CLK=250 LANE_RATE=10
+
+global xcvr_config_paths
+
+# Parameter description:
+#   LANE_RATE: Value of lane rate [gbps]
+#   REF_CLK: Value of the reference clock [MHz] (usually LANE_RATE/20 or LANE_RATE/40)
+#   PLL_TYPE: The PLL used for driving the link [CPLL/QPLL]
+#   XCVR_RX_LANE_RATE: Value of lane rate for the RX link [gbps] (Optional)
+#   XCVR_RX_REF_CLK: Value of the reference clock for the RX link [MHz] (usually XCVR_RX_LANE_RATE/20 or XCVR_RX_LANE_RATE/40) (Optional)
+#   XCVR_RX_PLL_TYPE: The PLL used for driving the RX link [CPLL/QPLL1/QPLL0] (Optional)
+#   JESD_MODE: Used link layer encoder mode [default: 8B10B - JESD 204B] (Optional)
+
+set xcvr_config_paths [adi_xcvr_project [list \
+  LANE_RATE [get_env_param LANE_RATE   10] \
+  REF_CLK   [get_env_param REF_CLK    250] \
+  PLL_TYPE  [get_env_param PLL_TYPE  QPLL] \
+]]
+
 # Parameter description:
 #   JESD_MODE : Used link layer encoder mode
 #      64B66B - 64b66b link layer defined in JESD 204C, uses Xilinx IP as Physical layer
@@ -31,7 +54,6 @@ source $ad_hdl_dir/projects/scripts/adi_board.tcl
 #   [RX/TX]_NUM_LINKS : Number of links
 #
 #  !!! For this carrier only 8B10B mode is supported !!!
-#
 
 adi_project ad9081_fmca_ebz_zc706 0 [list \
   JESD_MODE         8B10B \
@@ -58,4 +80,3 @@ adi_project_files ad9081_fmca_ebz_zc706 [list \
   "$ad_hdl_dir/projects/common/zc706/zc706_system_constr.xdc" ]
 
 adi_project_run ad9081_fmca_ebz_zc706
-

--- a/projects/ad9081_fmca_ebz/zcu102/README.md
+++ b/projects/ad9081_fmca_ebz/zcu102/README.md
@@ -41,7 +41,7 @@ The overwritable parameters from the environment are:
 
 ### Example configurations
 
-#### JESD204B subclass 1, TX mode 17, RX mode 18, VCXO 100 MHz (default)
+#### JESD204B subclass 1, TX mode 9, RX mode 10, VCXO 100 MHz (default)
 
 This specific command is equivalent to running `make` only:
 
@@ -51,6 +51,22 @@ RX_LANE_RATE=10 \
 TX_LANE_RATE=10 \
 RX_JESD_M=8 \
 RX_JESD_L=4 \
+RX_JESD_S=1 \
+TX_JESD_M=8 \
+TX_JESD_L=4 \
+TX_JESD_S=1
+```
+
+Corresponding device tree: [zynqmp-zcu102-rev10-ad9081-m8-l4.dts](https://github.com/analogdevicesinc/linux/blob/main/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-ad9081-m8-l4.dts)
+
+#### JESD204B subclass 1, TX mode 17, RX mode 18, VCXO 100 MHz
+
+```
+make JESD_MODE=8B10B \
+RX_LANE_RATE=15 \
+TX_LANE_RATE=15 \
+RX_JESD_M=4 \
+RX_JESD_L=8 \
 RX_JESD_S=1 \
 TX_JESD_M=4 \
 TX_JESD_L=8 \

--- a/projects/ad9081_fmca_ebz/zcu102/system_bd.tcl
+++ b/projects/ad9081_fmca_ebz/zcu102/system_bd.tcl
@@ -1,5 +1,5 @@
 ###############################################################################
-## Copyright (C) 2019-2024 Analog Devices, Inc. All rights reserved.
+## Copyright (C) 2019-2024, 2026 Analog Devices, Inc. All rights reserved.
 ### SPDX short identifier: ADIBSD
 ###############################################################################
 
@@ -59,48 +59,3 @@ SYNC_EXT=$TDD_SYNC_EXT\
 SYNC_EXT_CDC=$TDD_SYNC_EXT_CDC"
 
 sysid_gen_sys_init_file $sys_cstring 10
-
-# Parameters for 15.5Gpbs lane rate
-
-ad_ip_parameter util_mxfe_xcvr CONFIG.RX_CLK25_DIV 31
-ad_ip_parameter util_mxfe_xcvr CONFIG.TX_CLK25_DIV 31
-ad_ip_parameter util_mxfe_xcvr CONFIG.CPLL_CFG0 0x1fa
-ad_ip_parameter util_mxfe_xcvr CONFIG.CPLL_CFG1 0x23
-ad_ip_parameter util_mxfe_xcvr CONFIG.CPLL_CFG2 0x2
-ad_ip_parameter util_mxfe_xcvr CONFIG.CPLL_FBDIV 2
-ad_ip_parameter util_mxfe_xcvr CONFIG.A_TXDIFFCTRL 0xc
-ad_ip_parameter util_mxfe_xcvr CONFIG.RXCDR_CFG0 0x3
-ad_ip_parameter util_mxfe_xcvr CONFIG.RXCDR_CFG2_GEN2 0x265
-ad_ip_parameter util_mxfe_xcvr CONFIG.RXCDR_CFG2_GEN4 0x164
-ad_ip_parameter util_mxfe_xcvr CONFIG.RXCDR_CFG3 0x1A
-ad_ip_parameter util_mxfe_xcvr CONFIG.RXCDR_CFG3_GEN2 0x1A
-ad_ip_parameter util_mxfe_xcvr CONFIG.RXCDR_CFG3_GEN3 0x1A
-ad_ip_parameter util_mxfe_xcvr CONFIG.RXCDR_CFG3_GEN4 0x12
-ad_ip_parameter util_mxfe_xcvr CONFIG.CH_HSPMUX 0x6868
-ad_ip_parameter util_mxfe_xcvr CONFIG.PREIQ_FREQ_BST 1
-ad_ip_parameter util_mxfe_xcvr CONFIG.RXPI_CFG0 0x4
-ad_ip_parameter util_mxfe_xcvr CONFIG.RXPI_CFG1 0x0
-ad_ip_parameter util_mxfe_xcvr CONFIG.TXPI_CFG 0x0
-ad_ip_parameter util_mxfe_xcvr CONFIG.TX_PI_BIASSET 3
-
-ad_ip_parameter util_mxfe_xcvr CONFIG.QPLL_REFCLK_DIV 1
-ad_ip_parameter util_mxfe_xcvr CONFIG.POR_CFG 0x0
-ad_ip_parameter util_mxfe_xcvr CONFIG.QPLL_CFG0 0x333c
-ad_ip_parameter util_mxfe_xcvr CONFIG.QPLL_CFG4 0x45
-ad_ip_parameter util_mxfe_xcvr CONFIG.QPLL_FBDIV 20
-ad_ip_parameter util_mxfe_xcvr CONFIG.PPF0_CFG 0xF00
-ad_ip_parameter util_mxfe_xcvr CONFIG.QPLL_CP 0xFF
-ad_ip_parameter util_mxfe_xcvr CONFIG.QPLL_CP_G3 0xF
-ad_ip_parameter util_mxfe_xcvr CONFIG.QPLL_LPF 0x2FF
-
-# Overwrite parameter for lower lane rates which use CPLL
-if {$ad_project_params(RX_LANE_RATE) < 12} {
-  ad_ip_parameter util_mxfe_xcvr CONFIG.RX_WIDEMODE_CDR 0x0
-  ad_ip_parameter util_mxfe_xcvr CONFIG.RXPI_CFG0 0x200
-  ad_ip_parameter util_mxfe_xcvr CONFIG.RXPI_CFG1 0xFD
-
-  ad_ip_parameter util_mxfe_xcvr CONFIG.RXCDR_CFG3 0x12
-  ad_ip_parameter util_mxfe_xcvr CONFIG.RXCDR_CFG3_GEN2 0x12
-  ad_ip_parameter util_mxfe_xcvr CONFIG.RXCDR_CFG3_GEN3 0x12
-  ad_ip_parameter util_mxfe_xcvr CONFIG.RXCDR_CFG3_GEN4 0x12
-}

--- a/projects/ad9081_fmca_ebz/zcu102/system_project.tcl
+++ b/projects/ad9081_fmca_ebz/zcu102/system_project.tcl
@@ -1,5 +1,5 @@
 ###############################################################################
-## Copyright (C) 2019-2023 Analog Devices, Inc. All rights reserved.
+## Copyright (C) 2019-2023, 2026 Analog Devices, Inc. All rights reserved.
 ### SPDX short identifier: ADIBSD
 ###############################################################################
 
@@ -12,11 +12,35 @@ source $ad_hdl_dir/projects/scripts/adi_board.tcl
 #
 #   Use over-writable parameters from the environment.
 #
-#    e.g.
-#      make RX_JESD_L=4 RX_JESD_M=8 RX_JESD_S=1 TX_JESD_L=4 TX_JESD_M=8 TX_JESD_S=1
-#      make RX_JESD_L=8 RX_JESD_M=4 RX_JESD_S=1 TX_JESD_L=8 TX_JESD_M=4 TX_JESD_S=1
-
+#    e.g. XCVR only
+#      make PLL_TYPE=QPLL0 REF_CLK=500 LANE_RATE=10
 #
+#    e.g. JESD only
+#      make RX_JESD_L=8 RX_JESD_M=4 RX_JESD_S=1 TX_JESD_L=8 TX_JESD_M=4 TX_JESD_S=1
+#
+#    e.g. JESD and XCVR
+#      make JESD_MODE=8B10B RX_LANE_RATE=2 TX_LANE_RATE=4 RX_JESD_M=8 RX_JESD_L=2 RX_JESD_S=1 TX_JESD_M=8 \
+#           TX_JESD_L=4 TX_JESD_S=1 PLL_TYPE=QPLL0 REF_CLK=100 LANE_RATE=4 XCVR_RX_PLL_TYPE=CPLL XCVR_RX_LANE_RATE=2
+#      make JESD_MODE=64B66B RX_LANE_RATE=5.98 TX_LANE_RATE=11.96 RX_JESD_M=8 RX_JESD_L=1 RX_JESD_S=1 RX_JESD_NP=12 \
+#           TX_JESD_M=8 TX_JESD_L=1 TX_JESD_S=1 TX_JESD_NP=12 PLL_TYPE=QPLL0 REF_CLK=362.424242 LANE_RATE=11.96
+
+global xcvr_config_paths
+
+# Parameter description:
+#   LANE_RATE: Value of lane rate [gbps]
+#   REF_CLK: Value of the reference clock [MHz] (usually LANE_RATE/20 or LANE_RATE/40)
+#   PLL_TYPE: The PLL used for driving the link [CPLL/QPLL1/QPLL0]
+#   XCVR_RX_LANE_RATE: Value of lane rate for the RX link [gbps] (Optional)
+#   XCVR_RX_REF_CLK: Value of the reference clock for the RX link [MHz] (usually XCVR_RX_LANE_RATE/20 or XCVR_RX_LANE_RATE/40) (Optional)
+#   XCVR_RX_PLL_TYPE: The PLL used for driving the RX link [CPLL/QPLL1/QPLL0] (Optional)
+#   JESD_MODE: Used link layer encoder mode [64B66B - JESD 204C, 8B10B - JESD 204B] (Optional)
+
+set xcvr_config_paths [adi_xcvr_project [list \
+  LANE_RATE [get_env_param LANE_RATE    10] \
+  REF_CLK   [get_env_param REF_CLK     500] \
+  PLL_TYPE  [get_env_param PLL_TYPE  QPLL0] \
+]]
+
 # Parameter description:
 #   JESD_MODE : Used link layer encoder mode
 #      64B66B - 64b66b link layer defined in JESD 204C, uses Xilinx IP as Physical layer
@@ -28,7 +52,6 @@ source $ad_hdl_dir/projects/scripts/adi_board.tcl
 #   [RX/TX]_JESD_L : Number of lanes per link
 #   [RX/TX]_JESD_NP : Number of bits per sample, only 16 is supported
 #   [RX/TX]_NUM_LINKS : Number of links, matches numer of MxFE devices
-#
 
 adi_project ad9081_fmca_ebz_zcu102 0 [list \
   JESD_MODE        [get_env_param JESD_MODE      8B10B ] \
@@ -63,6 +86,4 @@ adi_project_files ad9081_fmca_ebz_zcu102 [list \
   "$ad_hdl_dir/library/common/ad_iobuf.v" \
   "$ad_hdl_dir/projects/common/zcu102/zcu102_system_constr.xdc" ]
 
-
 adi_project_run ad9081_fmca_ebz_zcu102
-

--- a/projects/adrv9026/README.md
+++ b/projects/adrv9026/README.md
@@ -3,6 +3,7 @@
 - Evaluation board product page: [EVAL-ADRV9026/ADRV9029](https://www.analog.com/eval-adrv9026)
 - System documentation: https://wiki.analog.com/resources/eval/user-guides/adrv9026/quickstart
 - HDL project documentation: https://analogdevicesinc.github.io/hdl/projects/adrv9026/index.html
+- Transceiver configuration support for Xilinx carriers (xcvr_wizard): https://analogdevicesinc.github.io/hdl/library/jesd204/xgt_wizard/index.html
 - Evaluation board VADJ: 1.8V
 
 ## Supported parts

--- a/projects/adrv9026/common/adrv9026_bd.tcl
+++ b/projects/adrv9026/common/adrv9026_bd.tcl
@@ -1,10 +1,11 @@
 ###############################################################################
-## Copyright (C) 2023-2025 Analog Devices, Inc. All rights reserved.
+## Copyright (C) 2023-2026 Analog Devices, Inc. All rights reserved.
 ### SPDX short identifier: ADIBSD
 ###############################################################################
 
 source $ad_hdl_dir/library/jesd204/scripts/jesd204.tcl
 source $ad_hdl_dir/projects/common/xilinx/data_offload_bd.tcl
+source $ad_hdl_dir/library/xilinx/scripts/xcvr_automation.tcl
 
 set ORX_ENABLE $ad_project_params(ORX_ENABLE)      ; # 0 = Disabled ; 1 = Enabled
 
@@ -239,63 +240,19 @@ if {$ORX_ENABLE} {
 }
 
 # common cores
-ad_ip_instance util_adxcvr util_adrv9026_xcvr
-ad_ip_parameter util_adrv9026_xcvr CONFIG.RX_NUM_OF_LANES [expr $MAX_RX_NUM_OF_LANES + $MAX_RX_OS_NUM_OF_LANES]
-ad_ip_parameter util_adrv9026_xcvr CONFIG.TX_NUM_OF_LANES $MAX_TX_NUM_OF_LANES
-ad_ip_parameter util_adrv9026_xcvr CONFIG.LINK_MODE $ENCODER_SEL
-ad_ip_parameter util_adrv9026_xcvr CONFIG.RX_LANE_RATE $RX_LANE_RATE
-ad_ip_parameter util_adrv9026_xcvr CONFIG.TX_LANE_RATE $TX_LANE_RATE
-ad_ip_parameter util_adrv9026_xcvr CONFIG.RX_OUT_DIV 1
-ad_ip_parameter util_adrv9026_xcvr CONFIG.TX_OUT_DIV 1
-ad_ip_parameter util_adrv9026_xcvr CONFIG.CPLL_FBDIV_4_5 5
-ad_ip_parameter util_adrv9026_xcvr CONFIG.RX_CDR_CFG 0x0b000023ff10400020
-ad_ip_parameter util_adrv9026_xcvr CONFIG.TX_LANE_INVERT 5
-ad_ip_parameter util_adrv9026_xcvr CONFIG.RX_LANE_INVERT 15
+global xcvr_config_paths
 
-if {$JESD_MODE == "8B10B"} {
-  ad_ip_parameter util_adrv9026_xcvr CONFIG.CPLL_FBDIV 4
-  ad_ip_parameter util_adrv9026_xcvr CONFIG.RX_CLK25_DIV 10
-  ad_ip_parameter util_adrv9026_xcvr CONFIG.TX_CLK25_DIV 10
-  ad_ip_parameter util_adrv9026_xcvr CONFIG.RX_PMA_CFG 0x001E7080
-  ad_ip_parameter util_adrv9026_xcvr CONFIG.QPLL_FBDIV 40
-} else {
-  ad_ip_parameter util_adrv9026_xcvr CONFIG.CPLL_FBDIV 2
-  ad_ip_parameter util_adrv9026_xcvr CONFIG.RX_CLK25_DIV 20
-  ad_ip_parameter util_adrv9026_xcvr CONFIG.TX_CLK25_DIV 20
-  ad_ip_parameter util_adrv9026_xcvr CONFIG.RX_PMA_CFG 0x280A
-  ad_ip_parameter util_adrv9026_xcvr CONFIG.QPLL_FBDIV 33
-  ad_ip_parameter util_adrv9026_xcvr CONFIG.QPLL_REFCLK_DIV 1
-  ad_ip_parameter util_adrv9026_xcvr CONFIG.CPLL_CFG0 0x1FA
-  ad_ip_parameter util_adrv9026_xcvr CONFIG.CPLL_CFG1 0x23
-  ad_ip_parameter util_adrv9026_xcvr CONFIG.CPLL_CFG2 0x2
-  ad_ip_parameter util_adrv9026_xcvr CONFIG.A_TXDIFFCTRL 0xC
-  ad_ip_parameter util_adrv9026_xcvr CONFIG.RXCDR_CFG0 0x3
-  ad_ip_parameter util_adrv9026_xcvr CONFIG.RXCDR_CFG2_GEN2 0x269
-  ad_ip_parameter util_adrv9026_xcvr CONFIG.RXCDR_CFG2_GEN4 0x164
-  ad_ip_parameter util_adrv9026_xcvr CONFIG.RXCDR_CFG3 0x12
-  ad_ip_parameter util_adrv9026_xcvr CONFIG.RXCDR_CFG3_GEN2 0x12
-  ad_ip_parameter util_adrv9026_xcvr CONFIG.RXCDR_CFG3_GEN3 0x12
-  ad_ip_parameter util_adrv9026_xcvr CONFIG.RXCDR_CFG3_GEN4 0x12
-  ad_ip_parameter util_adrv9026_xcvr CONFIG.CH_HSPMUX 0x6868
-  ad_ip_parameter util_adrv9026_xcvr CONFIG.PREIQ_FREQ_BST 1
-  ad_ip_parameter util_adrv9026_xcvr CONFIG.RXPI_CFG0 0x4
-  ad_ip_parameter util_adrv9026_xcvr CONFIG.RXPI_CFG1 0x0
-  ad_ip_parameter util_adrv9026_xcvr CONFIG.TXPI_CFG 0x0
-  ad_ip_parameter util_adrv9026_xcvr CONFIG.TX_PI_BIASSET 3
-  ad_ip_parameter util_adrv9026_xcvr CONFIG.POR_CFG 0x0
-  ad_ip_parameter util_adrv9026_xcvr CONFIG.QPLL_CFG0 0x333C
-  ad_ip_parameter util_adrv9026_xcvr CONFIG.QPLL_CFG4 0x45
-  ad_ip_parameter util_adrv9026_xcvr CONFIG.PPF0_CFG 0xF00
-  ad_ip_parameter util_adrv9026_xcvr CONFIG.QPLL_CP 0xFF
-  ad_ip_parameter util_adrv9026_xcvr CONFIG.QPLL_CP_G3 0xF
-  ad_ip_parameter util_adrv9026_xcvr CONFIG.QPLL_LPF 0x31D
-  ad_ip_parameter util_adrv9026_xcvr CONFIG.RXDFE_KH_CFG2 {0x2631}
-  ad_ip_parameter util_adrv9026_xcvr CONFIG.RXDFE_KH_CFG3 {0x411C}
-  ad_ip_parameter util_adrv9026_xcvr CONFIG.RX_WIDEMODE_CDR {"01"}
-  ad_ip_parameter util_adrv9026_xcvr CONFIG.RX_XMODE_SEL {"0"}
-  ad_ip_parameter util_adrv9026_xcvr CONFIG.TXPI_CFG0 {0x0000}
-  ad_ip_parameter util_adrv9026_xcvr CONFIG.TXPI_CFG1 {0x0000}
-}
+set util_adxcvr_parameters [adi_xcvr_parameters $xcvr_config_paths [list \
+  RX_NUM_OF_LANES [expr $MAX_RX_NUM_OF_LANES + $MAX_RX_OS_NUM_OF_LANES]\
+  TX_NUM_OF_LANES $MAX_TX_NUM_OF_LANES\
+  RX_LANE_RATE $RX_LANE_RATE\
+  TX_LANE_RATE $TX_LANE_RATE\
+  LINK_MODE $ENCODER_SEL\
+  RX_LANE_INVERT 15\
+  TX_LANE_INVERT 5\
+]]
+
+ad_ip_instance util_adxcvr util_adrv9026_xcvr $util_adxcvr_parameters
 
 # xcvr interfaces
 

--- a/projects/adrv9026/vcu118/system_bd.tcl
+++ b/projects/adrv9026/vcu118/system_bd.tcl
@@ -1,5 +1,5 @@
 ###############################################################################
-## Copyright (C) 2024-2025 Analog Devices, Inc. All rights reserved.
+## Copyright (C) 2024-2026 Analog Devices, Inc. All rights reserved.
 ### SPDX short identifier: ADIBSD
 ###############################################################################
 
@@ -14,7 +14,7 @@ set mem_init_sys_path [get_env_param ADI_PROJECT_DIR ""]mem_init_sys.txt;
 
 #system ID
 ad_ip_parameter axi_sysid_0 CONFIG.ROM_ADDR_BITS 10
-ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "[pwd]/$mem_init_sys_path"
+ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "$mem_init_sys_file_path/mem_init_sys.txt"
 ad_ip_parameter rom_sys_0 CONFIG.ROM_ADDR_BITS 10
 
 set sys_cstring "JESD_MODE=$ad_project_params(JESD_MODE)\
@@ -38,6 +38,6 @@ S=$ad_project_params(RX_OS_JESD_S)\
 NP=$ad_project_params(RX_OS_JESD_NP)\
 LINKS=$ad_project_params(RX_OS_NUM_LINKS)"
 
-sysid_gen_sys_init_file
+sysid_gen_sys_init_file $sys_cstring 10
 
 source ../common/adrv9026_bd.tcl

--- a/projects/adrv9026/vcu118/system_project.tcl
+++ b/projects/adrv9026/vcu118/system_project.tcl
@@ -1,5 +1,5 @@
 ###############################################################################
-## Copyright (C) 2024-2025 Analog Devices, Inc. All rights reserved.
+## Copyright (C) 2024-2026 Analog Devices, Inc. All rights reserved.
 ### SPDX short identifier: ADIBSD
 ###############################################################################
 
@@ -10,14 +10,40 @@ source $ad_hdl_dir/projects/scripts/adi_board.tcl
 # get_env_param retrieves parameter value from the environment if exists,
 # other case use the default value
 #
-# Use over-writable parameters from the environment.
+#    Use over-writable parameters from the environment.
 #
-# e.g.
-#   RX-OS disabled: make
-#   RX-OS Non-LinkSharing:
-#    - JESD204B: make ORX_ENABLE=1 RX_OS_JESD_M=4 RX_OS_JESD_L=2 RX_OS_JESD_S=1 RX_OS_JESD_NP=16 RX_JESD_L=2 RX_TPL_WIDTH=8
-#    - JESD204C: make JESD_MODE=64B66B ORX_ENABLE=1 TX_LANE_RATE=16.22 RX_LANE_RATE=16.22 \
-#                RX_OS_JESD_M=4 RX_OS_JESD_L=2 RX_OS_JESD_S=1 RX_OS_JESD_NP=16 RX_JESD_L=2
+#    e.g. JESD only
+#      RX-OS disabled: make
+#      RX-OS Non-LinkSharing:
+#       - JESD204B: make ORX_ENABLE=1 RX_OS_JESD_M=4 RX_OS_JESD_L=2 RX_OS_JESD_S=1 RX_OS_JESD_NP=16 RX_JESD_L=2 RX_TPL_WIDTH=8
+#       - JESD204C: make JESD_MODE=64B66B ORX_ENABLE=1 TX_LANE_RATE=16.22 RX_LANE_RATE=16.22 \
+#                        RX_OS_JESD_M=4 RX_OS_JESD_L=2 RX_OS_JESD_S=1 RX_OS_JESD_NP=16 RX_JESD_L=2
+#
+#    e.g. XCVR only
+#      make PLL_TYPE=QPLL0 REF_CLK=245.75 LANE_RATE=9.83
+#
+#    e.g. JESD and XCVR
+#      make JESD_MODE=8B10B ORX_ENABLE=1 RX_OS_JESD_M=4 RX_OS_JESD_L=2 RX_OS_JESD_S=1 RX_OS_JESD_NP=16 RX_JESD_L=2 RX_TPL_WIDTH=8 \
+#           PLL_TYPE=QPLL0 REF_CLK=245.75 LANE_RATE=9.83
+#      make JESD_MODE=64B66B ORX_ENABLE=1 TX_LANE_RATE=16.22 RX_LANE_RATE=16.22 RX_OS_JESD_M=4 RX_OS_JESD_L=2 RX_OS_JESD_S=1 \
+#           RX_OS_JESD_NP=16 RX_JESD_L=2 PLL_TYPE=QPLL0 REF_CLK=245.76 LANE_RATE=16.22016
+
+global xcvr_config_paths
+
+# Parameter description:
+#   LANE_RATE: Value of lane rate [gbps]
+#   REF_CLK: Value of the reference clock [MHz] (usually LANE_RATE/20 or LANE_RATE/40)
+#   PLL_TYPE: The PLL used for driving the link [CPLL/QPLL1/QPLL0]
+#   XCVR_RX_LANE_RATE: Value of lane rate for the RX link [gbps] (Optional)
+#   XCVR_RX_REF_CLK: Value of the reference clock for the RX link [MHz] (usually XCVR_RX_LANE_RATE/20 or XCVR_RX_LANE_RATE/40) (Optional)
+#   XCVR_RX_PLL_TYPE: The PLL used for driving the RX link [CPLL/QPLL1/QPLL0] (Optional)
+#   JESD_MODE: Used link layer encoder mode [64B66B - JESD 204C, 8B10B - JESD 204B] (Optional)
+
+set xcvr_config_paths [adi_xcvr_project [list \
+  LANE_RATE [get_env_param LANE_RATE     9.83] \
+  REF_CLK   [get_env_param REF_CLK     245.75] \
+  PLL_TYPE  [get_env_param PLL_TYPE     QPLL0] \
+]]
 
 # Parameter description:
 #   JESD_MODE : Used link layer encoder mode

--- a/projects/adrv9026/zcu102/system_bd.tcl
+++ b/projects/adrv9026/zcu102/system_bd.tcl
@@ -1,5 +1,5 @@
 ###############################################################################
-## Copyright (C) 2023-2025 Analog Devices, Inc. All rights reserved.
+## Copyright (C) 2023-2026 Analog Devices, Inc. All rights reserved.
 ### SPDX short identifier: ADIBSD
 ###############################################################################
 
@@ -12,7 +12,7 @@ source $ad_hdl_dir/projects/scripts/adi_pd.tcl
 
 #system ID
 ad_ip_parameter axi_sysid_0 CONFIG.ROM_ADDR_BITS 10
-ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "[pwd]/mem_init_sys.txt"
+ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "$mem_init_sys_file_path/mem_init_sys.txt"
 ad_ip_parameter rom_sys_0 CONFIG.ROM_ADDR_BITS 10
 
 set sys_cstring "JESD_MODE=$ad_project_params(JESD_MODE)\
@@ -36,7 +36,7 @@ S=$ad_project_params(RX_OS_JESD_S)\
 NP=$ad_project_params(RX_OS_JESD_NP)\
 LINKS=$ad_project_params(RX_OS_NUM_LINKS)"
 
-sysid_gen_sys_init_file $sys_cstring;
+sysid_gen_sys_init_file $sys_cstring 10
 
 ad_ip_instance clk_wiz dma_clk_wiz
 ad_ip_parameter dma_clk_wiz CONFIG.PRIMITIVE MMCM

--- a/projects/adrv9026/zcu102/system_project.tcl
+++ b/projects/adrv9026/zcu102/system_project.tcl
@@ -1,5 +1,5 @@
 ###############################################################################
-## Copyright (C) 2023-2025 Analog Devices, Inc. All rights reserved.
+## Copyright (C) 2023-2026 Analog Devices, Inc. All rights reserved.
 ### SPDX short identifier: ADIBSD
 ###############################################################################
 
@@ -10,14 +10,40 @@ source $ad_hdl_dir/projects/scripts/adi_board.tcl
 # get_env_param retrieves parameter value from the environment if exists,
 # other case use the default value
 #
-# Use over-writable parameters from the environment.
+#    Use over-writable parameters from the environment.
 #
-# e.g.
-#   RX-OS disabled: make
-#   RX-OS Non-LinkSharing:
-#    - JESD204B: make ORX_ENABLE=1 RX_OS_JESD_M=4 RX_OS_JESD_L=2 RX_OS_JESD_S=1 RX_OS_JESD_NP=16 RX_JESD_L=2 RX_TPL_WIDTH=8
-#    - JESD204C: make JESD_MODE=64B66B ORX_ENABLE=1 TX_LANE_RATE=16.22 RX_LANE_RATE=16.22 \
-#                RX_OS_JESD_M=4 RX_OS_JESD_L=2 RX_OS_JESD_S=1 RX_OS_JESD_NP=16 RX_JESD_L=2
+#    e.g. JESD only
+#      RX-OS disabled: make
+#      RX-OS Non-LinkSharing:
+#       - JESD204B: make ORX_ENABLE=1 RX_OS_JESD_M=4 RX_OS_JESD_L=2 RX_OS_JESD_S=1 RX_OS_JESD_NP=16 RX_JESD_L=2 RX_TPL_WIDTH=8
+#       - JESD204C: make JESD_MODE=64B66B ORX_ENABLE=1 TX_LANE_RATE=16.22 RX_LANE_RATE=16.22 \
+#                       RX_OS_JESD_M=4 RX_OS_JESD_L=2 RX_OS_JESD_S=1 RX_OS_JESD_NP=16 RX_JESD_L=2
+#
+#    e.g. XCVR only
+#      make PLL_TYPE=QPLL0 REF_CLK=245.75 LANE_RATE=9.83
+#
+#    e.g. JESD and XCVR
+#      make JESD_MODE=8B10B ORX_ENABLE=1 RX_OS_JESD_M=4 RX_OS_JESD_L=2 RX_OS_JESD_S=1 RX_OS_JESD_NP=16 RX_JESD_L=2 RX_TPL_WIDTH=8 \
+#           PLL_TYPE=QPLL0 REF_CLK=245.75 LANE_RATE=9.83 XCVR_RX_PLL_TYPE=CPLL
+#      make JESD_MODE=64B66B ORX_ENABLE=1 TX_LANE_RATE=16.22 RX_LANE_RATE=16.22 RX_OS_JESD_M=4 RX_OS_JESD_L=2 RX_OS_JESD_S=1 \
+#           RX_OS_JESD_NP=16 RX_JESD_L=2 PLL_TYPE=QPLL0 REF_CLK=491.5151515 LANE_RATE=16.22
+
+global xcvr_config_paths
+
+# Parameter description:
+#   LANE_RATE: Value of lane rate [gbps]
+#   REF_CLK: Value of the reference clock [MHz] (usually LANE_RATE/20 or LANE_RATE/40)
+#   PLL_TYPE: The PLL used for driving the link [CPLL/QPLL1/QPLL0]
+#   XCVR_RX_LANE_RATE: Value of lane rate for the RX link [gbps] (Optional)
+#   XCVR_RX_REF_CLK: Value of the reference clock for the RX link [MHz] (usually XCVR_RX_LANE_RATE/20 or XCVR_RX_LANE_RATE/40) (Optional)
+#   XCVR_RX_PLL_TYPE: The PLL used for driving the RX link [CPLL/QPLL1/QPLL0] (Optional)
+#   JESD_MODE: Used link layer encoder mode [64B66B - JESD 204C, 8B10B - JESD 204B] (Optional)
+
+set xcvr_config_paths [adi_xcvr_project [list \
+  LANE_RATE [get_env_param LANE_RATE 9.83] \
+  REF_CLK   [get_env_param REF_CLK 245.75] \
+  PLL_TYPE  [get_env_param PLL_TYPE QPLL0] \
+]]
 
 # Parameter description:
 #   JESD_MODE : Used link layer encoder mode

--- a/projects/scripts/gtwiz_parser.pl
+++ b/projects/scripts/gtwiz_parser.pl
@@ -1,7 +1,7 @@
 #!/usr/bin/perl -w
 
 ###############################################################################
-## Copyright (C) 2022-2023 Analog Devices, Inc. All rights reserved.
+## Copyright (C) 2022-2023, 2026 Analog Devices, Inc. All rights reserved.
 ### SPDX short identifier: ADIBSD
 #
 # This script is meant to be used together with gtwizard_generator.tcl
@@ -382,7 +382,7 @@ sub gen_drp_cmd {
     #print "$param_value\n";
     ## ignore all attributes which are related to unused features and
     ## double check attribute validity
-    if ($param_name =~ /^(?!ES_)(?!PCIE_)(?!TXPI_)(?!TX_PI_BIASSET)/) {
+    if ($param_name =~ /^(?!ES_)(?!PCIE_)/) {
       if (exists $$xcvr_params_ref{$param_name}) {
         my $param_value_hex = $param_value;
         $param_value_hex =~ s/^.*'b//;

--- a/projects/scripts/gtwizard_generator.tcl
+++ b/projects/scripts/gtwizard_generator.tcl
@@ -1,5 +1,5 @@
 ###############################################################################
-## Copyright (C) 2022-2023, 2025 Analog Devices, Inc. All rights reserved.
+## Copyright (C) 2022-2023, 2025-2026 Analog Devices, Inc. All rights reserved.
 ### SPDX short identifier: ADIBSD
 #
 # CPLL - generate reference clocks for a given Lane Rate
@@ -117,7 +117,9 @@ proc qpll_ref_clk_gen { gt_type  lane_rate } {
 ## inside a Ultrascale or Ultrascale+ project.
 ##
 ###############################################################################
-proc ad_gth_generator { {lane_rate_l {}} {pll_type {}}  {ref_clk_l {}} } {
+proc ad_gth_generator { {lane_rate_l {}} {pll_type {}}  {ref_clk_l {}} {jesd_mode "8B10B"} {xcvr_rx_pll_type {}} {xcvr_rx_lane_rate {}} {xcvr_rx_ref_clk {}} } {
+
+  puts "NOTE: JESD mode is $jesd_mode. "
 
   set prj_name [get_property NAME [current_project]]
 
@@ -230,6 +232,54 @@ proc ad_gth_generator { {lane_rate_l {}} {pll_type {}}  {ref_clk_l {}} } {
     }
   }
 
+  if {$jesd_mode eq "64B66B"} {
+    set pll_min_range [expr {2 * $pll_min_range}]
+    set pll_max_range [expr {2 * $pll_max_range}]
+  }
+
+  if {$xcvr_rx_pll_type eq ""} {
+    set xcvr_rx_pll_type $pll_type
+  }
+
+  if {$xcvr_rx_pll_type ne $pll_type} {
+    switch $xcvr_rx_pll_type {
+      CPLL {
+        set rx_pll_min_range 0.5
+        set rx_pll_max_range 12.5
+      }
+      QPLL0 {
+        set rx_pll_min_range 0.6125
+        set rx_pll_max_range 16.375
+      }
+      QPLL {
+        if {[string equal $gt_type GTXE2]} {
+          set rx_pll_min_range 0.5
+          set rx_pll_max_range 10.3125
+        } else {
+          puts "Invalid RX PLL type -- $xcvr_rx_pll_type (QPLL is only valid for 7-series)"
+          return 1
+        }
+      }
+      QPLL1 {
+        set rx_pll_min_range 0.5
+        set rx_pll_max_range 13.0
+      }
+      default {
+        puts "Invalid RX PLL type -- $xcvr_rx_pll_type"
+        return 1
+      }
+    }
+    if {$jesd_mode eq "64B66B"} {
+      set rx_pll_min_range [expr {2 * $rx_pll_min_range}]
+      set rx_pll_max_range [expr {2 * $rx_pll_max_range}]
+    }
+    set rx_lr_check [expr {$xcvr_rx_lane_rate ne "" ? $xcvr_rx_lane_rate : [lindex $lane_rate_l 0]}]
+    if {$rx_lr_check ne "" && ($rx_lr_check < $rx_pll_min_range || $rx_lr_check > $rx_pll_max_range)} {
+      puts "ERROR: RX lane rate $rx_lr_check is out of $xcvr_rx_pll_type range \[$rx_pll_min_range - $rx_pll_max_range\]."
+      return 1
+    }
+  }
+
   set inst_num 0
   foreach lane_rate $lane_rate_l {
 
@@ -280,10 +330,42 @@ proc ad_gth_generator { {lane_rate_l {}} {pll_type {}}  {ref_clk_l {}} } {
           set ref_clk [lindex $ref_clk_float 0].[join $float_l ""]
         }
 
-        set ip_name "$gt_type\_$pll_type\_$lane_rate_txt\_$ref_clk_txt"
+        set ip_suffix ""
+        if {$xcvr_rx_pll_type ne $pll_type} {
+          append ip_suffix "_RX${xcvr_rx_pll_type}"
+        }
+        if {$xcvr_rx_lane_rate ne "" && $xcvr_rx_lane_rate ne $lane_rate} {
+          set rx_lr_txt [string map {. _} $xcvr_rx_lane_rate]
+          append ip_suffix "_RXLR${rx_lr_txt}"
+        }
+        if {$xcvr_rx_ref_clk ne "" && $xcvr_rx_ref_clk ne $ref_clk} {
+          set rx_rc_txt [lindex [split $xcvr_rx_ref_clk "."] 0]
+          append ip_suffix "_RXRC${rx_rc_txt}"
+        }
+        set ip_name "$gt_type\_$pll_type${ip_suffix}\_$lane_rate_txt\_$ref_clk_txt"
+        #set ip_name "$gt_type\_$pll_type\_$lane_rate_txt\_$ref_clk_txt"
         incr inst_num
 
         ## check if it is 7series or ultrascale/ultrascale+
+
+        if {$jesd_mode eq "64B66B"} {
+          set gt_encoding "64B66B"
+          set gt_encoding_7s "64B/66B"
+          set gt_user_data_width 64
+          if {[string equal $gt_type GTHE3] || [string equal $gt_type GTHE4]} {
+            set gt_int_data_width 32
+          } else {
+            set gt_int_data_width 64
+          }
+        } else {
+          set gt_encoding "8B10B"
+          set gt_encoding_7s "8B/10B"
+          set gt_user_data_width 32
+          set gt_int_data_width 40
+        }
+
+        set rx_lr [expr {$xcvr_rx_lane_rate ne "" ? $xcvr_rx_lane_rate : $lane_rate}]
+        set rx_rc [expr {$xcvr_rx_ref_clk ne "" ? $xcvr_rx_ref_clk : $ref_clk}]
 
         if {[string equal $gt_type GTXE2]} {
           ## 7 series
@@ -291,20 +373,22 @@ proc ad_gth_generator { {lane_rate_l {}} {pll_type {}}  {ref_clk_l {}} } {
           if {[lsearch [get_ips] $ip_name] == -1} {
 
             set float_clk [format "%.3f" [expr {$ref_clk}]]
+            set rx_float_clk [format "%.3f" [expr {$rx_rc}]]
 
             create_ip -name gtwizard -vendor xilinx.com -library ip -version 3.6 -module_name $ip_name
 
             set_property -dict [list \
             CONFIG.identical_protocol_file {JESD204} \
             CONFIG.identical_val_tx_reference_clock $float_clk \
-            CONFIG.identical_val_rx_reference_clock $float_clk \
-            CONFIG.gt0_val_rx_reference_clock $float_clk \
+            CONFIG.identical_val_rx_reference_clock $rx_float_clk \
+            CONFIG.gt0_val_rx_reference_clock $rx_float_clk \
             CONFIG.gt0_val_tx_reference_clock $float_clk \
             CONFIG.identical_val_tx_line_rate $lane_rate \
-            CONFIG.identical_val_rx_line_rate $lane_rate \
-            CONFIG.gt0_val_rx_line_rate $lane_rate \
+            CONFIG.identical_val_rx_line_rate $rx_lr \
+            CONFIG.gt0_val_rx_line_rate $rx_lr \
             CONFIG.gt0_val_tx_line_rate $lane_rate \
             CONFIG.gt_val_tx_pll $pll_type \
+            CONFIG.gt_val_rx_pll $xcvr_rx_pll_type \
             CONFIG.gt0_usesharedlogic {1} \
             CONFIG.advanced_clocking {true} \
             CONFIG.gt_val_drp {false} \
@@ -343,12 +427,12 @@ proc ad_gth_generator { {lane_rate_l {}} {pll_type {}}  {ref_clk_l {}} } {
             CONFIG.gt15_val_tx_refclk {REFCLK1_Q3} \
             CONFIG.gt15_val_rx_refclk {REFCLK1_Q3} \
             CONFIG.gt0_val_rxusrclk {RXOUTCLK} \
-            CONFIG.gt0_val_decoding {8B/10B} \
-            CONFIG.gt0_val_encoding {8B/10B} \
-            CONFIG.gt0_val_tx_data_width {32} \
-            CONFIG.gt0_val_tx_int_datawidth {40} \
-            CONFIG.gt0_val_rx_data_width {32} \
-            CONFIG.gt0_val_rx_int_datawidth {40} \
+            CONFIG.gt0_val_decoding $gt_encoding_7s \
+            CONFIG.gt0_val_encoding $gt_encoding_7s \
+            CONFIG.gt0_val_tx_data_width $gt_user_data_width \
+            CONFIG.gt0_val_tx_int_datawidth $gt_int_data_width \
+            CONFIG.gt0_val_rx_data_width $gt_user_data_width \
+            CONFIG.gt0_val_rx_int_datawidth $gt_int_data_width \
             CONFIG.gt0_val_port_rxchariscomma {true} \
             CONFIG.gt0_val_port_rxcharisk {true} \
             CONFIG.gt0_val_align_pcomma_value {0101111100} \
@@ -396,13 +480,15 @@ proc ad_gth_generator { {lane_rate_l {}} {pll_type {}}  {ref_clk_l {}} } {
                 CONFIG.TX_LINE_RATE $lane_rate \
                 CONFIG.TX_PLL_TYPE $pll_type \
                 CONFIG.TX_REFCLK_FREQUENCY $ref_clk \
-                CONFIG.TX_DATA_ENCODING {8B10B} \
-                CONFIG.TX_INT_DATA_WIDTH {40} \
-                CONFIG.RX_LINE_RATE $lane_rate \
-                CONFIG.RX_PLL_TYPE $pll_type \
-                CONFIG.RX_REFCLK_FREQUENCY $ref_clk \
-                CONFIG.RX_DATA_DECODING {8B10B} \
-                CONFIG.RX_INT_DATA_WIDTH {40} \
+                CONFIG.TX_DATA_ENCODING $gt_encoding \
+                CONFIG.TX_USER_DATA_WIDTH $gt_user_data_width \
+                CONFIG.TX_INT_DATA_WIDTH $gt_int_data_width \
+                CONFIG.RX_LINE_RATE $rx_lr \
+                CONFIG.RX_PLL_TYPE $xcvr_rx_pll_type \
+                CONFIG.RX_REFCLK_FREQUENCY $rx_rc \
+                CONFIG.RX_DATA_DECODING $gt_encoding \
+                CONFIG.RX_USER_DATA_WIDTH $gt_user_data_width \
+                CONFIG.RX_INT_DATA_WIDTH $gt_int_data_width \
                 CONFIG.RX_EQ_MODE {LPM} \
                 CONFIG.RX_COMMA_P_ENABLE {true} \
                 CONFIG.RX_COMMA_M_ENABLE {true} \
@@ -440,7 +526,7 @@ proc ad_gth_generator { {lane_rate_l {}} {pll_type {}}  {ref_clk_l {}} } {
 ## GitHub documentation: https://analogdevicesinc.github.io/hdl/library/jesd204/xgt_wizard/index.html
 ##
 ###############################################################################
-proc get_diff_params { {lane_rate_l {}} {pll_type {}}  {ref_clk_l {}} {keep_ip "true"} } {
+proc get_diff_params { {lane_rate_l {}} {pll_type {}}  {ref_clk_l {}} {jesd_mode "8B10B"} {xcvr_rx_pll_type {}} {xcvr_rx_lane_rate {}} {xcvr_rx_ref_clk {}} {keep_ip "true"} } {
 
   ## Get the gt_type for the board
   set board [string range [get_property PART [current_project]] 0 6]
@@ -489,7 +575,7 @@ proc get_diff_params { {lane_rate_l {}} {pll_type {}}  {ref_clk_l {}} {keep_ip "
   set hdl_projects_path [file normalize [file join $current_dir "../.."]]
 
   ## Generate configurations
-  ad_gth_generator $lane_rate_l $pll_type $ref_clk_l
+  ad_gth_generator $lane_rate_l $pll_type $ref_clk_l $jesd_mode $xcvr_rx_pll_type $xcvr_rx_lane_rate $xcvr_rx_ref_clk
 
   ## Call parser script gtwiz_parser.pl
   cd $project_name\.gen/sources_1/ip
@@ -537,6 +623,4 @@ proc get_diff_params { {lane_rate_l {}} {pll_type {}}  {ref_clk_l {}} {keep_ip "
   } else {
     puts "For running the parser script you should be in ip directory"
   }
-
-
 }

--- a/projects/xcvr_wizard/README.md
+++ b/projects/xcvr_wizard/README.md
@@ -6,6 +6,6 @@
 
 This project is used internally to generate transceiver configuration files for
 Xilinx carriers. The generated configuration files are later parsed and used by
-other HDL projects (e.g., ADRV9009, DAQ2, DAQ3).
+other HDL projects (e.g., AD9081, AD9083, ADRV9009, ADRV9026, DAQ2, DAQ3).
 Please enter the folder for the FPGA carrier you want to use
 and read the README.md.

--- a/projects/xcvr_wizard/kc705/README.md
+++ b/projects/xcvr_wizard/kc705/README.md
@@ -19,6 +19,12 @@ The overwritable parameters from the environment:
 - LANE_RATE: Value of lane rate [gbps]
 - REF_CLK: Value of the reference clock [MHz] (usually LANE_RATE/20 or LANE_RATE/40)
 - PLL_TYPE: The PLL used for driving the link [CPLL/QPLL]
+- JESD_MODE: Link layer encoding mode [8B10B] (Optional, default: 8B10B)
+- XCVR_RX_LANE_RATE: Value of lane rate for the RX link [gbps] (Optional)
+- XCVR_RX_REF_CLK: Value of the reference clock for the RX link [MHz] (usually
+  XCVR_RX_LANE_RATE/20 or XCVR_RX_LANE_RATE/40) (Optional)
+- XCVR_RX_PLL_TYPE: The PLL used for driving the RX link [CPLL/QPLL1/QPLL0]
+  (Optional)
 
 Note: When running make with parameters, a new folder specific to the chosen
 configuration is created under the project directory. The generated IPs and

--- a/projects/xcvr_wizard/kc705/system_bd.tcl
+++ b/projects/xcvr_wizard/kc705/system_bd.tcl
@@ -1,11 +1,20 @@
 ###############################################################################
-## Copyright (C) 2025 Analog Devices, Inc. All rights reserved.
+## Copyright (C) 2025-2026 Analog Devices, Inc. All rights reserved.
 ### SPDX short identifier: ADIBSD
 ###############################################################################
 
 set LANE_RATE $ad_project_params(LANE_RATE)   ; # [gbps]
 set PLL_TYPE  $ad_project_params(PLL_TYPE)    ; # [CPLL/QPLL]
 set REF_CLK   $ad_project_params(REF_CLK)     ; # [MHz]
+set JESD_MODE $ad_project_params(JESD_MODE)
+
+foreach rx_param {XCVR_RX_PLL_TYPE XCVR_RX_LANE_RATE XCVR_RX_REF_CLK} {
+    if {[info exists ad_project_params($rx_param)] && $ad_project_params($rx_param) ne ""} {
+        set $rx_param $ad_project_params($rx_param)
+    } else {
+        set $rx_param ""
+    }
+}
 
 source $ad_hdl_dir/projects/scripts/gtwizard_generator.tcl
-get_diff_params $LANE_RATE $PLL_TYPE $REF_CLK
+get_diff_params $LANE_RATE $PLL_TYPE $REF_CLK $JESD_MODE $XCVR_RX_PLL_TYPE $XCVR_RX_LANE_RATE $XCVR_RX_REF_CLK

--- a/projects/xcvr_wizard/kc705/system_project.tcl
+++ b/projects/xcvr_wizard/kc705/system_project.tcl
@@ -1,5 +1,5 @@
 ###############################################################################
-## Copyright (C) 2025 Analog Devices, Inc. All rights reserved.
+## Copyright (C) 2025-2026 Analog Devices, Inc. All rights reserved.
 ### SPDX short identifier: ADIBSD
 ###############################################################################
 
@@ -11,9 +11,17 @@ source $ad_hdl_dir/projects/scripts/adi_board.tcl
 # LANE_RATE: Value of lane rate [gbps]
 # REF_CLK: Value of the reference clock [MHz] (usually LANE_RATE/20 or LANE_RATE/40)
 # PLL_TYPE: The PLL used for driving the link [CPLL/QPLL]
+# JESD_MODE: Used link layer encoder mode [64B66B - JESD 204C, 8B10B - JESD 204B] (Optional)
+# XCVR_RX_LANE_RATE: Value of lane rate for the RX link [gbps] (Optional)
+# XCVR_RX_REF_CLK: Value of the reference clock for the RX link [MHz] (usually XCVR_RX_LANE_RATE/20 or XCVR_RX_LANE_RATE/40) (Optional)
+# XCVR_RX_PLL_TYPE: The PLL used for driving the RX link [CPLL/QPLL1/QPLL0] (Optional)
 
 adi_project xcvr_wizard_kc705 0 [list \
-  LANE_RATE   [get_env_param LANE_RATE        10 ] \
-  REF_CLK     [get_env_param REF_CLK         500 ] \
-  PLL_TYPE    [get_env_param PLL_TYPE       QPLL ] \
+  LANE_RATE         [get_env_param LANE_RATE         10 ] \
+  REF_CLK           [get_env_param REF_CLK          500 ] \
+  PLL_TYPE          [get_env_param PLL_TYPE        QPLL ] \
+  JESD_MODE         [get_env_param JESD_MODE       8B10B] \
+  XCVR_RX_PLL_TYPE  [get_env_param XCVR_RX_PLL_TYPE  {} ] \
+  XCVR_RX_LANE_RATE [get_env_param XCVR_RX_LANE_RATE {} ] \
+  XCVR_RX_REF_CLK   [get_env_param XCVR_RX_REF_CLK   {} ] \
 ]

--- a/projects/xcvr_wizard/kcu105/README.md
+++ b/projects/xcvr_wizard/kcu105/README.md
@@ -18,6 +18,12 @@ The overwritable parameters from the environment:
 - LANE_RATE: Value of lane rate [gbps]
 - REF_CLK: Value of the reference clock [MHz] (usually LANE_RATE/20 or LANE_RATE/40)
 - PLL_TYPE: The PLL used for driving the link [CPLL/QPLL]
+- JESD_MODE: Link layer encoding mode [8B10B] (Optional, default: 8B10B)
+- XCVR_RX_LANE_RATE: Value of lane rate for the RX link [gbps] (Optional)
+- XCVR_RX_REF_CLK: Value of the reference clock for the RX link [MHz] (usually
+  XCVR_RX_LANE_RATE/20 or XCVR_RX_LANE_RATE/40) (Optional)
+- XCVR_RX_PLL_TYPE: The PLL used for driving the RX link [CPLL/QPLL1/QPLL0]
+  (Optional)
 
 Note: When running make with parameters, a new folder specific to the chosen
 configuration is created under the project directory. The generated IPs and

--- a/projects/xcvr_wizard/kcu105/system_bd.tcl
+++ b/projects/xcvr_wizard/kcu105/system_bd.tcl
@@ -1,11 +1,20 @@
 ###############################################################################
-## Copyright (C) 2025 Analog Devices, Inc. All rights reserved.
+## Copyright (C) 2025-2026 Analog Devices, Inc. All rights reserved.
 ### SPDX short identifier: ADIBSD
 ###############################################################################
 
 set LANE_RATE $ad_project_params(LANE_RATE)   ; # [gbps]
 set PLL_TYPE  $ad_project_params(PLL_TYPE)    ; # [CPLL/QPLL0/QPLL1]
 set REF_CLK   $ad_project_params(REF_CLK)     ; # [MHz]
+set JESD_MODE $ad_project_params(JESD_MODE)
+
+foreach rx_param {XCVR_RX_PLL_TYPE XCVR_RX_LANE_RATE XCVR_RX_REF_CLK} {
+    if {[info exists ad_project_params($rx_param)] && $ad_project_params($rx_param) ne ""} {
+        set $rx_param $ad_project_params($rx_param)
+    } else {
+        set $rx_param ""
+    }
+}
 
 source $ad_hdl_dir/projects/scripts/gtwizard_generator.tcl
-get_diff_params $LANE_RATE $PLL_TYPE $REF_CLK
+get_diff_params $LANE_RATE $PLL_TYPE $REF_CLK $JESD_MODE $XCVR_RX_PLL_TYPE $XCVR_RX_LANE_RATE $XCVR_RX_REF_CLK

--- a/projects/xcvr_wizard/kcu105/system_project.tcl
+++ b/projects/xcvr_wizard/kcu105/system_project.tcl
@@ -1,5 +1,5 @@
 ###############################################################################
-## Copyright (C) 2025 Analog Devices, Inc. All rights reserved.
+## Copyright (C) 2025-2026 Analog Devices, Inc. All rights reserved.
 ### SPDX short identifier: ADIBSD
 ###############################################################################
 
@@ -11,9 +11,17 @@ source $ad_hdl_dir/projects/scripts/adi_board.tcl
 # LANE_RATE: Value of lane rate [gbps]
 # REF_CLK: Value of the reference clock [MHz] (usually LANE_RATE/20 or LANE_RATE/40)
 # PLL_TYPE: The PLL used for driving the link [CPLL/QPLL0/QPLL1]
+# JESD_MODE: Used link layer encoder mode [64B66B - JESD 204C, 8B10B - JESD 204B] (Optional)
+# XCVR_RX_LANE_RATE: Value of lane rate for the RX link [gbps] (Optional)
+# XCVR_RX_REF_CLK: Value of the reference clock for the RX link [MHz] (usually XCVR_RX_LANE_RATE/20 or XCVR_RX_LANE_RATE/40) (Optional)
+# XCVR_RX_PLL_TYPE: The PLL used for driving the RX link [CPLL/QPLL1/QPLL0] (Optional)
 
 adi_project xcvr_wizard_kcu105 0 [list \
-  LANE_RATE   [get_env_param LANE_RATE        10 ] \
-  REF_CLK     [get_env_param REF_CLK         500 ] \
-  PLL_TYPE    [get_env_param PLL_TYPE      QPLL0 ] \
+  LANE_RATE         [get_env_param LANE_RATE         10 ] \
+  REF_CLK           [get_env_param REF_CLK          500 ] \
+  PLL_TYPE          [get_env_param PLL_TYPE       QPLL0 ] \
+  JESD_MODE         [get_env_param JESD_MODE       8B10B] \
+  XCVR_RX_PLL_TYPE  [get_env_param XCVR_RX_PLL_TYPE  {} ] \
+  XCVR_RX_LANE_RATE [get_env_param XCVR_RX_LANE_RATE {} ] \
+  XCVR_RX_REF_CLK   [get_env_param XCVR_RX_REF_CLK   {} ] \
 ]

--- a/projects/xcvr_wizard/scripts/adi_xcvr_xilinx.tcl
+++ b/projects/xcvr_wizard/scripts/adi_xcvr_xilinx.tcl
@@ -70,8 +70,9 @@ proc adi_xcvr_project {parameters_for_make {carrier_name ""}} {
     set gt_xcvr_file {}
 
     foreach {key value} $parameters_for_make {
+        if {$value eq ""} { continue }
         lappend formatted_params "$key=$value"
-        set key_parsed [string map {"LANE_" "" "_" ""} $key]
+        set key_parsed [string map {"JESD" "" "LANE" "" "_" ""} $key]
         set value_parrsed [string map {. _} $value]
         set ad_project_make_params($key) $value_parrsed
         set tok "${key_parsed}${value_parrsed}"
@@ -83,11 +84,22 @@ proc adi_xcvr_project {parameters_for_make {carrier_name ""}} {
 
     append make_command " " [join $formatted_params " "]
     set gt_xcvr_file [join  $gt_xcvr_file "_"]
-    set config_parser_dir_name "${xcvr_type}_${ad_project_make_params(PLL_TYPE)}_${ad_project_make_params(LANE_RATE)}_${ad_project_make_params(REF_CLK)}"
+    set config_parser_dir_name "${xcvr_type}_${ad_project_make_params(PLL_TYPE)}"
+    foreach {rx_key tx_key prefix} {
+      XCVR_RX_PLL_TYPE  PLL_TYPE  RX
+      XCVR_RX_LANE_RATE LANE_RATE RXLR
+      XCVR_RX_REF_CLK   REF_CLK   RXRC
+    } {
+      if {[info exists ad_project_make_params($rx_key)]
+          && $ad_project_make_params($rx_key) ne ""
+          && $ad_project_make_params($rx_key) ne $ad_project_make_params($tx_key)} {
+        append config_parser_dir_name "_${prefix}$ad_project_make_params($rx_key)"
+      }
+    }
+    append config_parser_dir_name "_${ad_project_make_params(LANE_RATE)}_${ad_project_make_params(REF_CLK)}"
     set file_local_param [string tolower $config_parser_dir_name]
     append file_local_param "_common.v"
   }
-
   eval exec $make_command
   cd $current_dir
 

--- a/projects/xcvr_wizard/vcu118/README.md
+++ b/projects/xcvr_wizard/vcu118/README.md
@@ -18,6 +18,12 @@ The overwritable parameters from the environment:
 - LANE_RATE: Value of lane rate [gbps]
 - REF_CLK: Value of the reference clock [MHz] (usually LANE_RATE/20 or LANE_RATE/40)
 - PLL_TYPE: The PLL used for driving the link [CPLL/QPLL]
+- JESD_MODE: Link layer encoding mode [8B10B/64B66B] (Optional, default: 8B10B)
+- XCVR_RX_LANE_RATE: Value of lane rate for the RX link [gbps] (Optional)
+- XCVR_RX_REF_CLK: Value of the reference clock for the RX link [MHz] (usually
+  XCVR_RX_LANE_RATE/20 or XCVR_RX_LANE_RATE/40) (Optional)
+- XCVR_RX_PLL_TYPE: The PLL used for driving the RX link [CPLL/QPLL1/QPLL0]
+  (Optional)
 
 Note: When running make with parameters, a new folder specific to the chosen
 configuration is created under the project directory. The generated IPs and

--- a/projects/xcvr_wizard/vcu118/system_bd.tcl
+++ b/projects/xcvr_wizard/vcu118/system_bd.tcl
@@ -1,11 +1,20 @@
 ###############################################################################
-## Copyright (C) 2025 Analog Devices, Inc. All rights reserved.
+## Copyright (C) 2025-2026 Analog Devices, Inc. All rights reserved.
 ### SPDX short identifier: ADIBSD
 ###############################################################################
 
 set LANE_RATE $ad_project_params(LANE_RATE)   ; # [gbps]
 set PLL_TYPE  $ad_project_params(PLL_TYPE)    ; # [CPLL/QPLL0/QPLL1]
 set REF_CLK   $ad_project_params(REF_CLK)     ; # [MHz]
+set JESD_MODE $ad_project_params(JESD_MODE)
+
+foreach rx_param {XCVR_RX_PLL_TYPE XCVR_RX_LANE_RATE XCVR_RX_REF_CLK} {
+    if {[info exists ad_project_params($rx_param)] && $ad_project_params($rx_param) ne ""} {
+        set $rx_param $ad_project_params($rx_param)
+    } else {
+        set $rx_param ""
+    }
+}
 
 source $ad_hdl_dir/projects/scripts/gtwizard_generator.tcl
-get_diff_params $LANE_RATE $PLL_TYPE $REF_CLK
+get_diff_params $LANE_RATE $PLL_TYPE $REF_CLK $JESD_MODE $XCVR_RX_PLL_TYPE $XCVR_RX_LANE_RATE $XCVR_RX_REF_CLK

--- a/projects/xcvr_wizard/vcu118/system_project.tcl
+++ b/projects/xcvr_wizard/vcu118/system_project.tcl
@@ -1,5 +1,5 @@
 ###############################################################################
-## Copyright (C) 2025 Analog Devices, Inc. All rights reserved.
+## Copyright (C) 2025-2026 Analog Devices, Inc. All rights reserved.
 ### SPDX short identifier: ADIBSD
 ###############################################################################
 
@@ -11,9 +11,17 @@ source $ad_hdl_dir/projects/scripts/adi_board.tcl
 # LANE_RATE: Value of lane rate [gbps]
 # REF_CLK: Value of the reference clock [MHz] (usually LANE_RATE/20 or LANE_RATE/40)
 # PLL_TYPE: The PLL used for driving the link [CPLL/QPLL0/QPLL1]
+# JESD_MODE: Used link layer encoder mode [64B66B - JESD 204C, 8B10B - JESD 204B]
+# XCVR_RX_LANE_RATE: Value of lane rate for the RX link [gbps] (Optional)
+# XCVR_RX_REF_CLK: Value of the reference clock for the RX link [MHz] (usually XCVR_RX_LANE_RATE/20 or XCVR_RX_LANE_RATE/40) (Optional)
+# XCVR_RX_PLL_TYPE: The PLL used for driving the RX link [CPLL/QPLL1/QPLL0] (Optional)
 
 adi_project xcvr_wizard_vcu118 0 [list \
-  LANE_RATE   [get_env_param LANE_RATE        10 ] \
-  REF_CLK     [get_env_param REF_CLK         500 ] \
-  PLL_TYPE    [get_env_param PLL_TYPE      QPLL0 ] \
+  LANE_RATE         [get_env_param LANE_RATE         10 ] \
+  REF_CLK           [get_env_param REF_CLK          500 ] \
+  PLL_TYPE          [get_env_param PLL_TYPE       QPLL0 ] \
+  JESD_MODE         [get_env_param JESD_MODE       8B10B] \
+  XCVR_RX_PLL_TYPE  [get_env_param XCVR_RX_PLL_TYPE  {} ] \
+  XCVR_RX_LANE_RATE [get_env_param XCVR_RX_LANE_RATE {} ] \
+  XCVR_RX_REF_CLK   [get_env_param XCVR_RX_REF_CLK   {} ] \
 ]

--- a/projects/xcvr_wizard/zc706/README.md
+++ b/projects/xcvr_wizard/zc706/README.md
@@ -18,6 +18,12 @@ The overwritable parameters from the environment:
 - LANE_RATE: Value of lane rate [gbps]
 - REF_CLK: Value of the reference clock [MHz] (usually LANE_RATE/20 or LANE_RATE/40)
 - PLL_TYPE: The PLL used for driving the link [CPLL/QPLL]
+- JESD_MODE: Link layer encoding mode [8B10B] (Optional, default: 8B10B)
+- XCVR_RX_LANE_RATE: Value of lane rate for the RX link [gbps] (Optional)
+- XCVR_RX_REF_CLK: Value of the reference clock for the RX link [MHz] (usually
+  XCVR_RX_LANE_RATE/20 or XCVR_RX_LANE_RATE/40) (Optional)
+- XCVR_RX_PLL_TYPE: The PLL used for driving the RX link [CPLL/QPLL1/QPLL0]
+  (Optional)
 
 Note: When running make with parameters, a new folder specific to the chosen
 configuration is created under the project directory. The generated IPs and

--- a/projects/xcvr_wizard/zc706/system_bd.tcl
+++ b/projects/xcvr_wizard/zc706/system_bd.tcl
@@ -1,11 +1,20 @@
 ###############################################################################
-## Copyright (C) 2025 Analog Devices, Inc. All rights reserved.
+## Copyright (C) 2025-2026 Analog Devices, Inc. All rights reserved.
 ### SPDX short identifier: ADIBSD
 ###############################################################################
 
 set LANE_RATE $ad_project_params(LANE_RATE)   ; # [gbps]
 set PLL_TYPE  $ad_project_params(PLL_TYPE)    ; # [CPLL/QPLL]
 set REF_CLK   $ad_project_params(REF_CLK)     ; # [MHz]
+set JESD_MODE $ad_project_params(JESD_MODE)
+
+foreach rx_param {XCVR_RX_PLL_TYPE XCVR_RX_LANE_RATE XCVR_RX_REF_CLK} {
+    if {[info exists ad_project_params($rx_param)] && $ad_project_params($rx_param) ne ""} {
+        set $rx_param $ad_project_params($rx_param)
+    } else {
+        set $rx_param ""
+    }
+}
 
 source $ad_hdl_dir/projects/scripts/gtwizard_generator.tcl
-get_diff_params $LANE_RATE $PLL_TYPE $REF_CLK
+get_diff_params $LANE_RATE $PLL_TYPE $REF_CLK $JESD_MODE $XCVR_RX_PLL_TYPE $XCVR_RX_LANE_RATE $XCVR_RX_REF_CLK

--- a/projects/xcvr_wizard/zc706/system_project.tcl
+++ b/projects/xcvr_wizard/zc706/system_project.tcl
@@ -1,5 +1,5 @@
 ###############################################################################
-## Copyright (C) 2025 Analog Devices, Inc. All rights reserved.
+## Copyright (C) 2025-2026 Analog Devices, Inc. All rights reserved.
 ### SPDX short identifier: ADIBSD
 ###############################################################################
 
@@ -11,9 +11,17 @@ source $ad_hdl_dir/projects/scripts/adi_board.tcl
 # LANE_RATE: Value of lane rate [gbps]
 # REF_CLK: Value of the reference clock [MHz] (usually LANE_RATE/20 or LANE_RATE/40)
 # PLL_TYPE: The PLL used for driving the link [CPLL/QPLL]
+# JESD_MODE: Used link layer encoder mode [64B66B - JESD 204C, 8B10B - JESD 204B] (Optional)
+# XCVR_RX_LANE_RATE: Value of lane rate for the RX link [gbps] (Optional)
+# XCVR_RX_REF_CLK: Value of the reference clock for the RX link [MHz] (usually XCVR_RX_LANE_RATE/20 or XCVR_RX_LANE_RATE/40) (Optional)
+# XCVR_RX_PLL_TYPE: The PLL used for driving the RX link [CPLL/QPLL1/QPLL0] (Optional)
 
 adi_project xcvr_wizard_zc706 0 [list \
-  LANE_RATE   [get_env_param LANE_RATE        10 ] \
-  REF_CLK     [get_env_param REF_CLK         500 ] \
-  PLL_TYPE    [get_env_param PLL_TYPE       QPLL ] \
+  LANE_RATE         [get_env_param LANE_RATE         10 ] \
+  REF_CLK           [get_env_param REF_CLK          500 ] \
+  PLL_TYPE          [get_env_param PLL_TYPE        QPLL ] \
+  JESD_MODE         [get_env_param JESD_MODE       8B10B] \
+  XCVR_RX_PLL_TYPE  [get_env_param XCVR_RX_PLL_TYPE  {} ] \
+  XCVR_RX_LANE_RATE [get_env_param XCVR_RX_LANE_RATE {} ] \
+  XCVR_RX_REF_CLK   [get_env_param XCVR_RX_REF_CLK   {} ] \
 ]

--- a/projects/xcvr_wizard/zcu102/README.md
+++ b/projects/xcvr_wizard/zcu102/README.md
@@ -16,8 +16,15 @@ If other configurations are desired, then the parameters from the HDL project (s
 The overwritable parameters from the environment:
 
 - LANE_RATE: Value of lane rate [gbps]
-- REF_CLK: Value of the reference clock [MHz] (usually LANE_RATE/20 or LANE_RATE/40)
+- REF_CLK: Value of the reference clock [MHz] (usually LANE_RATE/20 or
+  LANE_RATE/40)
 - PLL_TYPE: The PLL used for driving the link [CPLL/QPLL]
+- JESD_MODE: Link layer encoding mode [8B10B/64B66B] (Optional, default: 8B10B)
+- XCVR_RX_LANE_RATE: Value of lane rate for the RX link [gbps] (Optional)
+- XCVR_RX_REF_CLK: Value of the reference clock for the RX link [MHz] (usually
+  XCVR_RX_LANE_RATE/20 or XCVR_RX_LANE_RATE/40) (Optional)
+- XCVR_RX_PLL_TYPE: The PLL used for driving the RX link [CPLL/QPLL1/QPLL0]
+  (Optional)
 
 Note: When running make with parameters, a new folder specific to the chosen
 configuration is created under the project directory. The generated IPs and

--- a/projects/xcvr_wizard/zcu102/system_bd.tcl
+++ b/projects/xcvr_wizard/zcu102/system_bd.tcl
@@ -1,11 +1,20 @@
 ###############################################################################
-## Copyright (C) 2025 Analog Devices, Inc. All rights reserved.
+## Copyright (C) 2025-2026 Analog Devices, Inc. All rights reserved.
 ### SPDX short identifier: ADIBSD
 ###############################################################################
 
 set LANE_RATE $ad_project_params(LANE_RATE)   ; # [gbps]
 set PLL_TYPE  $ad_project_params(PLL_TYPE)    ; # [CPLL/QPLL0/QPLL1]
 set REF_CLK   $ad_project_params(REF_CLK)     ; # [MHz]
+set JESD_MODE $ad_project_params(JESD_MODE)
+
+foreach rx_param {XCVR_RX_PLL_TYPE XCVR_RX_LANE_RATE XCVR_RX_REF_CLK} {
+    if {[info exists ad_project_params($rx_param)] && $ad_project_params($rx_param) ne ""} {
+        set $rx_param $ad_project_params($rx_param)
+    } else {
+        set $rx_param ""
+    }
+}
 
 source $ad_hdl_dir/projects/scripts/gtwizard_generator.tcl
-get_diff_params $LANE_RATE $PLL_TYPE $REF_CLK
+get_diff_params $LANE_RATE $PLL_TYPE $REF_CLK $JESD_MODE $XCVR_RX_PLL_TYPE $XCVR_RX_LANE_RATE $XCVR_RX_REF_CLK

--- a/projects/xcvr_wizard/zcu102/system_project.tcl
+++ b/projects/xcvr_wizard/zcu102/system_project.tcl
@@ -1,5 +1,5 @@
 ###############################################################################
-## Copyright (C) 2025 Analog Devices, Inc. All rights reserved.
+## Copyright (C) 2025-2026 Analog Devices, Inc. All rights reserved.
 ### SPDX short identifier: ADIBSD
 ###############################################################################
 
@@ -11,9 +11,17 @@ source $ad_hdl_dir/projects/scripts/adi_board.tcl
 # LANE_RATE: Value of lane rate [gbps]
 # REF_CLK: Value of the reference clock [MHz] (usually LANE_RATE/20 or LANE_RATE/40)
 # PLL_TYPE: The PLL used for driving the link [CPLL/QPLL0/QPLL1]
+# JESD_MODE: Used link layer encoder mode [64B66B - JESD 204C, 8B10B - JESD 204B]
+# XCVR_RX_LANE_RATE: Value of lane rate for the RX link [gbps] (Optional)
+# XCVR_RX_REF_CLK: Value of the reference clock for the RX link [MHz] (usually XCVR_RX_LANE_RATE/20 or XCVR_RX_LANE_RATE/40) (Optional)
+# XCVR_RX_PLL_TYPE: The PLL used for driving the RX link [CPLL/QPLL1/QPLL0] (Optional)
 
 adi_project xcvr_wizard_zcu102 0 [list \
-  LANE_RATE   [get_env_param LANE_RATE        10 ] \
-  REF_CLK     [get_env_param REF_CLK         500 ] \
-  PLL_TYPE    [get_env_param PLL_TYPE      QPLL0 ] \
+  LANE_RATE         [get_env_param LANE_RATE         10 ] \
+  REF_CLK           [get_env_param REF_CLK          500 ] \
+  PLL_TYPE          [get_env_param PLL_TYPE       QPLL0 ] \
+  JESD_MODE         [get_env_param JESD_MODE       8B10B] \
+  XCVR_RX_PLL_TYPE  [get_env_param XCVR_RX_PLL_TYPE  {} ] \
+  XCVR_RX_LANE_RATE [get_env_param XCVR_RX_LANE_RATE {} ] \
+  XCVR_RX_REF_CLK   [get_env_param XCVR_RX_REF_CLK   {} ] \
 ]


### PR DESCRIPTION
## PR Description

Extended XCVR automation support for JESD204C.
Added support for asymmetric RX/TX configurations.
Integrated XCVR automation support into AD9081 and ADRV9026.
Updated the Xilinx FPGAs Transceivers Wizard documentation.

## PR Type
- [ ] Bug fix (change that fixes an issue)
- [x] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)
- [ ] Documentation

## PR Checklist
- [x] I have followed the code style guidelines
- [x] I have performed a self-review of changes
- [x] I have compiled all hdl projects and libraries affected by this PR
- [x] I have tested in hardware affected projects, at least on relevant boards
- [x] I have commented my code, at least hard-to-understand parts
- [x] I have signed off all commits from this PR
- [x] I have updated the documentation (wiki pages, ReadMe files, Copyright etc)
- [ ] I have not introduced new Warnings/Critical Warnings on compilation
- [x] I have added new hdl testbenches or updated existing ones
