### PR TITLE
gen_sbom: Add tool to generate SPDX3 SBOMs

### DIFF
--- a/.github/scripts/README.md
+++ b/.github/scripts/README.md
@@ -322,3 +322,29 @@ Generates a dependency tree of the repository, including licenses.
 ```
 python3 .github/scripts/makefile_deps_tree.py
 ```
+
+---
+
+## User guide for [gen_sbom.py](https://github.com/analogdevicesinc/hdl/tree/main/.github/scripts/gen_sbom.py)
+
+### Prerequisites
+
+* the script must be run while being in the root directory (/hdl)
+* uses Python 3.x
+
+### What does it do
+
+Generates one SPDX 3.0.1 JSON-LD SBOM per HDL project.
+
+Uses the Makefile PROJECT_NAME + LIB_DEPS to generate a dependency tree,
+them the SDPX short identifier to describe the license per library.
+
+### Usage
+
+Configuration:
+  OUT      path to write the SBOMs to
+  VERSION  version used in package URLs, e.g. a git tag/sha
+
+```
+OUT=$(mktemp -d) VERSION=2023_R2_p1 python3 .github/scripts/gen_sbom.py
+```

--- a/.github/scripts/README.md
+++ b/.github/scripts/README.md
@@ -303,3 +303,22 @@ python3 check_guideline.py -p  ./library/axi_ad9783/axi_ad9783.v ./library/commo
 # Check and edit a specific file given by absolute/relative path
 python3 check_guideline.py -pe ./library/axi_ad9783/axi_ad9783_if.v >> warnings.txt
 ```
+
+---
+
+## User guide for [makefile_deps_tree.py](https://github.com/analogdevicesinc/hdl/tree/main/.github/scripts/makefile_deps_tree.py)
+
+### Prerequisites
+
+* the script must be run while being in the root directory (/hdl)
+* uses Python 3.x
+
+### What does it do
+
+Generates a dependency tree of the repository, including licenses.
+
+### Usage
+
+```
+python3 .github/scripts/makefile_deps_tree.py
+```

--- a/.github/scripts/gen_sbom.py
+++ b/.github/scripts/gen_sbom.py
@@ -1,0 +1,292 @@
+#!/usr/bin/python3
+"""
+Generate one SPDX 3.0.1 SBOM per HDL project.
+
+Each Makefile with "PROJECT_NAME := ..." becomes an SBOM; its "LIB_DEPS" become
+dependsOn relationships to library packages, each with its declared license.
+The FPGA vendor SDK used is a build-scoped dependency.
+
+Environment:
+  OUT      path to write the SBOMs to.
+  VERSION  version for the package URL (git tag, branch or sha),
+           e.g. pkg:github/analogdevicesinc/hdl@2023_R2_p1
+
+Usage:
+  OUT=/path/to/out VERSION=2023_R2_p1 python3 .github/scripts/gen_sbom.py
+"""
+
+import datetime
+import glob
+import json
+import os
+import re
+import sys
+from os import path, environ, getcwd
+from urllib.parse import quote
+from makefile_deps_tree import get_deps_tree, sdk_packages_for_project, DEFAULT_LICENSE
+
+PURL_TYPE = "github"
+PURL_NAMESPACE = "analogdevicesinc"
+PURL_NAME = "hdl"
+VCS_URL = "https://github.com/analogdevicesinc/hdl"
+
+TOOL_NAME = "hdl-sbom-gen"
+TOOL_VERSION = "1.0.0"
+
+
+
+def purl(version, subpath=None):
+    """Build a PURL"""
+    namespace = quote(PURL_NAMESPACE.lower(), safe="")
+    name = quote(PURL_NAME.lower(), safe="")
+    p = f"pkg:{PURL_TYPE}/{namespace}/{name}@{quote(str(version), safe='')}"
+    if subpath:
+        segments = [s for s in subpath.split("/") if s not in ("", ".", "..")]
+        p += "#" + "/".join(quote(s, safe="") for s in segments)
+    return p
+
+
+def generic_purl(vendor, name, version):
+    """Build a generic package URL for a build SDK."""
+    return "pkg:generic/{}/{}@{}".format(
+        quote(vendor.lower(), safe=""),
+        quote(name.lower(), safe=""),
+        quote(str(version), safe=""),
+    )
+
+
+def env_versions(repo):
+    """Parse the SDK versions from scripts/adi_env.tcl."""
+    text = open(path.join(repo, "scripts", "adi_env.tcl"), errors="replace").read()
+
+    def tcl_string(var):
+        match = re.search(r'^\s*set\s+' + re.escape(var) + r'\s+"([^"]+)"', text, re.M)
+        if not match:
+            sys.exit(f"error: '{var}' not found in scripts/adi_env.tcl")
+        return match.group(1)
+
+    return {
+        "vivado": tcl_string("required_vivado_version"),
+        "quartus": tcl_string("required_quartus_version"),
+        "quartus_std": tcl_string("required_quartus_std_version"),
+        "lattice": tcl_string("required_lattice_version"),
+    }
+
+
+
+
+def get_projects(repo, versions):
+    """Yield (rel_dir, project_name, lib_deps, sdk_packages) for every project in deps tree."""
+    deps = get_deps_tree()
+    projects = deps["projects"]
+    for key, pdata in projects.items():
+        rel_dir = key.replace(".", "/")  # path (slash) form for SPDX output/url
+        project_name = key
+        lib_deps = pdata.get("lib_deps", [])
+        sdk_kind = pdata.get("sdk_kind")
+        sdk_packages = sdk_packages_for_project(sdk_kind, rel_dir, versions)
+        yield rel_dir, project_name, lib_deps, sdk_packages
+
+
+def build_spdx(repo, rel_dir, project_name, lib_deps, sdk_packages, version, created, libraries):
+    """Return an SPDX 3.0.1 JSON-LD dict for one project.
+
+    SpdxDocument -> software_Sbom -> software_Package (project)
+      dependsOn -> library packages; hasDeclaredLicense -> LicenseExpression
+    """
+    slug = rel_dir.replace("/", "-")
+    ns = f"urn:analog.com:hdl:{version}:{slug}"
+
+    graph = []
+    element_ids = []
+
+    def add(elem):
+        elem["creationInfo"] = "_:creationinfo"
+        graph.append(elem)
+        return elem["spdxId"]
+
+    def _id(tag):
+        return f"{ns}:{tag}"
+
+    # Deduplicated LicenseExpression nodes.
+    lic_ids = {}
+
+    def lic_id(expr):
+        if expr not in lic_ids:
+            node = {
+                "type":                              "simplelicensing_LicenseExpression",
+                "spdxId":                            _id(f"lic/{len(lic_ids)}"),
+                "simplelicensing_licenseExpression": expr,
+            }
+            refs = re.findall(r"LicenseRef-[\w.-]+", expr)
+            if refs:
+                node["simplelicensing_customIdToUri"] = [{
+                    "type":  "DictionaryEntry",
+                    "key":   ref,
+                    "value": f"{VCS_URL}/blob/{version}/LICENSE_ADIJESD204"
+                             if ref == "LicenseRef-ADIJESD204-commercial"
+                             else f"{VCS_URL}/blob/{version}/LICENSE",
+                } for ref in refs]
+            lic_ids[expr] = node["spdxId"]
+            add(node)
+        return lic_ids[expr]
+
+    id_org = add({
+        "type": "Organization",
+        "spdxId": _id("org/analog"),
+        "name": "Analog Devices Inc.",
+        "externalIdentifier": [{
+            "type": "ExternalIdentifier",
+            "externalIdentifierType": "email",
+            "identifier": "hdl@analog.com",
+        }],
+    })
+    id_tool = add({
+        "type": "Tool",
+        "spdxId": _id("tool"),
+        "name": TOOL_NAME,
+        "summary": f"{TOOL_NAME} {TOOL_VERSION}",
+    })
+
+    id_pkg = _id("pkg/project")
+    element_ids.append(add({
+        "type": "software_Package",
+        "spdxId": id_pkg,
+        "name": project_name,
+        "software_packageVersion": version,
+        "software_primaryPurpose": "configuration",
+        "software_packageUrl": purl(version, f"projects/{rel_dir}"),
+        "externalRef": [{
+            "type": "ExternalRef",
+            "externalRefType": "vcs",
+            "locator": [VCS_URL],
+        }],
+    }))
+
+    # Build SDK packages.
+    sdk_ids = []
+    for idx, sdk in enumerate(sdk_packages):
+        sdk_id = _id(f"pkg/sdk/{idx}")
+        sdk_ids.append(sdk_id)
+        element_ids.append(add({
+            "type": "software_Package",
+            "spdxId": sdk_id,
+            "name": sdk["name"],
+            "software_packageVersion": sdk["version"],
+            "software_primaryPurpose": "application",
+            "software_packageUrl": sdk["purl"],
+        }))
+
+    if sdk_ids:
+        element_ids.append(add({
+            "type": "LifecycleScopedRelationship",
+            "spdxId": _id("rel/build-sdk-depends-on"),
+            "from": id_pkg,
+            "relationshipType": "dependsOn",
+            "scope": "build",
+            "to": sdk_ids,
+        }))
+
+    # Library packages + their declared licenses.
+    lib_ids = []
+    for idx, dep in enumerate(lib_deps):
+        lib_id = _id(f"pkg/lib/{idx}")
+        lib_ids.append(lib_id)
+        element_ids.append(add({
+            "type": "software_Package",
+            "spdxId": lib_id,
+            "name": dep,
+            "software_packageVersion": version,
+            "software_primaryPurpose": "library",
+            "software_packageUrl": purl(version, f"library/{dep}"),
+        }))
+        license_expr = libraries.get(dep, {}).get('license', DEFAULT_LICENSE)
+        element_ids.append(add({
+            "type": "Relationship",
+            "spdxId": _id(f"rel/lib-license/{idx}"),
+            "relationshipType": "hasDeclaredLicense",
+            "from": lib_id,
+            "to": [lic_id(license_expr)],
+        }))
+
+    if lib_ids:
+        element_ids.append(add({
+            "type": "Relationship",
+            "spdxId": _id("rel/depends-on"),
+            "relationshipType": "dependsOn",
+            "from": id_pkg,
+            "to": lib_ids,
+            "completeness": "complete",
+        }))
+
+    element_ids.append(add({
+        "type": "Relationship",
+        "spdxId": _id("rel/project-license"),
+        "relationshipType": "hasDeclaredLicense",
+        "from": id_pkg,
+        "to": [lic_id(DEFAULT_LICENSE)],
+    }))
+
+    # LicenseExpression nodes were added to `graph` but not to element_ids yet.
+    element_ids += [e["spdxId"] for e in graph
+                    if e["type"] == "simplelicensing_LicenseExpression"]
+
+    id_sbom = add({
+        "type": "software_Sbom",
+        "spdxId": _id("sbom"),
+        "name": f"hdl-{slug}-{version}",
+        "rootElement": [id_pkg],
+        "element": element_ids,
+        "software_sbomType": ["source"],
+    })
+    add({
+        "type": "SpdxDocument",
+        "spdxId": _id("document"),
+        "rootElement": [id_sbom],
+        "element": [id_sbom, id_org, id_tool] + element_ids,
+        "profileConformance": ["core", "software", "simpleLicensing"],
+    })
+
+    creation_info = {
+        "type": "CreationInfo",
+        "@id": "_:creationinfo",
+        "specVersion": "3.0.1",
+        "createdBy": [id_org],
+        "createdUsing": [id_tool],
+        "created": created,
+    }
+
+    return {
+        "@context": "https://spdx.org/rdf/3.0.1/spdx-context.jsonld",
+        "@graph": [creation_info] + graph,
+    }
+
+
+def main():
+    out = environ.get("OUT")
+    version = environ.get("VERSION", "unknown")
+    if not out:
+        sys.exit("error: env variables 'OUT' must be set")
+    repo = getcwd()
+    if not path.isfile(path.join(repo, "LICENSE_ADIBSD")):
+        sys.exit(f"error: '{repo}' is not an hdl repository (no 'LICENSE_ADIBSD')")
+
+    os.makedirs(out, exist_ok=True)
+    created = datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+    sdk_versions = env_versions(repo)
+
+    deps_tree = get_deps_tree()
+    count = 0
+    for rel_dir, name, deps, sdk_packages in sorted(get_projects(repo, sdk_versions)):
+        doc = build_spdx(repo, rel_dir, name, deps, sdk_packages, version, created, deps_tree['libraries'])
+        fname = rel_dir.replace("/", ".") + ".sbom.spdx30.json"
+        with open(path.join(out, fname), "w") as f:
+            json.dump(doc, f, indent=2)
+        count += 1
+
+    print(f"wrote {count} SBOM(s) to {out}", file=sys.stderr)
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/scripts/makefile_deps_tree.py
+++ b/.github/scripts/makefile_deps_tree.py
@@ -1,0 +1,131 @@
+import os
+import re
+import json
+
+MAKEFILE_ASSIGN = re.compile(r'^(.*?)\s*\+=\s*(.+)$')
+LIB_DEPS_KEYS = ['GENERIC_DEPS', 'XILINX_DEPS', 'INTEL_DEPS', 'LATTICE_DEPS', 'XILINX_LIB_DEPS']
+
+SDK_DEFS = {
+    "xilinx": [{
+        "name": "AMD Vivado",
+        "vendor": "amd",
+        "package": "vivado",
+        "version_key": "vivado",
+    }],
+    "intel": [{
+        "name": "Intel Quartus",
+        "vendor": "intel",
+        "package": "quartus",
+        "version_key": "quartus",
+    }],
+    "lattice": [{
+        "name": "Lattice Radiant",
+        "vendor": "lattice",
+        "package": "radiant",
+        "version_key": "lattice",
+    }, {
+        "name": "Lattice Propel",
+        "vendor": "lattice",
+        "package": "propel",
+        "version_key": "lattice",
+    }],
+}
+
+def sdk_packages_for_project(kind, rel_dir, versions):
+    """Return SDK package definitions for a project."""
+    if not kind:
+        return []
+    project_versions = dict(versions)
+    if kind == "intel" and rel_dir.split("/")[-1] in ("de10nano", "c5soc"):
+        project_versions["quartus"] = project_versions["quartus_std"]
+
+    packages = []
+    for sdk in SDK_DEFS[kind]:
+        version = project_versions[sdk["version_key"]]
+        packages.append({
+            "name": sdk["name"],
+            "version": version,
+            "purl": f"pkg:generic/{sdk['vendor']}/{sdk['package']}@{version}",
+        })
+    return packages
+
+LICENSE_MAP = {
+    "ADIJESD204":   "LicenseRef-ADIJESD204-Commercial",
+    "ADIBSD":       "GPL-2.0-only OR ADIBSD",
+    "LGPL":         "LGPL-2.1-only",
+    "BSD-1-Clause": "BSD-1-Clause",
+}
+DEFAULT_LICENSE = "GPL-2.0-only OR ADIBSD"
+
+def get_deps_tree():
+    projects, libraries = {}, {}
+    for root, dirs, files in os.walk('projects'):
+        if 'Makefile' in files:
+            path = os.path.join(root, 'Makefile')
+            with open(path) as mf:
+                lines = mf.readlines()
+            if not any('PROJECT_NAME' in line for line in lines):
+                continue
+            rel = os.path.relpath(root, 'projects').split(os.sep)
+            key = rel[0] if len(rel) == 1 else f"{rel[0]}.{rel[1]}"
+            assigns = {}
+            for line in lines:
+                m = MAKEFILE_ASSIGN.match(line.strip())
+                if m:
+                    assigns.setdefault(m.group(1), []).append(m.group(2))
+            sdk_kind = None
+            for line in lines:
+                m = re.match(r'^\s*include\s+\S*project-(xilinx|intel|lattice)\.mk\s*$', line.strip())
+                if m:
+                    sdk_kind = m.group(1)
+                    break
+            projects[key] = {
+                'm_deps': [os.path.normpath(os.path.join(root, d)) for d in assigns.get('M_DEPS', [])],
+                'lib_deps': assigns.get('LIB_DEPS', []),
+                'sdk_kind': sdk_kind
+            }
+
+    for root, dirs, files in os.walk('library'):
+        if 'Makefile' in files:
+            path = os.path.join(root, 'Makefile')
+            rel = os.path.relpath(root, 'library')
+            assigns = {}
+            with open(path) as mf:
+                for line in mf:
+                    m = MAKEFILE_ASSIGN.match(line.strip())
+                    if m:
+                        assigns.setdefault(m.group(1), []).append(m.group(2))
+            license_expr = DEFAULT_LICENSE
+            for ext in ('.v', '.sv', '.vh', '.vhd'):
+                for dirpath, _, fnames in os.walk(root):
+                    for fname in fnames:
+                        if not fname.endswith(ext):
+                            continue
+                        fpath = os.path.join(dirpath, fname)
+                        if ".gen" in fpath:
+                            continue
+                        with open(fpath, errors="replace") as f:
+                            m = re.search(r"SPDX short identifier:\s*(\S+)", f.read(1024))
+                        if m:
+                            license_expr = LICENSE_MAP.get(m.group(1), DEFAULT_LICENSE)
+                            break
+                    else:
+                        continue
+                    break
+            libraries.setdefault(rel, {})
+            libraries[rel]["license"] = license_expr
+            for k in LIB_DEPS_KEYS:
+                if k in assigns:
+                    if k == 'XILINX_LIB_DEPS':
+                        libraries[rel].setdefault(k, []).extend(assigns[k])
+                    else:
+                        libraries[rel].setdefault(k, []).extend([
+                            os.path.normpath(os.path.join(root, d)) for d in assigns[k]
+                        ])
+    return {'projects': projects, 'libraries': libraries}
+
+if __name__ == '__main__':
+    print(json.dumps(get_deps_tree(), indent=2))
+
+# Export LICENSE constants for downstream use
+__all__ = ['get_deps_tree', 'sdk_packages_for_project', 'DEFAULT_LICENSE', 'LICENSE_MAP']


### PR DESCRIPTION

## PR Description

Add gen_sbom.py to generate SPDX 3.0.1 JSON-LD SBOM per HDL project.

For each Makefile under projects/ with PROJECT_NAME, use LIB_DEPS to create the  depends on relationship with the libraries. For the libraries, the license is obtained from the SPDX short identifier, with fallback to the ADI dual license.

  OUT=$(mktemp -d) VERSION=2023_R2_p1 python3 .github/scripts/gen_sbom.py

Users can link to our hdl projects using PURL:
```
pkg:github/analogdevicesinc/hdl@v1.0.0#projects/ad353xr/coraz7s
```
Uses "#projects/ad353xr/coraz7s" instead of "?project=ad353xr/coraz7s" because

```
A PURL is a URL composed of seven components:

    scheme:type/namespace/name@version?qualifiers#subpath
```
https://github.com/package-url/purl-spec/blob/main/docs/specification/standard/specification.md?plain=1#L5C1-L7C58
So it fits in the subpath before creating a custom qualifier

Checked manually and with validator
https://tools.spdx.org/app/validate/
as well as uploading to our SCA platform after downgrading to SPDX2

## PR Type
- [ ] Bug fix (change that fixes an issue)
- [x] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)
- [ ] Documentation

## PR Checklist
- [ ] I have followed the code style guidelines
- [ ] I have performed a self-review of changes
- [ ] I have compiled all hdl projects and libraries affected by this PR
- [ ] I have tested in hardware affected projects, at least on relevant boards
- [ ] I have commented my code, at least hard-to-understand parts
- [ ] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe files, Copyright etc)
- [ ] I have not introduced new Warnings/Critical Warnings on compilation
- [ ] I have added new hdl testbenches or updated existing ones
