### PR TITLE
[JESD204]: Agilex 5 support with AD9081 example design

### DIFF
--- a/library/intel/adi_jesd204/adi_jesd204_hw.tcl
+++ b/library/intel/adi_jesd204/adi_jesd204_hw.tcl
@@ -1,5 +1,5 @@
 ###############################################################################
-## Copyright (C) 2016-2025 Analog Devices, Inc. All rights reserved.
+## Copyright (C) 2016-2026 Analog Devices, Inc. All rights reserved.
 ### SPDX short identifier: ADIJESD204
 ###############################################################################
 
@@ -110,6 +110,12 @@ ad_ip_parameter DATA_PATH_WIDTH INTEGER 4 false { \
   DISPLAY_NAME "Data path width" \
   DISPLAY_UNITS "octets" \
   ALLOWED_RANGES {4 8} \
+}
+
+ad_ip_parameter EXTERNAL_PHY BOOLEAN 0 false { \
+  DISPLAY_HINT "radio" \
+  DISPLAY_NAME "External PHY" \
+  ALLOWED_RANGES { "0:Internal" "1:External" }
 }
 
 proc create_phy_reset_control {tx num_of_lanes sysclk_frequency} {
@@ -288,10 +294,25 @@ proc jesd204_validate {{quiet false}} {
   set num_of_lanes [get_parameter_value "NUM_OF_LANES"]
   set tx_or_rx_n [get_parameter_value "TX_OR_RX_N"]
   set link_mode [get_parameter_value "LINK_MODE"]
+  set external_phy [get_parameter_value "EXTERNAL_PHY"]
 
-  if {$device_family != "Arria 10" && $device_family != "Stratix 10" && $device_family != "Agilex 7"} {
+  if {$device_family != "Arria 10" && $device_family != "Stratix 10" && $device_family != "Agilex 7" && $device_family != "Agilex 5"} {
     if {!$quiet} {
-      send_message error "Only Arria 10/Startix 10/Agilex 7 are supported."
+      send_message error "Only Arria 10/Startix 10/Agilex 7/Agilex 5 are supported."
+    }
+    return false
+  }
+
+  if {$external_phy && $device_family != "Agilex 5"} {
+    if {!$quiet} {
+      send_message error "Only Agilex 5 supports external PHY."
+    }
+    return false
+  }
+
+  if {$device_family == "Agilex 5" && !$external_phy} {
+    if {!$quiet} {
+      send_message error "Agilex 5 supports only external PHY."
     }
     return false
   }
@@ -312,9 +333,9 @@ proc jesd204_validate {{quiet false}} {
       return false
     }
   } else {
-    if {$device_family != "Agilex 7"} {
+    if {$device_family != "Agilex 7" && $device_family != "Agilex 5"} {
       if {!$quiet} {
-        send_message error "JESD204C is only supported on Agilex 7 devices."
+        send_message error "JESD204C is only supported on Agilex 7 / Agilex 5 devices."
         return false
       }
     }
@@ -344,6 +365,7 @@ proc jesd204_compose {} {
   set tpl_data_path_width [get_parameter_value "TPL_DATA_PATH_WIDTH"]
   set data_path_width [get_parameter_value "DATA_PATH_WIDTH"]
   set link_mode [get_parameter_value "LINK_MODE"]
+  set external_phy [get_parameter_value "EXTERNAL_PHY"]
 
   set sip_tile ""
   set sip_tile_info [quartus::device::get_part_info -sip_tile $device]
@@ -471,10 +493,11 @@ proc jesd204_compose {} {
   } elseif {$device_family == "Agilex 7"} {
 
     ## No fPLL here, PLL embedded in Native PHY
-
+  } elseif {$device_family == "Agilex 5"} {
+    ## No fPLL here, PLL embedded in Native PHY
   } else {
     ## Unsupported device
-    send_message error "Only Arria 10/Stratix 10/Agilex 7 are supported."
+    send_message error "Only Arria 10/Stratix 10/Agilex 7/Agilex 5 are supported."
   }
 
   add_interface link_clk clock source
@@ -516,79 +539,120 @@ proc jesd204_compose {} {
     create_phy_reset_control $tx_or_rx_n $num_of_lanes $sysclk_frequency
   }
 
-  add_instance phy jesd204_phy
-  set_instance_parameter_value phy ID $id
-  set_instance_parameter_value phy LINK_MODE $link_mode
-  set_instance_parameter_value phy DEVICE $device_family
-  set_instance_parameter_value phy SOFT_PCS $soft_pcs
-  set_instance_parameter_value phy TX_OR_RX_N $tx_or_rx_n
-  set_instance_parameter_value phy LANE_RATE $lane_rate
-  set_instance_parameter_value phy REFCLK_FREQUENCY $refclk_frequency
-  set_instance_parameter_value phy NUM_OF_LANES $num_of_lanes
-  set_instance_parameter_value phy REGISTER_INPUTS $input_pipeline
-  set_instance_parameter_value phy LANE_INVERT $lane_invert
-  set_instance_parameter_value phy BONDING_CLOCKS_EN $bonding_clocks_en
+  if {!$external_phy} {
+    add_instance phy jesd204_phy
+    set_instance_parameter_value phy ID $id
+    set_instance_parameter_value phy LINK_MODE $link_mode
+    set_instance_parameter_value phy DEVICE $device_family
+    set_instance_parameter_value phy SOFT_PCS $soft_pcs
+    set_instance_parameter_value phy TX_OR_RX_N $tx_or_rx_n
+    set_instance_parameter_value phy LANE_RATE $lane_rate
+    set_instance_parameter_value phy REFCLK_FREQUENCY $refclk_frequency
+    set_instance_parameter_value phy NUM_OF_LANES $num_of_lanes
+    set_instance_parameter_value phy REGISTER_INPUTS $input_pipeline
+    set_instance_parameter_value phy LANE_INVERT $lane_invert
+    set_instance_parameter_value phy BONDING_CLOCKS_EN $bonding_clocks_en
 
-  add_connection link_reset.out_reset phy.link_reset
-  add_connection sys_clock.clk phy.reconfig_clk
-  add_connection sys_clock.clk_reset phy.reconfig_reset
+    add_connection link_reset.out_reset phy.link_reset
+    add_connection sys_clock.clk phy.reconfig_clk
+    add_connection sys_clock.clk_reset phy.reconfig_reset
 
-  ## connect the required device clock
+    ## connect the required device clock
 
-  if {$ext_device_clk_en} {
-    add_instance ext_device_clock altera_clock_bridge
-    set_instance_parameter_value ext_device_clock {EXPLICIT_CLOCK_RATE} [expr $deviceclk_frequency*1000000]
-    set_instance_parameter_value ext_device_clock {NUM_CLOCK_OUTPUTS} 2
-    add_interface device_clk clock sink
-    set_interface_property device_clk EXPORT_OF ext_device_clock.in_clk
-  }
+    if {$ext_device_clk_en} {
+      add_instance ext_device_clock altera_clock_bridge
+      set_instance_parameter_value ext_device_clock {EXPLICIT_CLOCK_RATE} [expr $deviceclk_frequency*1000000]
+      set_instance_parameter_value ext_device_clock {NUM_CLOCK_OUTPUTS} 2
+      add_interface device_clk clock sink
+      set_interface_property device_clk EXPORT_OF ext_device_clock.in_clk
+    }
 
-  add_connection $link_clock phy.link_clk
-  set_interface_property link_clk EXPORT_OF $device_clock_export
+    add_connection $link_clock phy.link_clk
+    set_interface_property link_clk EXPORT_OF $device_clock_export
 
-  if {$device_family == "Arria 10" || $device_family == "Stratix 10"} {
-    if {$tx_or_rx_n} {
-      create_lane_pll $id $tx_or_rx_n $pllclk_frequency $refclk_frequency $num_of_lanes $bonding_clocks_en
-      if {$num_of_lanes > 6} {
-          if {$bonding_clocks_en} {
-              add_connection lane_pll.tx_bonding_clocks phy.bonding_clocks
-          } else {
-              add_connection lane_pll.tx_serial_clk   phy.serial_clk_x1
-              add_connection lane_pll.mcgb_serial_clk phy.serial_clk_xN
-          }
-      } else {
-          add_connection lane_pll.tx_serial_clk phy.serial_clk_x1
+    if {$device_family == "Arria 10" || $device_family == "Stratix 10"} {
+      if {$tx_or_rx_n} {
+        create_lane_pll $id $tx_or_rx_n $pllclk_frequency $refclk_frequency $num_of_lanes $bonding_clocks_en
+        if {$num_of_lanes > 6} {
+            if {$bonding_clocks_en} {
+                add_connection lane_pll.tx_bonding_clocks phy.bonding_clocks
+            } else {
+                add_connection lane_pll.tx_serial_clk   phy.serial_clk_x1
+                add_connection lane_pll.mcgb_serial_clk phy.serial_clk_xN
+            }
+        } else {
+            add_connection lane_pll.tx_serial_clk phy.serial_clk_x1
+        }
       }
     }
-  }
 
-  if {$device_family == "Arria 10" || $device_family == "Stratix 10"} {
-   # add_connection ref_clock.out_clk phy.ref_clk
+    if {$device_family == "Arria 10" || $device_family == "Stratix 10"} {
+    # add_connection ref_clock.out_clk phy.ref_clk
+    } elseif {$device_family == "Agilex 7"} {
 
-  } elseif {$device_family == "Agilex 7"} {
-    add_connection phy.clkout link_clock.in_clk
+      add_connection phy.clkout link_clock.in_clk
+      add_connection phy.clkout2 phy.phy_clk
+      add_connection link_reset.out_reset phy.phy_reset
 
-    add_connection phy.clkout2 phy.phy_clk
-    add_connection link_reset.out_reset phy.phy_reset
+      # PHY <-> AXI_XCVR
+      #TODO: Fix me
+      # if {$tx_or_rx_n} {
+      #   add_connection axi_xcvr.core_pll_locked phy.pll_locked
+      # } else {
+      #   add_connection axi_xcvr.rx_lockedtodata phy.rx_lockedtodata
+      # }
+      add_connection axi_xcvr.ready     phy.ready
+      add_connection axi_xcvr.reset     phy.reset
+      add_connection axi_xcvr.reset_ack phy.reset_ack
 
-    # PHY <-> AXI_XCVR
-    if {$tx_or_rx_n} {
-      add_connection axi_xcvr.core_pll_locked phy.pll_locked
+      add_connection axi_xcvr.if_up_rst phy.link_reset
+
+      ## Export ref clocks
+      add_interface ref_clk ftile_hssi_reference_clock sink
+      set_interface_property ref_clk EXPORT_OF phy.ref_clk
     } else {
-      add_connection axi_xcvr.rx_lockedtodata phy.rx_lockedtodata
+      ## Unsupported device
+      send_message error "Only Arria 10/Stratix 10/Agilex 7 are supported."
     }
-    add_connection axi_xcvr.ready     phy.ready
-    add_connection axi_xcvr.reset     phy.reset
-    add_connection axi_xcvr.reset_ack phy.reset_ack
-
-    add_connection axi_xcvr.if_up_rst phy.link_reset
-
-    ## Export ref clocks
-    add_interface ref_clk ftile_hssi_reference_clock sink
-    set_interface_property ref_clk EXPORT_OF phy.ref_clk
   } else {
-    ## Unsupported device
-    send_message error "Only Arria 10/Stratix 10/Agilex 7 are supported."
+    # External PHY, no PHY instance created, just export the interfaces
+
+    if {$ext_device_clk_en} {
+      add_instance ext_device_clock altera_clock_bridge
+      set_instance_parameter_value ext_device_clock {EXPLICIT_CLOCK_RATE} [expr $deviceclk_frequency*1000000]
+      set_instance_parameter_value ext_device_clock {NUM_CLOCK_OUTPUTS} 2
+      add_interface device_clk clock sink
+      set_interface_property device_clk EXPORT_OF ext_device_clock.in_clk
+    }
+
+    set_interface_property link_clk EXPORT_OF $device_clock_export
+
+    # When running in gearbox mode, the device clock will be slower
+    # than the link clock so we can't use it
+    if {$data_path_width < $tpl_data_path_width} {
+      add_interface phy_link_clk clock sink
+      set_interface_property phy_link_clk EXPORT_OF link_clock.in_clk
+    } else {
+      add_connection $device_clock link_clock.in_clk
+    }
+
+    add_interface ready conduit end
+    add_interface reset conduit end
+    add_interface reset_ack conduit end
+    add_interface if_up_rst reset source
+
+    set_interface_property ready EXPORT_OF axi_xcvr.ready
+    set_interface_property reset EXPORT_OF axi_xcvr.reset
+    set_interface_property reset_ack EXPORT_OF axi_xcvr.reset_ack
+    set_interface_property if_up_rst EXPORT_OF axi_xcvr.if_up_rst
+
+    if {$tx_or_rx_n} {
+      add_interface tx_pll_locked conduit end
+      set_interface_property tx_pll_locked EXPORT_OF axi_xcvr.core_pll_locked
+    } else {
+      add_interface rx_is_lockedtodata conduit end
+      set_interface_property rx_is_lockedtodata EXPORT_OF axi_xcvr.rx_lockedtodata
+    }
   }
 
   if {$tx_or_rx_n} {
@@ -661,17 +725,32 @@ proc jesd204_compose {} {
     } else {
       set j $i
     }
-    add_connection jesd204_${tx_rx}.${tx_rx}_phy${j} phy.phy_${i}
+    if {!$external_phy} {
+      add_connection jesd204_${tx_rx}.${tx_rx}_phy${j} phy.phy_${i}
+    } else {
+      add_interface ${tx_rx}_phy${j} conduit end
+      set_interface_property ${tx_rx}_phy${j} EXPORT_OF jesd204_${tx_rx}.${tx_rx}_phy${j}
+    }
   }
 
-  if {$device_family == "Arria 10" || $device_family == "Stratix 10"} {
-    for {set i 0} {$i < $num_of_lanes} {incr i} {
-      add_interface phy_reconfig_${i} avalon slave
-      set_interface_property phy_reconfig_${i} EXPORT_OF phy.reconfig_avmm_${i}
+  if {!$external_phy} {
+    if {$device_family == "Arria 10" || $device_family == "Stratix 10"} {
+      for {set i 0} {$i < $num_of_lanes} {incr i} {
+        add_interface phy_reconfig_${i} avalon slave
+        set_interface_property phy_reconfig_${i} EXPORT_OF phy.reconfig_avmm_${i}
+      }
+    } elseif {$device_family == "Agilex 7"} {
+      add_interface phy_reconfig avalon slave
+      set_interface_property phy_reconfig EXPORT_OF phy.reconfig_avmm
     }
-  } elseif {$device_family == "Agilex 7"} {
-    add_interface phy_reconfig avalon slave
-    set_interface_property phy_reconfig EXPORT_OF phy.reconfig_avmm
+
+    add_interface serial_data conduit end
+    set_interface_property serial_data EXPORT_OF phy.serial_data
+
+    if {$device_family == "Agilex 7"} {
+      add_interface serial_data_n conduit end
+      set_interface_property serial_data_n EXPORT_OF phy.serial_data_n
+    }
   }
 
   add_interface interrupt interrupt end
@@ -692,12 +771,4 @@ proc jesd204_compose {} {
 
   add_interface sync conduit end
   set_interface_property sync EXPORT_OF jesd204_${tx_rx}.sync
-
-  add_interface serial_data conduit end
-  set_interface_property serial_data EXPORT_OF phy.serial_data
-
-  if {$device_family == "Agilex 7"} {
-    add_interface serial_data_n conduit end
-    set_interface_property serial_data_n EXPORT_OF phy.serial_data_n
-  }
 }

--- a/library/intel/axi_adxcvr/axi_adxcvr.v
+++ b/library/intel/axi_adxcvr/axi_adxcvr.v
@@ -1,6 +1,6 @@
 // ***************************************************************************
 // ***************************************************************************
-// Copyright (C) 2014-2024 Analog Devices, Inc. All rights reserved.
+// Copyright (C) 2014-2026 Analog Devices, Inc. All rights reserved.
 //
 // In this HDL repository, there are many different and unique modules, consisting
 // of various HDL (Verilog or VHDL) components. The individual modules are
@@ -105,6 +105,48 @@ module axi_adxcvr #(
 
   assign xcvr_reset = up_rst;
 
+  // CDC
+  wire [READY_W-1:0] up_ready_s;
+  wire [READY_W-1:0] up_reset_ack_s;
+  wire               up_pll_locked_s;
+  wire               up_rx_lockedtodata_s;
+
+  sync_bits #(
+    .NUM_OF_BITS(1),
+    .ASYNC_CLK(1)
+  ) i_pll_locked_cdc (
+    .in_bits(&up_pll_locked),
+    .out_clk(up_clk),
+    .out_resetn(up_rstn),
+    .out_bits(up_pll_locked_s));
+
+  sync_bits #(
+    .NUM_OF_BITS(1),
+    .ASYNC_CLK(1)
+  ) i_rx_lockedtodata_cdc (
+    .in_bits(&up_rx_lockedtodata),
+    .out_clk(up_clk),
+    .out_resetn(up_rstn),
+    .out_bits(up_rx_lockedtodata_s));
+
+  sync_bits #(
+    .NUM_OF_BITS(READY_W),
+    .ASYNC_CLK(1)
+  ) i_ready_cdc (
+    .in_bits(up_ready),
+    .out_clk(up_clk),
+    .out_resetn(up_rstn),
+    .out_bits(up_ready_s));
+
+  sync_bits #(
+    .NUM_OF_BITS(READY_W),
+    .ASYNC_CLK(1)
+  ) i_reset_ack_cdc (
+    .in_bits(up_reset_ack),
+    .out_clk(up_clk),
+    .out_resetn(up_rstn),
+    .out_bits(up_reset_ack_s));
+
   // instantiations
 
   axi_adxcvr_up #(
@@ -120,10 +162,10 @@ module axi_adxcvr #(
     .READY_W (READY_W)
   ) i_up (
     .up_rst (up_rst),
-    .up_pll_locked (&up_pll_locked),
-    .up_rx_lockedtodata (&up_rx_lockedtodata),
-    .up_ready (up_ready),
-    .up_reset_ack (up_reset_ack),
+    .up_pll_locked (up_pll_locked_s),
+    .up_rx_lockedtodata (up_rx_lockedtodata_s),
+    .up_ready (up_ready_s),
+    .up_reset_ack (up_reset_ack_s),
     .up_rstn (up_rstn),
     .up_clk (up_clk),
     .up_wreq (up_wreq),

--- a/library/intel/axi_adxcvr/axi_adxcvr_constr.sdc
+++ b/library/intel/axi_adxcvr/axi_adxcvr_constr.sdc
@@ -1,0 +1,13 @@
+###############################################################################
+## Copyright (C) 2025-2026 Analog Devices, Inc. All rights reserved.
+### SPDX short identifier: ADIJESD204
+###############################################################################
+
+set script_dir [file dirname [info script]]
+
+source "$script_dir/util_cdc_constr.tcl"
+
+util_cdc_sync_bits_constr {*|sync_bits:i_pll_locked_cdc}
+util_cdc_sync_bits_constr {*|sync_bits:i_rx_lockedtodata_cdc}
+util_cdc_sync_bits_constr {*|sync_bits:i_ready_cdc}
+util_cdc_sync_bits_constr {*|sync_bits:i_reset_ack_cdc}

--- a/library/intel/axi_adxcvr/axi_adxcvr_hw.tcl
+++ b/library/intel/axi_adxcvr/axi_adxcvr_hw.tcl
@@ -1,5 +1,5 @@
 ###############################################################################
-## Copyright (C) 2016-2025 Analog Devices, Inc. All rights reserved.
+## Copyright (C) 2016-2026 Analog Devices, Inc. All rights reserved.
 ### SPDX short identifier: ADIBSD
 ###############################################################################
 
@@ -20,10 +20,12 @@ set_module_property VALIDATION_CALLBACK info_param_validate
 # files
 
 ad_ip_files axi_adxcvr [list \
-  $ad_hdl_dir/library/util_cdc/sync_bits.v \
   $ad_hdl_dir/library/common/up_axi.v \
   axi_adxcvr_up.v \
   axi_adxcvr.v \
+  axi_adxcvr_constr.sdc \
+  $ad_hdl_dir/library/util_cdc/sync_bits.v \
+  $ad_hdl_dir/library/util_cdc/util_cdc_constr.tcl \
 ]
 
 # parameters
@@ -76,7 +78,8 @@ proc p_axi_adxcvr {} {
   }
 
   # 105 = Agilex, see adi_intel_device_info_enc.tcl
-  if {$fpga_technology == 105} {
+  if {$fpga_technology == 105 || $fpga_technology == 106} {
+
     add_interface ready conduit end
     add_interface_port ready up_ready ${rx_tx}_ready input 1
 
@@ -87,11 +90,21 @@ proc p_axi_adxcvr {} {
     add_interface_port reset_ack up_reset_ack ${rx_tx}_reset_ack input 1
 
     if {$m_tx_or_rx_n == 0} {
-      add_interface rx_lockedtodata conduit end
-      add_interface_port rx_lockedtodata up_rx_lockedtodata rx_is_lockedtodata input $m_num_of_lanes
+      if {$fpga_technology == 105} {
+        add_interface rx_lockedtodata conduit end
+        add_interface_port rx_lockedtodata up_rx_lockedtodata rx_is_lockedtodata input $m_num_of_lanes
+      } else {
+        add_interface rx_lockedtodata conduit end
+        add_interface_port rx_lockedtodata up_rx_lockedtodata o_rx_is_lockedtodata input $m_num_of_lanes
+      }
     } else {
-      add_interface core_pll_locked conduit end
-      add_interface_port core_pll_locked up_pll_locked ${rx_tx}_pll_locked Input $m_num_of_lanes
+      if {$fpga_technology == 105} {
+        add_interface core_pll_locked conduit end
+        add_interface_port core_pll_locked up_pll_locked tx_pll_locked Input $m_num_of_lanes
+      } else {
+        add_interface core_pll_locked conduit end
+        add_interface_port core_pll_locked up_pll_locked o_tx_pll_locked Input $m_num_of_lanes
+      }
     }
 
   } else {

--- a/library/intel/axi_adxcvr/axi_adxcvr_up.v
+++ b/library/intel/axi_adxcvr/axi_adxcvr_up.v
@@ -1,6 +1,6 @@
 // ***************************************************************************
 // ***************************************************************************
-// Copyright (C) 2014-2025 Analog Devices, Inc. All rights reserved.
+// Copyright (C) 2014-2026 Analog Devices, Inc. All rights reserved.
 //
 // In this HDL repository, there are many different and unique modules, consisting
 // of various HDL (Verilog or VHDL) components. The individual modules are
@@ -48,7 +48,7 @@ module axi_adxcvr_up #(
   parameter   integer XCVR_TYPE = 0,
   parameter   integer TX_OR_RX_N = 0,
   parameter   integer NUM_OF_LANES = 4,
-  parameter           READY_W = (FPGA_TECHNOLOGY != 105) ?  NUM_OF_LANES : 1
+  parameter           READY_W = (FPGA_TECHNOLOGY != 105 && FPGA_TECHNOLOGY != 106) ?  NUM_OF_LANES : 1
 ) (
   // xcvr, lane-pll and ref-pll are shared
 
@@ -56,7 +56,7 @@ module axi_adxcvr_up #(
   input                         up_pll_locked,
   input                         up_rx_lockedtodata,
   input   [READY_W-1:0]         up_ready,
-  input   [READY_W-1:0]         up_reset_ack,
+  input                         up_reset_ack,
 
   // bus interface
 
@@ -81,19 +81,19 @@ module axi_adxcvr_up #(
   reg                           up_wreq_d = 'd0;
   reg     [31:0]                up_scratch = 'd0;
   reg                           up_resetn = 'd0;
+  reg     [ 3:0]                up_rst_cnt = 'd8;
   reg                           up_status_int = 'd0;
   reg                           up_rreq_d = 'd0;
   reg     [31:0]                up_rdata_d = 'd0;
 
   // internal signals
 
-  wire                          up_all_ready_s;
+  wire                          up_ready_s;
   wire    [31:0]                up_status_32_s;
   wire    [31:0]                up_rparam_s;
+  wire                          up_reset_ack_latched_s;
 
-  wire                          up_pll_locked_s;
-  wire                          up_rx_lockedtodata_s;
-  wire                          up_ready_s;
+  reg                           up_reset_ack_latched = 'd0;
 
   // defaults
 
@@ -123,80 +123,47 @@ module axi_adxcvr_up #(
     end
   end
 
-  generate if (FPGA_TECHNOLOGY == 105) begin
-    sync_bits #(
-      .NUM_OF_BITS (3),
-      .ASYNC_CLK (1)
-    ) i_sync_input_ctrl (
-      .in_bits ({up_ready, up_pll_locked, up_rx_lockedtodata}),
-      .out_resetn (1'b1),
-      .out_clk (up_clk),
-      .out_bits({up_ready_s, up_pll_locked_s, up_rx_lockedtodata_s}));
-  end else begin
-    assign up_ready_s = up_ready;
-    assign up_pll_locked_s = up_pll_locked;
-    assign up_rx_lockedtodata_s = up_rx_lockedtodata;
-  end
-  endgenerate
-
-  assign up_all_ready_s = & up_status_32_s[(NUM_OF_LANES-1):0];
+  assign up_rst = up_rst_cnt[3];
+  assign up_ready_s = & up_status_32_s[NUM_OF_LANES:1];
   assign up_status_32_s[31:(NUM_OF_LANES+1)] = 'd0;
-  assign up_status_32_s[NUM_OF_LANES] = FPGA_TECHNOLOGY == 105 ? TX_OR_RX_N ? up_pll_locked_s : up_rx_lockedtodata_s :
-                                                                 up_pll_locked_s;
-  assign up_status_32_s[(NUM_OF_LANES-1):0] = FPGA_TECHNOLOGY == 105 ? {NUM_OF_LANES{up_ready_s}} : up_ready_s;
+  assign up_status_32_s[NUM_OF_LANES] = (FPGA_TECHNOLOGY == 105 || FPGA_TECHNOLOGY == 106) ? TX_OR_RX_N ? up_pll_locked : up_rx_lockedtodata :
+                                                                 up_pll_locked;
+  assign up_status_32_s[(NUM_OF_LANES-1):0] = (FPGA_TECHNOLOGY == 105 || FPGA_TECHNOLOGY == 106) ? {NUM_OF_LANES{up_ready}} : up_ready;
 
-  generate if (FPGA_TECHNOLOGY == 105) begin
-    wire up_reset_ack_s;
-    reg  up_rst_d;
-
-    sync_bits #(
-      .NUM_OF_BITS (1),
-      .ASYNC_CLK (1)
-    ) i_sync_reset_ack (
-      .in_bits (up_reset_ack),
-      .out_resetn (1'b1),
-      .out_clk (up_clk),
-      .out_bits(up_reset_ack_s));
-
-    always @(negedge up_rstn or posedge up_clk) begin
-      if (up_rstn == 0) begin
-        up_rst_d <= 1'b1;
-      end else if (up_resetn == 1'b0) begin
-        up_rst_d <= 1'b1;
-      end else if (up_reset_ack_s) begin
-        up_rst_d <= 1'b0;
-      end
-    end
-    assign up_rst = up_rst_d;
-  end else begin
-    reg [3:0] up_rst_cnt = 'd8;
-
-    always @(negedge up_rstn or posedge up_clk) begin
-      if (up_rstn == 0) begin
-        up_rst_cnt <= 4'h8;
-      end else begin
-        if (up_resetn == 1'b0) begin
-          up_rst_cnt <= 4'h8;
-        end else if (up_rst_cnt[3] == 1'b1) begin
-          up_rst_cnt <= up_rst_cnt + 1'b1;
-        end
-      end
-    end
-    assign up_rst = up_rst_cnt[3];
-  end
-  endgenerate
+  assign up_reset_ack_latched_s = (FPGA_TECHNOLOGY == 105 || FPGA_TECHNOLOGY == 106) ? up_reset_ack_latched : 1'b1;
 
   always @(negedge up_rstn or posedge up_clk) begin
     if (up_rstn == 0) begin
+      up_rst_cnt <= 4'h8;
       up_status_int <= 1'b0;
     end else begin
       if (up_resetn == 1'b0) begin
+        up_rst_cnt <= 4'h8;
+      end else if (up_rst_cnt[3] == 1'b1 && up_reset_ack_latched_s) begin
+        up_rst_cnt <= up_rst_cnt + 1'b1;
+      end
+      if (up_resetn == 1'b0) begin
         up_status_int <= 1'b0;
-      end else if (up_all_ready_s) begin
+      end else if (up_ready_s == 1'b1) begin
         up_status_int <= 1'b1;
       end
     end
   end
+
+  generate if (FPGA_TECHNOLOGY == 105 || FPGA_TECHNOLOGY == 106) begin
+    always @(negedge up_rstn or posedge up_clk) begin
+      if (up_rstn == 1'b0) begin
+        up_reset_ack_latched <= 1'b0;
+      end else begin
+        if (up_resetn == 1'b0) begin
+          up_reset_ack_latched <= 1'b0;
+        end else if (up_reset_ack == 1'b1) begin
+          up_reset_ack_latched <= 1'b1;
+        end
+      end
+    end
+  end
+  endgenerate
 
   // Specific to Intel
 

--- a/library/intel/common/f2sdram_adapter/Makefile
+++ b/library/intel/common/f2sdram_adapter/Makefile
@@ -1,0 +1,11 @@
+####################################################################################
+## Copyright (c) 2018 - 2023 Analog Devices, Inc.
+### SPDX short identifier: BSD-1-Clause
+## Auto-generated, do not modify!
+####################################################################################
+
+LIBRARY_NAME := f2sdram_adapter
+
+INTEL_DEPS += f2sdram_adapter.tcl
+
+include ../../../scripts/library.mk

--- a/library/intel/common/f2sdram_adapter/f2sdram_adapter_hw.tcl
+++ b/library/intel/common/f2sdram_adapter/f2sdram_adapter_hw.tcl
@@ -1,0 +1,416 @@
+#
+# SPDX-License-Identifier: MIT-0
+# SPDX-FileCopyrightText: Copyright (C) 2025 Altera Corporation
+#
+
+package require -exact qsys 24.3
+
+
+#
+# module f2sdram_adapter
+#
+set_module_property DESCRIPTION ""
+set_module_property NAME f2sdram_adapter
+set_module_property VERSION 1.0
+set_module_property INTERNAL false
+set_module_property OPAQUE_ADDRESS_MAP true
+set_module_property AUTHOR "RSF"
+set_module_property DISPLAY_NAME f2sdram_adapter
+set_module_property INSTANTIATE_IN_SYSTEM_MODULE true
+set_module_property EDITABLE true
+set_module_property REPORT_TO_TALKBACK false
+set_module_property ALLOW_GREYBOX_GENERATION false
+set_module_property REPORT_HIERARCHY false
+set_module_property LOAD_ELABORATION_LIMIT 0
+set_module_property PRE_COMP_MODULE_ENABLED false
+set_module_property ELABORATION_CALLBACK elaboration
+
+#
+# parameters
+#
+add_parameter ADDRESS_WIDTH INTEGER "40"
+set_parameter_property ADDRESS_WIDTH DEFAULT_VALUE 40
+set_parameter_property ADDRESS_WIDTH DISPLAY_NAME ADDRESS_WIDTH
+set_parameter_property ADDRESS_WIDTH HDL_PARAMETER true
+set_parameter_property ADDRESS_WIDTH VISIBLE true
+set_parameter_property ADDRESS_WIDTH ALLOWED_RANGES {32 40}
+
+add_parameter DATA_WIDTH INTEGER "256"
+set_parameter_property DATA_WIDTH DEFAULT_VALUE 256
+set_parameter_property DATA_WIDTH DISPLAY_NAME DATA_WIDTH
+set_parameter_property DATA_WIDTH HDL_PARAMETER true
+set_parameter_property DATA_WIDTH VISIBLE true
+set_parameter_property DATA_WIDTH ALLOWED_RANGES {64 128 256}
+
+#
+# file sets
+#
+add_fileset QUARTUS_SYNTH QUARTUS_SYNTH generate_verilog
+
+add_fileset SIM_VERILOG SIM_VERILOG generate_verilog
+
+add_fileset SIM_VHDL SIM_VHDL generate_verilog
+
+proc elaboration {} {
+set ADDRESS_WIDTH          [ get_parameter_value ADDRESS_WIDTH ]
+set DATA_WIDTH          [ get_parameter_value DATA_WIDTH ]
+}
+#
+# display items
+#
+
+
+#
+# connection point clock
+#
+add_interface clock clock end
+set_interface_property clock ENABLED true
+set_interface_property clock EXPORT_OF ""
+set_interface_property clock PORT_NAME_MAP ""
+set_interface_property clock CMSIS_SVD_VARIABLES ""
+set_interface_property clock SVD_ADDRESS_GROUP ""
+set_interface_property clock IPXACT_REGISTER_MAP_VARIABLES ""
+set_interface_property clock SV_INTERFACE_TYPE ""
+set_interface_property clock SV_INTERFACE_MODPORT_TYPE ""
+
+add_interface_port clock clk clk Input 1
+
+
+#
+# connection point reset
+#
+add_interface reset reset end
+set_interface_property reset associatedClock clock
+set_interface_property reset synchronousEdges DEASSERT
+set_interface_property reset ENABLED true
+set_interface_property reset EXPORT_OF ""
+set_interface_property reset PORT_NAME_MAP ""
+set_interface_property reset CMSIS_SVD_VARIABLES ""
+set_interface_property reset SVD_ADDRESS_GROUP ""
+set_interface_property reset IPXACT_REGISTER_MAP_VARIABLES ""
+set_interface_property reset SV_INTERFACE_TYPE ""
+set_interface_property reset SV_INTERFACE_MODPORT_TYPE ""
+
+add_interface_port reset reset reset Input 1
+
+
+#
+# connection point axi4_man
+#
+add_interface axi4_man axi4 start
+set_interface_property axi4_man associatedClock clock
+set_interface_property axi4_man associatedReset reset
+set_interface_property axi4_man wakeupSignals false
+set_interface_property axi4_man uniqueIdSupport false
+set_interface_property axi4_man poison false
+set_interface_property axi4_man traceSignals false
+set_interface_property axi4_man readIssuingCapability 1
+set_interface_property axi4_man writeIssuingCapability 1
+set_interface_property axi4_man combinedIssuingCapability 1
+set_interface_property axi4_man issuesINCRBursts true
+set_interface_property axi4_man issuesWRAPBursts true
+set_interface_property axi4_man issuesFIXEDBursts true
+set_interface_property axi4_man ENABLED true
+set_interface_property axi4_man EXPORT_OF ""
+set_interface_property axi4_man PORT_NAME_MAP ""
+set_interface_property axi4_man CMSIS_SVD_VARIABLES ""
+set_interface_property axi4_man SVD_ADDRESS_GROUP ""
+set_interface_property axi4_man IPXACT_REGISTER_MAP_VARIABLES ""
+set_interface_property axi4_man SV_INTERFACE_TYPE ""
+set_interface_property axi4_man SV_INTERFACE_MODPORT_TYPE ""
+
+add_interface_port axi4_man man_araddr araddr Output ADDRESS_WIDTH
+add_interface_port axi4_man man_arburst arburst Output 2
+add_interface_port axi4_man man_arcache arcache Output 4
+add_interface_port axi4_man man_arid arid Output 5
+add_interface_port axi4_man man_arlen arlen Output 8
+add_interface_port axi4_man man_arlock arlock Output 1
+add_interface_port axi4_man man_arprot arprot Output 3
+add_interface_port axi4_man man_arqos arqos Output 4
+add_interface_port axi4_man man_arready arready Input 1
+add_interface_port axi4_man man_arsize arsize Output 3
+add_interface_port axi4_man man_arvalid arvalid Output 1
+add_interface_port axi4_man man_awaddr awaddr Output ADDRESS_WIDTH
+add_interface_port axi4_man man_awburst awburst Output 2
+add_interface_port axi4_man man_awcache awcache Output 4
+add_interface_port axi4_man man_awid awid Output 5
+add_interface_port axi4_man man_awlen awlen Output 8
+add_interface_port axi4_man man_awlock awlock Output 1
+add_interface_port axi4_man man_awprot awprot Output 3
+add_interface_port axi4_man man_awqos awqos Output 4
+add_interface_port axi4_man man_awready awready Input 1
+add_interface_port axi4_man man_awsize awsize Output 3
+add_interface_port axi4_man man_awvalid awvalid Output 1
+add_interface_port axi4_man man_bid bid Input 5
+add_interface_port axi4_man man_bready bready Output 1
+add_interface_port axi4_man man_bresp bresp Input 2
+add_interface_port axi4_man man_bvalid bvalid Input 1
+add_interface_port axi4_man man_rdata rdata Input DATA_WIDTH
+add_interface_port axi4_man man_rid rid Input 5
+add_interface_port axi4_man man_rlast rlast Input 1
+add_interface_port axi4_man man_rready rready Output 1
+add_interface_port axi4_man man_rresp rresp Input 2
+add_interface_port axi4_man man_rvalid rvalid Input 1
+add_interface_port axi4_man man_wdata wdata Output DATA_WIDTH
+add_interface_port axi4_man man_wlast wlast Output 1
+add_interface_port axi4_man man_wready wready Input 1
+add_interface_port axi4_man man_wstrb wstrb Output DATA_WIDTH/8
+add_interface_port axi4_man man_wvalid wvalid Output 1
+add_interface_port axi4_man man_aruser aruser Output 8
+add_interface_port axi4_man man_awuser awuser Output 8
+add_interface_port axi4_man man_wuser wuser Output 8
+add_interface_port axi4_man man_buser buser Input 8
+add_interface_port axi4_man man_arregion arregion Output 4
+add_interface_port axi4_man man_ruser ruser Input 8
+add_interface_port axi4_man man_awregion awregion Output 4
+
+
+#
+# connection point axi4_sub
+#
+add_interface axi4_sub axi4 end
+set_interface_property axi4_sub associatedClock clock
+set_interface_property axi4_sub associatedReset reset
+set_interface_property axi4_sub wakeupSignals false
+set_interface_property axi4_sub uniqueIdSupport false
+set_interface_property axi4_sub poison false
+set_interface_property axi4_sub traceSignals false
+set_interface_property axi4_sub readAcceptanceCapability 1
+set_interface_property axi4_sub writeAcceptanceCapability 1
+set_interface_property axi4_sub combinedAcceptanceCapability 1
+set_interface_property axi4_sub readDataReorderingDepth 1
+set_interface_property axi4_sub bridgesToMaster ""
+set_interface_property axi4_sub dfhFeatureGuid 0
+set_interface_property axi4_sub dfhGroupId 0
+set_interface_property axi4_sub dfhParameterId ""
+set_interface_property axi4_sub dfhParameterName ""
+set_interface_property axi4_sub dfhParameterVersion ""
+set_interface_property axi4_sub dfhParameterData ""
+set_interface_property axi4_sub dfhParameterDataLength ""
+set_interface_property axi4_sub dfhFeatureMajorVersion 0
+set_interface_property axi4_sub dfhFeatureMinorVersion 0
+set_interface_property axi4_sub dfhFeatureId 35
+set_interface_property axi4_sub ENABLED true
+set_interface_property axi4_sub EXPORT_OF ""
+set_interface_property axi4_sub PORT_NAME_MAP ""
+set_interface_property axi4_sub CMSIS_SVD_VARIABLES ""
+set_interface_property axi4_sub SVD_ADDRESS_GROUP ""
+set_interface_property axi4_sub IPXACT_REGISTER_MAP_VARIABLES ""
+set_interface_property axi4_sub SV_INTERFACE_TYPE ""
+set_interface_property axi4_sub SV_INTERFACE_MODPORT_TYPE ""
+
+add_interface_port axi4_sub sub_araddr araddr Input ADDRESS_WIDTH
+add_interface_port axi4_sub sub_arburst arburst Input 2
+add_interface_port axi4_sub sub_arcache arcache Input 4
+add_interface_port axi4_sub sub_arid arid Input 5
+add_interface_port axi4_sub sub_arlen arlen Input 8
+add_interface_port axi4_sub sub_arlock arlock Input 1
+add_interface_port axi4_sub sub_arprot arprot Input 3
+add_interface_port axi4_sub sub_arqos arqos Input 4
+add_interface_port axi4_sub sub_arready arready Output 1
+add_interface_port axi4_sub sub_arsize arsize Input 3
+add_interface_port axi4_sub sub_arvalid arvalid Input 1
+add_interface_port axi4_sub sub_awaddr awaddr Input ADDRESS_WIDTH
+add_interface_port axi4_sub sub_awburst awburst Input 2
+add_interface_port axi4_sub sub_awcache awcache Input 4
+add_interface_port axi4_sub sub_awid awid Input 5
+add_interface_port axi4_sub sub_awlen awlen Input 8
+add_interface_port axi4_sub sub_awlock awlock Input 1
+add_interface_port axi4_sub sub_awprot awprot Input 3
+add_interface_port axi4_sub sub_awqos awqos Input 4
+add_interface_port axi4_sub sub_awready awready Output 1
+add_interface_port axi4_sub sub_awsize awsize Input 3
+add_interface_port axi4_sub sub_awvalid awvalid Input 1
+add_interface_port axi4_sub sub_bid bid Output 5
+add_interface_port axi4_sub sub_bready bready Input 1
+add_interface_port axi4_sub sub_bresp bresp Output 2
+add_interface_port axi4_sub sub_bvalid bvalid Output 1
+add_interface_port axi4_sub sub_rdata rdata Output DATA_WIDTH
+add_interface_port axi4_sub sub_rid rid Output 5
+add_interface_port axi4_sub sub_rlast rlast Output 1
+add_interface_port axi4_sub sub_rready rready Input 1
+add_interface_port axi4_sub sub_rresp rresp Output 2
+add_interface_port axi4_sub sub_rvalid rvalid Output 1
+add_interface_port axi4_sub sub_wdata wdata Input DATA_WIDTH
+add_interface_port axi4_sub sub_wlast wlast Input 1
+add_interface_port axi4_sub sub_wready wready Output 1
+add_interface_port axi4_sub sub_wstrb wstrb Input DATA_WIDTH/8
+add_interface_port axi4_sub sub_wvalid wvalid Input 1
+add_interface_port axi4_sub sub_aruser aruser Input 8
+add_interface_port axi4_sub sub_awuser awuser Input 8
+add_interface_port axi4_sub sub_wuser wuser Input 8
+add_interface_port axi4_sub sub_buser buser Output 8
+add_interface_port axi4_sub sub_arregion arregion Input 4
+add_interface_port axi4_sub sub_ruser ruser Output 8
+add_interface_port axi4_sub sub_awregion awregion Input 4
+
+proc generate_verilog { output_name } {
+set verilog_code {
+// ****************************************************************************
+//
+// SPDX-License-Identifier: MIT-0
+// SPDX-FileCopyrightText: Copyright (C) 2025 Altera Corporation
+//
+// ****************************************************************************
+
+`timescale 1 ps / 1 ps
+module ${output_name} #(
+    parameter ADDRESS_WIDTH = 40,
+    parameter DATA_WIDTH = 256
+) (
+
+	//
+	// clock and reset
+	//
+	input  wire         clk,
+	input  wire         reset,
+
+	//
+	// AXI4 subordinate
+	//
+	input  wire \[ADDRESS_WIDTH-1:0\]  sub_araddr,
+	input  wire \[1:0\]   sub_arburst,
+	input  wire \[3:0\]   sub_arcache,
+	input  wire \[4:0\]   sub_arid,
+	input  wire \[7:0\]   sub_arlen,
+	input  wire         sub_arlock,
+	input  wire \[2:0\]   sub_arprot,
+	input  wire \[3:0\]   sub_arqos,
+	output wire         sub_arready,
+	input  wire \[2:0\]   sub_arsize,
+	input  wire         sub_arvalid,
+	input  wire \[ADDRESS_WIDTH-1:0\]  sub_awaddr,
+	input  wire \[1:0\]   sub_awburst,
+	input  wire \[3:0\]   sub_awcache,
+	input  wire \[4:0\]   sub_awid,
+	input  wire \[7:0\]   sub_awlen,
+	input  wire         sub_awlock,
+	input  wire \[2:0\]   sub_awprot,
+	input  wire \[3:0\]   sub_awqos,
+	output wire         sub_awready,
+	input  wire \[2:0\]   sub_awsize,
+	input  wire         sub_awvalid,
+	output wire \[4:0\]   sub_bid,
+	input  wire         sub_bready,
+	output wire \[1:0\]   sub_bresp,
+	output wire         sub_bvalid,
+	output wire \[DATA_WIDTH-1:0\] sub_rdata,
+	output wire \[4:0\]   sub_rid,
+	output wire         sub_rlast,
+	input  wire         sub_rready,
+	output wire \[1:0\]   sub_rresp,
+	output wire         sub_rvalid,
+	input  wire \[DATA_WIDTH-1:0\] sub_wdata,
+	input  wire         sub_wlast,
+	output wire         sub_wready,
+	input  wire \[DATA_WIDTH/8-1:0\]  sub_wstrb,
+	input  wire         sub_wvalid,
+	input  wire \[7:0\]   sub_aruser,
+	input  wire \[7:0\]   sub_awuser,
+	input  wire \[7:0\]   sub_wuser,
+	output wire \[7:0\]   sub_buser,
+	input  wire \[3:0\]   sub_arregion,
+	output wire \[7:0\]   sub_ruser,
+	input  wire \[3:0\]   sub_awregion,
+
+	//
+	// AXI4 manager
+	//
+	output wire \[ADDRESS_WIDTH-1:0\]  man_araddr,
+	output wire \[1:0\]   man_arburst,
+	output wire \[3:0\]   man_arcache,
+	output wire \[4:0\]   man_arid,
+	output wire \[7:0\]   man_arlen,
+	output wire         man_arlock,
+	output wire \[2:0\]   man_arprot,
+	output wire \[3:0\]   man_arqos,
+	input  wire         man_arready,
+	output wire \[2:0\]   man_arsize,
+	output wire         man_arvalid,
+	output wire \[ADDRESS_WIDTH-1:0\]  man_awaddr,
+	output wire \[1:0\]   man_awburst,
+	output wire \[3:0\]   man_awcache,
+	output wire \[4:0\]   man_awid,
+	output wire \[7:0\]   man_awlen,
+	output wire         man_awlock,
+	output wire \[2:0\]   man_awprot,
+	output wire \[3:0\]   man_awqos,
+	input  wire         man_awready,
+	output wire \[2:0\]   man_awsize,
+	output wire         man_awvalid,
+	input  wire \[4:0\]   man_bid,
+	output wire         man_bready,
+	input  wire \[1:0\]   man_bresp,
+	input  wire         man_bvalid,
+	input  wire \[DATA_WIDTH-1:0\] man_rdata,
+	input  wire \[4:0\]   man_rid,
+	input  wire         man_rlast,
+	output wire         man_rready,
+	input  wire \[1:0\]   man_rresp,
+	input  wire         man_rvalid,
+	output wire \[DATA_WIDTH-1:0\] man_wdata,
+	output wire         man_wlast,
+	input  wire         man_wready,
+	output wire \[DATA_WIDTH/8-1:0\]  man_wstrb,
+	output wire         man_wvalid,
+	output wire \[7:0\]   man_aruser,
+	output wire \[7:0\]   man_awuser,
+	output wire \[7:0\]   man_wuser,
+	input  wire \[7:0\]   man_buser,
+	output wire \[3:0\]   man_arregion,
+	input  wire \[7:0\]   man_ruser,
+	output wire \[3:0\]   man_awregion
+);
+
+assign sub_ruser   = man_ruser;
+assign sub_wready  = man_wready;
+assign sub_rid     = man_rid;
+assign sub_arready = man_arready;
+assign sub_bresp   = man_bresp;
+assign sub_rdata   = man_rdata;
+assign sub_awready = man_awready;
+assign sub_rlast   = man_rlast;
+assign sub_buser   = man_buser;
+assign sub_rresp   = man_rresp;
+assign sub_bid     = man_bid;
+assign sub_bvalid  = man_bvalid;
+assign sub_rvalid  = man_rvalid;
+
+assign man_wuser    = 8'h00;
+assign man_awburst  = sub_awburst;
+assign man_arregion = 4'h0;
+assign man_arlen    = sub_arlen;
+assign man_arqos    = 4'h0;
+assign man_awuser   = 8'hE0;
+assign man_wstrb    = sub_wstrb;
+assign man_rready   = sub_rready;
+assign man_awlen    = sub_awlen;
+assign man_awqos    = 4'h0;
+assign man_arcache  = 4'h2;
+assign man_araddr   = sub_araddr;
+assign man_wvalid   = sub_wvalid;
+assign man_arprot   = 3'b011;
+assign man_arvalid  = sub_arvalid;
+assign man_awprot   = 3'b011;
+assign man_wdata    = sub_wdata;
+assign man_arid     = sub_arid;
+assign man_awcache  = 4'h2;
+assign man_arlock   = 1'b0;
+assign man_awlock   = 1'b0;
+assign man_awaddr   = sub_awaddr;
+assign man_arburst  = sub_arburst;
+assign man_arsize   = sub_arsize;
+assign man_bready   = sub_bready;
+assign man_wlast    = sub_wlast;
+assign man_awregion = 4'h0;
+assign man_awid     = sub_awid;
+assign man_awsize   = sub_awsize;
+assign man_awvalid  = sub_awvalid;
+assign man_aruser   = 8'hE0;
+
+endmodule
+}
+
+add_fileset_file "${output_name}.v" VERILOG TEXT [subst ${verilog_code}]
+
+}

--- a/library/intel/jesd204_phy/Makefile
+++ b/library/intel/jesd204_phy/Makefile
@@ -9,6 +9,7 @@ LIBRARY_NAME := jesd204_phy
 INTEL_DEPS += jesd204_phy_glue.v
 INTEL_DEPS += jesd204_phy_glue_hw.tcl
 INTEL_DEPS += jesd204_phy_hw.tcl
+INTEL_DEPS += jesd204_e_tile_phy_hw.tcl
 
 INTEL_LIB_DEPS += jesd204/jesd204_soft_pcs_rx
 INTEL_LIB_DEPS += jesd204/jesd204_soft_pcs_tx

--- a/library/intel/jesd204_phy/jesd204_e_tile_phy_hw.tcl
+++ b/library/intel/jesd204_phy/jesd204_e_tile_phy_hw.tcl
@@ -1,0 +1,363 @@
+###############################################################################
+## Copyright (C) 2025-2026 Analog Devices, Inc. All rights reserved.
+### SPDX short identifier: ADIJESD204
+###############################################################################
+
+package require qsys 14.0
+
+source ../../../scripts/adi_env.tcl
+source $ad_hdl_dir/library/scripts/adi_ip_intel.tcl
+
+ad_ip_create jesd204_e_tile_phy "ADI JESD204 E-Tile PHY"
+set_module_property COMPOSITION_CALLBACK jesd204_e_tile_phy_composition_callback
+set_module_property INTERNAL false
+
+# parameters
+
+ad_ip_parameter DEVICE STRING "Agilex 5" false
+ad_ip_parameter ID NATURAL 0 false
+ad_ip_parameter LINK_MODE INTEGER 1 false
+ad_ip_parameter LANE_RATE FLOAT 10000 false
+ad_ip_parameter REFCLK_FREQUENCY FLOAT 500.0 false
+ad_ip_parameter NUM_OF_LANES POSITIVE 4 false
+ad_ip_parameter INPUT_PIPELINE_STAGES INTEGER 0 false
+ad_ip_parameter LANE_INVERT INTEGER 0 false
+ad_ip_parameter EXTERNAL_LINK_CLK BOOLEAN false false
+ad_ip_parameter INSTANTIATE_RESET_CONTROLLER BOOLEAN true false
+
+proc jesd204_e_tile_phy_composition_callback {} {
+  set device [get_parameter_value "DEVICE"]
+  set link_mode [get_parameter_value "LINK_MODE"]
+  set lane_rate [get_parameter_value "LANE_RATE"]
+  set refclk_frequency [get_parameter_value "REFCLK_FREQUENCY"]
+  set id [get_parameter_value "ID"]
+  set num_of_lanes [get_parameter_value "NUM_OF_LANES"]
+  set register_inputs [get_parameter_value "INPUT_PIPELINE_STAGES"]
+  set lane_invert [get_parameter_value "LANE_INVERT"]
+  set external_link_clk [get_parameter_value "EXTERNAL_LINK_CLK"]
+  set instantiate_reset_controller [get_parameter_value "INSTANTIATE_RESET_CONTROLLER"]
+
+  if {$device != "Agilex 5"} {
+    send_message error "Only Agilex 5 is supported."
+  }
+
+  if {$link_mode == 1} {
+    set link_clk_frequency [expr $lane_rate / 40]
+    set phy_clk_frequency [expr $lane_rate / 20]
+    set pma_width 20
+    set datapath_width 4
+    set usr_pll_div 40
+  } else {
+    set link_clk_frequency [expr $lane_rate / 66]
+    set phy_clk_frequency [expr $lane_rate / 32]
+    set pma_width 32
+    set datapath_width 8
+    if {$lane_rate >= 16300} {
+      set usr_pll_div 33
+    } else {
+      set usr_pll_div 66
+    }
+  }
+
+  add_instance tx_link_clock clock_source
+  set_instance_parameter_value tx_link_clock {clockFrequency} [expr $link_clk_frequency*1000000]
+  add_interface tx_link_clock clock sink
+  set_interface_property tx_link_clock EXPORT_OF tx_link_clock.clk_in
+  add_interface tx_link_reset reset sink
+  set_interface_property tx_link_reset EXPORT_OF tx_link_clock.clk_in_reset
+
+  add_instance rx_link_clock clock_source
+  set_instance_parameter_value rx_link_clock {clockFrequency} [expr $link_clk_frequency*1000000]
+  add_interface rx_link_clock clock sink
+  set_interface_property rx_link_clock EXPORT_OF rx_link_clock.clk_in
+  add_interface rx_link_reset reset sink
+  set_interface_property rx_link_reset EXPORT_OF rx_link_clock.clk_in_reset
+
+  # Instantiate native PHY in duplex mode because
+  # Agilex 5 can't merge transceivers in dual simplex mode
+  # unless you use an "approved" intel protocol IP
+  add_instance native_phy intel_directphy_gts
+  set_instance_parameter_value native_phy duplex_mode {duplex}
+  set_instance_parameter_value native_phy xcvr_type "FGT"
+  set_instance_parameter_value native_phy syspll_outclk_freq_mhz $phy_clk_frequency
+  set_instance_parameter_value native_phy num_xcvr_per_sys $num_of_lanes
+  set_instance_parameter_value native_phy clocking_mode "syspll"
+  set_instance_parameter_value native_phy pma_modulation "NRZ"
+  set_instance_parameter_value native_phy pma_data_rate $lane_rate
+  set_instance_parameter_value native_phy pma_width $pma_width
+  set_instance_parameter_value native_phy l_av1_enable 1
+  set_instance_parameter_value native_phy refclk_recovery_en 1
+  set_instance_parameter_value native_phy rx_deskew_en 0
+
+  # TX side parameters
+  set_instance_parameter_value native_phy tx_pll_refclk_freq_mhz [format {%.6f} $refclk_frequency]
+  set_instance_parameter_value native_phy pmaif_tx_fifo_mode_s "elastic"
+  set_instance_parameter_value native_phy pldif_tx_double_width_transfer_enable 1
+  set_instance_parameter_value native_phy pldif_tx_fifo_mode "phase_comp"
+  set_instance_parameter_value native_phy pldif_tile_tx_fifo_mode "phase_comp"
+  set_instance_parameter_value native_phy pldif_tx_fifo_pfull_thld 10
+  set_instance_parameter_value native_phy tx_pll_txuserclk1_enable 1
+  set_instance_parameter_value native_phy tx_pll_txuserclk_div $usr_pll_div
+  set_instance_parameter_value native_phy enable_port_tx_clkout2 1
+  set_instance_parameter_value native_phy pldif_tx_clkout_sel "TX_USER_CLK1"
+  set_instance_parameter_value native_phy pldif_tx_clkout_div 1
+  set_instance_parameter_value native_phy pldif_tx_clkout2_sel "TX_WORD_CLK"
+  set_instance_parameter_value native_phy pldif_tx_clkout2_div 2
+  # set_instance_parameter_value native_phy tx_pll_realtime_lock_enable 1
+
+  # RX side parameters
+  set_instance_parameter_value native_phy rx_pll_refclk_freq_mhz [format {%.6f} $refclk_frequency]
+  set_instance_parameter_value native_phy pmaif_rx_fifo_mode_s "elastic"
+  set_instance_parameter_value native_phy pldif_rx_double_width_transfer_enable 1
+  set_instance_parameter_value native_phy rx_cdr_rxuserclk_enable 1
+  set_instance_parameter_value native_phy rx_cdr_rxuserclk_div $usr_pll_div
+  set_instance_parameter_value native_phy pldif_rx_fifo_pfull_thld 10
+  set_instance_parameter_value native_phy enable_port_rx_clkout2 1
+  set_instance_parameter_value native_phy pldif_rx_clkout_sel "RX_USER_CLK1"
+  set_instance_parameter_value native_phy pldif_rx_clkout_div 1
+  set_instance_parameter_value native_phy pldif_rx_clkout2_sel "RX_WORD_CLK"
+  set_instance_parameter_value native_phy pldif_rx_clkout2_div 2
+  set_instance_parameter_value native_phy rx_serdes_adapt_mode {auto}
+
+  if {$instantiate_reset_controller} {
+    # GTS Reset IP
+    add_instance gts_reset_phy intel_srcss_gts
+    set_instance_parameter_value gts_reset_phy NUM_BANKS_SHORELINE [expr int(ceil($num_of_lanes / 4.0))]
+    set_instance_parameter_value gts_reset_phy NUM_LANES_SHORELINE $num_of_lanes
+
+    add_connection gts_reset_phy.o_pma_cu_clk native_phy.i_pma_cu_clk
+    add_connection gts_reset_phy.o_src_rs_grant native_phy.i_src_rs_grant
+    add_connection native_phy.o_src_rs_req gts_reset_phy.i_src_rs_req
+    add_connection native_phy.o_refclk_bus_out gts_reset_phy.i_refclk_bus_out
+
+    add_interface gts_reset_src_rs_priority conduit end
+    set_interface_property gts_reset_src_rs_priority EXPORT_OF gts_reset_phy.i_src_rs_priority
+  } else {
+    # Use external reset controller
+    add_interface o_src_rs_req conduit end
+    set_interface_property o_src_rs_req EXPORT_OF native_phy.o_src_rs_req
+
+    # add_interface o_refclk_bus_out conduit end
+    # set_interface_property o_refclk_bus_out EXPORT_OF native_phy.o_refclk_bus_out
+
+    add_interface i_pma_cu_clk conduit end
+    set_interface_property i_pma_cu_clk EXPORT_OF native_phy.i_pma_cu_clk
+
+    add_interface i_src_rs_grant conduit end
+    set_interface_property i_src_rs_grant EXPORT_OF native_phy.i_src_rs_grant
+
+    add_interface i_refclk_cmd_bus_in conduit end
+    set_interface_property i_refclk_cmd_bus_in EXPORT_OF native_phy.i_refclk_cmd_bus_in
+
+    add_interface o_refclk_status_bus_out conduit end
+    set_interface_property o_refclk_status_bus_out EXPORT_OF native_phy.o_refclk_status_bus_out
+  }
+
+  # Instantiate PHY glues (RX and TX)
+  add_instance phy_glue jesd204_phy_glue
+  set_instance_parameter_value phy_glue DEVICE $device
+  set_instance_parameter_value phy_glue SOFT_PCS 1
+  set_instance_parameter_value phy_glue NUM_OF_LANES $num_of_lanes
+  set_instance_parameter_value phy_glue LANE_INVERT $lane_invert
+  set_instance_parameter_value phy_glue BONDING_CLOCKS_EN 0
+  set_instance_parameter_value phy_glue LINK_MODE $link_mode
+
+  # Connect PHY to GLUE
+
+  add_interface rx_ref_clk clock sink
+  set_interface_property rx_ref_clk EXPORT_OF phy_glue.rx_ref_clk
+
+  add_interface tx_ref_clk clock sink
+  set_interface_property tx_ref_clk EXPORT_OF phy_glue.tx_ref_clk
+
+  add_interface system_pll_clk clock sink
+  set_interface_property system_pll_clk EXPORT_OF phy_glue.system_pll_clk
+
+  add_interface system_pll_lock conduit end
+  set_interface_property system_pll_lock EXPORT_OF native_phy.i_system_pll_lock
+
+  add_interface tx_reset conduit end
+  set_interface_property tx_reset EXPORT_OF native_phy.i_tx_reset
+  add_interface rx_reset conduit end
+  set_interface_property rx_reset EXPORT_OF native_phy.i_rx_reset
+  foreach x {reset_ack ready} {
+    add_interface tx_${x} conduit end
+    set_interface_property tx_${x} EXPORT_OF native_phy.o_tx_${x}
+    add_interface rx_${x} conduit end
+    set_interface_property rx_${x} EXPORT_OF native_phy.o_rx_${x}
+  }
+
+  add_interface tx_pll_locked conduit end
+  set_interface_property tx_pll_locked EXPORT_OF native_phy.o_tx_pll_locked
+
+  add_interface rx_is_lockedtodata conduit end
+  set_interface_property rx_is_lockedtodata EXPORT_OF native_phy.o_rx_is_lockedtodata
+
+  foreach x {serial_data serial_data_n} {
+    add_interface tx_${x} conduit end
+    set_interface_property tx_${x} EXPORT_OF native_phy.o_tx_${x}
+    add_interface rx_${x} conduit end
+    set_interface_property rx_${x} EXPORT_OF native_phy.i_rx_${x}
+  }
+
+  if {$link_mode == 2} {
+    # lane rate / 64
+    add_connection phy_glue.tx_clkout2_0 phy_glue.tx_coreclkin
+    add_connection phy_glue.rx_clkout2_0 phy_glue.rx_coreclkin
+  } else {
+    # device_clk (lane rate / 40)
+    add_connection tx_link_clock.clk phy_glue.tx_coreclkin
+    add_connection rx_link_clock.clk phy_glue.rx_coreclkin
+  }
+
+  add_connection phy_glue.phy_tx_coreclkin native_phy.i_tx_coreclkin
+  add_connection phy_glue.phy_rx_coreclkin native_phy.i_rx_coreclkin
+  # Reconfig interface
+  add_connection phy_glue.phy_reconfig_clk native_phy.i_reconfig_clk
+  add_connection phy_glue.phy_reconfig_reset native_phy.i_reconfig_reset
+  add_connection phy_glue.phy_reconfig_avmm native_phy.reconfig
+
+  add_interface reconfig_clk clock sink
+  set_interface_property reconfig_clk EXPORT_OF phy_glue.reconfig_clk
+
+  add_interface reconfig_reset reset sink
+  set_interface_property reconfig_reset EXPORT_OF phy_glue.reconfig_reset
+
+  add_interface reconfig_avmm avalon slave
+  set_interface_property reconfig_avmm EXPORT_OF phy_glue.reconfig_avmm
+
+  # connect ref clock and output clock from - to GLUE
+  add_connection phy_glue.phy_tx_ref_clk native_phy.i_tx_pll_refclk_p
+  add_connection phy_glue.phy_rx_ref_clk native_phy.i_rx_cdr_refclk_p
+  add_connection phy_glue.phy_system_pll_clk native_phy.i_system_pll_clk
+
+  # add_connection phy_glue.phy_refclk_xcvr gts_pll.refclk_xcvr
+
+  foreach x [list clkout2 clkout] {
+    add_connection phy_glue.phy_tx_${x} native_phy.o_tx_${x}
+    add_connection phy_glue.phy_rx_${x} native_phy.o_rx_${x}
+  }
+
+  # This is lane rate / 40 (jesd204b) or lane rate / 64 (jesd204c)
+  add_interface tx_clkout2 clock source
+  set_interface_property tx_clkout2 EXPORT_OF phy_glue.tx_clkout2_0
+  add_interface rx_clkout2 clock source
+  set_interface_property rx_clkout2 EXPORT_OF phy_glue.rx_clkout2_0
+
+  # This is lane rate / 40 (jesd204b) or lane rate / 66 (jesd204c)
+  add_interface tx_clkout clock source
+  set_interface_property tx_clkout EXPORT_OF phy_glue.tx_clkout_0
+  add_interface rx_clkout clock source
+  set_interface_property rx_clkout EXPORT_OF phy_glue.rx_clkout_0
+
+  add_connection phy_glue.phy_i_tx_parallel_data native_phy.i_tx_parallel_data
+  add_connection phy_glue.phy_o_rx_parallel_data native_phy.o_rx_parallel_data
+
+  # Connect GLUE with PCS
+  for {set i 0} {$i < $num_of_lanes} {incr i} {
+    add_interface phy_tx_${i} conduit end
+    add_interface phy_rx_${i} conduit end
+    if {$link_mode == 1} {
+      # JESD204B
+      # TX
+      add_instance soft_pcs_tx_${i} jesd204_soft_pcs_tx
+      set_instance_parameter_value soft_pcs_tx_${i} IFC_TYPE 1
+      set_instance_parameter_value soft_pcs_tx_${i} INVERT_OUTPUTS \
+        [expr ($lane_invert >> $i) & 1]
+      add_connection tx_link_clock.clk soft_pcs_tx_${i}.clock
+      add_connection tx_link_clock.clk_reset soft_pcs_tx_${i}.reset
+      add_connection phy_glue.tx_raw_data_${i} soft_pcs_tx_${i}.tx_raw_data
+
+      set_interface_property phy_tx_${i} EXPORT_OF soft_pcs_tx_${i}.tx_phy
+
+      # RX
+      add_instance soft_pcs_rx_${i} jesd204_soft_pcs_rx
+      set_instance_parameter_value soft_pcs_rx_${i} IFC_TYPE 1
+      set_instance_parameter_value soft_pcs_rx_${i} REGISTER_INPUTS $register_inputs
+      set_instance_parameter_value soft_pcs_rx_${i} INVERT_INPUTS \
+        [expr ($lane_invert >> $i) & 1]
+      add_connection rx_link_clock.clk soft_pcs_rx_${i}.clock
+      add_connection rx_link_clock.clk_reset soft_pcs_rx_${i}.reset
+      add_connection phy_glue.rx_raw_data_${i} soft_pcs_rx_${i}.rx_raw_data
+
+      set_interface_property phy_rx_${i} EXPORT_OF soft_pcs_rx_${i}.rx_phy
+    } else {
+      # JESD204C
+      # TX
+      add_instance tx_adapter_${i} jesd204_f_tile_adapter_tx
+      set_instance_parameter_value tx_adapter_${i} DEVICE {Agilex 5}
+
+      add_connection phy_glue.tx_clkout2_0     tx_adapter_${i}.phy_tx_clock
+      add_connection tx_link_clock.clk         tx_adapter_${i}.link_clock
+      add_connection tx_link_clock.clk_reset   tx_adapter_${i}.reset
+      add_connection phy_glue.tx_raw_data_${i} tx_adapter_${i}.phy_tx_parallel_data
+
+      set_interface_property phy_tx_${i} EXPORT_OF tx_adapter_${i}.link_tx
+
+      # instantiate the CDC fifo
+      add_instance tx_fifo_${i} fifo
+      set_instance_parameter_value tx_fifo_${i} GUI_CLOCKS_ARE_SYNCHRONIZED {0}
+      set_instance_parameter_value tx_fifo_${i} GUI_Clock {4}
+      set_instance_parameter_value tx_fifo_${i} GUI_DISABLE_DCFIFO_EMBEDDED_TIMING_CONSTRAINT {1}
+      set_instance_parameter_value tx_fifo_${i} GUI_Depth {32}
+      set_instance_parameter_value tx_fifo_${i} GUI_Empty {1}
+      set_instance_parameter_value tx_fifo_${i} GUI_Full {1}
+      set_instance_parameter_value tx_fifo_${i} GUI_LegacyRREQ {1}
+      set_instance_parameter_value tx_fifo_${i} GUI_MAX_DEPTH {Auto}
+      set_instance_parameter_value tx_fifo_${i} GUI_RAM_BLOCK_TYPE {Auto}
+      set_instance_parameter_value tx_fifo_${i} GUI_UsedW {1}
+      set_instance_parameter_value tx_fifo_${i} GUI_Width {66}
+      set_instance_parameter_value tx_fifo_${i} GUI_dc_aclr {1}
+      set_instance_parameter_value tx_fifo_${i} GUI_delaypipe {5}
+      set_instance_parameter_value tx_fifo_${i} GUI_diff_widths {0}
+      set_instance_parameter_value tx_fifo_${i} GUI_output_width {8}
+      set_instance_parameter_value tx_fifo_${i} GUI_read_aclr_synch {1}
+      set_instance_parameter_value tx_fifo_${i} GUI_rsEmpty {1}
+      set_instance_parameter_value tx_fifo_${i} GUI_synStage {3}
+      set_instance_parameter_value tx_fifo_${i} GUI_write_aclr_synch {1}
+      set_instance_parameter_value tx_fifo_${i} GUI_wsEmpty {0}
+      set_instance_parameter_value tx_fifo_${i} GUI_wsFull {1}
+
+      add_connection tx_fifo_${i}.fifo_input  tx_adapter_${i}.fifo_input
+      add_connection tx_fifo_${i}.fifo_output tx_adapter_${i}.fifo_output
+
+      # RX
+      add_instance rx_adapter_${i} jesd204_f_tile_adapter_rx
+      set_instance_parameter_value rx_adapter_${i} DEVICE {Agilex 5}
+
+      add_connection phy_glue.rx_clkout2_0      rx_adapter_${i}.phy_rx_clock
+      add_connection rx_link_clock.clk          rx_adapter_${i}.link_clock
+      add_connection rx_link_clock.clk_reset    rx_adapter_${i}.reset
+      add_connection phy_glue.rx_raw_data_${i}  rx_adapter_${i}.phy_rx_parallel_data
+
+      set_interface_property phy_rx_${i} EXPORT_OF rx_adapter_${i}.link_rx
+
+      # instantiate the CDC fifo
+      add_instance rx_fifo_${i} fifo
+      set_instance_parameter_value rx_fifo_${i} GUI_CLOCKS_ARE_SYNCHRONIZED {0}
+      set_instance_parameter_value rx_fifo_${i} GUI_Clock {4}
+      set_instance_parameter_value rx_fifo_${i} GUI_DISABLE_DCFIFO_EMBEDDED_TIMING_CONSTRAINT {1}
+      set_instance_parameter_value rx_fifo_${i} GUI_Depth {32}
+      set_instance_parameter_value rx_fifo_${i} GUI_Empty {1}
+      set_instance_parameter_value rx_fifo_${i} GUI_Full {1}
+      set_instance_parameter_value rx_fifo_${i} GUI_LegacyRREQ {1}
+      set_instance_parameter_value rx_fifo_${i} GUI_MAX_DEPTH {Auto}
+      set_instance_parameter_value rx_fifo_${i} GUI_RAM_BLOCK_TYPE {Auto}
+      set_instance_parameter_value rx_fifo_${i} GUI_UsedW {1}
+      set_instance_parameter_value rx_fifo_${i} GUI_Width {66}
+      set_instance_parameter_value rx_fifo_${i} GUI_dc_aclr {1}
+      set_instance_parameter_value rx_fifo_${i} GUI_delaypipe {5}
+      set_instance_parameter_value rx_fifo_${i} GUI_diff_widths {0}
+      set_instance_parameter_value rx_fifo_${i} GUI_output_width {8}
+      set_instance_parameter_value rx_fifo_${i} GUI_read_aclr_synch {1}
+      set_instance_parameter_value rx_fifo_${i} GUI_rsEmpty {1}
+      set_instance_parameter_value rx_fifo_${i} GUI_synStage {3}
+      set_instance_parameter_value rx_fifo_${i} GUI_write_aclr_synch {1}
+      set_instance_parameter_value rx_fifo_${i} GUI_wsEmpty {0}
+      set_instance_parameter_value rx_fifo_${i} GUI_wsFull {1}
+
+      add_connection rx_fifo_${i}.fifo_input  rx_adapter_${i}.fifo_input
+      add_connection rx_fifo_${i}.fifo_output rx_adapter_${i}.fifo_output
+    }
+  }
+}

--- a/library/intel/jesd204_phy/jesd204_phy_glue_hw.tcl
+++ b/library/intel/jesd204_phy/jesd204_phy_glue_hw.tcl
@@ -1,5 +1,5 @@
 ###############################################################################
-## Copyright (C) 2016-2022, 2024 Analog Devices, Inc. All rights reserved.
+## Copyright (C) 2016-2022, 2024-2025 Analog Devices, Inc. All rights reserved.
 ### SPDX short identifier: ADIJESD204
 ###############################################################################
 
@@ -79,7 +79,7 @@ proc glue_add_if_port {num ifname port role dir width {bcast false} {phy_role {}
   }
 
   set device [get_parameter DEVICE]
-  if {[string equal $device "Agilex 7"]} {
+  if {[string equal $device "Agilex 7"] || [string equal $device "Agilex 5"]} {
     if {$phy_role == {}} {
       set phy_role $port
     }
@@ -214,13 +214,13 @@ proc jesd204_phy_glue_elab {} {
   } elseif {[string equal $device "Stratix 10"]} {
     set reconfig_avmm_address_width 11
     set unused_width_per_lane 40
-  } elseif {[string equal $device "Agilex 7"]} {
+  } elseif {[string equal $device "Agilex 7"] || [string equal $device "Agilex 5"]} {
     set parallel_data_w 80
     set reconfig_avmm_address_width [expr 18 + int(ceil((log($num_of_lanes) / log(2))))]
     # Unused are unused here
     set unused_width_per_lane 88
   } else {
-    send_message error "Only Arria 10/Stratix 10/Agilex 7 are supported."
+    send_message error "Only Arria 10/Stratix 10/Agilex 7/Agilex 5 are supported."
   }
 
   if {[string equal $device "Agilex 7"]} {
@@ -242,8 +242,30 @@ proc jesd204_phy_glue_elab {} {
     glue_add_if_port 1 reconfig_avmm reconfig_writedata writedata Input 32 true writedata
     glue_add_if_port 1 reconfig_avmm reconfig_byteenable byteenable Input 4 true byteenable
 
-  } else {
+  } elseif {[string equal $device "Agilex 5"]} {
+    glue_add_if 1 reconfig_clk clock sink true
+    glue_add_if_port 1 reconfig_clk reconfig_clk clk Input 1 true clk
 
+    glue_add_if 1 reconfig_reset reset sink true
+    glue_add_if_port 1 reconfig_reset reconfig_reset reset Input 1 true reset
+
+    glue_add_if 1 reconfig_avmm avalon sink true
+    set_interface_property reconfig_avmm associatedClock reconfig_clk
+    set_interface_property reconfig_avmm associatedReset reconfig_reset
+    set_interface_property reconfig_avmm maximumPendingReadTransactions 4
+
+    glue_add_if_port 1 reconfig_avmm reconfig_write write Input 1 true write
+    glue_add_if_port 1 reconfig_avmm reconfig_read read Input 1 true read
+    glue_add_if_port 1 reconfig_avmm reconfig_address address Input $reconfig_avmm_address_width true address
+
+    glue_add_if_port 1 reconfig_avmm i_reconfig_byteenable byteenable Input 4 true byteenable
+    glue_add_if_port 1 reconfig_avmm i_reconfig_writedata writedata Input 32 true writedata
+
+    glue_add_if_port 1 reconfig_avmm o_reconfig_readdata readdata Output 32 true readdata
+    glue_add_if_port 1 reconfig_avmm o_reconfig_readdatavalid readdatavalid Output 1 true readdatavalid
+    glue_add_if_port 1 reconfig_avmm o_reconfig_waitrequest waitrequest Output 1 true waitrequest
+
+  } else {
     glue_add_if $num_of_lanes reconfig_clk clock sink true
     glue_add_if_port $num_of_lanes reconfig_clk reconfig_clk clk Input 1 true
 
@@ -267,31 +289,24 @@ proc jesd204_phy_glue_elab {} {
   set_interface_property reconfig_reset associatedClock reconfig_clk
   set_interface_property reconfig_reset synchronousEdges DEASSERT
 
-  if {[get_parameter TX_OR_RX_N]} {
+  if {[string equal $device "Agilex 5"]} {
+    # For Agilex 5 we instantiate a duplex PHY
 
+    glue_add_if 1 system_pll_clk clock sink true
+    glue_add_if_port 1 system_pll_clk system_pll_clk clk Input 1 true clk
+
+    # TX glue signals
     glue_add_if $num_of_lanes tx_coreclkin clock sink true
-    glue_add_if_port $num_of_lanes tx_coreclkin tx_coreclkin clk Input 1 true
+    glue_add_if_port $num_of_lanes tx_coreclkin i_tx_coreclkin clk Input 1 true
 
-    if {[string equal $device "Agilex 7"]} {
-      glue_add_if $num_of_lanes ref_clk ftile_hssi_reference_clock sink true
-      glue_add_if_port $num_of_lanes ref_clk ref_clk clk Input 1 true clk
+    glue_add_if 1 tx_ref_clk clock sink true
+    glue_add_if_port 1 tx_ref_clk tx_ref_clk clk Input 1 true clk
 
-      glue_add_if $num_of_lanes tx_clkout2 clock source
-      glue_add_if_port $num_of_lanes tx_clkout2 tx_clkout2 clk Output 1
+    glue_add_if $num_of_lanes tx_clkout2 clock source
+    glue_add_if_port $num_of_lanes tx_clkout2 o_tx_clkout2 clk Output 1
 
-      glue_add_if $num_of_lanes tx_clkout clock source
-      glue_add_if_port $num_of_lanes tx_clkout tx_clkout clk Output 1
-    } else {
-      glue_add_if $num_of_lanes tx_clkout clock source
-      glue_add_if_port $num_of_lanes tx_clkout tx_clkout clk Output 1
-
-      if {$bonding_clocks_en && $num_of_lanes > 6} {
-          glue_add_if $num_of_lanes tx_bonding_clocks hssi_bonded_clock sink true
-          glue_add_if_port $num_of_lanes tx_bonding_clocks tx_bonding_clocks clk Input 6 true
-      } else {
-          glue_add_tx_serial_clk $num_of_lanes
-      }
-    }
+    glue_add_if $num_of_lanes tx_clkout clock source
+    glue_add_if_port $num_of_lanes tx_clkout o_tx_clkout clk Output 1
 
     if {$soft_pcs} {
       set unused_width [expr $num_of_lanes * $unused_width_per_lane]
@@ -301,58 +316,33 @@ proc jesd204_phy_glue_elab {} {
       for {set i 0} {$i < $num_of_lanes} {incr i} {
         add_interface tx_raw_data_${i} conduit start
       }
-      glue_add_if_port_conduit $num_of_lanes tx_raw_data raw_data tx_parallel_data Input $parallel_data_w
+      glue_add_if_port_conduit $num_of_lanes tx_raw_data raw_data i_tx_parallel_data Input $parallel_data_w
     } else {
-      set unused_width [expr $num_of_lanes * 92]
-
-      for {set i 0} {$i < $num_of_lanes} {incr i} {
-        add_interface tx_phy_${i} conduit start
-      }
-      glue_add_if_port_conduit $num_of_lanes tx_phy char tx_parallel_data Input 32
-      glue_add_if_port_conduit $num_of_lanes tx_phy charisk tx_datak Input 4
+      send_message error "Only soft PCS is supported on Agilex 5."
     }
 
     glue_add_const_conduit unused_tx_parallel_data $unused_width
 
-    add_interface phy_tx_polinv conduit end
-    add_interface_port phy_tx_polinv polinv tx_polinv Output $num_of_lanes
-    set_port_property polinv TERMINATION $soft_pcs
-  } else {
-
+    # RX glue signals
     glue_add_if $num_of_lanes rx_coreclkin clock sink true
-    glue_add_if_port $num_of_lanes rx_coreclkin rx_coreclkin clk Input 1 true
+    glue_add_if_port $num_of_lanes rx_coreclkin i_rx_coreclkin clk Input 1 true
 
-    if {[string equal $device "Agilex 7"]} {
-      glue_add_if $num_of_lanes ref_clk ftile_hssi_reference_clock sink true
-      glue_add_if_port $num_of_lanes ref_clk ref_clk clk Input 1 true clk
+    glue_add_if 1 rx_ref_clk clock sink true
+    glue_add_if_port 1 rx_ref_clk rx_ref_clk clk Input 1 true clk
 
-      glue_add_if $num_of_lanes rx_clkout2 clock source
-      glue_add_if_port $num_of_lanes rx_clkout2 rx_clkout2 clk Output 1
+    glue_add_if $num_of_lanes rx_clkout2 clock source
+    glue_add_if_port $num_of_lanes rx_clkout2 o_rx_clkout2 clk Output 1
 
-      glue_add_if $num_of_lanes rx_clkout clock source
-      glue_add_if_port $num_of_lanes rx_clkout rx_clkout clk Output 1
-    } else {
-      glue_add_if 1 rx_cdr_refclk0 clock sink true
-      glue_add_if_port 1 rx_cdr_refclk0 rx_cdr_refclk0 clk Input 1 true
-
-      glue_add_if $num_of_lanes rx_clkout clock source
-      glue_add_if_port $num_of_lanes rx_clkout rx_clkout clk Output 1
-    }
+    glue_add_if $num_of_lanes rx_clkout clock source
+    glue_add_if_port $num_of_lanes rx_clkout o_rx_clkout clk Output 1
 
     if {$soft_pcs} {
       for {set i 0} {$i < $num_of_lanes} {incr i} {
         add_interface rx_raw_data_${i} conduit start
       }
-      glue_add_if_port_conduit $num_of_lanes rx_raw_data raw_data rx_parallel_data Output $parallel_data_w
+      glue_add_if_port_conduit $num_of_lanes rx_raw_data raw_data o_rx_parallel_data Output $parallel_data_w
     } else {
-      for {set i 0} {$i < $num_of_lanes} {incr i} {
-        add_interface rx_phy_${i} conduit start
-      }
-      glue_add_if_port_conduit $num_of_lanes rx_phy char rx_parallel_data Output 32
-      glue_add_if_port_conduit $num_of_lanes rx_phy charisk rx_datak Output 4
-      glue_add_if_port_conduit $num_of_lanes rx_phy disperr rx_disperr Output 4
-      glue_add_if_port_conduit $num_of_lanes rx_phy notintable rx_errdetect Output 4
-      glue_add_if_port_conduit $num_of_lanes rx_phy patternalign_en rx_std_wa_patternalign Input 1
+      send_message error "Only soft PCS is supported on Agilex 5."
     }
 
     add_interface const_out conduit end
@@ -363,6 +353,106 @@ proc jesd204_phy_glue_elab {} {
     add_interface phy_rx_polinv conduit end
     add_interface_port phy_rx_polinv polinv rx_polinv Output $num_of_lanes
     set_port_property polinv TERMINATION $soft_pcs
+
+  } else {
+
+    if {[get_parameter TX_OR_RX_N]} {
+
+      glue_add_if $num_of_lanes tx_coreclkin clock sink true
+      glue_add_if_port $num_of_lanes tx_coreclkin tx_coreclkin clk Input 1 true
+
+      if {[string equal $device "Agilex 7"]} {
+        glue_add_if $num_of_lanes ref_clk ftile_hssi_reference_clock sink true
+        glue_add_if_port $num_of_lanes ref_clk ref_clk clk Input 1 true clk
+
+        glue_add_if $num_of_lanes tx_clkout2 clock source
+        glue_add_if_port $num_of_lanes tx_clkout2 tx_clkout2 clk Output 1
+
+        glue_add_if $num_of_lanes tx_clkout clock source
+        glue_add_if_port $num_of_lanes tx_clkout tx_clkout clk Output 1
+
+      } else {
+        glue_add_if $num_of_lanes tx_clkout clock source
+        glue_add_if_port $num_of_lanes tx_clkout tx_clkout clk Output 1
+
+        if {$bonding_clocks_en && $num_of_lanes > 6} {
+            glue_add_if $num_of_lanes tx_bonding_clocks hssi_bonded_clock sink true
+            glue_add_if_port $num_of_lanes tx_bonding_clocks tx_bonding_clocks clk Input 6 true
+        } else {
+            glue_add_tx_serial_clk $num_of_lanes
+        }
+      }
+
+      if {$soft_pcs} {
+        set unused_width [expr $num_of_lanes * $unused_width_per_lane]
+
+        glue_add_const_conduit tx_enh_data_valid $num_of_lanes
+
+        for {set i 0} {$i < $num_of_lanes} {incr i} {
+          add_interface tx_raw_data_${i} conduit start
+        }
+        glue_add_if_port_conduit $num_of_lanes tx_raw_data raw_data tx_parallel_data Input $parallel_data_w
+      } else {
+        set unused_width [expr $num_of_lanes * 92]
+
+        for {set i 0} {$i < $num_of_lanes} {incr i} {
+          add_interface tx_phy_${i} conduit start
+        }
+        glue_add_if_port_conduit $num_of_lanes tx_phy char tx_parallel_data Input 32
+        glue_add_if_port_conduit $num_of_lanes tx_phy charisk tx_datak Input 4
+      }
+
+      glue_add_const_conduit unused_tx_parallel_data $unused_width
+
+      add_interface phy_tx_polinv conduit end
+      add_interface_port phy_tx_polinv polinv tx_polinv Output $num_of_lanes
+      set_port_property polinv TERMINATION $soft_pcs
+    } else {
+      glue_add_if $num_of_lanes rx_coreclkin clock sink true
+      glue_add_if_port $num_of_lanes rx_coreclkin rx_coreclkin clk Input 1 true
+
+      if {[string equal $device "Agilex 7"]} {
+        glue_add_if $num_of_lanes ref_clk ftile_hssi_reference_clock sink true
+        glue_add_if_port $num_of_lanes ref_clk ref_clk clk Input 1 true clk
+
+        glue_add_if $num_of_lanes rx_clkout2 clock source
+        glue_add_if_port $num_of_lanes rx_clkout2 rx_clkout2 clk Output 1
+
+        glue_add_if $num_of_lanes rx_clkout clock source
+        glue_add_if_port $num_of_lanes rx_clkout rx_clkout clk Output 1
+      } else {
+        glue_add_if 1 rx_cdr_refclk0 clock sink true
+        glue_add_if_port 1 rx_cdr_refclk0 rx_cdr_refclk0 clk Input 1 true
+
+        glue_add_if $num_of_lanes rx_clkout clock source
+        glue_add_if_port $num_of_lanes rx_clkout rx_clkout clk Output 1
+      }
+
+      if {$soft_pcs} {
+        for {set i 0} {$i < $num_of_lanes} {incr i} {
+          add_interface rx_raw_data_${i} conduit start
+        }
+        glue_add_if_port_conduit $num_of_lanes rx_raw_data raw_data rx_parallel_data Output $parallel_data_w
+      } else {
+        for {set i 0} {$i < $num_of_lanes} {incr i} {
+          add_interface rx_phy_${i} conduit start
+        }
+        glue_add_if_port_conduit $num_of_lanes rx_phy char rx_parallel_data Output 32
+        glue_add_if_port_conduit $num_of_lanes rx_phy charisk rx_datak Output 4
+        glue_add_if_port_conduit $num_of_lanes rx_phy disperr rx_disperr Output 4
+        glue_add_if_port_conduit $num_of_lanes rx_phy notintable rx_errdetect Output 4
+        glue_add_if_port_conduit $num_of_lanes rx_phy patternalign_en rx_std_wa_patternalign Input 1
+      }
+
+      add_interface const_out conduit end
+      add_interface_port const_out const_out const_out Output 1
+      set_port_property const_out TERMINATION true
+      set const_offset 1
+
+      add_interface phy_rx_polinv conduit end
+      add_interface_port phy_rx_polinv polinv rx_polinv Output $num_of_lanes
+      set_port_property polinv TERMINATION $soft_pcs
+    }
   }
 
   set_parameter_value WIDTH $sig_offset

--- a/library/intel/jesd204c/jesd204_f_tile_adapter_rx/jesd204_f_tile_adapter_rx_hw.tcl
+++ b/library/intel/jesd204c/jesd204_f_tile_adapter_rx/jesd204_f_tile_adapter_rx_hw.tcl
@@ -1,5 +1,5 @@
 ###############################################################################
-## Copyright (C) 2024 Analog Devices, Inc. All rights reserved.
+## Copyright (C) 2024-2026 Analog Devices, Inc. All rights reserved.
 ### SPDX short identifier: ADIJESD204
 ################################################################################
 
@@ -8,7 +8,7 @@ package require qsys
 source ../../../../scripts/adi_env.tcl
 source $ad_hdl_dir/library/scripts/adi_ip_intel.tcl
 
-ad_ip_create jesd204_f_tile_adapter_rx "ADI JESD204C F-Tile PHY Adapter RX"
+ad_ip_create jesd204_f_tile_adapter_rx "ADI JESD204C E/F-Tile PHY Adapter RX"
 
 # parameters
 

--- a/library/intel/jesd204c/jesd204_f_tile_adapter_tx/jesd204_f_tile_adapter_tx_hw.tcl
+++ b/library/intel/jesd204c/jesd204_f_tile_adapter_tx/jesd204_f_tile_adapter_tx_hw.tcl
@@ -8,7 +8,7 @@ package require qsys
 source ../../../../scripts/adi_env.tcl
 source $ad_hdl_dir/library/scripts/adi_ip_intel.tcl
 
-ad_ip_create jesd204_f_tile_adapter_tx "ADI JESD204C F-Tile PHY Adapter TX"
+ad_ip_create jesd204_f_tile_adapter_tx "ADI JESD204C E/F-Tile PHY Adapter TX"
 
 # parameters
 

--- a/library/scripts/adi_intel_device_info_enc.tcl
+++ b/library/scripts/adi_intel_device_info_enc.tcl
@@ -42,7 +42,8 @@ set fpga_technology_list { \
         { "Cyclone 10" 102 } \
         { "Arria 10"   103 } \
         { "Stratix 10" 104 } \
-        { "Agilex 7"   105 }}
+        { "Agilex 7"   105 } \
+        { "Agilex 5"   106 }}
 
 set fpga_family_list { \
         { Unknown   0 } \
@@ -52,7 +53,8 @@ set fpga_family_list { \
         { GZ        4 } \
         { "SE Base" 5 } \
         { "I-Series with HPS only" 6 } \
-        { TX        6 }}
+        { TX        6 } \
+        { "E-Series with Quad HPS and with XCVR" 7 }}
 
        #technology 5 generation
        # family Arria SX
@@ -82,7 +84,8 @@ set dev_package_list { \
         { TQFP     10 } \
         { UBGA     11 } \
         { UFBGA    12 } \
-        { MBGA     13 }}
+        { MBGA     13 } \
+        { VPBGA    14 }}
 
 # Ball-Grid Array (BGA)
 # Ceramic Pin-Grid Array (PGA)
@@ -95,6 +98,8 @@ set dev_package_list { \
 # Power Quad Flat Pack (RQFP)
 # Thin Quad Flat Pack (TQFP)
 # Ultra FineLine BGA (UBGA-UFBGA)
+# Micro Fineline BGA (MBGA)
+# Variable Pitch BGA (VPBGA)
 
 # transceiver speedgrade
 set xcvr_type_list { 0 9 }
@@ -135,7 +140,7 @@ proc get_part_param {} {
     }
 
     # user and system values (sys_val)
-    if { $fpga_technology == "{{Agilex 7}}" } {
+    if { $fpga_technology == "{{Agilex 7}}" || $fpga_technology == "{{Agilex 5}}" } {
       # TODO : Transform VID2 to some voltage
       set fpga_voltage "0"
     } else {

--- a/library/util_adcfifo/util_adcfifo.v
+++ b/library/util_adcfifo/util_adcfifo.v
@@ -1,6 +1,6 @@
 // ***************************************************************************
 // ***************************************************************************
-// Copyright (C) 2015-2023 Analog Devices, Inc. All rights reserved.
+// Copyright (C) 2015-2023, 2026 Analog Devices, Inc. All rights reserved.
 //
 // In this HDL repository, there are many different and unique modules, consisting
 // of various HDL (Verilog or VHDL) components. The individual modules are
@@ -211,29 +211,29 @@ module util_adcfifo #(
 
   generate
   if (FPGA_TECHNOLOGY == 1) begin
-  mem_asym i_mem_asym (
-    .mem_i_wrclock_clk (adc_clk),
-    .mem_i_wren_wren (adc_wr_int),
-    .mem_i_wraddress_wraddress (adc_waddr_int),
-    .mem_i_datain_datain (adc_wdata_int),
-    .mem_i_rdclock_clk (dma_clk),
-    .mem_i_rdaddress_rdaddress (dma_raddr[DMA_ADDRESS_WIDTH-1:0]),
-    .mem_o_dataout_dataout (dma_rdata_s));
+    mem_asym i_mem_asym (
+      .mem_i_wrclock_clk (adc_clk),
+      .mem_i_wren_wren (adc_wr_int),
+      .mem_i_wraddress_wraddress (adc_waddr_int),
+      .mem_i_datain_datain (adc_wdata_int),
+      .mem_i_rdclock_clk (dma_clk),
+      .mem_i_rdaddress_rdaddress (dma_raddr[DMA_ADDRESS_WIDTH-1:0]),
+      .mem_o_dataout_dataout (dma_rdata_s));
   end else begin
-  ad_mem_asym #(
-    .A_ADDRESS_WIDTH (ADC_ADDRESS_WIDTH),
-    .A_DATA_WIDTH (ADC_DATA_WIDTH),
-    .B_ADDRESS_WIDTH (DMA_ADDRESS_WIDTH),
-    .B_DATA_WIDTH (DMA_DATA_WIDTH)
-  ) i_mem_asym (
-    .clka (adc_clk),
-    .wea (adc_wr_int),
-    .addra (adc_waddr_int),
-    .dina (adc_wdata_int),
-    .clkb (dma_clk),
-    .reb (1'b1),
-    .addrb (dma_raddr[DMA_ADDRESS_WIDTH-1:0]),
-    .doutb (dma_rdata_s));
+    ad_mem_asym #(
+      .A_ADDRESS_WIDTH (ADC_ADDRESS_WIDTH),
+      .A_DATA_WIDTH (ADC_DATA_WIDTH),
+      .B_ADDRESS_WIDTH (DMA_ADDRESS_WIDTH),
+      .B_DATA_WIDTH (DMA_DATA_WIDTH)
+    ) i_mem_asym (
+      .clka (adc_clk),
+      .wea (adc_wr_int),
+      .addra (adc_waddr_int),
+      .dina (adc_wdata_int),
+      .clkb (dma_clk),
+      .reb (1'b1),
+      .addrb (dma_raddr[DMA_ADDRESS_WIDTH-1:0]),
+      .doutb (dma_rdata_s));
   end
   endgenerate
 

--- a/library/util_adcfifo/util_adcfifo_hw.tcl
+++ b/library/util_adcfifo/util_adcfifo_hw.tcl
@@ -38,15 +38,17 @@ proc p_util_adcfifo {} {
   set m_adc_data_width [get_parameter_value "ADC_DATA_WIDTH"]
   set m_dma_addr_width [get_parameter_value "DMA_ADDRESS_WIDTH"]
   set m_dma_data_width [get_parameter_value "DMA_DATA_WIDTH"]
+  set m_fpga_technology [get_parameter_value "FPGA_TECHNOLOGY"]
 
   # intel memory
-
-  add_hdl_instance mem_asym intel_mem_asym 1.0
-  set_instance_parameter_value mem_asym DEVICE_FAMILY $m_device_family
-  set_instance_parameter_value mem_asym A_ADDRESS_WIDTH 0
-  set_instance_parameter_value mem_asym A_DATA_WIDTH $m_adc_data_width
-  set_instance_parameter_value mem_asym B_ADDRESS_WIDTH $m_dma_addr_width
-  set_instance_parameter_value mem_asym B_DATA_WIDTH $m_dma_data_width
+  if {$m_fpga_technology == 1} {
+    add_hdl_instance mem_asym intel_mem_asym 1.0
+    set_instance_parameter_value mem_asym DEVICE_FAMILY $m_device_family
+    set_instance_parameter_value mem_asym A_ADDRESS_WIDTH 0
+    set_instance_parameter_value mem_asym A_DATA_WIDTH $m_adc_data_width
+    set_instance_parameter_value mem_asym B_ADDRESS_WIDTH $m_dma_addr_width
+    set_instance_parameter_value mem_asym B_DATA_WIDTH $m_dma_data_width
+  }
 
   # interfaces
 

--- a/projects/ad9081_fmca_ebz/a5e/Makefile
+++ b/projects/ad9081_fmca_ebz/a5e/Makefile
@@ -1,0 +1,29 @@
+####################################################################################
+## Copyright (c) 2018 - 2024 Analog Devices, Inc.
+### SPDX short identifier: BSD-1-Clause
+## Auto-generated, do not modify!
+####################################################################################
+
+PROJECT_NAME := ad9081_fmca_ebz_a5e
+
+M_DEPS += ../common/ad9081_fmca_ebz_qsys.tcl
+M_DEPS += ../../scripts/adi_pd.tcl
+M_DEPS += ../../common/intel/dacfifo_qsys.tcl
+M_DEPS += ../../common/intel/adcfifo_qsys.tcl
+M_DEPS += ../../common/a5e/a5e_system_qsys.tcl
+M_DEPS += ../../common/a5e/a5e_system_assign.tcl
+M_DEPS += ../../../library/common/ad_3w_spi.v
+
+LIB_DEPS += axi_dmac
+LIB_DEPS += axi_sysid
+LIB_DEPS += jesd204/ad_ip_jesd204_tpl_adc
+LIB_DEPS += jesd204/ad_ip_jesd204_tpl_dac
+LIB_DEPS += sysid_rom
+LIB_DEPS += util_pack/util_cpack2
+LIB_DEPS += util_pack/util_upack2
+
+INTEL_LIB_DEPS += intel/adi_jesd204
+INTEL_LIB_DEPS += intel/jesd204c/jesd204_f_tile_adapter_rx
+INTEL_LIB_DEPS += intel/jesd204c/jesd204_f_tile_adapter_tx
+
+include ../../scripts/project-intel.mk

--- a/projects/ad9081_fmca_ebz/a5e/gts_refclk_reset.v
+++ b/projects/ad9081_fmca_ebz/a5e/gts_refclk_reset.v
@@ -1,0 +1,120 @@
+// ***************************************************************************
+// ***************************************************************************
+// Copyright (C) 2026 Analog Devices, Inc. All rights reserved.
+//
+// In this HDL repository, there are many different and unique modules, consisting
+// of various HDL (Verilog or VHDL) components. The individual modules are
+// developed independently, and may be accompanied by separate and unique license
+// terms.
+//
+// The user should read each of these license terms, and understand the
+// freedoms and responsibilities that he or she has by using this source/core.
+//
+// This core is distributed in the hope that it will be useful, but WITHOUT ANY
+// WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+// A PARTICULAR PURPOSE.
+//
+// Redistribution and use of source or resulting binaries, with or without modification
+// of this file, are permitted under one of the following two license terms:
+//
+//   1. The GNU General Public License version 2 as published by the
+//      Free Software Foundation, which can be found in the top level directory
+//      of this repository (LICENSE_GPL2), and also online at:
+//      <https://www.gnu.org/licenses/old-licenses/gpl-2.0.html>
+//
+// OR
+//
+//   2. An ADI specific BSD license, which can be found in the top level directory
+//      of this repository (LICENSE_ADIBSD), and also on-line at:
+//      https://github.com/analogdevicesinc/hdl/blob/main/LICENSE_ADIBSD
+//      This will allow to generate bit files and not release the source code,
+//      as long as it attaches to an ADI device.
+//
+// ***************************************************************************
+// ***************************************************************************
+
+`timescale 1ns/100ps
+
+// GTS refclk buffer control state machine.
+//
+// Drives the GTS reset controller's refclk_on request based on the aggregated
+// refclk-ready status. On a rising edge of refclk_ready it requests the refclk
+// buffers on, waits for the acknowledge, and re-requests them whenever a refclk
+// failure is reported while the reference clock is still expected to be ready.
+
+module gts_refclk_reset #(
+  parameter REFCLK_ON_WIDTH      = 10,
+  parameter FAIL_STATUS_WIDTH    = 8
+) (
+  input                             clk,
+  input                             resetn,
+
+  input                             refclk_ready,
+  input                             refclk_on_ack,
+  input   [FAIL_STATUS_WIDTH-1:0]   refclk_fail_status,
+
+  output reg [REFCLK_ON_WIDTH-1:0]  refclk_on
+);
+
+  localparam GTS_STATE_WIDTH      = 2;
+
+  localparam GTS_REFCLK_IDLE      = 2'd0;
+  localparam GTS_REFCLK_REQ_ON    = 2'd1;
+  localparam GTS_REFCLK_WAIT_ACK  = 2'd2;
+  localparam GTS_REFCLK_ACTIVE    = 2'd3;
+
+  reg [GTS_STATE_WIDTH-1:0] gts_refclk_state;
+  reg                       refclk_ready_d;
+  wire                      refclk_fail_detected;
+
+  assign refclk_fail_detected = |refclk_fail_status;
+
+  always @(posedge clk or negedge resetn) begin
+    if (!resetn) begin
+      refclk_on <= 'd0;
+      gts_refclk_state <= GTS_REFCLK_IDLE;
+      refclk_ready_d <= 1'b0;
+    end else begin
+      refclk_ready_d <= refclk_ready;
+
+      case (gts_refclk_state)
+        GTS_REFCLK_IDLE: begin
+          refclk_on <= 'd0;
+          if (refclk_ready && !refclk_ready_d) begin
+            gts_refclk_state <= GTS_REFCLK_REQ_ON;
+          end
+        end
+
+        GTS_REFCLK_REQ_ON: begin
+          refclk_on <= {REFCLK_ON_WIDTH{1'b1}};
+          gts_refclk_state <= GTS_REFCLK_WAIT_ACK;
+        end
+
+        GTS_REFCLK_WAIT_ACK: begin
+          if (refclk_on_ack) begin
+            refclk_on <= 'd0;
+            gts_refclk_state <= GTS_REFCLK_ACTIVE;
+          end
+          if (!refclk_ready) begin
+            refclk_on <= 'd0;
+            gts_refclk_state <= GTS_REFCLK_IDLE;
+          end
+        end
+
+        GTS_REFCLK_ACTIVE: begin
+          if (refclk_fail_detected && refclk_ready) begin
+            gts_refclk_state <= GTS_REFCLK_REQ_ON;
+          end
+          if (!refclk_ready) begin
+            gts_refclk_state <= GTS_REFCLK_IDLE;
+          end
+        end
+
+        default: begin
+          gts_refclk_state <= GTS_REFCLK_IDLE;
+        end
+      endcase
+    end
+  end
+
+endmodule

--- a/projects/ad9081_fmca_ebz/a5e/system_constr.sdc
+++ b/projects/ad9081_fmca_ebz/a5e/system_constr.sdc
@@ -1,0 +1,30 @@
+###############################################################################
+## Copyright (C) 2025-2026 Analog Devices, Inc. All rights reserved.
+### SPDX short identifier: ADIBSD
+###############################################################################
+
+source ../../common/a5e/system_constr.sdc
+
+create_clock  -period "4.16666 ns"  -name ref_clk        [get_ports {fpga_refclk_in}]
+create_clock  -period "4.16666 ns"  -name tx_device_clk  [get_ports {clkin10}]
+create_clock  -period "4.16666 ns"  -name rx_device_clk  [get_ports {clkin6}]
+
+# Ignore these paths since the data is moving through an async fifo inside the link layer
+set_clock_groups -asynchronous \
+    -group [get_clocks tx_device_clk] \
+    -group [get_clocks rx_device_clk] \
+    -group [get_clocks {i_system_bd|jesd204_phy|jesd204_phy|native_phy|sip_inst|o_rx_clkout[0]}] \
+    -group [get_clocks {i_system_bd|jesd204_phy|jesd204_phy|native_phy|sip_inst|o_tx_clkout[0]}]
+
+# # Constraint SYSREFs
+# # Assumption is that REFCLK and SYSREF have similar propagation delay,
+# # and the SYSREF is a source synchronous Edge-Aligned signal to REFCLK
+set device_clk_period [get_clock_info -period tx_device_clk]
+set_input_delay \
+  -clock tx_device_clk \
+  [expr $device_clk_period / 8] \
+  [get_ports {sysref2}]
+
+set_false_path \
+  -from [get_keepers -no_duplicates {i_system_bd|sys_hps|sys_hps|sm_hps|sundancemesa_hps_inst~intosc_clk.reg}] \
+  -to   [get_keepers -no_duplicates {i_system_bd|sys_hps|sys_hps|sm_hps|sundancemesa_hps_inst~intosc_clk.reg}]

--- a/projects/ad9081_fmca_ebz/a5e/system_project.tcl
+++ b/projects/ad9081_fmca_ebz/a5e/system_project.tcl
@@ -1,0 +1,225 @@
+###############################################################################
+## Copyright (C) 2025-2026 Analog Devices, Inc. All rights reserved.
+### SPDX short identifier: ADIBSD
+###############################################################################
+
+source ../../../scripts/adi_env.tcl
+source ../../scripts/adi_project_intel.tcl
+
+# get_env_param retrieves parameter value from the environment if exists,
+# other case use the default value
+#
+#   Use over-writable parameters from the environment.
+#
+#    e.g.
+#      make RX_RATE=10 TX_RATE=10 RX_JESD_L=4 RX_JESD_M=8 RX_JESD_S=1 RX_JESD_NP=16 TX_JESD_L=4 TX_JESD_M=8 TX_JESD_S=1 TX_JESD_NP=16
+#      make RX_RATE=2.5 TX_RATE=2.5 RX_JESD_L=8 RX_JESD_M=4 RX_JESD_S=1 RX_JESD_NP=16 TX_JESD_L=8 TX_JESD_M=4 TX_JESD_S=1 TX_JESD_NP=16
+#      make RX_RATE=10 TX_RATE=10 RX_JESD_L=2 RX_JESD_M=8 RX_JESD_S=1 RX_JESD_NP=12 TX_JESD_L=2 TX_JESD_M=8 TX_JESD_S=1 TX_JESD_NP=12
+#
+# Lane Rate = I/Q Sample Rate x M x N' x (10 \ 8) \ L
+
+# Parameter description:
+#
+#   JESD_MODE : Used link layer encoder mode
+#      64B66B - 64b66b link layer defined in JESD 204C, uses Intel IP with a custom gearbox as Physical layer
+#      8B10B  - 8b10b link layer defined in JESD 204B, uses Intel IP as Physical layer
+#
+#   RX_LANE_RATE :  Lane rate of the Rx link ( MxFE to FPGA )
+#   TX_LANE_RATE :  Lane rate of the Tx link ( FPGA to MxFE )
+#   REF_CLK_RATE : Frequency of reference clock in MHz used in 64B66B mode (LANE_RATE/66) or 8B10B mode (LANE_RATE/40)
+#   DEVICE_CLK_RATE: Frequency of the device clock in MHz, usually equal to REF_CLK_RATE
+#   [RX/TX]_JESD_M : Number of converters per link
+#   [RX/TX]_JESD_L : Number of lanes per link
+#   [RX/TX]_JESD_S : Number of samples per frame
+#   [RX/TX]_JESD_NP : Number of bits per sample
+#   [RX/TX]_NUM_LINKS : Number of links
+#   [RX/TX]_KS_PER_CHANNEL : Number of samples stored in internal buffers in kilosamples per converter (M)
+#
+
+adi_project ad9081_fmca_ebz_a5e [list \
+  JESD_MODE            [get_env_param JESD_MODE        8B10B ] \
+  RX_LANE_RATE         [get_env_param RX_LANE_RATE       9.6 ] \
+  TX_LANE_RATE         [get_env_param TX_LANE_RATE       9.6 ] \
+  REF_CLK_RATE         [get_env_param REF_CLK_RATE       240 ] \
+  DEVICE_CLK_RATE      [get_env_param DEVICE_CLK_RATE    240 ] \
+  RX_JESD_M            [get_env_param RX_JESD_M            2 ] \
+  RX_JESD_L            [get_env_param RX_JESD_L            2 ] \
+  RX_JESD_S            [get_env_param RX_JESD_S            1 ] \
+  RX_JESD_NP           [get_env_param RX_JESD_NP          16 ] \
+  RX_NUM_LINKS         [get_env_param RX_NUM_LINKS         1 ] \
+  RX2_JESD_M           [get_env_param RX2_JESD_M           2 ] \
+  RX2_JESD_L           [get_env_param RX2_JESD_L           2 ] \
+  RX2_JESD_S           [get_env_param RX2_JESD_S           1 ] \
+  RX2_JESD_NP          [get_env_param RX2_JESD_NP         16 ] \
+  RX2_NUM_LINKS        [get_env_param RX2_NUM_LINKS        1 ] \
+  TX_JESD_M            [get_env_param TX_JESD_M            4 ] \
+  TX_JESD_L            [get_env_param TX_JESD_L            2 ] \
+  TX_JESD_S            [get_env_param TX_JESD_S            1 ] \
+  TX_JESD_NP           [get_env_param TX_JESD_NP          16 ] \
+  TX_NUM_LINKS         [get_env_param TX_NUM_LINKS         1 ] \
+  RX_KS_PER_CHANNEL    [get_env_param RX_KS_PER_CHANNEL   32 ] \
+  RX2_KS_PER_CHANNEL   [get_env_param RX2_KS_PER_CHANNEL  32 ] \
+  TX_KS_PER_CHANNEL    [get_env_param TX_KS_PER_CHANNEL   32 ] \
+]
+
+source $ad_hdl_dir/projects/common/a5e/a5e_system_assign.tcl
+
+# files
+
+set_global_assignment -name VERILOG_FILE ../../../library/common/ad_3w_spi.v
+set_global_assignment -name VERILOG_FILE ./gts_refclk_reset.v
+
+set_instance_assignment -name IO_STANDARD "1.2-V TRUE DIFFERENTIAL SIGNALING" -to fpga_syncin_0
+set_instance_assignment -name IO_STANDARD "DIFFERENTIAL 1.2-V HSTL"           -to fpga_syncout_0
+set_instance_assignment -name IO_STANDARD "DIFFERENTIAL 1.2-V HSTL"           -to fpga_syncout_1
+set_instance_assignment -name IO_STANDARD "1.2-V TRUE DIFFERENTIAL SIGNALING" -to sysref2
+set_instance_assignment -name IO_STANDARD "1.2-V TRUE DIFFERENTIAL SIGNALING" -to clkin6
+set_instance_assignment -name IO_STANDARD "1.2-V TRUE DIFFERENTIAL SIGNALING" -to clkin10
+set_instance_assignment -name IO_STANDARD "CURRENT MODE LOGIC (CML)"          -to fpga_refclk_in
+
+set_instance_assignment -name GLOBAL_SIGNAL "GLOBAL CLOCK"                    -to clkin10
+
+set_location_assignment PIN_AG83  -to "agc0[0]"             ; ## D20  LA17_CC_P
+set_location_assignment PIN_AC83  -to "agc0[1]"             ; ## D21  LA17_CC_N
+set_location_assignment PIN_AG57  -to "agc1[0]"             ; ## C22  LA18_CC_P
+set_location_assignment PIN_AG53  -to "agc1[1]"             ; ## C23  LA18_CC_N
+set_location_assignment PIN_Y67   -to "agc2[0]"             ; ## G21  LA20_P
+set_location_assignment PIN_Y65   -to "agc2[1]"             ; ## G22  LA20_N
+set_location_assignment PIN_Y77   -to "agc3[0]"             ; ## H25  LA21_P
+set_location_assignment PIN_Y74   -to "agc3[1]"             ; ## H26  LA21_N
+set_location_assignment PIN_T55   -to "clkin6(n)"           ; ## G03  CLK1_M2C_N
+set_location_assignment PIN_P55   -to "clkin6"              ; ## G02  CLK1_M2C_P
+set_location_assignment PIN_B42   -to "clkin10(n)"          ; ## G07  LA00_N_CC
+set_location_assignment PIN_A45   -to "clkin10"             ; ## G06  LA00_P_CC
+set_location_assignment PIN_AV16  -to "fpga_refclk_in"      ; ## D04  GBTCLK1_M2C_P
+set_location_assignment PIN_AV21  -to "fpga_refclk_in(n)"   ; ## D05  GBTCLK1_M2C_N
+
+set_location_assignment PIN_BF1   -to "rx_data[0]"            ; ## A14  DP4_M2C_P
+set_location_assignment PIN_BF3   -to "rx_data_n[0]"          ; ## A15  DP4_M2C_N
+set_location_assignment PIN_BD1   -to "rx_data[1]"            ; ## A18  DP5_M2C_P
+set_location_assignment PIN_BD3   -to "rx_data_n[1]"          ; ## A19  DP5_M2C_N
+set_location_assignment PIN_BB1   -to "rx2_data[0]"         ; ## B16  DP6_M2C_P
+set_location_assignment PIN_BB3   -to "rx2_data_n[0]"       ; ## B17  DP6_M2C_N
+set_location_assignment PIN_AY1   -to "rx2_data[1]"         ; ## B12  DP7_M2C_P
+set_location_assignment PIN_AY3   -to "rx2_data_n[1]"       ; ## B13  DP7_M2C_N
+
+set_location_assignment PIN_BE7   -to "tx_data[0]"          ; ## A34  DP4_C2M_P
+set_location_assignment PIN_BE10  -to "tx_data_n[0]"        ; ## A35  DP4_C2M_N
+set_location_assignment PIN_BC7   -to "tx_data[1]"          ; ## A38  DP5_C2M_P
+set_location_assignment PIN_BC10  -to "tx_data_n[1]"        ; ## A39  DP5_C2M_N
+set_location_assignment PIN_BA7   -to "tx_data[2]"          ; ## B36  DP6_C2M_P
+set_location_assignment PIN_BA10  -to "tx_data_n[2]"        ; ## B37  DP6_C2M_N
+set_location_assignment PIN_AW7   -to "tx_data[3]"          ; ## B32  DP7_C2M_P
+set_location_assignment PIN_AW10  -to "tx_data_n[3]"        ; ## B33  DP7_C2M_N
+
+set_location_assignment PIN_A51   -to "fpga_syncin_0(n)"    ; ## H08  LA02_N
+set_location_assignment PIN_B51   -to "fpga_syncin_0"       ; ## H07  LA02_P
+set_location_assignment PIN_B54   -to "fpga_syncin_1_n"     ; ## G10  LA03_N
+set_location_assignment PIN_A54   -to "fpga_syncin_1_p"     ; ## G09  LA03_P
+set_location_assignment PIN_A48   -to "fpga_syncout_0(n)"   ; ## D09  LA01_CC_N
+set_location_assignment PIN_B45   -to "fpga_syncout_0"      ; ## D08  LA01_CC_P
+set_location_assignment PIN_F44   -to "fpga_syncout_1(n)"   ; ## C11  LA06_N
+set_location_assignment PIN_D44   -to "fpga_syncout_1"      ; ## C10  LA06_P
+set_location_assignment PIN_V58   -to "gpio[0]"             ; ## H19  LA15_P
+set_location_assignment PIN_T58   -to "gpio[1]"             ; ## H20  LA15_N
+set_location_assignment PIN_B85   -to "gpio[2]"             ; ## H22  LA19_P
+set_location_assignment PIN_A85   -to "gpio[3]"             ; ## H23  LA19_N
+set_location_assignment PIN_V47   -to "gpio[4]"             ; ## D17  LA13_P
+set_location_assignment PIN_T47   -to "gpio[5]"             ; ## D18  LA13_N
+set_location_assignment PIN_K44   -to "gpio[6]"             ; ## C18  LA14_P
+set_location_assignment PIN_M44   -to "gpio[7]"             ; ## C19  LA14_N
+set_location_assignment PIN_P44   -to "gpio[8]"             ; ## G18  LA16_P
+set_location_assignment PIN_T44   -to "gpio[9]"             ; ## G19  LA16_N
+set_location_assignment PIN_K74   -to "gpio[10]"            ; ## G25  LA22_N
+set_location_assignment PIN_F58   -to "hmc_gpio1"           ; ## H17  LA11_N
+set_location_assignment PIN_H47   -to "hmc_sync"            ; ## H14  LA07_N
+set_location_assignment PIN_M47   -to "irqb[0]"             ; ## G12  LA08_P
+set_location_assignment PIN_K47   -to "irqb[1]"             ; ## G13  LA08_N
+set_location_assignment PIN_F47   -to "rstb"                ; ## H13  LA07_P
+set_location_assignment PIN_M58   -to "rxen[0]"             ; ## C14  LA10_P
+set_location_assignment PIN_K58   -to "rxen[1]"             ; ## C15  LA10_N
+set_location_assignment PIN_B56   -to "spi0_csb"            ; ## D11  LA05_P
+set_location_assignment PIN_A60   -to "spi0_miso"           ; ## D12  LA05_N
+set_location_assignment PIN_A63   -to "spi0_mosi"           ; ## H10  LA04_P
+set_location_assignment PIN_B60   -to "spi0_sclk"           ; ## H11  LA04_N
+set_location_assignment PIN_Y58   -to "spi1_csb"            ; ## G15  LA12_P
+set_location_assignment PIN_H58   -to "spi1_sclk"           ; ## H16  LA11_P
+set_location_assignment PIN_Y55   -to "spi1_sdio"           ; ## G16  LA12_N
+set_location_assignment PIN_Y47   -to "sysref2(n)"          ; ## H05  CLK0_M2C_N
+set_location_assignment PIN_Y44   -to "sysref2"             ; ## H04  CLK0_M2C_P
+set_location_assignment PIN_F55   -to "txen[0]"             ; ## D14  LA09_P
+set_location_assignment PIN_D55   -to "txen[1]"             ; ## D15  LA09_N
+
+set tx_num_lanes [get_env_param TX_JESD_L 8]
+for {set j 0} {$j < $tx_num_lanes} {incr j} {
+  set_instance_assignment -name IO_STANDARD "HSSI DIFFERENTIAL I/O" -to tx_data[$j]
+  set_instance_assignment -name IO_STANDARD "HSSI DIFFERENTIAL I/O" -to tx_data_n[$j]
+
+  set_instance_assignment -name HSSI_PARAMETER "tx_eq_main_tap=55" -to  tx_data[$j]
+  set_instance_assignment -name HSSI_PARAMETER "tx_eq_pre_tap_1=0" -to  tx_data[$j]
+  set_instance_assignment -name HSSI_PARAMETER "tx_eq_pre_tap_2=0" -to  tx_data[$j]
+  set_instance_assignment -name HSSI_PARAMETER "tx_eq_post_tap_1=0" -to tx_data[$j]
+  set_instance_assignment -name HSSI_PARAMETER "tx_eq_main_tap=55" -to  tx_data_n[$j]
+  set_instance_assignment -name HSSI_PARAMETER "tx_eq_pre_tap_1=0" -to  tx_data_n[$j]
+  set_instance_assignment -name HSSI_PARAMETER "tx_eq_pre_tap_2=0" -to  tx_data_n[$j]
+  set_instance_assignment -name HSSI_PARAMETER "tx_eq_post_tap_1=0" -to tx_data_n[$j]
+}
+
+set rx_num_lanes [get_env_param RX_JESD_L 8]
+for {set j 0} {$j < $rx_num_lanes} {incr j} {
+  set_instance_assignment -name IO_STANDARD "HSSI DIFFERENTIAL I/O" -to rx_data[$j]
+  set_instance_assignment -name IO_STANDARD "HSSI DIFFERENTIAL I/O" -to rx_data_n[$j]
+  set_instance_assignment -name HSSI_PARAMETER "rx_adaptation_mode=RX_ADAPTATION_MODE_FLUX_ADAPTATION" -to rx_data[$j]
+  set_instance_assignment -name HSSI_PARAMETER "rx_adaptation_mode=RX_ADAPTATION_MODE_FLUX_ADAPTATION" -to rx_data_n[$j]
+}
+
+set rx2_num_lanes [get_env_param RX2_JESD_L 8]
+for {set j 0} {$j < $rx2_num_lanes} {incr j} {
+  set_instance_assignment -name IO_STANDARD "HSSI DIFFERENTIAL I/O" -to rx2_data[$j]
+  set_instance_assignment -name IO_STANDARD "HSSI DIFFERENTIAL I/O" -to rx2_data_n[$j]
+  set_instance_assignment -name HSSI_PARAMETER "rx_adaptation_mode=RX_ADAPTATION_MODE_FLUX_ADAPTATION" -to rx2_data[$j]
+  set_instance_assignment -name HSSI_PARAMETER "rx_adaptation_mode=RX_ADAPTATION_MODE_FLUX_ADAPTATION" -to rx2_data_n[$j]
+}
+
+set_instance_assignment -name IO_STANDARD "1.2 V" -to agc0[0]
+set_instance_assignment -name IO_STANDARD "1.2 V" -to agc0[1]
+set_instance_assignment -name IO_STANDARD "1.2 V" -to agc1[0]
+set_instance_assignment -name IO_STANDARD "1.2 V" -to agc1[1]
+set_instance_assignment -name IO_STANDARD "1.2 V" -to agc2[0]
+set_instance_assignment -name IO_STANDARD "1.2 V" -to agc2[1]
+set_instance_assignment -name IO_STANDARD "1.2 V" -to agc3[0]
+set_instance_assignment -name IO_STANDARD "1.2 V" -to agc3[1]
+set_instance_assignment -name IO_STANDARD "1.2 V" -to gpio[0]
+set_instance_assignment -name IO_STANDARD "1.2 V" -to gpio[1]
+set_instance_assignment -name IO_STANDARD "1.2 V" -to gpio[2]
+set_instance_assignment -name IO_STANDARD "1.2 V" -to gpio[3]
+set_instance_assignment -name IO_STANDARD "1.2 V" -to gpio[4]
+set_instance_assignment -name IO_STANDARD "1.2 V" -to gpio[5]
+set_instance_assignment -name IO_STANDARD "1.2 V" -to gpio[6]
+set_instance_assignment -name IO_STANDARD "1.2 V" -to gpio[7]
+set_instance_assignment -name IO_STANDARD "1.2 V" -to gpio[8]
+set_instance_assignment -name IO_STANDARD "1.2 V" -to gpio[9]
+set_instance_assignment -name IO_STANDARD "1.2 V" -to gpio[10]
+set_instance_assignment -name IO_STANDARD "1.2 V" -to fpga_syncin_1_p
+set_instance_assignment -name IO_STANDARD "1.2 V" -to fpga_syncin_1_n
+set_instance_assignment -name IO_STANDARD "1.2 V" -to hmc_gpio1
+set_instance_assignment -name IO_STANDARD "1.2 V" -to hmc_sync
+set_instance_assignment -name IO_STANDARD "1.2 V" -to irqb[0]
+set_instance_assignment -name IO_STANDARD "1.2 V" -to irqb[1]
+set_instance_assignment -name IO_STANDARD "1.2 V" -to rstb
+set_instance_assignment -name IO_STANDARD "1.2 V" -to rxen[0]
+set_instance_assignment -name IO_STANDARD "1.2 V" -to rxen[1]
+set_instance_assignment -name IO_STANDARD "1.2 V" -to spi0_csb
+set_instance_assignment -name IO_STANDARD "1.2 V" -to spi0_miso
+set_instance_assignment -name IO_STANDARD "1.2 V" -to spi0_mosi
+set_instance_assignment -name IO_STANDARD "1.2 V" -to spi0_sclk
+set_instance_assignment -name IO_STANDARD "1.2 V" -to spi1_csb
+set_instance_assignment -name IO_STANDARD "1.2 V" -to spi1_sclk
+set_instance_assignment -name IO_STANDARD "1.2 V" -to spi1_sdio
+set_instance_assignment -name IO_STANDARD "1.2 V" -to txen[0]
+set_instance_assignment -name IO_STANDARD "1.2 V" -to txen[1]
+
+# set optimization to get a better timing closure
+set_global_assignment -name OPTIMIZATION_MODE "Superior Performance with Maximum Placement Effort"
+
+execute_flow -compile

--- a/projects/ad9081_fmca_ebz/a5e/system_qsys.tcl
+++ b/projects/ad9081_fmca_ebz/a5e/system_qsys.tcl
@@ -1,0 +1,297 @@
+###############################################################################
+## Copyright (C) 2025-2026 Analog Devices, Inc. All rights reserved.
+### SPDX short identifier: ADIBSD
+###############################################################################
+
+## ADC FIFO depth in samples per converter
+set adc_fifo_samples_per_converter [expr $ad_project_params(RX_KS_PER_CHANNEL)*1024]
+## RX2 ADC FIFO depth in samples per converter
+set adc_rx2_fifo_samples_per_converter [expr $ad_project_params(RX2_KS_PER_CHANNEL)*1024]
+## DAC FIFO depth in samples per converter
+set dac_fifo_samples_per_converter [expr $ad_project_params(TX_KS_PER_CHANNEL)*1024]
+
+source $ad_hdl_dir/projects/scripts/adi_pd.tcl
+source $ad_hdl_dir/projects/common/intel/dacfifo_qsys.tcl
+source $ad_hdl_dir/projects/common/intel/adcfifo_qsys.tcl
+source $ad_hdl_dir/projects/common/a5e/a5e_system_qsys.tcl
+
+set jesd_mode $ad_project_params(JESD_MODE)
+
+set jesd204_ref_clock [format {%.6f} $ad_project_params(REF_CLK_RATE)]
+if {$jesd_mode == "64B66B"} {
+  set syspll_freq [format {%.6f} [expr $ad_project_params(RX_LANE_RATE)*1000 / 32]]
+} else {
+  set syspll_freq [format {%.6f} [expr $ad_project_params(RX_LANE_RATE)*1000 / 20]]
+}
+
+set TRANSCEIVER_TYPE "E-Tile"
+if [info exists ad_project_dir] {
+  source ../../common/ad9081_fmca_ebz_qsys.tcl
+} else {
+  source ../common/ad9081_fmca_ebz_qsys.tcl
+}
+
+# RX2 parameters
+set RX2_NUM_OF_LINKS $ad_project_params(RX2_NUM_LINKS)
+
+# RX2 JESD parameter per link
+set RX2_JESD_M     $ad_project_params(RX2_JESD_M)
+set RX2_JESD_L     $ad_project_params(RX2_JESD_L)
+set RX2_JESD_S     $ad_project_params(RX2_JESD_S)
+set RX2_JESD_NP    $ad_project_params(RX2_JESD_NP)
+
+if {$JESD_MODE == "8B10B"} {
+  set RX2_DATA_PATH_WIDTH 4
+  set RX2_TPL_DATA_PATH_WIDTH 4
+  if {$RX2_JESD_NP==12} {
+    set RX2_TPL_DATA_PATH_WIDTH 6
+  }
+} else {
+  set RX2_DATA_PATH_WIDTH 8
+  set RX2_TPL_DATA_PATH_WIDTH 8
+  if {$RX2_JESD_NP==12} {
+    set RX2_TPL_DATA_PATH_WIDTH 12
+  }
+}
+
+set RX2_NUM_OF_LANES      [expr $RX2_JESD_L * $RX2_NUM_OF_LINKS]
+set RX2_NUM_OF_CONVERTERS [expr $RX2_JESD_M * $RX2_NUM_OF_LINKS]
+set RX2_SAMPLES_PER_FRAME $RX2_JESD_S
+set RX2_SAMPLE_WIDTH      $RX2_JESD_NP
+set RX2_DMA_SAMPLE_WIDTH  16
+
+set RX2_OCTETS_PER_FRAME    [expr $RX2_NUM_OF_CONVERTERS * $RX2_SAMPLES_PER_FRAME * $RX2_SAMPLE_WIDTH / (8 * $RX2_NUM_OF_LANES)] ; # F
+if {$RX2_OCTETS_PER_FRAME > $RX2_TPL_DATA_PATH_WIDTH} {
+  set RX2_TPL_DATA_PATH_WIDTH $RX2_OCTETS_PER_FRAME
+}
+
+set RX2_SAMPLES_PER_CHANNEL [expr $RX2_NUM_OF_LANES * 8*$RX2_TPL_DATA_PATH_WIDTH / \
+                                ($RX2_NUM_OF_CONVERTERS * $RX2_SAMPLE_WIDTH)]
+
+set adc_rx2_fifo_name mxfe_rx2_adc_fifo
+set adc_rx2_data_width [expr 8*$RX2_TPL_DATA_PATH_WIDTH*$RX2_NUM_OF_LANES*$RX2_DMA_SAMPLE_WIDTH/$RX2_SAMPLE_WIDTH]
+set adc_rx2_dma_data_width $adc_rx2_data_width
+set adc_rx2_fifo_address_width [expr int(ceil(log(($adc_rx2_fifo_samples_per_converter*$RX2_NUM_OF_CONVERTERS) / ($adc_rx2_data_width/$RX2_DMA_SAMPLE_WIDTH))/log(2)))]
+
+# Extend the shared PHY / GTS reset instances to cover the RX2 lanes
+
+set_instance_parameter_value jesd204_phy {NUM_OF_LANES} [expr $RX_NUM_OF_LANES + $RX2_NUM_OF_LANES]
+set_instance_parameter_value gts_reset_phy NUM_BANKS_SHORELINE [expr int(ceil(($RX_NUM_OF_LANES + $RX2_NUM_OF_LANES) / 4.0))]
+set_instance_parameter_value gts_reset_phy NUM_LANES_SHORELINE [expr $RX_NUM_OF_LANES + $RX2_NUM_OF_LANES]
+
+# RX2 JESD204 clock bridge
+
+add_instance rx2_device_clk altera_clock_bridge
+set_instance_parameter_value rx2_device_clk {EXPLICIT_CLOCK_RATE} [expr $DEVICE_CLK_RATE * $RX2_DATA_PATH_WIDTH / $RX2_TPL_DATA_PATH_WIDTH ]
+
+# RX2 JESD204 PHY-Link layer
+
+add_instance mxfe_rx2_jesd204 adi_jesd204
+set_instance_parameter_value mxfe_rx2_jesd204 {ID} {0}
+set_instance_parameter_value mxfe_rx2_jesd204 {LINK_MODE} $LINK_MODE
+set_instance_parameter_value mxfe_rx2_jesd204 {TX_OR_RX_N} {0}
+set_instance_parameter_value mxfe_rx2_jesd204 {SOFT_PCS} {true}
+set_instance_parameter_value mxfe_rx2_jesd204 {LANE_RATE} $RX_LANE_RATE
+set_instance_parameter_value mxfe_rx2_jesd204 {SYSCLK_FREQUENCY} {100.0}
+set_instance_parameter_value mxfe_rx2_jesd204 {REFCLK_FREQUENCY} $REF_CLK_RATE
+set_instance_parameter_value mxfe_rx2_jesd204 {INPUT_PIPELINE_STAGES} {2}
+set_instance_parameter_value mxfe_rx2_jesd204 {NUM_OF_LANES} $RX2_NUM_OF_LANES
+set_instance_parameter_value mxfe_rx2_jesd204 {EXT_DEVICE_CLK_EN} {1}
+set_instance_parameter_value mxfe_rx2_jesd204 {TPL_DATA_PATH_WIDTH} $RX2_TPL_DATA_PATH_WIDTH
+set_instance_parameter_value mxfe_rx2_jesd204 {DATA_PATH_WIDTH} $RX2_DATA_PATH_WIDTH
+set_instance_parameter_value mxfe_rx2_jesd204 {EXTERNAL_PHY} $EXTERNAL_PHY
+# set_instance_parameter_value mxfe_rx_jesd204 {LANE_MAP} {5 7 0 1 2 3 4 6}
+
+
+add_instance mxfe_rx2_tpl ad_ip_jesd204_tpl_adc
+set_instance_parameter_value mxfe_rx2_tpl {ID} {0}
+set_instance_parameter_value mxfe_rx2_tpl {NUM_CHANNELS} $RX2_NUM_OF_CONVERTERS
+set_instance_parameter_value mxfe_rx2_tpl {NUM_LANES} $RX2_NUM_OF_LANES
+set_instance_parameter_value mxfe_rx2_tpl {BITS_PER_SAMPLE} $RX2_SAMPLE_WIDTH
+set_instance_parameter_value mxfe_rx2_tpl {CONVERTER_RESOLUTION} $RX2_SAMPLE_WIDTH
+set_instance_parameter_value mxfe_rx2_tpl {TWOS_COMPLEMENT} {1}
+set_instance_parameter_value mxfe_rx2_tpl {OCTETS_PER_BEAT} $RX2_TPL_DATA_PATH_WIDTH
+set_instance_parameter_value mxfe_rx2_tpl {DMA_BITS_PER_SAMPLE} $RX2_DMA_SAMPLE_WIDTH
+
+# RX2 pack
+
+add_instance mxfe_rx2_cpack util_cpack2
+set_instance_parameter_value mxfe_rx2_cpack {NUM_OF_CHANNELS} $RX2_NUM_OF_CONVERTERS
+set_instance_parameter_value mxfe_rx2_cpack {SAMPLES_PER_CHANNEL} $RX2_SAMPLES_PER_CHANNEL
+set_instance_parameter_value mxfe_rx2_cpack {SAMPLE_DATA_WIDTH} $RX2_DMA_SAMPLE_WIDTH
+
+# RX2 data offload buffer
+
+ad_adcfifo_create $adc_rx2_fifo_name $adc_rx2_data_width $adc_rx2_dma_data_width $adc_rx2_fifo_address_width 0
+
+# RX2 DMA instance
+
+add_instance mxfe_rx2_dma axi_dmac
+set_instance_parameter_value mxfe_rx2_dma {ID} {0}
+set_instance_parameter_value mxfe_rx2_dma {DMA_DATA_WIDTH_SRC} $adc_rx2_dma_data_width
+set_instance_parameter_value mxfe_rx2_dma {DMA_DATA_WIDTH_DEST} $adc_rx2_dma_data_width
+set_instance_parameter_value mxfe_rx2_dma {DMA_LENGTH_WIDTH} {24}
+set_instance_parameter_value mxfe_rx2_dma {DMA_2D_TRANSFER} {0}
+set_instance_parameter_value mxfe_rx2_dma {AXI_SLICE_DEST} {1}
+set_instance_parameter_value mxfe_rx2_dma {AXI_SLICE_SRC} {1}
+set_instance_parameter_value mxfe_rx2_dma {SYNC_TRANSFER_START} {0}
+set_instance_parameter_value mxfe_rx2_dma {CYCLIC} {0}
+set_instance_parameter_value mxfe_rx2_dma {DMA_TYPE_DEST} {0}
+set_instance_parameter_value mxfe_rx2_dma {DMA_TYPE_SRC} {1}
+set_instance_parameter_value mxfe_rx2_dma {FIFO_SIZE} {16}
+set_instance_parameter_value mxfe_rx2_dma {DMA_AXI_PROTOCOL_DEST} {0}
+set_instance_parameter_value mxfe_rx2_dma {MAX_BYTES_PER_BURST} {2048}
+
+# clocks and resets
+
+# system clock and reset
+add_connection sys_clk.clk mxfe_rx2_jesd204.sys_clk
+add_connection sys_clk.clk mxfe_rx2_tpl.s_axi_clock
+add_connection sys_clk.clk mxfe_rx2_dma.s_axi_clock
+
+add_connection sys_clk.clk_reset mxfe_rx2_jesd204.sys_resetn
+add_connection sys_clk.clk_reset mxfe_rx2_tpl.s_axi_reset
+add_connection sys_clk.clk_reset mxfe_rx2_dma.s_axi_reset
+
+# device clock and reset
+add_connection rx2_device_clk.out_clk mxfe_rx2_jesd204.device_clk
+add_connection rx2_device_clk.out_clk mxfe_rx2_tpl.link_clk
+if {$EXTERNAL_PHY} {
+  if {$RX2_TPL_DATA_PATH_WIDTH > $RX2_DATA_PATH_WIDTH} {
+    add_connection jesd204_phy.rx_clkout mxfe_rx2_jesd204.phy_link_clk
+  }
+}
+add_connection rx2_device_clk.out_clk mxfe_rx2_cpack.clk
+add_connection rx2_device_clk.out_clk $adc_rx2_fifo_name.if_adc_clk
+
+add_connection mxfe_rx2_jesd204.link_reset mxfe_rx2_cpack.reset
+add_connection mxfe_rx2_jesd204.link_reset $adc_rx2_fifo_name.if_adc_rst
+
+# dma clock and reset
+add_connection sys_dma_clk.clk $adc_rx2_fifo_name.if_dma_clk
+add_connection sys_dma_clk.clk mxfe_rx2_dma.if_s_axis_aclk
+add_connection sys_dma_clk.clk mxfe_rx2_dma.m_dest_axi_clock
+
+add_connection sys_dma_clk.clk_reset mxfe_rx2_dma.m_dest_axi_reset
+
+#
+## Exported signals
+#
+
+add_interface rx2_sysref       conduit end
+add_interface rx2_sync         conduit end
+add_interface rx2_device_clk   clock   sink
+
+set_interface_property rx2_sysref       EXPORT_OF mxfe_rx2_jesd204.sysref
+set_interface_property rx2_sync         EXPORT_OF mxfe_rx2_jesd204.sync
+set_interface_property rx2_device_clk   EXPORT_OF rx2_device_clk.in_clk
+
+add_interface rx2_ref_clk      clock   sink
+add_interface tx_os_ref_clk    clock   sink
+add_interface rx2_serial_data  conduit end
+
+if {$TRANSCEIVER_TYPE == "F-Tile" || $TRANSCEIVER_TYPE == "E-Tile"} {
+  add_interface rx2_serial_data_n  conduit end
+}
+
+# RX2 PHY exports and connections
+set_interface_property mxfe_rx2_jesd204_reset_ack EXPORT_OF mxfe_rx2_jesd204.reset_ack
+set_interface_property mxfe_rx2_jesd204_ready EXPORT_OF mxfe_rx2_jesd204.ready
+set_interface_property mxfe_rx2_jesd204_rx_is_lockedtodata EXPORT_OF mxfe_rx2_jesd204.rx_is_lockedtodata
+
+for {set i 0} {$i < $RX2_NUM_OF_LANES} {incr i} {
+  set idx [expr $RX_NUM_OF_LANES + $i]
+  add_connection jesd204_phy.phy_rx_${idx} mxfe_rx2_jesd204.rx_phy${i}
+}
+
+#
+## Data interface / data path
+#
+
+# RX2 link to tpl
+add_connection mxfe_rx2_jesd204.link_sof mxfe_rx2_tpl.if_link_sof
+add_connection mxfe_rx2_jesd204.link_data mxfe_rx2_tpl.link_data
+# RX2 tpl to cpack
+for {set i 0} {$i < $RX2_NUM_OF_CONVERTERS} {incr i} {
+  add_connection mxfe_rx2_tpl.adc_ch_$i mxfe_rx2_cpack.adc_ch_$i
+}
+add_connection mxfe_rx2_tpl.if_adc_dovf $adc_rx2_fifo_name.if_adc_wovf
+# RX2 cpack to offload
+add_connection mxfe_rx2_cpack.if_packed_fifo_wr_en $adc_rx2_fifo_name.if_adc_wr
+add_connection mxfe_rx2_cpack.if_packed_fifo_wr_data $adc_rx2_fifo_name.if_adc_wdata
+# RX2 offload to dma
+add_connection $adc_rx2_fifo_name.if_dma_xfer_req mxfe_rx2_dma.if_s_axis_xfer_req
+add_connection $adc_rx2_fifo_name.m_axis mxfe_rx2_dma.s_axis
+# RX2 dma to HPS
+ad_dma_interconnect mxfe_rx2_dma.m_dest_axi 0x0000000 $adc_rx2_dma_data_width
+
+#
+## address map
+#
+
+ad_cpu_interconnect 0x000B0000 mxfe_rx2_jesd204.link_reconfig
+ad_cpu_interconnect 0x000B4000 mxfe_rx2_jesd204.link_management
+ad_cpu_interconnect 0x000B8000 mxfe_rx2_tpl.s_axi
+ad_cpu_interconnect 0x000BC000 mxfe_rx2_dma.s_axi
+
+#
+## interrupts
+#
+
+ad_cpu_interrupt  9  mxfe_rx2_jesd204.interrupt
+ad_cpu_interrupt 12  mxfe_rx2_dma.interrupt_sender
+
+# GTS PLL
+add_instance gts_pll intel_systemclk_gts
+set_instance_parameter_value gts_pll syspll_mod_0 {User Configuration}
+set_instance_parameter_value gts_pll syspll_freq_mhz_0 $syspll_freq
+set_instance_parameter_value gts_pll refclk_xcvr_freq_mhz_0 $jesd204_ref_clock
+
+add_interface i_refclk_rdy conduit end
+add_interface o_pll_lock   conduit end
+add_interface refclk_xcvr  clock sink
+add_interface o_syspll_c0  clock source
+
+set_interface_property i_refclk_rdy EXPORT_OF gts_pll.i_refclk_rdy
+set_interface_property o_pll_lock   EXPORT_OF gts_pll.o_pll_lock
+set_interface_property refclk_xcvr  EXPORT_OF gts_pll.refclk_xcvr
+set_interface_property o_syspll_c0  EXPORT_OF gts_pll.o_syspll_c0
+
+# Internal 100 MHz clock exported
+add_instance sys_cpu_clk_bridge altera_clock_bridge
+set_instance_parameter_value sys_cpu_clk_bridge {EXPLICIT_CLOCK_RATE} {100000000}
+add_connection sys_clk.clk sys_cpu_clk_bridge.in_clk
+
+add_interface sys_cpu_clk clock source
+set_interface_property sys_cpu_clk EXPORT_OF sys_cpu_clk_bridge.out_clk
+
+#system ID
+set_instance_parameter_value axi_sysid_0 {ROM_ADDR_BITS} {10}
+set_instance_parameter_value rom_sys_0 {PATH_TO_FILE} "$mem_init_sys_file_path/mem_init_sys.txt"
+set_instance_parameter_value rom_sys_0 {ROM_ADDR_BITS} {10}
+
+set sys_cstring "$ad_project_params(JESD_MODE)\
+RX:RATE=$ad_project_params(RX_LANE_RATE)\
+M=$ad_project_params(RX_JESD_M)\
+L=$ad_project_params(RX_JESD_L)\
+S=$ad_project_params(RX_JESD_S)\
+NP=$ad_project_params(RX_JESD_NP)\
+LINKS=$ad_project_params(RX_NUM_LINKS)\
+KS/CH=$ad_project_params(RX_KS_PER_CHANNEL)\
+M2=$ad_project_params(RX2_JESD_M)\
+L2=$ad_project_params(RX2_JESD_L)\
+S2=$ad_project_params(RX2_JESD_S)\
+NP2=$ad_project_params(RX2_JESD_NP)\
+LINKS2=$ad_project_params(RX2_NUM_LINKS)\
+KS2/CH=$ad_project_params(RX2_KS_PER_CHANNEL)\
+TX:RATE=$ad_project_params(TX_LANE_RATE)\
+M=$ad_project_params(TX_JESD_M)\
+L=$ad_project_params(TX_JESD_L)\
+S=$ad_project_params(TX_JESD_S)\
+NP=$ad_project_params(TX_JESD_NP)\
+LINKS=$ad_project_params(TX_NUM_LINKS)\
+KS/CH=$ad_project_params(TX_KS_PER_CHANNEL)\
+REF_CLK=$ad_project_params(REF_CLK_RATE)\
+DEV_CLK=$ad_project_params(DEVICE_CLK_RATE)"
+
+sysid_gen_sys_init_file sys_cstring 10

--- a/projects/ad9081_fmca_ebz/a5e/system_top.v
+++ b/projects/ad9081_fmca_ebz/a5e/system_top.v
@@ -1,0 +1,509 @@
+// ***************************************************************************
+// ***************************************************************************
+// Copyright (C) 2025-2026 Analog Devices, Inc. All rights reserved.
+//
+// In this HDL repository, there are many different and unique modules, consisting
+// of various HDL (Verilog or VHDL) components. The individual modules are
+// developed independently, and may be accompanied by separate and unique license
+// terms.
+//
+// The user should read each of these license terms, and understand the
+// freedoms and responsibilities that he or she has by using this source/core.
+//
+// This core is distributed in the hope that it will be useful, but WITHOUT ANY
+// WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+// A PARTICULAR PURPOSE.
+//
+// Redistribution and use of source or resulting binaries, with or without modification
+// of this file, are permitted under one of the following two license terms:
+//
+//   1. The GNU General Public License version 2 as published by the
+//      Free Software Foundation, which can be found in the top level directory
+//      of this repository (LICENSE_GPL2), and also online at:
+//      <https://www.gnu.org/licenses/old-licenses/gpl-2.0.html>
+//
+// OR
+//
+//   2. An ADI specific BSD license, which can be found in the top level directory
+//      of this repository (LICENSE_ADIBSD), and also on-line at:
+//      https://github.com/analogdevicesinc/hdl/blob/main/LICENSE_ADIBSD
+//      This will allow to generate bit files and not release the source code,
+//      as long as it attaches to an ADI device.
+//
+// ***************************************************************************
+// ***************************************************************************
+
+`timescale 1ns/100ps
+
+module system_top #(
+  // Dummy parameters to workaround critical warning
+  parameter JESD_MODE          = "8B10B",
+  parameter RX_LANE_RATE       = 9.6,
+  parameter TX_LANE_RATE       = 9.6,
+  parameter REF_CLK_RATE       = 240,
+  parameter DEVICE_CLK_RATE    = 240,
+  parameter RX_JESD_M          = 2,
+  parameter RX_JESD_L          = 2,
+  parameter RX_JESD_S          = 1,
+  parameter RX_JESD_NP         = 16,
+  parameter RX_NUM_LINKS       = 1,
+  parameter RX2_JESD_M         = 2,
+  parameter RX2_JESD_L         = 2,
+  parameter RX2_JESD_S         = 1,
+  parameter RX2_JESD_NP        = 16,
+  parameter RX2_NUM_LINKS      = 1,
+  parameter TX_JESD_M          = 4,
+  parameter TX_JESD_L          = 2,
+  parameter TX_JESD_S          = 1,
+  parameter TX_JESD_NP         = 16,
+  parameter TX_NUM_LINKS       = 1,
+  parameter RX_KS_PER_CHANNEL  = 32,
+  parameter TX_KS_PER_CHANNEL  = 32,
+  parameter RX2_KS_PER_CHANNEL = 32
+) (
+
+    // clock and resets
+  input            sys_clk,
+  input            hps_osc_clk,
+  input            sys_resetn,
+
+  // board gpio
+  output  [3:0]    fpga_led,
+  input   [3:0]    fpga_dipsw,
+  input   [3:0]    fpga_btn,
+
+  // hps-emif
+  input            emif_hps_ref_clk,
+  output           emif_hps_mem_ck_t,
+  output           emif_hps_mem_ck_c,
+  output [ 16:0]   emif_hps_mem_a,
+  output           emif_hps_mem_act_n,
+  output [  1:0]   emif_hps_mem_ba,
+  output [  1:0]   emif_hps_mem_bg,
+  output           emif_hps_mem_cke,
+  output           emif_hps_mem_cs_n,
+  output           emif_hps_mem_odt,
+  output           emif_hps_mem_reset_n,
+  output           emif_hps_mem_par,
+  input            emif_hps_mem_alert_n,
+  input            emif_hps_oct_rzqin,
+  inout  [  4:0]   emif_hps_mem_dqs_t,
+  inout  [  4:0]   emif_hps_mem_dqs_c,
+  inout  [ 39:0]   emif_hps_mem_dq,
+  inout  [  4:0]   emif_hps_mem_dbi_n,
+
+  // hps-sdmmc
+  output           hps_sdmmc_clk,
+  inout            hps_sdmmc_cmd,
+  inout   [ 3:0]   hps_sdmmc_d,
+
+  // hps-emac
+  input            hps_emac_rxclk,
+  input            hps_emac_rxctl,
+  input   [ 3:0]   hps_emac_rxd,
+  output           hps_emac_txclk,
+  output           hps_emac_txctl,
+  output  [ 3:0]   hps_emac_txd,
+  output           hps_emac_pps,
+  input            hps_emac_pps_trig,
+  output           hps_emac_mdc,
+  inout            hps_emac_mdio,
+
+  // usb31
+  input            usb31_io_vbus_det,
+  input            usb31_io_flt_bar,
+  output           usb31_io_usb_ctrl,
+  input            usb31_io_usb31_id,
+  input            usb31_phy_refclk_p,
+  input            usb31_phy_rx_serial_n,
+  input            usb31_phy_rx_serial_p,
+  output           usb31_phy_tx_serial_n,
+  output           usb31_phy_tx_serial_p,
+
+  // hps-usb
+  input            hps_usb_clk,
+  input            hps_usb_dir,
+  input            hps_usb_nxt,
+  output           hps_usb_stp,
+  inout   [ 7:0]   hps_usb_d,
+
+  // hps-uart
+  input            hps_uart_rx,
+  output           hps_uart_tx,
+
+  // hps-i2c
+  inout            hps_i2c_sda,
+  inout            hps_i2c_scl,
+
+  // hps-jtag
+  input            hps_jtag_tck,
+  input            hps_jtag_tms,
+  output           hps_jtag_tdo,
+  input            hps_jtag_tdi,
+
+  // hps-gpio
+  inout            hps_gpio0_io0,
+  inout            hps_gpio0_io1,
+  inout            hps_gpio0_io11,
+  inout            hps_gpio1_io3,
+  inout            hps_gpio1_io4,
+
+  // FMC HPC IOs
+
+  // lane interface
+  input                   clkin6,
+  input                   clkin10,
+  input                   fpga_refclk_in,
+
+  output  [TX_JESD_L-1:0]    tx_data,
+  output  [TX_JESD_L-1:0]    tx_data_n,
+  input   [RX_JESD_L-1:0]    rx_data,
+  input   [RX_JESD_L-1:0]    rx_data_n,
+  input   [RX2_JESD_L-1:0] rx2_data,
+  input   [RX2_JESD_L-1:0] rx2_data_n,
+  input                   fpga_syncin_0,
+  input                   fpga_syncin_1_n,
+  input                   fpga_syncin_1_p,
+  output                  fpga_syncout_0,
+  output                  fpga_syncout_1,
+  // input                   fpga_syncout_1_n,
+  // input                   fpga_syncout_1_p,
+  input                   sysref2,
+
+  // spi
+  output                  spi0_csb,
+  input                   spi0_miso,
+  output                  spi0_mosi,
+  output                  spi0_sclk,
+  output                  spi1_csb,
+  output                  spi1_sclk,
+  inout                   spi1_sdio,
+
+  // gpio
+  input   [1:0]           agc0,
+  input   [1:0]           agc1,
+  input   [1:0]           agc2,
+  input   [1:0]           agc3,
+  input   [10:0]          gpio,
+  inout                   hmc_gpio1,
+  output                  hmc_sync,
+  input   [1:0]           irqb,
+  output                  rstb,
+  output  [1:0]           rxen,
+  output  [1:0]           txen
+);
+
+  localparam NUM_BANKS = (RX_JESD_L + RX2_JESD_L) > 4 ? 2 : 1;
+  localparam PHY_OS_PMA_CLK_IDX = RX_JESD_L > 4 ? 1 : 0;
+
+  // internal signals
+  wire  [63:0]  gpio_i;
+  wire  [63:0]  gpio_o;
+  wire          sys_cpu_clk;
+  wire          ninit_done;
+  wire          sys_reset_n;
+  wire          h2f_reset;
+  wire          h2f_warm_reset_reset_ack;
+  wire          h2f_warm_reset_reset_req;
+  wire [ 1:0]   usb31_io_usb_ctrl_s;
+  wire          pma_cu_clk;
+  wire          refclk_fail_stat;
+  wire          syspll_clk;
+  wire          syspll_lock;
+  wire          dacfifo_bypass;
+  wire          refclk_ready;
+  wire          refclk_ready_rx;
+  wire          refclk_ready_tx;
+  wire          refclk_ready_os;
+  wire [TX_JESD_L-1:0] phy_tx_pll_locked_o_tx_pll_locked;
+  wire [RX_JESD_L+RX2_JESD_L-1:0] gts_reset_o_src_rs_grant_src_rs_grant;
+  wire [RX_JESD_L+RX2_JESD_L-1:0] gts_reset_i_src_rs_req_src_rs_req;
+  wire [PHY_OS_PMA_CLK_IDX:0] gts_reset_o_pma_cu_clk_clk;
+  wire          gts_reset_i_refclk_bus_out_refclk_bus_out;
+  wire [ 9:0]   jesd204_phy_o_refclk_bus_out_refclk_bus_out;
+
+  wire  [ 7:0]  spi_csn_s;
+  wire          spi_clk;
+  wire          spi_mosi;
+
+  assign h2f_warm_reset_reset_ack = h2f_warm_reset_reset_req;
+
+  // ADXCVR -> PHY
+  wire jesd204_phy_rx_reset_ack_rx_reset_ack;
+  wire jesd204_phy_rx_ready_rx_ready;
+  wire [RX2_JESD_L+RX_JESD_L-1:0] jesd204_phy_rx_is_lockedtodata_o_rx_is_lockedtodata;
+
+  wire mxfe_rx_jesd204_ready_rx_ready;
+  wire mxfe_rx_jesd204_reset_ack_rx_reset_ack;
+  wire [RX_JESD_L-1:0] mxfe_rx_jesd204_rx_is_lockedtodata_o_rx_is_lockedtodata;
+
+  wire mxfe_rx2_jesd204_ready_rx_ready;
+  wire mxfe_rx2_jesd204_reset_ack_rx_reset_ack;
+  wire [RX2_JESD_L-1:0] mxfe_rx2_jesd204_rx_is_lockedtodata_o_rx_is_lockedtodata;
+
+  assign mxfe_rx_jesd204_reset_ack_rx_reset_ack = jesd204_phy_rx_reset_ack_rx_reset_ack;
+  assign mxfe_rx2_jesd204_reset_ack_rx_reset_ack = jesd204_phy_rx_reset_ack_rx_reset_ack;
+  assign mxfe_rx_jesd204_ready_rx_ready = jesd204_phy_rx_ready_rx_ready;
+  assign mxfe_rx2_jesd204_ready_rx_ready = jesd204_phy_rx_ready_rx_ready;
+  assign mxfe_rx_jesd204_rx_is_lockedtodata_o_rx_is_lockedtodata = jesd204_phy_rx_is_lockedtodata_o_rx_is_lockedtodata[RX_JESD_L-1:0];
+  assign mxfe_rx2_jesd204_rx_is_lockedtodata_o_rx_is_lockedtodata = jesd204_phy_rx_is_lockedtodata_o_rx_is_lockedtodata[RX2_JESD_L+RX_JESD_L-1:RX_JESD_L];
+
+  // Board GPIOs
+  assign fpga_led      = gpio_o[3:0];
+  assign gpio_i[ 3: 0] = gpio_o[3:0];
+  assign gpio_i[ 7: 4] = fpga_dipsw;
+  assign gpio_i[11: 8] = fpga_btn;
+
+  // HMC GPIOs
+  assign gpio_i[44] = agc0[0];
+  assign gpio_i[45] = agc0[1];
+  assign gpio_i[46] = agc1[0];
+  assign gpio_i[47] = agc1[1];
+  assign gpio_i[48] = agc2[0];
+  assign gpio_i[49] = agc2[1];
+  assign gpio_i[50] = agc3[0];
+  assign gpio_i[51] = agc3[1];
+  assign gpio_i[52] = irqb[0];
+  assign gpio_i[53] = irqb[1];
+
+  assign hmc_gpio1  = gpio_o[43];
+  assign hmc_sync   = gpio_o[54];
+  assign rstb       = gpio_o[55];
+  assign rxen[0]    = gpio_o[56];
+  assign rxen[1]    = gpio_o[57];
+  assign txen[0]    = gpio_o[58];
+  assign txen[1]    = gpio_o[59];
+
+  assign dacfifo_bypass  = gpio_o[60];
+  assign refclk_ready_rx = gpio_o[61];
+  assign refclk_ready_tx = gpio_o[62];
+  assign refclk_ready_os = gpio_o[63];
+
+  // Unused GPIOs
+  assign gpio_i[63:54] = gpio_o[63:54];
+  assign gpio_i[43:32] = gpio_o[43:32];
+  assign gpio_i[31:12] = gpio_o[31:12];
+
+  // assignmnets
+  assign sys_reset_n = sys_resetn & ~h2f_reset & ~ninit_done;
+
+  assign usb31_io_usb_ctrl = usb31_io_usb_ctrl_s[1];
+
+  assign spi0_csb = spi_csn_s[0];
+  assign spi1_csb = spi_csn_s[1];
+
+  assign spi0_sclk = spi_clk;
+  assign spi1_sclk = spi_clk;
+
+  assign spi0_mosi = spi_mosi;
+
+  ad_3w_spi #(
+    .NUM_OF_SLAVES(1)
+  ) i_spi_hmc (
+    .spi_csn (spi_csn_s[1]),
+    .spi_clk (spi_clk),
+    .spi_mosi (spi_mosi),
+    .spi_miso (spi_hmc_miso),
+    .spi_sdio (spi1_sdio),
+    .spi_dir ());
+
+  assign spi_miso = ~spi_csn_s[0] ? spi0_miso :
+                    ~spi_csn_s[1] ? spi_hmc_miso :
+                    1'b0;
+
+  assign refclk_ready = refclk_ready_tx || refclk_ready_rx || refclk_ready_os;
+
+  wire [9:0]                        gts_reset_i_refclk_on_refclk_on;
+  wire [9:0]                        gts_reset_i_src_rs_refclk_status_bus_refclk_status_bus_out;
+  wire [7:0]                        gts_reset_o_refclk_fail_status_refclk_fail_status;
+  wire                              gts_reset_o_refclk_on_ack_refclk_on_ack;
+  wire [9:0]                        gts_reset_o_src_rs_refclk_cmd_bus_refclk_cmd_bus_in;
+
+  assign gts_reset_i_src_rs_refclk_status_bus_refclk_status_bus_out = jesd204_phy_o_refclk_bus_out_refclk_bus_out;
+
+  // GTS refclk buffer control state machine
+  gts_refclk_reset #(
+    .REFCLK_ON_WIDTH   (10),
+    .FAIL_STATUS_WIDTH (8)
+  ) i_gts_refclk_reset (
+    .clk                (sys_cpu_clk),
+    .resetn             (sys_reset_n),
+    .refclk_ready       (refclk_ready),
+    .refclk_on_ack      (gts_reset_o_refclk_on_ack_refclk_on_ack),
+    .refclk_fail_status (gts_reset_o_refclk_fail_status_refclk_fail_status),
+    .refclk_on          (gts_reset_i_refclk_on_refclk_on));
+
+  system_bd i_system_bd (
+    .sys_clk_clk                                                (sys_clk),
+    .sys_hps_io_hps_osc_clk                                     (hps_osc_clk),
+
+    .sys_rst_reset_n                                            (sys_reset_n),
+    .rst_ninit_done                                             (ninit_done),
+    .h2f_reset_reset                                            (h2f_reset),
+    .h2f_warm_reset_reset_req                                   (h2f_warm_reset_reset_req),
+    .h2f_warm_reset_reset_ack                                   (h2f_warm_reset_reset_ack),
+
+    .f2h_irq1_in_irq                                            ('h0),
+    .pr_rom_data_nc_rom_data                                    ('h0),
+    .o_pma_cu_clk_clk                                           (pma_cu_clk),
+
+    .hps_emif_mem_0_mem_cke                                     (emif_hps_mem_cke),
+    .hps_emif_mem_0_mem_odt                                     (emif_hps_mem_odt),
+    .hps_emif_mem_0_mem_cs_n                                    (emif_hps_mem_cs_n),
+    .hps_emif_mem_0_mem_a                                       (emif_hps_mem_a),
+    .hps_emif_mem_0_mem_ba                                      (emif_hps_mem_ba),
+    .hps_emif_mem_0_mem_bg                                      (emif_hps_mem_bg),
+    .hps_emif_mem_0_mem_act_n                                   (emif_hps_mem_act_n),
+    .hps_emif_mem_0_mem_par                                     (emif_hps_mem_par),
+    .hps_emif_mem_0_mem_dq                                      (emif_hps_mem_dq),
+    .hps_emif_mem_0_mem_dqs_t                                   (emif_hps_mem_dqs_t),
+    .hps_emif_mem_0_mem_dqs_c                                   (emif_hps_mem_dqs_c),
+    .hps_emif_mem_0_mem_alert_n                                 (emif_hps_mem_alert_n),
+    .hps_emif_mem_ck_0_mem_ck_t                                 (emif_hps_mem_ck_t),
+    .hps_emif_mem_ck_0_mem_ck_c                                 (emif_hps_mem_ck_c),
+    .hps_emif_mem_reset_n_mem_reset_n                           (emif_hps_mem_reset_n),
+    .hps_emif_oct_0_oct_rzqin                                   (emif_hps_oct_rzqin),
+    .hps_emif_ref_clk_0_clk                                     (emif_hps_ref_clk),
+    .hps_emif_mem_0_mem_dbi_n                                   (emif_hps_mem_dbi_n),
+
+    .sys_hps_io_sdmmc_data0                                     (hps_sdmmc_d[0]),
+    .sys_hps_io_sdmmc_data1                                     (hps_sdmmc_d[1]),
+    .sys_hps_io_sdmmc_data2                                     (hps_sdmmc_d[2]),
+    .sys_hps_io_sdmmc_data3                                     (hps_sdmmc_d[3]),
+    .sys_hps_io_sdmmc_cclk                                      (hps_sdmmc_clk),
+    .sys_hps_io_sdmmc_cmd                                       (hps_sdmmc_cmd),
+
+    .sys_hps_io_usb1_clk                                        (hps_usb_clk),
+    .sys_hps_io_usb1_stp                                        (hps_usb_stp),
+    .sys_hps_io_usb1_dir                                        (hps_usb_dir),
+    .sys_hps_io_usb1_nxt                                        (hps_usb_nxt),
+    .sys_hps_io_usb1_data0                                      (hps_usb_d[0]),
+    .sys_hps_io_usb1_data1                                      (hps_usb_d[1]),
+    .sys_hps_io_usb1_data2                                      (hps_usb_d[2]),
+    .sys_hps_io_usb1_data3                                      (hps_usb_d[3]),
+    .sys_hps_io_usb1_data4                                      (hps_usb_d[4]),
+    .sys_hps_io_usb1_data5                                      (hps_usb_d[5]),
+    .sys_hps_io_usb1_data6                                      (hps_usb_d[6]),
+    .sys_hps_io_usb1_data7                                      (hps_usb_d[7]),
+
+    .sys_hps_io_emac2_tx_clk                                    (hps_emac_txclk),
+    .sys_hps_io_emac2_tx_ctl                                    (hps_emac_txctl),
+    .sys_hps_io_emac2_rx_clk                                    (hps_emac_rxclk),
+    .sys_hps_io_emac2_rx_ctl                                    (hps_emac_rxctl),
+    .sys_hps_io_emac2_txd0                                      (hps_emac_txd[0]),
+    .sys_hps_io_emac2_txd1                                      (hps_emac_txd[1]),
+    .sys_hps_io_emac2_txd2                                      (hps_emac_txd[2]),
+    .sys_hps_io_emac2_txd3                                      (hps_emac_txd[3]),
+    .sys_hps_io_emac2_rxd0                                      (hps_emac_rxd[0]),
+    .sys_hps_io_emac2_rxd1                                      (hps_emac_rxd[1]),
+    .sys_hps_io_emac2_rxd2                                      (hps_emac_rxd[2]),
+    .sys_hps_io_emac2_rxd3                                      (hps_emac_rxd[3]),
+    .sys_hps_io_emac2_pps                                       (hps_emac_pps),
+    .sys_hps_io_emac2_pps_trig                                  (hps_emac_pps_trig),
+
+    .sys_hps_io_mdio2_mdio                                      (hps_emac_mdio),
+    .sys_hps_io_mdio2_mdc                                       (hps_emac_mdc),
+
+    .sys_hps_io_uart0_tx                                        (hps_uart_tx),
+    .sys_hps_io_uart0_rx                                        (hps_uart_rx),
+
+    .sys_hps_io_i3c1_sda                                        (hps_i2c_sda),
+    .sys_hps_io_i3c1_scl                                        (hps_i2c_scl),
+
+    .sys_hps_io_jtag_tck                                        (hps_jtag_tck),
+    .sys_hps_io_jtag_tms                                        (hps_jtag_tms),
+    .sys_hps_io_jtag_tdo                                        (hps_jtag_tdo),
+    .sys_hps_io_jtag_tdi                                        (hps_jtag_tdi),
+
+    .usb31_io_vbus_det                                          (usb31_io_vbus_det),
+    .usb31_io_flt_bar                                           (usb31_io_flt_bar),
+    .usb31_io_usb_ctrl                                          (usb31_io_usb_ctrl_s),
+    .usb31_io_usb31_id                                          (usb31_io_usb31_id),
+
+    .usb31_phy_pma_cpu_clk_clk                                  (pma_cu_clk),
+    .usb31_phy_refclk_p_clk                                     (usb31_phy_refclk_p),
+    .usb31_phy_rx_serial_n_i_rx_serial_n                        (usb31_phy_rx_serial_n),
+    .usb31_phy_rx_serial_p_i_rx_serial_p                        (usb31_phy_rx_serial_p),
+    .usb31_phy_tx_serial_n_o_tx_serial_n                        (usb31_phy_tx_serial_n),
+    .usb31_phy_tx_serial_p_o_tx_serial_p                        (usb31_phy_tx_serial_p),
+
+    .sys_hps_io_gpio0                                           (hps_gpio0_io0),
+    .sys_hps_io_gpio1                                           (hps_gpio0_io1),
+    .sys_hps_io_gpio11                                          (hps_gpio0_io11),
+    .sys_hps_io_gpio27                                          (hps_gpio1_io3),
+    .sys_hps_io_gpio28                                          (hps_gpio1_io4),
+
+    .sys_gpio_bd_in_port                                        (gpio_i[31:0]),
+    .sys_gpio_bd_out_port                                       (gpio_o[31:0]),
+    .sys_gpio_in_export                                         (gpio_i[63:32]),
+    .sys_gpio_out_export                                        (gpio_o[63:32]),
+
+    .sys_cpu_clk_clk                                            (sys_cpu_clk),
+
+    .gts_reset_src_rs_priority_src_rs_priority                  ('h0),
+    .gts_reset_i_src_rs_refclk_status_bus_refclk_status_bus_out (gts_reset_i_src_rs_refclk_status_bus_refclk_status_bus_out),
+		.gts_reset_o_refclk_fail_status_refclk_fail_status          (gts_reset_o_refclk_fail_status_refclk_fail_status),
+		.gts_reset_o_refclk_on_ack_refclk_on_ack                    (gts_reset_o_refclk_on_ack_refclk_on_ack),
+		.gts_reset_i_refclk_on_refclk_on                            (gts_reset_i_refclk_on_refclk_on),
+		.gts_reset_o_src_rs_refclk_cmd_bus_refclk_cmd_bus_in        (gts_reset_o_src_rs_refclk_cmd_bus_refclk_cmd_bus_in),
+    .gts_reset_o_src_rs_grant_src_rs_grant                      (gts_reset_o_src_rs_grant_src_rs_grant),
+    .gts_reset_i_src_rs_req_src_rs_req                          (gts_reset_i_src_rs_req_src_rs_req),
+    .gts_reset_o_pma_cu_clk_clk                                 (gts_reset_o_pma_cu_clk_clk),
+
+    .jesd204_phy_i_pma_cu_clk_clk                               (gts_reset_o_pma_cu_clk_clk[PHY_OS_PMA_CLK_IDX]),
+    .jesd204_phy_i_src_rs_grant_src_rs_grant                    (gts_reset_o_src_rs_grant_src_rs_grant),
+    .jesd204_phy_o_src_rs_req_src_rs_req                        (gts_reset_i_src_rs_req_src_rs_req),
+    .jesd204_phy_o_refclk_status_bus_out_refclk_status_bus_out  (jesd204_phy_o_refclk_bus_out_refclk_bus_out),
+    .jesd204_phy_i_refclk_cmd_bus_in_refclk_cmd_bus_in          (gts_reset_o_src_rs_refclk_cmd_bus_refclk_cmd_bus_in),
+
+    .jesd204_phy_rx_reset_ack_rx_reset_ack                      (jesd204_phy_rx_reset_ack_rx_reset_ack),
+    .jesd204_phy_rx_ready_rx_ready                              (jesd204_phy_rx_ready_rx_ready),
+    .jesd204_phy_rx_is_lockedtodata_o_rx_is_lockedtodata        (jesd204_phy_rx_is_lockedtodata_o_rx_is_lockedtodata),
+
+    .mxfe_rx_jesd204_ready_rx_ready                             (mxfe_rx_jesd204_ready_rx_ready),
+    .mxfe_rx_jesd204_reset_ack_rx_reset_ack                     (mxfe_rx_jesd204_reset_ack_rx_reset_ack),
+    .mxfe_rx_jesd204_rx_is_lockedtodata_o_rx_is_lockedtodata    (mxfe_rx_jesd204_rx_is_lockedtodata_o_rx_is_lockedtodata),
+
+    .mxfe_rx2_jesd204_ready_rx_ready                            (mxfe_rx2_jesd204_ready_rx_ready),
+    .mxfe_rx2_jesd204_reset_ack_rx_reset_ack                    (mxfe_rx2_jesd204_reset_ack_rx_reset_ack),
+    .mxfe_rx2_jesd204_rx_is_lockedtodata_o_rx_is_lockedtodata   (mxfe_rx2_jesd204_rx_is_lockedtodata_o_rx_is_lockedtodata),
+
+    .o_pll_lock_o_pll_lock                                      (syspll_lock),
+    .o_syspll_c0_clk                                            (syspll_clk),
+    .refclk_xcvr_clk                                            (fpga_refclk_in),
+    .i_refclk_rdy_data                                          (refclk_ready),
+
+    .system_pll_clk_clk                                         (syspll_clk),
+    .system_pll_lock_system_pll_lock                            (syspll_lock),
+
+    .phy_tx_pll_locked_o_tx_pll_locked                          (phy_tx_pll_locked_o_tx_pll_locked),
+    .tx_pll_locked_o_tx_pll_locked                              (phy_tx_pll_locked_o_tx_pll_locked[TX_JESD_L-1:0]),
+
+    .dacfifo_bypass_bypass                                      (dacfifo_bypass),
+    // FMC HPC
+    .sys_spi_MISO                                               (spi_miso),
+    .sys_spi_MOSI                                               (spi_mosi),
+    .sys_spi_SCLK                                               (spi_clk),
+    .sys_spi_SS_n                                               (spi_csn_s),
+    .tx_serial_data_o_tx_serial_data                            (tx_data),
+    .tx_serial_data_n_o_tx_serial_data_n                        (tx_data_n),
+    .tx_ref_clk_clk                                             (fpga_refclk_in),
+    .tx_sync_export                                             (fpga_syncin_0),
+    .tx_sysref_export                                           (sysref2),
+    .tx_device_clk_clk                                          (clkin10),
+    .rx_serial_data_i_rx_serial_data                            ({rx2_data, rx_data}),
+    .rx_serial_data_n_i_rx_serial_data_n                        ({rx2_data_n, rx_data_n}),
+    .rx_ref_clk_clk                                             (fpga_refclk_in),
+    .rx_sync_export                                             (fpga_syncout_0),
+    .rx_sysref_export                                           (sysref2),
+    .rx2_device_clk_clk                                         (clkin6),
+    .rx2_sync_export                                            (fpga_syncout_1),
+    .rx2_sysref_export                                          (sysref2),
+    .rx_device_clk_clk                                          (clkin6),
+    .mxfe_gpio_export                                           ({1'b0,              // 14
+                                                                  1'b0,              // 13
+                                                                  fpga_syncin_1_n,   // 12
+                                                                  fpga_syncin_1_p,   // 11
+                                                                  gpio}));           // 10:0
+
+endmodule

--- a/projects/ad9081_fmca_ebz/common/ad9081_fmca_ebz_qsys.tcl
+++ b/projects/ad9081_fmca_ebz/common/ad9081_fmca_ebz_qsys.tcl
@@ -1,11 +1,13 @@
 ###############################################################################
-## Copyright (C) 2021-2024 Analog Devices, Inc. All rights reserved.
+## Copyright (C) 2021-2026 Analog Devices, Inc. All rights reserved.
 ### SPDX short identifier: ADIBSD
 ###############################################################################
 
 set JESD_MODE [ expr { [info exists ad_project_params(JESD_MODE)] \
                           ? $ad_project_params(JESD_MODE) : "8B10B" } ]
 set LINK_MODE [expr {$JESD_MODE == "8B10B"} ? 1 : 2]
+
+set EXTERNAL_PHY [expr {$TRANSCEIVER_TYPE == "E-Tile"} ? 1 : 0]
 
 # RX parameters
 set RX_NUM_OF_LINKS $ad_project_params(RX_NUM_LINKS)
@@ -36,8 +38,14 @@ set RX_SAMPLES_PER_FRAME $RX_JESD_S
 set RX_SAMPLE_WIDTH      $RX_JESD_NP
 set RX_DMA_SAMPLE_WIDTH  16
 
+set RX_OCTETS_PER_FRAME    [expr $RX_NUM_OF_CONVERTERS * $RX_SAMPLES_PER_FRAME * $RX_SAMPLE_WIDTH / (8 * $RX_NUM_OF_LANES)] ; # F
+if {$RX_OCTETS_PER_FRAME > $RX_TPL_DATA_PATH_WIDTH} {
+  set RX_TPL_DATA_PATH_WIDTH $RX_OCTETS_PER_FRAME
+}
+
 set RX_SAMPLES_PER_CHANNEL [expr $RX_NUM_OF_LANES * 8*$RX_TPL_DATA_PATH_WIDTH / \
                                 ($RX_NUM_OF_CONVERTERS * $RX_SAMPLE_WIDTH)]
+
 
 # TX parameters
 set TX_NUM_OF_LINKS $ad_project_params(TX_NUM_LINKS)
@@ -69,6 +77,11 @@ set TX_SAMPLES_PER_FRAME $TX_JESD_S
 set TX_SAMPLE_WIDTH      $TX_JESD_NP
 set TX_DMA_SAMPLE_WIDTH  16
 
+set TX_OCTETS_PER_FRAME    [expr $TX_NUM_OF_CONVERTERS * $TX_SAMPLES_PER_FRAME * $TX_SAMPLE_WIDTH / (8 * $TX_NUM_OF_LANES)] ; # F
+if {$TX_OCTETS_PER_FRAME > $TX_TPL_DATA_PATH_WIDTH} {
+  set TX_TPL_DATA_PATH_WIDTH $TX_OCTETS_PER_FRAME
+}
+
 set TX_SAMPLES_PER_CHANNEL [expr $TX_NUM_OF_LANES * 8*$TX_TPL_DATA_PATH_WIDTH / \
                                 ($TX_NUM_OF_CONVERTERS * $TX_SAMPLE_WIDTH)]
 
@@ -92,17 +105,67 @@ set dac_data_width [expr 8*$TX_TPL_DATA_PATH_WIDTH*$TX_NUM_OF_LANES*$TX_DMA_SAMP
 set dac_dma_data_width $dac_data_width
 set dac_fifo_address_width [expr int(ceil(log(($dac_fifo_samples_per_converter*$TX_NUM_OF_CONVERTERS) / ($dac_data_width/$TX_DMA_SAMPLE_WIDTH))/log(2)))]
 
+if {$EXTERNAL_PHY && $RX_NUM_OF_LANES < $TX_NUM_OF_LANES} {
+  send_message error "In duplex mode RX_NUM_OF_LANES >= TX_NUM_OF_LANES!"
+}
+
 # JESD204 clock bridges
 
 add_instance tx_device_clk altera_clock_bridge
-set_instance_parameter_value tx_device_clk {EXPLICIT_CLOCK_RATE} $DEVICE_CLK_RATE
+set_instance_parameter_value tx_device_clk {EXPLICIT_CLOCK_RATE} [expr $DEVICE_CLK_RATE * $TX_DATA_PATH_WIDTH / $TX_TPL_DATA_PATH_WIDTH]
 
 add_instance rx_device_clk altera_clock_bridge
-set_instance_parameter_value rx_device_clk {EXPLICIT_CLOCK_RATE} $DEVICE_CLK_RATE
+set_instance_parameter_value rx_device_clk {EXPLICIT_CLOCK_RATE} [expr $DEVICE_CLK_RATE * $RX_DATA_PATH_WIDTH / $RX_TPL_DATA_PATH_WIDTH]
 
 #
 ## IP instantions and configuration
 #
+
+if {$EXTERNAL_PHY} {
+  add_instance jesd204_phy jesd204_e_tile_phy
+  set_instance_parameter_value jesd204_phy {LINK_MODE} $LINK_MODE
+  set_instance_parameter_value jesd204_phy {LANE_RATE} $RX_LANE_RATE
+  set_instance_parameter_value jesd204_phy {REFCLK_FREQUENCY} $REF_CLK_RATE
+  set_instance_parameter_value jesd204_phy {NUM_OF_LANES} $RX_NUM_OF_LANES
+  set_instance_parameter_value jesd204_phy {INPUT_PIPELINE_STAGES} {2}
+  set_instance_parameter_value jesd204_phy {EXTERNAL_LINK_CLK} {1}
+  set_instance_parameter_value jesd204_phy {INSTANTIATE_RESET_CONTROLLER} {0}
+
+  add_interface system_pll_clk clock sink
+  set_interface_property system_pll_clk EXPORT_OF jesd204_phy.system_pll_clk
+
+  add_interface system_pll_lock conduit end
+  set_interface_property system_pll_lock EXPORT_OF jesd204_phy.system_pll_lock
+
+  # GTS reset IP
+  add_instance gts_reset_phy intel_srcss_gts
+  set_instance_parameter_value gts_reset_phy NUM_BANKS_SHORELINE [expr int(ceil($RX_NUM_OF_LANES / 4.0))]
+  set_instance_parameter_value gts_reset_phy NUM_LANES_SHORELINE $RX_NUM_OF_LANES
+
+  set_interface_property gts_reset_src_rs_priority EXPORT_OF gts_reset_phy.i_src_rs_priority
+  set_interface_property gts_reset_i_refclk_on EXPORT_OF gts_reset_phy.i_refclk_on
+  set_interface_property gts_reset_o_refclk_on_ack EXPORT_OF gts_reset_phy.o_refclk_on_ack
+  set_interface_property gts_reset_i_src_rs_refclk_status_bus EXPORT_OF gts_reset_phy.i_src_rs_refclk_status_bus_out
+  set_interface_property gts_reset_o_src_rs_refclk_cmd_bus EXPORT_OF gts_reset_phy.o_src_rs_refclk_cmd_bus_in
+  set_interface_property gts_reset_o_src_rs_grant EXPORT_OF gts_reset_phy.o_src_rs_grant
+  set_interface_property gts_reset_i_src_rs_req EXPORT_OF gts_reset_phy.i_src_rs_req
+  set_interface_property gts_reset_o_pma_cu_clk EXPORT_OF gts_reset_phy.o_pma_cu_clk
+  set_interface_property gts_reset_o_refclk_fail_status EXPORT_OF gts_reset_phy.o_refclk_fail_status
+
+  foreach phy {jesd204_phy} {
+    add_interface ${phy}_i_pma_cu_clk conduit end
+    add_interface ${phy}_i_src_rs_grant conduit end
+    add_interface ${phy}_o_src_rs_req conduit end
+    add_interface ${phy}_i_refclk_cmd_bus_in conduit end
+    add_interface ${phy}_o_refclk_status_bus_out conduit end
+
+    set_interface_property ${phy}_i_pma_cu_clk EXPORT_OF ${phy}.i_pma_cu_clk
+    set_interface_property ${phy}_i_src_rs_grant EXPORT_OF ${phy}.i_src_rs_grant
+    set_interface_property ${phy}_o_src_rs_req EXPORT_OF ${phy}.o_src_rs_req
+    set_interface_property ${phy}_i_refclk_cmd_bus_in EXPORT_OF ${phy}.i_refclk_cmd_bus_in
+    set_interface_property ${phy}_o_refclk_status_bus_out EXPORT_OF ${phy}.o_refclk_status_bus_out
+  }
+}
 
 # RX JESD204 PHY-Link layer
 
@@ -119,6 +182,7 @@ set_instance_parameter_value mxfe_rx_jesd204 {NUM_OF_LANES} $RX_NUM_OF_LANES
 set_instance_parameter_value mxfe_rx_jesd204 {EXT_DEVICE_CLK_EN} {1}
 set_instance_parameter_value mxfe_rx_jesd204 {TPL_DATA_PATH_WIDTH} $RX_TPL_DATA_PATH_WIDTH
 set_instance_parameter_value mxfe_rx_jesd204 {DATA_PATH_WIDTH} $RX_DATA_PATH_WIDTH
+set_instance_parameter_value mxfe_rx_jesd204 {EXTERNAL_PHY} $EXTERNAL_PHY
 # set_instance_parameter_value mxfe_rx_jesd204 {LANE_MAP} {5 7 0 1 2 3 4 6}
 
 
@@ -146,6 +210,7 @@ set_instance_parameter_value mxfe_tx_jesd204 {NUM_OF_LANES} $TX_NUM_OF_LANES
 set_instance_parameter_value mxfe_tx_jesd204 {EXT_DEVICE_CLK_EN} {1}
 set_instance_parameter_value mxfe_tx_jesd204 {TPL_DATA_PATH_WIDTH} $TX_TPL_DATA_PATH_WIDTH
 set_instance_parameter_value mxfe_tx_jesd204 {DATA_PATH_WIDTH} $TX_DATA_PATH_WIDTH
+set_instance_parameter_value mxfe_tx_jesd204 {EXTERNAL_PHY} $EXTERNAL_PHY
 # set_instance_parameter_value mxfe_tx_jesd204 {LANE_MAP} {5 7 0 1 2 3 4 6}
 
 
@@ -157,8 +222,6 @@ set_instance_parameter_value mxfe_tx_tpl {BITS_PER_SAMPLE} $TX_SAMPLE_WIDTH
 set_instance_parameter_value mxfe_tx_tpl {CONVERTER_RESOLUTION} $TX_SAMPLE_WIDTH
 set_instance_parameter_value mxfe_tx_tpl {OCTETS_PER_BEAT} $TX_TPL_DATA_PATH_WIDTH
 set_instance_parameter_value mxfe_tx_tpl {DMA_BITS_PER_SAMPLE} $TX_DMA_SAMPLE_WIDTH
-# Disable DDS for now to make implementation faster
-# set_instance_parameter_value mxfe_tx_tpl {DATAPATH_DISABLE} {true}
 
 # pack(s) & unpack(s)
 
@@ -175,8 +238,11 @@ set_instance_parameter_value mxfe_rx_cpack {SAMPLE_DATA_WIDTH} $RX_DMA_SAMPLE_WI
 
 # RX and TX data offload buffers
 
-ad_adcfifo_create $adc_fifo_name $adc_data_width $adc_dma_data_width $adc_fifo_address_width
-ad_dacfifo_create $dac_fifo_name $dac_data_width $dac_dma_data_width $dac_fifo_address_width
+ad_adcfifo_create $adc_fifo_name    $adc_data_width    $adc_dma_data_width    $adc_fifo_address_width
+ad_dacfifo_create $dac_fifo_name    $dac_data_width    $dac_dma_data_width    $dac_fifo_address_width
+
+add_interface dacfifo_bypass conduit end
+set_interface_property dacfifo_bypass EXPORT_OF $dac_fifo_name.if_bypass
 
 # RX and TX DMA instance and connections
 
@@ -186,8 +252,8 @@ set_instance_parameter_value mxfe_tx_dma {DMA_DATA_WIDTH_SRC} $dac_dma_data_widt
 set_instance_parameter_value mxfe_tx_dma {DMA_DATA_WIDTH_DEST} $dac_dma_data_width
 set_instance_parameter_value mxfe_tx_dma {DMA_LENGTH_WIDTH} {24}
 set_instance_parameter_value mxfe_tx_dma {DMA_2D_TRANSFER} {0}
-set_instance_parameter_value mxfe_tx_dma {AXI_SLICE_DEST} {0}
-set_instance_parameter_value mxfe_tx_dma {AXI_SLICE_SRC} {0}
+set_instance_parameter_value mxfe_tx_dma {AXI_SLICE_DEST} {1}
+set_instance_parameter_value mxfe_tx_dma {AXI_SLICE_SRC} {1}
 set_instance_parameter_value mxfe_tx_dma {SYNC_TRANSFER_START} {0}
 set_instance_parameter_value mxfe_tx_dma {CYCLIC} {1}
 set_instance_parameter_value mxfe_tx_dma {DMA_TYPE_DEST} {1}
@@ -203,8 +269,8 @@ set_instance_parameter_value mxfe_rx_dma {DMA_DATA_WIDTH_SRC} $adc_dma_data_widt
 set_instance_parameter_value mxfe_rx_dma {DMA_DATA_WIDTH_DEST} $adc_dma_data_width
 set_instance_parameter_value mxfe_rx_dma {DMA_LENGTH_WIDTH} {24}
 set_instance_parameter_value mxfe_rx_dma {DMA_2D_TRANSFER} {0}
-set_instance_parameter_value mxfe_rx_dma {AXI_SLICE_DEST} {0}
-set_instance_parameter_value mxfe_rx_dma {AXI_SLICE_SRC} {0}
+set_instance_parameter_value mxfe_rx_dma {AXI_SLICE_DEST} {1}
+set_instance_parameter_value mxfe_rx_dma {AXI_SLICE_SRC} {1}
 set_instance_parameter_value mxfe_rx_dma {SYNC_TRANSFER_START} {0}
 set_instance_parameter_value mxfe_rx_dma {CYCLIC} {0}
 set_instance_parameter_value mxfe_rx_dma {DMA_TYPE_DEST} {0}
@@ -224,9 +290,8 @@ add_connection sys_clk.clk_reset mxfe_gpio.reset
 add_interface mxfe_gpio conduit end
 set_interface_property mxfe_gpio EXPORT_OF mxfe_gpio.external_connection
 
-#
-## clocks and resets
-#
+
+# clocks and resets
 
 # system clock and reset
 
@@ -248,13 +313,26 @@ add_connection sys_clk.clk_reset mxfe_tx_dma.s_axi_reset
 
 add_connection rx_device_clk.out_clk mxfe_rx_jesd204.device_clk
 add_connection rx_device_clk.out_clk mxfe_rx_tpl.link_clk
+if {$EXTERNAL_PHY} {
+  add_connection jesd204_phy.rx_clkout jesd204_phy.rx_link_clock
+  if {$RX_TPL_DATA_PATH_WIDTH > $RX_DATA_PATH_WIDTH} {
+    add_connection jesd204_phy.rx_clkout mxfe_rx_jesd204.phy_link_clk
+  }
+}
 add_connection rx_device_clk.out_clk mxfe_rx_cpack.clk
 add_connection rx_device_clk.out_clk $adc_fifo_name.if_adc_clk
 
 add_connection tx_device_clk.out_clk mxfe_tx_jesd204.device_clk
 add_connection tx_device_clk.out_clk mxfe_tx_tpl.link_clk
+if {$EXTERNAL_PHY} {
+  add_connection jesd204_phy.tx_clkout jesd204_phy.tx_link_clock
+  if {$TX_TPL_DATA_PATH_WIDTH > $TX_DATA_PATH_WIDTH} {
+    add_connection jesd204_phy.tx_clkout mxfe_tx_jesd204.phy_link_clk
+  }
+}
 add_connection tx_device_clk.out_clk mxfe_tx_upack.clk
 add_connection tx_device_clk.out_clk $dac_fifo_name.if_dac_clk
+
 
 add_connection mxfe_rx_jesd204.link_reset mxfe_rx_cpack.reset
 add_connection mxfe_rx_jesd204.link_reset $adc_fifo_name.if_adc_rst
@@ -281,39 +359,78 @@ add_connection sys_dma_clk.clk_reset $dac_fifo_name.if_dma_rst
 ## Exported signals
 #
 
-add_interface rx_ref_clk      clock   sink
-# add_interface rx_pll_clk      clock   sink
-add_interface rx_sysref       conduit end
-add_interface rx_sync         conduit end
-add_interface rx_serial_data  conduit end
-add_interface tx_ref_clk      clock   sink
-# add_interface tx_pll_clk      clock   sink
-add_interface rx_device_clk   clock   sink
-add_interface tx_serial_data  conduit end
-add_interface tx_sysref       conduit end
-add_interface tx_sync         conduit end
-add_interface tx_device_clk   clock   sink
+add_interface rx_sysref        conduit end
+add_interface rx_sync          conduit end
+add_interface rx_device_clk    clock   sink
+add_interface tx_sysref        conduit end
+add_interface tx_sync          conduit end
+add_interface tx_device_clk    clock   sink
 
-set_interface_property rx_ref_clk       EXPORT_OF mxfe_rx_jesd204.ref_clk
-# set_interface_property rx_pll_clk       EXPORT_OF mxfe_rx_jesd204.pll_clk
 set_interface_property rx_sysref        EXPORT_OF mxfe_rx_jesd204.sysref
 set_interface_property rx_sync          EXPORT_OF mxfe_rx_jesd204.sync
-set_interface_property rx_serial_data   EXPORT_OF mxfe_rx_jesd204.serial_data
 set_interface_property rx_device_clk    EXPORT_OF rx_device_clk.in_clk
-
-set_interface_property tx_ref_clk       EXPORT_OF mxfe_tx_jesd204.ref_clk
-# set_interface_property tx_pll_clk       EXPORT_OF mxfe_tx_jesd204.pll_clk
 set_interface_property tx_sysref        EXPORT_OF mxfe_tx_jesd204.sysref
 set_interface_property tx_sync          EXPORT_OF mxfe_tx_jesd204.sync
-set_interface_property tx_serial_data   EXPORT_OF mxfe_tx_jesd204.serial_data
 set_interface_property tx_device_clk    EXPORT_OF tx_device_clk.in_clk
 
-if {$TRANSCEIVER_TYPE == "F-Tile"} {
-  add_interface tx_serial_data_n   conduit end
-  add_interface rx_serial_data_n   conduit end
+add_interface rx_ref_clk         clock   sink
+add_interface rx_serial_data     conduit end
+add_interface tx_ref_clk         clock   sink
+add_interface tx_serial_data     conduit end
 
-  set_interface_property rx_serial_data_n   EXPORT_OF mxfe_rx_jesd204.serial_data_n
-  set_interface_property tx_serial_data_n   EXPORT_OF mxfe_tx_jesd204.serial_data_n
+if {$TRANSCEIVER_TYPE == "F-Tile" || $TRANSCEIVER_TYPE == "E-Tile"} {
+  add_interface tx_serial_data_n     conduit end
+  add_interface rx_serial_data_n     conduit end
+}
+
+if {!$EXTERNAL_PHY} {
+  set_interface_property rx_ref_clk       EXPORT_OF mxfe_rx_jesd204.ref_clk
+  set_interface_property rx_serial_data   EXPORT_OF mxfe_rx_jesd204.serial_data
+  set_interface_property tx_ref_clk       EXPORT_OF mxfe_tx_jesd204.ref_clk
+  set_interface_property tx_serial_data   EXPORT_OF mxfe_tx_jesd204.serial_data
+
+  if {$TRANSCEIVER_TYPE == "F-Tile"} {
+    set_interface_property rx_serial_data_n   EXPORT_OF mxfe_rx_jesd204.serial_data_n
+    set_interface_property tx_serial_data_n   EXPORT_OF mxfe_tx_jesd204.serial_data_n
+  }
+} else {
+  add_connection mxfe_tx_jesd204.if_up_rst jesd204_phy.tx_link_reset
+  add_connection mxfe_tx_jesd204.reset     jesd204_phy.tx_reset
+  add_connection jesd204_phy.tx_reset_ack  mxfe_tx_jesd204.reset_ack
+  add_connection jesd204_phy.tx_ready      mxfe_tx_jesd204.ready
+
+  # Export those two so we can have TX_L < RX_L otherwise Quartus complains about
+  # the number of bits mismatch...
+  add_interface phy_tx_pll_locked conduit end
+  set_interface_property phy_tx_pll_locked EXPORT_OF jesd204_phy.tx_pll_locked
+
+  add_interface tx_pll_locked conduit end
+  set_interface_property tx_pll_locked EXPORT_OF mxfe_tx_jesd204.tx_pll_locked
+
+  for {set i 0} {$i < $TX_NUM_OF_LANES} {incr i} {
+    add_connection mxfe_tx_jesd204.tx_phy${i} jesd204_phy.phy_tx_${i}
+  }
+
+  add_connection mxfe_rx_jesd204.if_up_rst jesd204_phy.rx_link_reset
+  add_connection mxfe_rx_jesd204.reset     jesd204_phy.rx_reset
+
+  set_interface_property jesd204_phy_rx_is_lockedtodata EXPORT_OF jesd204_phy.rx_is_lockedtodata
+  set_interface_property mxfe_rx_jesd204_rx_is_lockedtodata EXPORT_OF mxfe_rx_jesd204.rx_is_lockedtodata
+  set_interface_property jesd204_phy_rx_ready EXPORT_OF jesd204_phy.rx_ready
+  set_interface_property mxfe_rx_jesd204_ready EXPORT_OF mxfe_rx_jesd204.ready
+  set_interface_property jesd204_phy_rx_reset_ack EXPORT_OF jesd204_phy.rx_reset_ack
+  set_interface_property mxfe_rx_jesd204_reset_ack EXPORT_OF mxfe_rx_jesd204.reset_ack
+
+  for {set i 0} {$i < $RX_NUM_OF_LANES} {incr i} {
+    add_connection jesd204_phy.phy_rx_${i} mxfe_rx_jesd204.rx_phy${i}
+  }
+
+  set_interface_property rx_ref_clk          EXPORT_OF jesd204_phy.rx_ref_clk
+  set_interface_property rx_serial_data      EXPORT_OF jesd204_phy.rx_serial_data
+  set_interface_property rx_serial_data_n    EXPORT_OF jesd204_phy.rx_serial_data_n
+  set_interface_property tx_ref_clk          EXPORT_OF jesd204_phy.tx_ref_clk
+  set_interface_property tx_serial_data      EXPORT_OF jesd204_phy.tx_serial_data
+  set_interface_property tx_serial_data_n    EXPORT_OF jesd204_phy.tx_serial_data_n
 }
 
 #
@@ -335,7 +452,11 @@ add_connection mxfe_rx_cpack.if_packed_fifo_wr_data $adc_fifo_name.if_adc_wdata
 add_connection $adc_fifo_name.if_dma_xfer_req mxfe_rx_dma.if_s_axis_xfer_req
 add_connection $adc_fifo_name.m_axis mxfe_rx_dma.s_axis
 # RX dma to HPS
-ad_dma_interconnect mxfe_rx_dma.m_dest_axi
+if {$TRANSCEIVER_TYPE == "E-Tile"} {
+  ad_dma_interconnect mxfe_rx_dma.m_dest_axi 0x0000000 $adc_dma_data_width
+} else {
+  ad_dma_interconnect mxfe_rx_dma.m_dest_axi
+}
 
 # TX link to tpl
 add_connection mxfe_tx_tpl.link_data mxfe_tx_jesd204.link_data
@@ -351,11 +472,15 @@ add_connection $dac_fifo_name.if_dac_dunf mxfe_tx_tpl.if_dac_dunf
 add_connection mxfe_tx_dma.if_m_axis_xfer_req $dac_fifo_name.if_dma_xfer_req
 add_connection mxfe_tx_dma.m_axis $dac_fifo_name.s_axis
 # TX dma to HPS
-ad_dma_interconnect mxfe_tx_dma.m_src_axi
+if {$TRANSCEIVER_TYPE == "E-Tile"} {
+  ad_dma_interconnect mxfe_tx_dma.m_src_axi 0x0000000 $dac_dma_data_width
+} else {
+  ad_dma_interconnect mxfe_tx_dma.m_src_axi
+}
 
 # reconfiguration interface sharing for A10soc
 
-if {$TRANSCEIVER_TYPE != "F-Tile"} {
+if {$TRANSCEIVER_TYPE != "F-Tile" && $TRANSCEIVER_TYPE != "E-Tile"} {
   set MAX_NUM_OF_LANES $TX_NUM_OF_LANES
   if {$RX_NUM_OF_LANES > $TX_NUM_OF_LANES} {
     set MAX_NUM_OF_LANES $RX_NUM_OF_LANES
@@ -377,32 +502,40 @@ if {$TRANSCEIVER_TYPE != "F-Tile"} {
 
 ## NOTE: if bridge is used, the address will be bridge_base_addr + peripheral_base_addr
 #
+if {!$EXTERNAL_PHY} {
+  if {$TRANSCEIVER_TYPE == "F-Tile"} {
+    ad_cpu_interconnect 0x00000000 mxfe_rx_jesd204.phy_reconfig "avl_mm_bridge_0" 0x10000000 25
+    ad_cpu_interconnect 0x00800000 mxfe_tx_jesd204.phy_reconfig "avl_mm_bridge_0"
+  } else {
+    ad_cpu_interconnect 0x00020000 mxfe_rx_jesd204.link_pll_reconfig "avl_mm_bridge_0" 0x00040000
+    if {$RX_NUM_OF_LANES > 0} {ad_cpu_interconnect 0x00000000 avl_adxcfg_0.rcfg_s0    "avl_mm_bridge_0"}
+    if {$RX_NUM_OF_LANES > 1} {ad_cpu_interconnect 0x00002000 avl_adxcfg_1.rcfg_s0    "avl_mm_bridge_0"}
+    if {$RX_NUM_OF_LANES > 2} {ad_cpu_interconnect 0x00004000 avl_adxcfg_2.rcfg_s0    "avl_mm_bridge_0"}
+    if {$RX_NUM_OF_LANES > 3} {ad_cpu_interconnect 0x00006000 avl_adxcfg_3.rcfg_s0    "avl_mm_bridge_0"}
+    if {$RX_NUM_OF_LANES > 4} {ad_cpu_interconnect 0x00008000 avl_adxcfg_4.rcfg_s0    "avl_mm_bridge_0"}
+    if {$RX_NUM_OF_LANES > 5} {ad_cpu_interconnect 0x0000A000 avl_adxcfg_5.rcfg_s0    "avl_mm_bridge_0"}
+    if {$RX_NUM_OF_LANES > 6} {ad_cpu_interconnect 0x0000C000 avl_adxcfg_6.rcfg_s0    "avl_mm_bridge_0"}
+    if {$RX_NUM_OF_LANES > 7} {ad_cpu_interconnect 0x0000E000 avl_adxcfg_7.rcfg_s0    "avl_mm_bridge_0"}
 
-if {$TRANSCEIVER_TYPE == "F-Tile"} {
-  ad_cpu_interconnect 0x00000000 mxfe_rx_jesd204.phy_reconfig "avl_mm_bridge_0" 0x10000000 25
-  ad_cpu_interconnect 0x00800000 mxfe_tx_jesd204.phy_reconfig "avl_mm_bridge_0"
+    ad_cpu_interconnect 0x00020000 mxfe_tx_jesd204.link_pll_reconfig "avl_mm_bridge_1" 0x00080000
+    if {$TX_NUM_OF_LANES > 0} {ad_cpu_interconnect 0x00000000 avl_adxcfg_0.rcfg_s1    "avl_mm_bridge_1"}
+    if {$TX_NUM_OF_LANES > 1} {ad_cpu_interconnect 0x00002000 avl_adxcfg_1.rcfg_s1    "avl_mm_bridge_1"}
+    if {$TX_NUM_OF_LANES > 2} {ad_cpu_interconnect 0x00004000 avl_adxcfg_2.rcfg_s1    "avl_mm_bridge_1"}
+    if {$TX_NUM_OF_LANES > 3} {ad_cpu_interconnect 0x00006000 avl_adxcfg_3.rcfg_s1    "avl_mm_bridge_1"}
+    if {$TX_NUM_OF_LANES > 4} {ad_cpu_interconnect 0x00008000 avl_adxcfg_4.rcfg_s1    "avl_mm_bridge_1"}
+    if {$TX_NUM_OF_LANES > 5} {ad_cpu_interconnect 0x0000A000 avl_adxcfg_5.rcfg_s1    "avl_mm_bridge_1"}
+    if {$TX_NUM_OF_LANES > 6} {ad_cpu_interconnect 0x0000C000 avl_adxcfg_6.rcfg_s1    "avl_mm_bridge_1"}
+    if {$TX_NUM_OF_LANES > 7} {ad_cpu_interconnect 0x0000E000 avl_adxcfg_7.rcfg_s1    "avl_mm_bridge_1"}
+
+    ad_cpu_interconnect 0x000D0000 mxfe_tx_jesd204.lane_pll_reconfig
+  }
 } else {
-  ad_cpu_interconnect 0x00020000 mxfe_rx_jesd204.link_pll_reconfig "avl_mm_bridge_0" 0x00040000
-  if {$RX_NUM_OF_LANES > 0} {ad_cpu_interconnect 0x00000000 avl_adxcfg_0.rcfg_s0    "avl_mm_bridge_0"}
-  if {$RX_NUM_OF_LANES > 1} {ad_cpu_interconnect 0x00002000 avl_adxcfg_1.rcfg_s0    "avl_mm_bridge_0"}
-  if {$RX_NUM_OF_LANES > 2} {ad_cpu_interconnect 0x00004000 avl_adxcfg_2.rcfg_s0    "avl_mm_bridge_0"}
-  if {$RX_NUM_OF_LANES > 3} {ad_cpu_interconnect 0x00006000 avl_adxcfg_3.rcfg_s0    "avl_mm_bridge_0"}
-  if {$RX_NUM_OF_LANES > 4} {ad_cpu_interconnect 0x00008000 avl_adxcfg_4.rcfg_s0    "avl_mm_bridge_0"}
-  if {$RX_NUM_OF_LANES > 5} {ad_cpu_interconnect 0x0000A000 avl_adxcfg_5.rcfg_s0    "avl_mm_bridge_0"}
-  if {$RX_NUM_OF_LANES > 6} {ad_cpu_interconnect 0x0000C000 avl_adxcfg_6.rcfg_s0    "avl_mm_bridge_0"}
-  if {$RX_NUM_OF_LANES > 7} {ad_cpu_interconnect 0x0000E000 avl_adxcfg_7.rcfg_s0    "avl_mm_bridge_0"}
-
-  ad_cpu_interconnect 0x00020000 mxfe_tx_jesd204.link_pll_reconfig "avl_mm_bridge_1" 0x00080000
-  if {$TX_NUM_OF_LANES > 0} {ad_cpu_interconnect 0x00000000 avl_adxcfg_0.rcfg_s1    "avl_mm_bridge_1"}
-  if {$TX_NUM_OF_LANES > 1} {ad_cpu_interconnect 0x00002000 avl_adxcfg_1.rcfg_s1    "avl_mm_bridge_1"}
-  if {$TX_NUM_OF_LANES > 2} {ad_cpu_interconnect 0x00004000 avl_adxcfg_2.rcfg_s1    "avl_mm_bridge_1"}
-  if {$TX_NUM_OF_LANES > 3} {ad_cpu_interconnect 0x00006000 avl_adxcfg_3.rcfg_s1    "avl_mm_bridge_1"}
-  if {$TX_NUM_OF_LANES > 4} {ad_cpu_interconnect 0x00008000 avl_adxcfg_4.rcfg_s1    "avl_mm_bridge_1"}
-  if {$TX_NUM_OF_LANES > 5} {ad_cpu_interconnect 0x0000A000 avl_adxcfg_5.rcfg_s1    "avl_mm_bridge_1"}
-  if {$TX_NUM_OF_LANES > 6} {ad_cpu_interconnect 0x0000C000 avl_adxcfg_6.rcfg_s1    "avl_mm_bridge_1"}
-  if {$TX_NUM_OF_LANES > 7} {ad_cpu_interconnect 0x0000E000 avl_adxcfg_7.rcfg_s1    "avl_mm_bridge_1"}
-
-  ad_cpu_interconnect 0x000D0000 mxfe_tx_jesd204.lane_pll_reconfig
+  # One bridge for rx_adxcvr, the other for tx_adxcvr
+  ad_cpu_interconnect 0x00000000 jesd204_phy.reconfig_avmm "avl_mm_bridge_0" 0x01000000 22
+  ad_cpu_interconnect 0x00000000 jesd204_phy.reconfig_avmm "avl_mm_bridge_1" 0x02000000 22
+  set_instance_parameter_value avl_mm_bridge_0 {MAX_PENDING_RESPONSES} {1}
+  add_connection sys_clk.clk jesd204_phy.reconfig_clk
+  add_connection sys_clk.clk_reset jesd204_phy.reconfig_reset
 }
 
 ad_cpu_interconnect 0x000C0000 mxfe_rx_jesd204.link_reconfig
@@ -419,8 +552,8 @@ ad_cpu_interconnect 0x000E0000 mxfe_gpio.s1
 ## interrupts
 #
 
-ad_cpu_interrupt 11  mxfe_rx_dma.interrupt_sender
-ad_cpu_interrupt 12  mxfe_tx_dma.interrupt_sender
+ad_cpu_interrupt 10  mxfe_rx_dma.interrupt_sender
+ad_cpu_interrupt 11  mxfe_tx_dma.interrupt_sender
 ad_cpu_interrupt 13  mxfe_rx_jesd204.interrupt
 ad_cpu_interrupt 14  mxfe_tx_jesd204.interrupt
 ad_cpu_interrupt 15  mxfe_gpio.irq

--- a/projects/common/a5e/Makefile
+++ b/projects/common/a5e/Makefile
@@ -1,0 +1,17 @@
+####################################################################################
+## Copyright (c) 2018 - 2025 Analog Devices, Inc.
+### SPDX short identifier: BSD-1-Clause
+## Auto-generated, do not modify!
+####################################################################################
+
+PROJECT_NAME := template_a5e
+
+M_DEPS += ../../common/a5e/a5e_system_qsys.tcl
+M_DEPS += ../../common/a5e/a5e_system_assign.tcl
+
+LIB_DEPS += axi_sysid
+LIB_DEPS += sysid_rom
+
+INTEL_LIB_DEPS += intel/common/f2sdram_adapter
+
+include ../../scripts/project-intel.mk

--- a/projects/common/a5e/a5e_system_assign.tcl
+++ b/projects/common/a5e/a5e_system_assign.tcl
@@ -1,0 +1,392 @@
+###############################################################################
+## Copyright (C) 2025-2026 Analog Devices, Inc. All rights reserved.
+### SPDX short identifier: ADIBSD
+###############################################################################
+
+# Agilex5e carrier defaults
+# clocks and resets
+
+set_location_assignment PIN_BK109 -to sys_clk
+set_location_assignment PIN_N134  -to hps_osc_clk
+set_location_assignment PIN_BR112 -to sys_resetn
+
+set_instance_assignment -name IO_STANDARD "3.3-V LVCMOS" -to sys_clk
+set_instance_assignment -name IO_STANDARD "1.8 V" -to hps_osc_clk
+set_instance_assignment -name IO_STANDARD "3.3-V LVCMOS" -to sys_resetn
+
+# hps-emif
+
+set_location_assignment PIN_H108 -to emif_hps_mem_ck_t
+set_location_assignment PIN_F108 -to emif_hps_mem_ck_c
+set_instance_assignment -name IO_STANDARD "DIFFERENTIAL 1.2-V SSTL" -to emif_hps_mem_ck_t
+set_instance_assignment -name IO_STANDARD "DIFFERENTIAL 1.2-V SSTL" -to emif_hps_mem_ck_c
+
+set_location_assignment PIN_AB117 -to emif_hps_ref_clk
+set_location_assignment PIN_Y117  -to "emif_hps_ref_clk(n)"
+
+set_location_assignment PIN_T114  -to emif_hps_mem_a[0]
+set_location_assignment PIN_P114  -to emif_hps_mem_a[1]
+set_location_assignment PIN_V117  -to emif_hps_mem_a[2]
+set_location_assignment PIN_T117  -to emif_hps_mem_a[3]
+set_location_assignment PIN_M114  -to emif_hps_mem_a[4]
+set_location_assignment PIN_K114  -to emif_hps_mem_a[5]
+set_location_assignment PIN_V108  -to emif_hps_mem_a[6]
+set_location_assignment PIN_T108  -to emif_hps_mem_a[7]
+set_location_assignment PIN_T105  -to emif_hps_mem_a[8]
+set_location_assignment PIN_P105  -to emif_hps_mem_a[9]
+set_location_assignment PIN_M105  -to emif_hps_mem_a[10]
+set_location_assignment PIN_K105  -to emif_hps_mem_a[11]
+set_location_assignment PIN_AG111 -to emif_hps_mem_a[12]
+set_location_assignment PIN_Y114  -to emif_hps_mem_a[13]
+set_location_assignment PIN_AB114 -to emif_hps_mem_a[14]
+set_location_assignment PIN_AK107 -to emif_hps_mem_a[15]
+set_location_assignment PIN_AK104 -to emif_hps_mem_a[16]
+
+for {set i 0} {$i < 17} {incr i} {
+    set_instance_assignment -name IO_STANDARD "SSTL-12" -to emif_hps_mem_a[$i]
+}
+
+set_location_assignment PIN_M117  -to emif_hps_mem_act_n
+set_location_assignment PIN_AB108 -to emif_hps_mem_ba[0]
+set_location_assignment PIN_Y105  -to emif_hps_mem_ba[1]
+set_location_assignment PIN_AB105 -to emif_hps_mem_bg[0]
+set_location_assignment PIN_F117  -to emif_hps_mem_bg[1]
+set_location_assignment PIN_F105  -to emif_hps_mem_cke
+set_location_assignment PIN_K117  -to emif_hps_mem_cs_n
+set_location_assignment PIN_F114  -to emif_hps_mem_odt
+set_location_assignment PIN_H117  -to emif_hps_mem_reset_n
+set_location_assignment PIN_K108  -to emif_hps_mem_par
+set_location_assignment PIN_Y108  -to emif_hps_mem_alert_n
+
+foreach signal {mem_act_n mem_ba[0] mem_ba[1] mem_bg[0] mem_bg[1] mem_cke mem_cs_n mem_odt mem_reset_n mem_par} {
+    set_instance_assignment -name IO_STANDARD "SSTL-12" -to emif_hps_$signal
+}
+
+set_location_assignment PIN_B122 -to emif_hps_mem_dqs_t[0]
+set_location_assignment PIN_AG90 -to emif_hps_mem_dqs_t[1]
+set_location_assignment PIN_K95  -to emif_hps_mem_dqs_t[2]
+set_location_assignment PIN_F95  -to emif_hps_mem_dqs_t[3]
+set_location_assignment PIN_A101 -to emif_hps_mem_dqs_t[4]
+set_location_assignment PIN_A125 -to emif_hps_mem_dqs_c[0]
+set_location_assignment PIN_AG93 -to emif_hps_mem_dqs_c[1]
+set_location_assignment PIN_M95  -to emif_hps_mem_dqs_c[2]
+set_location_assignment PIN_D95  -to emif_hps_mem_dqs_c[3]
+set_location_assignment PIN_B101 -to emif_hps_mem_dqs_c[4]
+
+for {set i 0} {$i < 5} {incr i} {
+    set_instance_assignment -name IO_STANDARD "DIFFERENTIAL 1.2-V POD" -to emif_hps_mem_dqs_t[$i]
+    set_instance_assignment -name IO_STANDARD "DIFFERENTIAL 1.2-V POD" -to emif_hps_mem_dqs_c[$i]
+}
+
+# Data bus
+set_location_assignment PIN_B128  -to emif_hps_mem_dq[0]
+set_location_assignment PIN_B116  -to emif_hps_mem_dq[1]
+set_location_assignment PIN_A128  -to emif_hps_mem_dq[2]
+set_location_assignment PIN_A116  -to emif_hps_mem_dq[3]
+set_location_assignment PIN_A130  -to emif_hps_mem_dq[4]
+set_location_assignment PIN_B113  -to emif_hps_mem_dq[5]
+set_location_assignment PIN_B130  -to emif_hps_mem_dq[6]
+set_location_assignment PIN_A113  -to emif_hps_mem_dq[7]
+set_location_assignment PIN_AC100 -to emif_hps_mem_dq[8]
+set_location_assignment PIN_Y84   -to emif_hps_mem_dq[9]
+set_location_assignment PIN_Y95   -to emif_hps_mem_dq[10]
+set_location_assignment PIN_AC96  -to emif_hps_mem_dq[11]
+set_location_assignment PIN_AG100 -to emif_hps_mem_dq[12]
+set_location_assignment PIN_Y87   -to emif_hps_mem_dq[13]
+set_location_assignment PIN_Y98   -to emif_hps_mem_dq[14]
+set_location_assignment PIN_AG104 -to emif_hps_mem_dq[15]
+set_location_assignment PIN_T98   -to emif_hps_mem_dq[16]
+set_location_assignment PIN_M84   -to emif_hps_mem_dq[17]
+set_location_assignment PIN_P95   -to emif_hps_mem_dq[18]
+set_location_assignment PIN_T84   -to emif_hps_mem_dq[19]
+set_location_assignment PIN_V98   -to emif_hps_mem_dq[20]
+set_location_assignment PIN_P84   -to emif_hps_mem_dq[21]
+set_location_assignment PIN_T95   -to emif_hps_mem_dq[22]
+set_location_assignment PIN_K84   -to emif_hps_mem_dq[23]
+set_location_assignment PIN_K98   -to emif_hps_mem_dq[24]
+set_location_assignment PIN_K87   -to emif_hps_mem_dq[25]
+set_location_assignment PIN_H98   -to emif_hps_mem_dq[26]
+set_location_assignment PIN_M87   -to emif_hps_mem_dq[27]
+set_location_assignment PIN_M98   -to emif_hps_mem_dq[28]
+set_location_assignment PIN_D84   -to emif_hps_mem_dq[29]
+set_location_assignment PIN_F98   -to emif_hps_mem_dq[30]
+set_location_assignment PIN_F84   -to emif_hps_mem_dq[31]
+set_location_assignment PIN_B106  -to emif_hps_mem_dq[32]
+set_location_assignment PIN_A91   -to emif_hps_mem_dq[33]
+set_location_assignment PIN_A106  -to emif_hps_mem_dq[34]
+set_location_assignment PIN_A94   -to emif_hps_mem_dq[35]
+set_location_assignment PIN_A110  -to emif_hps_mem_dq[36]
+set_location_assignment PIN_B91   -to emif_hps_mem_dq[37]
+set_location_assignment PIN_B103  -to emif_hps_mem_dq[38]
+set_location_assignment PIN_B88   -to emif_hps_mem_dq[39]
+
+for {set i 0} {$i < 40} {incr i} {
+    set_instance_assignment -name IO_STANDARD "1.2-V POD" -to emif_hps_mem_dq[$i]
+}
+
+set_location_assignment PIN_AK111 -to emif_hps_oct_rzqin
+set_instance_assignment -name IO_STANDARD "1.2-V" -to emif_hps_oct_rzqin
+
+set_location_assignment PIN_B119 -to emif_hps_mem_dbi_n[0]
+set_location_assignment PIN_AC90 -to emif_hps_mem_dbi_n[1]
+set_location_assignment PIN_V87  -to emif_hps_mem_dbi_n[2]
+set_location_assignment PIN_H87  -to emif_hps_mem_dbi_n[3]
+set_location_assignment PIN_B97  -to emif_hps_mem_dbi_n[4]
+
+set_instance_assignment -name IO_STANDARD "1.2-V POD" -to emif_hps_mem_dbi_n[0]
+set_instance_assignment -name IO_STANDARD "1.2-V POD" -to emif_hps_mem_dbi_n[1]
+set_instance_assignment -name IO_STANDARD "1.2-V POD" -to emif_hps_mem_dbi_n[2]
+set_instance_assignment -name IO_STANDARD "1.2-V POD" -to emif_hps_mem_dbi_n[3]
+set_instance_assignment -name IO_STANDARD "1.2-V POD" -to emif_hps_mem_dbi_n[4]
+
+# hps-sdmmc
+
+set_location_assignment PIN_AB132 -to hps_sdmmc_cmd
+set_instance_assignment -name IO_STANDARD "1.8-V" -to hps_sdmmc_cmd
+set_location_assignment PIN_E135 -to hps_sdmmc_d[0]
+set_instance_assignment -name IO_STANDARD "1.8-V" -to hps_sdmmc_d[0]
+set_location_assignment PIN_F132 -to hps_sdmmc_d[1]
+set_instance_assignment -name IO_STANDARD "1.8-V" -to hps_sdmmc_d[1]
+set_location_assignment PIN_AA135 -to hps_sdmmc_d[2]
+set_instance_assignment -name IO_STANDARD "1.8-V" -to hps_sdmmc_d[2]
+set_location_assignment PIN_V127 -to hps_sdmmc_d[3]
+set_instance_assignment -name IO_STANDARD "1.8-V" -to hps_sdmmc_d[3]
+set_location_assignment PIN_D132 -to hps_sdmmc_clk
+set_instance_assignment -name IO_STANDARD "1.8-V" -to hps_sdmmc_clk
+
+# i2c
+
+set_location_assignment PIN_N135 -to hps_i2c_sda
+set_location_assignment PIN_AK120 -to hps_i2c_scl
+
+set_instance_assignment -name IO_STANDARD "1.8-V" -to hps_i2c_sda
+set_instance_assignment -name IO_STANDARD "1.8-V" -to hps_i2c_scl
+
+# usb3.1
+
+set_location_assignment PIN_AP120 -to usb31_phy_refclk_p
+set_location_assignment PIN_AP115 -to "usb31_phy_refclk_p(n)"
+set_location_assignment PIN_CF121 -to usb31_io_vbus_det
+set_location_assignment PIN_CG135 -to usb31_io_flt_bar
+set_location_assignment PIN_CF118 -to usb31_io_usb31_id
+set_location_assignment PIN_CL128 -to usb31_io_usb_ctrl
+set_location_assignment PIN_AM135 -to usb31_phy_rx_serial_p
+set_location_assignment PIN_AM133 -to usb31_phy_rx_serial_n
+set_location_assignment PIN_AN129 -to usb31_phy_tx_serial_p
+set_location_assignment PIN_AN126 -to usb31_phy_tx_serial_n
+
+set_instance_assignment -name IO_STANDARD "CURRENT MODE LOGIC (CML)" -to usb31_phy_refclk_p
+set_instance_assignment -name IO_STANDARD "CURRENT MODE LOGIC (CML)" -to "usb31_phy_refclk_p(n)"
+
+set_instance_assignment -name IO_STANDARD "3.3-V LVCMOS" -to usb31_io_vbus_det
+set_instance_assignment -name IO_STANDARD "3.3-V LVCMOS" -to usb31_io_flt_bar
+set_instance_assignment -name IO_STANDARD "3.3-V LVCMOS" -to usb31_io_usb31_id
+set_instance_assignment -name IO_STANDARD "3.3-V LVCMOS" -to usb31_io_usb_ctrl
+
+set_instance_assignment -name IO_STANDARD "HIGH SPEED DIFFERENTIAL I/O" -to usb31_phy_rx_serial_p
+set_instance_assignment -name IO_STANDARD "HIGH SPEED DIFFERENTIAL I/O" -to usb31_phy_rx_serial_n
+set_instance_assignment -name IO_STANDARD "HIGH SPEED DIFFERENTIAL I/O" -to usb31_phy_tx_serial_p
+set_instance_assignment -name IO_STANDARD "HIGH SPEED DIFFERENTIAL I/O" -to usb31_phy_tx_serial_n
+
+# hps-usb
+
+set_location_assignment PIN_P132  -to hps_usb_clk
+set_location_assignment PIN_L135  -to hps_usb_stp
+set_location_assignment PIN_J135  -to hps_usb_dir
+set_location_assignment PIN_AD134 -to hps_usb_nxt
+set_location_assignment PIN_AD135 -to hps_usb_d[0]
+set_location_assignment PIN_M132  -to hps_usb_d[1]
+set_location_assignment PIN_K132  -to hps_usb_d[2]
+set_location_assignment PIN_AG129 -to hps_usb_d[3]
+set_location_assignment PIN_J134  -to hps_usb_d[4]
+set_location_assignment PIN_AG120 -to hps_usb_d[5]
+set_location_assignment PIN_G134  -to hps_usb_d[6]
+set_location_assignment PIN_G135  -to hps_usb_d[7]
+
+set_instance_assignment -name IO_STANDARD "1.8 V" -to hps_usb_clk
+set_instance_assignment -name IO_STANDARD "1.8 V" -to hps_usb_stp
+set_instance_assignment -name IO_STANDARD "1.8 V" -to hps_usb_dir
+set_instance_assignment -name IO_STANDARD "1.8 V" -to hps_usb_nxt
+set_instance_assignment -name CURRENT_STRENGTH_NEW 8MA -to hps_usb_stp
+set_instance_assignment -name WEAK_PULL_UP_RESISTOR ON -to hps_usb_clk
+set_instance_assignment -name WEAK_PULL_UP_RESISTOR ON -to hps_usb_dir
+set_instance_assignment -name WEAK_PULL_UP_RESISTOR ON -to hps_usb_nxt
+
+for {set i 0} {$i < 8} {incr i} {
+    set_instance_assignment -name IO_STANDARD "1.8 V" -to hps_usb_d[$i]
+    set_instance_assignment -name CURRENT_STRENGTH_NEW 8MA -to hps_usb_d[$i]
+    set_instance_assignment -name WEAK_PULL_UP_RESISTOR ON -to hps_usb_d[$i]
+}
+
+# hps-uart
+
+set_location_assignment PIN_W134  -to hps_uart_tx
+set_location_assignment PIN_AK115 -to hps_uart_rx
+
+set_instance_assignment -name IO_STANDARD "1.8 V" -to hps_uart_tx
+set_instance_assignment -name IO_STANDARD "1.8 V" -to hps_uart_rx
+set_instance_assignment -name CURRENT_STRENGTH_NEW 4MA -to hps_uart_tx
+set_instance_assignment -name WEAK_PULL_UP_RESISTOR ON -to hps_uart_rx
+
+# hps-jtag
+
+set_location_assignment PIN_T124 -to hps_jtag_tdo
+set_location_assignment PIN_Y132 -to hps_jtag_tms
+set_location_assignment PIN_P124 -to hps_jtag_tdi
+set_location_assignment PIN_T127 -to hps_jtag_tck
+
+set_instance_assignment -name IO_STANDARD "1.8 V" -to hps_jtag_tck
+set_instance_assignment -name IO_STANDARD "1.8 V" -to hps_jtag_tms
+set_instance_assignment -name IO_STANDARD "1.8 V" -to hps_jtag_tdo
+set_instance_assignment -name IO_STANDARD "1.8 V" -to hps_jtag_tdi
+set_instance_assignment -name CURRENT_STRENGTH_NEW 4MA -to hps_jtag_tdo
+set_instance_assignment -name WEAK_PULL_UP_RESISTOR ON -to hps_jtag_tck
+set_instance_assignment -name WEAK_PULL_UP_RESISTOR ON -to hps_jtag_tms
+set_instance_assignment -name WEAK_PULL_UP_RESISTOR ON -to hps_jtag_tdi
+
+# hps-emac
+
+set_location_assignment PIN_M124  -to hps_emac_rxclk
+set_location_assignment PIN_AB127 -to hps_emac_rxctl
+set_location_assignment PIN_H127  -to hps_emac_rxd[0]
+set_location_assignment PIN_AB124 -to hps_emac_rxd[1]
+set_location_assignment PIN_F124  -to hps_emac_rxd[2]
+set_location_assignment PIN_D124  -to hps_emac_rxd[3]
+set_location_assignment PIN_M127  -to hps_emac_txclk
+set_location_assignment PIN_K127  -to hps_emac_txctl
+set_location_assignment PIN_K124  -to hps_emac_txd[0]
+set_location_assignment PIN_Y127  -to hps_emac_txd[1]
+set_location_assignment PIN_F127  -to hps_emac_txd[2]
+set_location_assignment PIN_Y124  -to hps_emac_txd[3]
+set_location_assignment PIN_U134  -to hps_emac_pps
+set_location_assignment PIN_AL120 -to hps_emac_pps_trig
+set_location_assignment PIN_AG115 -to hps_emac_mdc
+set_location_assignment PIN_R134  -to hps_emac_mdio
+
+set_instance_assignment -name IO_STANDARD "1.8 V" -to hps_emac_txclk
+set_instance_assignment -name IO_STANDARD "1.8 V" -to hps_emac_txctl
+set_instance_assignment -name IO_STANDARD "1.8 V" -to hps_emac_rxclk
+set_instance_assignment -name IO_STANDARD "1.8 V" -to hps_emac_rxctl
+set_instance_assignment -name IO_STANDARD "1.8 V" -to hps_emac_rxd[0]
+set_instance_assignment -name IO_STANDARD "1.8 V" -to hps_emac_txd[0]
+set_instance_assignment -name IO_STANDARD "1.8 V" -to hps_emac_rxd[1]
+set_instance_assignment -name IO_STANDARD "1.8 V" -to hps_emac_txd[1]
+set_instance_assignment -name IO_STANDARD "1.8 V" -to hps_emac_rxd[2]
+set_instance_assignment -name IO_STANDARD "1.8 V" -to hps_emac_txd[2]
+set_instance_assignment -name IO_STANDARD "1.8 V" -to hps_emac_rxd[3]
+set_instance_assignment -name IO_STANDARD "1.8 V" -to hps_emac_txd[3]
+set_instance_assignment -name IO_STANDARD "1.8 V" -to hps_emac_mdio
+set_instance_assignment -name IO_STANDARD "1.8 V" -to hps_emac_mdc
+set_instance_assignment -name IO_STANDARD "1.8-V" -to hps_emac_pps
+set_instance_assignment -name IO_STANDARD "1.8-V" -to hps_emac_pps_trig
+
+set_instance_assignment -name CURRENT_STRENGTH_NEW 4MA -to hps_emac_txclk
+set_instance_assignment -name CURRENT_STRENGTH_NEW 4MA -to hps_emac_mdio
+set_instance_assignment -name CURRENT_STRENGTH_NEW 4MA -to hps_emac_mdc
+set_instance_assignment -name CURRENT_STRENGTH_NEW 8MA -to hps_emac_txctl
+set_instance_assignment -name CURRENT_STRENGTH_NEW 8MA -to hps_emac_txd[0]
+set_instance_assignment -name CURRENT_STRENGTH_NEW 8MA -to hps_emac_txd[1]
+set_instance_assignment -name CURRENT_STRENGTH_NEW 8MA -to hps_emac_txd[2]
+set_instance_assignment -name CURRENT_STRENGTH_NEW 8MA -to hps_emac_txd[3]
+
+set_instance_assignment -name WEAK_PULL_UP_RESISTOR ON -to hps_emac_rxclk
+set_instance_assignment -name WEAK_PULL_UP_RESISTOR ON -to hps_emac_rxctl
+set_instance_assignment -name WEAK_PULL_UP_RESISTOR ON -to hps_emac_rxd[0]
+set_instance_assignment -name WEAK_PULL_UP_RESISTOR ON -to hps_emac_rxd[1]
+set_instance_assignment -name WEAK_PULL_UP_RESISTOR ON -to hps_emac_rxd[2]
+set_instance_assignment -name WEAK_PULL_UP_RESISTOR ON -to hps_emac_rxd[3]
+set_instance_assignment -name WEAK_PULL_UP_RESISTOR ON -to hps_emac_mdio
+
+set_instance_assignment -name AUTO_OPEN_DRAIN_PINS ON -to hps_emac_mdio
+
+# Gpio
+
+set_location_assignment PIN_BM59 -to fpga_led[0]
+set_location_assignment PIN_BH59 -to fpga_led[1]
+set_location_assignment PIN_BH62 -to fpga_led[2]
+set_location_assignment PIN_BK59 -to fpga_led[3]
+
+set_instance_assignment -name IO_STANDARD "1.1 V" -to fpga_led[0]
+set_instance_assignment -name IO_STANDARD "1.1 V" -to fpga_led[1]
+set_instance_assignment -name IO_STANDARD "1.1 V" -to fpga_led[2]
+set_instance_assignment -name IO_STANDARD "1.1 V" -to fpga_led[3]
+set_instance_assignment -name SLEW_RATE 0 -to fpga_led[0]
+set_instance_assignment -name SLEW_RATE 0 -to fpga_led[1]
+set_instance_assignment -name SLEW_RATE 0 -to fpga_led[2]
+set_instance_assignment -name SLEW_RATE 0 -to fpga_led[3]
+
+set_location_assignment PIN_CH12 -to fpga_dipsw[0]
+set_location_assignment PIN_BU22 -to fpga_dipsw[1]
+set_location_assignment PIN_BW19 -to fpga_dipsw[2]
+set_location_assignment PIN_BH28 -to fpga_dipsw[3]
+
+set_instance_assignment -name IO_STANDARD "3.3-V LVCMOS" -to fpga_dipsw[0]
+set_instance_assignment -name IO_STANDARD "3.3-V LVCMOS" -to fpga_dipsw[1]
+set_instance_assignment -name IO_STANDARD "3.3-V LVCMOS" -to fpga_dipsw[2]
+set_instance_assignment -name IO_STANDARD "3.3-V LVCMOS" -to fpga_dipsw[3]
+set_instance_assignment -name WEAK_PULL_UP_RESISTOR ON -to fpga_dipsw[0]
+set_instance_assignment -name WEAK_PULL_UP_RESISTOR ON -to fpga_dipsw[1]
+set_instance_assignment -name WEAK_PULL_UP_RESISTOR ON -to fpga_dipsw[2]
+set_instance_assignment -name WEAK_PULL_UP_RESISTOR ON -to fpga_dipsw[3]
+
+set_location_assignment PIN_BK31 -to fpga_btn[0]
+set_location_assignment PIN_BP22 -to fpga_btn[1]
+set_location_assignment PIN_BK28 -to fpga_btn[2]
+set_location_assignment PIN_BR22 -to fpga_btn[3]
+set_instance_assignment -name IO_STANDARD "3.3-V LVCMOS" -to fpga_btn[0]
+set_instance_assignment -name IO_STANDARD "3.3-V LVCMOS" -to fpga_btn[1]
+set_instance_assignment -name IO_STANDARD "3.3-V LVCMOS" -to fpga_btn[2]
+set_instance_assignment -name IO_STANDARD "3.3-V LVCMOS" -to fpga_btn[3]
+
+set_location_assignment PIN_W135  -to hps_gpio0_io0
+set_location_assignment PIN_U135  -to hps_gpio0_io1
+set_location_assignment PIN_AG123 -to hps_gpio1_io3
+set_location_assignment PIN_B134  -to hps_gpio1_io4
+set_location_assignment PIN_T132  -to hps_gpio0_io11
+
+set_instance_assignment -name IO_STANDARD "1.8 V" -to hps_gpio0_io0
+set_instance_assignment -name IO_STANDARD "1.8 V" -to hps_gpio0_io1
+set_instance_assignment -name IO_STANDARD "1.8 V" -to hps_gpio1_io3
+set_instance_assignment -name IO_STANDARD "1.8 V" -to hps_gpio1_io4
+set_instance_assignment -name IO_STANDARD "1.8 V" -to hps_gpio0_io11
+set_instance_assignment -name CURRENT_STRENGTH_NEW 2MA -to hps_gpio0_io0
+set_instance_assignment -name CURRENT_STRENGTH_NEW 2MA -to hps_gpio0_io1
+set_instance_assignment -name CURRENT_STRENGTH_NEW 2MA -to hps_gpio1_io3
+set_instance_assignment -name CURRENT_STRENGTH_NEW 2MA -to hps_gpio1_io4
+set_instance_assignment -name CURRENT_STRENGTH_NEW 2MA -to hps_gpio0_io11
+set_instance_assignment -name WEAK_PULL_UP_RESISTOR ON -to hps_gpio0_io0
+set_instance_assignment -name WEAK_PULL_UP_RESISTOR ON -to hps_gpio0_io1
+set_instance_assignment -name WEAK_PULL_UP_RESISTOR ON -to hps_gpio0_io11
+
+# Agilex development kit's global assignments
+
+set_global_assignment -name HPS_DAP_NO_CERTIFICATE on
+set_global_assignment -name QSPI_OWNERSHIP HPS
+set_global_assignment -name ENABLE_INTERMEDIATE_SNAPSHOTS ON
+set_global_assignment -name USE_HPS_COLD_RESET SDM_IO11
+set_global_assignment -name USE_CONF_DONE SDM_IO12
+set_global_assignment -name HPS_INITIALIZATION "HPS FIRST"
+set_global_assignment -name DEVICE_INITIALIZATION_CLOCK OSC_CLK_1_125MHZ
+set_global_assignment -name HPS_DAP_SPLIT_MODE "SDM PINS"
+set_global_assignment -name VID_OPERATION_MODE "PMBUS MASTER"
+set_global_assignment -name USE_PWRMGT_SCL SDM_IO0
+set_global_assignment -name USE_PWRMGT_SDA SDM_IO16
+set_global_assignment -name PWRMGT_BUS_SPEED_MODE "400 KHZ"
+set_global_assignment -name PWRMGT_PAGE_COMMAND_ENABLE ON
+set_global_assignment -name PWRMGT_SLAVE_DEVICE_TYPE OTHER
+set_global_assignment -name PWRMGT_SLAVE_DEVICE0_ADDRESS 74
+set_global_assignment -name PWRMGT_SLAVE_DEVICE1_ADDRESS 75
+set_global_assignment -name PWRMGT_SLAVE_DEVICE2_ADDRESS 00
+set_global_assignment -name PWRMGT_SLAVE_DEVICE3_ADDRESS 00
+set_global_assignment -name PWRMGT_SLAVE_DEVICE4_ADDRESS 00
+set_global_assignment -name PWRMGT_SLAVE_DEVICE5_ADDRESS 00
+set_global_assignment -name PWRMGT_SLAVE_DEVICE6_ADDRESS 00
+set_global_assignment -name PWRMGT_SLAVE_DEVICE7_ADDRESS 00
+set_global_assignment -name PWRMGT_TRANSLATED_VOLTAGE_VALUE_UNIT VOLTS
+set_global_assignment -name STRATIX_JTAG_USER_CODE 4
+set_global_assignment -name USE_CHECKSUM_AS_USERCODE OFF
+
+set_global_assignment -name DEVICE_INITIALIZATION_CLOCK OSC_CLK_1_125MHz
+
+# Workaround for Quartus 25.1 incomplete IO assignment becoming a critical warning
+set_global_assignment -name MESSAGE_DISABLE 15714

--- a/projects/common/a5e/a5e_system_qsys.tcl
+++ b/projects/common/a5e/a5e_system_qsys.tcl
@@ -1,0 +1,804 @@
+###############################################################################
+## Copyright (C) 2025-2026 Analog Devices, Inc. All rights reserved.
+### SPDX short identifier: ADIBSD
+###############################################################################
+
+# Agilex5e carrier qsys
+
+set system_type "Agilex 5"
+
+# clocks & reset
+
+add_instance sys_clk clock_source
+add_interface sys_clk clock sink
+set_interface_property sys_clk EXPORT_OF sys_clk.clk_in
+add_interface sys_rst reset sink
+set_interface_property sys_rst EXPORT_OF sys_clk.clk_in_reset
+set_instance_parameter_value sys_clk {clockFrequency} {100000000.0}
+set_instance_parameter_value sys_clk {clockFrequencyKnown} {1}
+set_instance_parameter_value sys_clk {resetSynchronousEdges} {DEASSERT}
+
+add_instance agilex_reset altera_s10_user_rst_clkgate
+add_interface rst_ninit_done reset source
+set_interface_property rst EXPORT_OF agilex_reset.ninit_done
+
+# gts reset sequencer
+add_instance gts_reset intel_srcss_gts
+set_instance_parameter_value gts_reset {SRC_RS_DISABLE} {1}
+set_instance_parameter_value gts_reset {NUM_BANKS_SHORELINE} {1}
+
+# hps
+# round-about way - qsys-script doesn't support {*}?
+
+variable  hps_io_list
+
+proc set_hps_io {io_index io_type} {
+
+  global hps_io_list
+  lappend hps_io_list $io_type
+}
+
+set_hps_io HPS_IOA_1   GPIO0:IO0
+set_hps_io HPS_IOA_2   GPIO0:IO1
+set_hps_io HPS_IOA_3   UART0:TX
+set_hps_io HPS_IOA_4   UART0:RX
+set_hps_io HPS_IOA_5   EMAC2:PPS2
+set_hps_io HPS_IOA_6   EMAC2:PPSTRIG2
+set_hps_io HPS_IOA_7   MDIO2:MDIO
+set_hps_io HPS_IOA_8   MDIO2:MDC
+set_hps_io HPS_IOA_9   I3C1:SDA
+set_hps_io HPS_IOA_10  I3C1:SCL
+set_hps_io HPS_IOA_11  HCLK:HPS_OSC_CLK
+set_hps_io HPS_IOA_12  GPIO0:IO11
+set_hps_io HPS_IOA_13  USB1:CLK
+set_hps_io HPS_IOA_14  USB1:STP
+set_hps_io HPS_IOA_15  USB1:DIR
+set_hps_io HPS_IOA_16  USB1:DATA0
+set_hps_io HPS_IOA_17  USB1:DATA1
+set_hps_io HPS_IOA_18  USB1:NXT
+set_hps_io HPS_IOA_19  USB1:DATA2
+set_hps_io HPS_IOA_20  USB1:DATA3
+set_hps_io HPS_IOA_21  USB1:DATA4
+set_hps_io HPS_IOA_22  USB1:DATA5
+set_hps_io HPS_IOA_23  USB1:DATA6
+set_hps_io HPS_IOA_24  USB1:DATA7
+set_hps_io HPS_IOB_1   SDMMC:DATA0
+set_hps_io HPS_IOB_2   SDMMC:DATA1
+set_hps_io HPS_IOB_3   SDMMC:CCLK
+set_hps_io HPS_IOB_4   GPIO1:IO3
+set_hps_io HPS_IOB_5   GPIO1:IO4
+set_hps_io HPS_IOB_6   SDMMC:DATA2
+set_hps_io HPS_IOB_7   SDMMC:DATA3
+set_hps_io HPS_IOB_8   SDMMC:CMD
+set_hps_io HPS_IOB_9   JTAG:TCK
+set_hps_io HPS_IOB_10  JTAG:TMS
+set_hps_io HPS_IOB_11  JTAG:TDO
+set_hps_io HPS_IOB_12  JTAG:TDI
+set_hps_io HPS_IOB_13  EMAC2:TX_CLK
+set_hps_io HPS_IOB_14  EMAC2:TX_CTL
+set_hps_io HPS_IOB_15  EMAC2:RX_CLK
+set_hps_io HPS_IOB_16  EMAC2:RX_CTL
+set_hps_io HPS_IOB_17  EMAC2:TXD0
+set_hps_io HPS_IOB_18  EMAC2:TXD1
+set_hps_io HPS_IOB_19  EMAC2:RXD0
+set_hps_io HPS_IOB_20  EMAC2:RXD1
+set_hps_io HPS_IOB_21  EMAC2:TXD2
+set_hps_io HPS_IOB_22  EMAC2:TXD3
+set_hps_io HPS_IOB_23  EMAC2:RXD2
+set_hps_io HPS_IOB_24  EMAC2:RXD3
+
+add_instance sys_hps intel_agilex_5_soc
+set_instance_parameter_value sys_hps ATB_Enable {0}
+set_instance_parameter_value sys_hps CM_Mode {N/A}
+set_instance_parameter_value sys_hps CM_PinMuxing {Unused}
+set_instance_parameter_value sys_hps CTI_Enable {0}
+set_instance_parameter_value sys_hps DMA_Enable {No No No No No No No No}
+set_instance_parameter_value sys_hps Debug_APB_Enable {0}
+set_instance_parameter_value sys_hps EMAC0_Mode {N/A}
+set_instance_parameter_value sys_hps EMAC0_PPS_Enable {false}
+set_instance_parameter_value sys_hps EMAC0_PTP {0}
+set_instance_parameter_value sys_hps EMAC0_PinMuxing {Unused}
+set_instance_parameter_value sys_hps EMAC1_Mode {N/A}
+set_instance_parameter_value sys_hps EMAC1_PPS_Enable {false}
+set_instance_parameter_value sys_hps EMAC1_PTP {0}
+set_instance_parameter_value sys_hps EMAC1_PinMuxing {Unused}
+set_instance_parameter_value sys_hps EMAC2_Mode {RGMII_with_MDIO}
+set_instance_parameter_value sys_hps EMAC2_PPS_Enable {false}
+set_instance_parameter_value sys_hps EMAC2_PTP {0}
+set_instance_parameter_value sys_hps EMAC2_PinMuxing {IO}
+set_instance_parameter_value sys_hps EMIF_AXI_Enable {1}
+set_instance_parameter_value sys_hps EMIF_Topology {1}
+set_instance_parameter_value sys_hps F2H_IRQ_Enable {1}
+set_instance_parameter_value sys_hps F2H_free_clk_mhz {125}
+set_instance_parameter_value sys_hps F2H_free_clock_enable {0}
+set_instance_parameter_value sys_hps FPGA_EMAC0_gtx_clk_mhz {125.0}
+set_instance_parameter_value sys_hps FPGA_EMAC0_md_clk_mhz {2.5}
+set_instance_parameter_value sys_hps FPGA_EMAC1_gtx_clk_mhz {125.0}
+set_instance_parameter_value sys_hps FPGA_EMAC1_md_clk_mhz {2.5}
+set_instance_parameter_value sys_hps FPGA_EMAC2_gtx_clk_mhz {125.0}
+set_instance_parameter_value sys_hps FPGA_EMAC2_md_clk_mhz {2.5}
+set_instance_parameter_value sys_hps FPGA_I2C0_sclk_mhz {125.0}
+set_instance_parameter_value sys_hps FPGA_I2C1_sclk_mhz {125.0}
+set_instance_parameter_value sys_hps FPGA_I2CEMAC0_clk_mhz {125.0}
+set_instance_parameter_value sys_hps FPGA_I2CEMAC1_clk_mhz {125.0}
+set_instance_parameter_value sys_hps FPGA_I2CEMAC2_clk_mhz {125.0}
+set_instance_parameter_value sys_hps FPGA_I3C0_sclk_mhz {125.0}
+set_instance_parameter_value sys_hps FPGA_I3C1_sclk_mhz {125.0}
+set_instance_parameter_value sys_hps FPGA_SPIM0_sclk_mhz {125.0}
+set_instance_parameter_value sys_hps FPGA_SPIM1_sclk_mhz {125.0}
+set_instance_parameter_value sys_hps GP_Enable {0}
+set_instance_parameter_value sys_hps H2F_Address_Width {38}
+set_instance_parameter_value sys_hps H2F_IRQ_DMA_Enable0 {0}
+set_instance_parameter_value sys_hps H2F_IRQ_DMA_Enable1 {0}
+set_instance_parameter_value sys_hps H2F_IRQ_ECC_SERR_Enable {0}
+set_instance_parameter_value sys_hps H2F_IRQ_EMAC0_Enable {0}
+set_instance_parameter_value sys_hps H2F_IRQ_EMAC1_Enable {0}
+set_instance_parameter_value sys_hps H2F_IRQ_EMAC2_Enable {0}
+set_instance_parameter_value sys_hps H2F_IRQ_GPIO0_Enable {0}
+set_instance_parameter_value sys_hps H2F_IRQ_GPIO1_Enable {0}
+set_instance_parameter_value sys_hps H2F_IRQ_I2C0_Enable {0}
+set_instance_parameter_value sys_hps H2F_IRQ_I2C1_Enable {0}
+set_instance_parameter_value sys_hps H2F_IRQ_I2CEMAC0_Enable {0}
+set_instance_parameter_value sys_hps H2F_IRQ_I2CEMAC1_Enable {0}
+set_instance_parameter_value sys_hps H2F_IRQ_I2CEMAC2_Enable {0}
+set_instance_parameter_value sys_hps H2F_IRQ_I3C0_Enable {0}
+set_instance_parameter_value sys_hps H2F_IRQ_I3C1_Enable {0}
+set_instance_parameter_value sys_hps H2F_IRQ_L4Timer_Enable {0}
+set_instance_parameter_value sys_hps H2F_IRQ_NAND_Enable {0}
+set_instance_parameter_value sys_hps H2F_IRQ_PeriphClock_Enable {0}
+set_instance_parameter_value sys_hps H2F_IRQ_SDMMC_Enable {0}
+set_instance_parameter_value sys_hps H2F_IRQ_SPIM0_Enable {0}
+set_instance_parameter_value sys_hps H2F_IRQ_SPIM1_Enable {0}
+set_instance_parameter_value sys_hps H2F_IRQ_SPIS0_Enable {0}
+set_instance_parameter_value sys_hps H2F_IRQ_SPIS1_Enable {0}
+set_instance_parameter_value sys_hps H2F_IRQ_SYSTimer_Enable {0}
+set_instance_parameter_value sys_hps H2F_IRQ_UART0_Enable {0}
+set_instance_parameter_value sys_hps H2F_IRQ_UART1_Enable {0}
+set_instance_parameter_value sys_hps H2F_IRQ_USB0_Enable {0}
+set_instance_parameter_value sys_hps H2F_IRQ_USB1_Enable {0}
+set_instance_parameter_value sys_hps H2F_IRQ_Watchdog_Enable {0}
+set_instance_parameter_value sys_hps H2F_Width {128}
+set_instance_parameter_value sys_hps HPS_IO_Enable $hps_io_list
+set_instance_parameter_value sys_hps I2C0_Mode {N/A}
+set_instance_parameter_value sys_hps I2C0_PinMuxing {Unused}
+set_instance_parameter_value sys_hps I2C1_Mode {N/A}
+set_instance_parameter_value sys_hps I2C1_PinMuxing {Unused}
+set_instance_parameter_value sys_hps I2CEMAC0_Mode {N/A}
+set_instance_parameter_value sys_hps I2CEMAC0_PinMuxing {Unused}
+set_instance_parameter_value sys_hps I2CEMAC1_Mode {N/A}
+set_instance_parameter_value sys_hps I2CEMAC1_PinMuxing {Unused}
+set_instance_parameter_value sys_hps I2CEMAC2_Mode {N/A}
+set_instance_parameter_value sys_hps I2CEMAC2_PinMuxing {Unused}
+set_instance_parameter_value sys_hps I3C0_Mode {N/A}
+set_instance_parameter_value sys_hps I3C0_PinMuxing {Unused}
+set_instance_parameter_value sys_hps I3C1_Mode {N/A}
+set_instance_parameter_value sys_hps I3C1_PinMuxing {IO}
+set_instance_parameter_value sys_hps IO_INPUT_DELAY0 {-1}
+set_instance_parameter_value sys_hps IO_INPUT_DELAY1 {-1}
+set_instance_parameter_value sys_hps IO_INPUT_DELAY10 {-1}
+set_instance_parameter_value sys_hps IO_INPUT_DELAY11 {-1}
+set_instance_parameter_value sys_hps IO_INPUT_DELAY12 {-1}
+set_instance_parameter_value sys_hps IO_INPUT_DELAY13 {-1}
+set_instance_parameter_value sys_hps IO_INPUT_DELAY14 {-1}
+set_instance_parameter_value sys_hps IO_INPUT_DELAY15 {-1}
+set_instance_parameter_value sys_hps IO_INPUT_DELAY16 {-1}
+set_instance_parameter_value sys_hps IO_INPUT_DELAY17 {-1}
+set_instance_parameter_value sys_hps IO_INPUT_DELAY18 {-1}
+set_instance_parameter_value sys_hps IO_INPUT_DELAY19 {-1}
+set_instance_parameter_value sys_hps IO_INPUT_DELAY2 {-1}
+set_instance_parameter_value sys_hps IO_INPUT_DELAY20 {-1}
+set_instance_parameter_value sys_hps IO_INPUT_DELAY21 {-1}
+set_instance_parameter_value sys_hps IO_INPUT_DELAY22 {-1}
+set_instance_parameter_value sys_hps IO_INPUT_DELAY23 {-1}
+set_instance_parameter_value sys_hps IO_INPUT_DELAY24 {-1}
+set_instance_parameter_value sys_hps IO_INPUT_DELAY25 {-1}
+set_instance_parameter_value sys_hps IO_INPUT_DELAY26 {-1}
+set_instance_parameter_value sys_hps IO_INPUT_DELAY27 {-1}
+set_instance_parameter_value sys_hps IO_INPUT_DELAY28 {-1}
+set_instance_parameter_value sys_hps IO_INPUT_DELAY29 {-1}
+set_instance_parameter_value sys_hps IO_INPUT_DELAY3 {-1}
+set_instance_parameter_value sys_hps IO_INPUT_DELAY30 {-1}
+set_instance_parameter_value sys_hps IO_INPUT_DELAY31 {-1}
+set_instance_parameter_value sys_hps IO_INPUT_DELAY32 {-1}
+set_instance_parameter_value sys_hps IO_INPUT_DELAY33 {-1}
+set_instance_parameter_value sys_hps IO_INPUT_DELAY34 {-1}
+set_instance_parameter_value sys_hps IO_INPUT_DELAY35 {-1}
+set_instance_parameter_value sys_hps IO_INPUT_DELAY36 {-1}
+set_instance_parameter_value sys_hps IO_INPUT_DELAY37 {-1}
+set_instance_parameter_value sys_hps IO_INPUT_DELAY38 {21}
+set_instance_parameter_value sys_hps IO_INPUT_DELAY39 {-1}
+set_instance_parameter_value sys_hps IO_INPUT_DELAY4 {-1}
+set_instance_parameter_value sys_hps IO_INPUT_DELAY40 {-1}
+set_instance_parameter_value sys_hps IO_INPUT_DELAY41 {-1}
+set_instance_parameter_value sys_hps IO_INPUT_DELAY42 {-1}
+set_instance_parameter_value sys_hps IO_INPUT_DELAY43 {-1}
+set_instance_parameter_value sys_hps IO_INPUT_DELAY44 {-1}
+set_instance_parameter_value sys_hps IO_INPUT_DELAY45 {-1}
+set_instance_parameter_value sys_hps IO_INPUT_DELAY46 {-1}
+set_instance_parameter_value sys_hps IO_INPUT_DELAY47 {-1}
+set_instance_parameter_value sys_hps IO_INPUT_DELAY5 {-1}
+set_instance_parameter_value sys_hps IO_INPUT_DELAY6 {-1}
+set_instance_parameter_value sys_hps IO_INPUT_DELAY7 {-1}
+set_instance_parameter_value sys_hps IO_INPUT_DELAY8 {-1}
+set_instance_parameter_value sys_hps IO_INPUT_DELAY9 {-1}
+set_instance_parameter_value sys_hps IO_OUTPUT_DELAY0 {-1}
+set_instance_parameter_value sys_hps IO_OUTPUT_DELAY1 {-1}
+set_instance_parameter_value sys_hps IO_OUTPUT_DELAY10 {-1}
+set_instance_parameter_value sys_hps IO_OUTPUT_DELAY11 {-1}
+set_instance_parameter_value sys_hps IO_OUTPUT_DELAY12 {-1}
+set_instance_parameter_value sys_hps IO_OUTPUT_DELAY13 {-1}
+set_instance_parameter_value sys_hps IO_OUTPUT_DELAY14 {-1}
+set_instance_parameter_value sys_hps IO_OUTPUT_DELAY15 {-1}
+set_instance_parameter_value sys_hps IO_OUTPUT_DELAY16 {-1}
+set_instance_parameter_value sys_hps IO_OUTPUT_DELAY17 {-1}
+set_instance_parameter_value sys_hps IO_OUTPUT_DELAY18 {-1}
+set_instance_parameter_value sys_hps IO_OUTPUT_DELAY19 {-1}
+set_instance_parameter_value sys_hps IO_OUTPUT_DELAY2 {-1}
+set_instance_parameter_value sys_hps IO_OUTPUT_DELAY20 {-1}
+set_instance_parameter_value sys_hps IO_OUTPUT_DELAY21 {-1}
+set_instance_parameter_value sys_hps IO_OUTPUT_DELAY22 {-1}
+set_instance_parameter_value sys_hps IO_OUTPUT_DELAY23 {-1}
+set_instance_parameter_value sys_hps IO_OUTPUT_DELAY24 {-1}
+set_instance_parameter_value sys_hps IO_OUTPUT_DELAY25 {-1}
+set_instance_parameter_value sys_hps IO_OUTPUT_DELAY26 {-1}
+set_instance_parameter_value sys_hps IO_OUTPUT_DELAY27 {-1}
+set_instance_parameter_value sys_hps IO_OUTPUT_DELAY28 {-1}
+set_instance_parameter_value sys_hps IO_OUTPUT_DELAY29 {-1}
+set_instance_parameter_value sys_hps IO_OUTPUT_DELAY3 {-1}
+set_instance_parameter_value sys_hps IO_OUTPUT_DELAY30 {-1}
+set_instance_parameter_value sys_hps IO_OUTPUT_DELAY31 {-1}
+set_instance_parameter_value sys_hps IO_OUTPUT_DELAY32 {-1}
+set_instance_parameter_value sys_hps IO_OUTPUT_DELAY33 {-1}
+set_instance_parameter_value sys_hps IO_OUTPUT_DELAY34 {-1}
+set_instance_parameter_value sys_hps IO_OUTPUT_DELAY35 {-1}
+set_instance_parameter_value sys_hps IO_OUTPUT_DELAY36 {21}
+set_instance_parameter_value sys_hps IO_OUTPUT_DELAY37 {-1}
+set_instance_parameter_value sys_hps IO_OUTPUT_DELAY38 {-1}
+set_instance_parameter_value sys_hps IO_OUTPUT_DELAY39 {-1}
+set_instance_parameter_value sys_hps IO_OUTPUT_DELAY4 {-1}
+set_instance_parameter_value sys_hps IO_OUTPUT_DELAY40 {-1}
+set_instance_parameter_value sys_hps IO_OUTPUT_DELAY41 {-1}
+set_instance_parameter_value sys_hps IO_OUTPUT_DELAY42 {-1}
+set_instance_parameter_value sys_hps IO_OUTPUT_DELAY43 {-1}
+set_instance_parameter_value sys_hps IO_OUTPUT_DELAY44 {-1}
+set_instance_parameter_value sys_hps IO_OUTPUT_DELAY45 {-1}
+set_instance_parameter_value sys_hps IO_OUTPUT_DELAY46 {-1}
+set_instance_parameter_value sys_hps IO_OUTPUT_DELAY47 {-1}
+set_instance_parameter_value sys_hps IO_OUTPUT_DELAY5 {-1}
+set_instance_parameter_value sys_hps IO_OUTPUT_DELAY6 {-1}
+set_instance_parameter_value sys_hps IO_OUTPUT_DELAY7 {-1}
+set_instance_parameter_value sys_hps IO_OUTPUT_DELAY8 {-1}
+set_instance_parameter_value sys_hps IO_OUTPUT_DELAY9 {-1}
+set_instance_parameter_value sys_hps JTAG_Enable {0}
+set_instance_parameter_value sys_hps LWH2F_Address_Width {29}
+set_instance_parameter_value sys_hps LWH2F_Width {32}
+set_instance_parameter_value sys_hps MPLL_C0_Override_mhz {800.0}
+set_instance_parameter_value sys_hps MPLL_C1_Override_mhz {800.0}
+set_instance_parameter_value sys_hps MPLL_C2_Override_mhz {533.33}
+set_instance_parameter_value sys_hps MPLL_C3_Override_mhz {400.0}
+set_instance_parameter_value sys_hps MPLL_Clock_Source {0}
+set_instance_parameter_value sys_hps MPLL_Override {1}
+set_instance_parameter_value sys_hps MPLL_VCO_Override_mhz {3200.0}
+set_instance_parameter_value sys_hps MPU_Events_Enable {0}
+set_instance_parameter_value sys_hps MPU_clk_freq_override_mhz {533.33}
+set_instance_parameter_value sys_hps MPU_clk_override {1}
+set_instance_parameter_value sys_hps MPU_clk_src_override {2}
+set_instance_parameter_value sys_hps MPU_core01_freq_override_mhz {800.0}
+set_instance_parameter_value sys_hps MPU_core01_src_override {1}
+set_instance_parameter_value sys_hps MPU_core23_src_override {0}
+set_instance_parameter_value sys_hps MPU_core2_freq_override_mhz {800.0}
+set_instance_parameter_value sys_hps MPU_core3_freq_override_mhz {800.0}
+set_instance_parameter_value sys_hps NAND_Mode {N/A}
+set_instance_parameter_value sys_hps NAND_PinMuxing {Unused}
+set_instance_parameter_value sys_hps NOC_clk_cs_debug_div {4}
+set_instance_parameter_value sys_hps NOC_clk_cs_div {1}
+set_instance_parameter_value sys_hps NOC_clk_cs_trace_div {4}
+set_instance_parameter_value sys_hps NOC_clk_free_l4_div {4}
+set_instance_parameter_value sys_hps NOC_clk_periph_l4_div {2}
+set_instance_parameter_value sys_hps NOC_clk_phy_div {1}
+set_instance_parameter_value sys_hps NOC_clk_slow_l4_div {4}
+set_instance_parameter_value sys_hps NOC_clk_src_select {3}
+set_instance_parameter_value sys_hps PLL_CLK0 {Unused}
+set_instance_parameter_value sys_hps PLL_CLK1 {Unused}
+set_instance_parameter_value sys_hps PLL_CLK2 {Unused}
+set_instance_parameter_value sys_hps PLL_CLK3 {Unused}
+set_instance_parameter_value sys_hps PLL_CLK4 {Unused}
+set_instance_parameter_value sys_hps PPLL_C0_Override_mhz {600.0}
+set_instance_parameter_value sys_hps PPLL_C1_Override_mhz {600.0}
+set_instance_parameter_value sys_hps PPLL_C2_Override_mhz {24.0}
+set_instance_parameter_value sys_hps PPLL_C3_Override_mhz {500.0}
+set_instance_parameter_value sys_hps PPLL_Clock_Source {0}
+set_instance_parameter_value sys_hps PPLL_Override {1}
+set_instance_parameter_value sys_hps PPLL_VCO_Override_mhz {3000.0}
+set_instance_parameter_value sys_hps Periph_clk_emac0_sel {250}
+set_instance_parameter_value sys_hps Periph_clk_emac1_sel {250}
+set_instance_parameter_value sys_hps Periph_clk_emac2_sel {250}
+set_instance_parameter_value sys_hps Periph_clk_override {0}
+set_instance_parameter_value sys_hps Periph_emac_ptp_freq_override {400.0}
+set_instance_parameter_value sys_hps Periph_emac_ptp_src_override {7}
+set_instance_parameter_value sys_hps Periph_emaca_src_override {7}
+set_instance_parameter_value sys_hps Periph_emacb_src_override {7}
+set_instance_parameter_value sys_hps Periph_gpio_freq_override {400.0}
+set_instance_parameter_value sys_hps Periph_gpio_src_override {3}
+set_instance_parameter_value sys_hps Periph_psi_freq_override {500.0}
+set_instance_parameter_value sys_hps Periph_psi_src_override {7}
+set_instance_parameter_value sys_hps Periph_usb_freq_override {20.0}
+set_instance_parameter_value sys_hps Periph_usb_src_override {3}
+set_instance_parameter_value sys_hps Pwr_a55_core0_1_on {1}
+set_instance_parameter_value sys_hps Pwr_a76_core2_on {1}
+set_instance_parameter_value sys_hps Pwr_a76_core3_on {1}
+set_instance_parameter_value sys_hps Pwr_boot_core_sel {0}
+set_instance_parameter_value sys_hps Pwr_cpu_app_select {0}
+set_instance_parameter_value sys_hps Pwr_mpu_l3_cache_size {2}
+set_instance_parameter_value sys_hps Rst_h2f_cold_en {0}
+set_instance_parameter_value sys_hps Rst_hps_warm_en {0}
+set_instance_parameter_value sys_hps Rst_sdm_wd_config {0}
+set_instance_parameter_value sys_hps Rst_watchdog_en {0}
+set_instance_parameter_value sys_hps SDMMC_Mode {4-bit}
+set_instance_parameter_value sys_hps SDMMC_PinMuxing {IO}
+set_instance_parameter_value sys_hps SPIM0_Mode {N/A}
+set_instance_parameter_value sys_hps SPIM0_PinMuxing {Unused}
+set_instance_parameter_value sys_hps SPIM1_Mode {N/A}
+set_instance_parameter_value sys_hps SPIM1_PinMuxing {Unused}
+set_instance_parameter_value sys_hps SPIS0_Mode {N/A}
+set_instance_parameter_value sys_hps SPIS0_PinMuxing {Unused}
+set_instance_parameter_value sys_hps SPIS1_Mode {N/A}
+set_instance_parameter_value sys_hps SPIS1_PinMuxing {Unused}
+set_instance_parameter_value sys_hps STM_Enable {0}
+set_instance_parameter_value sys_hps TPIU_Select {HPS Clock Manager}
+set_instance_parameter_value sys_hps TRACE_Mode {N/A}
+set_instance_parameter_value sys_hps TRACE_PinMuxing {Unused}
+set_instance_parameter_value sys_hps UART0_Mode {No_flow_control}
+set_instance_parameter_value sys_hps UART0_PinMuxing {IO}
+set_instance_parameter_value sys_hps UART1_Mode {N/A}
+set_instance_parameter_value sys_hps UART1_PinMuxing {Unused}
+set_instance_parameter_value sys_hps USB0_Mode {N/A}
+set_instance_parameter_value sys_hps USB0_PinMuxing {Unused}
+set_instance_parameter_value sys_hps USB1_Mode {default}
+set_instance_parameter_value sys_hps USB1_PinMuxing {IO}
+set_instance_parameter_value sys_hps User0_clk_enable {1}
+set_instance_parameter_value sys_hps User0_clk_freq {250}
+set_instance_parameter_value sys_hps User0_clk_src_select {7}
+set_instance_parameter_value sys_hps User1_clk_enable {0}
+set_instance_parameter_value sys_hps User1_clk_freq {500.0}
+set_instance_parameter_value sys_hps User1_clk_src_select {7}
+set_instance_parameter_value sys_hps eosc1_clk_mhz {25.0}
+set_instance_parameter_value sys_hps f2s_SMMU {0}
+set_instance_parameter_value sys_hps f2s_address_width {32}
+set_instance_parameter_value sys_hps f2s_data_width {Unused}
+set_instance_parameter_value sys_hps f2s_mode {ace5lite}
+set_instance_parameter_value sys_hps f2sdram_SMMU {0}
+set_instance_parameter_value sys_hps f2sdram_address_width {32}
+set_instance_parameter_value sys_hps f2sdram_data_width {Unused}
+set_instance_parameter_value sys_hps hps_ioa10_opd_en {0}
+set_instance_parameter_value sys_hps hps_ioa11_opd_en {0}
+set_instance_parameter_value sys_hps hps_ioa12_opd_en {0}
+set_instance_parameter_value sys_hps hps_ioa13_opd_en {0}
+set_instance_parameter_value sys_hps hps_ioa14_opd_en {0}
+set_instance_parameter_value sys_hps hps_ioa15_opd_en {0}
+set_instance_parameter_value sys_hps hps_ioa16_opd_en {0}
+set_instance_parameter_value sys_hps hps_ioa17_opd_en {0}
+set_instance_parameter_value sys_hps hps_ioa18_opd_en {0}
+set_instance_parameter_value sys_hps hps_ioa19_opd_en {0}
+set_instance_parameter_value sys_hps hps_ioa1_opd_en {0}
+set_instance_parameter_value sys_hps hps_ioa20_opd_en {0}
+set_instance_parameter_value sys_hps hps_ioa21_opd_en {0}
+set_instance_parameter_value sys_hps hps_ioa22_opd_en {0}
+set_instance_parameter_value sys_hps hps_ioa23_opd_en {0}
+set_instance_parameter_value sys_hps hps_ioa24_opd_en {0}
+set_instance_parameter_value sys_hps hps_ioa2_opd_en {0}
+set_instance_parameter_value sys_hps hps_ioa3_opd_en {0}
+set_instance_parameter_value sys_hps hps_ioa4_opd_en {0}
+set_instance_parameter_value sys_hps hps_ioa5_opd_en {0}
+set_instance_parameter_value sys_hps hps_ioa6_opd_en {0}
+set_instance_parameter_value sys_hps hps_ioa7_opd_en {0}
+set_instance_parameter_value sys_hps hps_ioa8_opd_en {0}
+set_instance_parameter_value sys_hps hps_ioa9_opd_en {0}
+set_instance_parameter_value sys_hps hps_iob10_opd_en {0}
+set_instance_parameter_value sys_hps hps_iob11_opd_en {0}
+set_instance_parameter_value sys_hps hps_iob12_opd_en {0}
+set_instance_parameter_value sys_hps hps_iob13_opd_en {0}
+set_instance_parameter_value sys_hps hps_iob14_opd_en {0}
+set_instance_parameter_value sys_hps hps_iob15_opd_en {0}
+set_instance_parameter_value sys_hps hps_iob16_opd_en {0}
+set_instance_parameter_value sys_hps hps_iob17_opd_en {0}
+set_instance_parameter_value sys_hps hps_iob18_opd_en {0}
+set_instance_parameter_value sys_hps hps_iob19_opd_en {0}
+set_instance_parameter_value sys_hps hps_iob1_opd_en {0}
+set_instance_parameter_value sys_hps hps_iob20_opd_en {0}
+set_instance_parameter_value sys_hps hps_iob21_opd_en {0}
+set_instance_parameter_value sys_hps hps_iob22_opd_en {0}
+set_instance_parameter_value sys_hps hps_iob23_opd_en {0}
+set_instance_parameter_value sys_hps hps_iob24_opd_en {0}
+set_instance_parameter_value sys_hps hps_iob2_opd_en {0}
+set_instance_parameter_value sys_hps hps_iob3_opd_en {0}
+set_instance_parameter_value sys_hps hps_iob4_opd_en {0}
+set_instance_parameter_value sys_hps hps_iob5_opd_en {0}
+set_instance_parameter_value sys_hps hps_iob6_opd_en {0}
+set_instance_parameter_value sys_hps hps_iob7_opd_en {0}
+set_instance_parameter_value sys_hps hps_iob8_opd_en {0}
+set_instance_parameter_value sys_hps hps_iob9_opd_en {0}
+
+add_interface h2f_reset reset source
+set_interface_property h2f_reset EXPORT_OF sys_hps.h2f_reset
+
+add_connection sys_clk.clk sys_hps.hps2fpga_axi_clock
+add_connection sys_clk.clk_reset sys_hps.hps2fpga_axi_reset
+add_connection sys_clk.clk sys_hps.lwhps2fpga_axi_clock
+add_connection sys_clk.clk_reset sys_hps.lwhps2fpga_axi_reset
+add_connection sys_clk.clk sys_hps.usb31_phy_reconfig_clk
+add_connection sys_clk.clk_reset sys_hps.usb31_phy_reconfig_rst
+
+add_interface sys_hps_io conduit end
+set_interface_property sys_hps_io EXPORT_OF sys_hps.hps_io
+
+# common dma interfaces
+
+add_instance sys_dma_clk clock_source
+set_instance_parameter_value sys_dma_clk {resetSynchronousEdges} {DEASSERT}
+set_instance_parameter_value sys_dma_clk {clockFrequency} {250000000.0}
+set_instance_parameter_value sys_dma_clk {clockFrequencyKnown} {true}
+add_connection sys_clk.clk_reset sys_dma_clk.clk_in_reset
+add_connection sys_hps.h2f_user0_clk sys_dma_clk.clk_in
+
+# hps emif
+
+add_component emif_hps ip/template_a5ed065es/emif_io96b_hps.ip emif_io96b_hps emif_io96b_hps_inst
+load_component emif_hps
+set_component_parameter_value EMIF_PROTOCOL {DDR4_COMP}
+set_component_parameter_value EMIF_REF_CLK_SHARING {0}
+set_component_parameter_value EMIF_RZQ_SHARING {0}
+set_component_parameter_value EMIF_SHOW_INTERNAL_SETTINGS {0}
+set_component_parameter_value EMIF_TOPOLOGY {1x32}
+set_component_project_property HIDE_FROM_IP_CATALOG {false}
+
+set_component_sub_module_parameter_value emif_0_ddr4comp ADV_CAL_ENABLE_MARGIN {0}
+set_component_sub_module_parameter_value emif_0_ddr4comp ADV_CAL_ENABLE_REQ {1}
+set_component_sub_module_parameter_value emif_0_ddr4comp ADV_CAL_ENABLE_WEQ {1}
+set_component_sub_module_parameter_value emif_0_ddr4comp ANALOG_PARAM_DERIVATION_PARAM_NAME {}
+set_component_sub_module_parameter_value emif_0_ddr4comp AXI4_ADDR_WIDTH {40}
+set_component_sub_module_parameter_value emif_0_ddr4comp AXI4_USER_WIDTH {32}
+set_component_sub_module_parameter_value emif_0_ddr4comp CTRL_AUTO_PRECHARGE_EN {0}
+set_component_sub_module_parameter_value emif_0_ddr4comp CTRL_DMDBI_EN {0}
+set_component_sub_module_parameter_value emif_0_ddr4comp CTRL_DM_EN {1}
+set_component_sub_module_parameter_value emif_0_ddr4comp CTRL_ECC_AUTOCORRECT_EN {1}
+set_component_sub_module_parameter_value emif_0_ddr4comp CTRL_PERFORMANCE_PROFILE {SEQ}
+set_component_sub_module_parameter_value emif_0_ddr4comp CTRL_RD_DBI_EN {0}
+set_component_sub_module_parameter_value emif_0_ddr4comp CTRL_SCRAMBLER_EN {0}
+set_component_sub_module_parameter_value emif_0_ddr4comp CTRL_WR_DBI_EN {0}
+set_component_sub_module_parameter_value emif_0_ddr4comp DIAG_EXTRA_PARAMETERS {}
+set_component_sub_module_parameter_value emif_0_ddr4comp DIAG_HMC_ADDR_SWAP_EN {0}
+set_component_sub_module_parameter_value emif_0_ddr4comp EX_DESIGN_PMON_EN {0}
+set_component_sub_module_parameter_value emif_0_ddr4comp EX_DESIGN_PMON_INTERNAL_JAMB_EN {1}
+set_component_sub_module_parameter_value emif_0_ddr4comp HPS_EMIF_RZQ_SHARING {0}
+set_component_sub_module_parameter_value emif_0_ddr4comp INSTANCE_ID {0}
+set_component_sub_module_parameter_value emif_0_ddr4comp IS_HPS {1}
+set_component_sub_module_parameter_value emif_0_ddr4comp JEDEC_OVERRIDE_TABLE_PARAM_NAME {}
+set_component_sub_module_parameter_value emif_0_ddr4comp MEM_3DS_EN {0}
+set_component_sub_module_parameter_value emif_0_ddr4comp MEM_AC_MIRRORING_EN {0}
+set_component_sub_module_parameter_value emif_0_ddr4comp MEM_AC_PARITY_EN {0}
+set_component_sub_module_parameter_value emif_0_ddr4comp MEM_AC_PARITY_LATENCY_MODE {0.0}
+set_component_sub_module_parameter_value emif_0_ddr4comp MEM_AL_CYC {0.0}
+set_component_sub_module_parameter_value emif_0_ddr4comp MEM_A_WIDTH {17}
+set_component_sub_module_parameter_value emif_0_ddr4comp MEM_BANK_ADDR_WIDTH {2}
+set_component_sub_module_parameter_value emif_0_ddr4comp MEM_BANK_GROUP_ADDR_WIDTH {2}
+set_component_sub_module_parameter_value emif_0_ddr4comp MEM_CHANNEL_ADDR_NUM_BITS {36}
+set_component_sub_module_parameter_value emif_0_ddr4comp MEM_CHANNEL_CAPACITY_GBITS {64}
+set_component_sub_module_parameter_value emif_0_ddr4comp MEM_CHANNEL_CS_WIDTH {1}
+set_component_sub_module_parameter_value emif_0_ddr4comp MEM_CHANNEL_ECC_DQ_WIDTH {8}
+set_component_sub_module_parameter_value emif_0_ddr4comp MEM_CKE_WIDTH {1}
+set_component_sub_module_parameter_value emif_0_ddr4comp MEM_CK_WIDTH {1}
+set_component_sub_module_parameter_value emif_0_ddr4comp MEM_CLAMSHELL_EN {0}
+set_component_sub_module_parameter_value emif_0_ddr4comp MEM_CL_CYC {12.0}
+set_component_sub_module_parameter_value emif_0_ddr4comp MEM_COL_ADDR_WIDTH {10}
+set_component_sub_module_parameter_value emif_0_ddr4comp MEM_CS_WIDTH {1}
+set_component_sub_module_parameter_value emif_0_ddr4comp MEM_CS_WIDTH_PHYSICAL {1}
+set_component_sub_module_parameter_value emif_0_ddr4comp MEM_CWL_CYC {9.0}
+set_component_sub_module_parameter_value emif_0_ddr4comp MEM_C_WIDTH {0}
+set_component_sub_module_parameter_value emif_0_ddr4comp MEM_DIE_DENSITY_GBITS {16}
+set_component_sub_module_parameter_value emif_0_ddr4comp MEM_DIE_DQ_WIDTH {8}
+set_component_sub_module_parameter_value emif_0_ddr4comp MEM_DQ_PER_DQS {8}
+set_component_sub_module_parameter_value emif_0_ddr4comp MEM_DQ_VREF {35}
+set_component_sub_module_parameter_value emif_0_ddr4comp MEM_FINE_GRANULARITY_REFRESH_MODE {1.0}
+set_component_sub_module_parameter_value emif_0_ddr4comp MEM_NUM_CHANNELS {1}
+set_component_sub_module_parameter_value emif_0_ddr4comp MEM_NUM_CHANNELS_PER_IO96 {1}
+set_component_sub_module_parameter_value emif_0_ddr4comp MEM_NUM_IO96 {1}
+set_component_sub_module_parameter_value emif_0_ddr4comp MEM_ODT_DQ_X_IDLE {off}
+set_component_sub_module_parameter_value emif_0_ddr4comp MEM_ODT_DQ_X_NON_TGT_RD {off}
+set_component_sub_module_parameter_value emif_0_ddr4comp MEM_ODT_DQ_X_NON_TGT_WR {off}
+set_component_sub_module_parameter_value emif_0_ddr4comp MEM_ODT_DQ_X_RON {7}
+set_component_sub_module_parameter_value emif_0_ddr4comp MEM_ODT_DQ_X_TGT_WR {4}
+set_component_sub_module_parameter_value emif_0_ddr4comp MEM_ODT_NOM {off}
+set_component_sub_module_parameter_value emif_0_ddr4comp MEM_ODT_PARK {4}
+set_component_sub_module_parameter_value emif_0_ddr4comp MEM_ODT_WR {off}
+set_component_sub_module_parameter_value emif_0_ddr4comp MEM_OPERATING_FREQ_MHZ {800}
+set_component_sub_module_parameter_value emif_0_ddr4comp MEM_OPERATING_FREQ_MHZ_AUTOSET_EN {0}
+set_component_sub_module_parameter_value emif_0_ddr4comp MEM_PAGE_SIZE {1024.0}
+set_component_sub_module_parameter_value emif_0_ddr4comp MEM_RANKS_SHARE_CK_EN {1}
+set_component_sub_module_parameter_value emif_0_ddr4comp MEM_RD_PREAMBLE_MODE {1.0}
+set_component_sub_module_parameter_value emif_0_ddr4comp MEM_ROW_ADDR_WIDTH {17}
+set_component_sub_module_parameter_value emif_0_ddr4comp MEM_SPEEDBIN {3200AA}
+set_component_sub_module_parameter_value emif_0_ddr4comp MEM_SPEEDBIN_DATARATE {3200}
+set_component_sub_module_parameter_value emif_0_ddr4comp MEM_TCCD_DLR_NS {5.0}
+set_component_sub_module_parameter_value emif_0_ddr4comp MEM_TCCD_L_NS {5.0}
+set_component_sub_module_parameter_value emif_0_ddr4comp MEM_TCCD_S_NS {4.0}
+set_component_sub_module_parameter_value emif_0_ddr4comp MEM_TCKESR_CYC {5.0}
+set_component_sub_module_parameter_value emif_0_ddr4comp MEM_TCKE_NS {4.0}
+set_component_sub_module_parameter_value emif_0_ddr4comp MEM_TCKSRE_NS {8.0}
+set_component_sub_module_parameter_value emif_0_ddr4comp MEM_TCKSRX_NS {8.0}
+set_component_sub_module_parameter_value emif_0_ddr4comp MEM_TCK_CL_CWL_MAX_NS {1.5}
+set_component_sub_module_parameter_value emif_0_ddr4comp MEM_TCK_CL_CWL_MIN_NS {1.25}
+set_component_sub_module_parameter_value emif_0_ddr4comp MEM_TCPDED_NS {4.0}
+set_component_sub_module_parameter_value emif_0_ddr4comp MEM_TDQSCK_MAX_MIN_NS {0.225}
+set_component_sub_module_parameter_value emif_0_ddr4comp MEM_TDQSCK_NS {0.0}
+set_component_sub_module_parameter_value emif_0_ddr4comp MEM_TDQSS_CYC {0.0}
+set_component_sub_module_parameter_value emif_0_ddr4comp MEM_TDSH_NS {0.18}
+set_component_sub_module_parameter_value emif_0_ddr4comp MEM_TDSS_NS {0.18}
+set_component_sub_module_parameter_value emif_0_ddr4comp MEM_TFAW_DLR_NS {20.0}
+set_component_sub_module_parameter_value emif_0_ddr4comp MEM_TFAW_NS {35.0}
+set_component_sub_module_parameter_value emif_0_ddr4comp MEM_TIH_NS {140000.0}
+set_component_sub_module_parameter_value emif_0_ddr4comp MEM_TIS_NS {115000.0}
+set_component_sub_module_parameter_value emif_0_ddr4comp MEM_TMOD_NS {24.0}
+set_component_sub_module_parameter_value emif_0_ddr4comp MEM_TMPRR_NS {1.0}
+set_component_sub_module_parameter_value emif_0_ddr4comp MEM_TMRD_NS {8.0}
+set_component_sub_module_parameter_value emif_0_ddr4comp MEM_TQSH_NS {0.4}
+set_component_sub_module_parameter_value emif_0_ddr4comp MEM_TRAS_MAX_NS {70200.0}
+set_component_sub_module_parameter_value emif_0_ddr4comp MEM_TRAS_MIN_NS {35.0}
+set_component_sub_module_parameter_value emif_0_ddr4comp MEM_TRAS_NS {35.0}
+set_component_sub_module_parameter_value emif_0_ddr4comp MEM_TRCD_NS {15.0}
+set_component_sub_module_parameter_value emif_0_ddr4comp MEM_TRC_NS {50.0}
+set_component_sub_module_parameter_value emif_0_ddr4comp MEM_TREFI_NS {7800.0}
+set_component_sub_module_parameter_value emif_0_ddr4comp MEM_TRFC_DLR_NS {190.0}
+set_component_sub_module_parameter_value emif_0_ddr4comp MEM_TRFC_NS {550.0}
+set_component_sub_module_parameter_value emif_0_ddr4comp MEM_TRP_NS {15.0}
+set_component_sub_module_parameter_value emif_0_ddr4comp MEM_TRRD_DLR_NS {4.0}
+set_component_sub_module_parameter_value emif_0_ddr4comp MEM_TRRD_L_NS {6.0}
+set_component_sub_module_parameter_value emif_0_ddr4comp MEM_TRRD_S_NS {5.0}
+set_component_sub_module_parameter_value emif_0_ddr4comp MEM_TRTP_NS {7.5}
+set_component_sub_module_parameter_value emif_0_ddr4comp MEM_TWLH_NS {0.13}
+set_component_sub_module_parameter_value emif_0_ddr4comp MEM_TWLS_NS {0.13}
+set_component_sub_module_parameter_value emif_0_ddr4comp MEM_TWR_CRC_DM_NS {5.0}
+set_component_sub_module_parameter_value emif_0_ddr4comp MEM_TWR_NS {15.0}
+set_component_sub_module_parameter_value emif_0_ddr4comp MEM_TWTR_L_CRC_DM_NS {5.0}
+set_component_sub_module_parameter_value emif_0_ddr4comp MEM_TWTR_L_NS {6.0}
+set_component_sub_module_parameter_value emif_0_ddr4comp MEM_TWTR_S_CRC_DM_NS {5.0}
+set_component_sub_module_parameter_value emif_0_ddr4comp MEM_TWTR_S_NS {2.0}
+set_component_sub_module_parameter_value emif_0_ddr4comp MEM_TXP_NS {5.0}
+set_component_sub_module_parameter_value emif_0_ddr4comp MEM_TXS_DLL_NS {597.0}
+set_component_sub_module_parameter_value emif_0_ddr4comp MEM_TXS_NS {560.0}
+set_component_sub_module_parameter_value emif_0_ddr4comp MEM_TZQCS_NS {128.0}
+set_component_sub_module_parameter_value emif_0_ddr4comp MEM_TZQINIT_CYC {1024.0}
+set_component_sub_module_parameter_value emif_0_ddr4comp MEM_TZQOPER_CYC {512.0}
+set_component_sub_module_parameter_value emif_0_ddr4comp MEM_VREF_DQ_X_RANGE {2}
+set_component_sub_module_parameter_value emif_0_ddr4comp MEM_VREF_DQ_X_VALUE {67.75}
+set_component_sub_module_parameter_value emif_0_ddr4comp MEM_WR_CRC_EN {0.0}
+set_component_sub_module_parameter_value emif_0_ddr4comp MEM_WR_PREAMBLE_MODE {1.0}
+set_component_sub_module_parameter_value emif_0_ddr4comp PHY_AC_PLACEMENT {BOT}
+set_component_sub_module_parameter_value emif_0_ddr4comp PHY_ALERT_N_PLACEMENT {AC2}
+set_component_sub_module_parameter_value emif_0_ddr4comp PHY_FORCE_MIN_4_AC_LANES_EN {0}
+set_component_sub_module_parameter_value emif_0_ddr4comp PHY_REFCLK_ADVANCED_SELECT_EN {1}
+set_component_sub_module_parameter_value emif_0_ddr4comp PHY_REFCLK_FREQ_MHZ {100.0}
+set_component_sub_module_parameter_value emif_0_ddr4comp PHY_REFCLK_FREQ_MHZ_AUTOSET_EN {0}
+set_component_sub_module_parameter_value emif_0_ddr4comp PHY_SWIZZLE_MAP {BYTE_SWIZZLE_CH0=0 X X X 1 2 3 ECC;PIN_SWIZZLE_CH0_DQS0=0 2 6 4 1 3 5 7;PIN_SWIZZLE_CH0_DQS1=12 15 8 11 14 10 13 9;PIN_SWIZZLE_CH0_DQS2=20 16 18 22 23 17 19 21;PIN_SWIZZLE_CH0_DQS3=26 30 28 24 25 27 31 29;PIN_SWIZZLE_CH0_ECC=2 6 0 4 5 3 7 1;}
+set_component_sub_module_parameter_value emif_0_ddr4comp PHY_TERM_X_AC_OUTPUT_IO_STD_TYPE {SSTL}
+set_component_sub_module_parameter_value emif_0_ddr4comp PHY_TERM_X_CK_OUTPUT_IO_STD_TYPE {DF_SSTL}
+set_component_sub_module_parameter_value emif_0_ddr4comp PHY_TERM_X_CS_OUTPUT_IO_STD_TYPE {SSTL}
+set_component_sub_module_parameter_value emif_0_ddr4comp PHY_TERM_X_DQS_IO_STD_TYPE {DF_POD}
+set_component_sub_module_parameter_value emif_0_ddr4comp PHY_TERM_X_DQ_IO_STD_TYPE {POD}
+set_component_sub_module_parameter_value emif_0_ddr4comp PHY_TERM_X_DQ_SLEW_RATE {FASTEST}
+set_component_sub_module_parameter_value emif_0_ddr4comp PHY_TERM_X_DQ_VREF {68.3}
+set_component_sub_module_parameter_value emif_0_ddr4comp PHY_TERM_X_GPIO_IO_STD_TYPE {LVCMOS}
+set_component_sub_module_parameter_value emif_0_ddr4comp PHY_TERM_X_REFCLK_IO_STD_TYPE {TRUE_DIFF}
+set_component_sub_module_parameter_value emif_0_ddr4comp PHY_TERM_X_R_S_AC_OUTPUT_OHM {SERIES_34_OHM_CAL}
+set_component_sub_module_parameter_value emif_0_ddr4comp PHY_TERM_X_R_S_CK_OUTPUT_OHM {SERIES_34_OHM_CAL}
+set_component_sub_module_parameter_value emif_0_ddr4comp PHY_TERM_X_R_S_CS_OUTPUT_OHM {SERIES_34_OHM_CAL}
+set_component_sub_module_parameter_value emif_0_ddr4comp PHY_TERM_X_R_S_DQ_OUTPUT_OHM {SERIES_34_OHM_CAL}
+set_component_sub_module_parameter_value emif_0_ddr4comp PHY_TERM_X_R_T_DQ_INPUT_OHM {RT_50_OHM_CAL}
+set_component_sub_module_parameter_value emif_0_ddr4comp PHY_TERM_X_R_T_GPIO_INPUT_OHM {RT_OFF}
+set_component_sub_module_parameter_value emif_0_ddr4comp PHY_TERM_X_R_T_REFCLK_INPUT_OHM {RT_DIFF}
+set_component_sub_module_parameter_value emif_0_ddr4comp PLACEMENT_SCHEMES {DDR4_X32_3AC_BOT}
+set_component_sub_module_parameter_value emif_0_ddr4comp S0_AXID_WIDTH {7}
+set_component_sub_module_parameter_value emif_0_ddr4comp SYSINFO_BOARD {default}
+set_component_sub_module_parameter_value emif_0_ddr4comp SYSINFO_BOARD_TRAIT {}
+set_component_sub_module_parameter_value emif_0_ddr4comp SYSINFO_DEVICE {A5ED065AB32AE1V}
+set_component_sub_module_parameter_value emif_0_ddr4comp SYSINFO_DEVICE_BASE_DIE {SM7}
+set_component_sub_module_parameter_value emif_0_ddr4comp SYSINFO_DEVICE_DIE_REVISIONS {MAIN_SM7_REVA}
+set_component_sub_module_parameter_value emif_0_ddr4comp SYSINFO_DEVICE_FAMILY {Agilex 5}
+set_component_sub_module_parameter_value emif_0_ddr4comp SYSINFO_DEVICE_GROUP {B}
+set_component_sub_module_parameter_value emif_0_ddr4comp SYSINFO_DEVICE_IOBANK_REVISION {IO96B}
+set_component_sub_module_parameter_value emif_0_ddr4comp SYSINFO_DEVICE_POWER_MODEL {STANDARD_POWER_FIXED}
+set_component_sub_module_parameter_value emif_0_ddr4comp SYSINFO_DEVICE_SPEEDGRADE {6}
+set_component_sub_module_parameter_value emif_0_ddr4comp SYSINFO_DEVICE_TEMPERATURE_GRADE {EXTENDED}
+set_component_sub_module_parameter_value emif_0_ddr4comp SYSINFO_SUPPORTS_VID {0}
+set_component_sub_module_parameter_value emif_0_ddr4comp TURNAROUND_R2R_DIFFCS_CYC {0}
+set_component_sub_module_parameter_value emif_0_ddr4comp TURNAROUND_R2R_SAMECS_CYC {0}
+set_component_sub_module_parameter_value emif_0_ddr4comp TURNAROUND_R2W_DIFFCS_CYC {0}
+set_component_sub_module_parameter_value emif_0_ddr4comp TURNAROUND_R2W_SAMECS_CYC {0}
+set_component_sub_module_parameter_value emif_0_ddr4comp TURNAROUND_W2R_DIFFCS_CYC {0}
+set_component_sub_module_parameter_value emif_0_ddr4comp TURNAROUND_W2R_SAMECS_CYC {0}
+set_component_sub_module_parameter_value emif_0_ddr4comp TURNAROUND_W2W_DIFFCS_CYC {0}
+set_component_sub_module_parameter_value emif_0_ddr4comp TURNAROUND_W2W_SAMECS_CYC {0}
+save_component
+
+add_connection emif_hps.io96b0_to_hps sys_hps.io96b0_to_hps
+
+# cache coherency
+
+# add_instance sys_hps_cache_coherency altera_ace5lite_cache_coherency_translator
+# set_instance_parameter_value sys_hps_cache_coherency F2H_ADDRESS_WIDTH {32}
+
+# add_connection sys_dma_clk.clk sys_hps_cache_coherency.clock
+# add_connection sys_dma_clk.clk_reset sys_hps_cache_coherency.reset
+# add_connection sys_hps_cache_coherency.m0 sys_hps.fpga2hps
+
+# add_connection sys_dma_clk.clk sys_hps.fpga2hps_clock
+# add_connection sys_dma_clk.clk_reset sys_hps.fpga2hps_reset
+
+# jtag
+
+add_instance fpga_m altera_jtag_avalon_master
+# add_instance hps_m  altera_jtag_avalon_master
+
+# add_connection sys_clk.clk hps_m.clk
+add_connection sys_clk.clk fpga_m.clk
+# add_connection sys_clk.clk_reset hps_m.clk_reset
+add_connection sys_clk.clk_reset fpga_m.clk_reset
+
+# add_connection hps_m.master sys_hps_cache_coherency.s0
+add_connection fpga_m.master sys_hps.usb31_phy_reconfig_slave
+
+# system id
+
+add_instance axi_sysid_0 axi_sysid
+add_instance rom_sys_0 sysid_rom
+
+add_connection axi_sysid_0.if_rom_addr rom_sys_0.if_rom_addr
+add_connection rom_sys_0.if_rom_data axi_sysid_0.if_sys_rom_data
+add_connection sys_clk.clk rom_sys_0.if_clk
+add_connection sys_clk.clk axi_sysid_0.s_axi_clock
+add_connection sys_clk.clk_reset axi_sysid_0.s_axi_reset
+
+add_interface pr_rom_data_nc conduit end
+set_interface_property pr_rom_data_nc EXPORT_OF axi_sysid_0.if_pr_rom_data
+
+# cpu/hps handling
+
+proc ad_dma_interconnect {m_port {m_addr 0x00000000} {data_width 128}} {
+    # We cannot enable the f2sdram bridge if we don't use it
+    # So we instantiate it as disabled and only enable it
+    # if we are using it in the design
+    set f2sdram_data_width [get_instance_parameter_value sys_hps f2sdram_data_width]
+    if {$f2sdram_data_width == 0} {
+      set_instance_parameter_value sys_hps f2sdram_data_width $data_width
+      add_connection sys_dma_clk.clk sys_hps.f2sdram_axi_clock
+      add_connection sys_dma_clk.clk_reset sys_hps.f2sdram_axi_reset
+
+      # This adapter is needed, otherwise the bridge doesn't work...
+      add_instance f2sdram_adapter f2sdram_adapter
+      set_instance_parameter_value f2sdram_adapter {DATA_WIDTH} $data_width
+      set_instance_parameter_value f2sdram_adapter {ADDRESS_WIDTH} {32}
+
+      add_connection sys_dma_clk.clk f2sdram_adapter.clock
+      add_connection sys_dma_clk.clk_reset f2sdram_adapter.reset
+      add_connection f2sdram_adapter.axi4_man sys_hps.f2sdram
+
+      set_interface_property h2f_warm_reset EXPORT_OF sys_hps.h2f_warm_reset_handshake
+    }
+    add_connection ${m_port} f2sdram_adapter.axi4_sub
+    set_connection_parameter_value ${m_port}/f2sdram_adapter.axi4_sub baseAddress ${m_addr}
+}
+
+proc ad_cpu_interrupt {m_irq m_port} {
+
+    add_connection sys_hps.fpga2hps_interrupt_irq0 ${m_port}
+    set_connection_parameter_value sys_hps.fpga2hps_interrupt_irq0/${m_port} irqNumber ${m_irq}
+}
+
+proc ad_cpu_interconnect {m_base m_port {avl_bridge ""} {avl_bridge_base 0x00000000} {avl_address_width 18}} {
+  if {[string equal ${avl_bridge} ""]} {
+    add_connection sys_hps.lwhps2fpga ${m_port}
+    set_connection_parameter_value sys_hps.lwhps2fpga/${m_port} baseAddress ${m_base}
+  } else {
+    if {[lsearch -exact [get_instances] ${avl_bridge}] == -1} {
+      ## Instantiate the bridge and connect the interfaces
+      add_instance ${avl_bridge} altera_avalon_mm_bridge
+      set_instance_parameter_value ${avl_bridge} {ADDRESS_WIDTH} $avl_address_width
+      set_instance_parameter_value ${avl_bridge} {SYNC_RESET} {1}
+      add_connection sys_hps.lwhps2fpga ${avl_bridge}.s0
+      set_connection_parameter_value sys_hps.lwhps2fpga/${avl_bridge}.s0 baseAddress ${avl_bridge_base}
+      add_connection sys_clk.clk ${avl_bridge}.clk
+      add_connection sys_clk.clk_reset ${avl_bridge}.reset
+    }
+    add_connection ${avl_bridge}.m0 ${m_port}
+    set_connection_parameter_value ${avl_bridge}.m0/${m_port} baseAddress ${m_base}
+  }
+}
+
+# gpio-bd
+
+add_instance sys_gpio_bd altera_avalon_pio
+set_instance_parameter_value sys_gpio_bd {direction} {InOut}
+set_instance_parameter_value sys_gpio_bd {generateIRQ} {1}
+set_instance_parameter_value sys_gpio_bd {width} {32}
+
+add_connection sys_clk.clk sys_gpio_bd.clk
+add_connection sys_clk.clk_reset sys_gpio_bd.reset
+add_interface sys_gpio_bd conduit end
+set_interface_property sys_gpio_bd EXPORT_OF sys_gpio_bd.external_connection
+
+# gpio-in
+
+add_instance sys_gpio_in altera_avalon_pio
+set_instance_parameter_value sys_gpio_in {direction} {Input}
+set_instance_parameter_value sys_gpio_in {generateIRQ} {1}
+set_instance_parameter_value sys_gpio_in {width} {32}
+
+add_connection sys_clk.clk_reset sys_gpio_in.reset
+add_connection sys_clk.clk sys_gpio_in.clk
+add_interface sys_gpio_in conduit end
+set_interface_property sys_gpio_in EXPORT_OF sys_gpio_in.external_connection
+
+# gpio-out
+
+add_instance sys_gpio_out altera_avalon_pio
+set_instance_parameter_value sys_gpio_out {direction} {Output}
+set_instance_parameter_value sys_gpio_out {generateIRQ} {0}
+set_instance_parameter_value sys_gpio_out {width} {32}
+
+add_connection sys_clk.clk_reset sys_gpio_out.reset
+add_connection sys_clk.clk sys_gpio_out.clk
+add_interface sys_gpio_out conduit end
+set_interface_property sys_gpio_out EXPORT_OF sys_gpio_out.external_connection
+
+# spi
+
+add_instance sys_spi altera_avalon_spi
+set_instance_parameter_value sys_spi {clockPhase} {0}
+set_instance_parameter_value sys_spi {clockPolarity} {0}
+set_instance_parameter_value sys_spi {dataWidth} {8}
+set_instance_parameter_value sys_spi {masterSPI} {1}
+set_instance_parameter_value sys_spi {numberOfSlaves} {8}
+set_instance_parameter_value sys_spi {targetClockRate} {10000000.0}
+
+add_connection sys_clk.clk_reset sys_spi.reset
+add_connection sys_clk.clk sys_spi.clk
+add_interface sys_spi conduit end
+set_interface_property sys_spi EXPORT_OF sys_spi.external
+
+## connections
+
+# exports
+
+set_interface_property o_pma_cu_clk EXPORT_OF gts_reset.o_pma_cu_clk
+
+set_interface_property f2h_irq1_in EXPORT_OF sys_hps.fpga2hps_interrupt_irq1
+set_interface_property usb31_io EXPORT_OF sys_hps.usb31_io
+set_interface_property usb31_phy_refclk_p EXPORT_OF sys_hps.usb31_phy_refclk_p
+set_interface_property usb31_phy_refclk_n EXPORT_OF sys_hps.usb31_phy_refclk_n
+set_interface_property usb31_phy_rx_serial_n EXPORT_OF sys_hps.usb31_phy_rx_serial_n
+set_interface_property usb31_phy_rx_serial_p EXPORT_OF sys_hps.usb31_phy_rx_serial_p
+set_interface_property usb31_phy_tx_serial_n EXPORT_OF sys_hps.usb31_phy_tx_serial_n
+set_interface_property usb31_phy_tx_serial_p EXPORT_OF sys_hps.usb31_phy_tx_serial_p
+set_interface_property usb31_phy_pma_cpu_clk EXPORT_OF sys_hps.usb31_phy_pma_cpu_clk
+
+set_interface_property hps_emif_mem_0 EXPORT_OF emif_hps.mem_0
+set_interface_property hps_emif_mem_ck_0 EXPORT_OF emif_hps.mem_ck_0
+set_interface_property hps_emif_mem_reset_n EXPORT_OF emif_hps.mem_reset_n
+set_interface_property hps_emif_oct_0 EXPORT_OF emif_hps.oct_0
+set_interface_property hps_emif_ref_clk_0 EXPORT_OF emif_hps.ref_clk
+
+# cpu interconnect
+
+ad_cpu_interconnect 0x000000d0 sys_gpio_bd.s1 "avl_peripheral_mm_bridge"
+ad_cpu_interconnect 0x00000000 sys_gpio_in.s1 "avl_peripheral_mm_bridge"
+ad_cpu_interconnect 0x00000020 sys_gpio_out.s1 "avl_peripheral_mm_bridge"
+ad_cpu_interconnect 0x00000040 sys_spi.spi_control_port "avl_peripheral_mm_bridge"
+ad_cpu_interconnect 0x00018000 axi_sysid_0.s_axi "avl_peripheral_mm_bridge"
+
+# interrupts
+
+ad_cpu_interrupt 5 sys_gpio_in.irq
+ad_cpu_interrupt 6 sys_gpio_bd.irq
+ad_cpu_interrupt 7 sys_spi.irq
+
+set xcvr_reconfig_addr_width 11

--- a/projects/common/a5e/system_constr.sdc
+++ b/projects/common/a5e/system_constr.sdc
@@ -1,0 +1,24 @@
+###############################################################################
+## Copyright (C) 2025 Analog Devices, Inc. All rights reserved.
+### SPDX short identifier: ADIBSD
+###############################################################################
+
+create_clock -period "10.000 ns"  -name sys_clk_100mhz      [get_ports {sys_clk}]
+create_clock -period "10.000 ns"  -name emif_ref_clk        [get_ports {emif_hps_ref_clk}]
+
+derive_clock_uncertainty
+
+# Set multicycle path for warm_reset_handshake signal
+set_multicycle_path 2 -setup \
+    -from [get_registers {*|u_agilex_hps|intel_agilex_5_soc_inst|sm_hps|sundancemesa_hps_inst~intosc_clk.reg}] \
+    -to [get_registers {*|u_agilex_hps|intel_agilex_5_soc_inst|sm_hps|sundancemesa_hps_inst~intosc_clk.reg}]
+set_multicycle_path 1 -hold \
+    -from [get_registers {*|u_agilex_hps|intel_agilex_5_soc_inst|sm_hps|sundancemesa_hps_inst~intosc_clk.reg}] \
+    -to [get_registers {*|u_agilex_hps|intel_agilex_5_soc_inst|sm_hps|sundancemesa_hps_inst~intosc_clk.reg}]
+
+set_clock_groups -asynchronous \
+    -group [get_clocks {hps_internal_osc}] \
+    -group [get_clocks {sys_clk_100mhz}]
+
+set_false_path \
+    -from [get_registers *altera_reset_synchronizer:alt_rst_sync_uq1|altera_reset_synchronizer_int_chain_out*]

--- a/projects/common/a5e/system_project.tcl
+++ b/projects/common/a5e/system_project.tcl
@@ -1,0 +1,13 @@
+###############################################################################
+## Copyright (C) 2025 Analog Devices, Inc. All rights reserved.
+### SPDX short identifier: ADIBSD
+###############################################################################
+
+source ../../../scripts/adi_env.tcl
+source ../../scripts/adi_project_intel.tcl
+
+adi_project template_a5e
+
+source $ad_hdl_dir/projects/common/a5e/a5e_system_assign.tcl
+
+execute_flow -compile

--- a/projects/common/a5e/system_qsys.tcl
+++ b/projects/common/a5e/system_qsys.tcl
@@ -1,0 +1,15 @@
+###############################################################################
+## Copyright (C) 2025 Analog Devices, Inc. All rights reserved.
+### SPDX short identifier: ADIBSD
+###############################################################################
+
+source $ad_hdl_dir/projects/scripts/adi_pd.tcl
+source $ad_hdl_dir/projects/common/a5e/a5e_system_qsys.tcl
+
+#system ID
+set_instance_parameter_value axi_sysid_0 {ROM_ADDR_BITS} {9}
+set_instance_parameter_value rom_sys_0 {ROM_ADDR_BITS} {9}
+
+set_instance_parameter_value rom_sys_0 {PATH_TO_FILE} "[pwd]/mem_init_sys.txt"
+
+sysid_gen_sys_init_file;

--- a/projects/common/a5e/system_top.v
+++ b/projects/common/a5e/system_top.v
@@ -1,0 +1,258 @@
+// ***************************************************************************
+// ***************************************************************************
+// Copyright (C) 2025-2026 Analog Devices, Inc. All rights reserved.
+//
+// In this HDL repository, there are many different and unique modules, consisting
+// of various HDL (Verilog or VHDL) components. The individual modules are
+// developed independently, and may be accompanied by separate and unique license
+// terms.
+//
+// The user should read each of these license terms, and understand the
+// freedoms and responsibilities that he or she has by using this source/core.
+//
+// This core is distributed in the hope that it will be useful, but WITHOUT ANY
+// WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+// A PARTICULAR PURPOSE.
+//
+// Redistribution and use of source or resulting binaries, with or without modification
+// of this file, are permitted under one of the following two license terms:
+//
+//   1. The GNU General Public License version 2 as published by the
+//      Free Software Foundation, which can be found in the top level directory
+//      of this repository (LICENSE_GPL2), and also online at:
+//      <https://www.gnu.org/licenses/old-licenses/gpl-2.0.html>
+//
+// OR
+//
+//   2. An ADI specific BSD license, which can be found in the top level directory
+//      of this repository (LICENSE_ADIBSD), and also on-line at:
+//      https://github.com/analogdevicesinc/hdl/blob/main/LICENSE_ADIBSD
+//      This will allow to generate bit files and not release the source code,
+//      as long as it attaches to an ADI device.
+//
+// ***************************************************************************
+// ***************************************************************************
+
+`timescale 1ns/100ps
+
+module system_top (
+
+  // clock and resets
+  input            sys_clk,
+  input            hps_osc_clk,
+  input            sys_resetn,
+
+  // board gpio
+  output  [3:0]    fpga_led,
+  input   [3:0]    fpga_dipsw,
+  input   [3:0]    fpga_btn,
+
+  // hps-emif
+  input            emif_hps_ref_clk,
+  output           emif_hps_mem_ck_t,
+  output           emif_hps_mem_ck_c,
+  output [ 16:0]   emif_hps_mem_a,
+  output           emif_hps_mem_act_n,
+  output [  1:0]   emif_hps_mem_ba,
+  output [  1:0]   emif_hps_mem_bg,
+  output           emif_hps_mem_cke,
+  output           emif_hps_mem_cs_n,
+  output           emif_hps_mem_odt,
+  output           emif_hps_mem_reset_n,
+  output           emif_hps_mem_par,
+  input            emif_hps_mem_alert_n,
+  input            emif_hps_oct_rzqin,
+  inout  [  4:0]   emif_hps_mem_dqs_t,
+  inout  [  4:0]   emif_hps_mem_dqs_c,
+  inout  [ 39:0]   emif_hps_mem_dq,
+  inout  [  4:0]   emif_hps_mem_dbi_n,
+
+  // hps-sdmmc
+  output           hps_sdmmc_clk,
+  inout            hps_sdmmc_cmd,
+  inout   [ 3:0]   hps_sdmmc_d,
+
+  // hps-emac
+  input            hps_emac_rxclk,
+  input            hps_emac_rxctl,
+  input   [ 3:0]   hps_emac_rxd,
+  output           hps_emac_txclk,
+  output           hps_emac_txctl,
+  output  [ 3:0]   hps_emac_txd,
+  output           hps_emac_pps,
+  input            hps_emac_pps_trig,
+  output           hps_emac_mdc,
+  inout            hps_emac_mdio,
+
+  // usb31
+  input            usb31_io_vbus_det,
+  input            usb31_io_flt_bar,
+  output           usb31_io_usb_ctrl,
+  input            usb31_io_usb31_id,
+  input            usb31_phy_refclk_p,
+  input            usb31_phy_rx_serial_n,
+  input            usb31_phy_rx_serial_p,
+  output           usb31_phy_tx_serial_n,
+  output           usb31_phy_tx_serial_p,
+
+  // hps-usb
+  input            hps_usb_clk,
+  input            hps_usb_dir,
+  input            hps_usb_nxt,
+  output           hps_usb_stp,
+  inout   [ 7:0]   hps_usb_d,
+
+  // hps-uart
+  input            hps_uart_rx,
+  output           hps_uart_tx,
+
+  // hps-i2c
+  inout            hps_i2c_sda,
+  inout            hps_i2c_scl,
+
+  // hps-jtag
+  input            hps_jtag_tck,
+  input            hps_jtag_tms,
+  output           hps_jtag_tdo,
+  input            hps_jtag_tdi,
+
+  // hps-gpio
+  inout            hps_gpio0_io0,
+  inout            hps_gpio0_io1,
+  inout            hps_gpio0_io11,
+  inout            hps_gpio1_io3,
+  inout            hps_gpio1_io4
+);
+
+  // internal signals
+  wire  [63:0]  gpio_i;
+  wire  [63:0]  gpio_o;
+  wire          ninit_done;
+  wire          sys_reset_n;
+  wire          h2f_reset;
+  wire [ 1:0]   usb31_io_usb_ctrl_s;
+  wire          pma_cu_clk;
+
+  // Board GPIOs
+  assign fpga_led      = gpio_o[3:0];
+  assign gpio_i[ 3: 0] = gpio_o[3:0];
+  assign gpio_i[ 7: 4] = fpga_dipsw;
+  assign gpio_i[11: 8] = fpga_btn;
+
+  // Unused GPIOs
+  assign gpio_i[31:12] = gpio_o[31:12];
+  assign gpio_i[63:32] = gpio_o[63:32];
+
+  assign sys_reset_n   = sys_resetn & ~h2f_reset & ~ninit_done;
+
+  assign usb31_io_usb_ctrl = usb31_io_usb_ctrl_s[1];
+
+  system_bd i_system_bd (
+    .sys_clk_clk                                             (sys_clk),
+    .sys_hps_io_hps_osc_clk                                  (hps_osc_clk),
+
+    .sys_rst_reset_n                                         (sys_reset_n),
+    .rst_ninit_done                                          (ninit_done),
+    .h2f_reset_reset                                         (h2f_reset),
+
+    .f2h_irq1_in_irq                                         ('h0),
+    .pr_rom_data_nc_rom_data                                 ('h0),
+    .o_pma_cu_clk_clk                                        (pma_cu_clk),
+
+    .hps_emif_mem_0_mem_cke                                  (emif_hps_mem_cke),
+    .hps_emif_mem_0_mem_odt                                  (emif_hps_mem_odt),
+    .hps_emif_mem_0_mem_cs_n                                 (emif_hps_mem_cs_n),
+    .hps_emif_mem_0_mem_a                                    (emif_hps_mem_a),
+    .hps_emif_mem_0_mem_ba                                   (emif_hps_mem_ba),
+    .hps_emif_mem_0_mem_bg                                   (emif_hps_mem_bg),
+    .hps_emif_mem_0_mem_act_n                                (emif_hps_mem_act_n),
+    .hps_emif_mem_0_mem_par                                  (emif_hps_mem_par),
+    .hps_emif_mem_0_mem_dq                                   (emif_hps_mem_dq),
+    .hps_emif_mem_0_mem_dqs_t                                (emif_hps_mem_dqs_t),
+    .hps_emif_mem_0_mem_dqs_c                                (emif_hps_mem_dqs_c),
+    .hps_emif_mem_0_mem_alert_n                              (emif_hps_mem_alert_n),
+    .hps_emif_mem_ck_0_mem_ck_t                              (emif_hps_mem_ck_t),
+    .hps_emif_mem_ck_0_mem_ck_c                              (emif_hps_mem_ck_c),
+    .hps_emif_mem_reset_n_mem_reset_n                        (emif_hps_mem_reset_n),
+    .hps_emif_oct_0_oct_rzqin                                (emif_hps_oct_rzqin),
+    .hps_emif_ref_clk_0_clk                                  (emif_hps_ref_clk),
+    .hps_emif_mem_0_mem_dbi_n                                (emif_hps_mem_dbi_n),
+
+    .sys_hps_io_sdmmc_data0                                  (hps_sdmmc_d[0]),
+    .sys_hps_io_sdmmc_data1                                  (hps_sdmmc_d[1]),
+    .sys_hps_io_sdmmc_data2                                  (hps_sdmmc_d[2]),
+    .sys_hps_io_sdmmc_data3                                  (hps_sdmmc_d[3]),
+    .sys_hps_io_sdmmc_cclk                                   (hps_sdmmc_clk),
+    .sys_hps_io_sdmmc_cmd                                    (hps_sdmmc_cmd),
+
+    .sys_hps_io_usb1_clk                                     (hps_usb_clk),
+    .sys_hps_io_usb1_stp                                     (hps_usb_stp),
+    .sys_hps_io_usb1_dir                                     (hps_usb_dir),
+    .sys_hps_io_usb1_nxt                                     (hps_usb_nxt),
+    .sys_hps_io_usb1_data0                                   (hps_usb_d[0]),
+    .sys_hps_io_usb1_data1                                   (hps_usb_d[1]),
+    .sys_hps_io_usb1_data2                                   (hps_usb_d[2]),
+    .sys_hps_io_usb1_data3                                   (hps_usb_d[3]),
+    .sys_hps_io_usb1_data4                                   (hps_usb_d[4]),
+    .sys_hps_io_usb1_data5                                   (hps_usb_d[5]),
+    .sys_hps_io_usb1_data6                                   (hps_usb_d[6]),
+    .sys_hps_io_usb1_data7                                   (hps_usb_d[7]),
+
+    .sys_hps_io_emac2_tx_clk                                 (hps_emac_txclk),
+    .sys_hps_io_emac2_tx_ctl                                 (hps_emac_txctl),
+    .sys_hps_io_emac2_rx_clk                                 (hps_emac_rxclk),
+    .sys_hps_io_emac2_rx_ctl                                 (hps_emac_rxctl),
+    .sys_hps_io_emac2_txd0                                   (hps_emac_txd[0]),
+    .sys_hps_io_emac2_txd1                                   (hps_emac_txd[1]),
+    .sys_hps_io_emac2_txd2                                   (hps_emac_txd[2]),
+    .sys_hps_io_emac2_txd3                                   (hps_emac_txd[3]),
+    .sys_hps_io_emac2_rxd0                                   (hps_emac_rxd[0]),
+    .sys_hps_io_emac2_rxd1                                   (hps_emac_rxd[1]),
+    .sys_hps_io_emac2_rxd2                                   (hps_emac_rxd[2]),
+    .sys_hps_io_emac2_rxd3                                   (hps_emac_rxd[3]),
+    .sys_hps_io_emac2_pps                                    (hps_emac_pps),
+    .sys_hps_io_emac2_pps_trig                               (hps_emac_pps_trig),
+
+    .sys_hps_io_mdio2_mdio                                   (hps_emac_mdio),
+    .sys_hps_io_mdio2_mdc                                    (hps_emac_mdc),
+
+    .sys_hps_io_uart0_tx                                     (hps_uart_tx),
+    .sys_hps_io_uart0_rx                                     (hps_uart_rx),
+
+    .sys_hps_io_i3c1_sda                                     (hps_i2c_sda),
+    .sys_hps_io_i3c1_scl                                     (hps_i2c_scl),
+
+    .sys_hps_io_jtag_tck                                     (hps_jtag_tck),
+    .sys_hps_io_jtag_tms                                     (hps_jtag_tms),
+    .sys_hps_io_jtag_tdo                                     (hps_jtag_tdo),
+    .sys_hps_io_jtag_tdi                                     (hps_jtag_tdi),
+
+    .usb31_io_vbus_det                                       (usb31_io_vbus_det),
+    .usb31_io_flt_bar                                        (usb31_io_flt_bar),
+    .usb31_io_usb_ctrl                                       (usb31_io_usb_ctrl_s),
+    .usb31_io_usb31_id                                       (usb31_io_usb31_id),
+
+    .usb31_phy_pma_cpu_clk_clk                               (pma_cu_clk),
+    .usb31_phy_refclk_p_clk                                  (usb31_phy_refclk_p),
+    .usb31_phy_rx_serial_n_i_rx_serial_n                     (usb31_phy_rx_serial_n),
+    .usb31_phy_rx_serial_p_i_rx_serial_p                     (usb31_phy_rx_serial_p),
+    .usb31_phy_tx_serial_n_o_tx_serial_n                     (usb31_phy_tx_serial_n),
+    .usb31_phy_tx_serial_p_o_tx_serial_p                     (usb31_phy_tx_serial_p),
+
+    .sys_hps_io_gpio0                                        (hps_gpio0_io0),
+    .sys_hps_io_gpio1                                        (hps_gpio0_io1),
+    .sys_hps_io_gpio11                                       (hps_gpio0_io11),
+    .sys_hps_io_gpio27                                       (hps_gpio1_io3),
+    .sys_hps_io_gpio28                                       (hps_gpio1_io4),
+
+    .sys_gpio_bd_in_port                                     (gpio_i[31:0]),
+    .sys_gpio_bd_out_port                                    (gpio_o[31:0]),
+    .sys_gpio_in_export                                      (gpio_i[63:32]),
+    .sys_gpio_out_export                                     (gpio_o[63:32]),
+
+    .sys_spi_MISO                                            (1'b0),
+    .sys_spi_MOSI                                            (),
+    .sys_spi_SCLK                                            (),
+    .sys_spi_SS_n                                            ());
+
+endmodule

--- a/projects/common/intel/adcfifo_qsys.tcl
+++ b/projects/common/intel/adcfifo_qsys.tcl
@@ -3,7 +3,7 @@
 ### SPDX short identifier: ADIBSD
 ###############################################################################
 
-proc ad_adcfifo_create {adc_fifo_name adc_data_width dma_data_width adc_fifo_address_width} {
+proc ad_adcfifo_create {adc_fifo_name adc_data_width dma_data_width adc_fifo_address_width {fpga_technology 1}} {
 
   if {$adc_data_width != $dma_data_width} {
     return -code error [format "ERROR: util_adcfifo adc/dma widths must be the same!"]
@@ -13,6 +13,6 @@ proc ad_adcfifo_create {adc_fifo_name adc_data_width dma_data_width adc_fifo_add
   set_instance_parameter_value $adc_fifo_name {DMA_ADDRESS_WIDTH} $adc_fifo_address_width
   set_instance_parameter_value $adc_fifo_name {ADC_DATA_WIDTH} $adc_data_width
   set_instance_parameter_value $adc_fifo_name {DMA_DATA_WIDTH} $dma_data_width
-
+  set_instance_parameter_value $adc_fifo_name {FPGA_TECHNOLOGY} $fpga_technology
 }
 

--- a/projects/scripts/adi_project_intel.tcl
+++ b/projects/scripts/adi_project_intel.tcl
@@ -74,6 +74,12 @@ proc adi_project {project_name {parameter_list {}}} {
     set system_qip_file ${ad_project_dir}/system_bd/synthesis/system_bd.qip
   }
 
+  if [regexp "_a5e" $project_name] {
+    set family "Agilex 5"
+    set device A5ED065BB32AE6SR0
+    set system_qip_file ${ad_project_dir}/system_bd/synthesis/system_bd.qip
+  }
+
   # version check
 
   set m_version [lindex $quartus(version) 1]


### PR DESCRIPTION
## PR Description

This PR adds support for the GTS transceivers found inside the Agilex 5 devkits inside the JESD204 framework.

With that support, there is an ad9081 example project configured for jesd204b with dual link support on the Rx side and one Tx link.

## PR Type
- [ ] Bug fix (change that fixes an issue)
- [x] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)
- [ ] Documentation

## PR Checklist
- [x] I have followed the code style guidelines
- [x] I have performed a self-review of changes
- [ ] I have compiled all hdl projects and libraries affected by this PR
- [x] I have tested in hardware affected projects, at least on relevant boards
- [x] I have commented my code, at least hard-to-understand parts
- [ ] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe files, Copyright etc)
- [ ] I have not introduced new Warnings/Critical Warnings on compilation
- [ ] I have added new hdl testbenches or updated existing ones
