### PR TITLE
SPI slave interface for AD4080-FMC-EVB

### DIFF
--- a/docs/library/index.rst
+++ b/docs/library/index.rst
@@ -91,6 +91,7 @@ Utilities
    cn0363/index
    common/ad_dds/index
    corundum/index
+   spi_slave/index
    util_axis_fifo/index
    util_axis_fifo_asym/index
    util_extract/index

--- a/docs/library/spi_slave/block_diagram.svg
+++ b/docs/library/spi_slave/block_diagram.svg
@@ -1,0 +1,343 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   width="440"
+   height="160"
+   viewBox="0 0 440 160"
+   version="1.1"
+   font-family="'Liberation Sans', Helvetica, Arial, sans-serif"
+   id="svg25"
+   sodipodi:docname="block_diagram.svg"
+   inkscape:version="1.4.4 (dcaf3e7, 2026-05-05)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+     id="namedview25"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:zoom="2.8933333"
+     inkscape:cx="303.28341"
+     inkscape:cy="143.43318"
+     inkscape:window-width="2400"
+     inkscape:window-height="1262"
+     inkscape:window-x="4792"
+     inkscape:window-y="-8"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg25" />
+  <defs
+     id="defs1">
+    <marker
+       id="arw"
+       overflow="visible"
+       orient="auto">
+      <path
+         transform="scale(0.5)"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         fill="#000000"
+         fill-rule="evenodd"
+         stroke="#000000"
+         stroke-width="1pt"
+         id="path1" />
+    </marker>
+    <marker
+       id="arw-9"
+       overflow="visible"
+       orient="auto">
+      <path
+         transform="scale(0.5)"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         fill="#000000"
+         fill-rule="evenodd"
+         stroke="#000000"
+         stroke-width="1pt"
+         id="path1-4" />
+    </marker>
+    <marker
+       id="marker2"
+       overflow="visible"
+       orient="auto">
+      <path
+         transform="scale(0.5)"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         fill="#000000"
+         fill-rule="evenodd"
+         stroke="#000000"
+         stroke-width="1pt"
+         id="path2" />
+    </marker>
+    <marker
+       id="marker3"
+       overflow="visible"
+       orient="auto">
+      <path
+         transform="scale(0.5)"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         fill="#000000"
+         fill-rule="evenodd"
+         stroke="#000000"
+         stroke-width="1pt"
+         id="path3" />
+    </marker>
+    <marker
+       id="marker4"
+       overflow="visible"
+       orient="auto">
+      <path
+         transform="scale(0.5)"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         fill="#000000"
+         fill-rule="evenodd"
+         stroke="#000000"
+         stroke-width="1pt"
+         id="path4" />
+    </marker>
+  </defs>
+  <!-- IP boundary -->
+  <rect
+     x="123.1264"
+     y="7.2047448"
+     width="238.49373"
+     height="118.17116"
+     fill="#d3d7cf"
+     fill-rule="evenodd"
+     stroke="#000000"
+     stroke-width="0.976382"
+     id="rect1"
+     style="fill:none" />
+  <text
+     x="133.24884"
+     y="24.327188"
+     font-size="12px"
+     font-weight="bold"
+     id="text1"><tspan
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-family:'Liberation Sans', Helvetica, Arial, sans-serif;-inkscape-font-specification:'Liberation Sans, Helvetica, Arial, sans-serif'"
+       id="tspan25">SPI_SLAVE</tspan></text>
+  <!-- side annotations -->
+  <!-- asynchronous FIFO -->
+  <rect
+     x="145.13824"
+     y="35.207378"
+     width="95"
+     height="75"
+     fill="#fce94f"
+     fill-rule="evenodd"
+     stroke="#000"
+     stroke-width="1"
+     id="rect3"
+     style="fill:#ffcccc;fill-opacity:1;stroke:#a01414;stroke-opacity:1" />
+  <text
+     x="192.82948"
+     y="75.649765"
+     text-anchor="middle"
+     font-size="12px"
+     id="text4"><tspan
+       sodipodi:role="line"
+       id="tspan26"
+       x="192.82948"
+       y="75.649765">util_axis_fifo</tspan><tspan
+       sodipodi:role="line"
+       id="tspan27"
+       x="192.82948"
+       y="90.649765" /></text>
+  <text
+     x="207"
+     y="139"
+     text-anchor="middle"
+     font-size="12px"
+     id="text5" />
+  <text
+     x="207"
+     y="158"
+     text-anchor="middle"
+     font-size="9px"
+     fill="#333333"
+     id="text6" />
+  <!-- SPI shift logic -->
+  <rect
+     x="277.24927"
+     y="35.071674"
+     width="62.12587"
+     height="75.271034"
+     fill="#729fcf"
+     fill-rule="evenodd"
+     stroke="#000"
+     stroke-width="0.728969"
+     id="rect6"
+     style="fill:#ffcccc;fill-opacity:1;stroke:#a01414;stroke-opacity:1" />
+  <text
+     x="310.64514"
+     y="70.576035"
+     text-anchor="middle"
+     font-size="12px"
+     id="text7">SPI shift</text>
+  <text
+     x="310.99078"
+     y="82.082947"
+     text-anchor="middle"
+     font-size="12px"
+     id="text8">register</text>
+  <!-- FIFO -> shift register -->
+  <line
+     x1="240.82948"
+     y1="73.24424"
+     x2="273.36462"
+     y2="73.24424"
+     stroke="#000000"
+     stroke-width="1.15697"
+     marker-end="url(#arw)"
+     id="line10" />
+  <!-- write-interface inputs -->
+  <g
+     stroke="#000000"
+     stroke-width="1.2"
+     marker-end="url(#arw)"
+     id="g14"
+     transform="translate(-14.861751,-59.792627)">
+    <line
+       x1="95"
+       y1="108"
+       x2="160"
+       y2="108"
+       id="line11" />
+    <line
+       x1="95"
+       y1="124"
+       x2="160"
+       y2="124"
+       id="line12" />
+    <line
+       x1="95"
+       y1="140"
+       x2="160"
+       y2="140"
+       id="line13" />
+    <line
+       x1="95"
+       y1="156"
+       x2="160"
+       y2="156"
+       id="line14" />
+  </g>
+  <g
+     font-size="11px"
+     text-anchor="end"
+     id="g17"
+     transform="translate(30.414746,-67.741935)">
+    <text
+       x="90"
+       y="112"
+       id="text14">data[DATA_WIDTH-1:0]</text>
+    <text
+       x="90"
+       y="128"
+       id="text15">data_valid</text>
+    <text
+       x="90"
+       y="144"
+       id="text16">data_clk</text>
+    <text
+       x="90"
+       y="160"
+       id="text17">data_rst</text>
+  </g>
+  <!-- SPI-interface inputs -->
+  <!-- SPI-interface outputs -->
+  <g
+     font-size="11px"
+     text-anchor="start"
+     id="g23"
+     transform="translate(-70.506912,-38.709678)">
+    <text
+       x="434.41739"
+       y="81.350227"
+       id="text20">spi_cs</text>
+    <text
+       x="434.41739"
+       y="98.239632"
+       id="text21">spi_sclk</text>
+    <text
+       x="434.41739"
+       y="117.34101"
+       id="text22">spi_miso</text>
+    <text
+       x="434.37979"
+       y="133.19354"
+       id="text23">data_ready_n</text>
+  </g>
+  <!-- system clock / reset -->
+  <g
+     stroke="#000000"
+     stroke-width="1.2"
+     marker-end="url(#arw)"
+     id="g24"
+     transform="matrix(0.73760662,0,0,0.50773741,67.753424,11.569352)">
+    <line
+       x1="310"
+       y1="262"
+       x2="310"
+       y2="200"
+       id="line23" />
+    <line
+       x1="350"
+       y1="262"
+       x2="350"
+       y2="200"
+       id="line24" />
+  </g>
+  <g
+     font-size="11px"
+     text-anchor="middle"
+     id="g25"
+     transform="translate(-17.281106,-120.62212)">
+    <text
+       x="313.45621"
+       y="273.85254"
+       id="text24">clk</text>
+    <text
+       x="345.50693"
+       y="273.85254"
+       id="text25">resetn</text>
+  </g>
+  <g
+     stroke="#000000"
+     stroke-width="1.2"
+     marker-end="url(#arw-9)"
+     id="g14-8"
+     transform="matrix(-1,0,0,1,539.51014,-106.79738)"
+     style="marker-end:url(#arw-9)">
+    <line
+       x1="130.59908"
+       y1="155.00461"
+       x2="195.59908"
+       y2="155.00461"
+       id="line11-2"
+       style="marker-end:url(#arw-9)" />
+    <line
+       x1="130.59908"
+       y1="171.00461"
+       x2="195.59908"
+       y2="171.00461"
+       id="line12-4"
+       style="marker-end:url(#arw-9)" />
+    <line
+       x1="200.55162"
+       y1="190.11522"
+       x2="135.55161"
+       y2="190.11522"
+       id="line13-5"
+       style="marker-end:url(#arw-9)" />
+    <line
+       x1="200.55162"
+       y1="206.11522"
+       x2="135.55161"
+       y2="206.11522"
+       id="line14-5"
+       style="marker-end:url(#arw-9)" />
+  </g>
+</svg>

--- a/docs/library/spi_slave/index.rst
+++ b/docs/library/spi_slave/index.rst
@@ -1,0 +1,96 @@
+.. _spi_slave:
+
+SPI Slave
+===============================================================================
+
+.. hdl-component-diagram::
+
+The :git-hdl:`SPI Slave <library/spi_slave>` peripheral buffers a stream of
+data samples in an asynchronous FIFO and streams them out to an external SPI
+master. It lets a device that is not on the processor bus (for example a
+microcontroller acting as an SPI controller) read data captured in the FPGA
+fabric, without involving the processor or a DMA.
+
+A typical use case is to expose ADC samples over a PMOD connector: the write
+side of the FIFO is driven by the converter data path in the ADC clock domain,
+while the read side is clocked by the system clock and shifted out on the SPI
+interface under control of the external master.
+
+Files
+-------------------------------------------------------------------------------
+
+.. list-table::
+   :header-rows: 1
+
+   * - Name
+     - Description
+   * - :git-hdl:`library/spi_slave/spi_slave.v`
+     - Verilog source for the peripheral
+   * - :git-hdl:`library/spi_slave/spi_slave_ip.tcl`
+     - Tcl script to generate the Vivado IP Integrator project for the
+       peripheral
+
+Block Diagram
+-------------------------------------------------------------------------------
+
+.. image:: block_diagram.svg
+   :alt: SPI Slave block diagram
+   :align: center
+
+Configuration Parameters
+-------------------------------------------------------------------------------
+
+.. hdl-parameters::
+   :path: library/spi_slave
+
+Interface
+-------------------------------------------------------------------------------
+
+.. hdl-interfaces::
+   :path: library/spi_slave
+
+Detailed Description
+-------------------------------------------------------------------------------
+
+The peripheral spans two clock domains, joined by an asynchronous FIFO
+(:ref:`util_axis_fifo`):
+
+- **Write side (data domain).** Samples presented on ``data`` are written into
+  the FIFO on every ``data_clk`` cycle for which ``data_valid`` is asserted.
+  This side is held in reset by the active-high ``data_rst``. The FIFO holds
+  ``2**ADDRESS_WIDTH`` words of ``DATA_WIDTH`` bits.
+- **Read / SPI side (system clock domain).** The FIFO read side, the pin
+  synchronizers and the shift logic all run on ``clk`` and are reset by the
+  active-low ``resetn``.
+
+The asynchronous ``spi_cs`` and ``spi_sclk`` inputs are first brought into the
+``clk`` domain through a two-stage synchronizer (``util_cdc``) and then edge
+detected.
+
+The SPI interface operates in **Mode 3** (clock idles high, data changes on the
+falling edge and is sampled by the master on the rising edge), MSB first, with
+``DATA_WIDTH`` bits per transfer:
+
+#. ``data_ready_n`` reflects FIFO occupancy: it is driven low whenever at least
+   one word is available to be read. The external master can poll it to know
+   when a new sample is ready.
+#. On the falling edge of ``spi_cs`` (start of a transfer) the next FIFO word
+   is loaded into the shift register, its MSB is presented on ``spi_miso``, and
+   the word is popped from the FIFO.
+#. On each following SPI clock edge the shift register advances by one bit,
+   presenting the next bit on ``spi_miso``, until all ``DATA_WIDTH`` bits have
+   been shifted out.
+
+The external master should frame each read as a single ``DATA_WIDTH``-bit,
+chip-select-asserted transfer.
+
+.. note::
+
+   The peripheral only sources data; it has no MOSI input and ignores anything
+   the master drives towards it. The number of bits per transfer is fixed by
+   ``DATA_WIDTH`` and must match the master's word length.
+
+References
+-------------------------------------------------------------------------------
+
+* HDL IP core at :git-hdl:`library/spi_slave`

--- a/docs/projects/ad4080_fmc_evb/ad4080_fmc_evb_zed_spi_slave_block_diagram.svg
+++ b/docs/projects/ad4080_fmc_evb/ad4080_fmc_evb_zed_spi_slave_block_diagram.svg
@@ -1,0 +1,1802 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="160.82281mm"
+   height="160mm"
+   viewBox="0 0 160.82281 160"
+   version="1.1"
+   id="svg29591"
+   inkscape:version="1.4.4 (dcaf3e7, 2026-05-05)"
+   sodipodi:docname="ad4080_fmc_evb_zed_spi_slave_block_diagram.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+     id="namedview29593"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:document-units="mm"
+     showgrid="false"
+     inkscape:zoom="2.0938812"
+     inkscape:cx="261.95373"
+     inkscape:cy="390.66209"
+     inkscape:window-width="2400"
+     inkscape:window-height="1262"
+     inkscape:window-x="4792"
+     inkscape:window-y="-8"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="layer1"
+     inkscape:showpageshadow="2"
+     inkscape:deskcolor="#d1d1d1" />
+  <defs
+     id="defs29588">
+    <rect
+       x="199.91928"
+       y="437.32342"
+       width="124.61185"
+       height="107.38907"
+       id="rect3" />
+    <rect
+       x="152.64107"
+       y="344.79321"
+       width="66.527191"
+       height="21.275192"
+       id="rect1" />
+    <marker
+       inkscape:stockid="TriangleInM"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="TriangleInM-7-1"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         inkscape:connector-curvature="0"
+         id="path4660-1-6"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="scale(-0.4)" />
+    </marker>
+    <marker
+       inkscape:stockid="TriangleOutM"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker9011"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         inkscape:connector-curvature="0"
+         id="path9009"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="scale(0.4)" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker1216-7"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="TriangleOutM">
+      <path
+         transform="scale(0.4)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         id="path1214-5"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker1216-9-3"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="TriangleOutM">
+      <path
+         transform="scale(0.4)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         id="path1214-1-6"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker1216-0-3"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="TriangleOutM">
+      <path
+         transform="scale(0.4)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         id="path1214-3-7"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker1216-0-3-9"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="TriangleOutM">
+      <path
+         transform="scale(0.4)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         id="path1214-3-7-7"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker1216"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="TriangleOutM"
+       inkscape:collect="always">
+      <path
+         transform="scale(0.4)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         id="path1214"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker1216-9"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="TriangleOutM">
+      <path
+         transform="scale(0.4)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         id="path1214-1"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:stockid="TriangleInM"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker30716"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         inkscape:connector-curvature="0"
+         id="path30714"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="scale(-0.4)" />
+    </marker>
+    <marker
+       inkscape:stockid="TriangleOutM"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="TriangleOutM-2-8"
+       style="overflow:visible"
+       inkscape:isstock="true"
+       inkscape:collect="always">
+      <path
+         inkscape:connector-curvature="0"
+         id="path4669-5-5"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="scale(0.4)" />
+    </marker>
+    <marker
+       inkscape:stockid="TriangleInM"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="TriangleInM-7"
+       style="overflow:visible"
+       inkscape:isstock="true"
+       inkscape:collect="always">
+      <path
+         inkscape:connector-curvature="0"
+         id="path4660-1"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="scale(-0.4)" />
+    </marker>
+    <marker
+       inkscape:stockid="TriangleOutM"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="TriangleOutM-2"
+       style="overflow:visible"
+       inkscape:isstock="true"
+       inkscape:collect="always">
+      <path
+         inkscape:connector-curvature="0"
+         id="path4669-5"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="scale(0.4)" />
+    </marker>
+    <marker
+       inkscape:stockid="TriangleInM"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="TriangleInM"
+       style="overflow:visible"
+       inkscape:isstock="true"
+       inkscape:collect="always">
+      <path
+         id="path4660"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="scale(-0.4)"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:stockid="TriangleOutM"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="TriangleOutM"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path4669"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="scale(0.4)"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <rect
+       x="505.75934"
+       y="440.80817"
+       width="91.509193"
+       height="18.625698"
+       id="rect4760" />
+    <rect
+       x="505.75934"
+       y="440.80817"
+       width="91.509193"
+       height="18.625698"
+       id="rect4760-6" />
+    <rect
+       x="298.96634"
+       y="469.9407"
+       width="124.17132"
+       height="41.072052"
+       id="rect24670" />
+    <rect
+       x="298.96634"
+       y="469.9407"
+       width="124.17132"
+       height="41.072052"
+       id="rect24670-6" />
+    <marker
+       style="overflow:visible"
+       id="TriangleInM-3"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="TriangleInM"
+       inkscape:isstock="true">
+      <path
+         transform="scale(-0.4)"
+         style="fill:context-stroke;fill-rule:evenodd;stroke:context-stroke;stroke-width:1pt"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         id="path42185" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="marker51146"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="TriangleInM"
+       inkscape:isstock="true">
+      <path
+         transform="scale(-0.4)"
+         style="fill:context-stroke;fill-rule:evenodd;stroke:context-stroke;stroke-width:1pt"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         id="path51144" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="TriangleInM-0"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="TriangleInM"
+       inkscape:isstock="true">
+      <path
+         transform="scale(-0.4)"
+         style="fill:context-stroke;fill-rule:evenodd;stroke:context-stroke;stroke-width:1pt"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         id="path42185-3" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="marker51146-9"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="TriangleInM"
+       inkscape:isstock="true">
+      <path
+         transform="scale(-0.4)"
+         style="fill:context-stroke;fill-rule:evenodd;stroke:context-stroke;stroke-width:1pt"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         id="path51144-3" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="TriangleOutM-0"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="TriangleOutM"
+       inkscape:isstock="true">
+      <path
+         transform="scale(0.4)"
+         style="fill:context-stroke;fill-rule:evenodd;stroke:context-stroke;stroke-width:1pt"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         id="path42194" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="TriangleOutM-6"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="TriangleOutM"
+       inkscape:isstock="true">
+      <path
+         transform="scale(0.4)"
+         style="fill:context-stroke;fill-rule:evenodd;stroke:context-stroke;stroke-width:1pt"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         id="path42194-3" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="TriangleOutM-45"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="TriangleOutM"
+       inkscape:isstock="true">
+      <path
+         transform="scale(0.4)"
+         style="fill:context-stroke;fill-rule:evenodd;stroke:context-stroke;stroke-width:1pt"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         id="path42194-03" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="TriangleOutM-6-1"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="TriangleOutM"
+       inkscape:isstock="true">
+      <path
+         transform="scale(0.4)"
+         style="fill:context-stroke;fill-rule:evenodd;stroke:context-stroke;stroke-width:1pt"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         id="path42194-3-3" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="TriangleOutM-45-7"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="TriangleOutM"
+       inkscape:isstock="true">
+      <path
+         transform="scale(0.4)"
+         style="fill:context-stroke;fill-rule:evenodd;stroke:context-stroke;stroke-width:1pt"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         id="path42194-03-3" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="TriangleOutM-6-1-9"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="TriangleOutM"
+       inkscape:isstock="true">
+      <path
+         transform="scale(0.4)"
+         style="fill:context-stroke;fill-rule:evenodd;stroke:context-stroke;stroke-width:1pt"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         id="path42194-3-3-6" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="TriangleOutM-45-7-3"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="TriangleOutM"
+       inkscape:isstock="true">
+      <path
+         transform="scale(0.4)"
+         style="fill:context-stroke;fill-rule:evenodd;stroke:context-stroke;stroke-width:1pt"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         id="path42194-03-3-3" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="TriangleOutM-6-1-9-9"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="TriangleOutM"
+       inkscape:isstock="true">
+      <path
+         transform="scale(0.4)"
+         style="fill:context-stroke;fill-rule:evenodd;stroke:context-stroke;stroke-width:1pt"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         id="path42194-3-3-6-9" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="TriangleOutM-45-3"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="TriangleOutM"
+       inkscape:isstock="true">
+      <path
+         transform="scale(0.4)"
+         style="fill:context-stroke;fill-rule:evenodd;stroke:context-stroke;stroke-width:1pt"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         id="path42194-03-5" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="TriangleOutM-6-1-7"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="TriangleOutM"
+       inkscape:isstock="true">
+      <path
+         transform="scale(0.4)"
+         style="fill:context-stroke;fill-rule:evenodd;stroke:context-stroke;stroke-width:1pt"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         id="path42194-3-3-0" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="TriangleOutM-45-3-2"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="TriangleOutM"
+       inkscape:isstock="true">
+      <path
+         transform="scale(0.4)"
+         style="fill:context-stroke;fill-rule:evenodd;stroke:context-stroke;stroke-width:1pt"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         id="path42194-03-5-4" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="TriangleOutM-45-3-2-9"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="TriangleOutM"
+       inkscape:isstock="true">
+      <path
+         transform="scale(0.4)"
+         style="fill:context-stroke;fill-rule:evenodd;stroke:context-stroke;stroke-width:1pt"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         id="path42194-03-5-4-1" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="TriangleOutM-6-1-7-6-7"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="TriangleOutM"
+       inkscape:isstock="true">
+      <path
+         transform="scale(0.4)"
+         style="fill:context-stroke;fill-rule:evenodd;stroke:context-stroke;stroke-width:1pt"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         id="path42194-3-3-0-2-2" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="TriangleOutM-8"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="TriangleOutM"
+       inkscape:isstock="true">
+      <path
+         transform="scale(0.4)"
+         style="fill:context-stroke;fill-rule:evenodd;stroke:context-stroke;stroke-width:1pt"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         id="path42194-38" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="TriangleOutM-6-7"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="TriangleOutM"
+       inkscape:isstock="true">
+      <path
+         transform="scale(0.4)"
+         style="fill:context-stroke;fill-rule:evenodd;stroke:context-stroke;stroke-width:1pt"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         id="path42194-3-36" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker1216-4"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="TriangleOutM"
+       inkscape:collect="always">
+      <path
+         transform="scale(0.4)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         id="path1214-51"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker1216-9-6"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="TriangleOutM">
+      <path
+         transform="scale(0.4)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         id="path1214-1-4"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker1216-71"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="TriangleOutM"
+       inkscape:collect="always">
+      <path
+         transform="scale(0.4)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         id="path1214-8"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker1216-9-9"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="TriangleOutM">
+      <path
+         transform="scale(0.4)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         id="path1214-1-7"
+         inkscape:connector-curvature="0" />
+    </marker>
+  </defs>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(-45.687375,-26.530943)">
+    <rect
+       style="display:inline;vector-effect:none;fill:none;fill-opacity:1;stroke:#3f4b55;stroke-width:0.333552;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:0.333552, 1.00066;stroke-dashoffset:0;stroke-opacity:1;shape-rendering:crispEdges;enable-background:new"
+       id="rect6078-6"
+       width="76.035355"
+       height="86.956375"
+       x="79.388474"
+       y="69.981445"
+       inkscape:export-xdpi="224.36"
+       inkscape:export-ydpi="224.36" />
+    <rect
+       style="display:inline;fill:none;fill-opacity:1;stroke:#3f4b55;stroke-width:0.436;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:0.436, 1.308;stroke-dashoffset:0;stroke-opacity:1;shape-rendering:crispEdges;enable-background:new"
+       id="rect6078"
+       width="45.067265"
+       height="73.748421"
+       x="156.29265"
+       y="78.586243"
+       inkscape:export-xdpi="224.36"
+       inkscape:export-ydpi="224.36" />
+    <rect
+       style="fill:#fefdfe;fill-opacity:1;fill-rule:evenodd;stroke:#071414;stroke-width:0.4;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:75.5906;stroke-opacity:1"
+       id="rect46745"
+       width="48.594585"
+       height="66.989983"
+       x="110.19932"
+       y="79.802864" />
+    <rect
+       style="display:inline;fill:#000000;fill-opacity:0;fill-rule:nonzero;stroke:#000000;stroke-width:0.322172;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:0;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;shape-rendering:crispEdges;enable-background:new"
+       id="rect4477"
+       width="156.84618"
+       height="140.18372"
+       x="45.848461"
+       y="42.419094"
+       inkscape:export-xdpi="224.36"
+       inkscape:export-ydpi="224.36" />
+    <path
+       sodipodi:nodetypes="cc"
+       inkscape:connector-curvature="0"
+       id="path4518"
+       d="M 133.57232,45.349186 V 40.279672"
+       style="display:inline;fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:0.396875;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-start:url(#TriangleInM);marker-end:url(#TriangleOutM);shape-rendering:crispEdges;enable-background:new"
+       inkscape:export-xdpi="224.36"
+       inkscape:export-ydpi="224.36" />
+    <path
+       sodipodi:nodetypes="cc"
+       inkscape:connector-curvature="0"
+       id="path4518-5"
+       d="M 140.48242,45.347446 V 40.304278"
+       style="display:inline;fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:0.396875;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-start:url(#TriangleInM-7);marker-end:url(#TriangleOutM-2);shape-rendering:crispEdges;enable-background:new"
+       inkscape:export-xdpi="224.36"
+       inkscape:export-ydpi="224.36" />
+    <path
+       sodipodi:nodetypes="cc"
+       inkscape:connector-curvature="0"
+       id="path4518-5-9"
+       d="M 147.39251,45.34172 V 40.272264"
+       style="display:inline;fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:0.396875;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-start:url(#TriangleInM-7-1);marker-end:url(#TriangleOutM-2-8);shape-rendering:crispEdges;enable-background:new"
+       inkscape:export-xdpi="224.36"
+       inkscape:export-ydpi="224.36" />
+    <rect
+       transform="scale(-1,1)"
+       style="display:inline;fill:#ebebeb;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.500933;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:0;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;shape-rendering:crispEdges"
+       id="rect4136"
+       width="111.22163"
+       height="19.844805"
+       x="-164.83311"
+       y="46.539265"
+       inkscape:export-xdpi="224.36"
+       inkscape:export-ydpi="224.36" />
+    <path
+       style="display:inline;fill:#a2dcea;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.529167;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;shape-rendering:crispEdges"
+       d="M 157.54764,46.715505 V 66.42975"
+       id="path4179"
+       inkscape:connector-curvature="0"
+       inkscape:export-xdpi="224.36"
+       inkscape:export-ydpi="224.36" />
+    <path
+       style="display:inline;fill:#a2dcea;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.529167;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;shape-rendering:crispEdges"
+       d="M 150.76627,46.715505 V 66.42975"
+       id="path4179-9"
+       inkscape:connector-curvature="0"
+       inkscape:export-xdpi="224.36"
+       inkscape:export-ydpi="224.36" />
+    <path
+       style="display:inline;fill:#a2dcea;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.529167;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;shape-rendering:crispEdges"
+       d="M 123.64077,46.715505 V 66.42975"
+       id="path4179-0"
+       inkscape:connector-curvature="0"
+       inkscape:export-xdpi="224.36"
+       inkscape:export-ydpi="224.36" />
+    <path
+       style="display:inline;fill:#a2dcea;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.529167;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;shape-rendering:crispEdges"
+       d="M 130.42215,46.715505 V 66.42975"
+       id="path4179-4"
+       inkscape:connector-curvature="0"
+       inkscape:export-xdpi="224.36"
+       inkscape:export-ydpi="224.36" />
+    <path
+       style="display:inline;fill:#a2dcea;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.529167;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;shape-rendering:crispEdges"
+       d="M 137.20352,46.715505 V 66.42975"
+       id="path4179-7"
+       inkscape:connector-curvature="0"
+       inkscape:export-xdpi="224.36"
+       inkscape:export-ydpi="224.36" />
+    <path
+       style="display:inline;fill:#a2dcea;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.529167;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;shape-rendering:crispEdges"
+       d="M 143.98489,46.715505 V 66.42975"
+       id="path4179-41"
+       inkscape:connector-curvature="0"
+       inkscape:export-xdpi="224.36"
+       inkscape:export-ydpi="224.36" />
+    <path
+       style="display:inline;fill:#a2dcea;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.529167;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;shape-rendering:crispEdges"
+       d="M 116.8594,46.715505 V 66.42975"
+       id="path4179-0-3"
+       inkscape:connector-curvature="0"
+       inkscape:export-xdpi="224.36"
+       inkscape:export-ydpi="224.36" />
+    <text
+       transform="matrix(0,-1.0072219,0.9928299,0,0,0)"
+       id="text4229"
+       y="142.68727"
+       x="-62.18874"
+       style="font-style:normal;font-weight:normal;font-size:3.175px;line-height:0%;font-family:Arial;letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;shape-rendering:crispEdges"
+       xml:space="preserve"
+       inkscape:export-xdpi="224.36"
+       inkscape:export-ydpi="224.36"><tspan
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:2.97656px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial Bold';stroke-width:0.264583px"
+         y="142.68727"
+         x="-62.18874"
+         id="tspan4231"
+         sodipodi:role="line">Ethernet</tspan></text>
+    <text
+       transform="matrix(0,-1.0072219,0.9928299,0,0,0)"
+       id="text4233"
+       y="149.24825"
+       x="-60.271706"
+       style="font-style:normal;font-weight:normal;font-size:3.175px;line-height:0%;font-family:Arial;letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;shape-rendering:crispEdges"
+       xml:space="preserve"
+       inkscape:export-xdpi="224.36"
+       inkscape:export-ydpi="224.36"><tspan
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:2.97656px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial Bold';stroke-width:0.264583px"
+         y="149.24825"
+         x="-60.271706"
+         id="tspan4235"
+         sodipodi:role="line">UART</tspan></text>
+    <text
+       transform="matrix(0,-1.0072219,0.9928299,0,0,0)"
+       id="text4237"
+       y="136.0764"
+       x="-60.204849"
+       style="font-style:normal;font-weight:normal;font-size:3.175px;line-height:0%;font-family:Arial;letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;shape-rendering:crispEdges"
+       xml:space="preserve"
+       inkscape:export-xdpi="224.36"
+       inkscape:export-ydpi="224.36"><tspan
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:2.97656px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial Bold';stroke-width:0.264583px"
+         y="136.0764"
+         x="-60.204849"
+         id="tspan4239"
+         sodipodi:role="line">DDRx</tspan></text>
+    <text
+       transform="matrix(0,-1.0072219,0.9928299,0,0,0)"
+       id="text4241"
+       y="162.90863"
+       x="-58.415714"
+       style="font-style:normal;font-weight:normal;font-size:3.175px;line-height:0%;font-family:Arial;letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;shape-rendering:crispEdges"
+       xml:space="preserve"
+       inkscape:export-xdpi="224.36"
+       inkscape:export-ydpi="224.36"><tspan
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:2.97656px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial Bold';stroke-width:0.264583px"
+         y="162.90863"
+         x="-58.415714"
+         id="tspan4243"
+         sodipodi:role="line">SPI</tspan></text>
+    <text
+       transform="matrix(0,-1.0072219,0.9928299,0,0,0)"
+       id="text4245"
+       y="156.43456"
+       x="-58.398273"
+       style="font-style:normal;font-weight:normal;font-size:3.175px;line-height:0%;font-family:Arial;letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;shape-rendering:crispEdges"
+       xml:space="preserve"
+       inkscape:export-xdpi="224.36"
+       inkscape:export-ydpi="224.36"><tspan
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:2.97656px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial Bold';stroke-width:0.264583px"
+         y="156.43456"
+         x="-58.398273"
+         id="tspan4247"
+         sodipodi:role="line">I<tspan
+   style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:2.97656px;font-family:Arial;-inkscape-font-specification:'Arial Bold';baseline-shift:super;stroke-width:0.264583px"
+   id="tspan4485">2</tspan>C</tspan></text>
+    <text
+       transform="matrix(0,-1.0072219,0.9928299,0,0,0)"
+       id="text4251"
+       y="129.04584"
+       x="-63.036072"
+       style="font-style:normal;font-weight:normal;font-size:3.175px;line-height:0%;font-family:Arial;letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;shape-rendering:crispEdges"
+       xml:space="preserve"
+       inkscape:export-xdpi="224.36"
+       inkscape:export-ydpi="224.36"><tspan
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:2.97656px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial Bold';stroke-width:0.264583px"
+         y="129.04584"
+         x="-63.036072"
+         id="tspan4253"
+         sodipodi:role="line">Interrupts</tspan></text>
+    <text
+       transform="scale(0.9928299,1.0072219)"
+       id="text4311"
+       y="27.874945"
+       x="82.596695"
+       style="font-style:normal;font-weight:normal;font-size:3.175px;line-height:0%;font-family:Arial;letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;shape-rendering:crispEdges"
+       xml:space="preserve"><tspan
+         y="27.874945"
+         x="82.596695"
+         id="tspan4313"
+         sodipodi:role="line"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:3.96875px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial Bold';stroke-width:0.264583px" /></text>
+    <text
+       transform="matrix(0,-1.0072219,0.9928299,0,0,0)"
+       id="text4301"
+       y="121.95177"
+       x="-60.131454"
+       style="font-style:normal;font-weight:normal;font-size:3.175px;line-height:0%;font-family:Arial;letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;shape-rendering:crispEdges"
+       xml:space="preserve"
+       inkscape:export-xdpi="224.36"
+       inkscape:export-ydpi="224.36"><tspan
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:2.97656px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial Bold';stroke-width:0.264583px"
+         y="121.95177"
+         x="-60.131454"
+         id="tspan4303"
+         sodipodi:role="line">Timer</tspan></text>
+    <rect
+       style="display:inline;vector-effect:none;fill:#ffcccc;fill-opacity:1;fill-rule:nonzero;stroke:#a01414;stroke-width:0.264583;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;shape-rendering:crispEdges;enable-background:new"
+       id="rect4589"
+       width="3.9288628"
+       height="4.2094946"
+       x="53.282852"
+       y="36.366516"
+       inkscape:export-xdpi="224.36"
+       inkscape:export-ydpi="224.36" />
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;font-size:3.175px;line-height:0%;font-family:Arial;letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;shape-rendering:crispEdges;enable-background:new"
+       x="58.305683"
+       y="39.394981"
+       id="text4595"
+       inkscape:export-xdpi="224.36"
+       inkscape:export-ydpi="224.36"><tspan
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:3.30729px;line-height:1.25;font-family:Arial;-inkscape-font-specification:Arial;stroke-width:0.264583px"
+         sodipodi:role="line"
+         id="tspan4597"
+         x="58.305683"
+         y="39.394981">Receive path</tspan></text>
+    <rect
+       style="display:inline;vector-effect:none;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.486876;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:0;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;shape-rendering:crispEdges;enable-background:new"
+       id="rect4487"
+       width="6.6456137"
+       height="53.193066"
+       x="55.800285"
+       y="85.137817"
+       inkscape:export-xdpi="224.36"
+       inkscape:export-ydpi="224.36" />
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:3.88056px;line-height:0%;font-family:Arial;-inkscape-font-specification:'Arial, Bold';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;shape-rendering:crispEdges;enable-background:new"
+       x="-136.32645"
+       y="60.250889"
+       id="text4489"
+       transform="rotate(-90)"
+       inkscape:export-xdpi="224.36"
+       inkscape:export-ydpi="224.36"><tspan
+         sodipodi:role="line"
+         id="tspan4491"
+         x="-136.32645"
+         y="60.250889"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:3.88056px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial, Bold';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;stroke-width:0.264583px">MEMORY INTERCONNECT</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;font-size:3.175px;line-height:0%;font-family:Arial;letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:0.858696;stroke:none;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;shape-rendering:crispEdges;enable-background:new"
+       x="179.62912"
+       y="57.091106"
+       id="text4482"
+       inkscape:export-xdpi="224.36"
+       inkscape:export-ydpi="224.36"><tspan
+         sodipodi:role="line"
+         x="179.62912"
+         y="57.091106"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:5.29167px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:0.858696;stroke-width:0.264583px"
+         id="tspan3725">ZedBoard</tspan></text>
+    <rect
+       style="display:inline;vector-effect:none;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.478442;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:0;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;shape-rendering:crispEdges;enable-background:new"
+       id="rect4488"
+       width="7.645824"
+       height="92.035782"
+       x="198.63475"
+       y="65.548294"
+       inkscape:export-xdpi="224.36"
+       inkscape:export-ydpi="224.36" />
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;font-size:3.175px;line-height:0%;font-family:Arial;letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;shape-rendering:crispEdges;enable-background:new"
+       x="-136.48291"
+       y="204.2204"
+       id="text4491"
+       transform="rotate(-90)"
+       inkscape:export-xdpi="224.36"
+       inkscape:export-ydpi="224.36"><tspan
+         sodipodi:role="line"
+         id="tspan4493"
+         x="-136.48291"
+         y="204.2204"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:4.63021px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial Bold';stroke-width:0.264583px">FMC CONNECTOR</tspan></text>
+    <rect
+       style="display:inline;fill:none;fill-opacity:1;stroke:#3f4b55;stroke-width:0.538112;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:0.538112, 1.61435;stroke-dashoffset:0;stroke-opacity:1;shape-rendering:crispEdges;enable-background:new"
+       id="rect6057"
+       width="27.030113"
+       height="86.814651"
+       x="48.339287"
+       y="69.953239"
+       inkscape:export-xdpi="224.36"
+       inkscape:export-ydpi="224.36" />
+    <rect
+       y="73.397713"
+       x="72.880264"
+       height="73.077057"
+       width="9.149436"
+       id="rect5786"
+       style="display:inline;vector-effect:none;fill:#ffcccc;fill-opacity:1;fill-rule:nonzero;stroke:#a01414;stroke-width:0.225601;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;shape-rendering:crispEdges;enable-background:new"
+       inkscape:export-xdpi="224.36"
+       inkscape:export-ydpi="224.36" />
+    <text
+       transform="rotate(-90)"
+       id="text5788"
+       y="79.038582"
+       x="-114.37154"
+       style="font-style:normal;font-weight:normal;font-size:3.175px;line-height:0%;font-family:Arial;letter-spacing:0px;word-spacing:0px;display:inline;fill:#28170b;fill-opacity:1;stroke:none;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;shape-rendering:crispEdges;enable-background:new"
+       xml:space="preserve"
+       inkscape:export-xdpi="224.36"
+       inkscape:export-ydpi="224.36"><tspan
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:4.63021px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial Bold';fill:#28170b;stroke:none;stroke-width:0.264583px;stroke-opacity:1"
+         y="79.038582"
+         x="-114.37154"
+         id="tspan5790"
+         sodipodi:role="line">DMA</tspan></text>
+    <text
+       transform="scale(0.9928299,1.0072219)"
+       id="text4311-0"
+       y="57.409237"
+       x="69.524628"
+       style="font-style:normal;font-weight:normal;font-size:3.175px;line-height:0%;font-family:Arial;letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;shape-rendering:crispEdges;enable-background:new"
+       xml:space="preserve"
+       inkscape:export-xdpi="224.36"
+       inkscape:export-ydpi="224.36"><tspan
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:3.96875px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial Bold';stroke-width:0.264583px"
+         y="57.409237"
+         x="69.524628"
+         id="tspan4313-9"
+         sodipodi:role="line">ARM (Zynq) </tspan></text>
+    <g
+       id="g5654"
+       style="display:inline;fill:#a01414;fill-opacity:1;stroke:#a01414;stroke-width:0.91193;stroke-opacity:1;shape-rendering:crispEdges;enable-background:new"
+       transform="matrix(0.32827811,0,0,0.26434798,19.943177,-34.962379)"
+       inkscape:export-xdpi="224.36"
+       inkscape:export-ydpi="224.36">
+      <path
+         inkscape:connector-curvature="0"
+         id="path5656"
+         d="m 130.73937,546.2302 10.03208,14.84925 v -6.80591 l 20.46375,-3e-5 c 0,-16.08362 0,0 0,-16.08362 l -20.46375,3e-5 v -6.80591 l -10.03208,14.84925"
+         style="fill:#a01414;fill-opacity:1;fill-rule:evenodd;stroke:#a01414;stroke-width:0.91193px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1"
+         sodipodi:nodetypes="cccccccc" />
+    </g>
+    <g
+       id="g5654-3"
+       style="display:inline;fill:#a01414;fill-opacity:1;stroke:#a01414;stroke-width:0.57429;stroke-opacity:1;shape-rendering:crispEdges;enable-background:new"
+       transform="matrix(0.80784318,0,0,0.27086297,-22.589664,-39.068558)"
+       inkscape:export-xdpi="224.36"
+       inkscape:export-ydpi="224.36">
+      <path
+         inkscape:connector-curvature="0"
+         id="path5656-0"
+         d="m 130.73937,546.2302 10.03208,14.84925 v -6.80591 l 20.46375,-3e-5 c 0,-16.08362 0,0 0,-16.08362 l -20.46375,3e-5 v -6.80591 l -10.03208,14.84925"
+         style="fill:#a01414;fill-opacity:1;fill-rule:evenodd;stroke:#a01414;stroke-width:0.57429px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1"
+         sodipodi:nodetypes="cccccccc" />
+    </g>
+    <g
+       id="g5654-2"
+       style="display:inline;fill:#a01414;fill-opacity:1;stroke:#a01414;stroke-opacity:1;shape-rendering:crispEdges;enable-background:new"
+       transform="matrix(0.46245287,0,0,0.26458333,24.934835,-101.65513)" />
+    <text
+       id="text11366-4-8"
+       y="76.660919"
+       x="112.0732"
+       style="font-style:normal;font-weight:normal;font-size:3.175px;line-height:0%;font-family:Arial;letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;shape-rendering:crispEdges;enable-background:new"
+       xml:space="preserve"><tspan
+         id="tspan11370-7-5"
+         y="76.660919"
+         x="112.0732"
+         sodipodi:role="line"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:3.30729px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:center;text-anchor:middle;stroke-width:0.264583px" /></text>
+    <path
+       sodipodi:nodetypes="cc"
+       inkscape:connector-curvature="0"
+       id="path1206"
+       d="M 198.39343,93.188272 H 160.98307"
+       style="fill:none;stroke:#000000;stroke-width:0.529167;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#marker1216);shape-rendering:crispEdges" />
+    <path
+       sodipodi:nodetypes="cc"
+       inkscape:connector-curvature="0"
+       id="path1206-9"
+       d="M 198.66335,98.320588 H 161.25301"
+       style="display:inline;fill:none;stroke:#000000;stroke-width:0.529167;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#marker1216-9);shape-rendering:crispEdges;enable-background:new" />
+    <text
+       id="text2401"
+       y="95.740036"
+       x="168.36563"
+       style="font-style:normal;font-weight:normal;font-size:4.42089px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583;shape-rendering:crispEdges"
+       xml:space="preserve"
+       transform="scale(1.0443046,0.95757502)"><tspan
+         style="font-size:3.68407px;stroke-width:0.264583"
+         y="95.740036"
+         x="168.36563"
+         id="tspan2399"
+         sodipodi:role="line">DA_p</tspan></text>
+    <text
+       id="text2401-0"
+       y="101.55558"
+       x="168.4097"
+       style="font-style:normal;font-weight:normal;font-size:4.42089px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583;shape-rendering:crispEdges"
+       xml:space="preserve"
+       transform="scale(1.0443046,0.95757502)"><tspan
+         style="font-size:3.68407px;stroke-width:0.264583"
+         y="101.55558"
+         x="168.4097"
+         id="tspan2399-27"
+         sodipodi:role="line">DA_n</tspan></text>
+    <path
+       sodipodi:nodetypes="cc"
+       inkscape:connector-curvature="0"
+       id="path1206-5"
+       d="M 198.38955,108.54186 H 160.9792"
+       style="fill:none;stroke:#000000;stroke-width:0.529167;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#marker1216-4);shape-rendering:crispEdges" />
+    <path
+       sodipodi:nodetypes="cc"
+       inkscape:connector-curvature="0"
+       id="path1206-9-1"
+       d="M 198.65947,113.67417 H 161.24913"
+       style="display:inline;fill:none;stroke:#000000;stroke-width:0.529167;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#marker1216-9-6);shape-rendering:crispEdges;enable-background:new" />
+    <text
+       id="text2401-7"
+       y="111.77386"
+       x="168.36203"
+       style="font-style:normal;font-weight:normal;font-size:4.42089px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583;shape-rendering:crispEdges"
+       xml:space="preserve"
+       transform="scale(1.0443046,0.95757502)"><tspan
+         style="font-size:3.68407px;stroke-width:0.264583"
+         y="111.77386"
+         x="168.36203"
+         id="tspan2399-4"
+         sodipodi:role="line">DB_p</tspan></text>
+    <text
+       id="text2401-0-2"
+       y="117.58939"
+       x="168.4061"
+       style="font-style:normal;font-weight:normal;font-size:4.42089px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583;shape-rendering:crispEdges"
+       xml:space="preserve"
+       transform="scale(1.0443046,0.95757502)"><tspan
+         style="font-size:3.68407px;stroke-width:0.264583"
+         y="117.58939"
+         x="168.4061"
+         id="tspan2399-27-7"
+         sodipodi:role="line">DB_n</tspan></text>
+    <g
+       style="display:inline;shape-rendering:crispEdges;enable-background:new"
+       id="ddr"
+       transform="matrix(0.37593397,0,0,0.37593391,-17.27073,-132.78758)"
+       inkscape:export-xdpi="224.36"
+       inkscape:export-ydpi="224.36">
+      <rect
+         style="opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.8;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+         id="rect8406"
+         width="29.358675"
+         height="11.248666"
+         x="-453.55264"
+         y="391.80267"
+         transform="rotate(-90)" />
+      <rect
+         style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.67501;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.673913"
+         id="rect8408"
+         width="4.6139379"
+         height="6.8413563"
+         x="-451.4805"
+         y="394.00632"
+         transform="rotate(-90)" />
+      <rect
+         y="394.00632"
+         x="-444.69791"
+         height="6.8413563"
+         width="4.6139379"
+         id="rect8410"
+         style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.67501;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.673913"
+         transform="rotate(-90)" />
+      <rect
+         y="394.00632"
+         x="-431.13275"
+         height="6.8413563"
+         width="4.6139379"
+         id="rect8414"
+         style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.67501;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.673913"
+         transform="rotate(-90)" />
+      <rect
+         style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.67501;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.673913"
+         id="rect8416"
+         width="4.6139379"
+         height="6.8413563"
+         x="-437.91531"
+         y="394.00632"
+         transform="rotate(-90)" />
+      <path
+         style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:0.5506;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         d="m 402.9495,451.34818 h 3.46837 v -24.7395 h -3.63159"
+         id="path8420"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cccc" />
+      <path
+         style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1.067;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         d="M 406.04958,449.00384 H 404.6091"
+         id="path8422"
+         inkscape:connector-curvature="0" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path8424"
+         d="M 406.04958,430.92913 H 404.6091"
+         style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1.067;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+      <path
+         style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1.067;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         d="M 406.04958,433.33004 H 404.6091"
+         id="path8426"
+         inkscape:connector-curvature="0" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path8428"
+         d="M 406.04958,435.45913 H 404.6091"
+         style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1.067;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+      <path
+         style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1.067;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         d="M 406.04958,437.86003 H 404.6091"
+         id="path8430"
+         inkscape:connector-curvature="0" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path8432"
+         d="M 406.04958,439.98913 H 404.6091"
+         style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1.067;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+      <path
+         style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1.067;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         d="M 406.04958,442.34471 H 404.6091"
+         id="path8434"
+         inkscape:connector-curvature="0" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path8436"
+         d="M 406.04958,444.51915 H 404.6091"
+         style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1.067;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+      <path
+         style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1.067;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         d="M 406.04958,446.82944 H 404.6091"
+         id="path8438"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1.067;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         d="M 406.04958,430.92913 H 404.6091"
+         id="path8440"
+         inkscape:connector-curvature="0" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path8450"
+         d="M 406.04958,428.80003 H 404.6091"
+         style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1.067;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    </g>
+    <g
+       style="display:inline;shape-rendering:crispEdges;enable-background:new"
+       id="g8892"
+       transform="matrix(0.26458333,0,0,0.26458333,40.080594,-84.382617)"
+       inkscape:export-xdpi="224.36"
+       inkscape:export-ydpi="224.36">
+      <rect
+         y="431.09491"
+         x="366.68005"
+         height="23.063002"
+         width="26.832939"
+         id="rect8762"
+         style="opacity:1;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:1.33851;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+      <path
+         inkscape:connector-curvature="0"
+         id="rect8764"
+         d="m 371.84168,433.47704 h 16.31637 c 1.2826,0 2.31516,1.03257 2.31516,2.31517 v 13.22948 c 0,1.28259 -1.03256,2.31515 -2.31516,2.31515 h -16.31637 c -1.2826,0 -2.31516,-1.03256 -2.31516,-2.31515 v -13.22948 c 0,-1.2826 1.03256,-2.31517 2.31516,-2.31517 z"
+         style="opacity:1;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:1.2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+      <g
+         style="fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-opacity:1"
+         transform="matrix(1.2472877,0,0,1.2472877,-94.749819,-45.663902)"
+         id="g8811">
+        <path
+           id="rect8801"
+           d="m 371.16019,393.86166 h 6.77743 v 5.24892 h -6.77743 z"
+           style="opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:#ffffff;stroke-width:0.479248;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+           inkscape:connector-curvature="0" />
+        <path
+           id="rect8809"
+           d="m 383.3136,393.86166 h 6.77743 v 5.24892 h -6.77743 z"
+           style="opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:#ffffff;stroke-width:0.479248;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+           inkscape:connector-curvature="0" />
+      </g>
+      <path
+         sodipodi:nodetypes="ccccc"
+         inkscape:connector-curvature="0"
+         id="path8818"
+         d="m 369.52814,445.26083 h 5.8318 v 2.82613 h 1.54776 v 3.24584"
+         style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1.2;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+      <path
+         style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1.2;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         d="m 390.47422,445.29053 h -5.89282 v 2.80734 h -1.56397 v 3.22427"
+         id="path8820"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccccc" />
+      <rect
+         y="447.10886"
+         x="369.1405"
+         height="3.8938534"
+         width="4.5168324"
+         id="rect8824"
+         style="opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.973;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+      <rect
+         style="opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.973;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+         id="rect8826"
+         width="4.5168324"
+         height="3.8938534"
+         x="386.27451"
+         y="447.10886" />
+      <rect
+         y="433.60046"
+         x="371.85117"
+         height="5.1640501"
+         width="1.2438545"
+         id="rect8828"
+         style="opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.308598;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+      <rect
+         style="opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.308598;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+         id="rect8830"
+         width="1.2438545"
+         height="5.1640501"
+         x="384.39578"
+         y="433.60046" />
+      <rect
+         y="433.60046"
+         x="381.88687"
+         height="5.1640501"
+         width="1.2438545"
+         id="rect8832"
+         style="opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.308598;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+      <rect
+         style="opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.308598;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+         id="rect8834"
+         width="1.2438545"
+         height="5.1640501"
+         x="379.37793"
+         y="433.60046" />
+      <rect
+         y="433.60046"
+         x="376.86902"
+         height="5.1640501"
+         width="1.2438545"
+         id="rect8836"
+         style="opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.308598;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+      <rect
+         style="opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.308598;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+         id="rect8838"
+         width="1.2438545"
+         height="5.1640501"
+         x="374.36008"
+         y="433.60046" />
+      <rect
+         style="opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.308598;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+         id="rect8840"
+         width="1.2438545"
+         height="5.1640501"
+         x="386.90469"
+         y="433.60046" />
+    </g>
+    <g
+       id="uart"
+       transform="matrix(0,-0.10973853,0.10973855,0,102.98407,90.423989)"
+       style="display:inline;stroke-width:2.41103;stroke-miterlimit:4;stroke-dasharray:none;shape-rendering:crispEdges;enable-background:new"
+       inkscape:export-xdpi="224.36"
+       inkscape:export-ydpi="224.36">
+      <rect
+         ry="4.5"
+         y="388.11218"
+         x="490.75"
+         height="28.75"
+         width="70"
+         id="rect8910"
+         style="opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:2.41103;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+      <path
+         sodipodi:nodetypes="sssssssss"
+         inkscape:connector-curvature="0"
+         id="rect8912"
+         d="m 507.25,394.11218 h 37 c 2.493,0 5.47668,2.20628 4.5,4.5 l -3.3,7.75 c -0.97668,2.29372 -3.507,4.5 -6,4.5 h -27.8 c -2.493,0 -4.37391,-2.22795 -5.4,-4.5 l -3.5,-7.75 c -1.02609,-2.27205 2.007,-4.5 4.5,-4.5 z"
+         style="opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:2.41103;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+      <circle
+         r="3.1875"
+         cy="402.48718"
+         cx="497.5126"
+         id="path8915"
+         style="opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:2.41103;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+      <circle
+         style="opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:2.41103;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+         id="circle8917"
+         cx="554.13763"
+         cy="402.48718"
+         r="3.1875" />
+      <ellipse
+         ry="1.0625"
+         rx="1"
+         cy="399.79968"
+         cx="513.7403"
+         id="path8919"
+         style="opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:2.41103;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+      <ellipse
+         ry="1.0625"
+         rx="1"
+         cy="399.79968"
+         cx="537.7403"
+         id="ellipse8923"
+         style="opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:2.41103;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+      <ellipse
+         style="opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:2.41103;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+         id="ellipse8925"
+         cx="531.7403"
+         cy="399.79968"
+         rx="1"
+         ry="1.0625" />
+      <ellipse
+         ry="1.0625"
+         rx="1"
+         cy="399.79968"
+         cx="525.7403"
+         id="ellipse8927"
+         style="opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:2.41103;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+      <ellipse
+         style="opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:2.41103;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+         id="ellipse8929"
+         cx="519.7403"
+         cy="399.79968"
+         rx="1"
+         ry="1.0625" />
+      <ellipse
+         style="opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:2.41103;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+         id="ellipse8921"
+         cx="516.7403"
+         cy="405.79968"
+         rx="1"
+         ry="1.0625" />
+      <ellipse
+         ry="1.0625"
+         rx="1"
+         cy="405.79968"
+         cx="534.7403"
+         id="ellipse8931"
+         style="opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:2.41103;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+      <ellipse
+         style="opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:2.41103;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+         id="ellipse8933"
+         cx="528.7403"
+         cy="405.79968"
+         rx="1"
+         ry="1.0625" />
+      <ellipse
+         ry="1.0625"
+         rx="1"
+         cy="405.79968"
+         cx="522.7403"
+         id="ellipse8935"
+         style="opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:2.41103;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+    </g>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:3.43958px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Bold';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;letter-spacing:0px;word-spacing:0px;display:inline;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.268639;shape-rendering:crispEdges;enable-background:new"
+       x="64.748016"
+       y="112.67403"
+       id="text2401-61-1-54-8"
+       transform="scale(1.0162353,0.98402408)"
+       inkscape:export-xdpi="224.36"
+       inkscape:export-ydpi="224.36"><tspan
+         sodipodi:role="line"
+         id="tspan2399-9-2-70-3"
+         x="64.748016"
+         y="112.67403"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:3.43958px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Bold';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;fill:#ffffff;fill-opacity:1;stroke-width:0.268639">64</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:3.43958px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Bold';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;letter-spacing:0px;word-spacing:0px;display:inline;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.269;stroke-miterlimit:4;stroke-dasharray:none;shape-rendering:crispEdges;enable-background:new"
+       x="90.575462"
+       y="111.75716"
+       id="text2401-61-1-54-8-3"
+       transform="scale(1.0162353,0.98402408)"
+       inkscape:export-xdpi="224.36"
+       inkscape:export-ydpi="224.36"><tspan
+         sodipodi:role="line"
+         id="tspan2399-9-2-70-3-9"
+         x="90.575462"
+         y="111.75716"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:3.43958px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Bold';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;fill:#ffffff;fill-opacity:1;stroke-width:0.269;stroke-miterlimit:4;stroke-dasharray:none">32/16</tspan></text>
+    <rect
+       style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#a01414;stroke-width:0.426;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:0.0426, 0.0426;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect19131"
+       width="39.872944"
+       height="23.023788"
+       x="115.95037"
+       y="88.13372" />
+    <rect
+       style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#a01414;stroke-width:0.426002;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:0.0426002, 0.0426002;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect19131-2"
+       width="39.872944"
+       height="6.1456804"
+       x="114.85004"
+       y="138.39899" />
+    <rect
+       style="fill:#ffcccc;fill-opacity:1;fill-rule:evenodd;stroke:#a01414;stroke-width:0.426;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:0.0426, 0.0426;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect958"
+       width="15.066154"
+       height="11.580877"
+       x="138.83858"
+       y="97.383614" />
+    <rect
+       style="fill:#ffcccc;fill-opacity:1;fill-rule:evenodd;stroke:#a01414;stroke-width:0.426;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:0.0426, 0.0426;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect958-1"
+       width="18.344688"
+       height="13.827947"
+       x="115.95206"
+       y="114.81905" />
+    <text
+       xml:space="preserve"
+       transform="matrix(0.1434475,0,0,0.13069708,67.337038,44.068862)"
+       id="text4758"
+       style="font-size:14px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial, Normal';white-space:pre;shape-inside:url(#rect4760);display:inline;stroke-width:1.93234"><tspan
+         x="505.75977"
+         y="453.41916"
+         id="tspan9">ad_serdes_in</tspan></text>
+    <rect
+       style="fill:#ffcccc;fill-opacity:1;fill-rule:evenodd;stroke:#a01414;stroke-width:0.426;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:0.0426, 0.0426;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect958-2"
+       width="15.066154"
+       height="11.580877"
+       x="117.95731"
+       y="97.263992" />
+    <text
+       xml:space="preserve"
+       transform="matrix(0.1434475,0,0,0.13069708,49.127482,44.136482)"
+       id="text4758-5"
+       style="font-size:14px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial, Normal';white-space:pre;shape-inside:url(#rect4760-6);display:inline;stroke-width:1.93234"><tspan
+         x="505.75977"
+         y="453.41916"
+         id="tspan10">ad_pack</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-size:4.20337px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial, Normal';stroke-width:0.264583"
+       x="123.9485"
+       y="93.775139"
+       id="text21502"
+       transform="scale(1.0050352,0.99499002)"><tspan
+         sodipodi:role="line"
+         id="tspan21500"
+         style="stroke-width:0.264583"
+         x="123.9485"
+         y="93.775139">ad408x_phy</tspan></text>
+    <text
+       xml:space="preserve"
+       transform="matrix(0.13201657,0,0,0.13069708,78.342228,59.439291)"
+       id="text24668"
+       style="font-size:16px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial, Normal';white-space:pre;shape-inside:url(#rect24670);display:inline;stroke-width:2.01426"><tspan
+         x="298.9668"
+         y="484.35348"
+         id="tspan11">ADC COMMON</tspan></text>
+    <rect
+       style="fill:#ffcccc;fill-opacity:1;fill-rule:evenodd;stroke:#a01414;stroke-width:0.426;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:0.0426, 0.0426;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect958-1-1"
+       width="18.344688"
+       height="13.827947"
+       x="136.71077"
+       y="114.69421" />
+    <text
+       xml:space="preserve"
+       transform="matrix(0.13201657,0,0,0.13069708,99.100946,59.314451)"
+       id="text24668-1"
+       style="font-size:16px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial, Normal';white-space:pre;shape-inside:url(#rect24670-6);display:inline;stroke-width:2.01426"><tspan
+         x="298.9668"
+         y="484.35348"
+         id="tspan12">ADC CHANNEL</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-size:4.20337px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial, Normal';stroke-width:0.264583"
+       x="127.25005"
+       y="143.25801"
+       id="text41823"
+       transform="scale(1.0050352,0.99499002)"><tspan
+         sodipodi:role="line"
+         id="tspan41821"
+         style="stroke-width:0.264583"
+         x="127.25005"
+         y="143.25801">UP_AXI</tspan></text>
+    <path
+       style="fill:#a01414;fill-opacity:1;stroke:#a01414;stroke-width:0.6;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:20;stroke-opacity:1;marker-start:url(#TriangleInM-3);marker-end:url(#marker51146)"
+       d="m 146.57665,130.75804 c 0,5.55326 0,5.33969 0,5.33969"
+       id="path42520-2" />
+    <path
+       style="fill:#a01414;fill-opacity:1;stroke:#a01414;stroke-width:0.6;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:20;stroke-opacity:1;marker-start:url(#TriangleInM-0);marker-end:url(#marker51146-9)"
+       d="m 124.37647,130.79376 c 0,5.55327 0,5.33969 0,5.33969"
+       id="path42520-2-7" />
+    <text
+       xml:space="preserve"
+       style="font-size:3.15252px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial, Normal';stroke-width:0.264583"
+       x="124.64314"
+       y="85.316605"
+       id="text49535"
+       transform="scale(1.0050352,0.99499002)"><tspan
+         sodipodi:role="line"
+         id="tspan49533"
+         style="font-size:3.15252px;stroke-width:0.264583"
+         x="124.64314"
+         y="85.316605">AXI-AD408X IP </tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.64583px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;stroke-width:0.264583"
+       x="49.604683"
+       y="154.91524"
+       id="text41772"><tspan
+         sodipodi:role="line"
+         id="tspan41770"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.64583px;font-family:Arial;-inkscape-font-specification:'Arial, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;stroke-width:0.264583"
+         x="49.604683"
+         y="154.91524">DMA_CLK=100MHz</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.64583px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;stroke-width:0.264583"
+       x="79.652069"
+       y="155.11121"
+       id="text41772-4"><tspan
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.64583px;font-family:Sans;-inkscape-font-specification:'Sans, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;stroke-width:0.264583"
+         x="79.652069"
+         y="155.11121"
+         id="tspan1"
+         sodipodi:role="line">REF_CLK: DCO_CLK(400MHz) / 2 </tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.64583px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;stroke-width:0.264583"
+       x="157.8167"
+       y="149.63438"
+       id="text41772-4-7"><tspan
+         sodipodi:role="line"
+         id="tspan41770-2-5"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.64583px;font-family:Arial;-inkscape-font-specification:'Arial, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;stroke-width:0.264583"
+         x="157.8167"
+         y="149.63438">REF_CLK= DCO_CLK(400MHz) </tspan></text>
+    <path
+       sodipodi:nodetypes="cc"
+       inkscape:connector-curvature="0"
+       id="path1206-6"
+       d="M 198.38955,132.66641 H 160.9792"
+       style="fill:none;stroke:#000000;stroke-width:0.529167;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#marker1216-71);shape-rendering:crispEdges" />
+    <path
+       sodipodi:nodetypes="cc"
+       inkscape:connector-curvature="0"
+       id="path1206-9-12"
+       d="M 198.65949,137.79872 H 161.24913"
+       style="display:inline;fill:none;stroke:#000000;stroke-width:0.529167;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#marker1216-9-9);shape-rendering:crispEdges;enable-background:new" />
+    <text
+       id="text2401-3"
+       y="136.96724"
+       x="166.88876"
+       style="font-style:normal;font-weight:normal;font-size:4.42089px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583;shape-rendering:crispEdges"
+       xml:space="preserve"
+       transform="scale(1.0443046,0.95757502)"><tspan
+         style="font-size:3.68407px;stroke-width:0.264583"
+         y="136.96724"
+         x="166.88876"
+         id="tspan2399-3"
+         sodipodi:role="line">DCO_p</tspan></text>
+    <text
+       id="text2401-0-8"
+       y="142.78278"
+       x="166.93283"
+       style="font-style:normal;font-weight:normal;font-size:4.42089px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583;shape-rendering:crispEdges"
+       xml:space="preserve"
+       transform="scale(1.0443046,0.95757502)"><tspan
+         style="font-size:3.68407px;stroke-width:0.264583"
+         y="142.78278"
+         x="166.93283"
+         id="tspan2399-27-77"
+         sodipodi:role="line">DCO_n</tspan></text>
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.498128;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-start:url(#TriangleInM-7-1);marker-end:url(#marker9011)"
+       d="m 160.90442,67.943553 -0.0847,5.47847 35.73134,-0.02886 v 0 0"
+       id="path54607"
+       sodipodi:nodetypes="ccccc" />
+    <text
+       xml:space="preserve"
+       style="font-size:2.11667px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial, Normal';stroke-width:0.264583"
+       x="163.6947"
+       y="71.951813"
+       id="text59898"><tspan
+         sodipodi:role="line"
+         id="tspan59896"
+         style="font-size:2.11667px;stroke-width:0.264583"
+         x="163.6947"
+         y="71.951813">AD4080/ADF4350/AD9508 SPI</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;font-size:10.5833px;line-height:1.25;font-family:sans-serif;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+       x="160.59171"
+       y="152.51469"
+       id="text3594"><tspan
+         sodipodi:role="line"
+         id="tspan3592"
+         style="stroke-width:0.264583"
+         x="160.59171"
+         y="152.51469" /></text>
+    <text
+       xml:space="preserve"
+       transform="matrix(0.26458333,0,0,0.26458333,45.687375,26.530943)"
+       id="text1"
+       style="text-align:start;writing-mode:lr-tb;direction:ltr;white-space:pre;shape-inside:url(#rect1);display:inline;fill:#ffffff;fill-opacity:1" />
+    <text
+       xml:space="preserve"
+       style="font-size:3.01358px;text-align:start;writing-mode:lr-tb;direction:ltr;text-anchor:start;fill:#000000;fill-opacity:1;stroke-width:0.251131"
+       x="89.098938"
+       y="110.49844"
+       id="text2"
+       transform="scale(0.94915879,1.0535645)"><tspan
+         id="tspan2"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.00906px;font-family:Sans;-inkscape-font-specification:'Sans, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;fill:#000000;fill-opacity:1;stroke-width:0.251131"
+         x="89.098938"
+         y="110.49844"
+         sodipodi:role="line">32 if ADC_N_BITS==20</tspan><tspan
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.00906px;font-family:Sans;-inkscape-font-specification:'Sans, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;fill:#000000;fill-opacity:1;stroke-width:0.251131"
+         x="89.098938"
+         y="114.26542"
+         sodipodi:role="line"
+         id="tspan3">16 if ADC_N_BITS&lt;=16</tspan></text>
+    <!-- ================= optional SPI_SLAVE datapath ================= -->
+    <!-- feeder: ADC data path -> spi_slave (write side) -->
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.39;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#TriangleOutM);shape-rendering:crispEdges"
+       d="m 139.54174,146.95532 v 5.18022"
+       id="path-ss-feed" />
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;font-size:2.54958px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial, Normal';fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.281073"
+       x="132.15479"
+       y="158.58562"
+       id="text-ss-feed"
+       transform="scale(1.0623254,0.94133116)"><tspan
+         sodipodi:role="line"
+         x="132.15479"
+         y="158.58562"
+         id="tspan-ss-feed1"
+         style="stroke-width:0.281073">adc_data /</tspan><tspan
+         sodipodi:role="line"
+         x="132.15479"
+         y="161.7726"
+         id="tspan-ss-feed2"
+         style="stroke-width:0.281073">adc_valid</tspan></text>
+    <!-- optional-mode dashed container -->
+    <!-- spi_slave IP block -->
+    <rect
+       style="display:inline;fill:#ffcccc;fill-opacity:1;fill-rule:nonzero;stroke:#a01414;stroke-width:0.434932;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;shape-rendering:crispEdges;enable-background:new"
+       id="rect-ss-block"
+       width="29.298174"
+       height="6.9443855"
+       x="125.45109"
+       y="153.12347" />
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-weight:bold;font-size:3.88px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial, Bold';fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+       x="140.13721"
+       y="157.63541"
+       id="text-ss-name"><tspan
+         sodipodi:role="line"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-family:Arial;-inkscape-font-specification:Arial;text-align:center;text-anchor:middle"
+         x="140.13721"
+         y="157.63541"
+         id="tspan-ss-name">SPI_SLAVE IP</tspan></text>
+    <!-- spi_slave <-> PMOD JB signal lines -->
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.477735;stroke-linecap:butt;stroke-dasharray:none;marker-end:url(#TriangleOutM);shape-rendering:crispEdges"
+       d="m 143.50499,160.26371 v 17.27906"
+       id="path-ss-cs" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.477735;stroke-linecap:butt;stroke-dasharray:none;marker-end:url(#TriangleOutM);shape-rendering:crispEdges"
+       d="m 148.75598,160.26371 v 17.27906"
+       id="path-ss-sclk" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.480331;stroke-linecap:butt;stroke-dasharray:none;marker-end:url(#TriangleOutM);shape-rendering:crispEdges"
+       d="M 133.0297,178.99787 V 161.37142"
+       id="path-ss-miso" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.480331;stroke-linecap:butt;stroke-dasharray:none;marker-end:url(#TriangleOutM);shape-rendering:crispEdges"
+       d="M 138.27048,178.99787 V 161.37142"
+       id="path-ss-rdy" />
+    <g
+       style="font-style:normal;font-weight:normal;font-size:2.1px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial, Normal';fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+       id="g-ss-labels"
+       transform="rotate(-90,148.74947,182.37168)">
+      <text
+         xml:space="preserve"
+         style="font-size:2.82222px;text-align:center;text-anchor:middle"
+         x="161.26805"
+         y="165.73715"
+         id="text-ss-l1"><tspan
+           x="161.26805"
+           y="165.73715"
+           id="tspan-ss-l1"
+           style="font-size:2.82222px">spi_cs</tspan></text>
+      <text
+         xml:space="preserve"
+         style="font-size:2.82222px;text-align:center;text-anchor:middle"
+         x="161.037"
+         y="170.7047"
+         id="text-ss-l2"><tspan
+           x="161.037"
+           y="170.7047"
+           id="tspan-ss-l2"
+           style="font-size:2.82222px">spi_sclk</tspan></text>
+      <text
+         xml:space="preserve"
+         style="font-size:2.82222px;line-height:1.25;text-align:center;text-anchor:middle"
+         x="161.35741"
+         y="175.94026"
+         id="text-ss-l3"><tspan
+           x="161.35741"
+           y="175.94026"
+           id="tspan-ss-l3"
+           style="font-size:2.82222px;line-height:1.25">spi_miso</tspan></text>
+      <text
+         xml:space="preserve"
+         style="font-size:2.82222px;line-height:1.25;text-align:center;text-anchor:middle;stroke-width:0.265;stroke-dasharray:none"
+         x="161.89351"
+         y="180.65506"
+         id="text-ss-l4"><tspan
+           x="161.89351"
+           y="180.65506"
+           id="tspan-ss-l4"
+           style="font-size:2.82222px;line-height:1.25;stroke-width:0.265;stroke-dasharray:none">data_ready_n</tspan></text>
+      <text
+         xml:space="preserve"
+         transform="matrix(0,0.26458333,-0.26458333,0,303.96476,79.041535)"
+         id="text3"
+         style="font-size:10.6667px;line-height:1.25;font-family:'Liberation Sans', Helvetica, Arial, sans-serif;-inkscape-font-specification:'Liberation Sans, Helvetica, Arial, sans-serif';writing-mode:lr-tb;direction:ltr;white-space:pre;shape-inside:url(#rect3);fill:#ffcccc;stroke:#a01414;stroke-width:1.00157;stroke-dasharray:none" />
+    </g>
+    <!-- PMOD JB connector -->
+    <rect
+       style="display:inline;vector-effect:none;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.478442;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:0;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;shape-rendering:crispEdges;enable-background:new"
+       id="rect-pmod"
+       width="7"
+       height="24"
+       x="179.18347"
+       y="-152.34366"
+       transform="rotate(90)" />
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-weight:bold;font-size:3.3px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial, Bold';fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+       x="133.8644"
+       y="183.65469"
+       id="text-pmod"><tspan
+         sodipodi:role="line"
+         x="133.8644"
+         y="183.65469"
+         id="tspan-pmod">PMOD JB</tspan></text>
+    <!-- PMOD header -> external SPI master -->
+    <!-- external SPI master (off-board) -->
+  </g>
+</svg>

--- a/docs/projects/ad4080_fmc_evb/index.rst
+++ b/docs/projects/ad4080_fmc_evb/index.rst
@@ -74,6 +74,53 @@ The data path and clock domains are depicted in the below diagram:
    :align: center
    :alt: AD4080-FMC-EVB/ZedBoard block diagram
 
+SPI slave interface
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The optional SPI slave interface is enabled at build time with the
+``SPI_SLAVE=1`` make parameter. It instantiates the :ref:`spi_slave` IP,
+which buffers the captured ADC samples in an asynchronous FIFO and streams
+them out to an external SPI master over the ZedBoard PMOD JB header,
+independently of the DMA data path. This lets a device that is not on the
+processor bus (for example a microcontroller acting as an SPI controller)
+read the ADC data without involving the processor or the DMA.
+
+.. image:: ../ad4080_fmc_evb/ad4080_fmc_evb_zed_spi_slave_block_diagram.svg
+   :width: 800
+   :align: center
+   :alt: AD4080-FMC-EVB/ZedBoard block diagram with the optional SPI slave
+
+The SPI slave operates in Mode 3 (clock idles high), MSB first, and only
+sources data (there is no MOSI). The external master polls
+``pmod_data_ready`` to know when a new sample is available and frames each
+read as a single transfer. The signals are routed to the PMOD JB header
+using the LVCMOS33 I/O standard, as follows:
+
+.. list-table::
+   :widths: 30 20 20 30
+   :header-rows: 1
+
+   * - Signal
+     - PMOD JB pin
+     - FPGA pin
+     - Direction (FPGA view)
+   * - ``pmod_spi_cs``
+     - JB1
+     - W12
+     - Input
+   * - ``pmod_spi_sclk``
+     - JB2
+     - W11
+     - Input
+   * - ``pmod_spi_miso``
+     - JB3
+     - V10
+     - Output
+   * - ``pmod_data_ready``
+     - JB4
+     - W8
+     - Output
+
 Clock scheme
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -201,6 +248,14 @@ Example of running the ``make`` command with parameters:
    $cd hdl/projects/ad4080_fmc_evb/zed
    $make ADC_N_BITS=16
 
+Example of running the ``make`` command with the optional SPI slave interface
+enabled on the PMOD JB header:
+
+.. shell::
+
+   $cd hdl/projects/ad4080_fmc_evb/zed
+   $make SPI_SLAVE=1
+
 The following table contains the parameters that can be used to configure this
 project:
 
@@ -214,6 +269,11 @@ project:
    |                | - 20                                                        |
    |                | - 16                                                        |
    |                | - 14                                                        |
+   +----------------+-------------------------------------------------------------+
+   | SPI_SLAVE      | Add the optional SPI slave (PMOD JB) interface (default: 0) |
+   |                |                                                             |
+   |                | - 0                                                         |
+   |                | - 1                                                         |
    +----------------+-------------------------------------------------------------+
 
 A more comprehensive build guide can be found in the :ref:`build_hdl` user guide.
@@ -271,6 +331,9 @@ HDL related
    * - AXI_SPDIF_TX
      - :git-hdl:`library/axi_spdif_tx`
      - ---
+   * - SPI_SLAVE
+     - :git-hdl:`library/spi_slave`
+     - :ref:`spi_slave`
    * - SYSID_ROM
      - :git-hdl:`library/sysid_rom`
      - :ref:`axi_sysid`

--- a/library/spi_slave/Makefile
+++ b/library/spi_slave/Makefile
@@ -1,0 +1,16 @@
+####################################################################################
+## Copyright (c) 2025 Analog Devices, Inc.
+### SPDX short identifier: BSD-1-Clause
+## Auto-generated, do not modify!
+####################################################################################
+
+LIBRARY_NAME := spi_slave
+
+GENERIC_DEPS += spi_slave.v
+
+XILINX_DEPS += spi_slave_ip.tcl
+
+XILINX_LIB_DEPS += util_axis_fifo
+XILINX_LIB_DEPS += util_cdc
+
+include ../scripts/library.mk

--- a/library/spi_slave/spi_slave.v
+++ b/library/spi_slave/spi_slave.v
@@ -1,0 +1,176 @@
+// ***************************************************************************
+// ***************************************************************************
+// Copyright (C) 2026 Analog Devices, Inc. All rights reserved.
+//
+// In this HDL repository, there are many different and unique modules, consisting
+// of various HDL (Verilog or VHDL) components. The individual modules are
+// developed independently, and may be accompanied by separate and unique license
+// terms.
+//
+// The user should read each of these license terms, and understand the
+// freedoms and responsibilities that he or she has by using this source/core.
+//
+// This core is distributed in the hope that it will be useful, but WITHOUT ANY
+// WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+// A PARTICULAR PURPOSE.
+//
+// Redistribution and use of source or resulting binaries, with or without modification
+// of this file, are permitted under one of the following two license terms:
+//
+//   1. The GNU General Public License version 2 as published by the
+//      Free Software Foundation, which can be found in the top level directory
+//      of this repository (LICENSE_GPL2), and also online at:
+//      <https://www.gnu.org/licenses/old-licenses/gpl-2.0.html>
+//
+// OR
+//
+//   2. An ADI specific BSD license, which can be found in the top level directory
+//      of this repository (LICENSE_ADIBSD), and also on-line at:
+//      https://github.com/analogdevicesinc/hdl/blob/main/LICENSE_ADIBSD
+//      This will allow to generate bit files and not release the source code,
+//      as long as it attaches to an ADI device.
+//
+// ***************************************************************************
+// ***************************************************************************
+
+`timescale 1ns/100ps
+
+/*
+ * SPI slave that buffers ADC samples in an asynchronous FIFO and streams them
+ * out to an external SPI master. The SPI pins are oversampled in the system
+ * clock domain (Mode 3, MSB-first, DATA_WIDTH bits per transfer).
+ */
+
+module spi_slave #(
+  parameter DATA_WIDTH = 32,
+  parameter ADDRESS_WIDTH = 1
+) (
+
+  // data write interface
+
+  input                       data_clk,
+  input                       data_rst,
+  input   [DATA_WIDTH-1:0]    data,
+  input                       data_valid,
+
+  // system clock / reset
+
+  input                       clk,
+  input                       resetn,
+
+  // external SPI slave interface
+
+  input                       spi_cs,
+  input                       spi_sclk,
+  output                      spi_miso,
+  output                      data_ready_n
+);
+
+  // internal signals
+
+  wire  [DATA_WIDTH-1:0]      m_axis_data;
+  wire                        m_axis_valid;
+  reg                         m_axis_ready = 1'b0;
+
+  wire  [1:0]                 spi_sync;
+  wire                        cs_sync;
+  wire                        sclk_sync;
+
+  // reset to 0 to match the synchronizer output and avoid a phantom edge
+  reg                         cs_d = 1'b0;
+  reg                         sclk_d = 1'b0;
+
+  reg   [DATA_WIDTH-1:0]      shift_reg = {DATA_WIDTH{1'b0}};
+  reg                         miso_reg = 1'b0;
+
+  // edge / level detection
+
+  wire                        cs_active;
+  wire                        cs_fall;
+  wire                        sclk_fall;
+
+  assign cs_active = ~cs_sync;             // CS is active low
+  assign cs_fall   = cs_d & ~cs_sync;      // CS asserted (high -> low)
+  assign sclk_fall = sclk_d & ~sclk_sync;  // SCK leading edge for Mode 3
+
+  assign spi_miso     = miso_reg;
+  // asserted (low) whenever a word is available to read
+  assign data_ready_n = ~m_axis_valid;
+
+  // synchronize the asynchronous SPI pins into the system clock domain
+
+  sync_bits #(
+    .NUM_OF_BITS (2),
+    .ASYNC_CLK (1)
+  ) i_spi_sync (
+    .in_bits ({spi_sclk, spi_cs}),
+    .out_resetn (resetn),
+    .out_clk (clk),
+    .out_bits (spi_sync));
+
+  assign cs_sync   = spi_sync[0];
+  assign sclk_sync = spi_sync[1];
+
+  always @(posedge clk) begin
+    if (resetn == 1'b0) begin
+      cs_d   <= 1'b0;
+      sclk_d <= 1'b0;
+    end else begin
+      cs_d   <= cs_sync;
+      sclk_d <= sclk_sync;
+    end
+  end
+
+  // SPI slave shift logic (Mode 3): one CS-framed transfer shifts out one
+  // FIFO word, MSB first
+
+  always @(posedge clk) begin
+    if (resetn == 1'b0) begin
+      shift_reg <= {DATA_WIDTH{1'b0}};
+      miso_reg  <= 1'b0;
+      m_axis_ready <= 1'b0;
+    end else begin
+      m_axis_ready <= 1'b0;
+      if (cs_fall) begin
+        shift_reg <= m_axis_data;
+        miso_reg  <= m_axis_data[DATA_WIDTH-1];
+        m_axis_ready <= m_axis_valid;
+      end else if (cs_active & sclk_fall) begin
+        miso_reg  <= shift_reg[DATA_WIDTH-1];
+        shift_reg <= {shift_reg[DATA_WIDTH-2:0], 1'b0};
+      end
+    end
+  end
+
+  // asynchronous sample FIFO: write side = data domain, read side = system clock
+
+  util_axis_fifo #(
+    .DATA_WIDTH (DATA_WIDTH),
+    .ADDRESS_WIDTH (ADDRESS_WIDTH),
+    .ASYNC_CLK (1),
+    .M_AXIS_REGISTERED (1),
+    .TLAST_EN (0),
+    .TKEEP_EN (0)
+  ) i_fifo (
+    .m_axis_aclk (clk),
+    .m_axis_aresetn (resetn),
+    .m_axis_ready (m_axis_ready),
+    .m_axis_valid (m_axis_valid),
+    .m_axis_data (m_axis_data),
+    .m_axis_tkeep (),
+    .m_axis_tlast (),
+    .m_axis_level (),
+    .m_axis_empty (),
+    .m_axis_almost_empty (),
+    .s_axis_aclk (data_clk),
+    .s_axis_aresetn (~data_rst),
+    .s_axis_ready (),
+    .s_axis_valid (data_valid),
+    .s_axis_data (data),
+    .s_axis_tkeep ({(DATA_WIDTH/8){1'b1}}),
+    .s_axis_tlast (1'b0),
+    .s_axis_room (),
+    .s_axis_full (),
+    .s_axis_almost_full ());
+
+endmodule

--- a/library/spi_slave/spi_slave_ip.tcl
+++ b/library/spi_slave/spi_slave_ip.tcl
@@ -1,0 +1,27 @@
+###############################################################################
+## Copyright (C) 2025 Analog Devices, Inc. All rights reserved.
+### SPDX short identifier: ADIBSD
+###############################################################################
+
+source ../../scripts/adi_env.tcl
+source $ad_hdl_dir/library/scripts/adi_ip_xilinx.tcl
+
+global VIVADO_IP_LIBRARY
+
+adi_ip_create spi_slave
+adi_ip_files spi_slave [list \
+  "spi_slave.v" \
+]
+
+adi_ip_properties_lite spi_slave
+
+adi_ip_add_core_dependencies [list \
+  analog.com:$VIVADO_IP_LIBRARY:util_cdc:1.0 \
+  analog.com:$VIVADO_IP_LIBRARY:util_axis_fifo:1.0 \
+]
+
+set_property display_name "ADI SPI Slave" [ipx::current_core]
+set_property description  "ADI SPI Slave" [ipx::current_core]
+
+ipx::create_xgui_files [ipx::current_core]
+ipx::save_core [ipx::current_core]

--- a/projects/ad4080_fmc_evb/common/ad4080_fmc_evb_bd.tcl
+++ b/projects/ad4080_fmc_evb/common/ad4080_fmc_evb_bd.tcl
@@ -86,3 +86,36 @@ ad_mem_hp1_interconnect $sys_cpu_clk sys_ps7/S_AXI_HP1
 ad_mem_hp1_interconnect $sys_cpu_clk axi_ad4080_dma/m_dest_axi
 
 ad_cpu_interrupt ps-13 mb-12 axi_ad4080_dma/irq
+
+# spi_slave helper: buffer adc samples and stream them to an spi master
+# (enabled with SPI_SLAVE=1)
+
+if {$ad_project_params(SPI_SLAVE) == 1} {
+
+  # pmod jb interface
+
+  create_bd_port -dir O pmod_spi_miso
+  create_bd_port -dir I pmod_spi_sclk
+  create_bd_port -dir I pmod_spi_cs
+  create_bd_port -dir O pmod_data_ready
+
+  ad_ip_instance spi_slave ad4080_spi_slave
+  ad_ip_parameter ad4080_spi_slave CONFIG.DATA_WIDTH $DMA_DATA_WIDTH_SRC
+
+  # fifo write side (adc clock domain)
+
+  ad_connect axi_ad4080_adc/adc_clk   ad4080_spi_slave/data_clk
+  ad_connect axi_ad4080_adc/adc_rst   ad4080_spi_slave/data_rst
+  ad_connect axi_ad4080_adc/adc_data  ad4080_spi_slave/data
+  ad_connect axi_ad4080_adc/adc_valid ad4080_spi_slave/data_valid
+
+  # spi read side (system clock)
+
+  ad_connect $sys_cpu_clk    ad4080_spi_slave/clk
+  ad_connect $sys_cpu_resetn ad4080_spi_slave/resetn
+
+  ad_connect pmod_spi_cs     ad4080_spi_slave/spi_cs
+  ad_connect pmod_spi_sclk   ad4080_spi_slave/spi_sclk
+  ad_connect pmod_spi_miso   ad4080_spi_slave/spi_miso
+  ad_connect pmod_data_ready ad4080_spi_slave/data_ready_n
+}

--- a/projects/ad4080_fmc_evb/zed/Makefile
+++ b/projects/ad4080_fmc_evb/zed/Makefile
@@ -20,7 +20,10 @@ LIB_DEPS += axi_hdmi_tx
 LIB_DEPS += axi_i2s_adi
 LIB_DEPS += axi_spdif_tx
 LIB_DEPS += axi_sysid
+LIB_DEPS += spi_slave
 LIB_DEPS += sysid_rom
+LIB_DEPS += util_axis_fifo
+LIB_DEPS += util_cdc
 LIB_DEPS += util_i2c_mixer
 
 include ../../scripts/project-xilinx.mk

--- a/projects/ad4080_fmc_evb/zed/system_constr_spi_slave.xdc
+++ b/projects/ad4080_fmc_evb/zed/system_constr_spi_slave.xdc
@@ -1,0 +1,16 @@
+###############################################################################
+## Copyright (C) 2025 Analog Devices, Inc. All rights reserved.
+### SPDX short identifier: ADIBSD
+###############################################################################
+
+# pmod jb - spi slave interface and data ready
+
+set_property -dict {PACKAGE_PIN W12  IOSTANDARD LVCMOS33} [get_ports pmod_spi_cs];     ## JB1
+set_property -dict {PACKAGE_PIN W11  IOSTANDARD LVCMOS33} [get_ports pmod_spi_sclk];   ## JB2
+set_property -dict {PACKAGE_PIN V10  IOSTANDARD LVCMOS33} [get_ports pmod_spi_miso];   ## JB3
+set_property -dict {PACKAGE_PIN W8   IOSTANDARD LVCMOS33} [get_ports pmod_data_ready]; ## JB4
+
+# spi pins are synchronized in fabric, not timed against the fabric clock
+
+set_false_path -from [get_ports {pmod_spi_cs pmod_spi_sclk}]
+set_false_path -to   [get_ports pmod_data_ready]

--- a/projects/ad4080_fmc_evb/zed/system_project.tcl
+++ b/projects/ad4080_fmc_evb/zed/system_project.tcl
@@ -6,16 +6,25 @@
 source ../../../scripts/adi_env.tcl
 source $ad_hdl_dir/projects/scripts/adi_project_xilinx.tcl
 source $ad_hdl_dir/projects/scripts/adi_board.tcl
+set ADI_POST_ROUTE_SCRIPT [file normalize $ad_hdl_dir/projects/scripts/auto_timing_fix_xilinx.tcl]
 
 set ADC_N_BITS [get_env_param ADC_N_BITS 20]
+set SPI_SLAVE [get_env_param SPI_SLAVE 0]
 
 adi_project ad4080_fmc_evb_zed 0 [list \
   ADC_N_BITS $ADC_N_BITS \
+  SPI_SLAVE $SPI_SLAVE \
 ]
+
 adi_project_files ad4080_fmc_evb_zed [list \
   "$ad_hdl_dir/library/common/ad_iobuf.v" \
   "$ad_hdl_dir/projects/common/zed/zed_system_constr.xdc" \
   "system_constr.xdc" \
   "system_top.v" ]
+
+if {$SPI_SLAVE == 1} {
+  adi_project_files ad4080_fmc_evb_zed [list "system_constr_spi_slave.xdc" ]
+  set_property verilog_define {SPI_SLAVE} [current_fileset]
+}
 
 adi_project_run ad4080_fmc_evb_zed

--- a/projects/ad4080_fmc_evb/zed/system_top.v
+++ b/projects/ad4080_fmc_evb/zed/system_top.v
@@ -1,6 +1,6 @@
 // ***************************************************************************
 // ***************************************************************************
-// Copyright (C) 2024-2025 Analog Devices, Inc. All rights reserved.
+// Copyright (C) 2024-2026 Analog Devices, Inc. All rights reserved.
 //
 // In this HDL repository, there are many different and unique modules, consisting
 // of various HDL (Verilog or VHDL) components. The individual modules are
@@ -122,6 +122,15 @@ module system_top (
   output          pd_v33b,
   output          osc_en,
   output          ad9508_sync,
+
+`ifdef SPI_SLAVE
+  // PMOD JB interface
+
+  input           pmod_spi_cs,
+  input           pmod_spi_sclk,
+  output          pmod_spi_miso,
+  output          pmod_data_ready,
+`endif
 
   // ADC SPI
 
@@ -252,6 +261,12 @@ module system_top (
     .iic_mux_sda_t (iic_mux_sda_t_s),
     .otg_vbusoc (otg_vbusoc),
     .spdif (spdif),
+`ifdef SPI_SLAVE
+    .pmod_spi_cs (pmod_spi_cs),
+    .pmod_spi_sclk (pmod_spi_sclk),
+    .pmod_spi_miso (pmod_spi_miso),
+    .pmod_data_ready (pmod_data_ready),
+`endif
     .spi0_clk_i (1'b0),
     .spi0_clk_o (ad4080_sclk),
     .spi0_csn_0_o (ad4080_csn),


### PR DESCRIPTION
## PR Description

Adds a SPI slave path so an external SPI master (e.g. a microcontroller) can read AD4080 samples over the ZedBoard PMOD JB header.

### What's added
- **`library/spi_slave`** — new IP that buffers converter samples in an asynchronous FIFO (`util_axis_fifo`) and shifts them out on an external SPI interface. Mode 3, MSB-first, source-only (no MOSI); `data_ready_n` signals that FIFO samples are available for the master to poll.
- **`ad4080_fmc_evb/zed` integration** — instantiated behind a new `SPI_SLAVE` make parameter (default `0`, off). The write side reuses the existing `adc_clk` (200 MHz, DCO/2) and the read/SPI side the system clock (100 MHz), so no new clocks are introduced.
- **Docs** — IP page (`docs/library/spi_slave`) and a new *SPI slave interface* section in the project doc, with block diagrams and the PMOD pinout.

To build the project, run the command in hdl/projects/ad4080_fmc_evb/zed:
make SPI_SLAVE=1


## PR Type
- [ ] Bug fix (change that fixes an issue)
- [x] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)
- [x] Documentation

## PR Checklist
- [x] I have followed the code style guidelines
- [x] I have performed a self-review of changes
- [x] I have compiled all hdl projects and libraries affected by this PR
- [x] I have tested in hardware affected projects, at least on relevant boards
- [x] I have commented my code, at least hard-to-understand parts
- [x] I have signed off all commits from this PR
- [x] I have updated the documentation (wiki pages, ReadMe files, Copyright etc)
- [x] I have not introduced new Warnings/Critical Warnings on compilation
- [ ] I have added new hdl testbenches or updated existing ones
