### PR TITLE
library/scripts: Fix Tcl 9.0 namespace resolution and export Lattice env paths

### DIFF
--- a/library/scripts/adi_ip_lattice.tcl
+++ b/library/scripts/adi_ip_lattice.tcl
@@ -93,7 +93,6 @@ namespace eval ipl {
             foreach file $interfaces_paths_list {
                 if {[regexp {^.+\/PropelIPLocal} $file PropelIPLocal_path]} {
                     puts $file
-                    set PropelIPLocal_path
                 }
             }
         }

--- a/library/scripts/adi_ip_lattice.tcl
+++ b/library/scripts/adi_ip_lattice.tcl
@@ -85,10 +85,10 @@ namespace eval ipl {
 
     set check [catch {exec cygpath --version}]
     if {$check == 0} {
-        set PropelIPLocal_path [exec cygpath -H]/[exec whoami]/PropelIPLocal
-        if {[info exists env(LATTICE_INTERFACE_SEARCH_PATH)]} {
+        variable PropelIPLocal_path [exec cygpath -H]/[exec whoami]/PropelIPLocal
+        if {[info exists ::env(LATTICE_INTERFACE_SEARCH_PATH)]} {
             set interfaces_paths_list \
-                [split $env(LATTICE_INTERFACE_SEARCH_PATH) ";"]
+                [split $::env(LATTICE_INTERFACE_SEARCH_PATH) ";"]
 
             foreach file $interfaces_paths_list {
                 if {[regexp {^.+\/PropelIPLocal} $file PropelIPLocal_path]} {
@@ -98,7 +98,7 @@ namespace eval ipl {
             }
         }
     } else {
-        set PropelIPLocal_path $env(HOME)/PropelIPLocal
+        variable PropelIPLocal_path $::env(HOME)/PropelIPLocal
     }
 
     #node: {name attributes content childs}
@@ -541,10 +541,12 @@ namespace eval ipl {
 #                       in default)
 ###############################################################################
     proc generate_interface {if {dpath ""}} {
+        variable PropelIPLocal_path
+
         if {$dpath == ""} {
             if {[info exists ::env(LATTICE_DEFAULT_PATHS)] && \
                 $::env(LATTICE_DEFAULT_PATHS) == 1} {
-                set dpaths [list ./ltt $ipl::PropelIPLocal_path/interfaces]
+                set dpaths [list ./ltt $PropelIPLocal_path/interfaces]
             } else {
                 set dpaths ./ltt
             }
@@ -557,8 +559,10 @@ namespace eval ipl {
     }
 
     proc generate_interface_on_path {if {dpath ""}} {
+        variable PropelIPLocal_path
+
         if {$dpath == ""} {
-            set dpath $ipl::PropelIPLocal_path/interfaces
+            set dpath $PropelIPLocal_path/interfaces
         }
 
         set abstractionDefinition [ipl::getnode \
@@ -1438,7 +1442,7 @@ namespace eval ipl {
             if {$id == ""} {
                 set ip \
                     [ipl::setnode ip_desc/xi:include $::ipl::inclid $node $ip]
-                incr ipl::inclid
+                incr ::ipl::inclid
             } else {
                 set ip [ipl::setnode ip_desc/xi:include $id $node $ip]
             }
@@ -1447,10 +1451,12 @@ namespace eval ipl {
     }
 
     proc generate_ip {ip {dpath ""} {ip_name ""}} {
+        variable PropelIPLocal_path
+
         if {$dpath == ""} {
             if {[info exists ::env(LATTICE_DEFAULT_PATHS)] && \
                 $::env(LATTICE_DEFAULT_PATHS) == 1} {
-                set dpaths [list ./ ltt $ipl::PropelIPLocal_path {}]
+                set dpaths [list ./ ltt $PropelIPLocal_path {}]
             } else {
                 set dpaths [list ./ ltt]
             }
@@ -1463,6 +1469,8 @@ namespace eval ipl {
     }
 
     proc generate_ip_on_path {ip {dpath ""} {ip_name ""}} {
+        variable PropelIPLocal_path
+
         if {$ip_name == ""} {
             set ip_name [ipl::getncont ip_desc/lsccip:general lsccip:name $ip]
         }
@@ -1471,7 +1479,7 @@ namespace eval ipl {
             exit 2
         }
         if {$dpath == ""} {
-            set dpath $ipl::PropelIPLocal_path
+            set dpath $PropelIPLocal_path
         }
         if {[file exist $dpath] != 1} {
             file mkdir $dpath
@@ -2165,32 +2173,32 @@ namespace eval ipl {
         return [ipl::setnode fdeps $dpath $flist $ip]
     }
 
-    set axi4_ports {
+    variable axi4_ports {
         awid awaddr awlen awsize awburst awlock awcache
         awprot awqos awvalid awready wid wdata wstrb wlast wvalid wready bid
         bresp bvalid bready arid araddr arlen arsize arburst arlock arcache
         arprot arqos arvalid arready rid rdata rresp rlast rvalid rready
     }
 
-    set axi4_lite_ports {
+    variable axi4_lite_ports {
         awaddr awprot awvalid awready wdata wstrb wvalid wready bresp bvalid
         bready araddr arprot arvalid arready rdata rresp rvalid rready
     }
 
-    set axi4_stream_ports {
+    variable axi4_stream_ports {
         tvalid tready tdata tstrb tkeep tlast tid tdest tuser
     }
 
-    set axi4_sream_pors {
+    variable axi4_sream_pors {
         valid ready data strb keep last id dest user
     }
 
     proc filter_ports {args} {
         array set opt [list -mod_data "" \
-            -portlist [concat $ipl::axi4_ports \
-                $ipl::axi4_lite_ports \
-                $ipl::axi4_stream_ports \
-                $ipl::axi4_sream_pors] \
+            -portlist [concat $::ipl::axi4_ports \
+                $::ipl::axi4_lite_ports \
+                $::ipl::axi4_stream_ports \
+                $::ipl::axi4_sream_pors] \
         {*}$args]
 
         set mod_data $opt(-mod_data)

--- a/library/scripts/lattice_tool_set.mk
+++ b/library/scripts/lattice_tool_set.mk
@@ -3,16 +3,16 @@
 ## SPDX short identifier: BSD-1-Clause
 ####################################################################################
 
-LATTICE_IP_TOOL ?= tclsh
+LATTICE_IP_TOOL := tclsh
 
 CYGPATH_VERSION := $(shell command -v cygpath --version)
 
 ifeq ($(LATTICE_DEFAULT_PATHS),1)
 ifneq ($(CYGPATH_VERSION),)
-LATTICE_DEFAULT_INTERFACE_PATH := $(shell cygpath -H)/$(shell whoami)/PropelIPLocal/interfaces
-LATTICE_DEFAULT_IP_PATH := $(shell cygpath -H)/$(shell whoami)/PropelIPLocal
+export LATTICE_DEFAULT_INTERFACE_PATH := $(shell cygpath -H)/$(shell whoami)/PropelIPLocal/interfaces
+export LATTICE_DEFAULT_IP_PATH := $(shell cygpath -H)/$(shell whoami)/PropelIPLocal
 else
-LATTICE_DEFAULT_INTERFACE_PATH := ~/PropelIPLocal/interfaces
-LATTICE_DEFAULT_IP_PATH := ~/PropelIPLocal
+export LATTICE_DEFAULT_INTERFACE_PATH := $(HOME)/PropelIPLocal/interfaces
+export LATTICE_DEFAULT_IP_PATH := $(HOME)/PropelIPLocal
 endif
 endif

--- a/library/scripts/lattice_tool_set.mk
+++ b/library/scripts/lattice_tool_set.mk
@@ -3,7 +3,7 @@
 ## SPDX short identifier: BSD-1-Clause
 ####################################################################################
 
-LATTICE_IP_TOOL := tclsh
+LATTICE_IP_TOOL ?= tclsh
 
 CYGPATH_VERSION := $(shell command -v cygpath --version)
 


### PR DESCRIPTION
### Description
This PR fixes namespace resolution errors and missing environment variable exports when generating Lattice IP libraries using modern Tcl interpreters (such as Tcl 9.0 on modern Linux distributions like Fedora).

### Motivation & Context
In #2128, vendor-specific Make targets were introduced as a workaround to skip Lattice IP generation when targeting other vendors (e.g., Xilinx). However, that approach was insufficient because certain common IP cores (such as `axi_ad9361`) still depend on the default library build flow, leaving the root issue unresolved. #2128 has been closed in favor of addressing the underlying build failure directly.

Under Tcl 9.0, variable and namespace scoping rules are strictly enforced:
1. Unqualified access to `env(...)` inside `namespace eval ipl` fails with `no such variable`.
2. Relative namespace qualification like `$ipl::axi4_ports` or `incr ipl::inclid` inside `namespace eval ipl` resolves incorrectly as child namespaces.
3. Variables declared with `set` at the namespace level were not accessible inside procedures without explicit `variable` linking.
4. `LATTICE_DEFAULT_INTERFACE_PATH` and `LATTICE_DEFAULT_IP_PATH` set in `lattice_tool_set.mk` were not exported to child `tclsh` processes, and unexpanded tildes (`~`) caused invalid filesystem paths on POSIX environments.

Fixing these issues restores full compatibility for `make lib` across all toolchains without needing to skip Lattice targets.

### Changes
- **`library/scripts/adi_ip_lattice.tcl`**:
  - Replaced un-scoped `$env(...)` with `$::env(...)` in the cygpath check and path lookups.
  - Declared `PropelIPLocal_path` and AXI port lists using `variable` inside `namespace eval ipl`.
  - Linked `variable PropelIPLocal_path` inside `generate_interface`, `generate_interface_on_path`, `generate_ip`, and `generate_ip_on_path`.
  - Qualified `::ipl::inclid` and `::ipl::axi4_*` to prevent relative namespace resolution errors.
- **`library/scripts/lattice_tool_set.mk`**:
  - Exported `LATTICE_DEFAULT_INTERFACE_PATH` and `LATTICE_DEFAULT_IP_PATH`.
  - Replaced unexpanded `~/` with `$(HOME)/` for POSIX environments.

### Related PRs / Issues
- Supersedes #2128

### PR Type
- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)
- [ ] Documentation

### PR Checklist
- [x] I have followed the code style guidelines
- [x] I have performed a self-review of changes
- [x] I have compiled all hdl projects and libraries affected by this PR
- [ ] I have tested in hardware affected projects, at least on relevant boards
- [x] I have commented my code, at least hard-to-understand parts
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe files, Copyright etc)
- [x] I have not introduced new Warnings/Critical Warnings on compilation
- [ ] I have added new hdl testbenches or updated existing ones