### PR TITLE
library: Add vendor-specific build targets to Makefiles

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ SUBPROJECTS := $(foreach projname,$(PROJECTS), \
 	$(foreach archname,$(notdir $(subst /Makefile,,$(wildcard projects/$(projname)/*/Makefile))), \
 		$(projname).$(archname))))
 
-.PHONY: lib all clean clean-ipcache clean-all $(SUBPROJECTS)
+.PHONY: lib lib-intel lib-xilinx lib-lattice all clean clean-ipcache clean-all $(SUBPROJECTS)
 
 $(SUBPROJECTS):
 	$(MAKE) -C projects/$(subst .,/,$@)

--- a/Makefile
+++ b/Makefile
@@ -35,6 +35,14 @@ $(SUBPROJECTS):
 lib:
 	$(MAKE) -C library/ all
 
+lib-intel:
+	$(MAKE) -C library/ intel
+
+lib-xilinx:
+	$(MAKE) -C library/ xilinx
+
+lib-lattice:
+	$(MAKE) -C library/ lattice
 
 all:
 	$(MAKE) -C projects/ all

--- a/library/Makefile
+++ b/library/Makefile
@@ -8,7 +8,7 @@
 
 include ../quiet.mk
 
-.PHONY: all lib clean clean-all
+.PHONY: all lib lib-intel lib-xilinx lib-lattice clean clean-all
 all: lib
 
 _LIBS := $(dir $(shell find . -mindepth 2 -name Makefile | sort))

--- a/library/Makefile
+++ b/library/Makefile
@@ -30,7 +30,7 @@ clean: $(_LIBS_CLEAN)
 clean-all: clean
 
 lib: $(_LIBS_ALL)
-lib-intel: $(_LIBS_XILINX)
+lib-intel: $(_LIBS_INTEL)
 lib-xilinx: $(_LIBS_XILINX)
 lib-lattice: $(_LIBS_LATTICE)
 

--- a/library/Makefile
+++ b/library/Makefile
@@ -21,7 +21,11 @@ _LIBS_LATTICE := $(addsuffix lattice, $(_LIBS))
 _LIBS_CLEAN := $(addsuffix clean, $(_LIBS))
 
 $(_LIBS_ALL) $(_LIBS_INTEL) $(_LIBS_XILINX) $(_LIBS_LATTICE):
-	$(MAKE) -C $(@D) $(@F)
+	@if $(MAKE) -C $(@D) -n $(@F) >/dev/null 2>&1; then \
+		$(MAKE) -C $(@D) $(@F); \
+	else \
+		echo "Skipping $(@F) in $(@D) (target not found)"; \
+	fi
 
 $(_LIBS_CLEAN):
 	$(MAKE) -C $(@D) $(@F)

--- a/library/Makefile
+++ b/library/Makefile
@@ -15,9 +15,12 @@ _LIBS := $(dir $(shell find . -mindepth 2 -name Makefile | sort))
 
 # Create virtual targets "$library/all", "$library/clean"
 _LIBS_ALL := $(addsuffix all, $(_LIBS))
+_LIBS_INTEL := $(addsuffix intel, $(filter-out %_ltt/, $(_LIBS)))
+_LIBS_XILINX := $(addsuffix xilinx, $(filter-out %_ltt/, $(_LIBS)))
+_LIBS_LATTICE := $(addsuffix lattice, $(_LIBS))
 _LIBS_CLEAN := $(addsuffix clean, $(_LIBS))
 
-$(_LIBS_ALL):
+$(_LIBS_ALL) $(_LIBS_INTEL) $(_LIBS_XILINX) $(_LIBS_LATTICE):
 	$(MAKE) -C $(@D) $(@F)
 
 $(_LIBS_CLEAN):
@@ -27,6 +30,9 @@ clean: $(_LIBS_CLEAN)
 clean-all: clean
 
 lib: $(_LIBS_ALL)
+lib-intel: $(_LIBS_XILINX)
+lib-xilinx: $(_LIBS_XILINX)
+lib-lattice: $(_LIBS_LATTICE)
 
 ####################################################################################
 ####################################################################################


### PR DESCRIPTION
## PR Description

This PR adds vendor-specific build targets (intel, xilinx, and lattice) to both the top-level Makefile and library/Makefile.

## Motivation & Context

Previously, building IP libraries required compiling all cores sequentially using make lib. This change allows developers to build only the IP cores required for a specific FPGA vendor toolchain (e.g., compiling only Xilinx/Intel IP cores while skipping Lattice-specific ones), significantly reducing build times and dependencies when working with a single toolchain.

## Changes

- library/Makefile:
    - Added _LIBS_INTEL, _LIBS_XILINX (filtering out %_ltt/ directories), and _LIBS_LATTICE virtual targets.
    - Added targets lib-intel, lib-xilinx, and lib-lattice.

- Makefile (root):
    - Added wrapper targets lib-intel, lib-xilinx, and lib-lattice to trigger recursive builds inside library/.


## PR Type
- [ ] Bug fix (change that fixes an issue)
- [x] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)
- [ ] Documentation

## PR Checklist
- [x] I have followed the code style guidelines
- [x] I have performed a self-review of changes
- [ ] I have compiled all hdl projects and libraries affected by this PR
- [ ] I have tested in hardware affected projects, at least on relevant boards
- [x] I have commented my code, at least hard-to-understand parts
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe files, Copyright etc)
- [x] I have not introduced new Warnings/Critical Warnings on compilation
- [ ] I have added new hdl testbenches or updated existing ones
