### PR TITLE
library/util_pack: Use m_axis_ready to reset accum

### DIFF
--- a/library/util_pack/util_cpack2/util_cpack2_impl.v
+++ b/library/util_pack/util_cpack2/util_cpack2_impl.v
@@ -70,6 +70,7 @@ module util_cpack2_impl #(
 
   // Control signals from the pack shell.
   wire ce;
+  wire flush;
   wire ready;
   wire reset_data;
 
@@ -112,6 +113,9 @@ module util_cpack2_impl #(
 
   assign ce = data_wr_en & out_ready_int;
 
+  // Downstream backpressure.
+  assign flush = ~out_ready_int;
+
   /*
    * The cpack core itself has no backpressure. Overflows can only happen
    * downstream.
@@ -146,6 +150,7 @@ module util_cpack2_impl #(
 
     .enable (enable),
     .ce (ce),
+    .flush (flush),
     .ready (ready),
     .in_data (interleaved_data),
     .out_data (out_data),

--- a/library/util_pack/util_pack_common/pack_shell.v
+++ b/library/util_pack/util_pack_common/pack_shell.v
@@ -50,6 +50,7 @@ module pack_shell #(
   input [NUM_OF_CHANNELS-1:0] enable,
 
   input ce,
+  input flush,
 
   output reg ready = 1'b0,
   input [NUM_OF_CHANNELS*SAMPLE_DATA_WIDTH*SAMPLES_PER_CHANNEL-1:0] in_data,
@@ -427,7 +428,11 @@ module pack_shell #(
              * residual data. I.e. when ready is asserted rotate is 0.
              */
             {ready,rotate} <= rotate + enable_count + 1'b1;
-          end else begin
+          end else if (flush == 1'b1) begin
+            /*
+             * Downstream backpressure: discard any partial accumulation so the
+             * next enabled window starts on a clean word boundary.
+             */
             ready <= 1'b0;
             rotate <= 'h0;
           end

--- a/library/util_pack/util_upack2/util_upack2_impl.v
+++ b/library/util_pack/util_upack2/util_upack2_impl.v
@@ -1,6 +1,6 @@
 // ***************************************************************************
 // ***************************************************************************
-// Copyright (C) 2018-2023, 2025 Analog Devices, Inc. All rights reserved.
+// Copyright (C) 2018-2023, 2025-2026 Analog Devices, Inc. All rights reserved.
 //
 // In this HDL repository, there are many different and unique modules, consisting
 // of various HDL (Verilog or VHDL) components. The individual modules are
@@ -103,6 +103,7 @@ module util_upack2_impl #(
 
     .enable (enable),
     .ce (ce),
+    .flush (1'b0),
     .ready (ready),
     .in_data (s_axis_data),
     .out_data (out_data),


### PR DESCRIPTION
## PR Description

This commit restores the idle behavior and splits it from the backpressure state which discards any partial accumulation, so that the next enabled window starts on a clean boundary.

This behavior was observed in a simulation which toggles CPACK's _fifo_wr_en_ input; in a JESD TPL - CPACK HW chain, the _fifo_wr_en_ input stays asserted since the jesd transfer is continuous, basically combining idle/flush when backpressured.

## PR Type
- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)
- [ ] Documentation

## PR Checklist
- [x] I have followed the code style guidelines
- [x] I have performed a self-review of changes
- [ ] I have compiled all hdl projects and libraries affected by this PR
- [x] I have tested in hardware affected projects, at least on relevant boards
- [x] I have commented my code, at least hard-to-understand parts
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe files, Copyright etc)
- [x] I have not introduced new Warnings/Critical Warnings on compilation
- [ ] I have added new hdl testbenches or updated existing ones
