### PR TITLE
i3c_controller_host_interface: infer interrupt line for Xilinx projects

### DIFF
--- a/library/i3c_controller/i3c_controller_host_interface/i3c_controller_host_interface_ip.tcl
+++ b/library/i3c_controller/i3c_controller_host_interface/i3c_controller_host_interface_ip.tcl
@@ -99,6 +99,9 @@ set cc [ipx::current_core]
 
 ipx::associate_bus_interfaces -clock s_axi_aclk -reset reset_n $cc
 
+# Infer interrupt
+ipx::infer_bus_interface irq xilinx.com:signal:interrupt_rtl:1.0 [ipx::current_core]
+
 ## ID
 set_property -dict [list \
   "value_validation_type" "range_long" \


### PR DESCRIPTION

## PR Description

Add interrupt line annotation to be included when generating xparameters.h.

I see the change on component.xml with the addition of:
```
    <spirit:busInterface>
      <spirit:name>irq</spirit:name>
      <spirit:busType spirit:vendor="xilinx.com" spirit:library="signal" spirit:name="interrupt" spirit:version="1.0"/>
      <spirit:abstractionType spirit:vendor="xilinx.com" spirit:library="signal" spirit:name="interrupt_rtl" spirit:version="1.0"/>
      <spirit:master/>
      <spirit:portMaps>
        <spirit:portMap>
          <spirit:logicalPort>
            <spirit:name>INTERRUPT</spirit:name>
          </spirit:logicalPort>
          <spirit:physicalPort>
            <spirit:name>irq</spirit:name>
          </spirit:physicalPort>
        </spirit:portMap>
      </spirit:portMaps>
      <spirit:parameters>
        <spirit:parameter>
          <spirit:name>SENSITIVITY</spirit:name>
          <spirit:value spirit:id="BUSIFPARAM_VALUE.IRQ.SENSITIVITY" spirit:choiceRef="choice_list_9ca20931">LEVEL_HIGH</spirit:value>
        </spirit:parameter>
      </spirit:parameters>
    </spirit:busInterface>
```

Tested:
```
$ cp ./hdl/i3c-infer-irq/projects/ad4062_ardz/coraz7s/ad4062_ardz_coraz7s.sdk/system_top.xsa \
  ./remote-bus/tools/bsp/system_top.xsa

$ vitis -s ./no-os/tools/scripts/platform/xilinx/util.py \
  get_arch \
./remote-bus/tools/bsp/bsp_ws \
./remote-bus/tools/bsp \
system_top.xsa \
"" IOP1_IOP1_mb ""

$ vitis -s ./no-os/tools/scripts/platform/xilinx/util.py \
  create_project \
./remote-bus/tools/bsp/bsp_ws \
./remote-bus/tools/bsp \
system_top.xsa \
  "" IOP1_IOP1_mb ""

$ cd remote-bus ; grep -r IOP1_IOP1_i3c_host_interface
tools/bsp/bsp_ws/bsp/IOP1_IOP1_mb/include/ip_drv_map.yaml:IOP1_IOP1_i3c_host_interface:
```
Generated dtsi:
```
  i3c_host_interface: i3c_controller_host_interface@44a00000 {
   interrupts = < 0 33 4 >;
   compatible = "xlnx,i3c-controller-host-interface-1.0";
   xlnx,pid-part-id = <0x0>;
   xlnx,pid-manuf-id = "000000000000000";
   xlnx,cmd-fifo-address-width = <4>;
   interrupt-parent = <&intc>;
   xlnx,ip-name = "i3c_controller_host_interface";
   xlnx,cmdr-fifo-address-width = <4>;
   reg = <0x44a00000 0x10000>;
   xlnx,pid-extra-id = <0x0>;
   clocks = <&clkc 15>;
   xlnx,sdi-fifo-address-width = <5>;
   xlnx,pid-type-selector = "1";
   xlnx,edk-iptype = "PERIPHERAL";
   xlnx,da = "0110001";
   xlnx,ibi-fifo-address-width = <4>;
   xlnx,id = <0>;
   status = "okay";
   clock-names = "s_axi_aclk";
   xlnx,sdo-fifo-address-width = <5>;
   interrupt-names = "irq";
   xlnx,pid-instance-id = "0000";
   xlnx,name = "i3c_host_interface";
  };
```

## PR Type
- [ ] Bug fix (change that fixes an issue)
- [x] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)
- [ ] Documentation

## PR Checklist
- [ ] I have followed the code style guidelines
- [ ] I have performed a self-review of changes
- [ ] I have compiled all hdl projects and libraries affected by this PR
- [ ] I have tested in hardware affected projects, at least on relevant boards
- [ ] I have commented my code, at least hard-to-understand parts
- [ ] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe files, Copyright etc)
- [ ] I have not introduced new Warnings/Critical Warnings on compilation
- [ ] I have added new hdl testbenches or updated existing ones
