### PR TITLE
docs: Fix broken ZedBoard link and signal name in SPI Engine regmap

### DIFF
--- a/docs/regmap/adi_regmap_spi_engine.txt
+++ b/docs/regmap/adi_regmap_spi_engine.txt
@@ -70,11 +70,11 @@ DATA_WIDTH
 ENDREG
 
 FIELD
-[23:16] NUM_OF_SDI
-NUM_OF_SDI
+[23:16] NUM_OF_SDIO
+NUM_OF_SDIO
 RO
-Number of SDI.
-It is equal with the maximum supported SDI lines in bits.
+Number of SDIOs.
+It is equal with the maximum supported SDIO lines in bits.
 ENDFIELD
 
 FIELD

--- a/docs/user_guide/architecture.rst
+++ b/docs/user_guide/architecture.rst
@@ -47,7 +47,7 @@ Example
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Take :adi:`FMCOMMS2 <AD-FMCOMMS2-EBZ>` with
-:xilinx:`ZedBoard <products/boards-and-kits/1-8dyf-11.html>`;
+`ZedBoard <https://digilent.com/shop/zedboard-zynq-7000-arm-fpga-soc-development-board>`__;
 the ``system_bd.tcl`` file will have the following designs sourced to be used:
 
 .. code-block:: tcl


### PR DESCRIPTION
## PR Description

- docs/regmap: Fix SPI Engine signal nameNUM_OF_SDI was renamed to NUM_OF_SDIO and its width was fixed in PR https://github.com/analogdevicesinc/hdl/pull/1808, but the renaming was missed in this place.
- docs/user_guide/architecture: Fix broken ZedBoard link

## PR Type
- [ ] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)
- [x] Documentation

## PR Checklist
- [x] I have followed the code style guidelines
- [x] I have performed a self-review of changes
- [ ] I have compiled all hdl projects and libraries affected by this PR
- [ ] I have tested in hardware affected projects, at least on relevant boards
- [ ] I have commented my code, at least hard-to-understand parts
- [x] I have signed off all commits from this PR
- [x] I have updated the documentation (wiki pages, ReadMe files, Copyright etc)
- [ ] I have not introduced new Warnings/Critical Warnings on compilation
- [ ] I have added new hdl testbenches or updated existing ones
