### PR TITLE
.github: Add documentation workflow and Containerfile

### DIFF
--- a/.github/container/Containerfile
+++ b/.github/container/Containerfile
@@ -1,0 +1,36 @@
+FROM opensuse/leap:16.0
+
+ENV version=v1
+ARG bashrc=https://raw.githubusercontent.com/analogdevicesinc/doctools/refs/heads/ci/bashrc
+ARG entrypoint_sh=https://raw.githubusercontent.com/analogdevicesinc/doctools/refs/heads/ci/entrypoint.sh
+ARG git_defaults_sh=https://raw.githubusercontent.com/analogdevicesinc/doctools/refs/heads/ci/git-defaults.sh
+ARG gh_actions_runner_sh=https://raw.githubusercontent.com/analogdevicesinc/doctools/refs/heads/ci/gh-actions-runner.sh
+
+RUN zypper update -y
+RUN zypper install -y --no-recommends \
+    tar unzip gzip curl jq libicu coreutils
+
+RUN useradd -m runner
+WORKDIR /home/runner
+
+ADD ${gh_actions_runner_sh} .
+RUN bash ./gh-actions-runner.sh && rm ./gh-actions-runner.sh
+
+COPY .github/container/install-deps.sh .
+RUN bash ./install-deps.sh && rm ./install-deps.sh
+
+RUN mkdir -p /usr/local/bin
+WORKDIR /usr/local/bin
+ADD ${entrypoint_sh} .
+RUN chmod +rx ./entrypoint.sh
+
+ADD ${git_defaults_sh} .
+RUN bash ./git-defaults.sh && rm ./git-defaults.sh
+
+USER runner
+WORKDIR /home/runner
+RUN curl -o .bashrc -L ${bashrc} ; \
+    chmod +x .bashrc
+
+ENTRYPOINT ["/bin/bash"]
+

--- a/.github/container/install-deps.sh
+++ b/.github/container/install-deps.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+set -e
+
+# core
+zypper install -y --no-recommends \
+    update-alternatives \
+    which wget make openssl openssl-devel ca-certificates ca-certificates-mozilla
+
+# utils
+zypper install -y --no-recommends \
+    git find tcl \
+    python313 python313-devel \
+    gcc13 gcc13-c++ \
+    graphviz
+
+# amd xilinx
+zypper install -y --no-recommends \
+    xorg-x11-server-Xvfb xlsclients \

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -1,0 +1,74 @@
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  build-doc:
+    runs-on: ${{ vars.RUNNER != '' && fromJSON(vars.RUNNER) || 'ubuntu-latest' }}
+    permissions:
+      contents: read
+    env:
+      SOURCE_AMD_XILINX: ${{ vars.SOURCE_AMD_XILINX }}
+
+    steps:
+    - uses: actions/checkout@v7
+    - name: Ensure SDKs
+      run: |
+        [[ -f "$SOURCE_AMD_XILINX" ]] && echo "vivado=true" >> $GITHUB_ENV || :
+
+    - name: Build libraries
+      if: ${{ env.vivado == 'true' }}
+      run: |
+        source "$SOURCE_AMD_XILINX"
+        cd library
+        make -j$(nproc)
+
+    - name: Install pip packages
+      run: |
+        python3 -m venv venv
+        source ./venv/bin/activate
+        python3 -m ensurepip
+        pip3 install -r docs/requirements.txt --upgrade
+
+    - name: Build doc
+      run: |
+        source ./venv/bin/activate
+
+        export GIT_LFS_TO_LINKS="true"
+        export GIT_ORG_REPOSITORY="${{ github.repository }}"
+        [ "${{ github.event_name }}" = "pull_request" ] \
+          && export GIT_BRANCH="${{ github.event.pull_request.head.ref }}" \
+          || export GIT_BRANCH="${{ github.ref_name }}"
+
+        [[ "${{ runner.debug }}" != "1" ]] && j_="-jauto"
+        cd docs
+        sphinx-build -b html $j_ -w "$warnfile" . _build/html --keep-going || err=$?
+        rm -rf _build/html/_sources
+
+    - name: Store the generated doc
+      uses: actions/upload-artifact@v7
+      with:
+        name: html
+        path: docs/_build/html
+
+  deploy:
+    runs-on: ${{ vars.RUNNER != '' && fromJSON(vars.RUNNER) || 'ubuntu-latest' }}
+    needs: [build-doc]
+    concurrency:
+      group: gh-pages
+    permissions:
+      contents: write
+    if: >
+      github.ref == 'refs/heads/main' ||
+      github.event_name == 'pull_request' ||
+      github.ref_type == 'tag'
+
+    steps:
+    - uses: analogdevicesinc/doctools/gh-pages-deploy@action
+      with:
+        new_tag: ${{ github.ref_type == 'tag' }}
+        tag: ${{ github.ref_name }}
+        name: html
+

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -44,7 +44,7 @@ jobs:
 
         [[ "${{ runner.debug }}" != "1" ]] && j_="-jauto"
         cd docs
-        sphinx-build -b html $j_ -w "$warnfile" . _build/html --keep-going || err=$?
+        sphinx-build -b dirhtml $j_ -w "$warnfile" . _build/html --keep-going || err=$?
         rm -rf _build/html/_sources
 
     - name: Store the generated doc


### PR DESCRIPTION
## PR Description

Add documentation build on GitHub Actions

Adds full featured documentation builds to GitHub Actions, including building the IP cores with AMD Xilinx tools to generate the IP-XACT metadata.
The IP-XACT is used to verify and complete the documentation, for example, generate the IP block SVG, enrich the parameters and ports tables.

If AMD Xilinx tools are not available (detect by settings64.sh missing), gracefully skip building the libs.

Currently does not checkouts external dependencies, causing:
```
Library corundum_core SKIPPED due to missing external dependencies
Library ethernet_k26 SKIPPED due to missing external dependencies
Library ethernet_adrv9009zu11eg SKIPPED due to missing external dependencies
Library ethernet_vcu118 SKIPPED due to missing external dependencies
Library ethernet_xcvu11p SKIPPED due to missing external dependencies
```

Future improvements:
- Libraries cache ; currently the action/checkout does 'git clean -xf .' internally (to save ~12m)
- External dependencies

Solves: 'hidden' documentation builds.

## PR Type
- [ ] Bug fix (change that fixes an issue)
- [X] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)
- [X] Documentation

## PR Checklist
- [ ] I have followed the code style guidelines
- [ ] I have performed a self-review of changes
- [ ] I have compiled all hdl projects and libraries affected by this PR
- [ ] I have tested in hardware affected projects, at least on relevant boards
- [ ] I have commented my code, at least hard-to-understand parts
- [ ] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe files, Copyright etc)
- [ ] I have not introduced new Warnings/Critical Warnings on compilation
- [ ] I have added new hdl testbenches or updated existing ones
