### PR TITLE
.github/docs: documentation -> system-level

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -29,7 +29,7 @@ source_suffix = '.rst'
 interref_repos = [
         'kuiper',
         'doctools',
-        'documentation',
+        'system-level',
         'no-OS',
         'linux',
         'precision-converters-firmware',

--- a/docs/projects/ad5706r/index.rst
+++ b/docs/projects/ad5706r/index.rst
@@ -121,7 +121,7 @@ Building the HDL project
 
 The design is built upon ADI's generic HDL reference design framework.
 ADI distributes the bit/elf files of these projects as part of the
-:external+documentation:ref:`kuiper`.
+:external+system-level:ref:`kuiper`.
 If you want to build the sources, ADI makes them available on the
 :git-hdl:`HDL repository </>`. To get the source you must
 `clone <https://git-scm.com/book/en/v2/Git-Basics-Getting-a-Git-Repository>`__

--- a/docs/projects/ad9081_fmca_ebz/index.rst
+++ b/docs/projects/ad9081_fmca_ebz/index.rst
@@ -141,7 +141,7 @@ Supported carriers
    For the carrier,
    :intel:`A10SoC <content/www/us/en/products/details/fpga/development-kits/arria/10-sx.html>`,
    the following reworks are mandatory:
-   :external+documentation:ref:`[Wiki] FMC Pin Connection Configuration <ad9081 quickstart a10soc>`
+   :external+system-level:ref:`[Wiki] FMC Pin Connection Configuration <ad9081 quickstart a10soc>`
 
 .. warning::
    For
@@ -541,7 +541,7 @@ Building the HDL project
 
 The design is built upon ADI's generic HDL reference design framework. ADI
 distributes the bit/elf files of these projects as part of the
-:external+documentation:ref:`ADI Kuiper Linux <kuiper>`. If you want to build
+:external+system-level:ref:`ADI Kuiper Linux <kuiper>`. If you want to build
 the sources, ADI makes them available on the :git-hdl:`HDL repository </>`. To
 get the source you must
 `clone <https://git-scm.com/book/en/v2/Git-Basics-Getting-a-Git-Repository>`__
@@ -816,9 +816,9 @@ Resources
 Systems related
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-- :external+documentation:ref:`AD9081 & AD9082 & AD9988 & AD9986 Prototyping Platform User Guide <ad9081>`
+- :external+system-level:ref:`AD9081 & AD9082 & AD9988 & AD9986 Prototyping Platform User Guide <ad9081>`
 - Here you can find all the quick start guides on wiki documentation
-  :external+documentation:ref:`AD9081/AD9082/AD9986/AD9988 Quick Start Guides <ad9081 quickstart>`
+  :external+system-level:ref:`AD9081/AD9082/AD9986/AD9988 Quick Start Guides <ad9081 quickstart>`
 
 Here you can find the quick start guides available for these evaluation boards:
 
@@ -834,11 +834,11 @@ Here you can find the quick start guides available for these evaluation boards:
      - Arria 10
      - FM87
    * - AD9081/AD9082/AD9986/AD9988
-     - :external+documentation:ref:`ZC706 <ad9081 quickstart zc706>`
-     - :external+documentation:ref:`ZCU102 <ad9081 quickstart zcu102>`
-     - :external+documentation:ref:`VCU118 <ad9081 quickstart vcu118>`
-     - :external+documentation:ref:`VCK190 <ad9081 quickstart vck190>`
-     - :external+documentation:ref:`A10SoC <ad9081 quickstart a10soc>`
+     - :external+system-level:ref:`ZC706 <ad9081 quickstart zc706>`
+     - :external+system-level:ref:`ZCU102 <ad9081 quickstart zcu102>`
+     - :external+system-level:ref:`VCU118 <ad9081 quickstart vcu118>`
+     - :external+system-level:ref:`VCK190 <ad9081 quickstart vck190>`
+     - :external+system-level:ref:`A10SoC <ad9081 quickstart a10soc>`
      - :dokuwiki:`FM87 <resources/eval/user-guides/ad9081/quickstart/fm87>`
 
 Hardware related

--- a/docs/projects/ad9083_evb/index.rst
+++ b/docs/projects/ad9083_evb/index.rst
@@ -273,7 +273,7 @@ Building the HDL project
 
 The design is built upon ADI's generic HDL reference design framework. ADI
 distributes the bit/elf files of these projects as part of the
-:external+documentation:ref:`ADI Kuiper Linux <kuiper>`. If you want to build
+:external+system-level:ref:`ADI Kuiper Linux <kuiper>`. If you want to build
 the sources, ADI makes them available on the :git-hdl:`HDL repository </>`. To
 get the source you must
 `clone <https://git-scm.com/book/en/v2/Git-Basics-Getting-a-Git-Repository>`__
@@ -336,7 +336,7 @@ Systems related
 
 - Another quick start guide using this evaluation board (but not using our HDL
   code) is
-  :external+documentation:ref:`AD9083-EVB evaluation using the ADS80V3EBZ capture board <eval-ad9083>`
+  :external+system-level:ref:`AD9083-EVB evaluation using the ADS80V3EBZ capture board <eval-ad9083>`
 
 Hardware related
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/projects/adrv9009/index.rst
+++ b/docs/projects/adrv9009/index.rst
@@ -296,7 +296,7 @@ Building the HDL project
 
 The design is built upon ADI's generic HDL reference design framework. ADI
 distributes the bit/elf files of these projects as part of the
-:external+documentation:ref:`ADI Kuiper Linux <kuiper>`. If you want to build
+:external+system-level:ref:`ADI Kuiper Linux <kuiper>`. If you want to build
 the sources, ADI makes them available on the :git-hdl:`HDL repository </>`. To
 get the source you must
 `clone <https://git-scm.com/book/en/v2/Git-Basics-Getting-a-Git-Repository>`__
@@ -427,7 +427,7 @@ Resources
 Systems related
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-- :external+documentation:ref:`ADRV9009 & ADRV9008 Prototyping Platform User Guide <adrv9009>`
+- :external+system-level:ref:`ADRV9009 & ADRV9008 Prototyping Platform User Guide <adrv9009>`
 
 Here you can find the quick start guides available for these evaluation boards:
 
@@ -438,7 +438,7 @@ Here you can find the quick start guides available for these evaluation boards:
    * - Evaluation board
      - Zynq UltraScale+ MP
    * - ADRV9009/ADRV9008
-     - :external+documentation:ref:`adrv9009 quickstart zynqmp`
+     - :external+system-level:ref:`adrv9009 quickstart zynqmp`
 
 Hardware related
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -510,7 +510,7 @@ HDL related
 Software related
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-- :external+documentation:ref:`ADRV9009 Linux driver page <iio-transceiver adrv9009>`
+- :external+system-level:ref:`ADRV9009 Linux driver page <iio-transceiver adrv9009>`
 
 - :git-linux:`ADRV9009 + ZCU102 device tree <arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-adrv9009-jesd204-fsm.dts>`
 - :git-linux:`ADRV9009 + ZC706 device tree <arch/arm/boot/dts/xilinx/zynq-zc706-adv7511-adrv9009-jesd204-fsm.dts>`

--- a/docs/projects/adrv9026/index.rst
+++ b/docs/projects/adrv9026/index.rst
@@ -678,7 +678,7 @@ Building the HDL project
 
 The design is built upon ADI's generic HDL reference design framework. ADI
 distributes the bit/elf files of these projects as part of the
-:external+documentation:ref:`ADI Kuiper Linux <kuiper>`. If you want to build
+:external+system-level:ref:`ADI Kuiper Linux <kuiper>`. If you want to build
 the sources, ADI makes them available on the :git-hdl:`HDL repository </>`. To
 get the source you must
 `clone <https://git-scm.com/book/en/v2/Git-Basics-Getting-a-Git-Repository>`__

--- a/docs/projects/adrv903x/index.rst
+++ b/docs/projects/adrv903x/index.rst
@@ -297,7 +297,7 @@ Building the HDL project
 
 The design is built upon ADI's generic HDL reference design framework.
 ADI distributes the bit/elf files of these projects as part of the
-:external+documentation:ref:`ADI Kuiper Linux <kuiper>`.
+:external+system-level:ref:`ADI Kuiper Linux <kuiper>`.
 If you want to build the sources, ADI makes them available on the
 :git-hdl:`HDL repository </>`. To get the source you must
 `clone <https://git-scm.com/book/en/v2/Git-Basics-Getting-a-Git-Repository>`__

--- a/docs/projects/adrv904x/index.rst
+++ b/docs/projects/adrv904x/index.rst
@@ -601,7 +601,7 @@ Building the HDL project
 
 The design is built upon ADI's generic HDL reference design framework.
 ADI distributes the bit/elf files of these projects as part of the
-:external+documentation:ref:`ADI Kuiper Linux <kuiper>`.
+:external+system-level:ref:`ADI Kuiper Linux <kuiper>`.
 If you want to build the sources, ADI makes them available on the
 :git-hdl:`HDL repository </>`. To get the source you must
 `clone <https://git-scm.com/book/en/v2/Git-Basics-Getting-a-Git-Repository>`__
@@ -774,7 +774,7 @@ Resources
 Systems related
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-- :external+documentation:ref:`adrv904x`
+- :external+system-level:ref:`adrv904x`
 
 Here you can find the quick start guides available for these evaluation boards:
 
@@ -785,7 +785,7 @@ Here you can find the quick start guides available for these evaluation boards:
    * - Evaluation board
      - Zynq UltraScale+ MP
    * - ADRV904X
-     - :external+documentation:ref:`adrv904x quickstart zcu102`
+     - :external+system-level:ref:`adrv904x quickstart zcu102`
 
 Hardware related
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/projects/adrv9371x/index.rst
+++ b/docs/projects/adrv9371x/index.rst
@@ -297,7 +297,7 @@ Building the HDL project
 
 The design is built upon ADI's generic HDL reference design framework. ADI
 distributes the bit/elf files of these projects as part of the
-:external+documentation:ref:`ADI Kuiper Linux <kuiper>`. If you want to build
+:external+system-level:ref:`ADI Kuiper Linux <kuiper>`. If you want to build
 the sources, ADI makes them available on the :git-hdl:`HDL repository </>`. To
 get the source you must
 `clone <https://git-scm.com/book/en/v2/Git-Basics-Getting-a-Git-Repository>`__

--- a/docs/projects/daq2/index.rst
+++ b/docs/projects/daq2/index.rst
@@ -466,7 +466,7 @@ Building the HDL project
 
 The design is built upon ADI's generic HDL reference design framework. ADI
 distributes the bit/elf files of these projects as part of the
-:external+documentation:ref:`ADI Kuiper Linux <kuiper>`. If you want to build
+:external+system-level:ref:`ADI Kuiper Linux <kuiper>`. If you want to build
 the sources, ADI makes them available on the :git-hdl:`HDL repository </>`. To
 get the source you must
 `clone <https://git-scm.com/book/en/v2/Git-Basics-Getting-a-Git-Repository>`__

--- a/docs/projects/daq3/index.rst
+++ b/docs/projects/daq3/index.rst
@@ -437,7 +437,7 @@ Building the HDL project
 
 The design is built upon ADI's generic HDL reference design framework. ADI
 distributes the bit/elf files of these projects as part of the
-:external+documentation:ref:`ADI Kuiper Linux <kuiper>`. If you want to build
+:external+system-level:ref:`ADI Kuiper Linux <kuiper>`. If you want to build
 the sources, ADI makes them available on the :git-hdl:`HDL repository </>`. To
 get the source you must
 `clone <https://git-scm.com/book/en/v2/Git-Basics-Getting-a-Git-Repository>`__
@@ -510,11 +510,11 @@ Resources
 Systems related
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-- :external+documentation:ref:`AD-FMCDAQ3-EBZ on KCU105 quick start guide <ad_fmcdaq3_ebz quickstart kcu105>`
-- :external+documentation:ref:`AD-FMCDAQ3-EBZ on VCU118 quick start guide <ad_fmcdaq3_ebz quickstart vcu118>`
-- :external+documentation:ref:`AD-FMCDAQ3-EBZ on ZC706 quick start guide <ad_fmcdaq3_ebz quickstart zc706>`
-- :external+documentation:ref:`AD-FMCDAQ3-EBZ on ZCU102 quick start guide <ad_fmcdaq3_ebz quickstart zcu102>`
-- :external+documentation:ref:`AD-FMCDAQ3-EBZ on A10GX (OBSOLETE) quick start guide <ad_fmcdaq3_ebz quickstart a10gx>`
+- :external+system-level:ref:`AD-FMCDAQ3-EBZ on KCU105 quick start guide <ad_fmcdaq3_ebz quickstart kcu105>`
+- :external+system-level:ref:`AD-FMCDAQ3-EBZ on VCU118 quick start guide <ad_fmcdaq3_ebz quickstart vcu118>`
+- :external+system-level:ref:`AD-FMCDAQ3-EBZ on ZC706 quick start guide <ad_fmcdaq3_ebz quickstart zc706>`
+- :external+system-level:ref:`AD-FMCDAQ3-EBZ on ZCU102 quick start guide <ad_fmcdaq3_ebz quickstart zcu102>`
+- :external+system-level:ref:`AD-FMCDAQ3-EBZ on A10GX (OBSOLETE) quick start guide <ad_fmcdaq3_ebz quickstart a10gx>`
 - :dokuwiki:`AD-FMCDAQ3-EBZ on MicroBlaze quick start guide <resources/eval/user-guides/ad-fmcdaq2-ebz/quickstart/microblaze>`
   (:dokuwiki:`here <resources/tools-software/linux-drivers/platforms/nios2>`
   you can find prebuilt images for this setup;
@@ -530,7 +530,7 @@ Hardware related
 
 - The schematic can be downloaded from
   :adi:`here <media/en/reference-design-documentation/design-integration-files/ad-fmcdaq3-ebz-designsupport.zip>`
-- :external+documentation:ref:`AD-FMCDAQ3-EBZ hardware overview <ad_fmcdaq3_ebz hardware>`
+- :external+system-level:ref:`AD-FMCDAQ3-EBZ hardware overview <ad_fmcdaq3_ebz hardware>`
 
 HDL related
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -611,10 +611,10 @@ Software related
 - DAQ3/ZC706 Linux device tree :git-linux:`zynq-zc706-adv7511-fmcdaq3.dts <arch/arm/boot/dts/xilinx/zynq-zc706-adv7511-fmcdaq3.dts>`
 - DAQ3/ZCU102 Linux device tree :git-linux:`zynqmp-zcu102-rev10-fmcdaq3.dts <arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-fmcdaq3.dts>`
 - :dokuwiki:`AD-FMCDAQ3-EBZ on Zynq ZC706 Linux quick start guide <resources/eval/user-guides/ad-fmcdaq2-ebz/software/linux/zynq>`
-- :external+documentation:ref:`AD-FMCDAQ3-EBZ baremetal (no-OS) guide <ad_fmcdaq3_ebz baremetal>`
+- :external+system-level:ref:`AD-FMCDAQ3-EBZ baremetal (no-OS) guide <ad_fmcdaq3_ebz baremetal>`
 - :dokuwiki:`AD-FMCDAQ3-EBZ on MicroBlaze no-OS quick start guide <resources/eval/user-guides/ad-fmcdaq2-ebz/software/linux/microblaze>`
 - :dokuwiki:`AD-FMCDAQ3-EBZ IIO Oscilloscope plugin <resources/eval/user-guides/ad-fmcdaq2-ebz/software/linux/applications/iio_scope>`
-- :external+documentation:ref:`FRU EEPROM (fru_dump) utility <software fru-dump>`
+- :external+system-level:ref:`FRU EEPROM (fru_dump) utility <software fru-dump>`
 
 .. include:: ../common/more_information.rst
 

--- a/docs/projects/fmcomms2/fir_filter.rst
+++ b/docs/projects/fmcomms2/fir_filter.rst
@@ -395,8 +395,8 @@ Generating the programing files
 More information at:
 
 - :ref:`build_hdl`
-- :external+documentation:ref:`linux-kernel zynq`
-- :external+documentation:ref:`linux-kernel microblaze`
+- :external+system-level:ref:`linux-kernel zynq`
+- :external+system-level:ref:`linux-kernel microblaze`
 
 Base system functionality
 -------------------------------------------------------------------------------


### PR DESCRIPTION
To consolidate with the developer.analog.com/docs name,
rename documentation to system-level.