### PR TITLE
daq2/a10soc: Replace adc/dacfifo with data_offload

### DIFF
--- a/docs/projects/daq2/index.rst
+++ b/docs/projects/daq2/index.rst
@@ -240,6 +240,8 @@ avl_adxcfg_2.rcfg_s1              0x0004_A000
 avl_adxcfg_3.rcfg_s1              0x0004_B000
 axi_ad9680_dma.s_axi              0x0004_C000
 axi_ad9680.s_axi                  0x0005_0000
+ad9144_data_offload.s_axi         0x0006_0000
+ad9680_data_offload.s_axi         0x0007_0000
 ================================= ===========
 
 SPI connections

--- a/projects/daq2/a10soc/Makefile
+++ b/projects/daq2/a10soc/Makefile
@@ -1,5 +1,5 @@
 ####################################################################################
-## Copyright (c) 2018 - 2023 Analog Devices, Inc.
+## Copyright (c) 2018 - 2026 Analog Devices, Inc.
 ### SPDX short identifier: BSD-1-Clause
 ## Auto-generated, do not modify!
 ####################################################################################
@@ -11,16 +11,16 @@ M_DEPS += ../../scripts/adi_pd.tcl
 M_DEPS += ../../daq2/common/daq2_spi.v
 M_DEPS += ../../common/a10soc/a10soc_system_qsys.tcl
 M_DEPS += ../../common/a10soc/a10soc_system_assign.tcl
-M_DEPS += ../../common/a10soc/a10soc_plddr4_dacfifo_qsys.tcl
+M_DEPS += ../../common/a10soc/a10soc_plddr4_data_offload_qsys.tcl
 M_DEPS += ../../common/a10soc/a10soc_plddr4_assign.tcl
 
 LIB_DEPS += axi_dmac
 LIB_DEPS += axi_sysid
+LIB_DEPS += intel/adi_data_offload
 LIB_DEPS += intel/adi_jesd204
 LIB_DEPS += jesd204/ad_ip_jesd204_tpl_adc
 LIB_DEPS += jesd204/ad_ip_jesd204_tpl_dac
 LIB_DEPS += sysid_rom
-LIB_DEPS += util_adcfifo
 LIB_DEPS += util_pack/util_cpack2
 LIB_DEPS += util_pack/util_upack2
 

--- a/projects/daq2/a10soc/system_qsys.tcl
+++ b/projects/daq2/a10soc/system_qsys.tcl
@@ -1,13 +1,18 @@
 ###############################################################################
-## Copyright (C) 2016-2023 Analog Devices, Inc. All rights reserved.
+## Copyright (C) 2016-2023, 2026 Analog Devices, Inc. All rights reserved.
 ### SPDX short identifier: ADIBSD
 ###############################################################################
 
-set dac_fifo_address_width 10
+set dac_data_offload_type 1                      ; ## PL_DDR
+set dac_data_offload_size [expr 1024*1024*1024]  ; ## 1 GB
+set dac_axi_data_width 512
+
+set adc_data_offload_type 0                      ; ## BRAM
+set adc_data_offload_size [expr 1024*1024]       ; ## 1 MB
 
 source $ad_hdl_dir/projects/scripts/adi_pd.tcl
 source $ad_hdl_dir/projects/common/a10soc/a10soc_system_qsys.tcl
-source $ad_hdl_dir/projects/common/a10soc/a10soc_plddr4_dacfifo_qsys.tcl
+source $ad_hdl_dir/projects/common/a10soc/a10soc_plddr4_data_offload_qsys.tcl
 
 if [info exists ad_project_dir] {
   source ../../common/daq2_qsys.tcl
@@ -15,11 +20,16 @@ if [info exists ad_project_dir] {
   source ../common/daq2_qsys.tcl
 }
 
+ad_data_offload_create $dac_data_offload_name
+
 #system ID
 set_instance_parameter_value axi_sysid_0 {ROM_ADDR_BITS} {9}
 set_instance_parameter_value rom_sys_0 {PATH_TO_FILE} "$mem_init_sys_file_path/mem_init_sys.txt"
 set_instance_parameter_value rom_sys_0 {ROM_ADDR_BITS} {9}
 
-set sys_cstring "DAC_FIFO_ADDR_WIDTH=$dac_fifo_address_width"
+set sys_cstring "ADC_OFFLOAD:TYPE=$adc_data_offload_type\
+SIZE=$adc_data_offload_size\
+DAC_OFFLOAD:TYPE=$dac_data_offload_type\
+SIZE=$dac_data_offload_size"
 
 sysid_gen_sys_init_file $sys_cstring

--- a/projects/daq2/a10soc/system_top.v
+++ b/projects/daq2/a10soc/system_top.v
@@ -1,6 +1,6 @@
 // ***************************************************************************
 // ***************************************************************************
-// Copyright (C) 2017-2023 Analog Devices, Inc. All rights reserved.
+// Copyright (C) 2017-2023, 2026 Analog Devices, Inc. All rights reserved.
 //
 // In this HDL repository, there are many different and unique modules, consisting
 // of various HDL (Verilog or VHDL) components. The individual modules are
@@ -163,8 +163,6 @@ module system_top (
 
   // internal signals
 
-  wire              sys_ddr_cal_success;
-  wire              sys_ddr_cal_fail;
   wire              sys_hps_resetn;
   wire              sys_resetn_s;
   wire    [ 63:0]   gpio_i;
@@ -172,7 +170,6 @@ module system_top (
   wire              spi_miso_s;
   wire              spi_mosi_s;
   wire    [  7:0]   spi_csn_s;
-  wire              dac_fifo_bypass;
 
   // assignments
 
@@ -191,7 +188,6 @@ module system_top (
   // gpio in & out are separate cores
 
   assign gpio_i[63:45] = gpio_o[63:45];
-  assign dac_fifo_bypass = gpio_o[44];
   assign gpio_i[44:44] = gpio_o[44:44];
   assign gpio_i[43:43] = trig;
 
@@ -245,8 +241,6 @@ module system_top (
     .sys_ddr_mem_mem_dbi_n (sys_ddr_dbi_n),
     .sys_ddr_oct_oct_rzqin (sys_ddr_rzq),
     .sys_ddr_ref_clk_clk (sys_ddr_ref_clk),
-    .sys_ddr_status_local_cal_success (sys_ddr_cal_success),
-    .sys_ddr_status_local_cal_fail (sys_ddr_cal_fail),
     .sys_gpio_bd_in_port (gpio_i[31:0]),
     .sys_gpio_bd_out_port (gpio_o[31:0]),
     .sys_gpio_in_export (gpio_i[63:32]),
@@ -323,7 +317,6 @@ module system_top (
     .sys_spi_SCLK (spi_clk),
     .sys_spi_SS_n (spi_csn_s),
     .tx_serial_data_tx_serial_data (tx_serial_data),
-    .tx_fifo_bypass_bypass (dac_fifo_bypass),
     .tx_ref_clk_clk (tx_ref_clk),
     .tx_sync_export (tx_sync),
     .tx_sysref_export (tx_sysref),

--- a/projects/daq2/common/daq2_qsys.tcl
+++ b/projects/daq2/common/daq2_qsys.tcl
@@ -1,5 +1,5 @@
 ###############################################################################
-## Copyright (C) 2016-2023 Analog Devices, Inc. All rights reserved.
+## Copyright (C) 2016-2023, 2026 Analog Devices, Inc. All rights reserved.
 ### SPDX short identifier: ADIBSD
 ###############################################################################
 
@@ -12,6 +12,7 @@ set RX_SAMPLE_WIDTH 16          ; # N/NP
 
 set RX_SAMPLES_PER_CHANNEL [expr $RX_NUM_OF_LANES * 32 / ($RX_NUM_OF_CONVERTERS * $RX_SAMPLE_WIDTH)]
 
+set adc_data_offload_name ad9680_data_offload
 set adc_data_width [expr $RX_SAMPLE_WIDTH * $RX_NUM_OF_CONVERTERS * $RX_SAMPLES_PER_CHANNEL]
 
 set TX_NUM_OF_LANES 4           ; # L
@@ -21,7 +22,7 @@ set TX_SAMPLE_WIDTH 16          ; # N/NP
 
 set TX_SAMPLES_PER_CHANNEL [expr $TX_NUM_OF_LANES * 32 / ($TX_NUM_OF_CONVERTERS * $TX_SAMPLE_WIDTH)]
 
-set dac_fifo_name avl_ad9144_fifo
+set dac_data_offload_name ad9144_data_offload
 set dac_data_width [expr $TX_SAMPLE_WIDTH * $TX_NUM_OF_CONVERTERS * $TX_SAMPLES_PER_CHANNEL]
 
 # ad9144-xcvr
@@ -66,25 +67,29 @@ add_instance util_ad9144_upack util_upack2
 set_instance_parameter_value util_ad9144_upack {NUM_OF_CHANNELS} $TX_NUM_OF_CONVERTERS
 set_instance_parameter_value util_ad9144_upack {SAMPLES_PER_CHANNEL} $TX_SAMPLES_PER_CHANNEL
 set_instance_parameter_value util_ad9144_upack {SAMPLE_DATA_WIDTH} $TX_SAMPLE_WIDTH
-set_instance_parameter_value util_ad9144_upack {INTERFACE_TYPE} {1}
+set_instance_parameter_value util_ad9144_upack {INTERFACE_TYPE} {0}
 
 add_connection ad9144_jesd204.link_clk util_ad9144_upack.clk
 add_connection ad9144_jesd204.link_reset util_ad9144_upack.reset
 add_connection axi_ad9144.dac_ch_0 util_ad9144_upack.dac_ch_0
 add_connection axi_ad9144.dac_ch_1 util_ad9144_upack.dac_ch_1
+add_connection axi_ad9144.if_dac_dunf util_ad9144_upack.if_fifo_rd_underflow
 
-# dac fifo
+# ad9144-data offload
 
-ad_dacfifo_create $dac_fifo_name $dac_data_width $dac_data_width $dac_fifo_address_width
+add_instance $dac_data_offload_name adi_data_offload
+set_instance_parameter_value $dac_data_offload_name {DATAPATH_TYPE} {1}
+set_instance_parameter_value $dac_data_offload_name {MEM_TYPE} $dac_data_offload_type
+set_instance_parameter_value $dac_data_offload_name {MEM_SIZE} $dac_data_offload_size
+set_instance_parameter_value $dac_data_offload_name {SOURCE_DWIDTH} $dac_data_width
+set_instance_parameter_value $dac_data_offload_name {DESTINATION_DWIDTH} $dac_data_width
+set_instance_parameter_value $dac_data_offload_name {AXI_DATA_WIDTH} $dac_axi_data_width
 
-add_interface tx_fifo_bypass conduit end
-set_interface_property tx_fifo_bypass EXPORT_OF avl_ad9144_fifo.if_bypass
-
-add_connection ad9144_jesd204.link_clk avl_ad9144_fifo.if_dac_clk
-add_connection ad9144_jesd204.link_reset avl_ad9144_fifo.if_dac_rst
-add_connection util_ad9144_upack.if_packed_fifo_rd_en avl_ad9144_fifo.if_dac_valid
-add_connection avl_ad9144_fifo.if_dac_data util_ad9144_upack.if_packed_fifo_rd_data
-add_connection avl_ad9144_fifo.if_dac_dunf axi_ad9144.if_dac_dunf
+add_connection sys_clk.clk $dac_data_offload_name.sys_clk
+add_connection sys_clk.clk_reset $dac_data_offload_name.sys_resetn
+add_connection ad9144_jesd204.link_clk $dac_data_offload_name.m_axis_aclk
+add_connection ad9144_jesd204.link_reset $dac_data_offload_name.m_axis_aresetn
+add_connection $dac_data_offload_name.m_axis util_ad9144_upack.s_axis
 
 # ad9144-dma
 
@@ -101,12 +106,13 @@ set_instance_parameter_value axi_ad9144_dma {DMA_TYPE_DEST} {1}
 set_instance_parameter_value axi_ad9144_dma {DMA_TYPE_SRC} {0}
 set_instance_parameter_value axi_ad9144_dma {FIFO_SIZE} {16}
 set_instance_parameter_value axi_ad9144_dma {HAS_AXIS_TLAST} {1}
+set_instance_parameter_value axi_ad9144_dma {HAS_AXIS_TKEEP} {1}
 
-add_connection sys_dma_clk.clk avl_ad9144_fifo.if_dma_clk
-add_connection sys_dma_clk.clk_reset avl_ad9144_fifo.if_dma_rst
+add_connection sys_dma_clk.clk $dac_data_offload_name.s_axis_aclk
+add_connection sys_dma_clk.clk_reset $dac_data_offload_name.s_axis_aresetn
 add_connection sys_dma_clk.clk axi_ad9144_dma.if_m_axis_aclk
-add_connection axi_ad9144_dma.m_axis avl_ad9144_fifo.s_axis
-add_connection axi_ad9144_dma.if_m_axis_xfer_req avl_ad9144_fifo.if_dma_xfer_req
+add_connection axi_ad9144_dma.m_axis $dac_data_offload_name.s_axis
+add_connection axi_ad9144_dma.if_m_axis_xfer_req $dac_data_offload_name.init_req
 add_connection sys_clk.clk_reset axi_ad9144_dma.s_axi_reset
 add_connection sys_clk.clk axi_ad9144_dma.s_axi_clock
 add_connection sys_dma_clk.clk_reset axi_ad9144_dma.m_src_axi_reset
@@ -155,25 +161,30 @@ add_instance util_ad9680_cpack util_cpack2
 set_instance_parameter_value util_ad9680_cpack {NUM_OF_CHANNELS} $RX_NUM_OF_CONVERTERS
 set_instance_parameter_value util_ad9680_cpack {SAMPLES_PER_CHANNEL} $RX_NUM_OF_LANES
 set_instance_parameter_value util_ad9680_cpack {SAMPLE_DATA_WIDTH} $RX_SAMPLE_WIDTH
+set_instance_parameter_value util_ad9680_cpack {INTERFACE_TYPE} {0}
 
 add_connection ad9680_jesd204.link_reset util_ad9680_cpack.reset
 add_connection ad9680_jesd204.link_clk util_ad9680_cpack.clk
 add_connection axi_ad9680.adc_ch_0 util_ad9680_cpack.adc_ch_0
 add_connection axi_ad9680.adc_ch_1 util_ad9680_cpack.adc_ch_1
+add_connection axi_ad9680.if_adc_dovf util_ad9680_cpack.if_fifo_wr_overflow
 
-# ad9680-fifo
+# ad9680-data offload
 
-add_instance ad9680_adcfifo util_adcfifo
-set_instance_parameter_value ad9680_adcfifo {ADC_DATA_WIDTH} $adc_data_width
-set_instance_parameter_value ad9680_adcfifo {DMA_DATA_WIDTH} $adc_data_width
-set_instance_parameter_value ad9680_adcfifo {DMA_ADDRESS_WIDTH} {16}
+add_instance $adc_data_offload_name adi_data_offload
+set_instance_parameter_value $adc_data_offload_name {DATAPATH_TYPE} {0}
+set_instance_parameter_value $adc_data_offload_name {MEM_TYPE} $adc_data_offload_type
+set_instance_parameter_value $adc_data_offload_name {MEM_SIZE} $adc_data_offload_size
+set_instance_parameter_value $adc_data_offload_name {SOURCE_DWIDTH} $adc_data_width
+set_instance_parameter_value $adc_data_offload_name {DESTINATION_DWIDTH} $adc_data_width
 
-add_connection sys_clk.clk_reset ad9680_adcfifo.if_adc_rst
-add_connection ad9680_jesd204.link_clk ad9680_adcfifo.if_adc_clk
-add_connection util_ad9680_cpack.if_packed_fifo_wr_en ad9680_adcfifo.if_adc_wr
-add_connection util_ad9680_cpack.if_packed_fifo_wr_data ad9680_adcfifo.if_adc_wdata
-add_connection sys_dma_clk.clk ad9680_adcfifo.if_dma_clk
-add_connection sys_dma_clk.clk_reset ad9680_adcfifo.if_adc_rst
+add_connection sys_clk.clk $adc_data_offload_name.sys_clk
+add_connection sys_clk.clk_reset $adc_data_offload_name.sys_resetn
+add_connection ad9680_jesd204.link_clk $adc_data_offload_name.s_axis_aclk
+add_connection ad9680_jesd204.link_reset $adc_data_offload_name.s_axis_aresetn
+add_connection util_ad9680_cpack.m_axis $adc_data_offload_name.s_axis
+add_connection sys_dma_clk.clk $adc_data_offload_name.m_axis_aclk
+add_connection sys_dma_clk.clk_reset $adc_data_offload_name.m_axis_aresetn
 
 # ad9680-dma
 
@@ -188,9 +199,8 @@ set_instance_parameter_value axi_ad9680_dma {DMA_TYPE_DEST} {0}
 set_instance_parameter_value axi_ad9680_dma {DMA_TYPE_SRC} {1}
 
 add_connection sys_dma_clk.clk axi_ad9680_dma.if_s_axis_aclk
-add_connection ad9680_adcfifo.m_axis axi_ad9680_dma.s_axis
-add_connection ad9680_adcfifo.if_dma_xfer_req axi_ad9680_dma.if_s_axis_xfer_req
-add_connection ad9680_adcfifo.if_adc_wovf axi_ad9680.if_adc_dovf
+add_connection $adc_data_offload_name.m_axis axi_ad9680_dma.s_axis
+add_connection $adc_data_offload_name.init_req axi_ad9680_dma.if_s_axis_xfer_req
 add_connection sys_clk.clk_reset axi_ad9680_dma.s_axi_reset
 add_connection sys_clk.clk axi_ad9680_dma.s_axi_clock
 add_connection sys_dma_clk.clk_reset axi_ad9680_dma.m_dest_axi_reset
@@ -229,6 +239,8 @@ ad_cpu_interconnect 0x0004a000 avl_adxcfg_2.rcfg_s1
 ad_cpu_interconnect 0x0004b000 avl_adxcfg_3.rcfg_s1
 ad_cpu_interconnect 0x0004c000 axi_ad9680_dma.s_axi
 ad_cpu_interconnect 0x00050000 axi_ad9680.s_axi
+ad_cpu_interconnect 0x00060000 $dac_data_offload_name.s_axi
+ad_cpu_interconnect 0x00070000 $adc_data_offload_name.s_axi
 
 # dma interconnects
 


### PR DESCRIPTION
## PR Description

This PR adds the Intel Data Offload IP in daq2/a10soc, replacing the adc/dacfifo IP.

Must be merged after this PR: https://github.com/analogdevicesinc/hdl/pull/2109

## PR Type
- [ ] Bug fix (change that fixes an issue)
- [x] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)
- [ ] Documentation

## PR Checklist
- [x] I have followed the code style guidelines
- [x] I have performed a self-review of changes
- [x] I have compiled all hdl projects and libraries affected by this PR
- [x] I have tested in hardware affected projects, at least on relevant boards
- [x] I have commented my code, at least hard-to-understand parts
- [x] I have signed off all commits from this PR
- [x] I have updated the documentation (wiki pages, ReadMe files, Copyright etc)
- [ ] I have not introduced new Warnings/Critical Warnings on compilation
- [ ] I have added new hdl testbenches or updated existing ones
