### PR TITLE
library/axi_hmcad15xx: fix 8-bit quad channel sample packing order

### DIFF
--- a/library/axi_hmcad15xx/axi_hmcad15xx_if.v
+++ b/library/axi_hmcad15xx/axi_hmcad15xx_if.v
@@ -213,8 +213,8 @@ module axi_hmcad15xx_if #(
       wr_data_int <= {data_out[6][ 7:0], data_out[7][ 7:0], data_out[4][ 7:0], data_out[5][ 7:0], data_out[2][ 7:0], data_out[3][ 7:0], data_out[0][ 7:0], data_out[1][ 7:0],
                       data_out[6][15:8], data_out[7][15:8], data_out[4][15:8], data_out[5][15:8], data_out[2][15:8], data_out[3][15:8], data_out[0][15:8], data_out[1][15:8]};
     end else if((resolution == 2'b00) && (mode == 3'b100)) begin  //  8-bit quad channel
-      wr_data_int <= {data_out[6][ 7:0], data_out[4][ 7:0], data_out[2][ 7:0], data_out[0][ 7:0], data_out[7][ 7:0], data_out[5][ 7:0], data_out[3][ 7:0], data_out[1][ 7:0],
-                      data_out[6][15:8], data_out[4][15:8], data_out[2][15:8], data_out[0][15:8], data_out[7][15:8], data_out[5][15:8], data_out[3][15:8], data_out[1][15:8]};
+      wr_data_int <= {data_out[7][ 7:0], data_out[5][ 7:0],	data_out[3][ 7:0], data_out[1][ 7:0], data_out[6][ 7:0], data_out[4][ 7:0], data_out[2][ 7:0], data_out[0][ 7:0],
+                      data_out[7][15:8], data_out[5][15:8], data_out[3][15:8], data_out[1][15:8], data_out[6][15:8], data_out[4][15:8], data_out[2][15:8], data_out[0][15:8]};
     end else if((resolution == 2'b00) && (mode == 3'b010)) begin  //  8-bit dual channel
       wr_data_int <= {data_out[7][ 7:0], data_out[3][ 7:0], data_out[6][ 7:0], data_out[2][ 7:0], data_out[5][ 7:0], data_out[1][ 7:0], data_out[4][ 7:0], data_out[0][ 7:0],
                       data_out[7][15:8], data_out[3][15:8], data_out[6][15:8], data_out[2][15:8], data_out[5][15:8], data_out[1][15:8], data_out[4][15:8], data_out[0][15:8]};


### PR DESCRIPTION
## PR Description

Fix lane ordering in "axi_hmcad15xx_if.v" for 8-bit quad channel mode. Even lanes first, followed by odd lanes.

## PR Type
- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)
- [ ] Documentation

## PR Checklist
- [x] I have followed the code style guidelines
- [ ] I have performed a self-review of changes
- [x] I have compiled all hdl projects and libraries affected by this PR
- [x] I have tested in hardware affected projects, at least on relevant boards
- [ ] I have commented my code, at least hard-to-understand parts
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe files, Copyright etc)
- [x] I have not introduced new Warnings/Critical Warnings on compilation
- [ ] I have added new hdl testbenches or updated existing ones
