### PR TITLE
library/util_hbm: Added missing dependency

### DIFF
--- a/library/util_hbm/Makefile
+++ b/library/util_hbm/Makefile
@@ -16,6 +16,8 @@ XILINX_DEPS += util_hbm_ooc.ttcl
 XILINX_DEPS += ../interfaces/if_do_ctrl.xml
 XILINX_DEPS += ../interfaces/if_do_ctrl_rtl.xml
 
+XILINX_LIB_DEPS += axi_dmac
+
 XILINX_INTERFACE_DEPS += interfaces
 
 include ../scripts/library.mk


### PR DESCRIPTION
## PR Description

The HBM core requires that the AXI_DMAC IP core is built. If the DMA is not used inside a project, then the HBM will throw an error, since the DMA is not built. The issue only manifests when someone is instantiating the IP while the DMA IP is not built, as this throws an error message.
Note: The IP is built regardless of the build status of the DMA and passes without issues. This behavior was observed in the data_offload_2 testbench in [this PR](https://github.com/analogdevicesinc/testbenches/pull/289).


## PR Type
- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)
- [ ] Documentation

## PR Checklist
- [x] I have followed the code style guidelines
- [x] I have performed a self-review of changes
- [ ] I have compiled all hdl projects and libraries affected by this PR
- [ ] I have tested in hardware affected projects, at least on relevant boards
- [ ] I have commented my code, at least hard-to-understand parts
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe files, Copyright etc)
- [x] I have not introduced new Warnings/Critical Warnings on compilation
- [x] I have added new hdl testbenches or updated existing ones
