### PR TITLE
projects: cn0506: zcu102: update PSU config for rmii version

### DIFF
--- a/projects/cn0506/zcu102/system_bd.tcl
+++ b/projects/cn0506/zcu102/system_bd.tcl
@@ -87,9 +87,7 @@ switch $INTF_CFG {
       CONFIG.PSU__ENET1__GRP_MDIO__ENABLE {1} \
       CONFIG.PSU__ENET1__GRP_MDIO__IO {EMIO} \
       CONFIG.PSU__ENET1__PERIPHERAL__ENABLE {1} \
-      CONFIG.PSU__ENET1__PERIPHERAL__IO {EMIO} \
-      CONFIG.PSU__PCIE__PERIPHERAL__ENABLE {0} \
-      CONFIG.PSU__SATA__PERIPHERAL__ENABLE {0}] [get_bd_cells sys_ps8]
+      CONFIG.PSU__ENET1__PERIPHERAL__IO {EMIO}] [get_bd_cells sys_ps8]
 
     create_bd_port -dir O reset_a
     create_bd_port -dir O reset_b


### PR DESCRIPTION
The PSU config for the cn0506-rmii version currently disables the PCIe and SATA peripherals which causes an error when the drivers try to initalize those nodes. Updated the .tcl script to be in line with the MII and RGMII versions.

## PR Description

The RMII version of the ZCU102+CN0506 currently throws dmesg error on boot because the SATA and PCIe peripherals are disabled in the PSU config. Updated the tcl script to be in line with the RGMII and MII versions, which do not disable anything and boot with no errors

## PR Type
- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)
- [ ] Documentation

## PR Checklist
- [x] I have followed the code style guidelines
- [x] I have performed a self-review of changes
- [x] I have compiled all hdl projects and libraries affected by this PR
- [x] I have tested in hardware affected projects, at least on relevant boards
- [ ] I have commented my code, at least hard-to-understand parts
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe files, Copyright etc)
- [x] I have not introduced new Warnings/Critical Warnings on compilation
- [ ] I have added new hdl testbenches or updated existing ones
